### PR TITLE
units: Make `amount::error` module private

### DIFF
--- a/api/units/all-features.txt
+++ b/api/units/all-features.txt
@@ -1,19 +1,15 @@
 #[non_exhaustive] pub enum bitcoin_units::amount::Denomination
 #[non_exhaustive] pub enum bitcoin_units::amount::ParseDenominationError
-#[non_exhaustive] pub enum bitcoin_units::amount::error::ParseDenominationError
 #[non_exhaustive] pub struct bitcoin_units::amount::MissingDenominationError
 #[non_exhaustive] pub struct bitcoin_units::amount::PossiblyConfusingDenominationError(_)
 #[non_exhaustive] pub struct bitcoin_units::amount::UnknownDenominationError(_)
-#[non_exhaustive] pub struct bitcoin_units::amount::error::MissingDenominationError
-#[non_exhaustive] pub struct bitcoin_units::amount::error::PossiblyConfusingDenominationError(_)
-#[non_exhaustive] pub struct bitcoin_units::amount::error::UnknownDenominationError(_)
 #[non_exhaustive] pub struct bitcoin_units::locktime::absolute::ConversionError
 #[non_exhaustive] pub struct bitcoin_units::parse::ParseIntError
 impl bitcoin_units::Amount
 impl bitcoin_units::SignedAmount
 impl bitcoin_units::amount::Denomination
 impl bitcoin_units::amount::Display
-impl bitcoin_units::amount::error::OutOfRangeError
+impl bitcoin_units::amount::OutOfRangeError
 impl bitcoin_units::amount::serde::SerdeAmount for bitcoin_units::Amount
 impl bitcoin_units::amount::serde::SerdeAmount for bitcoin_units::SignedAmount
 impl bitcoin_units::amount::serde::SerdeAmountForOpt for bitcoin_units::Amount
@@ -41,17 +37,17 @@ impl core::clone::Clone for bitcoin_units::Amount
 impl core::clone::Clone for bitcoin_units::SignedAmount
 impl core::clone::Clone for bitcoin_units::amount::Denomination
 impl core::clone::Clone for bitcoin_units::amount::Display
-impl core::clone::Clone for bitcoin_units::amount::error::InputTooLargeError
-impl core::clone::Clone for bitcoin_units::amount::error::InvalidCharacterError
-impl core::clone::Clone for bitcoin_units::amount::error::MissingDenominationError
-impl core::clone::Clone for bitcoin_units::amount::error::MissingDigitsError
-impl core::clone::Clone for bitcoin_units::amount::error::OutOfRangeError
-impl core::clone::Clone for bitcoin_units::amount::error::ParseAmountError
-impl core::clone::Clone for bitcoin_units::amount::error::ParseDenominationError
-impl core::clone::Clone for bitcoin_units::amount::error::ParseError
-impl core::clone::Clone for bitcoin_units::amount::error::PossiblyConfusingDenominationError
-impl core::clone::Clone for bitcoin_units::amount::error::TooPreciseError
-impl core::clone::Clone for bitcoin_units::amount::error::UnknownDenominationError
+impl core::clone::Clone for bitcoin_units::amount::InputTooLargeError
+impl core::clone::Clone for bitcoin_units::amount::InvalidCharacterError
+impl core::clone::Clone for bitcoin_units::amount::MissingDenominationError
+impl core::clone::Clone for bitcoin_units::amount::MissingDigitsError
+impl core::clone::Clone for bitcoin_units::amount::OutOfRangeError
+impl core::clone::Clone for bitcoin_units::amount::ParseAmountError
+impl core::clone::Clone for bitcoin_units::amount::ParseDenominationError
+impl core::clone::Clone for bitcoin_units::amount::ParseError
+impl core::clone::Clone for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::clone::Clone for bitcoin_units::amount::TooPreciseError
+impl core::clone::Clone for bitcoin_units::amount::UnknownDenominationError
 impl core::clone::Clone for bitcoin_units::block::BlockHeight
 impl core::clone::Clone for bitcoin_units::block::BlockInterval
 impl core::clone::Clone for bitcoin_units::block::TooBigForRelativeBlockHeightError
@@ -71,17 +67,17 @@ impl core::clone::Clone for bitcoin_units::weight::Weight
 impl core::cmp::Eq for bitcoin_units::Amount
 impl core::cmp::Eq for bitcoin_units::SignedAmount
 impl core::cmp::Eq for bitcoin_units::amount::Denomination
-impl core::cmp::Eq for bitcoin_units::amount::error::InputTooLargeError
-impl core::cmp::Eq for bitcoin_units::amount::error::InvalidCharacterError
-impl core::cmp::Eq for bitcoin_units::amount::error::MissingDenominationError
-impl core::cmp::Eq for bitcoin_units::amount::error::MissingDigitsError
-impl core::cmp::Eq for bitcoin_units::amount::error::OutOfRangeError
-impl core::cmp::Eq for bitcoin_units::amount::error::ParseAmountError
-impl core::cmp::Eq for bitcoin_units::amount::error::ParseDenominationError
-impl core::cmp::Eq for bitcoin_units::amount::error::ParseError
-impl core::cmp::Eq for bitcoin_units::amount::error::PossiblyConfusingDenominationError
-impl core::cmp::Eq for bitcoin_units::amount::error::TooPreciseError
-impl core::cmp::Eq for bitcoin_units::amount::error::UnknownDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::InputTooLargeError
+impl core::cmp::Eq for bitcoin_units::amount::InvalidCharacterError
+impl core::cmp::Eq for bitcoin_units::amount::MissingDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::MissingDigitsError
+impl core::cmp::Eq for bitcoin_units::amount::OutOfRangeError
+impl core::cmp::Eq for bitcoin_units::amount::ParseAmountError
+impl core::cmp::Eq for bitcoin_units::amount::ParseDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::ParseError
+impl core::cmp::Eq for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::TooPreciseError
+impl core::cmp::Eq for bitcoin_units::amount::UnknownDenominationError
 impl core::cmp::Eq for bitcoin_units::block::BlockHeight
 impl core::cmp::Eq for bitcoin_units::block::BlockInterval
 impl core::cmp::Eq for bitcoin_units::block::TooBigForRelativeBlockHeightError
@@ -111,17 +107,17 @@ impl core::cmp::Ord for bitcoin_units::weight::Weight
 impl core::cmp::PartialEq for bitcoin_units::Amount
 impl core::cmp::PartialEq for bitcoin_units::SignedAmount
 impl core::cmp::PartialEq for bitcoin_units::amount::Denomination
-impl core::cmp::PartialEq for bitcoin_units::amount::error::InputTooLargeError
-impl core::cmp::PartialEq for bitcoin_units::amount::error::InvalidCharacterError
-impl core::cmp::PartialEq for bitcoin_units::amount::error::MissingDenominationError
-impl core::cmp::PartialEq for bitcoin_units::amount::error::MissingDigitsError
-impl core::cmp::PartialEq for bitcoin_units::amount::error::OutOfRangeError
-impl core::cmp::PartialEq for bitcoin_units::amount::error::ParseAmountError
-impl core::cmp::PartialEq for bitcoin_units::amount::error::ParseDenominationError
-impl core::cmp::PartialEq for bitcoin_units::amount::error::ParseError
-impl core::cmp::PartialEq for bitcoin_units::amount::error::PossiblyConfusingDenominationError
-impl core::cmp::PartialEq for bitcoin_units::amount::error::TooPreciseError
-impl core::cmp::PartialEq for bitcoin_units::amount::error::UnknownDenominationError
+impl core::cmp::PartialEq for bitcoin_units::amount::InputTooLargeError
+impl core::cmp::PartialEq for bitcoin_units::amount::InvalidCharacterError
+impl core::cmp::PartialEq for bitcoin_units::amount::MissingDenominationError
+impl core::cmp::PartialEq for bitcoin_units::amount::MissingDigitsError
+impl core::cmp::PartialEq for bitcoin_units::amount::OutOfRangeError
+impl core::cmp::PartialEq for bitcoin_units::amount::ParseAmountError
+impl core::cmp::PartialEq for bitcoin_units::amount::ParseDenominationError
+impl core::cmp::PartialEq for bitcoin_units::amount::ParseError
+impl core::cmp::PartialEq for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::cmp::PartialEq for bitcoin_units::amount::TooPreciseError
+impl core::cmp::PartialEq for bitcoin_units::amount::UnknownDenominationError
 impl core::cmp::PartialEq for bitcoin_units::block::BlockHeight
 impl core::cmp::PartialEq for bitcoin_units::block::BlockInterval
 impl core::cmp::PartialEq for bitcoin_units::block::TooBigForRelativeBlockHeightError
@@ -149,18 +145,18 @@ impl core::cmp::PartialOrd for bitcoin_units::locktime::relative::Height
 impl core::cmp::PartialOrd for bitcoin_units::locktime::relative::Time
 impl core::cmp::PartialOrd for bitcoin_units::weight::Weight
 impl core::convert::AsRef<core::num::error::ParseIntError> for bitcoin_units::parse::ParseIntError
-impl core::convert::From<bitcoin_units::amount::error::InputTooLargeError> for bitcoin_units::amount::error::ParseAmountError
-impl core::convert::From<bitcoin_units::amount::error::InputTooLargeError> for bitcoin_units::amount::error::ParseError
-impl core::convert::From<bitcoin_units::amount::error::InvalidCharacterError> for bitcoin_units::amount::error::ParseAmountError
-impl core::convert::From<bitcoin_units::amount::error::InvalidCharacterError> for bitcoin_units::amount::error::ParseError
-impl core::convert::From<bitcoin_units::amount::error::MissingDigitsError> for bitcoin_units::amount::error::ParseAmountError
-impl core::convert::From<bitcoin_units::amount::error::MissingDigitsError> for bitcoin_units::amount::error::ParseError
-impl core::convert::From<bitcoin_units::amount::error::OutOfRangeError> for bitcoin_units::amount::error::ParseAmountError
-impl core::convert::From<bitcoin_units::amount::error::OutOfRangeError> for bitcoin_units::amount::error::ParseError
-impl core::convert::From<bitcoin_units::amount::error::ParseAmountError> for bitcoin_units::amount::error::ParseError
-impl core::convert::From<bitcoin_units::amount::error::ParseDenominationError> for bitcoin_units::amount::error::ParseError
-impl core::convert::From<bitcoin_units::amount::error::TooPreciseError> for bitcoin_units::amount::error::ParseAmountError
-impl core::convert::From<bitcoin_units::amount::error::TooPreciseError> for bitcoin_units::amount::error::ParseError
+impl core::convert::From<bitcoin_units::amount::InputTooLargeError> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::InputTooLargeError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::InvalidCharacterError> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::InvalidCharacterError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::MissingDigitsError> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::MissingDigitsError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::OutOfRangeError> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::OutOfRangeError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::ParseAmountError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::ParseDenominationError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::TooPreciseError> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::TooPreciseError> for bitcoin_units::amount::ParseError
 impl core::convert::From<bitcoin_units::block::BlockHeight> for u32
 impl core::convert::From<bitcoin_units::block::BlockInterval> for u32
 impl core::convert::From<bitcoin_units::fee_rate::FeeRate> for u64
@@ -170,9 +166,9 @@ impl core::convert::From<bitcoin_units::parse::ParseIntError> for bitcoin_units:
 impl core::convert::From<bitcoin_units::parse::ParseIntError> for bitcoin_units::parse::UnprefixedHexError
 impl core::convert::From<bitcoin_units::parse::ParseIntError> for core::num::error::ParseIntError
 impl core::convert::From<bitcoin_units::weight::Weight> for u64
-impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::error::ParseAmountError
-impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::error::ParseDenominationError
-impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::error::ParseError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::ParseDenominationError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::ParseError
 impl core::convert::From<core::convert::Infallible> for bitcoin_units::parse::PrefixedHexError
 impl core::convert::From<core::convert::Infallible> for bitcoin_units::parse::UnprefixedHexError
 impl core::convert::From<u16> for bitcoin_units::locktime::relative::Height
@@ -211,16 +207,16 @@ impl core::default::Default for bitcoin_units::SignedAmount
 impl core::default::Default for bitcoin_units::block::BlockInterval
 impl core::default::Default for bitcoin_units::locktime::relative::Height
 impl core::default::Default for bitcoin_units::locktime::relative::Time
-impl core::error::Error for bitcoin_units::amount::error::InputTooLargeError
-impl core::error::Error for bitcoin_units::amount::error::InvalidCharacterError
-impl core::error::Error for bitcoin_units::amount::error::MissingDigitsError
-impl core::error::Error for bitcoin_units::amount::error::OutOfRangeError
-impl core::error::Error for bitcoin_units::amount::error::ParseAmountError
-impl core::error::Error for bitcoin_units::amount::error::ParseDenominationError
-impl core::error::Error for bitcoin_units::amount::error::ParseError
-impl core::error::Error for bitcoin_units::amount::error::PossiblyConfusingDenominationError
-impl core::error::Error for bitcoin_units::amount::error::TooPreciseError
-impl core::error::Error for bitcoin_units::amount::error::UnknownDenominationError
+impl core::error::Error for bitcoin_units::amount::InputTooLargeError
+impl core::error::Error for bitcoin_units::amount::InvalidCharacterError
+impl core::error::Error for bitcoin_units::amount::MissingDigitsError
+impl core::error::Error for bitcoin_units::amount::OutOfRangeError
+impl core::error::Error for bitcoin_units::amount::ParseAmountError
+impl core::error::Error for bitcoin_units::amount::ParseDenominationError
+impl core::error::Error for bitcoin_units::amount::ParseError
+impl core::error::Error for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::error::Error for bitcoin_units::amount::TooPreciseError
+impl core::error::Error for bitcoin_units::amount::UnknownDenominationError
 impl core::error::Error for bitcoin_units::block::TooBigForRelativeBlockHeightError
 impl core::error::Error for bitcoin_units::locktime::absolute::ConversionError
 impl core::error::Error for bitcoin_units::locktime::absolute::ParseHeightError
@@ -233,17 +229,17 @@ impl core::fmt::Debug for bitcoin_units::Amount
 impl core::fmt::Debug for bitcoin_units::SignedAmount
 impl core::fmt::Debug for bitcoin_units::amount::Denomination
 impl core::fmt::Debug for bitcoin_units::amount::Display
-impl core::fmt::Debug for bitcoin_units::amount::error::InputTooLargeError
-impl core::fmt::Debug for bitcoin_units::amount::error::InvalidCharacterError
-impl core::fmt::Debug for bitcoin_units::amount::error::MissingDenominationError
-impl core::fmt::Debug for bitcoin_units::amount::error::MissingDigitsError
-impl core::fmt::Debug for bitcoin_units::amount::error::OutOfRangeError
-impl core::fmt::Debug for bitcoin_units::amount::error::ParseAmountError
-impl core::fmt::Debug for bitcoin_units::amount::error::ParseDenominationError
-impl core::fmt::Debug for bitcoin_units::amount::error::ParseError
-impl core::fmt::Debug for bitcoin_units::amount::error::PossiblyConfusingDenominationError
-impl core::fmt::Debug for bitcoin_units::amount::error::TooPreciseError
-impl core::fmt::Debug for bitcoin_units::amount::error::UnknownDenominationError
+impl core::fmt::Debug for bitcoin_units::amount::InputTooLargeError
+impl core::fmt::Debug for bitcoin_units::amount::InvalidCharacterError
+impl core::fmt::Debug for bitcoin_units::amount::MissingDenominationError
+impl core::fmt::Debug for bitcoin_units::amount::MissingDigitsError
+impl core::fmt::Debug for bitcoin_units::amount::OutOfRangeError
+impl core::fmt::Debug for bitcoin_units::amount::ParseAmountError
+impl core::fmt::Debug for bitcoin_units::amount::ParseDenominationError
+impl core::fmt::Debug for bitcoin_units::amount::ParseError
+impl core::fmt::Debug for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::fmt::Debug for bitcoin_units::amount::TooPreciseError
+impl core::fmt::Debug for bitcoin_units::amount::UnknownDenominationError
 impl core::fmt::Debug for bitcoin_units::block::BlockHeight
 impl core::fmt::Debug for bitcoin_units::block::BlockInterval
 impl core::fmt::Debug for bitcoin_units::block::TooBigForRelativeBlockHeightError
@@ -264,16 +260,16 @@ impl core::fmt::Display for bitcoin_units::Amount
 impl core::fmt::Display for bitcoin_units::SignedAmount
 impl core::fmt::Display for bitcoin_units::amount::Denomination
 impl core::fmt::Display for bitcoin_units::amount::Display
-impl core::fmt::Display for bitcoin_units::amount::error::InputTooLargeError
-impl core::fmt::Display for bitcoin_units::amount::error::InvalidCharacterError
-impl core::fmt::Display for bitcoin_units::amount::error::MissingDigitsError
-impl core::fmt::Display for bitcoin_units::amount::error::OutOfRangeError
-impl core::fmt::Display for bitcoin_units::amount::error::ParseAmountError
-impl core::fmt::Display for bitcoin_units::amount::error::ParseDenominationError
-impl core::fmt::Display for bitcoin_units::amount::error::ParseError
-impl core::fmt::Display for bitcoin_units::amount::error::PossiblyConfusingDenominationError
-impl core::fmt::Display for bitcoin_units::amount::error::TooPreciseError
-impl core::fmt::Display for bitcoin_units::amount::error::UnknownDenominationError
+impl core::fmt::Display for bitcoin_units::amount::InputTooLargeError
+impl core::fmt::Display for bitcoin_units::amount::InvalidCharacterError
+impl core::fmt::Display for bitcoin_units::amount::MissingDigitsError
+impl core::fmt::Display for bitcoin_units::amount::OutOfRangeError
+impl core::fmt::Display for bitcoin_units::amount::ParseAmountError
+impl core::fmt::Display for bitcoin_units::amount::ParseDenominationError
+impl core::fmt::Display for bitcoin_units::amount::ParseError
+impl core::fmt::Display for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::fmt::Display for bitcoin_units::amount::TooPreciseError
+impl core::fmt::Display for bitcoin_units::amount::UnknownDenominationError
 impl core::fmt::Display for bitcoin_units::block::BlockHeight
 impl core::fmt::Display for bitcoin_units::block::BlockInterval
 impl core::fmt::Display for bitcoin_units::block::TooBigForRelativeBlockHeightError
@@ -309,7 +305,7 @@ impl core::iter::traits::accum::Sum for bitcoin_units::weight::Weight
 impl core::marker::Copy for bitcoin_units::Amount
 impl core::marker::Copy for bitcoin_units::SignedAmount
 impl core::marker::Copy for bitcoin_units::amount::Denomination
