### PR TITLE
units: Improve parsing macros

### DIFF
--- a/api/units/all-features.txt
+++ b/api/units/all-features.txt
@@ -1193,8 +1193,6 @@ pub fn u64::from(value: bitcoin_units::weight::Weight) -> Self
 pub fn u64::mul(self, rhs: bitcoin_units::weight::Weight) -> Self::Output
 pub macro bitcoin_units::impl_parse_str!
 pub macro bitcoin_units::impl_parse_str_from_int_infallible!
-pub macro bitcoin_units::impl_tryfrom_str!
-pub macro bitcoin_units::impl_tryfrom_str_from_int_infallible!
 pub mod bitcoin_units
 pub mod bitcoin_units::amount
 pub mod bitcoin_units::amount::serde

--- a/api/units/alloc-only.txt
+++ b/api/units/alloc-only.txt
@@ -1064,8 +1064,6 @@ pub fn u64::from(value: bitcoin_units::weight::Weight) -> Self
 pub fn u64::mul(self, rhs: bitcoin_units::weight::Weight) -> Self::Output
 pub macro bitcoin_units::impl_parse_str!
 pub macro bitcoin_units::impl_parse_str_from_int_infallible!
-pub macro bitcoin_units::impl_tryfrom_str!
-pub macro bitcoin_units::impl_tryfrom_str_from_int_infallible!
 pub mod bitcoin_units
 pub mod bitcoin_units::amount
 pub mod bitcoin_units::block

--- a/api/units/no-features.txt
+++ b/api/units/no-features.txt
@@ -1018,8 +1018,6 @@ pub fn u64::from(value: bitcoin_units::weight::Weight) -> Self
 pub fn u64::mul(self, rhs: bitcoin_units::weight::Weight) -> Self::Output
 pub macro bitcoin_units::impl_parse_str!
 pub macro bitcoin_units::impl_parse_str_from_int_infallible!
-pub macro bitcoin_units::impl_tryfrom_str!
-pub macro bitcoin_units::impl_tryfrom_str_from_int_infallible!
 pub mod bitcoin_units
 pub mod bitcoin_units::amount
 pub mod bitcoin_units::block

--- a/units/src/parse.rs
+++ b/units/src/parse.rs
@@ -131,23 +131,6 @@ macro_rules! impl_parse_str_from_int_infallible {
     }
 }
 
-/// Implements `TryFrom<$from> for $to`.
-#[doc(hidden)]                  // Helper macro for `impl_parse_str`
-#[macro_export]
-macro_rules! impl_tryfrom_str {
-    ($($from:ty, $to:ty, $err:ty, $inner_fn:expr);*) => {
-        $(
-            impl $crate::_export::_core::convert::TryFrom<$from> for $to {
-                type Error = $err;
-
-                fn try_from(s: $from) -> $crate::_export::_core::result::Result<Self, Self::Error> {
-                    $inner_fn(s)
-                }
-            }
-        )*
-    }
-}
-
 /// Implements standard parsing traits for `$type` by calling into `$inner_fn`.
 #[macro_export]
 macro_rules! impl_parse_str {
@@ -163,6 +146,23 @@ macro_rules! impl_parse_str {
                 $inner_fn(s)
             }
         }
+    }
+}
+
+/// Implements `TryFrom<$from> for $to`.
+#[doc(hidden)]                  // Helper macro for `impl_parse_str`
+#[macro_export]
+macro_rules! impl_tryfrom_str {
+    ($($from:ty, $to:ty, $err:ty, $inner_fn:expr);*) => {
+        $(
+            impl $crate::_export::_core::convert::TryFrom<$from> for $to {
+                type Error = $err;
+
+                fn try_from(s: $from) -> $crate::_export::_core::result::Result<Self, Self::Error> {
+                    $inner_fn(s)
+                }
+            }
+        )*
     }
 }
 

--- a/units/src/parse.rs
+++ b/units/src/parse.rs
@@ -91,24 +91,6 @@ pub fn int<T: Integer, S: AsRef<str> + Into<InputString>>(s: S) -> Result<T, Par
     })
 }
 
-/// Implements `TryFrom<$from> for $to` using `parse::int`, mapping the output using infallible
-/// conversion function `fn`.
-#[doc(hidden)]                  // Helper macro for `impl_parse_str_from_int_infallible`
-#[macro_export]
-macro_rules! impl_tryfrom_str_from_int_infallible {
-    ($($from:ty, $to:ident, $inner:ident, $fn:ident);*) => {
-        $(
-        impl $crate::_export::_core::convert::TryFrom<$from> for $to {
-            type Error = $crate::parse::ParseIntError;
-
-            fn try_from(s: $from) -> $crate::_export::_core::result::Result<Self, Self::Error> {
-                $crate::parse::int::<$inner, $from>(s).map($to::$fn)
-            }
-        }
-        )*
-    }
-}
-
 /// Implements `FromStr` and `TryFrom<{&str, String, Box<str>}> for $to` using `parse::int`, mapping
 /// the output using infallible conversion function `fn`.
 ///
@@ -128,6 +110,24 @@ macro_rules! impl_parse_str_from_int_infallible {
             }
         }
 
