### PR TITLE
primitives: Add core re-exports

### DIFF
--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -33,6 +33,14 @@ extern crate std;
 #[macro_use]
 extern crate serde;
 
+#[doc(hidden)]
+pub mod _export {
+    /// A re-export of `core::*`.
+    pub mod _core {
+        pub use core::*;
+    }
+}
+
 pub mod block;
 pub mod locktime;
 pub mod merkle_tree;


### PR DESCRIPTION
This is not strictly needed but we would like to copy the public macros from `units` to primitives and they use `$crate::_export` paths.