### PR TITLE
api: Include generics in regex

### DIFF
--- a/contrib/api.sh
+++ b/contrib/api.sh
@@ -99,12 +99,12 @@ main() {
 
 # Print all public structs and enums.
 structs_and_enums() {
-    grep -oP 'pub (struct|enum) \K[\w:]+(?=\(|;| |$)' "$file" | sed "s/^${crate_full_name}:://"
+    grep -oP 'pub (struct|enum) \K[\w:]+(?:<[^>]+>)?(?=\(|;| |$)' "$file" | sed "s/^${crate_full_name}:://"
 }
 
 # Print all public structs and enums excluding error types.
 structs_and_enums_no_err() {
-    grep -oP 'pub (struct|enum) \K[\w:]+(?=\(|;| |$)' "$file" | sed "s/^${crate_full_name}:://" | grep -v Error
+    grep -oP 'pub (struct|enum) \K[\w:]+(?:<[^>]+>)?(?=\(|;| |$)' "$file" | sed "s/^${crate_full_name}:://" | grep -v Error
 }
 
 # Print all public traits.


### PR DESCRIPTION
The regex is still wrong, it misses structs with generics.

Currently `contrib/api.sh io types` returns:

ErrorKind
Error
Sink

But with this patch applied it returns:

FromStd<T>
ToStd<T>
ErrorKind
Cursor<T>
Error
Sink
Take<'a, R: bitcoin_io::Read + ?core::marker::Sized>


Thanks ChatGPT, good robot.