### PR TITLE
Remove unnecessary floating code comment

### DIFF
--- a/units/src/amount/signed.rs
+++ b/units/src/amount/signed.rs
@@ -288,8 +288,6 @@ impl SignedAmount {
         self.display_in(denom).show_denomination().to_string()
     }
 
-    // Some arithmetic that doesn't fit in [`core::ops`] traits.
-
     /// Gets the absolute value of this [`SignedAmount`].
     #[must_use]
     pub fn abs(self) -> SignedAmount { SignedAmount(self.0.abs()) }

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -298,8 +298,6 @@ impl Amount {
         self.display_in(denom).show_denomination().to_string()
     }
 
-    // Some arithmetic that doesn't fit in [`core::ops`] traits.
-
     /// Checked addition.
     ///
     /// Returns [`None`] if the sum is larger than [`Amount::MAX`].


### PR DESCRIPTION
Code comments that comment and arbitrary block "section" of code are almost always pointless and almost always go stale over time.

These particular code comments add almost no value.

Remove code comments.