### PR TITLE
io: Use get_ref / get_mut API

### DIFF
--- a/io/src/bridge.rs
+++ b/io/src/bridge.rs
@@ -12,18 +12,6 @@ impl<T> FromStd<T> {
     #[inline]
     pub const fn new(inner: T) -> Self { Self(inner) }
 
-    /// Returns the wrapped value.
-    #[inline]
-    pub fn into_inner(self) -> T { self.0 }
-
-    /// Returns a reference to the wrapped value.
-    #[inline]
-    pub fn inner(&self) -> &T { &self.0 }
-
-    /// Returns a mutable reference to the wrapped value.
-    #[inline]
-    pub fn inner_mut(&mut self) -> &mut T { &mut self.0 }
-
     /// Wraps a mutable reference to IO type.
     #[inline]
     pub fn new_mut(inner: &mut T) -> &mut Self {
@@ -38,6 +26,18 @@ impl<T> FromStd<T> {
         // SAFETY: the type is repr(transparent) and the pointer is created from Box
         unsafe { Box::from_raw(Box::into_raw(inner) as *mut Self) }
     }
+
+    /// Returns the wrapped value.
+    #[inline]
+    pub fn into_inner(self) -> T { self.0 }
+
+    /// Returns a reference to the wrapped value.
+    #[inline]
+    pub fn inner(&self) -> &T { &self.0 }
+
+    /// Returns a mutable reference to the wrapped value.
+    #[inline]
+    pub fn inner_mut(&mut self) -> &mut T { &mut self.0 }
 }
 
 impl<T: std::io::Read> super::Read for FromStd<T> {

--- a/io/src/bridge.rs
+++ b/io/src/bridge.rs
@@ -33,10 +33,20 @@ impl<T> FromStd<T> {
 
     /// Returns a reference to the wrapped value.
     #[inline]
+    pub fn get_ref(&self) -> &T { &self.0 }
+
+    /// Returns a mutable reference to the wrapped value.
+    #[inline]
+    pub fn get_mut(&mut self) -> &mut T { &mut self.0 }
+
+    /// Returns a reference to the wrapped value.
+    #[inline]
+    #[deprecated(since = "TBD", note = "use `get_ref()` instead")]
     pub fn inner(&self) -> &T { &self.0 }
 
     /// Returns a mutable reference to the wrapped value.
     #[inline]
+    #[deprecated(since = "TBD", note = "use `get_ref()` instead")]
     pub fn inner_mut(&mut self) -> &mut T { &mut self.0 }
 }
 


### PR DESCRIPTION
Currently in the `bridge` module to get a reference and mutable reference we provide the `as_inner` and `inner_mut` functions. These names are not in line with the `std::io` module which favours `get_ref` and `get_mut`.

Add inherent functions `get_ref` and `get_mut` for accessing the wrapped value in `bridge::ToStd` and deprecate `as_inner` and `inner_mut`.

To convince yourself this API is correct grep the stdlib `io` module for `fn get_ref` as opposed to `fn as_ref`.

Close: #3832