-impl core::marker::Copy for bitcoin_units::amount::error::OutOfRangeError
+impl core::marker::Copy for bitcoin_units::amount::OutOfRangeError
 impl core::marker::Copy for bitcoin_units::block::BlockHeight
 impl core::marker::Copy for bitcoin_units::block::BlockInterval
 impl core::marker::Copy for bitcoin_units::fee_rate::FeeRate
@@ -322,17 +318,17 @@ impl core::marker::Freeze for bitcoin_units::Amount
 impl core::marker::Freeze for bitcoin_units::SignedAmount
 impl core::marker::Freeze for bitcoin_units::amount::Denomination
 impl core::marker::Freeze for bitcoin_units::amount::Display
-impl core::marker::Freeze for bitcoin_units::amount::error::InputTooLargeError
-impl core::marker::Freeze for bitcoin_units::amount::error::InvalidCharacterError
-impl core::marker::Freeze for bitcoin_units::amount::error::MissingDenominationError
-impl core::marker::Freeze for bitcoin_units::amount::error::MissingDigitsError
-impl core::marker::Freeze for bitcoin_units::amount::error::OutOfRangeError
-impl core::marker::Freeze for bitcoin_units::amount::error::ParseAmountError
-impl core::marker::Freeze for bitcoin_units::amount::error::ParseDenominationError
-impl core::marker::Freeze for bitcoin_units::amount::error::ParseError
-impl core::marker::Freeze for bitcoin_units::amount::error::PossiblyConfusingDenominationError
-impl core::marker::Freeze for bitcoin_units::amount::error::TooPreciseError
-impl core::marker::Freeze for bitcoin_units::amount::error::UnknownDenominationError
+impl core::marker::Freeze for bitcoin_units::amount::InputTooLargeError
+impl core::marker::Freeze for bitcoin_units::amount::InvalidCharacterError
+impl core::marker::Freeze for bitcoin_units::amount::MissingDenominationError
+impl core::marker::Freeze for bitcoin_units::amount::MissingDigitsError
+impl core::marker::Freeze for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Freeze for bitcoin_units::amount::ParseAmountError
+impl core::marker::Freeze for bitcoin_units::amount::ParseDenominationError
+impl core::marker::Freeze for bitcoin_units::amount::ParseError
+impl core::marker::Freeze for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::Freeze for bitcoin_units::amount::TooPreciseError
+impl core::marker::Freeze for bitcoin_units::amount::UnknownDenominationError
 impl core::marker::Freeze for bitcoin_units::block::BlockHeight
 impl core::marker::Freeze for bitcoin_units::block::BlockInterval
 impl core::marker::Freeze for bitcoin_units::block::TooBigForRelativeBlockHeightError
@@ -353,17 +349,17 @@ impl core::marker::Send for bitcoin_units::Amount
 impl core::marker::Send for bitcoin_units::SignedAmount
 impl core::marker::Send for bitcoin_units::amount::Denomination
 impl core::marker::Send for bitcoin_units::amount::Display
-impl core::marker::Send for bitcoin_units::amount::error::InputTooLargeError
-impl core::marker::Send for bitcoin_units::amount::error::InvalidCharacterError
-impl core::marker::Send for bitcoin_units::amount::error::MissingDenominationError
-impl core::marker::Send for bitcoin_units::amount::error::MissingDigitsError
-impl core::marker::Send for bitcoin_units::amount::error::OutOfRangeError
-impl core::marker::Send for bitcoin_units::amount::error::ParseAmountError
-impl core::marker::Send for bitcoin_units::amount::error::ParseDenominationError
-impl core::marker::Send for bitcoin_units::amount::error::ParseError
-impl core::marker::Send for bitcoin_units::amount::error::PossiblyConfusingDenominationError
-impl core::marker::Send for bitcoin_units::amount::error::TooPreciseError
-impl core::marker::Send for bitcoin_units::amount::error::UnknownDenominationError
+impl core::marker::Send for bitcoin_units::amount::InputTooLargeError
+impl core::marker::Send for bitcoin_units::amount::InvalidCharacterError
+impl core::marker::Send for bitcoin_units::amount::MissingDenominationError
+impl core::marker::Send for bitcoin_units::amount::MissingDigitsError
+impl core::marker::Send for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Send for bitcoin_units::amount::ParseAmountError
+impl core::marker::Send for bitcoin_units::amount::ParseDenominationError
+impl core::marker::Send for bitcoin_units::amount::ParseError
+impl core::marker::Send for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::Send for bitcoin_units::amount::TooPreciseError
+impl core::marker::Send for bitcoin_units::amount::UnknownDenominationError
 impl core::marker::Send for bitcoin_units::block::BlockHeight
 impl core::marker::Send for bitcoin_units::block::BlockInterval
 impl core::marker::Send for bitcoin_units::block::TooBigForRelativeBlockHeightError
@@ -383,17 +379,17 @@ impl core::marker::Send for bitcoin_units::weight::Weight
 impl core::marker::StructuralPartialEq for bitcoin_units::Amount
 impl core::marker::StructuralPartialEq for bitcoin_units::SignedAmount
 impl core::marker::StructuralPartialEq for bitcoin_units::amount::Denomination
-impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::InputTooLargeError
-impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::InvalidCharacterError
-impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::MissingDenominationError
-impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::MissingDigitsError
-impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::OutOfRangeError
-impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::ParseAmountError
-impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::ParseDenominationError
-impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::ParseError
-impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::PossiblyConfusingDenominationError
-impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::TooPreciseError
-impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::UnknownDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::InputTooLargeError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::InvalidCharacterError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::MissingDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::MissingDigitsError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::OutOfRangeError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::ParseAmountError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::ParseDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::ParseError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::TooPreciseError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::UnknownDenominationError
 impl core::marker::StructuralPartialEq for bitcoin_units::block::BlockHeight
 impl core::marker::StructuralPartialEq for bitcoin_units::block::BlockInterval
 impl core::marker::StructuralPartialEq for bitcoin_units::block::TooBigForRelativeBlockHeightError
@@ -414,17 +410,17 @@ impl core::marker::Sync for bitcoin_units::Amount
 impl core::marker::Sync for bitcoin_units::SignedAmount
 impl core::marker::Sync for bitcoin_units::amount::Denomination
 impl core::marker::Sync for bitcoin_units::amount::Display
-impl core::marker::Sync for bitcoin_units::amount::error::InputTooLargeError
-impl core::marker::Sync for bitcoin_units::amount::error::InvalidCharacterError
-impl core::marker::Sync for bitcoin_units::amount::error::MissingDenominationError
-impl core::marker::Sync for bitcoin_units::amount::error::MissingDigitsError
-impl core::marker::Sync for bitcoin_units::amount::error::OutOfRangeError
-impl core::marker::Sync for bitcoin_units::amount::error::ParseAmountError
-impl core::marker::Sync for bitcoin_units::amount::error::ParseDenominationError
-impl core::marker::Sync for bitcoin_units::amount::error::ParseError
-impl core::marker::Sync for bitcoin_units::amount::error::PossiblyConfusingDenominationError
-impl core::marker::Sync for bitcoin_units::amount::error::TooPreciseError
-impl core::marker::Sync for bitcoin_units::amount::error::UnknownDenominationError
+impl core::marker::Sync for bitcoin_units::amount::InputTooLargeError
+impl core::marker::Sync for bitcoin_units::amount::InvalidCharacterError
+impl core::marker::Sync for bitcoin_units::amount::MissingDenominationError
+impl core::marker::Sync for bitcoin_units::amount::MissingDigitsError
+impl core::marker::Sync for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Sync for bitcoin_units::amount::ParseAmountError
+impl core::marker::Sync for bitcoin_units::amount::ParseDenominationError
+impl core::marker::Sync for bitcoin_units::amount::ParseError
+impl core::marker::Sync for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::Sync for bitcoin_units::amount::TooPreciseError
+impl core::marker::Sync for bitcoin_units::amount::UnknownDenominationError
 impl core::marker::Sync for bitcoin_units::block::BlockHeight
 impl core::marker::Sync for bitcoin_units::block::BlockInterval
 impl core::marker::Sync for bitcoin_units::block::TooBigForRelativeBlockHeightError
@@ -445,17 +441,17 @@ impl core::marker::Unpin for bitcoin_units::Amount
 impl core::marker::Unpin for bitcoin_units::SignedAmount
 impl core::marker::Unpin for bitcoin_units::amount::Denomination
 impl core::marker::Unpin for bitcoin_units::amount::Display
-impl core::marker::Unpin for bitcoin_units::amount::error::InputTooLargeError
-impl core::marker::Unpin for bitcoin_units::amount::error::InvalidCharacterError
-impl core::marker::Unpin for bitcoin_units::amount::error::MissingDenominationError
-impl core::marker::Unpin for bitcoin_units::amount::error::MissingDigitsError
-impl core::marker::Unpin for bitcoin_units::amount::error::OutOfRangeError
-impl core::marker::Unpin for bitcoin_units::amount::error::ParseAmountError
-impl core::marker::Unpin for bitcoin_units::amount::error::ParseDenominationError
-impl core::marker::Unpin for bitcoin_units::amount::error::ParseError
-impl core::marker::Unpin for bitcoin_units::amount::error::PossiblyConfusingDenominationError
-impl core::marker::Unpin for bitcoin_units::amount::error::TooPreciseError
-impl core::marker::Unpin for bitcoin_units::amount::error::UnknownDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::InputTooLargeError
+impl core::marker::Unpin for bitcoin_units::amount::InvalidCharacterError
+impl core::marker::Unpin for bitcoin_units::amount::MissingDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::MissingDigitsError
+impl core::marker::Unpin for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Unpin for bitcoin_units::amount::ParseAmountError
+impl core::marker::Unpin for bitcoin_units::amount::ParseDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::ParseError
+impl core::marker::Unpin for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::TooPreciseError
+impl core::marker::Unpin for bitcoin_units::amount::UnknownDenominationError
 impl core::marker::Unpin for bitcoin_units::block::BlockHeight
 impl core::marker::Unpin for bitcoin_units::block::BlockInterval
 impl core::marker::Unpin for bitcoin_units::block::TooBigForRelativeBlockHeightError
@@ -545,17 +541,17 @@ impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::Amount
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::SignedAmount
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::Denomination
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::Display
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::InputTooLargeError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::InvalidCharacterError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::MissingDenominationError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::MissingDigitsError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::OutOfRangeError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::ParseAmountError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::ParseDenominationError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::ParseError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::PossiblyConfusingDenominationError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::TooPreciseError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::UnknownDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::InputTooLargeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::InvalidCharacterError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::MissingDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::MissingDigitsError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::OutOfRangeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::ParseAmountError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::ParseDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::ParseError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::TooPreciseError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::UnknownDenominationError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::BlockHeight
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::BlockInterval
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::TooBigForRelativeBlockHeightError
@@ -576,17 +572,17 @@ impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::Amount
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::SignedAmount
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::Denomination
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::Display
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::InputTooLargeError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::InvalidCharacterError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::MissingDenominationError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::MissingDigitsError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::OutOfRangeError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::ParseAmountError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::ParseDenominationError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::ParseError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::PossiblyConfusingDenominationError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::TooPreciseError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::UnknownDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::InputTooLargeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::InvalidCharacterError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::MissingDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::MissingDigitsError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::OutOfRangeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::ParseAmountError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::ParseDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::ParseError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::TooPreciseError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::UnknownDenominationError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::BlockHeight
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::BlockInterval
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::TooBigForRelativeBlockHeightError
@@ -662,10 +658,8 @@ pub bitcoin_units::amount::Denomination::CentiBitcoin
 pub bitcoin_units::amount::Denomination::MicroBitcoin
 pub bitcoin_units::amount::Denomination::MilliBitcoin
 pub bitcoin_units::amount::Denomination::Satoshi
-pub bitcoin_units::amount::ParseDenominationError::PossiblyConfusing(bitcoin_units::amount::error::PossiblyConfusingDenominationError)
-pub bitcoin_units::amount::ParseDenominationError::Unknown(bitcoin_units::amount::error::UnknownDenominationError)
-pub bitcoin_units::amount::error::ParseDenominationError::PossiblyConfusing(bitcoin_units::amount::error::PossiblyConfusingDenominationError)
-pub bitcoin_units::amount::error::ParseDenominationError::Unknown(bitcoin_units::amount::error::UnknownDenominationError)
+pub bitcoin_units::amount::ParseDenominationError::PossiblyConfusing(bitcoin_units::amount::PossiblyConfusingDenominationError)
+pub bitcoin_units::amount::ParseDenominationError::Unknown(bitcoin_units::amount::UnknownDenominationError)
 pub const bitcoin_units::Amount::MAX: Self
 pub const bitcoin_units::Amount::MAX_MONEY: Self
 pub const bitcoin_units::Amount::MIN: Self
@@ -810,12 +804,12 @@ pub fn bitcoin_units::Amount::div(self, rhs: u64) -> Self::Output
 pub fn bitcoin_units::Amount::div_assign(&mut self, rhs: u64)
 pub fn bitcoin_units::Amount::eq(&self, other: &bitcoin_units::Amount) -> bool
 pub fn bitcoin_units::Amount::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::Amount::from_btc(btc: f64) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::ParseAmountError>
