### PR TITLE
hashes: Hide both macros

### DIFF
--- a/api/hashes/alloc-only.txt
+++ b/api/hashes/alloc-only.txt
@@ -859,7 +859,6 @@ pub fn bitcoin_hashes::siphash24::State::fmt(&self, f: &mut core::fmt::Formatter
 pub macro bitcoin_hashes::hash_newtype!
 pub macro bitcoin_hashes::impl_debug_only_for_newtype!
 pub macro bitcoin_hashes::impl_hex_for_newtype!
-pub macro bitcoin_hashes::serde_impl!
 pub macro bitcoin_hashes::sha256t_hash_newtype!
 pub macro bitcoin_hashes::sha256t_tag!
 pub mod bitcoin_hashes

--- a/api/hashes/no-features.txt
+++ b/api/hashes/no-features.txt
@@ -806,7 +806,6 @@ pub fn bitcoin_hashes::siphash24::State::clone(&self) -> bitcoin_hashes::siphash
 pub fn bitcoin_hashes::siphash24::State::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub macro bitcoin_hashes::hash_newtype!
 pub macro bitcoin_hashes::impl_debug_only_for_newtype!
-pub macro bitcoin_hashes::serde_impl!
 pub macro bitcoin_hashes::sha256t_hash_newtype!
 pub macro bitcoin_hashes::sha256t_tag!
 pub mod bitcoin_hashes

--- a/hashes/src/macros.rs
+++ b/hashes/src/macros.rs
@@ -533,6 +533,7 @@ macro_rules! serde_impl(
 ));
 
 /// Does an "empty" serde implementation for the configuration without serde feature.
+#[doc(hidden)]
 #[macro_export]
 #[cfg(not(feature = "serde"))]
 macro_rules! serde_impl(


### PR DESCRIPTION
We have two macro definitions feature gated on `serde`. At some stage we added the `doc(hidden)` attribute to one of them but forgot to add it to the other. This technically makes our features non-additive. This macro is "internal" so its unlikely that this is being used in the wild.

Add `doc(hidden)` to the `serde_impl` macro that is missing it.

Found by `cargo semver-checks` after recent upgrade to 0.38