### PR TITLE
Add parenthesis to explicitly show precedence

### DIFF
--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -723,7 +723,7 @@ mod tests {
     #[test]
     fn soft_fork_signalling() {
         for i in 0..31 {
-            let version_int = (0x20000000u32 ^ 1 << i) as i32;
+            let version_int = (0x20000000u32 ^ (1 << i)) as i32;
             let version = Version::from_consensus(version_int);
             if i < 29 {
                 assert!(version.is_signalling_soft_fork(i));
@@ -732,7 +732,7 @@ mod tests {
             }
         }
 
-        let segwit_signal = Version::from_consensus(0x20000000 ^ 1 << 1);
+        let segwit_signal = Version::from_consensus(0x20000000 ^ (1 << 1));
         assert!(!segwit_signal.is_signalling_soft_fork(0));
         assert!(segwit_signal.is_signalling_soft_fork(1));
         assert!(!segwit_signal.is_signalling_soft_fork(2));

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -618,8 +618,8 @@ impl U256 {
             carry = n >> 64; // and carry the high bits.
         }
 
-        let low = u128::from(split_le[0]) | u128::from(split_le[1]) << 64;
-        let high = u128::from(split_le[2]) | u128::from(split_le[3]) << 64;
+        let low = u128::from(split_le[0]) | (u128::from(split_le[1]) << 64);
+        let high = u128::from(split_le[2]) | (u128::from(split_le[3]) << 64);
         (Self(high, low), carry != 0)
     }
 
@@ -872,7 +872,7 @@ impl U256 {
         // (This is why we only care if the other non-msb dropped bits are all 0 or not,
         // so we can just OR them to make sure any bits show up somewhere.)
         let mantissa =
-            (mantissa + ((dropped_bits - (dropped_bits >> 127 & !mantissa)) >> 127)) as u64;
+            (mantissa + ((dropped_bits - ((dropped_bits >> 127) & !mantissa)) >> 127)) as u64;
         // Step 6: Calculate the exponent
         // If self is 0, exponent should be 0 (special meaning) and mantissa will end up 0 too
         // Otherwise, (255 - n) + 1022 so it simplifies to 1277 - n
@@ -1115,8 +1115,8 @@ mod tests {
         /// Constructs a new U256 from a big-endian array of u64's
         fn from_array(a: [u64; 4]) -> Self {
             let mut ret = U256::ZERO;
-            ret.0 = (a[0] as u128) << 64 ^ (a[1] as u128);
-            ret.1 = (a[2] as u128) << 64 ^ (a[3] as u128);
+            ret.0 = ((a[0] as u128) << 64) ^ (a[1] as u128);
+            ret.1 = ((a[2] as u128) << 64) ^ (a[3] as u128);
             ret
         }
     }
@@ -1559,11 +1559,11 @@ mod tests {
     #[test]
     fn u256_multiplication_bits_in_each_word() {
         // Put a digit in the least significant bit of each 64 bit word.
-        let u = 1_u128 << 64 | 1_u128;
+        let u = (1_u128 << 64) | 1_u128;
         let x = U256(u, u);
 
         // Put a digit in the second least significant bit of each 64 bit word.
-        let u = 2_u128 << 64 | 2_u128;
+        let u = (2_u128 << 64) | 2_u128;
         let y = U256(u, u);
 
         let (got, overflow) = x.overflowing_mul(y);

--- a/chacha20_poly1305/src/poly1305.rs
+++ b/chacha20_poly1305/src/poly1305.rs
@@ -134,10 +134,10 @@ impl Poly1305 {
             self.acc[i] = t & mask | self.acc[i] & !mask;
         }
         // Voodoo from donna to convert to [u32; 4].
-        let a0 = self.acc[0] | self.acc[1] << 26;
-        let a1 = self.acc[1] >> 6 | self.acc[2] << 20;
-        let a2 = self.acc[2] >> 12 | self.acc[3] << 14;
-        let a3 = self.acc[3] >> 18 | self.acc[4] << 8;
+        let a0 = self.acc[0] | (self.acc[1] << 26);
+        let a1 = (self.acc[1] >> 6) | (self.acc[2] << 20);
+        let a2 = (self.acc[2] >> 12) | (self.acc[3] << 14);
+        let a3 = (self.acc[3] >> 18) | (self.acc[4] << 8);
         let a = [a0, a1, a2, a3];
         // a + s
         let mut tag: [u64; 4] = [0; 4];
@@ -196,21 +196,21 @@ fn prepare_padded_message_slice(msg: &[u8], is_last: bool) -> [u32; 5] {
     // Encode number in five 26-bit limbs.
     let m0 = u32::from_le_bytes(fmt_msg[0..4].try_into().expect("Valid subset of 32.")) & BITMASK;
     let m1 =
-        u32::from_le_bytes(fmt_msg[3..7].try_into().expect("Valid subset of 32.")) >> 2 & BITMASK;
+        (u32::from_le_bytes(fmt_msg[3..7].try_into().expect("Valid subset of 32.")) >> 2) & BITMASK;
     let m2 =
-        u32::from_le_bytes(fmt_msg[6..10].try_into().expect("Valid subset of 32.")) >> 4 & BITMASK;
+        (u32::from_le_bytes(fmt_msg[6..10].try_into().expect("Valid subset of 32.")) >> 4) & BITMASK;
     let m3 =
-        u32::from_le_bytes(fmt_msg[9..13].try_into().expect("Valid subset of 32.")) >> 6 & BITMASK;
+        (u32::from_le_bytes(fmt_msg[9..13].try_into().expect("Valid subset of 32.")) >> 6) & BITMASK;
     let m4 =
-        u32::from_le_bytes(fmt_msg[12..16].try_into().expect("Valid subset of 32.")) >> 8 | hi_bit;
+        (u32::from_le_bytes(fmt_msg[12..16].try_into().expect("Valid subset of 32.")) >> 8) | hi_bit;
     [m0, m1, m2, m3, m4]
 }
 
 fn _print_acc(num: &[u32; 5]) {
-    let a0 = num[0] | num[1] << 26;
-    let a1 = num[1] >> 6 | num[2] << 20;
-    let a2 = num[2] >> 12 | num[3] << 14;
-    let a3 = num[3] >> 18 | num[4] << 8;
+    let a0 = num[0] | (num[1] << 26);
+    let a1 = (num[1] >> 6) | (num[2] << 20);
+    let a2 = (num[2] >> 12) | (num[3] << 14);
+    let a3 = (num[3] >> 18) | (num[4] << 8);
     let a = [a0, a1, a2, a3];
     let mut ret: [u8; 16] = [0; 16];
     for i in 0..a.len() {


### PR DESCRIPTION
Recent clippy nightly update introduces warnings about precedence. While ours are, IMO, clear the lint docs have some cases that are not so I don't think we should ignore this lint. Specifically I could easily miss this one

  1 << 2 + 3 equals 32, while (1 << 2) + 3 equals 7

ref: https://rust-lang.github.io/rust-clippy/master/#/precede

Add parenthesis to explicitly show precedence. Refactor only no logic changes.