-pub fn bitcoin_units::Amount::from_float_in(value: f64, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::ParseAmountError>
-pub fn bitcoin_units::Amount::from_int_btc<T: core::convert::Into<u64>>(whole_bitcoin: T) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::OutOfRangeError>
+pub fn bitcoin_units::Amount::from_btc(btc: f64) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::Amount::from_float_in(value: f64, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::Amount::from_int_btc<T: core::convert::Into<u64>>(whole_bitcoin: T) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::OutOfRangeError>
 pub fn bitcoin_units::Amount::from_str(s: &str) -> core::result::Result<Self, Self::Err>
-pub fn bitcoin_units::Amount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::ParseAmountError>
-pub fn bitcoin_units::Amount::from_str_with_denomination(s: &str) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::ParseError>
+pub fn bitcoin_units::Amount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::Amount::from_str_with_denomination(s: &str) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::ParseError>
 pub fn bitcoin_units::Amount::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin_units::Amount::mul(self, rhs: u64) -> Self::Output
 pub fn bitcoin_units::Amount::mul_assign(&mut self, rhs: u64)
@@ -836,7 +830,7 @@ pub fn bitcoin_units::Amount::sum<I: core::iter::traits::iterator::Iterator<Item
 pub fn bitcoin_units::Amount::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin_units::Amount>
 pub fn bitcoin_units::Amount::to_btc(self) -> f64
 pub fn bitcoin_units::Amount::to_float_in(self, denom: bitcoin_units::amount::Denomination) -> f64
-pub fn bitcoin_units::Amount::to_signed(self) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::OutOfRangeError>
+pub fn bitcoin_units::Amount::to_signed(self) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::OutOfRangeError>
 pub fn bitcoin_units::Amount::to_string_in(self, denom: bitcoin_units::amount::Denomination) -> alloc::string::String
 pub fn bitcoin_units::Amount::to_string_with_denomination(self, denom: bitcoin_units::amount::Denomination) -> alloc::string::String
 pub fn bitcoin_units::Amount::try_from(value: bitcoin_units::SignedAmount) -> core::result::Result<Self, Self::Error>
@@ -861,12 +855,12 @@ pub fn bitcoin_units::SignedAmount::div(self, rhs: i64) -> Self::Output
 pub fn bitcoin_units::SignedAmount::div_assign(&mut self, rhs: i64)
 pub fn bitcoin_units::SignedAmount::eq(&self, other: &bitcoin_units::SignedAmount) -> bool
 pub fn bitcoin_units::SignedAmount::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::SignedAmount::from_btc(btc: f64) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::ParseAmountError>
-pub fn bitcoin_units::SignedAmount::from_float_in(value: f64, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::ParseAmountError>
-pub fn bitcoin_units::SignedAmount::from_int_btc<T: core::convert::Into<i64>>(whole_bitcoin: T) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::OutOfRangeError>
+pub fn bitcoin_units::SignedAmount::from_btc(btc: f64) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::SignedAmount::from_float_in(value: f64, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::SignedAmount::from_int_btc<T: core::convert::Into<i64>>(whole_bitcoin: T) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::OutOfRangeError>
 pub fn bitcoin_units::SignedAmount::from_str(s: &str) -> core::result::Result<Self, Self::Err>
-pub fn bitcoin_units::SignedAmount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::ParseAmountError>
-pub fn bitcoin_units::SignedAmount::from_str_with_denomination(s: &str) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::ParseError>
+pub fn bitcoin_units::SignedAmount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::SignedAmount::from_str_with_denomination(s: &str) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::ParseError>
 pub fn bitcoin_units::SignedAmount::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin_units::SignedAmount::is_negative(self) -> bool
 pub fn bitcoin_units::SignedAmount::is_positive(self) -> bool
@@ -894,7 +888,7 @@ pub fn bitcoin_units::SignedAmount::to_btc(self) -> f64
 pub fn bitcoin_units::SignedAmount::to_float_in(self, denom: bitcoin_units::amount::Denomination) -> f64
 pub fn bitcoin_units::SignedAmount::to_string_in(self, denom: bitcoin_units::amount::Denomination) -> alloc::string::String
 pub fn bitcoin_units::SignedAmount::to_string_with_denomination(self, denom: bitcoin_units::amount::Denomination) -> alloc::string::String
-pub fn bitcoin_units::SignedAmount::to_unsigned(self) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::OutOfRangeError>
+pub fn bitcoin_units::SignedAmount::to_unsigned(self) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::OutOfRangeError>
 pub fn bitcoin_units::SignedAmount::try_from(value: bitcoin_units::Amount) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_units::SignedAmount::type_prefix(_: private::Token) -> &'static str
 pub fn bitcoin_units::SignedAmount::unchecked_add(self, rhs: bitcoin_units::SignedAmount) -> bitcoin_units::SignedAmount
@@ -910,62 +904,62 @@ pub fn bitcoin_units::amount::Denomination::hash<__H: core::hash::Hasher>(&self,
 pub fn bitcoin_units::amount::Display::clone(&self) -> bitcoin_units::amount::Display
 pub fn bitcoin_units::amount::Display::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_units::amount::Display::show_denomination(self) -> Self
-pub fn bitcoin_units::amount::error::InputTooLargeError::clone(&self) -> bitcoin_units::amount::error::InputTooLargeError
-pub fn bitcoin_units::amount::error::InputTooLargeError::eq(&self, other: &bitcoin_units::amount::error::InputTooLargeError) -> bool
-pub fn bitcoin_units::amount::error::InputTooLargeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::amount::error::InvalidCharacterError::clone(&self) -> bitcoin_units::amount::error::InvalidCharacterError
-pub fn bitcoin_units::amount::error::InvalidCharacterError::eq(&self, other: &bitcoin_units::amount::error::InvalidCharacterError) -> bool
-pub fn bitcoin_units::amount::error::InvalidCharacterError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::amount::error::MissingDenominationError::clone(&self) -> bitcoin_units::amount::error::MissingDenominationError
-pub fn bitcoin_units::amount::error::MissingDenominationError::eq(&self, other: &bitcoin_units::amount::error::MissingDenominationError) -> bool
-pub fn bitcoin_units::amount::error::MissingDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::amount::error::MissingDigitsError::clone(&self) -> bitcoin_units::amount::error::MissingDigitsError
-pub fn bitcoin_units::amount::error::MissingDigitsError::eq(&self, other: &bitcoin_units::amount::error::MissingDigitsError) -> bool
-pub fn bitcoin_units::amount::error::MissingDigitsError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::amount::error::OutOfRangeError::clone(&self) -> bitcoin_units::amount::error::OutOfRangeError
-pub fn bitcoin_units::amount::error::OutOfRangeError::eq(&self, other: &bitcoin_units::amount::error::OutOfRangeError) -> bool
-pub fn bitcoin_units::amount::error::OutOfRangeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::amount::error::OutOfRangeError::is_above_max(self) -> bool
-pub fn bitcoin_units::amount::error::OutOfRangeError::is_below_min(self) -> bool
-pub fn bitcoin_units::amount::error::OutOfRangeError::valid_range(self) -> (i64, u64)
-pub fn bitcoin_units::amount::error::ParseAmountError::clone(&self) -> bitcoin_units::amount::error::ParseAmountError
-pub fn bitcoin_units::amount::error::ParseAmountError::eq(&self, other: &bitcoin_units::amount::error::ParseAmountError) -> bool
-pub fn bitcoin_units::amount::error::ParseAmountError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::amount::error::ParseAmountError::from(never: core::convert::Infallible) -> Self
-pub fn bitcoin_units::amount::error::ParseAmountError::from(value: bitcoin_units::amount::error::InputTooLargeError) -> Self
-pub fn bitcoin_units::amount::error::ParseAmountError::from(value: bitcoin_units::amount::error::InvalidCharacterError) -> Self
-pub fn bitcoin_units::amount::error::ParseAmountError::from(value: bitcoin_units::amount::error::MissingDigitsError) -> Self
-pub fn bitcoin_units::amount::error::ParseAmountError::from(value: bitcoin_units::amount::error::OutOfRangeError) -> Self
-pub fn bitcoin_units::amount::error::ParseAmountError::from(value: bitcoin_units::amount::error::TooPreciseError) -> Self
-pub fn bitcoin_units::amount::error::ParseAmountError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
-pub fn bitcoin_units::amount::error::ParseDenominationError::clone(&self) -> bitcoin_units::amount::error::ParseDenominationError
-pub fn bitcoin_units::amount::error::ParseDenominationError::eq(&self, other: &bitcoin_units::amount::error::ParseDenominationError) -> bool
-pub fn bitcoin_units::amount::error::ParseDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::amount::error::ParseDenominationError::from(never: core::convert::Infallible) -> Self
-pub fn bitcoin_units::amount::error::ParseDenominationError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
-pub fn bitcoin_units::amount::error::ParseError::clone(&self) -> bitcoin_units::amount::error::ParseError
-pub fn bitcoin_units::amount::error::ParseError::eq(&self, other: &bitcoin_units::amount::error::ParseError) -> bool
-pub fn bitcoin_units::amount::error::ParseError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::InputTooLargeError) -> Self
-pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::InvalidCharacterError) -> Self
-pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::MissingDigitsError) -> Self
-pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::OutOfRangeError) -> Self
-pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::ParseAmountError) -> Self
-pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::ParseDenominationError) -> Self
-pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::TooPreciseError) -> Self
-pub fn bitcoin_units::amount::error::ParseError::from(never: core::convert::Infallible) -> Self
-pub fn bitcoin_units::amount::error::ParseError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
-pub fn bitcoin_units::amount::error::PossiblyConfusingDenominationError::clone(&self) -> bitcoin_units::amount::error::PossiblyConfusingDenominationError
-pub fn bitcoin_units::amount::error::PossiblyConfusingDenominationError::eq(&self, other: &bitcoin_units::amount::error::PossiblyConfusingDenominationError) -> bool
-pub fn bitcoin_units::amount::error::PossiblyConfusingDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::amount::error::PossiblyConfusingDenominationError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
-pub fn bitcoin_units::amount::error::TooPreciseError::clone(&self) -> bitcoin_units::amount::error::TooPreciseError
-pub fn bitcoin_units::amount::error::TooPreciseError::eq(&self, other: &bitcoin_units::amount::error::TooPreciseError) -> bool
-pub fn bitcoin_units::amount::error::TooPreciseError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::amount::error::UnknownDenominationError::clone(&self) -> bitcoin_units::amount::error::UnknownDenominationError
-pub fn bitcoin_units::amount::error::UnknownDenominationError::eq(&self, other: &bitcoin_units::amount::error::UnknownDenominationError) -> bool
-pub fn bitcoin_units::amount::error::UnknownDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::amount::error::UnknownDenominationError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_units::amount::InputTooLargeError::clone(&self) -> bitcoin_units::amount::InputTooLargeError
+pub fn bitcoin_units::amount::InputTooLargeError::eq(&self, other: &bitcoin_units::amount::InputTooLargeError) -> bool
+pub fn bitcoin_units::amount::InputTooLargeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::InvalidCharacterError::clone(&self) -> bitcoin_units::amount::InvalidCharacterError
+pub fn bitcoin_units::amount::InvalidCharacterError::eq(&self, other: &bitcoin_units::amount::InvalidCharacterError) -> bool
+pub fn bitcoin_units::amount::InvalidCharacterError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::MissingDenominationError::clone(&self) -> bitcoin_units::amount::MissingDenominationError
+pub fn bitcoin_units::amount::MissingDenominationError::eq(&self, other: &bitcoin_units::amount::MissingDenominationError) -> bool
+pub fn bitcoin_units::amount::MissingDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::MissingDigitsError::clone(&self) -> bitcoin_units::amount::MissingDigitsError
+pub fn bitcoin_units::amount::MissingDigitsError::eq(&self, other: &bitcoin_units::amount::MissingDigitsError) -> bool
+pub fn bitcoin_units::amount::MissingDigitsError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::OutOfRangeError::clone(&self) -> bitcoin_units::amount::OutOfRangeError
+pub fn bitcoin_units::amount::OutOfRangeError::eq(&self, other: &bitcoin_units::amount::OutOfRangeError) -> bool
+pub fn bitcoin_units::amount::OutOfRangeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::OutOfRangeError::is_above_max(self) -> bool
+pub fn bitcoin_units::amount::OutOfRangeError::is_below_min(self) -> bool
+pub fn bitcoin_units::amount::OutOfRangeError::valid_range(self) -> (i64, u64)
+pub fn bitcoin_units::amount::ParseAmountError::clone(&self) -> bitcoin_units::amount::ParseAmountError
+pub fn bitcoin_units::amount::ParseAmountError::eq(&self, other: &bitcoin_units::amount::ParseAmountError) -> bool
+pub fn bitcoin_units::amount::ParseAmountError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::ParseAmountError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::amount::ParseAmountError::from(value: bitcoin_units::amount::InputTooLargeError) -> Self
+pub fn bitcoin_units::amount::ParseAmountError::from(value: bitcoin_units::amount::InvalidCharacterError) -> Self
+pub fn bitcoin_units::amount::ParseAmountError::from(value: bitcoin_units::amount::MissingDigitsError) -> Self
+pub fn bitcoin_units::amount::ParseAmountError::from(value: bitcoin_units::amount::OutOfRangeError) -> Self
+pub fn bitcoin_units::amount::ParseAmountError::from(value: bitcoin_units::amount::TooPreciseError) -> Self
+pub fn bitcoin_units::amount::ParseAmountError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_units::amount::ParseDenominationError::clone(&self) -> bitcoin_units::amount::ParseDenominationError
+pub fn bitcoin_units::amount::ParseDenominationError::eq(&self, other: &bitcoin_units::amount::ParseDenominationError) -> bool
+pub fn bitcoin_units::amount::ParseDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::ParseDenominationError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::amount::ParseDenominationError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_units::amount::ParseError::clone(&self) -> bitcoin_units::amount::ParseError
+pub fn bitcoin_units::amount::ParseError::eq(&self, other: &bitcoin_units::amount::ParseError) -> bool
+pub fn bitcoin_units::amount::ParseError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::InputTooLargeError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::InvalidCharacterError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::MissingDigitsError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::OutOfRangeError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::ParseAmountError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::ParseDenominationError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::TooPreciseError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::amount::ParseError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_units::amount::PossiblyConfusingDenominationError::clone(&self) -> bitcoin_units::amount::PossiblyConfusingDenominationError
+pub fn bitcoin_units::amount::PossiblyConfusingDenominationError::eq(&self, other: &bitcoin_units::amount::PossiblyConfusingDenominationError) -> bool
+pub fn bitcoin_units::amount::PossiblyConfusingDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::PossiblyConfusingDenominationError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_units::amount::TooPreciseError::clone(&self) -> bitcoin_units::amount::TooPreciseError
+pub fn bitcoin_units::amount::TooPreciseError::eq(&self, other: &bitcoin_units::amount::TooPreciseError) -> bool
+pub fn bitcoin_units::amount::TooPreciseError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::UnknownDenominationError::clone(&self) -> bitcoin_units::amount::UnknownDenominationError
+pub fn bitcoin_units::amount::UnknownDenominationError::eq(&self, other: &bitcoin_units::amount::UnknownDenominationError) -> bool
+pub fn bitcoin_units::amount::UnknownDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::UnknownDenominationError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 pub fn bitcoin_units::amount::serde::SerdeAmount::des_btc<'d, D: serde::de::Deserializer<'d>>(d: D, _: private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
 pub fn bitcoin_units::amount::serde::SerdeAmount::des_sat<'d, D: serde::de::Deserializer<'d>>(d: D, _: private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
 pub fn bitcoin_units::amount::serde::SerdeAmount::des_str<'d, D: serde::de::Deserializer<'d>>(d: D, _: private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
@@ -1203,7 +1197,6 @@ pub macro bitcoin_units::impl_tryfrom_str!
 pub macro bitcoin_units::impl_tryfrom_str_from_int_infallible!
 pub mod bitcoin_units
 pub mod bitcoin_units::amount
-pub mod bitcoin_units::amount::error
 pub mod bitcoin_units::amount::serde
 pub mod bitcoin_units::amount::serde::as_btc
 pub mod bitcoin_units::amount::serde::as_btc::opt
@@ -1234,13 +1227,6 @@ pub struct bitcoin_units::amount::ParseAmountError(_)
 pub struct bitcoin_units::amount::ParseError(_)
 pub struct bitcoin_units::amount::SignedAmount(_)
 pub struct bitcoin_units::amount::TooPreciseError
-pub struct bitcoin_units::amount::error::InputTooLargeError
-pub struct bitcoin_units::amount::error::InvalidCharacterError
-pub struct bitcoin_units::amount::error::MissingDigitsError
-pub struct bitcoin_units::amount::error::OutOfRangeError
-pub struct bitcoin_units::amount::error::ParseAmountError(_)
-pub struct bitcoin_units::amount::error::ParseError(_)
-pub struct bitcoin_units::amount::error::TooPreciseError
 pub struct bitcoin_units::block::BlockHeight(pub u32)
 pub struct bitcoin_units::block::BlockInterval(pub u32)
 pub struct bitcoin_units::block::TooBigForRelativeBlockHeightError(_)
@@ -1263,14 +1249,14 @@ pub type &bitcoin_units::Amount::Output = bitcoin_units::Amount
 pub type &bitcoin_units::SignedAmount::Output = bitcoin_units::SignedAmount
 pub type &bitcoin_units::fee_rate::FeeRate::Output = bitcoin_units::fee_rate::FeeRate
 pub type &bitcoin_units::weight::Weight::Output = bitcoin_units::weight::Weight
-pub type bitcoin_units::Amount::Err = bitcoin_units::amount::error::ParseError
-pub type bitcoin_units::Amount::Error = bitcoin_units::amount::error::OutOfRangeError
+pub type bitcoin_units::Amount::Err = bitcoin_units::amount::ParseError
+pub type bitcoin_units::Amount::Error = bitcoin_units::amount::OutOfRangeError
 pub type bitcoin_units::Amount::Output = bitcoin_units::Amount
 pub type bitcoin_units::Amount::Output = bitcoin_units::fee_rate::FeeRate
-pub type bitcoin_units::SignedAmount::Err = bitcoin_units::amount::error::ParseError
-pub type bitcoin_units::SignedAmount::Error = bitcoin_units::amount::error::OutOfRangeError
+pub type bitcoin_units::SignedAmount::Err = bitcoin_units::amount::ParseError
+pub type bitcoin_units::SignedAmount::Error = bitcoin_units::amount::OutOfRangeError
 pub type bitcoin_units::SignedAmount::Output = bitcoin_units::SignedAmount
-pub type bitcoin_units::amount::Denomination::Err = bitcoin_units::amount::error::ParseDenominationError
+pub type bitcoin_units::amount::Denomination::Err = bitcoin_units::amount::ParseDenominationError
 pub type bitcoin_units::block::BlockHeight::Err = bitcoin_units::parse::ParseIntError
 pub type bitcoin_units::block::BlockHeight::Error = bitcoin_units::parse::ParseIntError
 pub type bitcoin_units::block::BlockHeight::Output = bitcoin_units::block::BlockHeight

--- a/api/units/alloc-only.txt
+++ b/api/units/alloc-only.txt
@@ -1,19 +1,15 @@
 #[non_exhaustive] pub enum bitcoin_units::amount::Denomination
 #[non_exhaustive] pub enum bitcoin_units::amount::ParseDenominationError
-#[non_exhaustive] pub enum bitcoin_units::amount::error::ParseDenominationError
 #[non_exhaustive] pub struct bitcoin_units::amount::MissingDenominationError
 #[non_exhaustive] pub struct bitcoin_units::amount::PossiblyConfusingDenominationError(_)
 #[non_exhaustive] pub struct bitcoin_units::amount::UnknownDenominationError(_)
-#[non_exhaustive] pub struct bitcoin_units::amount::error::MissingDenominationError
-#[non_exhaustive] pub struct bitcoin_units::amount::error::PossiblyConfusingDenominationError(_)
-#[non_exhaustive] pub struct bitcoin_units::amount::error::UnknownDenominationError(_)
 #[non_exhaustive] pub struct bitcoin_units::locktime::absolute::ConversionError
 #[non_exhaustive] pub struct bitcoin_units::parse::ParseIntError
 impl bitcoin_units::Amount
 impl bitcoin_units::SignedAmount
 impl bitcoin_units::amount::Denomination
 impl bitcoin_units::amount::Display
-impl bitcoin_units::amount::error::OutOfRangeError
+impl bitcoin_units::amount::OutOfRangeError
 impl bitcoin_units::block::BlockHeight
 impl bitcoin_units::block::BlockInterval
 impl bitcoin_units::fee_rate::FeeRate
@@ -37,17 +33,17 @@ impl core::clone::Clone for bitcoin_units::Amount
 impl core::clone::Clone for bitcoin_units::SignedAmount
 impl core::clone::Clone for bitcoin_units::amount::Denomination
 impl core::clone::Clone for bitcoin_units::amount::Display
-impl core::clone::Clone for bitcoin_units::amount::error::InputTooLargeError
-impl core::clone::Clone for bitcoin_units::amount::error::InvalidCharacterError
-impl core::clone::Clone for bitcoin_units::amount::error::MissingDenominationError
-impl core::clone::Clone for bitcoin_units::amount::error::MissingDigitsError
-impl core::clone::Clone for bitcoin_units::amount::error::OutOfRangeError
-impl core::clone::Clone for bitcoin_units::amount::error::ParseAmountError
-impl core::clone::Clone for bitcoin_units::amount::error::ParseDenominationError
-impl core::clone::Clone for bitcoin_units::amount::error::ParseError
-impl core::clone::Clone for bitcoin_units::amount::error::PossiblyConfusingDenominationError
-impl core::clone::Clone for bitcoin_units::amount::error::TooPreciseError
-impl core::clone::Clone for bitcoin_units::amount::error::UnknownDenominationError
+impl core::clone::Clone for bitcoin_units::amount::InputTooLargeError
+impl core::clone::Clone for bitcoin_units::amount::InvalidCharacterError
+impl core::clone::Clone for bitcoin_units::amount::MissingDenominationError
+impl core::clone::Clone for bitcoin_units::amount::MissingDigitsError
+impl core::clone::Clone for bitcoin_units::amount::OutOfRangeError
+impl core::clone::Clone for bitcoin_units::amount::ParseAmountError
+impl core::clone::Clone for bitcoin_units::amount::ParseDenominationError
+impl core::clone::Clone for bitcoin_units::amount::ParseError
+impl core::clone::Clone for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::clone::Clone for bitcoin_units::amount::TooPreciseError
+impl core::clone::Clone for bitcoin_units::amount::UnknownDenominationError
 impl core::clone::Clone for bitcoin_units::block::BlockHeight
 impl core::clone::Clone for bitcoin_units::block::BlockInterval
 impl core::clone::Clone for bitcoin_units::block::TooBigForRelativeBlockHeightError
@@ -67,17 +63,17 @@ impl core::clone::Clone for bitcoin_units::weight::Weight
 impl core::cmp::Eq for bitcoin_units::Amount
 impl core::cmp::Eq for bitcoin_units::SignedAmount
 impl core::cmp::Eq for bitcoin_units::amount::Denomination
-impl core::cmp::Eq for bitcoin_units::amount::error::InputTooLargeError
-impl core::cmp::Eq for bitcoin_units::amount::error::InvalidCharacterError
-impl core::cmp::Eq for bitcoin_units::amount::error::MissingDenominationError
-impl core::cmp::Eq for bitcoin_units::amount::error::MissingDigitsError
-impl core::cmp::Eq for bitcoin_units::amount::error::OutOfRangeError
-impl core::cmp::Eq for bitcoin_units::amount::error::ParseAmountError
-impl core::cmp::Eq for bitcoin_units::amount::error::ParseDenominationError
-impl core::cmp::Eq for bitcoin_units::amount::error::ParseError
-impl core::cmp::Eq for bitcoin_units::amount::error::PossiblyConfusingDenominationError
-impl core::cmp::Eq for bitcoin_units::amount::error::TooPreciseError
-impl core::cmp::Eq for bitcoin_units::amount::error::UnknownDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::InputTooLargeError
+impl core::cmp::Eq for bitcoin_units::amount::InvalidCharacterError
+impl core::cmp::Eq for bitcoin_units::amount::MissingDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::MissingDigitsError
+impl core::cmp::Eq for bitcoin_units::amount::OutOfRangeError
+impl core::cmp::Eq for bitcoin_units::amount::ParseAmountError
+impl core::cmp::Eq for bitcoin_units::amount::ParseDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::ParseError
+impl core::cmp::Eq for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::TooPreciseError
+impl core::cmp::Eq for bitcoin_units::amount::UnknownDenominationError
 impl core::cmp::Eq for bitcoin_units::block::BlockHeight
 impl core::cmp::Eq for bitcoin_units::block::BlockInterval
 impl core::cmp::Eq for bitcoin_units::block::TooBigForRelativeBlockHeightError
@@ -107,17 +103,17 @@ impl core::cmp::Ord for bitcoin_units::weight::Weight
 impl core::cmp::PartialEq for bitcoin_units::Amount
 impl core::cmp::PartialEq for bitcoin_units::SignedAmount
 impl core::cmp::PartialEq for bitcoin_units::amount::Denomination
-impl core::cmp::PartialEq for bitcoin_units::amount::error::InputTooLargeError
-impl core::cmp::PartialEq for bitcoin_units::amount::error::InvalidCharacterError
-impl core::cmp::PartialEq for bitcoin_units::amount::error::MissingDenominationError
-impl core::cmp::PartialEq for bitcoin_units::amount::error::MissingDigitsError
-impl core::cmp::PartialEq for bitcoin_units::amount::error::OutOfRangeError
-impl core::cmp::PartialEq for bitcoin_units::amount::error::ParseAmountError
-impl core::cmp::PartialEq for bitcoin_units::amount::error::ParseDenominationError
-impl core::cmp::PartialEq for bitcoin_units::amount::error::ParseError
-impl core::cmp::PartialEq for bitcoin_units::amount::error::PossiblyConfusingDenominationError
-impl core::cmp::PartialEq for bitcoin_units::amount::error::TooPreciseError
-impl core::cmp::PartialEq for bitcoin_units::amount::error::UnknownDenominationError
+impl core::cmp::PartialEq for bitcoin_units::amount::InputTooLargeError
+impl core::cmp::PartialEq for bitcoin_units::amount::InvalidCharacterError
+impl core::cmp::PartialEq for bitcoin_units::amount::MissingDenominationError
+impl core::cmp::PartialEq for bitcoin_units::amount::MissingDigitsError
+impl core::cmp::PartialEq for bitcoin_units::amount::OutOfRangeError
+impl core::cmp::PartialEq for bitcoin_units::amount::ParseAmountError
+impl core::cmp::PartialEq for bitcoin_units::amount::ParseDenominationError
+impl core::cmp::PartialEq for bitcoin_units::amount::ParseError
+impl core::cmp::PartialEq for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::cmp::PartialEq for bitcoin_units::amount::TooPreciseError
+impl core::cmp::PartialEq for bitcoin_units::amount::UnknownDenominationError
 impl core::cmp::PartialEq for bitcoin_units::block::BlockHeight
 impl core::cmp::PartialEq for bitcoin_units::block::BlockInterval
 impl core::cmp::PartialEq for bitcoin_units::block::TooBigForRelativeBlockHeightError
@@ -145,18 +141,18 @@ impl core::cmp::PartialOrd for bitcoin_units::locktime::relative::Height
 impl core::cmp::PartialOrd for bitcoin_units::locktime::relative::Time
 impl core::cmp::PartialOrd for bitcoin_units::weight::Weight
 impl core::convert::AsRef<core::num::error::ParseIntError> for bitcoin_units::parse::ParseIntError
-impl core::convert::From<bitcoin_units::amount::error::InputTooLargeError> for bitcoin_units::amount::error::ParseAmountError
-impl core::convert::From<bitcoin_units::amount::error::InputTooLargeError> for bitcoin_units::amount::error::ParseError
-impl core::convert::From<bitcoin_units::amount::error::InvalidCharacterError> for bitcoin_units::amount::error::ParseAmountError
-impl core::convert::From<bitcoin_units::amount::error::InvalidCharacterError> for bitcoin_units::amount::error::ParseError
-impl core::convert::From<bitcoin_units::amount::error::MissingDigitsError> for bitcoin_units::amount::error::ParseAmountError
-impl core::convert::From<bitcoin_units::amount::error::MissingDigitsError> for bitcoin_units::amount::error::ParseError
-impl core::convert::From<bitcoin_units::amount::error::OutOfRangeError> for bitcoin_units::amount::error::ParseAmountError
-impl core::convert::From<bitcoin_units::amount::error::OutOfRangeError> for bitcoin_units::amount::error::ParseError
-impl core::convert::From<bitcoin_units::amount::error::ParseAmountError> for bitcoin_units::amount::error::ParseError
-impl core::convert::From<bitcoin_units::amount::error::ParseDenominationError> for bitcoin_units::amount::error::ParseError
-impl core::convert::From<bitcoin_units::amount::error::TooPreciseError> for bitcoin_units::amount::error::ParseAmountError
-impl core::convert::From<bitcoin_units::amount::error::TooPreciseError> for bitcoin_units::amount::error::ParseError
+impl core::convert::From<bitcoin_units::amount::InputTooLargeError> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::InputTooLargeError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::InvalidCharacterError> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::InvalidCharacterError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::MissingDigitsError> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::MissingDigitsError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::OutOfRangeError> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::OutOfRangeError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::ParseAmountError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::ParseDenominationError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::TooPreciseError> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::TooPreciseError> for bitcoin_units::amount::ParseError
 impl core::convert::From<bitcoin_units::block::BlockHeight> for u32
 impl core::convert::From<bitcoin_units::block::BlockInterval> for u32
 impl core::convert::From<bitcoin_units::fee_rate::FeeRate> for u64
@@ -166,9 +162,9 @@ impl core::convert::From<bitcoin_units::parse::ParseIntError> for bitcoin_units:
 impl core::convert::From<bitcoin_units::parse::ParseIntError> for bitcoin_units::parse::UnprefixedHexError
 impl core::convert::From<bitcoin_units::parse::ParseIntError> for core::num::error::ParseIntError
 impl core::convert::From<bitcoin_units::weight::Weight> for u64
-impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::error::ParseAmountError
-impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::error::ParseDenominationError
-impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::error::ParseError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::ParseDenominationError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::ParseError
 impl core::convert::From<core::convert::Infallible> for bitcoin_units::parse::PrefixedHexError
 impl core::convert::From<core::convert::Infallible> for bitcoin_units::parse::UnprefixedHexError
 impl core::convert::From<u16> for bitcoin_units::locktime::relative::Height
@@ -211,17 +207,17 @@ impl core::fmt::Debug for bitcoin_units::Amount
 impl core::fmt::Debug for bitcoin_units::SignedAmount
 impl core::fmt::Debug for bitcoin_units::amount::Denomination
 impl core::fmt::Debug for bitcoin_units::amount::Display
-impl core::fmt::Debug for bitcoin_units::amount::error::InputTooLargeError
-impl core::fmt::Debug for bitcoin_units::amount::error::InvalidCharacterError
-impl core::fmt::Debug for bitcoin_units::amount::error::MissingDenominationError
-impl core::fmt::Debug for bitcoin_units::amount::error::MissingDigitsError
-impl core::fmt::Debug for bitcoin_units::amount::error::OutOfRangeError
-impl core::fmt::Debug for bitcoin_units::amount::error::ParseAmountError
-impl core::fmt::Debug for bitcoin_units::amount::error::ParseDenominationError
-impl core::fmt::Debug for bitcoin_units::amount::error::ParseError
-impl core::fmt::Debug for bitcoin_units::amount::error::PossiblyConfusingDenominationError
-impl core::fmt::Debug for bitcoin_units::amount::error::TooPreciseError
-impl core::fmt::Debug for bitcoin_units::amount::error::UnknownDenominationError
+impl core::fmt::Debug for bitcoin_units::amount::InputTooLargeError
+impl core::fmt::Debug for bitcoin_units::amount::InvalidCharacterError
+impl core::fmt::Debug for bitcoin_units::amount::MissingDenominationError
+impl core::fmt::Debug for bitcoin_units::amount::MissingDigitsError
+impl core::fmt::Debug for bitcoin_units::amount::OutOfRangeError
+impl core::fmt::Debug for bitcoin_units::amount::ParseAmountError
+impl core::fmt::Debug for bitcoin_units::amount::ParseDenominationError
+impl core::fmt::Debug for bitcoin_units::amount::ParseError
+impl core::fmt::Debug for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::fmt::Debug for bitcoin_units::amount::TooPreciseError
+impl core::fmt::Debug for bitcoin_units::amount::UnknownDenominationError
 impl core::fmt::Debug for bitcoin_units::block::BlockHeight
 impl core::fmt::Debug for bitcoin_units::block::BlockInterval
 impl core::fmt::Debug for bitcoin_units::block::TooBigForRelativeBlockHeightError
@@ -242,16 +238,16 @@ impl core::fmt::Display for bitcoin_units::Amount
 impl core::fmt::Display for bitcoin_units::SignedAmount
 impl core::fmt::Display for bitcoin_units::amount::Denomination
 impl core::fmt::Display for bitcoin_units::amount::Display
-impl core::fmt::Display for bitcoin_units::amount::error::InputTooLargeError
-impl core::fmt::Display for bitcoin_units::amount::error::InvalidCharacterError
-impl core::fmt::Display for bitcoin_units::amount::error::MissingDigitsError
-impl core::fmt::Display for bitcoin_units::amount::error::OutOfRangeError
-impl core::fmt::Display for bitcoin_units::amount::error::ParseAmountError
-impl core::fmt::Display for bitcoin_units::amount::error::ParseDenominationError
-impl core::fmt::Display for bitcoin_units::amount::error::ParseError
-impl core::fmt::Display for bitcoin_units::amount::error::PossiblyConfusingDenominationError
-impl core::fmt::Display for bitcoin_units::amount::error::TooPreciseError
-impl core::fmt::Display for bitcoin_units::amount::error::UnknownDenominationError
+impl core::fmt::Display for bitcoin_units::amount::InputTooLargeError
+impl core::fmt::Display for bitcoin_units::amount::InvalidCharacterError
+impl core::fmt::Display for bitcoin_units::amount::MissingDigitsError
+impl core::fmt::Display for bitcoin_units::amount::OutOfRangeError
+impl core::fmt::Display for bitcoin_units::amount::ParseAmountError
+impl core::fmt::Display for bitcoin_units::amount::ParseDenominationError
+impl core::fmt::Display for bitcoin_units::amount::ParseError
+impl core::fmt::Display for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::fmt::Display for bitcoin_units::amount::TooPreciseError
+impl core::fmt::Display for bitcoin_units::amount::UnknownDenominationError
 impl core::fmt::Display for bitcoin_units::block::BlockHeight
 impl core::fmt::Display for bitcoin_units::block::BlockInterval
 impl core::fmt::Display for bitcoin_units::block::TooBigForRelativeBlockHeightError
@@ -287,7 +283,7 @@ impl core::iter::traits::accum::Sum for bitcoin_units::weight::Weight
 impl core::marker::Copy for bitcoin_units::Amount
 impl core::marker::Copy for bitcoin_units::SignedAmount
 impl core::marker::Copy for bitcoin_units::amount::Denomination
-impl core::marker::Copy for bitcoin_units::amount::error::OutOfRangeError
+impl core::marker::Copy for bitcoin_units::amount::OutOfRangeError
 impl core::marker::Copy for bitcoin_units::block::BlockHeight
 impl core::marker::Copy for bitcoin_units::block::BlockInterval
 impl core::marker::Copy for bitcoin_units::fee_rate::FeeRate
@@ -300,17 +296,17 @@ impl core::marker::Freeze for bitcoin_units::Amount
 impl core::marker::Freeze for bitcoin_units::SignedAmount
 impl core::marker::Freeze for bitcoin_units::amount::Denomination
 impl core::marker::Freeze for bitcoin_units::amount::Display
-impl core::marker::Freeze for bitcoin_units::amount::error::InputTooLargeError
-impl core::marker::Freeze for bitcoin_units::amount::error::InvalidCharacterError
-impl core::marker::Freeze for bitcoin_units::amount::error::MissingDenominationError
-impl core::marker::Freeze for bitcoin_units::amount::error::MissingDigitsError
-impl core::marker::Freeze for bitcoin_units::amount::error::OutOfRangeError
-impl core::marker::Freeze for bitcoin_units::amount::error::ParseAmountError
-impl core::marker::Freeze for bitcoin_units::amount::error::ParseDenominationError
-impl core::marker::Freeze for bitcoin_units::amount::error::ParseError
-impl core::marker::Freeze for bitcoin_units::amount::error::PossiblyConfusingDenominationError
-impl core::marker::Freeze for bitcoin_units::amount::error::TooPreciseError
-impl core::marker::Freeze for bitcoin_units::amount::error::UnknownDenominationError
+impl core::marker::Freeze for bitcoin_units::amount::InputTooLargeError
+impl core::marker::Freeze for bitcoin_units::amount::InvalidCharacterError
+impl core::marker::Freeze for bitcoin_units::amount::MissingDenominationError
+impl core::marker::Freeze for bitcoin_units::amount::MissingDigitsError
+impl core::marker::Freeze for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Freeze for bitcoin_units::amount::ParseAmountError
+impl core::marker::Freeze for bitcoin_units::amount::ParseDenominationError
+impl core::marker::Freeze for bitcoin_units::amount::ParseError
+impl core::marker::Freeze for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::Freeze for bitcoin_units::amount::TooPreciseError
+impl core::marker::Freeze for bitcoin_units::amount::UnknownDenominationError
 impl core::marker::Freeze for bitcoin_units::block::BlockHeight
 impl core::marker::Freeze for bitcoin_units::block::BlockInterval
 impl core::marker::Freeze for bitcoin_units::block::TooBigForRelativeBlockHeightError
@@ -331,17 +327,17 @@ impl core::marker::Send for bitcoin_units::Amount
 impl core::marker::Send for bitcoin_units::SignedAmount
 impl core::marker::Send for bitcoin_units::amount::Denomination
 impl core::marker::Send for bitcoin_units::amount::Display
-impl core::marker::Send for bitcoin_units::amount::error::InputTooLargeError
-impl core::marker::Send for bitcoin_units::amount::error::InvalidCharacterError
-impl core::marker::Send for bitcoin_units::amount::error::MissingDenominationError
-impl core::marker::Send for bitcoin_units::amount::error::MissingDigitsError
-impl core::marker::Send for bitcoin_units::amount::error::OutOfRangeError
-impl core::marker::Send for bitcoin_units::amount::error::ParseAmountError
-impl core::marker::Send for bitcoin_units::amount::error::ParseDenominationError
-impl core::marker::Send for bitcoin_units::amount::error::ParseError
-impl core::marker::Send for bitcoin_units::amount::error::PossiblyConfusingDenominationError
-impl core::marker::Send for bitcoin_units::amount::error::TooPreciseError
-impl core::marker::Send for bitcoin_units::amount::error::UnknownDenominationError
+impl core::marker::Send for bitcoin_units::amount::InputTooLargeError
+impl core::marker::Send for bitcoin_units::amount::InvalidCharacterError
+impl core::marker::Send for bitcoin_units::amount::MissingDenominationError
+impl core::marker::Send for bitcoin_units::amount::MissingDigitsError
+impl core::marker::Send for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Send for bitcoin_units::amount::ParseAmountError
+impl core::marker::Send for bitcoin_units::amount::ParseDenominationError
+impl core::marker::Send for bitcoin_units::amount::ParseError
+impl core::marker::Send for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::Send for bitcoin_units::amount::TooPreciseError
+impl core::marker::Send for bitcoin_units::amount::UnknownDenominationError
 impl core::marker::Send for bitcoin_units::block::BlockHeight
 impl core::marker::Send for bitcoin_units::block::BlockInterval
 impl core::marker::Send for bitcoin_units::block::TooBigForRelativeBlockHeightError
@@ -361,17 +357,17 @@ impl core::marker::Send for bitcoin_units::weight::Weight
 impl core::marker::StructuralPartialEq for bitcoin_units::Amount
 impl core::marker::StructuralPartialEq for bitcoin_units::SignedAmount
 impl core::marker::StructuralPartialEq for bitcoin_units::amount::Denomination
-impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::InputTooLargeError
-impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::InvalidCharacterError
-impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::MissingDenominationError
-impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::MissingDigitsError
-impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::OutOfRangeError
-impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::ParseAmountError
-impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::ParseDenominationError
-impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::ParseError
-impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::PossiblyConfusingDenominationError
-impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::TooPreciseError
-impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::UnknownDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::InputTooLargeError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::InvalidCharacterError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::MissingDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::MissingDigitsError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::OutOfRangeError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::ParseAmountError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::ParseDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::ParseError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::TooPreciseError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::UnknownDenominationError
 impl core::marker::StructuralPartialEq for bitcoin_units::block::BlockHeight
 impl core::marker::StructuralPartialEq for bitcoin_units::block::BlockInterval
 impl core::marker::StructuralPartialEq for bitcoin_units::block::TooBigForRelativeBlockHeightError
@@ -392,17 +388,17 @@ impl core::marker::Sync for bitcoin_units::Amount
 impl core::marker::Sync for bitcoin_units::SignedAmount
 impl core::marker::Sync for bitcoin_units::amount::Denomination
 impl core::marker::Sync for bitcoin_units::amount::Display
-impl core::marker::Sync for bitcoin_units::amount::error::InputTooLargeError
-impl core::marker::Sync for bitcoin_units::amount::error::InvalidCharacterError
-impl core::marker::Sync for bitcoin_units::amount::error::MissingDenominationError
-impl core::marker::Sync for bitcoin_units::amount::error::MissingDigitsError
-impl core::marker::Sync for bitcoin_units::amount::error::OutOfRangeError
-impl core::marker::Sync for bitcoin_units::amount::error::ParseAmountError
-impl core::marker::Sync for bitcoin_units::amount::error::ParseDenominationError
-impl core::marker::Sync for bitcoin_units::amount::error::ParseError
-impl core::marker::Sync for bitcoin_units::amount::error::PossiblyConfusingDenominationError
-impl core::marker::Sync for bitcoin_units::amount::error::TooPreciseError
-impl core::marker::Sync for bitcoin_units::amount::error::UnknownDenominationError
+impl core::marker::Sync for bitcoin_units::amount::InputTooLargeError
+impl core::marker::Sync for bitcoin_units::amount::InvalidCharacterError
+impl core::marker::Sync for bitcoin_units::amount::MissingDenominationError
+impl core::marker::Sync for bitcoin_units::amount::MissingDigitsError
+impl core::marker::Sync for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Sync for bitcoin_units::amount::ParseAmountError
+impl core::marker::Sync for bitcoin_units::amount::ParseDenominationError
+impl core::marker::Sync for bitcoin_units::amount::ParseError
+impl core::marker::Sync for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::Sync for bitcoin_units::amount::TooPreciseError
+impl core::marker::Sync for bitcoin_units::amount::UnknownDenominationError
 impl core::marker::Sync for bitcoin_units::block::BlockHeight
 impl core::marker::Sync for bitcoin_units::block::BlockInterval
 impl core::marker::Sync for bitcoin_units::block::TooBigForRelativeBlockHeightError
@@ -423,17 +419,17 @@ impl core::marker::Unpin for bitcoin_units::Amount
 impl core::marker::Unpin for bitcoin_units::SignedAmount
 impl core::marker::Unpin for bitcoin_units::amount::Denomination
 impl core::marker::Unpin for bitcoin_units::amount::Display
-impl core::marker::Unpin for bitcoin_units::amount::error::InputTooLargeError
-impl core::marker::Unpin for bitcoin_units::amount::error::InvalidCharacterError
-impl core::marker::Unpin for bitcoin_units::amount::error::MissingDenominationError
-impl core::marker::Unpin for bitcoin_units::amount::error::MissingDigitsError
-impl core::marker::Unpin for bitcoin_units::amount::error::OutOfRangeError
-impl core::marker::Unpin for bitcoin_units::amount::error::ParseAmountError
-impl core::marker::Unpin for bitcoin_units::amount::error::ParseDenominationError
-impl core::marker::Unpin for bitcoin_units::amount::error::ParseError
-impl core::marker::Unpin for bitcoin_units::amount::error::PossiblyConfusingDenominationError
-impl core::marker::Unpin for bitcoin_units::amount::error::TooPreciseError
-impl core::marker::Unpin for bitcoin_units::amount::error::UnknownDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::InputTooLargeError
+impl core::marker::Unpin for bitcoin_units::amount::InvalidCharacterError
+impl core::marker::Unpin for bitcoin_units::amount::MissingDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::MissingDigitsError
+impl core::marker::Unpin for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Unpin for bitcoin_units::amount::ParseAmountError
+impl core::marker::Unpin for bitcoin_units::amount::ParseDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::ParseError
+impl core::marker::Unpin for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::TooPreciseError
+impl core::marker::Unpin for bitcoin_units::amount::UnknownDenominationError
 impl core::marker::Unpin for bitcoin_units::block::BlockHeight
 impl core::marker::Unpin for bitcoin_units::block::BlockInterval
 impl core::marker::Unpin for bitcoin_units::block::TooBigForRelativeBlockHeightError
@@ -523,17 +519,17 @@ impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::Amount
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::SignedAmount
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::Denomination
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::Display
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::InputTooLargeError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::InvalidCharacterError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::MissingDenominationError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::MissingDigitsError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::OutOfRangeError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::ParseAmountError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::ParseDenominationError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::ParseError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::PossiblyConfusingDenominationError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::TooPreciseError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::UnknownDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::InputTooLargeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::InvalidCharacterError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::MissingDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::MissingDigitsError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::OutOfRangeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::ParseAmountError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::ParseDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::ParseError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::TooPreciseError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::UnknownDenominationError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::BlockHeight
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::BlockInterval
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::TooBigForRelativeBlockHeightError
@@ -554,17 +550,17 @@ impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::Amount
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::SignedAmount
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::Denomination
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::Display
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::InputTooLargeError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::InvalidCharacterError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::MissingDenominationError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::MissingDigitsError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::OutOfRangeError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::ParseAmountError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::ParseDenominationError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::ParseError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::PossiblyConfusingDenominationError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::TooPreciseError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::UnknownDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::InputTooLargeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::InvalidCharacterError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::MissingDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::MissingDigitsError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::OutOfRangeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::ParseAmountError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::ParseDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::ParseError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::TooPreciseError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::UnknownDenominationError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::BlockHeight
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::BlockInterval
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::TooBigForRelativeBlockHeightError
@@ -613,10 +609,8 @@ pub bitcoin_units::amount::Denomination::CentiBitcoin
 pub bitcoin_units::amount::Denomination::MicroBitcoin
 pub bitcoin_units::amount::Denomination::MilliBitcoin
 pub bitcoin_units::amount::Denomination::Satoshi
-pub bitcoin_units::amount::ParseDenominationError::PossiblyConfusing(bitcoin_units::amount::error::PossiblyConfusingDenominationError)
-pub bitcoin_units::amount::ParseDenominationError::Unknown(bitcoin_units::amount::error::UnknownDenominationError)
-pub bitcoin_units::amount::error::ParseDenominationError::PossiblyConfusing(bitcoin_units::amount::error::PossiblyConfusingDenominationError)
-pub bitcoin_units::amount::error::ParseDenominationError::Unknown(bitcoin_units::amount::error::UnknownDenominationError)
+pub bitcoin_units::amount::ParseDenominationError::PossiblyConfusing(bitcoin_units::amount::PossiblyConfusingDenominationError)
+pub bitcoin_units::amount::ParseDenominationError::Unknown(bitcoin_units::amount::UnknownDenominationError)
 pub const bitcoin_units::Amount::MAX: Self
 pub const bitcoin_units::Amount::MAX_MONEY: Self
 pub const bitcoin_units::Amount::MIN: Self
@@ -757,12 +751,12 @@ pub fn bitcoin_units::Amount::div(self, rhs: u64) -> Self::Output
 pub fn bitcoin_units::Amount::div_assign(&mut self, rhs: u64)
 pub fn bitcoin_units::Amount::eq(&self, other: &bitcoin_units::Amount) -> bool
 pub fn bitcoin_units::Amount::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::Amount::from_btc(btc: f64) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::ParseAmountError>
-pub fn bitcoin_units::Amount::from_float_in(value: f64, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::ParseAmountError>
-pub fn bitcoin_units::Amount::from_int_btc<T: core::convert::Into<u64>>(whole_bitcoin: T) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::OutOfRangeError>
+pub fn bitcoin_units::Amount::from_btc(btc: f64) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::Amount::from_float_in(value: f64, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::Amount::from_int_btc<T: core::convert::Into<u64>>(whole_bitcoin: T) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::OutOfRangeError>
 pub fn bitcoin_units::Amount::from_str(s: &str) -> core::result::Result<Self, Self::Err>
-pub fn bitcoin_units::Amount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::ParseAmountError>
-pub fn bitcoin_units::Amount::from_str_with_denomination(s: &str) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::ParseError>
+pub fn bitcoin_units::Amount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::Amount::from_str_with_denomination(s: &str) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::ParseError>
 pub fn bitcoin_units::Amount::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin_units::Amount::mul(self, rhs: u64) -> Self::Output
 pub fn bitcoin_units::Amount::mul_assign(&mut self, rhs: u64)
@@ -777,7 +771,7 @@ pub fn bitcoin_units::Amount::sum<I: core::iter::traits::iterator::Iterator<Item
 pub fn bitcoin_units::Amount::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin_units::Amount>
 pub fn bitcoin_units::Amount::to_btc(self) -> f64
 pub fn bitcoin_units::Amount::to_float_in(self, denom: bitcoin_units::amount::Denomination) -> f64
-pub fn bitcoin_units::Amount::to_signed(self) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::OutOfRangeError>
+pub fn bitcoin_units::Amount::to_signed(self) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::OutOfRangeError>
 pub fn bitcoin_units::Amount::to_string_in(self, denom: bitcoin_units::amount::Denomination) -> alloc::string::String
 pub fn bitcoin_units::Amount::to_string_with_denomination(self, denom: bitcoin_units::amount::Denomination) -> alloc::string::String
 pub fn bitcoin_units::Amount::try_from(value: bitcoin_units::SignedAmount) -> core::result::Result<Self, Self::Error>
@@ -797,12 +791,12 @@ pub fn bitcoin_units::SignedAmount::div(self, rhs: i64) -> Self::Output
 pub fn bitcoin_units::SignedAmount::div_assign(&mut self, rhs: i64)
 pub fn bitcoin_units::SignedAmount::eq(&self, other: &bitcoin_units::SignedAmount) -> bool
 pub fn bitcoin_units::SignedAmount::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::SignedAmount::from_btc(btc: f64) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::ParseAmountError>
-pub fn bitcoin_units::SignedAmount::from_float_in(value: f64, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::ParseAmountError>
-pub fn bitcoin_units::SignedAmount::from_int_btc<T: core::convert::Into<i64>>(whole_bitcoin: T) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::OutOfRangeError>
+pub fn bitcoin_units::SignedAmount::from_btc(btc: f64) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::SignedAmount::from_float_in(value: f64, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::SignedAmount::from_int_btc<T: core::convert::Into<i64>>(whole_bitcoin: T) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::OutOfRangeError>
 pub fn bitcoin_units::SignedAmount::from_str(s: &str) -> core::result::Result<Self, Self::Err>
-pub fn bitcoin_units::SignedAmount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::ParseAmountError>
-pub fn bitcoin_units::SignedAmount::from_str_with_denomination(s: &str) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::ParseError>
+pub fn bitcoin_units::SignedAmount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::SignedAmount::from_str_with_denomination(s: &str) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::ParseError>
 pub fn bitcoin_units::SignedAmount::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin_units::SignedAmount::is_negative(self) -> bool
 pub fn bitcoin_units::SignedAmount::is_positive(self) -> bool
@@ -824,7 +818,7 @@ pub fn bitcoin_units::SignedAmount::to_btc(self) -> f64
 pub fn bitcoin_units::SignedAmount::to_float_in(self, denom: bitcoin_units::amount::Denomination) -> f64
 pub fn bitcoin_units::SignedAmount::to_string_in(self, denom: bitcoin_units::amount::Denomination) -> alloc::string::String
 pub fn bitcoin_units::SignedAmount::to_string_with_denomination(self, denom: bitcoin_units::amount::Denomination) -> alloc::string::String
-pub fn bitcoin_units::SignedAmount::to_unsigned(self) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::OutOfRangeError>
+pub fn bitcoin_units::SignedAmount::to_unsigned(self) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::OutOfRangeError>
 pub fn bitcoin_units::SignedAmount::try_from(value: bitcoin_units::Amount) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_units::SignedAmount::unchecked_add(self, rhs: bitcoin_units::SignedAmount) -> bitcoin_units::SignedAmount
 pub fn bitcoin_units::SignedAmount::unchecked_sub(self, rhs: bitcoin_units::SignedAmount) -> bitcoin_units::SignedAmount
@@ -838,57 +832,57 @@ pub fn bitcoin_units::amount::Denomination::hash<__H: core::hash::Hasher>(&self,
 pub fn bitcoin_units::amount::Display::clone(&self) -> bitcoin_units::amount::Display
 pub fn bitcoin_units::amount::Display::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_units::amount::Display::show_denomination(self) -> Self
-pub fn bitcoin_units::amount::error::InputTooLargeError::clone(&self) -> bitcoin_units::amount::error::InputTooLargeError
-pub fn bitcoin_units::amount::error::InputTooLargeError::eq(&self, other: &bitcoin_units::amount::error::InputTooLargeError) -> bool
-pub fn bitcoin_units::amount::error::InputTooLargeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::amount::error::InvalidCharacterError::clone(&self) -> bitcoin_units::amount::error::InvalidCharacterError
-pub fn bitcoin_units::amount::error::InvalidCharacterError::eq(&self, other: &bitcoin_units::amount::error::InvalidCharacterError) -> bool
-pub fn bitcoin_units::amount::error::InvalidCharacterError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::amount::error::MissingDenominationError::clone(&self) -> bitcoin_units::amount::error::MissingDenominationError
-pub fn bitcoin_units::amount::error::MissingDenominationError::eq(&self, other: &bitcoin_units::amount::error::MissingDenominationError) -> bool
-pub fn bitcoin_units::amount::error::MissingDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::amount::error::MissingDigitsError::clone(&self) -> bitcoin_units::amount::error::MissingDigitsError
-pub fn bitcoin_units::amount::error::MissingDigitsError::eq(&self, other: &bitcoin_units::amount::error::MissingDigitsError) -> bool
-pub fn bitcoin_units::amount::error::MissingDigitsError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::amount::error::OutOfRangeError::clone(&self) -> bitcoin_units::amount::error::OutOfRangeError
-pub fn bitcoin_units::amount::error::OutOfRangeError::eq(&self, other: &bitcoin_units::amount::error::OutOfRangeError) -> bool
-pub fn bitcoin_units::amount::error::OutOfRangeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::amount::error::OutOfRangeError::is_above_max(self) -> bool
-pub fn bitcoin_units::amount::error::OutOfRangeError::is_below_min(self) -> bool
-pub fn bitcoin_units::amount::error::OutOfRangeError::valid_range(self) -> (i64, u64)
-pub fn bitcoin_units::amount::error::ParseAmountError::clone(&self) -> bitcoin_units::amount::error::ParseAmountError
-pub fn bitcoin_units::amount::error::ParseAmountError::eq(&self, other: &bitcoin_units::amount::error::ParseAmountError) -> bool
-pub fn bitcoin_units::amount::error::ParseAmountError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::amount::error::ParseAmountError::from(never: core::convert::Infallible) -> Self
-pub fn bitcoin_units::amount::error::ParseAmountError::from(value: bitcoin_units::amount::error::InputTooLargeError) -> Self
-pub fn bitcoin_units::amount::error::ParseAmountError::from(value: bitcoin_units::amount::error::InvalidCharacterError) -> Self
-pub fn bitcoin_units::amount::error::ParseAmountError::from(value: bitcoin_units::amount::error::MissingDigitsError) -> Self
-pub fn bitcoin_units::amount::error::ParseAmountError::from(value: bitcoin_units::amount::error::OutOfRangeError) -> Self
-pub fn bitcoin_units::amount::error::ParseAmountError::from(value: bitcoin_units::amount::error::TooPreciseError) -> Self
-pub fn bitcoin_units::amount::error::ParseDenominationError::clone(&self) -> bitcoin_units::amount::error::ParseDenominationError
-pub fn bitcoin_units::amount::error::ParseDenominationError::eq(&self, other: &bitcoin_units::amount::error::ParseDenominationError) -> bool
-pub fn bitcoin_units::amount::error::ParseDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::amount::error::ParseDenominationError::from(never: core::convert::Infallible) -> Self
-pub fn bitcoin_units::amount::error::ParseError::clone(&self) -> bitcoin_units::amount::error::ParseError
-pub fn bitcoin_units::amount::error::ParseError::eq(&self, other: &bitcoin_units::amount::error::ParseError) -> bool
-pub fn bitcoin_units::amount::error::ParseError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::InputTooLargeError) -> Self
-pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::InvalidCharacterError) -> Self
-pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::MissingDigitsError) -> Self
-pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::OutOfRangeError) -> Self
-pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::ParseAmountError) -> Self
-pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::ParseDenominationError) -> Self
-pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::TooPreciseError) -> Self
-pub fn bitcoin_units::amount::error::ParseError::from(never: core::convert::Infallible) -> Self
-pub fn bitcoin_units::amount::error::PossiblyConfusingDenominationError::clone(&self) -> bitcoin_units::amount::error::PossiblyConfusingDenominationError
-pub fn bitcoin_units::amount::error::PossiblyConfusingDenominationError::eq(&self, other: &bitcoin_units::amount::error::PossiblyConfusingDenominationError) -> bool
-pub fn bitcoin_units::amount::error::PossiblyConfusingDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::amount::error::TooPreciseError::clone(&self) -> bitcoin_units::amount::error::TooPreciseError
-pub fn bitcoin_units::amount::error::TooPreciseError::eq(&self, other: &bitcoin_units::amount::error::TooPreciseError) -> bool
-pub fn bitcoin_units::amount::error::TooPreciseError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::amount::error::UnknownDenominationError::clone(&self) -> bitcoin_units::amount::error::UnknownDenominationError
-pub fn bitcoin_units::amount::error::UnknownDenominationError::eq(&self, other: &bitcoin_units::amount::error::UnknownDenominationError) -> bool
-pub fn bitcoin_units::amount::error::UnknownDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::InputTooLargeError::clone(&self) -> bitcoin_units::amount::InputTooLargeError
+pub fn bitcoin_units::amount::InputTooLargeError::eq(&self, other: &bitcoin_units::amount::InputTooLargeError) -> bool
+pub fn bitcoin_units::amount::InputTooLargeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::InvalidCharacterError::clone(&self) -> bitcoin_units::amount::InvalidCharacterError
+pub fn bitcoin_units::amount::InvalidCharacterError::eq(&self, other: &bitcoin_units::amount::InvalidCharacterError) -> bool
+pub fn bitcoin_units::amount::InvalidCharacterError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::MissingDenominationError::clone(&self) -> bitcoin_units::amount::MissingDenominationError
+pub fn bitcoin_units::amount::MissingDenominationError::eq(&self, other: &bitcoin_units::amount::MissingDenominationError) -> bool
+pub fn bitcoin_units::amount::MissingDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::MissingDigitsError::clone(&self) -> bitcoin_units::amount::MissingDigitsError
+pub fn bitcoin_units::amount::MissingDigitsError::eq(&self, other: &bitcoin_units::amount::MissingDigitsError) -> bool
+pub fn bitcoin_units::amount::MissingDigitsError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::OutOfRangeError::clone(&self) -> bitcoin_units::amount::OutOfRangeError
+pub fn bitcoin_units::amount::OutOfRangeError::eq(&self, other: &bitcoin_units::amount::OutOfRangeError) -> bool
+pub fn bitcoin_units::amount::OutOfRangeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::OutOfRangeError::is_above_max(self) -> bool
+pub fn bitcoin_units::amount::OutOfRangeError::is_below_min(self) -> bool
+pub fn bitcoin_units::amount::OutOfRangeError::valid_range(self) -> (i64, u64)
+pub fn bitcoin_units::amount::ParseAmountError::clone(&self) -> bitcoin_units::amount::ParseAmountError
+pub fn bitcoin_units::amount::ParseAmountError::eq(&self, other: &bitcoin_units::amount::ParseAmountError) -> bool
+pub fn bitcoin_units::amount::ParseAmountError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::ParseAmountError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::amount::ParseAmountError::from(value: bitcoin_units::amount::InputTooLargeError) -> Self
+pub fn bitcoin_units::amount::ParseAmountError::from(value: bitcoin_units::amount::InvalidCharacterError) -> Self
+pub fn bitcoin_units::amount::ParseAmountError::from(value: bitcoin_units::amount::MissingDigitsError) -> Self
+pub fn bitcoin_units::amount::ParseAmountError::from(value: bitcoin_units::amount::OutOfRangeError) -> Self
+pub fn bitcoin_units::amount::ParseAmountError::from(value: bitcoin_units::amount::TooPreciseError) -> Self
+pub fn bitcoin_units::amount::ParseDenominationError::clone(&self) -> bitcoin_units::amount::ParseDenominationError
+pub fn bitcoin_units::amount::ParseDenominationError::eq(&self, other: &bitcoin_units::amount::ParseDenominationError) -> bool
+pub fn bitcoin_units::amount::ParseDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::ParseDenominationError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::amount::ParseError::clone(&self) -> bitcoin_units::amount::ParseError
+pub fn bitcoin_units::amount::ParseError::eq(&self, other: &bitcoin_units::amount::ParseError) -> bool
+pub fn bitcoin_units::amount::ParseError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::InputTooLargeError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::InvalidCharacterError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::MissingDigitsError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::OutOfRangeError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::ParseAmountError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::ParseDenominationError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::TooPreciseError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::amount::PossiblyConfusingDenominationError::clone(&self) -> bitcoin_units::amount::PossiblyConfusingDenominationError
+pub fn bitcoin_units::amount::PossiblyConfusingDenominationError::eq(&self, other: &bitcoin_units::amount::PossiblyConfusingDenominationError) -> bool
+pub fn bitcoin_units::amount::PossiblyConfusingDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::TooPreciseError::clone(&self) -> bitcoin_units::amount::TooPreciseError
+pub fn bitcoin_units::amount::TooPreciseError::eq(&self, other: &bitcoin_units::amount::TooPreciseError) -> bool
+pub fn bitcoin_units::amount::TooPreciseError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::UnknownDenominationError::clone(&self) -> bitcoin_units::amount::UnknownDenominationError
+pub fn bitcoin_units::amount::UnknownDenominationError::eq(&self, other: &bitcoin_units::amount::UnknownDenominationError) -> bool
+pub fn bitcoin_units::amount::UnknownDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_units::block::BlockHeight::add(self, rhs: bitcoin_units::block::BlockInterval) -> Self::Output
 pub fn bitcoin_units::block::BlockHeight::clone(&self) -> bitcoin_units::block::BlockHeight
 pub fn bitcoin_units::block::BlockHeight::cmp(&self, other: &bitcoin_units::block::BlockHeight) -> core::cmp::Ordering
@@ -1074,7 +1068,6 @@ pub macro bitcoin_units::impl_tryfrom_str!
 pub macro bitcoin_units::impl_tryfrom_str_from_int_infallible!
 pub mod bitcoin_units
 pub mod bitcoin_units::amount
-pub mod bitcoin_units::amount::error
 pub mod bitcoin_units::block
 pub mod bitcoin_units::fee_rate
 pub mod bitcoin_units::locktime
@@ -1098,13 +1091,6 @@ pub struct bitcoin_units::amount::ParseAmountError(_)
 pub struct bitcoin_units::amount::ParseError(_)
 pub struct bitcoin_units::amount::SignedAmount(_)
 pub struct bitcoin_units::amount::TooPreciseError
-pub struct bitcoin_units::amount::error::InputTooLargeError
-pub struct bitcoin_units::amount::error::InvalidCharacterError
-pub struct bitcoin_units::amount::error::MissingDigitsError
-pub struct bitcoin_units::amount::error::OutOfRangeError
-pub struct bitcoin_units::amount::error::ParseAmountError(_)
-pub struct bitcoin_units::amount::error::ParseError(_)
-pub struct bitcoin_units::amount::error::TooPreciseError
 pub struct bitcoin_units::block::BlockHeight(pub u32)
 pub struct bitcoin_units::block::BlockInterval(pub u32)
 pub struct bitcoin_units::block::TooBigForRelativeBlockHeightError(_)
@@ -1125,14 +1111,14 @@ pub type &bitcoin_units::Amount::Output = bitcoin_units::Amount
 pub type &bitcoin_units::SignedAmount::Output = bitcoin_units::SignedAmount
 pub type &bitcoin_units::fee_rate::FeeRate::Output = bitcoin_units::fee_rate::FeeRate
 pub type &bitcoin_units::weight::Weight::Output = bitcoin_units::weight::Weight
-pub type bitcoin_units::Amount::Err = bitcoin_units::amount::error::ParseError
-pub type bitcoin_units::Amount::Error = bitcoin_units::amount::error::OutOfRangeError
+pub type bitcoin_units::Amount::Err = bitcoin_units::amount::ParseError
+pub type bitcoin_units::Amount::Error = bitcoin_units::amount::OutOfRangeError
 pub type bitcoin_units::Amount::Output = bitcoin_units::Amount
 pub type bitcoin_units::Amount::Output = bitcoin_units::fee_rate::FeeRate
-pub type bitcoin_units::SignedAmount::Err = bitcoin_units::amount::error::ParseError
-pub type bitcoin_units::SignedAmount::Error = bitcoin_units::amount::error::OutOfRangeError
+pub type bitcoin_units::SignedAmount::Err = bitcoin_units::amount::ParseError
+pub type bitcoin_units::SignedAmount::Error = bitcoin_units::amount::OutOfRangeError
 pub type bitcoin_units::SignedAmount::Output = bitcoin_units::SignedAmount
-pub type bitcoin_units::amount::Denomination::Err = bitcoin_units::amount::error::ParseDenominationError
+pub type bitcoin_units::amount::Denomination::Err = bitcoin_units::amount::ParseDenominationError
 pub type bitcoin_units::block::BlockHeight::Err = bitcoin_units::parse::ParseIntError
 pub type bitcoin_units::block::BlockHeight::Error = bitcoin_units::parse::ParseIntError
 pub type bitcoin_units::block::BlockHeight::Output = bitcoin_units::block::BlockHeight

--- a/api/units/no-features.txt
+++ b/api/units/no-features.txt
@@ -1,19 +1,15 @@
 #[non_exhaustive] pub enum bitcoin_units::amount::Denomination
 #[non_exhaustive] pub enum bitcoin_units::amount::ParseDenominationError
-#[non_exhaustive] pub enum bitcoin_units::amount::error::ParseDenominationError
 #[non_exhaustive] pub struct bitcoin_units::amount::MissingDenominationError
 #[non_exhaustive] pub struct bitcoin_units::amount::PossiblyConfusingDenominationError(_)
 #[non_exhaustive] pub struct bitcoin_units::amount::UnknownDenominationError(_)
-#[non_exhaustive] pub struct bitcoin_units::amount::error::MissingDenominationError
-#[non_exhaustive] pub struct bitcoin_units::amount::error::PossiblyConfusingDenominationError(_)
-#[non_exhaustive] pub struct bitcoin_units::amount::error::UnknownDenominationError(_)
 #[non_exhaustive] pub struct bitcoin_units::locktime::absolute::ConversionError
 #[non_exhaustive] pub struct bitcoin_units::parse::ParseIntError
 impl bitcoin_units::Amount
 impl bitcoin_units::SignedAmount
 impl bitcoin_units::amount::Denomination
 impl bitcoin_units::amount::Display
-impl bitcoin_units::amount::error::OutOfRangeError
+impl bitcoin_units::amount::OutOfRangeError
 impl bitcoin_units::block::BlockHeight
 impl bitcoin_units::block::BlockInterval
 impl bitcoin_units::fee_rate::FeeRate
@@ -37,17 +33,17 @@ impl core::clone::Clone for bitcoin_units::Amount
 impl core::clone::Clone for bitcoin_units::SignedAmount
 impl core::clone::Clone for bitcoin_units::amount::Denomination
 impl core::clone::Clone for bitcoin_units::amount::Display
-impl core::clone::Clone for bitcoin_units::amount::error::InputTooLargeError
-impl core::clone::Clone for bitcoin_units::amount::error::InvalidCharacterError
-impl core::clone::Clone for bitcoin_units::amount::error::MissingDenominationError
-impl core::clone::Clone for bitcoin_units::amount::error::MissingDigitsError
-impl core::clone::Clone for bitcoin_units::amount::error::OutOfRangeError
-impl core::clone::Clone for bitcoin_units::amount::error::ParseAmountError
-impl core::clone::Clone for bitcoin_units::amount::error::ParseDenominationError
-impl core::clone::Clone for bitcoin_units::amount::error::ParseError
-impl core::clone::Clone for bitcoin_units::amount::error::PossiblyConfusingDenominationError
-impl core::clone::Clone for bitcoin_units::amount::error::TooPreciseError
-impl core::clone::Clone for bitcoin_units::amount::error::UnknownDenominationError
+impl core::clone::Clone for bitcoin_units::amount::InputTooLargeError
+impl core::clone::Clone for bitcoin_units::amount::InvalidCharacterError
+impl core::clone::Clone for bitcoin_units::amount::MissingDenominationError
+impl core::clone::Clone for bitcoin_units::amount::MissingDigitsError
+impl core::clone::Clone for bitcoin_units::amount::OutOfRangeError
+impl core::clone::Clone for bitcoin_units::amount::ParseAmountError
+impl core::clone::Clone for bitcoin_units::amount::ParseDenominationError
+impl core::clone::Clone for bitcoin_units::amount::ParseError
+impl core::clone::Clone for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::clone::Clone for bitcoin_units::amount::TooPreciseError
+impl core::clone::Clone for bitcoin_units::amount::UnknownDenominationError
 impl core::clone::Clone for bitcoin_units::block::BlockHeight
 impl core::clone::Clone for bitcoin_units::block::BlockInterval
 impl core::clone::Clone for bitcoin_units::block::TooBigForRelativeBlockHeightError
@@ -67,17 +63,17 @@ impl core::clone::Clone for bitcoin_units::weight::Weight
 impl core::cmp::Eq for bitcoin_units::Amount
 impl core::cmp::Eq for bitcoin_units::SignedAmount
 impl core::cmp::Eq for bitcoin_units::amount::Denomination
-impl core::cmp::Eq for bitcoin_units::amount::error::InputTooLargeError
-impl core::cmp::Eq for bitcoin_units::amount::error::InvalidCharacterError
-impl core::cmp::Eq for bitcoin_units::amount::error::MissingDenominationError
-impl core::cmp::Eq for bitcoin_units::amount::error::MissingDigitsError
-impl core::cmp::Eq for bitcoin_units::amount::error::OutOfRangeError
-impl core::cmp::Eq for bitcoin_units::amount::error::ParseAmountError
-impl core::cmp::Eq for bitcoin_units::amount::error::ParseDenominationError
-impl core::cmp::Eq for bitcoin_units::amount::error::ParseError
-impl core::cmp::Eq for bitcoin_units::amount::error::PossiblyConfusingDenominationError
-impl core::cmp::Eq for bitcoin_units::amount::error::TooPreciseError
-impl core::cmp::Eq for bitcoin_units::amount::error::UnknownDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::InputTooLargeError
+impl core::cmp::Eq for bitcoin_units::amount::InvalidCharacterError
+impl core::cmp::Eq for bitcoin_units::amount::MissingDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::MissingDigitsError
+impl core::cmp::Eq for bitcoin_units::amount::OutOfRangeError
+impl core::cmp::Eq for bitcoin_units::amount::ParseAmountError
+impl core::cmp::Eq for bitcoin_units::amount::ParseDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::ParseError
+impl core::cmp::Eq for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::TooPreciseError
+impl core::cmp::Eq for bitcoin_units::amount::UnknownDenominationError
 impl core::cmp::Eq for bitcoin_units::block::BlockHeight
 impl core::cmp::Eq for bitcoin_units::block::BlockInterval
 impl core::cmp::Eq for bitcoin_units::block::TooBigForRelativeBlockHeightError
@@ -107,17 +103,17 @@ impl core::cmp::Ord for bitcoin_units::weight::Weight
 impl core::cmp::PartialEq for bitcoin_units::Amount
 impl core::cmp::PartialEq for bitcoin_units::SignedAmount
 impl core::cmp::PartialEq for bitcoin_units::amount::Denomination
-impl core::cmp::PartialEq for bitcoin_units::amount::error::InputTooLargeError
-impl core::cmp::PartialEq for bitcoin_units::amount::error::InvalidCharacterError
-impl core::cmp::PartialEq for bitcoin_units::amount::error::MissingDenominationError
-impl core::cmp::PartialEq for bitcoin_units::amount::error::MissingDigitsError
-impl core::cmp::PartialEq for bitcoin_units::amount::error::OutOfRangeError
-impl core::cmp::PartialEq for bitcoin_units::amount::error::ParseAmountError
-impl core::cmp::PartialEq for bitcoin_units::amount::error::ParseDenominationError
-impl core::cmp::PartialEq for bitcoin_units::amount::error::ParseError
-impl core::cmp::PartialEq for bitcoin_units::amount::error::PossiblyConfusingDenominationError
-impl core::cmp::PartialEq for bitcoin_units::amount::error::TooPreciseError
-impl core::cmp::PartialEq for bitcoin_units::amount::error::UnknownDenominationError
+impl core::cmp::PartialEq for bitcoin_units::amount::InputTooLargeError
+impl core::cmp::PartialEq for bitcoin_units::amount::InvalidCharacterError
+impl core::cmp::PartialEq for bitcoin_units::amount::MissingDenominationError
+impl core::cmp::PartialEq for bitcoin_units::amount::MissingDigitsError
+impl core::cmp::PartialEq for bitcoin_units::amount::OutOfRangeError
+impl core::cmp::PartialEq for bitcoin_units::amount::ParseAmountError
+impl core::cmp::PartialEq for bitcoin_units::amount::ParseDenominationError
+impl core::cmp::PartialEq for bitcoin_units::amount::ParseError
+impl core::cmp::PartialEq for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::cmp::PartialEq for bitcoin_units::amount::TooPreciseError
+impl core::cmp::PartialEq for bitcoin_units::amount::UnknownDenominationError
 impl core::cmp::PartialEq for bitcoin_units::block::BlockHeight
 impl core::cmp::PartialEq for bitcoin_units::block::BlockInterval
 impl core::cmp::PartialEq for bitcoin_units::block::TooBigForRelativeBlockHeightError
@@ -145,18 +141,18 @@ impl core::cmp::PartialOrd for bitcoin_units::locktime::relative::Height
 impl core::cmp::PartialOrd for bitcoin_units::locktime::relative::Time
 impl core::cmp::PartialOrd for bitcoin_units::weight::Weight
 impl core::convert::AsRef<core::num::error::ParseIntError> for bitcoin_units::parse::ParseIntError
-impl core::convert::From<bitcoin_units::amount::error::InputTooLargeError> for bitcoin_units::amount::error::ParseAmountError
-impl core::convert::From<bitcoin_units::amount::error::InputTooLargeError> for bitcoin_units::amount::error::ParseError
-impl core::convert::From<bitcoin_units::amount::error::InvalidCharacterError> for bitcoin_units::amount::error::ParseAmountError
-impl core::convert::From<bitcoin_units::amount::error::InvalidCharacterError> for bitcoin_units::amount::error::ParseError
-impl core::convert::From<bitcoin_units::amount::error::MissingDigitsError> for bitcoin_units::amount::error::ParseAmountError
-impl core::convert::From<bitcoin_units::amount::error::MissingDigitsError> for bitcoin_units::amount::error::ParseError
-impl core::convert::From<bitcoin_units::amount::error::OutOfRangeError> for bitcoin_units::amount::error::ParseAmountError
-impl core::convert::From<bitcoin_units::amount::error::OutOfRangeError> for bitcoin_units::amount::error::ParseError
-impl core::convert::From<bitcoin_units::amount::error::ParseAmountError> for bitcoin_units::amount::error::ParseError
-impl core::convert::From<bitcoin_units::amount::error::ParseDenominationError> for bitcoin_units::amount::error::ParseError
-impl core::convert::From<bitcoin_units::amount::error::TooPreciseError> for bitcoin_units::amount::error::ParseAmountError
-impl core::convert::From<bitcoin_units::amount::error::TooPreciseError> for bitcoin_units::amount::error::ParseError
+impl core::convert::From<bitcoin_units::amount::InputTooLargeError> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::InputTooLargeError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::InvalidCharacterError> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::InvalidCharacterError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::MissingDigitsError> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::MissingDigitsError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::OutOfRangeError> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::OutOfRangeError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::ParseAmountError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::ParseDenominationError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::TooPreciseError> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::TooPreciseError> for bitcoin_units::amount::ParseError
 impl core::convert::From<bitcoin_units::block::BlockHeight> for u32
 impl core::convert::From<bitcoin_units::block::BlockInterval> for u32
 impl core::convert::From<bitcoin_units::fee_rate::FeeRate> for u64
@@ -166,9 +162,9 @@ impl core::convert::From<bitcoin_units::parse::ParseIntError> for bitcoin_units:
 impl core::convert::From<bitcoin_units::parse::ParseIntError> for bitcoin_units::parse::UnprefixedHexError
 impl core::convert::From<bitcoin_units::parse::ParseIntError> for core::num::error::ParseIntError
 impl core::convert::From<bitcoin_units::weight::Weight> for u64
-impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::error::ParseAmountError
-impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::error::ParseDenominationError
-impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::error::ParseError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::ParseDenominationError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::ParseError
 impl core::convert::From<core::convert::Infallible> for bitcoin_units::parse::PrefixedHexError
 impl core::convert::From<core::convert::Infallible> for bitcoin_units::parse::UnprefixedHexError
 impl core::convert::From<u16> for bitcoin_units::locktime::relative::Height
@@ -195,17 +191,17 @@ impl core::fmt::Debug for bitcoin_units::Amount
 impl core::fmt::Debug for bitcoin_units::SignedAmount
 impl core::fmt::Debug for bitcoin_units::amount::Denomination
 impl core::fmt::Debug for bitcoin_units::amount::Display
-impl core::fmt::Debug for bitcoin_units::amount::error::InputTooLargeError
-impl core::fmt::Debug for bitcoin_units::amount::error::InvalidCharacterError
-impl core::fmt::Debug for bitcoin_units::amount::error::MissingDenominationError
-impl core::fmt::Debug for bitcoin_units::amount::error::MissingDigitsError
-impl core::fmt::Debug for bitcoin_units::amount::error::OutOfRangeError
-impl core::fmt::Debug for bitcoin_units::amount::error::ParseAmountError
-impl core::fmt::Debug for bitcoin_units::amount::error::ParseDenominationError
-impl core::fmt::Debug for bitcoin_units::amount::error::ParseError
-impl core::fmt::Debug for bitcoin_units::amount::error::PossiblyConfusingDenominationError
-impl core::fmt::Debug for bitcoin_units::amount::error::TooPreciseError
-impl core::fmt::Debug for bitcoin_units::amount::error::UnknownDenominationError
+impl core::fmt::Debug for bitcoin_units::amount::InputTooLargeError
+impl core::fmt::Debug for bitcoin_units::amount::InvalidCharacterError
+impl core::fmt::Debug for bitcoin_units::amount::MissingDenominationError
+impl core::fmt::Debug for bitcoin_units::amount::MissingDigitsError
+impl core::fmt::Debug for bitcoin_units::amount::OutOfRangeError
+impl core::fmt::Debug for bitcoin_units::amount::ParseAmountError
+impl core::fmt::Debug for bitcoin_units::amount::ParseDenominationError
+impl core::fmt::Debug for bitcoin_units::amount::ParseError
+impl core::fmt::Debug for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::fmt::Debug for bitcoin_units::amount::TooPreciseError
+impl core::fmt::Debug for bitcoin_units::amount::UnknownDenominationError
 impl core::fmt::Debug for bitcoin_units::block::BlockHeight
 impl core::fmt::Debug for bitcoin_units::block::BlockInterval
 impl core::fmt::Debug for bitcoin_units::block::TooBigForRelativeBlockHeightError
@@ -226,16 +222,16 @@ impl core::fmt::Display for bitcoin_units::Amount
 impl core::fmt::Display for bitcoin_units::SignedAmount
 impl core::fmt::Display for bitcoin_units::amount::Denomination
 impl core::fmt::Display for bitcoin_units::amount::Display
-impl core::fmt::Display for bitcoin_units::amount::error::InputTooLargeError
-impl core::fmt::Display for bitcoin_units::amount::error::InvalidCharacterError
-impl core::fmt::Display for bitcoin_units::amount::error::MissingDigitsError
-impl core::fmt::Display for bitcoin_units::amount::error::OutOfRangeError
-impl core::fmt::Display for bitcoin_units::amount::error::ParseAmountError
-impl core::fmt::Display for bitcoin_units::amount::error::ParseDenominationError
-impl core::fmt::Display for bitcoin_units::amount::error::ParseError
-impl core::fmt::Display for bitcoin_units::amount::error::PossiblyConfusingDenominationError
-impl core::fmt::Display for bitcoin_units::amount::error::TooPreciseError
-impl core::fmt::Display for bitcoin_units::amount::error::UnknownDenominationError
+impl core::fmt::Display for bitcoin_units::amount::InputTooLargeError
+impl core::fmt::Display for bitcoin_units::amount::InvalidCharacterError
+impl core::fmt::Display for bitcoin_units::amount::MissingDigitsError
+impl core::fmt::Display for bitcoin_units::amount::OutOfRangeError
+impl core::fmt::Display for bitcoin_units::amount::ParseAmountError
+impl core::fmt::Display for bitcoin_units::amount::ParseDenominationError
+impl core::fmt::Display for bitcoin_units::amount::ParseError
+impl core::fmt::Display for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::fmt::Display for bitcoin_units::amount::TooPreciseError
+impl core::fmt::Display for bitcoin_units::amount::UnknownDenominationError
 impl core::fmt::Display for bitcoin_units::block::BlockHeight
 impl core::fmt::Display for bitcoin_units::block::BlockInterval
 impl core::fmt::Display for bitcoin_units::block::TooBigForRelativeBlockHeightError
@@ -271,7 +267,7 @@ impl core::iter::traits::accum::Sum for bitcoin_units::weight::Weight
 impl core::marker::Copy for bitcoin_units::Amount
 impl core::marker::Copy for bitcoin_units::SignedAmount
 impl core::marker::Copy for bitcoin_units::amount::Denomination
-impl core::marker::Copy for bitcoin_units::amount::error::OutOfRangeError
+impl core::marker::Copy for bitcoin_units::amount::OutOfRangeError
 impl core::marker::Copy for bitcoin_units::block::BlockHeight
 impl core::marker::Copy for bitcoin_units::block::BlockInterval
 impl core::marker::Copy for bitcoin_units::fee_rate::FeeRate
@@ -284,17 +280,17 @@ impl core::marker::Freeze for bitcoin_units::Amount
 impl core::marker::Freeze for bitcoin_units::SignedAmount
 impl core::marker::Freeze for bitcoin_units::amount::Denomination
 impl core::marker::Freeze for bitcoin_units::amount::Display
-impl core::marker::Freeze for bitcoin_units::amount::error::InputTooLargeError
-impl core::marker::Freeze for bitcoin_units::amount::error::InvalidCharacterError
-impl core::marker::Freeze for bitcoin_units::amount::error::MissingDenominationError
-impl core::marker::Freeze for bitcoin_units::amount::error::MissingDigitsError
-impl core::marker::Freeze for bitcoin_units::amount::error::OutOfRangeError
-impl core::marker::Freeze for bitcoin_units::amount::error::ParseAmountError
-impl core::marker::Freeze for bitcoin_units::amount::error::ParseDenominationError
-impl core::marker::Freeze for bitcoin_units::amount::error::ParseError
-impl core::marker::Freeze for bitcoin_units::amount::error::PossiblyConfusingDenominationError
-impl core::marker::Freeze for bitcoin_units::amount::error::TooPreciseError
-impl core::marker::Freeze for bitcoin_units::amount::error::UnknownDenominationError
+impl core::marker::Freeze for bitcoin_units::amount::InputTooLargeError
+impl core::marker::Freeze for bitcoin_units::amount::InvalidCharacterError
+impl core::marker::Freeze for bitcoin_units::amount::MissingDenominationError
+impl core::marker::Freeze for bitcoin_units::amount::MissingDigitsError
+impl core::marker::Freeze for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Freeze for bitcoin_units::amount::ParseAmountError
+impl core::marker::Freeze for bitcoin_units::amount::ParseDenominationError
+impl core::marker::Freeze for bitcoin_units::amount::ParseError
+impl core::marker::Freeze for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::Freeze for bitcoin_units::amount::TooPreciseError
+impl core::marker::Freeze for bitcoin_units::amount::UnknownDenominationError
 impl core::marker::Freeze for bitcoin_units::block::BlockHeight
 impl core::marker::Freeze for bitcoin_units::block::BlockInterval
 impl core::marker::Freeze for bitcoin_units::block::TooBigForRelativeBlockHeightError
@@ -315,17 +311,17 @@ impl core::marker::Send for bitcoin_units::Amount
 impl core::marker::Send for bitcoin_units::SignedAmount
 impl core::marker::Send for bitcoin_units::amount::Denomination
 impl core::marker::Send for bitcoin_units::amount::Display
-impl core::marker::Send for bitcoin_units::amount::error::InputTooLargeError
-impl core::marker::Send for bitcoin_units::amount::error::InvalidCharacterError
-impl core::marker::Send for bitcoin_units::amount::error::MissingDenominationError
-impl core::marker::Send for bitcoin_units::amount::error::MissingDigitsError
-impl core::marker::Send for bitcoin_units::amount::error::OutOfRangeError
-impl core::marker::Send for bitcoin_units::amount::error::ParseAmountError
-impl core::marker::Send for bitcoin_units::amount::error::ParseDenominationError
-impl core::marker::Send for bitcoin_units::amount::error::ParseError
-impl core::marker::Send for bitcoin_units::amount::error::PossiblyConfusingDenominationError
-impl core::marker::Send for bitcoin_units::amount::error::TooPreciseError
-impl core::marker::Send for bitcoin_units::amount::error::UnknownDenominationError
+impl core::marker::Send for bitcoin_units::amount::InputTooLargeError
+impl core::marker::Send for bitcoin_units::amount::InvalidCharacterError
+impl core::marker::Send for bitcoin_units::amount::MissingDenominationError
+impl core::marker::Send for bitcoin_units::amount::MissingDigitsError
+impl core::marker::Send for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Send for bitcoin_units::amount::ParseAmountError
+impl core::marker::Send for bitcoin_units::amount::ParseDenominationError
+impl core::marker::Send for bitcoin_units::amount::ParseError
+impl core::marker::Send for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::Send for bitcoin_units::amount::TooPreciseError
+impl core::marker::Send for bitcoin_units::amount::UnknownDenominationError
 impl core::marker::Send for bitcoin_units::block::BlockHeight
 impl core::marker::Send for bitcoin_units::block::BlockInterval
 impl core::marker::Send for bitcoin_units::block::TooBigForRelativeBlockHeightError
@@ -345,17 +341,17 @@ impl core::marker::Send for bitcoin_units::weight::Weight
 impl core::marker::StructuralPartialEq for bitcoin_units::Amount
 impl core::marker::StructuralPartialEq for bitcoin_units::SignedAmount
 impl core::marker::StructuralPartialEq for bitcoin_units::amount::Denomination
-impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::InputTooLargeError
-impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::InvalidCharacterError
-impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::MissingDenominationError
-impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::MissingDigitsError
-impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::OutOfRangeError
-impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::ParseAmountError
-impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::ParseDenominationError
-impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::ParseError
-impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::PossiblyConfusingDenominationError
-impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::TooPreciseError
-impl core::marker::StructuralPartialEq for bitcoin_units::amount::error::UnknownDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::InputTooLargeError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::InvalidCharacterError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::MissingDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::MissingDigitsError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::OutOfRangeError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::ParseAmountError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::ParseDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::ParseError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::TooPreciseError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::UnknownDenominationError
 impl core::marker::StructuralPartialEq for bitcoin_units::block::BlockHeight
 impl core::marker::StructuralPartialEq for bitcoin_units::block::BlockInterval
 impl core::marker::StructuralPartialEq for bitcoin_units::block::TooBigForRelativeBlockHeightError
@@ -376,17 +372,17 @@ impl core::marker::Sync for bitcoin_units::Amount
 impl core::marker::Sync for bitcoin_units::SignedAmount
 impl core::marker::Sync for bitcoin_units::amount::Denomination
 impl core::marker::Sync for bitcoin_units::amount::Display
-impl core::marker::Sync for bitcoin_units::amount::error::InputTooLargeError
-impl core::marker::Sync for bitcoin_units::amount::error::InvalidCharacterError
-impl core::marker::Sync for bitcoin_units::amount::error::MissingDenominationError
-impl core::marker::Sync for bitcoin_units::amount::error::MissingDigitsError
-impl core::marker::Sync for bitcoin_units::amount::error::OutOfRangeError
-impl core::marker::Sync for bitcoin_units::amount::error::ParseAmountError
-impl core::marker::Sync for bitcoin_units::amount::error::ParseDenominationError
-impl core::marker::Sync for bitcoin_units::amount::error::ParseError
-impl core::marker::Sync for bitcoin_units::amount::error::PossiblyConfusingDenominationError
-impl core::marker::Sync for bitcoin_units::amount::error::TooPreciseError
-impl core::marker::Sync for bitcoin_units::amount::error::UnknownDenominationError
+impl core::marker::Sync for bitcoin_units::amount::InputTooLargeError
+impl core::marker::Sync for bitcoin_units::amount::InvalidCharacterError
+impl core::marker::Sync for bitcoin_units::amount::MissingDenominationError
+impl core::marker::Sync for bitcoin_units::amount::MissingDigitsError
+impl core::marker::Sync for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Sync for bitcoin_units::amount::ParseAmountError
+impl core::marker::Sync for bitcoin_units::amount::ParseDenominationError
+impl core::marker::Sync for bitcoin_units::amount::ParseError
+impl core::marker::Sync for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::Sync for bitcoin_units::amount::TooPreciseError
+impl core::marker::Sync for bitcoin_units::amount::UnknownDenominationError
 impl core::marker::Sync for bitcoin_units::block::BlockHeight
 impl core::marker::Sync for bitcoin_units::block::BlockInterval
 impl core::marker::Sync for bitcoin_units::block::TooBigForRelativeBlockHeightError
@@ -407,17 +403,17 @@ impl core::marker::Unpin for bitcoin_units::Amount
 impl core::marker::Unpin for bitcoin_units::SignedAmount
 impl core::marker::Unpin for bitcoin_units::amount::Denomination
 impl core::marker::Unpin for bitcoin_units::amount::Display
-impl core::marker::Unpin for bitcoin_units::amount::error::InputTooLargeError
-impl core::marker::Unpin for bitcoin_units::amount::error::InvalidCharacterError
-impl core::marker::Unpin for bitcoin_units::amount::error::MissingDenominationError
-impl core::marker::Unpin for bitcoin_units::amount::error::MissingDigitsError
-impl core::marker::Unpin for bitcoin_units::amount::error::OutOfRangeError
-impl core::marker::Unpin for bitcoin_units::amount::error::ParseAmountError
-impl core::marker::Unpin for bitcoin_units::amount::error::ParseDenominationError
-impl core::marker::Unpin for bitcoin_units::amount::error::ParseError
-impl core::marker::Unpin for bitcoin_units::amount::error::PossiblyConfusingDenominationError
-impl core::marker::Unpin for bitcoin_units::amount::error::TooPreciseError
-impl core::marker::Unpin for bitcoin_units::amount::error::UnknownDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::InputTooLargeError
+impl core::marker::Unpin for bitcoin_units::amount::InvalidCharacterError
+impl core::marker::Unpin for bitcoin_units::amount::MissingDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::MissingDigitsError
+impl core::marker::Unpin for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Unpin for bitcoin_units::amount::ParseAmountError
+impl core::marker::Unpin for bitcoin_units::amount::ParseDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::ParseError
+impl core::marker::Unpin for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::TooPreciseError
+impl core::marker::Unpin for bitcoin_units::amount::UnknownDenominationError
 impl core::marker::Unpin for bitcoin_units::block::BlockHeight
 impl core::marker::Unpin for bitcoin_units::block::BlockInterval
 impl core::marker::Unpin for bitcoin_units::block::TooBigForRelativeBlockHeightError
@@ -507,17 +503,17 @@ impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::Amount
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::SignedAmount
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::Denomination
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::Display
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::InputTooLargeError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::InvalidCharacterError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::MissingDenominationError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::MissingDigitsError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::OutOfRangeError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::ParseAmountError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::ParseDenominationError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::ParseError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::PossiblyConfusingDenominationError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::TooPreciseError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::error::UnknownDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::InputTooLargeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::InvalidCharacterError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::MissingDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::MissingDigitsError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::OutOfRangeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::ParseAmountError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::ParseDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::ParseError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::TooPreciseError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::UnknownDenominationError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::BlockHeight
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::BlockInterval
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::TooBigForRelativeBlockHeightError
@@ -538,17 +534,17 @@ impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::Amount
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::SignedAmount
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::Denomination
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::Display
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::InputTooLargeError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::InvalidCharacterError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::MissingDenominationError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::MissingDigitsError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::OutOfRangeError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::ParseAmountError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::ParseDenominationError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::ParseError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::PossiblyConfusingDenominationError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::TooPreciseError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::error::UnknownDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::InputTooLargeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::InvalidCharacterError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::MissingDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::MissingDigitsError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::OutOfRangeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::ParseAmountError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::ParseDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::ParseError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::TooPreciseError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::UnknownDenominationError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::BlockHeight
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::BlockInterval
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::TooBigForRelativeBlockHeightError
@@ -597,10 +593,8 @@ pub bitcoin_units::amount::Denomination::CentiBitcoin
 pub bitcoin_units::amount::Denomination::MicroBitcoin
 pub bitcoin_units::amount::Denomination::MilliBitcoin
 pub bitcoin_units::amount::Denomination::Satoshi
-pub bitcoin_units::amount::ParseDenominationError::PossiblyConfusing(bitcoin_units::amount::error::PossiblyConfusingDenominationError)
-pub bitcoin_units::amount::ParseDenominationError::Unknown(bitcoin_units::amount::error::UnknownDenominationError)
-pub bitcoin_units::amount::error::ParseDenominationError::PossiblyConfusing(bitcoin_units::amount::error::PossiblyConfusingDenominationError)
-pub bitcoin_units::amount::error::ParseDenominationError::Unknown(bitcoin_units::amount::error::UnknownDenominationError)
+pub bitcoin_units::amount::ParseDenominationError::PossiblyConfusing(bitcoin_units::amount::PossiblyConfusingDenominationError)
+pub bitcoin_units::amount::ParseDenominationError::Unknown(bitcoin_units::amount::UnknownDenominationError)
 pub const bitcoin_units::Amount::MAX: Self
 pub const bitcoin_units::Amount::MAX_MONEY: Self
 pub const bitcoin_units::Amount::MIN: Self
@@ -739,10 +733,10 @@ pub fn bitcoin_units::Amount::div(self, rhs: u64) -> Self::Output
 pub fn bitcoin_units::Amount::div_assign(&mut self, rhs: u64)
 pub fn bitcoin_units::Amount::eq(&self, other: &bitcoin_units::Amount) -> bool
 pub fn bitcoin_units::Amount::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::Amount::from_int_btc<T: core::convert::Into<u64>>(whole_bitcoin: T) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::OutOfRangeError>
+pub fn bitcoin_units::Amount::from_int_btc<T: core::convert::Into<u64>>(whole_bitcoin: T) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::OutOfRangeError>
 pub fn bitcoin_units::Amount::from_str(s: &str) -> core::result::Result<Self, Self::Err>
-pub fn bitcoin_units::Amount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::ParseAmountError>
-pub fn bitcoin_units::Amount::from_str_with_denomination(s: &str) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::ParseError>
+pub fn bitcoin_units::Amount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::Amount::from_str_with_denomination(s: &str) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::ParseError>
 pub fn bitcoin_units::Amount::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin_units::Amount::mul(self, rhs: u64) -> Self::Output
 pub fn bitcoin_units::Amount::mul_assign(&mut self, rhs: u64)
@@ -755,7 +749,7 @@ pub fn bitcoin_units::Amount::sub_assign(&mut self, rhs: &bitcoin_units::Amount)
 pub fn bitcoin_units::Amount::sub_assign(&mut self, rhs: bitcoin_units::Amount)
 pub fn bitcoin_units::Amount::sum<I: core::iter::traits::iterator::Iterator<Item = Self>>(iter: I) -> Self
 pub fn bitcoin_units::Amount::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin_units::Amount>
-pub fn bitcoin_units::Amount::to_signed(self) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::OutOfRangeError>
+pub fn bitcoin_units::Amount::to_signed(self) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::OutOfRangeError>
 pub fn bitcoin_units::Amount::try_from(value: bitcoin_units::SignedAmount) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_units::Amount::unchecked_add(self, rhs: bitcoin_units::Amount) -> bitcoin_units::Amount
 pub fn bitcoin_units::Amount::unchecked_sub(self, rhs: bitcoin_units::Amount) -> bitcoin_units::Amount
@@ -773,10 +767,10 @@ pub fn bitcoin_units::SignedAmount::div(self, rhs: i64) -> Self::Output
 pub fn bitcoin_units::SignedAmount::div_assign(&mut self, rhs: i64)
 pub fn bitcoin_units::SignedAmount::eq(&self, other: &bitcoin_units::SignedAmount) -> bool
 pub fn bitcoin_units::SignedAmount::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::SignedAmount::from_int_btc<T: core::convert::Into<i64>>(whole_bitcoin: T) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::OutOfRangeError>
+pub fn bitcoin_units::SignedAmount::from_int_btc<T: core::convert::Into<i64>>(whole_bitcoin: T) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::OutOfRangeError>
 pub fn bitcoin_units::SignedAmount::from_str(s: &str) -> core::result::Result<Self, Self::Err>
-pub fn bitcoin_units::SignedAmount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::ParseAmountError>
-pub fn bitcoin_units::SignedAmount::from_str_with_denomination(s: &str) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::error::ParseError>
+pub fn bitcoin_units::SignedAmount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::SignedAmount::from_str_with_denomination(s: &str) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::ParseError>
 pub fn bitcoin_units::SignedAmount::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin_units::SignedAmount::is_negative(self) -> bool
 pub fn bitcoin_units::SignedAmount::is_positive(self) -> bool
@@ -794,7 +788,7 @@ pub fn bitcoin_units::SignedAmount::sub_assign(&mut self, rhs: &bitcoin_units::S
 pub fn bitcoin_units::SignedAmount::sub_assign(&mut self, rhs: bitcoin_units::SignedAmount)
 pub fn bitcoin_units::SignedAmount::sum<I: core::iter::traits::iterator::Iterator<Item = Self>>(iter: I) -> Self
 pub fn bitcoin_units::SignedAmount::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin_units::SignedAmount>
-pub fn bitcoin_units::SignedAmount::to_unsigned(self) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::error::OutOfRangeError>
+pub fn bitcoin_units::SignedAmount::to_unsigned(self) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::OutOfRangeError>
 pub fn bitcoin_units::SignedAmount::try_from(value: bitcoin_units::Amount) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_units::SignedAmount::unchecked_add(self, rhs: bitcoin_units::SignedAmount) -> bitcoin_units::SignedAmount
 pub fn bitcoin_units::SignedAmount::unchecked_sub(self, rhs: bitcoin_units::SignedAmount) -> bitcoin_units::SignedAmount
@@ -808,57 +802,57 @@ pub fn bitcoin_units::amount::Denomination::hash<__H: core::hash::Hasher>(&self,
 pub fn bitcoin_units::amount::Display::clone(&self) -> bitcoin_units::amount::Display
 pub fn bitcoin_units::amount::Display::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_units::amount::Display::show_denomination(self) -> Self
-pub fn bitcoin_units::amount::error::InputTooLargeError::clone(&self) -> bitcoin_units::amount::error::InputTooLargeError
-pub fn bitcoin_units::amount::error::InputTooLargeError::eq(&self, other: &bitcoin_units::amount::error::InputTooLargeError) -> bool
-pub fn bitcoin_units::amount::error::InputTooLargeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::amount::error::InvalidCharacterError::clone(&self) -> bitcoin_units::amount::error::InvalidCharacterError
-pub fn bitcoin_units::amount::error::InvalidCharacterError::eq(&self, other: &bitcoin_units::amount::error::InvalidCharacterError) -> bool
-pub fn bitcoin_units::amount::error::InvalidCharacterError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::amount::error::MissingDenominationError::clone(&self) -> bitcoin_units::amount::error::MissingDenominationError
-pub fn bitcoin_units::amount::error::MissingDenominationError::eq(&self, other: &bitcoin_units::amount::error::MissingDenominationError) -> bool
-pub fn bitcoin_units::amount::error::MissingDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::amount::error::MissingDigitsError::clone(&self) -> bitcoin_units::amount::error::MissingDigitsError
-pub fn bitcoin_units::amount::error::MissingDigitsError::eq(&self, other: &bitcoin_units::amount::error::MissingDigitsError) -> bool
-pub fn bitcoin_units::amount::error::MissingDigitsError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::amount::error::OutOfRangeError::clone(&self) -> bitcoin_units::amount::error::OutOfRangeError
-pub fn bitcoin_units::amount::error::OutOfRangeError::eq(&self, other: &bitcoin_units::amount::error::OutOfRangeError) -> bool
-pub fn bitcoin_units::amount::error::OutOfRangeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::amount::error::OutOfRangeError::is_above_max(self) -> bool
-pub fn bitcoin_units::amount::error::OutOfRangeError::is_below_min(self) -> bool
-pub fn bitcoin_units::amount::error::OutOfRangeError::valid_range(self) -> (i64, u64)
-pub fn bitcoin_units::amount::error::ParseAmountError::clone(&self) -> bitcoin_units::amount::error::ParseAmountError
-pub fn bitcoin_units::amount::error::ParseAmountError::eq(&self, other: &bitcoin_units::amount::error::ParseAmountError) -> bool
-pub fn bitcoin_units::amount::error::ParseAmountError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::amount::error::ParseAmountError::from(never: core::convert::Infallible) -> Self
-pub fn bitcoin_units::amount::error::ParseAmountError::from(value: bitcoin_units::amount::error::InputTooLargeError) -> Self
-pub fn bitcoin_units::amount::error::ParseAmountError::from(value: bitcoin_units::amount::error::InvalidCharacterError) -> Self
-pub fn bitcoin_units::amount::error::ParseAmountError::from(value: bitcoin_units::amount::error::MissingDigitsError) -> Self
-pub fn bitcoin_units::amount::error::ParseAmountError::from(value: bitcoin_units::amount::error::OutOfRangeError) -> Self
-pub fn bitcoin_units::amount::error::ParseAmountError::from(value: bitcoin_units::amount::error::TooPreciseError) -> Self
-pub fn bitcoin_units::amount::error::ParseDenominationError::clone(&self) -> bitcoin_units::amount::error::ParseDenominationError
-pub fn bitcoin_units::amount::error::ParseDenominationError::eq(&self, other: &bitcoin_units::amount::error::ParseDenominationError) -> bool
-pub fn bitcoin_units::amount::error::ParseDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::amount::error::ParseDenominationError::from(never: core::convert::Infallible) -> Self
-pub fn bitcoin_units::amount::error::ParseError::clone(&self) -> bitcoin_units::amount::error::ParseError
-pub fn bitcoin_units::amount::error::ParseError::eq(&self, other: &bitcoin_units::amount::error::ParseError) -> bool
-pub fn bitcoin_units::amount::error::ParseError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::InputTooLargeError) -> Self
-pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::InvalidCharacterError) -> Self
-pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::MissingDigitsError) -> Self
-pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::OutOfRangeError) -> Self
-pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::ParseAmountError) -> Self
-pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::ParseDenominationError) -> Self
-pub fn bitcoin_units::amount::error::ParseError::from(e: bitcoin_units::amount::error::TooPreciseError) -> Self
-pub fn bitcoin_units::amount::error::ParseError::from(never: core::convert::Infallible) -> Self
-pub fn bitcoin_units::amount::error::PossiblyConfusingDenominationError::clone(&self) -> bitcoin_units::amount::error::PossiblyConfusingDenominationError
-pub fn bitcoin_units::amount::error::PossiblyConfusingDenominationError::eq(&self, other: &bitcoin_units::amount::error::PossiblyConfusingDenominationError) -> bool
-pub fn bitcoin_units::amount::error::PossiblyConfusingDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::amount::error::TooPreciseError::clone(&self) -> bitcoin_units::amount::error::TooPreciseError
-pub fn bitcoin_units::amount::error::TooPreciseError::eq(&self, other: &bitcoin_units::amount::error::TooPreciseError) -> bool
-pub fn bitcoin_units::amount::error::TooPreciseError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::amount::error::UnknownDenominationError::clone(&self) -> bitcoin_units::amount::error::UnknownDenominationError
-pub fn bitcoin_units::amount::error::UnknownDenominationError::eq(&self, other: &bitcoin_units::amount::error::UnknownDenominationError) -> bool
-pub fn bitcoin_units::amount::error::UnknownDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::InputTooLargeError::clone(&self) -> bitcoin_units::amount::InputTooLargeError
+pub fn bitcoin_units::amount::InputTooLargeError::eq(&self, other: &bitcoin_units::amount::InputTooLargeError) -> bool
+pub fn bitcoin_units::amount::InputTooLargeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::InvalidCharacterError::clone(&self) -> bitcoin_units::amount::InvalidCharacterError
+pub fn bitcoin_units::amount::InvalidCharacterError::eq(&self, other: &bitcoin_units::amount::InvalidCharacterError) -> bool
+pub fn bitcoin_units::amount::InvalidCharacterError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::MissingDenominationError::clone(&self) -> bitcoin_units::amount::MissingDenominationError
+pub fn bitcoin_units::amount::MissingDenominationError::eq(&self, other: &bitcoin_units::amount::MissingDenominationError) -> bool
+pub fn bitcoin_units::amount::MissingDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::MissingDigitsError::clone(&self) -> bitcoin_units::amount::MissingDigitsError
+pub fn bitcoin_units::amount::MissingDigitsError::eq(&self, other: &bitcoin_units::amount::MissingDigitsError) -> bool
+pub fn bitcoin_units::amount::MissingDigitsError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::OutOfRangeError::clone(&self) -> bitcoin_units::amount::OutOfRangeError
+pub fn bitcoin_units::amount::OutOfRangeError::eq(&self, other: &bitcoin_units::amount::OutOfRangeError) -> bool
+pub fn bitcoin_units::amount::OutOfRangeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::OutOfRangeError::is_above_max(self) -> bool
+pub fn bitcoin_units::amount::OutOfRangeError::is_below_min(self) -> bool
+pub fn bitcoin_units::amount::OutOfRangeError::valid_range(self) -> (i64, u64)
+pub fn bitcoin_units::amount::ParseAmountError::clone(&self) -> bitcoin_units::amount::ParseAmountError
+pub fn bitcoin_units::amount::ParseAmountError::eq(&self, other: &bitcoin_units::amount::ParseAmountError) -> bool
+pub fn bitcoin_units::amount::ParseAmountError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::ParseAmountError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::amount::ParseAmountError::from(value: bitcoin_units::amount::InputTooLargeError) -> Self
+pub fn bitcoin_units::amount::ParseAmountError::from(value: bitcoin_units::amount::InvalidCharacterError) -> Self
+pub fn bitcoin_units::amount::ParseAmountError::from(value: bitcoin_units::amount::MissingDigitsError) -> Self
+pub fn bitcoin_units::amount::ParseAmountError::from(value: bitcoin_units::amount::OutOfRangeError) -> Self
+pub fn bitcoin_units::amount::ParseAmountError::from(value: bitcoin_units::amount::TooPreciseError) -> Self
+pub fn bitcoin_units::amount::ParseDenominationError::clone(&self) -> bitcoin_units::amount::ParseDenominationError
+pub fn bitcoin_units::amount::ParseDenominationError::eq(&self, other: &bitcoin_units::amount::ParseDenominationError) -> bool
+pub fn bitcoin_units::amount::ParseDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::ParseDenominationError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::amount::ParseError::clone(&self) -> bitcoin_units::amount::ParseError
+pub fn bitcoin_units::amount::ParseError::eq(&self, other: &bitcoin_units::amount::ParseError) -> bool
+pub fn bitcoin_units::amount::ParseError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::InputTooLargeError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::InvalidCharacterError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::MissingDigitsError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::OutOfRangeError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::ParseAmountError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::ParseDenominationError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::TooPreciseError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::amount::PossiblyConfusingDenominationError::clone(&self) -> bitcoin_units::amount::PossiblyConfusingDenominationError
+pub fn bitcoin_units::amount::PossiblyConfusingDenominationError::eq(&self, other: &bitcoin_units::amount::PossiblyConfusingDenominationError) -> bool
+pub fn bitcoin_units::amount::PossiblyConfusingDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::TooPreciseError::clone(&self) -> bitcoin_units::amount::TooPreciseError
+pub fn bitcoin_units::amount::TooPreciseError::eq(&self, other: &bitcoin_units::amount::TooPreciseError) -> bool
+pub fn bitcoin_units::amount::TooPreciseError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::UnknownDenominationError::clone(&self) -> bitcoin_units::amount::UnknownDenominationError
+pub fn bitcoin_units::amount::UnknownDenominationError::eq(&self, other: &bitcoin_units::amount::UnknownDenominationError) -> bool
+pub fn bitcoin_units::amount::UnknownDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_units::block::BlockHeight::add(self, rhs: bitcoin_units::block::BlockInterval) -> Self::Output
 pub fn bitcoin_units::block::BlockHeight::clone(&self) -> bitcoin_units::block::BlockHeight
 pub fn bitcoin_units::block::BlockHeight::cmp(&self, other: &bitcoin_units::block::BlockHeight) -> core::cmp::Ordering
