### PR TITLE
Remove macro `debug_from_display`

### DIFF
--- a/bitcoin/src/blockdata/script/builder.rs
+++ b/bitcoin/src/blockdata/script/builder.rs
@@ -150,4 +150,8 @@ impl fmt::Display for Builder {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(&self.0, f) }
 }
 
-internals::debug_from_display!(Builder);
+impl fmt::Debug for Builder {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        fmt::Display::fmt(self, f)
+    }
+}

--- a/bitcoin/src/p2p/mod.rs
+++ b/bitcoin/src/p2p/mod.rs
@@ -24,7 +24,7 @@ use core::str::FromStr;
 use core::{fmt, ops};
 
 use hex::FromHex;
-use internals::{debug_from_display, impl_to_hex_from_lower_hex, write_err};
+use internals::{impl_to_hex_from_lower_hex, write_err};
 use io::{BufRead, Write};
 
 use crate::consensus::encode::{self, Decodable, Encodable};
@@ -291,7 +291,12 @@ impl fmt::Display for Magic {
         Ok(())
     }
 }
-debug_from_display!(Magic);
+
+impl fmt::Debug for Magic {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        fmt::Display::fmt(self, f)
+    }
+}
 
 impl fmt::LowerHex for Magic {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {

--- a/internals/src/macros.rs
+++ b/internals/src/macros.rs
@@ -2,21 +2,6 @@
 
 //! Various macros used by the Rust Bitcoin ecosystem.
 
-/// Implements `Debug` by calling through to `Display`.
-#[macro_export]
-macro_rules! debug_from_display {
-    ($thing:ident) => {
-        impl core::fmt::Debug for $thing {
-            fn fmt(
-                &self,
-                f: &mut core::fmt::Formatter,
-            ) -> core::result::Result<(), core::fmt::Error> {
-                core::fmt::Display::fmt(self, f)
-            }
-        }
-    };
-}
-
 /// Asserts a boolean expression at compile time.
 #[macro_export]
 macro_rules! const_assert {

--- a/primitives/src/opcodes.rs
+++ b/primitives/src/opcodes.rs
@@ -9,8 +9,6 @@
 
 use core::fmt;
 
-use internals::debug_from_display;
-
 #[cfg(feature = "serde")]
 use crate::prelude::ToString;
 
@@ -441,7 +439,11 @@ impl From<u8> for Opcode {
     fn from(b: u8) -> Opcode { Opcode { code: b } }
 }
 
-debug_from_display!(Opcode);
+impl fmt::Debug for Opcode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        fmt::Display::fmt(self, f)
+    }
+}
 
 #[cfg(feature = "serde")]
 impl serde::Serialize for Opcode {


### PR DESCRIPTION
Rust macros, while at times useful, are a maintenance nightmare. And we have been bitten by calling macros from other crates multiple times in the past.

In a push to just use less macros remove the `debug_from_display` macro and just write the code.

This is an API breaking change to `internals` but an internal change only to any of the _real_ crates.