### PR TITLE
Update to rust-ordered 0.4.0

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -303,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "ordered"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd8ca7e3c0ec0f0ae705488e2df4ea2eae87e97de8c8abd2bda12b23324cac9"
+checksum = "79c12388aac4f817eae0359011d67d4072ed84cfc63b0d9a7958ef476fb74bec"
 
 [[package]]
 name = "ppv-lite86"

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -311,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "ordered"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd8ca7e3c0ec0f0ae705488e2df4ea2eae87e97de8c8abd2bda12b23324cac9"
+checksum = "79c12388aac4f817eae0359011d67d4072ed84cfc63b0d9a7958ef476fb74bec"
 
 [[package]]
 name = "ppv-lite86"

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -39,7 +39,7 @@ arbitrary = { version = "1.4", optional = true }
 base64 = { version = "0.22.0", optional = true }
 # `bitcoinconsensus` version includes metadata which indicates the version of Core. Use `cargo tree` to see it.
 bitcoinconsensus = { version = "0.106.0", default-features = false, optional = true }
-ordered = { version = "0.3.0", optional = true }
+ordered = { version = "0.4.0", optional = true }
 serde = { version = "1.0.103", default-features = false, features = [ "derive", "alloc" ], optional = true }
 
 [dev-dependencies]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -29,7 +29,7 @@ io = { package = "bitcoin-io", version = "0.2.0", default-features = false }
 units = { package = "bitcoin-units", version = "0.2.0", default-features = false }
 
 arbitrary = { version = "1.4", optional = true }
-ordered = { version = "0.3.0", optional = true }
+ordered = { version = "0.4.0", optional = true }
 serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"], optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
We just released a version of `ordered` that makes `ArbitraryOrd` object safe - use it.

Upgrade to the latest version of `rust-ordered` - `v0.4.0`.