@@ -1028,7 +1022,6 @@ pub macro bitcoin_units::impl_tryfrom_str!
 pub macro bitcoin_units::impl_tryfrom_str_from_int_infallible!
 pub mod bitcoin_units
 pub mod bitcoin_units::amount
-pub mod bitcoin_units::amount::error
 pub mod bitcoin_units::block
 pub mod bitcoin_units::fee_rate
 pub mod bitcoin_units::locktime
@@ -1052,13 +1045,6 @@ pub struct bitcoin_units::amount::ParseAmountError(_)
 pub struct bitcoin_units::amount::ParseError(_)
 pub struct bitcoin_units::amount::SignedAmount(_)
 pub struct bitcoin_units::amount::TooPreciseError
-pub struct bitcoin_units::amount::error::InputTooLargeError
-pub struct bitcoin_units::amount::error::InvalidCharacterError
-pub struct bitcoin_units::amount::error::MissingDigitsError
-pub struct bitcoin_units::amount::error::OutOfRangeError
-pub struct bitcoin_units::amount::error::ParseAmountError(_)
-pub struct bitcoin_units::amount::error::ParseError(_)
-pub struct bitcoin_units::amount::error::TooPreciseError
 pub struct bitcoin_units::block::BlockHeight(pub u32)
 pub struct bitcoin_units::block::BlockInterval(pub u32)
 pub struct bitcoin_units::block::TooBigForRelativeBlockHeightError(_)
