### PR TITLE
Rename parameter `rhs` to `weight`

### DIFF
--- a/api/units/all-features.txt
+++ b/api/units/all-features.txt
@@ -713,8 +713,8 @@ pub const bitcoin_units::weight::Weight::WITNESS_SCALE_FACTOR: u64
 pub const bitcoin_units::weight::Weight::ZERO: bitcoin_units::weight::Weight
 pub const fn bitcoin_units::Amount::checked_add(self, rhs: bitcoin_units::Amount) -> core::option::Option<bitcoin_units::Amount>
 pub const fn bitcoin_units::Amount::checked_div(self, rhs: u64) -> core::option::Option<bitcoin_units::Amount>
-pub const fn bitcoin_units::Amount::checked_div_by_weight_ceil(self, rhs: bitcoin_units::weight::Weight) -> core::option::Option<bitcoin_units::fee_rate::FeeRate>
-pub const fn bitcoin_units::Amount::checked_div_by_weight_floor(self, rhs: bitcoin_units::weight::Weight) -> core::option::Option<bitcoin_units::fee_rate::FeeRate>
+pub const fn bitcoin_units::Amount::checked_div_by_weight_ceil(self, weight: bitcoin_units::weight::Weight) -> core::option::Option<bitcoin_units::fee_rate::FeeRate>
+pub const fn bitcoin_units::Amount::checked_div_by_weight_floor(self, weight: bitcoin_units::weight::Weight) -> core::option::Option<bitcoin_units::fee_rate::FeeRate>
 pub const fn bitcoin_units::Amount::checked_mul(self, rhs: u64) -> core::option::Option<bitcoin_units::Amount>
 pub const fn bitcoin_units::Amount::checked_rem(self, rhs: u64) -> core::option::Option<bitcoin_units::Amount>
 pub const fn bitcoin_units::Amount::checked_sub(self, rhs: bitcoin_units::Amount) -> core::option::Option<bitcoin_units::Amount>
@@ -737,7 +737,7 @@ pub const fn bitcoin_units::block::BlockInterval::to_u32(self) -> u32
 pub const fn bitcoin_units::fee_rate::FeeRate::checked_add(self, rhs: u64) -> core::option::Option<Self>
 pub const fn bitcoin_units::fee_rate::FeeRate::checked_div(self, rhs: u64) -> core::option::Option<Self>
 pub const fn bitcoin_units::fee_rate::FeeRate::checked_mul(self, rhs: u64) -> core::option::Option<Self>
-pub const fn bitcoin_units::fee_rate::FeeRate::checked_mul_by_weight(self, rhs: bitcoin_units::weight::Weight) -> core::option::Option<bitcoin_units::Amount>
+pub const fn bitcoin_units::fee_rate::FeeRate::checked_mul_by_weight(self, weight: bitcoin_units::weight::Weight) -> core::option::Option<bitcoin_units::Amount>
 pub const fn bitcoin_units::fee_rate::FeeRate::checked_sub(self, rhs: u64) -> core::option::Option<Self>
 pub const fn bitcoin_units::fee_rate::FeeRate::from_sat_per_kvb(sat_kvb: u64) -> Self
 pub const fn bitcoin_units::fee_rate::FeeRate::from_sat_per_kwu(sat_kwu: u64) -> Self

--- a/api/units/alloc-only.txt
+++ b/api/units/alloc-only.txt
@@ -664,8 +664,8 @@ pub const bitcoin_units::weight::Weight::WITNESS_SCALE_FACTOR: u64
 pub const bitcoin_units::weight::Weight::ZERO: bitcoin_units::weight::Weight
 pub const fn bitcoin_units::Amount::checked_add(self, rhs: bitcoin_units::Amount) -> core::option::Option<bitcoin_units::Amount>
 pub const fn bitcoin_units::Amount::checked_div(self, rhs: u64) -> core::option::Option<bitcoin_units::Amount>
-pub const fn bitcoin_units::Amount::checked_div_by_weight_ceil(self, rhs: bitcoin_units::weight::Weight) -> core::option::Option<bitcoin_units::fee_rate::FeeRate>
-pub const fn bitcoin_units::Amount::checked_div_by_weight_floor(self, rhs: bitcoin_units::weight::Weight) -> core::option::Option<bitcoin_units::fee_rate::FeeRate>
+pub const fn bitcoin_units::Amount::checked_div_by_weight_ceil(self, weight: bitcoin_units::weight::Weight) -> core::option::Option<bitcoin_units::fee_rate::FeeRate>
+pub const fn bitcoin_units::Amount::checked_div_by_weight_floor(self, weight: bitcoin_units::weight::Weight) -> core::option::Option<bitcoin_units::fee_rate::FeeRate>
 pub const fn bitcoin_units::Amount::checked_mul(self, rhs: u64) -> core::option::Option<bitcoin_units::Amount>
 pub const fn bitcoin_units::Amount::checked_rem(self, rhs: u64) -> core::option::Option<bitcoin_units::Amount>
 pub const fn bitcoin_units::Amount::checked_sub(self, rhs: bitcoin_units::Amount) -> core::option::Option<bitcoin_units::Amount>
