### PR TITLE
Remove usage of impl_from_infallible in leaf crates

### DIFF
--- a/hashes/src/error.rs
+++ b/hashes/src/error.rs
@@ -2,13 +2,16 @@
 
 //! Error code for the `hashes` crate.
 
+use core::convert::Infallible;
 use core::fmt;
 
 /// Attempted to create a hash from an invalid length slice.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FromSliceError(pub(crate) FromSliceErrorInner);
 
-impl_from_infallible!(FromSliceError);
+impl From<Infallible> for FromSliceError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
 
 impl FromSliceError {
     /// Returns the expected slice length.
@@ -25,7 +28,9 @@ pub(crate) struct FromSliceErrorInner {
     pub(crate) got: usize,
 }
 
-impl_from_infallible!(FromSliceErrorInner);
+impl From<Infallible> for FromSliceErrorInner {
+    fn from(never: Infallible) -> Self { match never {} }
+}
 
 impl fmt::Display for FromSliceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -35,19 +40,3 @@ impl fmt::Display for FromSliceError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for FromSliceError {}
-
-/// Derives `From<core::convert::Infallible>` for the given type.
-// This is a duplicate of `internals::impl_from_infallible`, see there for complete docs.
-#[doc(hidden)]
-macro_rules! impl_from_infallible {
-    ( $name:ident $(< $( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+ >)? ) => {
-        impl $(< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)?
-            From<core::convert::Infallible>
-        for $name
-            $(< $( $lt ),+ >)?
-        {
-            fn from(never: core::convert::Infallible) -> Self { match never {} }
-        }
-    }
-}
-pub(crate) use impl_from_infallible;

--- a/primitives/src/script/mod.rs
+++ b/primitives/src/script/mod.rs
@@ -8,6 +8,7 @@ mod borrowed;
 mod owned;
 
 use core::cmp::Ordering;
+use core::convert::Infallible;
 use core::fmt;
 use core::ops::{Deref, DerefMut};
 
@@ -158,7 +159,9 @@ pub struct RedeemScriptSizeError {
     pub size: usize,
 }
 
-internals::impl_from_infallible!(RedeemScriptSizeError);
+impl From<Infallible> for RedeemScriptSizeError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
 
 impl fmt::Display for RedeemScriptSizeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -176,7 +179,9 @@ pub struct WitnessScriptSizeError {
     pub size: usize,
 }
 
-internals::impl_from_infallible!(WitnessScriptSizeError);
+impl From<Infallible> for WitnessScriptSizeError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
 
 impl fmt::Display for WitnessScriptSizeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -12,6 +12,7 @@
 
 #[cfg(feature = "alloc")]
 use core::cmp;
+use core::convert::Infallible;
 use core::fmt;
 
 #[cfg(feature = "arbitrary")]
@@ -444,7 +445,9 @@ pub enum ParseOutPointError {
 }
 
 #[cfg(feature = "alloc")]
-internals::impl_from_infallible!(ParseOutPointError);
+impl From<Infallible> for ParseOutPointError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
 
 #[cfg(feature = "alloc")]
 impl fmt::Display for ParseOutPointError {

--- a/units/src/amount/error.rs
+++ b/units/src/amount/error.rs
@@ -2,6 +2,7 @@
 
 //! Error types for bitcoin amounts.
 
+use core::convert::Infallible;
 use core::fmt;
 
 use internals::error::InputString;
@@ -23,8 +24,13 @@ pub(crate) enum ParseErrorInner {
     MissingDenomination(MissingDenominationError),
 }
 
-internals::impl_from_infallible!(ParseError);
-internals::impl_from_infallible!(ParseErrorInner);
+impl From<Infallible> for ParseError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+impl From<Infallible> for ParseErrorInner {
+    fn from(never: Infallible) -> Self { match never {} }
+}
 
 impl From<ParseAmountError> for ParseError {
     fn from(e: ParseAmountError) -> Self { Self(ParseErrorInner::Amount(e)) }
@@ -114,8 +120,13 @@ impl From<InvalidCharacterError> for ParseAmountError {
     }
 }
 
-internals::impl_from_infallible!(ParseAmountError);
-internals::impl_from_infallible!(ParseAmountErrorInner);
+impl From<Infallible> for ParseAmountError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+impl From<Infallible> for ParseAmountErrorInner {
+    fn from(never: Infallible) -> Self { match never {} }
+}
 
 impl fmt::Display for ParseAmountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -318,7 +329,9 @@ pub enum ParseDenominationError {
     PossiblyConfusing(PossiblyConfusingDenominationError),
 }
 
-internals::impl_from_infallible!(ParseDenominationError);
+impl From<Infallible> for ParseDenominationError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
 
 impl fmt::Display for ParseDenominationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/units/src/amount/mod.rs
+++ b/units/src/amount/mod.rs
@@ -17,6 +17,7 @@ mod unsigned;
 mod verification;
 
 use core::cmp::Ordering;
+use core::convert::Infallible;
 use core::fmt;
 use core::str::FromStr;
 
@@ -292,7 +293,9 @@ enum InnerParseError {
     InvalidCharacter(InvalidCharacterError),
 }
 
-internals::impl_from_infallible!(InnerParseError);
+impl From<Infallible> for InnerParseError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
 
 impl InnerParseError {
     fn convert(self, is_signed: bool) -> ParseAmountError {

--- a/units/src/locktime/absolute.rs
+++ b/units/src/locktime/absolute.rs
@@ -2,6 +2,7 @@
 
 //! Provides [`Height`] and [`Time`] types used by the `rust-bitcoin` `absolute::LockTime` type.
 
+use core::convert::Infallible;
 use core::fmt;
 
 #[cfg(feature = "arbitrary")]
@@ -307,7 +308,9 @@ enum ParseError {
     Conversion(i64),
 }
 
-internals::impl_from_infallible!(ParseError);
+impl From<Infallible> for ParseError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
 
 impl ParseError {
     fn invalid_int<S: Into<InputString>>(s: S) -> impl FnOnce(core::num::ParseIntError) -> Self {

--- a/units/src/parse.rs
+++ b/units/src/parse.rs
@@ -2,6 +2,7 @@
 
 //! Parsing utilities.
 
+use core::convert::Infallible;
 use core::fmt;
 use core::str::FromStr;
 
@@ -313,8 +314,13 @@ enum PrefixedHexErrorInner {
     ParseInt(ParseIntError),
 }
 
-internals::impl_from_infallible!(PrefixedHexError);
-internals::impl_from_infallible!(PrefixedHexErrorInner);
+impl From<Infallible> for PrefixedHexError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+impl From<Infallible> for PrefixedHexErrorInner {
+    fn from(never: Infallible) -> Self { match never {} }
+}
 
 impl fmt::Display for PrefixedHexError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -359,8 +365,13 @@ enum UnprefixedHexErrorInner {
     ParseInt(ParseIntError),
 }
 
-internals::impl_from_infallible!(UnprefixedHexError);
-internals::impl_from_infallible!(UnprefixedHexErrorInner);
+impl From<Infallible> for UnprefixedHexError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+impl From<Infallible> for UnprefixedHexErrorInner {
+    fn from(never: Infallible) -> Self { match never {} }
+}
 
 impl fmt::Display for UnprefixedHexError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
Rust macros, while at times useful, are a maintenance nightmare. And we have been bitten by calling macros from other crates multiple times in the past.

In a push to just use less macros remove the usage of the `impl_from_infallible` macro in all the leaf crates and just write the code.