### PR TITLE
Update to latest `rust-ordered`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -303,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "ordered"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f0642533dea0bb58bd5cae31bafc1872429f0f12ac8c61fe2b4ba44f80b959b"
+checksum = "3cd8ca7e3c0ec0f0ae705488e2df4ea2eae87e97de8c8abd2bda12b23324cac9"
 
 [[package]]
 name = "ppv-lite86"

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -311,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "ordered"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f0642533dea0bb58bd5cae31bafc1872429f0f12ac8c61fe2b4ba44f80b959b"
+checksum = "3cd8ca7e3c0ec0f0ae705488e2df4ea2eae87e97de8c8abd2bda12b23324cac9"
 
 [[package]]
 name = "ppv-lite86"

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -39,7 +39,7 @@ arbitrary = { version = "1.4", optional = true }
 base64 = { version = "0.22.0", optional = true }
 # `bitcoinconsensus` version includes metadata which indicates the version of Core. Use `cargo tree` to see it.
 bitcoinconsensus = { version = "0.106.0", default-features = false, optional = true }
-ordered = { version = "0.2.0", optional = true }
+ordered = { version = "0.3.0", optional = true }
 serde = { version = "1.0.103", default-features = false, features = [ "derive", "alloc" ], optional = true }
 
 [dev-dependencies]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -29,7 +29,7 @@ io = { package = "bitcoin-io", version = "0.2.0", default-features = false }
 units = { package = "bitcoin-units", version = "0.2.0", default-features = false }
 
 arbitrary = { version = "1.4", optional = true }
-ordered = { version = "0.2.0", optional = true }
+ordered = { version = "0.3.0", optional = true }
 serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"], optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
I just went to town on the `rust-ordered` crate to get it ready for releasing a `1.0` version. None of the changes effect our usage here in `rust-bitcoin`.

Upgrade to the latest version of `rust-ordered` - `v0.3.0`.