@@ -688,7 +688,7 @@ pub const fn bitcoin_units::block::BlockInterval::to_u32(self) -> u32
 pub const fn bitcoin_units::fee_rate::FeeRate::checked_add(self, rhs: u64) -> core::option::Option<Self>
 pub const fn bitcoin_units::fee_rate::FeeRate::checked_div(self, rhs: u64) -> core::option::Option<Self>
 pub const fn bitcoin_units::fee_rate::FeeRate::checked_mul(self, rhs: u64) -> core::option::Option<Self>
-pub const fn bitcoin_units::fee_rate::FeeRate::checked_mul_by_weight(self, rhs: bitcoin_units::weight::Weight) -> core::option::Option<bitcoin_units::Amount>
+pub const fn bitcoin_units::fee_rate::FeeRate::checked_mul_by_weight(self, weight: bitcoin_units::weight::Weight) -> core::option::Option<bitcoin_units::Amount>
 pub const fn bitcoin_units::fee_rate::FeeRate::checked_sub(self, rhs: u64) -> core::option::Option<Self>
 pub const fn bitcoin_units::fee_rate::FeeRate::from_sat_per_kvb(sat_kvb: u64) -> Self
 pub const fn bitcoin_units::fee_rate::FeeRate::from_sat_per_kwu(sat_kwu: u64) -> Self

--- a/api/units/no-features.txt
+++ b/api/units/no-features.txt
@@ -670,7 +670,7 @@ pub const fn bitcoin_units::block::BlockInterval::to_u32(self) -> u32
 pub const fn bitcoin_units::fee_rate::FeeRate::checked_add(self, rhs: u64) -> core::option::Option<Self>
 pub const fn bitcoin_units::fee_rate::FeeRate::checked_div(self, rhs: u64) -> core::option::Option<Self>
 pub const fn bitcoin_units::fee_rate::FeeRate::checked_mul(self, rhs: u64) -> core::option::Option<Self>
-pub const fn bitcoin_units::fee_rate::FeeRate::checked_mul_by_weight(self, rhs: bitcoin_units::weight::Weight) -> core::option::Option<bitcoin_units::Amount>
+pub const fn bitcoin_units::fee_rate::FeeRate::checked_mul_by_weight(self, weight: bitcoin_units::weight::Weight) -> core::option::Option<bitcoin_units::Amount>
 pub const fn bitcoin_units::fee_rate::FeeRate::checked_sub(self, rhs: u64) -> core::option::Option<Self>
 pub const fn bitcoin_units::fee_rate::FeeRate::from_sat_per_kvb(sat_kvb: u64) -> Self
 pub const fn bitcoin_units::fee_rate::FeeRate::from_sat_per_kwu(sat_kwu: u64) -> Self

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -369,8 +369,8 @@ impl Amount {
     /// ```
     #[cfg(feature = "alloc")]
     #[must_use]
-    pub const fn checked_div_by_weight_ceil(self, rhs: Weight) -> Option<FeeRate> {
-        let wu = rhs.to_wu();
+    pub const fn checked_div_by_weight_ceil(self, weight: Weight) -> Option<FeeRate> {
+        let wu = weight.to_wu();
         // No `?` operator in const context.
         if let Some(sats) = self.0.checked_mul(1_000) {
             if let Some(wu_minus_one) = wu.checked_sub(1) {
@@ -392,10 +392,10 @@ impl Amount {
     /// Returns [`None`] if overflow occurred.
     #[cfg(feature = "alloc")]
     #[must_use]
-    pub const fn checked_div_by_weight_floor(self, rhs: Weight) -> Option<FeeRate> {
+    pub const fn checked_div_by_weight_floor(self, weight: Weight) -> Option<FeeRate> {
         // No `?` operator in const context.
         match self.0.checked_mul(1_000) {
-            Some(res) => match res.checked_div(rhs.to_wu()) {
+            Some(res) => match res.checked_div(weight.to_wu()) {
                 Some(fee_rate) => Some(FeeRate::from_sat_per_kwu(fee_rate)),
                 None => None,
             },

--- a/units/src/fee_rate.rs
+++ b/units/src/fee_rate.rs
@@ -108,9 +108,9 @@ impl FeeRate {
     ///
     /// [`None`] is returned if an overflow occurred.
     #[must_use]
-    pub const fn checked_mul_by_weight(self, rhs: Weight) -> Option<Amount> {
+    pub const fn checked_mul_by_weight(self, weight: Weight) -> Option<Amount> {
         // No `?` operator in const context.
-        match self.0.checked_mul(rhs.to_wu()) {
+        match self.0.checked_mul(weight.to_wu()) {
             Some(mul_res) => match mul_res.checked_add(999) {
                 Some(add_res) => Some(Amount::from_sat(add_res / 1000)),
                 None => None,


### PR DESCRIPTION
In ops functions we typically use `rhs` but for the more unconventional `checked_*_by_*` functions lets use a more descriptive parameter name.

Interestingly `cargo public-api` thinks this is an API breaking change. This is obviously an internal change but the api files are updated because the parameter names appear in the api text files.
