### PR TITLE
Deprecate DUST_RELAY_TX_FEE in favour of FeeRate::DUST

### DIFF
--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -273,7 +273,7 @@ crate::internal_macros::define_extension_trait! {
         ///
         /// [`minimal_non_dust_custom`]: Script::minimal_non_dust_custom
         fn minimal_non_dust(&self) -> crate::Amount {
-            self.minimal_non_dust_internal(DUST_RELAY_TX_FEE.into())
+            self.minimal_non_dust_internal(FeeRate::DUST)
         }
 
         /// Returns the minimum value an output with this script should have in order to be
@@ -288,7 +288,7 @@ crate::internal_macros::define_extension_trait! {
         ///
         /// [`minimal_non_dust`]: Script::minimal_non_dust
         fn minimal_non_dust_custom(&self, dust_relay_fee: FeeRate) -> crate::Amount {
-            self.minimal_non_dust_internal(dust_relay_fee.to_sat_per_kwu() * 4)
+            self.minimal_non_dust_internal(dust_relay_fee)
         }
 
         /// Counts the sigops for this Script using accurate counting.

--- a/bitcoin/src/policy.rs
+++ b/bitcoin/src/policy.rs
@@ -33,6 +33,7 @@ pub const DEFAULT_BYTES_PER_SIGOP: u32 = 20;
 
 /// The minimum feerate, in sats per kilo-virtualbyte, for defining dust. An output is considered
 /// dust if spending it under this feerate would cost more in fee.
+#[deprecated(since = "TBD", note = "Use `FeeRate::DUST` instead")]
 pub const DUST_RELAY_TX_FEE: u32 = 3_000;
 
 /// Minimum feerate, in sats per virtual kilobyte, for a transaction to be relayed by most nodes on

--- a/units/src/fee_rate.rs
+++ b/units/src/fee_rate.rs
@@ -41,6 +41,13 @@ impl FeeRate {
     pub const BROADCAST_MIN: FeeRate = FeeRate::from_sat_per_vb_unchecked(1);
 
     /// Fee rate used to compute dust amount.
+    ///
+    /// Dust depends on the -dustrelayfee value of the Bitcoin Core node you are broadcasting to and
+    /// effects which transactions are standard.
+    ///
+    /// The current value in [Bitcoin Core] (as of v26) is 3 sat/vByte.
+    ///
+    /// [Bitcoin Core]: <https://github.com/bitcoin/bitcoin/blob/fc7b21484703da606c5c69b23daee8c39506d90c/src/policy/policy.h#L55>
     pub const DUST: FeeRate = FeeRate::from_sat_per_vb_unchecked(3);
 
     /// Constructs a new [`FeeRate`] from satoshis per 1000 weight units.


### PR DESCRIPTION
This is just to remind us to do this after #3807. "After" because it touches the parameter of `non_minimal_dust_internal`

Both these consts are based on the value in Bitcoin Core

https://github.com/bitcoin/bitcoin/blob/fc7b21484703da606c5c69b23daee8c39506d90c/src/policy/policy.h#L55

Its not immediately obvious why we have both with hard coded values.

Deprecated the `bitcoin::policy::DUST_RELAY_TX_FEE` const and direct users to the `FeeRate::DUST` const.

In the `minimal_non_dust_internal` function use the concrete `FeeRate` type as parameter and use the `FeeRate::DUST` const instead of a `u32`.