@@ -1079,14 +1065,14 @@ pub type &bitcoin_units::Amount::Output = bitcoin_units::Amount
 pub type &bitcoin_units::SignedAmount::Output = bitcoin_units::SignedAmount
 pub type &bitcoin_units::fee_rate::FeeRate::Output = bitcoin_units::fee_rate::FeeRate
 pub type &bitcoin_units::weight::Weight::Output = bitcoin_units::weight::Weight
-pub type bitcoin_units::Amount::Err = bitcoin_units::amount::error::ParseError
-pub type bitcoin_units::Amount::Error = bitcoin_units::amount::error::OutOfRangeError
+pub type bitcoin_units::Amount::Err = bitcoin_units::amount::ParseError
+pub type bitcoin_units::Amount::Error = bitcoin_units::amount::OutOfRangeError
 pub type bitcoin_units::Amount::Output = bitcoin_units::Amount
 pub type bitcoin_units::Amount::Output = bitcoin_units::fee_rate::FeeRate
-pub type bitcoin_units::SignedAmount::Err = bitcoin_units::amount::error::ParseError
-pub type bitcoin_units::SignedAmount::Error = bitcoin_units::amount::error::OutOfRangeError
+pub type bitcoin_units::SignedAmount::Err = bitcoin_units::amount::ParseError
+pub type bitcoin_units::SignedAmount::Error = bitcoin_units::amount::OutOfRangeError
 pub type bitcoin_units::SignedAmount::Output = bitcoin_units::SignedAmount
