### PR TITLE
draft: Move casts to TOC

### DIFF
--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -442,12 +442,13 @@ impl Amount {
     /// # Errors
     ///
     /// If the amount is too big.
-    #[rustfmt::skip] // Moves code comments to the wrong line.
+    // [1] Cast ok, signed max is positive and fits in u64.
+    // [2] Cast ok, checked not too big above.
     pub fn to_signed(self) -> Result<SignedAmount, OutOfRangeError> {
-        if self.to_sat() > SignedAmount::MAX.to_sat() as u64 { // Cast ok, signed max is positive and fits in u64.
+        if self.to_sat() > SignedAmount::MAX.to_sat() as u64 { // Cast ok, [1]
             Err(OutOfRangeError::too_big(true))
         } else {
-            Ok(SignedAmount::from_sat(self.to_sat() as i64)) // Cast ok, checked not too big above.
+            Ok(SignedAmount::from_sat(self.to_sat() as i64)) // Cast ok, [2]
         }
     }
 


### PR DESCRIPTION
An idea, move all these Cast comments to a TOC (Table of Contents) so we don't need to mess with the format skips.  Maybe all the casts could be in a TOC file someplace.