+    }
+}
+
+/// Implements `TryFrom<$from> for $to` using `parse::int`, mapping the output using infallible
+/// conversion function `fn`.
+#[doc(hidden)]                  // Helper macro for `impl_parse_str_from_int_infallible`
+#[macro_export]
+macro_rules! impl_tryfrom_str_from_int_infallible {
+    ($($from:ty, $to:ident, $inner:ident, $fn:ident);*) => {
+        $(
+        impl $crate::_export::_core::convert::TryFrom<$from> for $to {
+            type Error = $crate::parse::ParseIntError;
+
+            fn try_from(s: $from) -> $crate::_export::_core::result::Result<Self, Self::Error> {
+                $crate::parse::int::<$inner, $from>(s).map($to::$fn)
+            }
+        }
+        )*
     }
 }
 

--- a/units/src/parse.rs
+++ b/units/src/parse.rs
@@ -91,10 +91,30 @@ pub fn int<T: Integer, S: AsRef<str> + Into<InputString>>(s: S) -> Result<T, Par
     })
 }
 
-/// Implements `FromStr` and `TryFrom<{&str, String, Box<str>}> for $to` using `parse::int`, mapping
-/// the output using infallible conversion function `fn`.
+/// Implements standard parsing traits for `$type` by calling `parse::int`.
 ///
-/// The `Error` type is `ParseIntError`
+/// Once the string is converted to an integer the infallible conversion function `fn` is used to
+/// create the type `to`.
+///
+/// Implements:
+///
+/// * `FromStr`
+/// * `TryFrom<&str>`
+///
+/// And if `alloc` feature is enabled in calling crate:
+///
+/// * `TryFrom<Box<str>>`
+/// * `TryFrom<String>`
+///
+/// # Arguments
+///
+/// * `to` - the type converted to e.g., `impl From<&str> for $to`.
+/// * `err` - the error type returned by `$inner_fn` (implies returned by `FromStr` and `TryFrom`).
+/// * `fn`: The infallible conversion function to call to convert from an integer.
+///
+/// # Errors
+///
+/// All implementations error using `units::parse::ParseIntError`.
 #[macro_export]
 macro_rules! impl_parse_str_from_int_infallible {
     ($to:ident, $inner:ident, $fn:ident) => {
@@ -113,8 +133,7 @@ macro_rules! impl_parse_str_from_int_infallible {
     }
 }
 
-/// Implements `TryFrom<$from> for $to` using `parse::int`, mapping the output using infallible
-/// conversion function `fn`.
+/// Implements `TryFrom<$from> for $to` using `parse::int` and mapping the output using `fn`.
 #[doc(hidden)]                  // Helper macro for `impl_parse_str_from_int_infallible`
 #[macro_export]
 macro_rules! impl_tryfrom_str_from_int_infallible {
@@ -131,7 +150,27 @@ macro_rules! impl_tryfrom_str_from_int_infallible {
     }
 }
 
-/// Implements standard parsing traits for `$type` by calling into `$inner_fn`.
+/// Implements standard parsing traits for `$type` by calling through to `$inner_fn`.
+///
+/// Implements:
+///
+/// * `FromStr`
+/// * `TryFrom<&str>`
+///
+/// And if `alloc` feature is enabled in calling crate:
+///
+/// * `TryFrom<Box<str>>`
+/// * `TryFrom<String>`
+///
+/// # Arguments
+///
+/// * `to` - the type converted to e.g., `impl From<&str> for $to`.
+/// * `err` - the error type returned by `$inner_fn` (implies returned by `FromStr` and `TryFrom`).
+/// * `inner_fn`: The fallible conversion function to call to convert from a string reference.
+///
+/// # Errors
+///
+/// All implementations error using `$err` (expected to be the error returned by `$inner_fn`).
 #[macro_export]
 macro_rules! impl_parse_str {
     ($to:ty, $err:ty, $inner_fn:expr) => {
@@ -149,7 +188,7 @@ macro_rules! impl_parse_str {
     }
 }
 
-/// Implements `TryFrom<$from> for $to`.
+/// Implements `TryFrom<$from> for $to` by calling `inner_fn`.
 #[doc(hidden)]                  // Helper macro for `impl_parse_str`
 #[macro_export]
 macro_rules! impl_tryfrom_str {

--- a/units/src/parse.rs
+++ b/units/src/parse.rs
@@ -93,6 +93,7 @@ pub fn int<T: Integer, S: AsRef<str> + Into<InputString>>(s: S) -> Result<T, Par
 
 /// Implements `TryFrom<$from> for $to` using `parse::int`, mapping the output using infallible
 /// conversion function `fn`.
+#[doc(hidden)]                  // Helper macro for `impl_parse_str_from_int_infallible`
 #[macro_export]
 macro_rules! impl_tryfrom_str_from_int_infallible {
     ($($from:ty, $to:ident, $inner:ident, $fn:ident);*) => {
@@ -131,6 +132,7 @@ macro_rules! impl_parse_str_from_int_infallible {
 }
 
 /// Implements `TryFrom<$from> for $to`.
+#[doc(hidden)]                  // Helper macro for `impl_parse_str`
 #[macro_export]
 macro_rules! impl_tryfrom_str {
     ($($from:ty, $to:ty, $err:ty, $inner_fn:expr);*) => {


### PR DESCRIPTION
Improve the parsing macros by hiding the helper macros and improving the rustdocs.

API breaking because of the addition of `doc(hidden)`.