### PR TITLE
Bound `Address` parsing on `NetworkValidationUnchecked`

### DIFF
--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -880,7 +880,7 @@ impl<V: NetworkValidation> fmt::Debug for Address<V> {
 ///   not a valid base58 address.
 ///
 /// - [`UnknownHrpError`] if the address does not begin with one of the above SegWit or
-///   legacy prifixes.
+///   legacy prefixes.
 impl FromStr for Address<NetworkUnchecked> {
     type Err = ParseError;
 


### PR DESCRIPTION
Currently it is not possible for downstream to use a generic on the `Address` type in structs in conjuncture with
derives (`serde::Deserialize` and `Display`) because our impls are only done for `NetworkUnchecked` (as they should be).

However, as observed by dpc, if we add a secondary marker trait and use it to bound the impls, implementing the new marker for `NetworkUnchecked` then downstream can use derives by way of

```
    #[derive(Serialize, Deserialize)]
    struct Foo<V>
        where V: NetworkValidation,
    {
        #[serde(bound(deserialize = "V: NetworkValidationUnchecked"))]
        address: Address<V>,
    }
```

This is cool as hell because the `Address` type is currently a royal PITA.

Patch 1 is trivial cleanup.

To get past a build error in `FromStr` I used this little trick
```rust
            // We know that `U` is only ever `NetworkUnchecked` but the compiler does not.
            Ok(Address(address.0, PhantomData::<U>))
```

Resolve: #3760
and
Close: #3856