-pub type bitcoin_units::amount::Denomination::Err = bitcoin_units::amount::error::ParseDenominationError
+pub type bitcoin_units::amount::Denomination::Err = bitcoin_units::amount::ParseDenominationError
 pub type bitcoin_units::block::BlockHeight::Err = bitcoin_units::parse::ParseIntError
 pub type bitcoin_units::block::BlockHeight::Error = bitcoin_units::parse::ParseIntError
 pub type bitcoin_units::block::BlockHeight::Output = bitcoin_units::block::BlockHeight

--- a/units/src/amount/mod.rs
+++ b/units/src/amount/mod.rs
@@ -5,7 +5,7 @@
 //! This module mainly introduces the [`Amount`] and [`SignedAmount`] types.
 //! We refer to the documentation on the types for more information.
 
-pub mod error;
+mod error;
 #[cfg(feature = "serde")]
 pub mod serde;
 

--- a/units/tests/api.rs
+++ b/units/tests/api.rs
@@ -124,17 +124,17 @@ struct Errors {
     i: amount::PossiblyConfusingDenominationError,
     j: amount::TooPreciseError,
     k: amount::UnknownDenominationError,
-    l: amount::error::InputTooLargeError,
-    m: amount::error::InvalidCharacterError,
-    n: amount::error::MissingDenominationError,
-    o: amount::error::MissingDigitsError,
-    p: amount::error::OutOfRangeError,
-    q: amount::error::ParseAmountError,
-    r: amount::error::ParseDenominationError,
-    s: amount::error::ParseError,
-    t: amount::error::PossiblyConfusingDenominationError,
-    u: amount::error::TooPreciseError,
-    v: amount::error::UnknownDenominationError,
+    l: amount::InputTooLargeError,
+    m: amount::InvalidCharacterError,
+    n: amount::MissingDenominationError,
+    o: amount::MissingDigitsError,
+    p: amount::OutOfRangeError,
+    q: amount::ParseAmountError,
+    r: amount::ParseDenominationError,
+    s: amount::ParseError,
+    t: amount::PossiblyConfusingDenominationError,
+    u: amount::TooPreciseError,
+    v: amount::UnknownDenominationError,
     w: block::TooBigForRelativeBlockHeightError,
     x: locktime::absolute::ConversionError,
     y: locktime::absolute::Height,
@@ -163,15 +163,6 @@ fn api_can_use_all_types_from_module_amount() {
         MissingDenominationError, MissingDigitsError, OutOfRangeError, ParseAmountError,
         ParseDenominationError, ParseError, PossiblyConfusingDenominationError, SignedAmount,
         TooPreciseError, UnknownDenominationError,
-    };
-}
-
-#[test]
-fn api_can_use_all_types_from_module_amount_error() {
-    use bitcoin_units::amount::error::{
-        InputTooLargeError, InvalidCharacterError, MissingDenominationError, MissingDigitsError,
-        OutOfRangeError, ParseAmountError, ParseDenominationError, ParseError,
-        PossiblyConfusingDenominationError, TooPreciseError, UnknownDenominationError,
     };
 }
 


### PR DESCRIPTION
The `untis::error` module is just a code organisation thing it should never have been public. We already re-export all the error types and this is verified by the `units/tests/api.rs` test file.

Make the module private and remove it from the paths in the `api` test.
