### PR TITLE
Address mutants in units

### DIFF
--- a/units/src/amount/mod.rs
+++ b/units/src/amount/mod.rs
@@ -285,6 +285,7 @@ fn parse_signed_to_satoshi(
     Ok((is_negative, value))
 }
 
+#[derive(Debug)]
 enum InnerParseError {
     Overflow { is_negative: bool },
     TooPrecise(TooPreciseError),

--- a/units/src/amount/serde.rs
+++ b/units/src/amount/serde.rs
@@ -391,6 +391,12 @@ mod tests {
     use super::*;
 
     #[test]
+    fn sanity_check() {
+        assert_eq!(Amount::type_prefix(private::Token), "u");
+        assert_eq!(SignedAmount::type_prefix(private::Token), "i");
+    }
+
+    #[test]
     fn can_serde_as_sat() {
         #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
         pub struct HasAmount {

--- a/units/src/block.rs
+++ b/units/src/block.rs
@@ -278,11 +278,29 @@ impl<'a> Arbitrary<'a> for BlockInterval {
 mod tests {
     use super::*;
 
+    #[test]
+    fn sanity_check() {
+        let height: u32 = BlockHeight(100).into();
+        assert_eq!(height, 100);
+
+        let interval: u32 = BlockInterval(100).into();
+        assert_eq!(interval, 100);
+
+        let interval_from_height: BlockInterval = relative::Height::from(10u16).into();
+        assert_eq!(interval_from_height.to_u32(), 10u32);
+
+        let invalid_height_greater = relative::Height::try_from(BlockInterval(u32::from(u16::MAX) + 1));
+        assert!(invalid_height_greater.is_err());
+
+        let valid_height = relative::Height::try_from(BlockInterval(u32::from(u16::MAX)));
+        assert!(valid_height.is_ok());
+    }
+
     // These tests are supposed to comprise an exhaustive list of available operations.
     #[test]
     fn all_available_ops() {
         // height - height = interval
-        assert!(BlockHeight(100) - BlockHeight(99) == BlockInterval(1));
+        assert!(BlockHeight(10) - BlockHeight(7) == BlockInterval(3));
 
         // height + interval = height
         assert!(BlockHeight(100) + BlockInterval(1) == BlockHeight(101));
@@ -294,7 +312,10 @@ mod tests {
         assert!(BlockInterval(1) + BlockInterval(2) == BlockInterval(3));
 
         // interval - interval = interval
-        assert!(BlockInterval(3) - BlockInterval(2) == BlockInterval(1));
+        assert!(BlockInterval(10) - BlockInterval(7) == BlockInterval(3));
+
+        assert!([BlockInterval(1), BlockInterval(2), BlockInterval(3)].iter().sum::<BlockInterval>() == BlockInterval(6));
+        assert!([BlockInterval(4), BlockInterval(5), BlockInterval(6)].into_iter().sum::<BlockInterval>() == BlockInterval(15));
 
         // interval += interval
         let mut int = BlockInterval(1);
@@ -302,8 +323,8 @@ mod tests {
         assert_eq!(int, BlockInterval(3));
 
         // interval -= interval
-        let mut int = BlockInterval(3);
-        int -= BlockInterval(2);
-        assert_eq!(int, BlockInterval(1));
+        let mut int = BlockInterval(10);
+        int -= BlockInterval(7);
+        assert_eq!(int, BlockInterval(3));
     }
 }

--- a/units/src/locktime/absolute.rs
+++ b/units/src/locktime/absolute.rs
@@ -473,6 +473,15 @@ mod tests {
     }
 
     #[test]
+    fn is_block_height_or_time() {
+        assert!(is_block_height(499_999_999));
+        assert!(!is_block_height(500_000_000));
+
+        assert!(!is_block_time(499_999_999));
+        assert!(is_block_time(500_000_000));
+    }
+
+    #[test]
     #[cfg(feature = "serde")]
     pub fn encode_decode_height() {
         serde_round_trip!(Height::ZERO);

--- a/units/src/locktime/relative.rs
+++ b/units/src/locktime/relative.rs
@@ -116,6 +116,8 @@ impl Time {
 
     /// Returns the `u32` value used to encode this locktime in an nSequence field or
     /// argument to `OP_CHECKSEQUENCEVERIFY`.
+    /// TODO: Skip this in cargo-mutants. It will replace | with ^, which will return the same
+    /// value since the XOR is always taken against the u16 and an all-zero bitmask
     #[inline]
     pub const fn to_consensus_u32(self) -> u32 {
         (1u32 << 22) | self.0 as u32 // cast safety: u32 is wider than u16 on all architectures
@@ -192,6 +194,13 @@ mod tests {
     use super::*;
 
     const MAXIMUM_ENCODABLE_SECONDS: u32 = u16::MAX as u32 * 512;
+
+    #[test]
+    fn sanity_check() {
+        assert_eq!(Height::MAX.to_consensus_u32(), u32::from(u16::MAX));
+        assert_eq!(Time::from_512_second_intervals(100).value(), 100u16);
+        assert_eq!(Time::from_512_second_intervals(100).to_consensus_u32(), 4_194_404u32); // 0x400064
+    }
 
     #[test]
     fn from_seconds_ceil_success() {

--- a/units/src/weight.rs
+++ b/units/src/weight.rs
@@ -251,6 +251,11 @@ mod tests {
     const FOUR: Weight = Weight(4);
 
     #[test]
+    fn sanity_check() {
+        assert_eq!(Weight::MIN_TRANSACTION, Weight(240));
+    }
+
+    #[test]
     fn from_kwu() {
         let got = Weight::from_kwu(1).unwrap();
         let want = Weight(1_000);
@@ -302,8 +307,8 @@ mod tests {
 
     #[test]
     fn to_kwu_floor() {
-        assert_eq!(Weight(1_000).to_kwu_floor(), 1);
-        assert_eq!(Weight(1_999).to_kwu_floor(), 1);
+        assert_eq!(Weight(5_000).to_kwu_floor(), 5);
+        assert_eq!(Weight(5_999).to_kwu_floor(), 5);
     }
 
     #[test]
@@ -314,8 +319,8 @@ mod tests {
 
     #[test]
     fn to_vb_floor() {
-        assert_eq!(Weight(4).to_vbytes_floor(), 1);
-        assert_eq!(Weight(5).to_vbytes_floor(), 1);
+        assert_eq!(Weight(8).to_vbytes_floor(), 2);
+        assert_eq!(Weight(9).to_vbytes_floor(), 2);
     }
 
     #[test]
@@ -374,14 +379,33 @@ mod tests {
     #[test]
     #[allow(clippy::op_ref)]
     fn subtract() {
-        let one = Weight(1);
-        let two = Weight(2);
+        let ten = Weight(10);
+        let seven = Weight(7);
         let three = Weight(3);
 
-        assert!(three - two == one);
-        assert!(&three - two == one);
-        assert!(three - &two == one);
-        assert!(&three - &two == one);
+        assert_eq!(ten - seven, three);
+        assert_eq!(&ten - seven, three);
+        assert_eq!(ten - &seven, three);
+        assert_eq!(&ten - &seven, three);
+    }
+
+    #[test]
+    #[allow(clippy::op_ref)]
+    fn multiply() {
+        let two = Weight(2);
+        let six = Weight(6);
+
+        assert_eq!(3_u64 * two, six);
+        assert_eq!(two * 3_u64, six);
+    }
+
+    #[test]
+    fn divide() {
+        let eight = Weight(8);
+        let four = Weight(4);
+
+        assert_eq!(eight / four, 2_u64);
+        assert_eq!(eight / 4_u64, Weight(2));
     }
 
     #[test]
@@ -404,5 +428,19 @@ mod tests {
         let mut f = Weight(3);
         f -= &Weight(2);
         assert_eq!(f, Weight(1));
+    }
+
+    #[test]
+    fn mul_assign() {
+        let mut w = Weight(3);
+        w *= 2_u64;
+        assert_eq!(w, Weight(6));
+    }
+
+    #[test]
+    fn div_assign() {
+        let mut w = Weight(8);
+        w /= Weight(4).into();
+        assert_eq!(w, Weight(2));
     }
 }


### PR DESCRIPTION
Preemptively addressing these mutants before introducing the `cargo-mutants` workflow. There are several types of changes:
- Changes that address mutants that were actually missing
- Changes that address test values that cause `cargo-mutants` to think mutants were missed. For example, `cargo-mutants` will replace the return values for unsigned integer types with 0 and 1. While this case might be tested, the test might be testing this with a call that results in 0 or 1. When `cargo-mutants` substitutes the function call with `Ok(1)`, the test will still pass, and it will consider this a mutant. `cargo-mutants` also replaces operations (+, -, /, %), bitwise operations (&, |, ^, etc), so an operation such as `3 - 2` results in a mutant because changing it to `3 / 2` yields the same result
- TODOs to ignore functions/impls in the future

I uased the following `mutants.toml` config file when running `cargo mutants` and skipped the `Debug`, `Arbitrary`, `Display`, and `Error` impls and the `kani` test:
```
additional_cargo_args = ["--all-features"]
examine_globs = ["units/src/**/*.rs"]
exclude_globs = ["units/src/amount/verification.rs"]
exclude_re = ["impl Debug", "impl Arbitrary", "impl Display", ".*Error", "<impl Visitor for VisitOptAmt<X>>"]
```

I wasn't sure the code for Displaying things needed to be tested with `cargo mutants`, but I'm less sure about the errors so i can kill those mutants too if needed