### PR TITLE
io: Add traits

### DIFF
--- a/api/io/all-features.txt
+++ b/api/io/all-features.txt
@@ -47,12 +47,14 @@ impl bitcoin_io::Write for std::net::tcp::TcpStream
 impl bitcoin_io::Write for std::os::unix::net::stream::UnixStream
 impl bitcoin_io::Write for std::process::ChildStdin
 impl core::clone::Clone for bitcoin_io::ErrorKind
+impl core::clone::Clone for bitcoin_io::Sink
 impl core::cmp::Eq for bitcoin_io::ErrorKind
 impl core::cmp::PartialEq for bitcoin_io::ErrorKind
 impl core::convert::From<bitcoin_io::Error> for std::io::error::Error
 impl core::convert::From<bitcoin_io::ErrorKind> for bitcoin_io::Error
 impl core::convert::From<core::convert::Infallible> for bitcoin_io::ErrorKind
 impl core::convert::From<std::io::error::Error> for bitcoin_io::Error
+impl core::default::Default for bitcoin_io::Sink
 impl core::error::Error for bitcoin_io::Error
 impl core::fmt::Debug for bitcoin_io::Error
 impl core::fmt::Debug for bitcoin_io::ErrorKind
@@ -60,6 +62,7 @@ impl core::fmt::Debug for bitcoin_io::Sink
 impl core::fmt::Display for bitcoin_io::Error
 impl core::hash::Hash for bitcoin_io::ErrorKind
 impl core::marker::Copy for bitcoin_io::ErrorKind
+impl core::marker::Copy for bitcoin_io::Sink
 impl core::marker::Freeze for bitcoin_io::Error
 impl core::marker::Freeze for bitcoin_io::ErrorKind
 impl core::marker::Freeze for bitcoin_io::Sink
@@ -102,11 +105,15 @@ impl<T: bitcoin_io::Read> std::io::Read for bitcoin_io::ToStd<T>
 impl<T: bitcoin_io::Write> bitcoin_io::Write for &mut T
 impl<T: bitcoin_io::Write> bitcoin_io::Write for bitcoin_io::ToStd<T>
 impl<T: bitcoin_io::Write> std::io::Write for bitcoin_io::ToStd<T>
+impl<T: core::clone::Clone> core::clone::Clone for bitcoin_io::Cursor<T>
+impl<T: core::cmp::Eq> core::cmp::Eq for bitcoin_io::Cursor<T>
+impl<T: core::cmp::PartialEq> core::cmp::PartialEq for bitcoin_io::Cursor<T>
 impl<T: core::convert::AsRef<[u8]>> bitcoin_io::BufRead for bitcoin_io::Cursor<T>
 impl<T: core::convert::AsRef<[u8]>> bitcoin_io::BufRead for std::io::cursor::Cursor<T>
 impl<T: core::convert::AsRef<[u8]>> bitcoin_io::Cursor<T>
 impl<T: core::convert::AsRef<[u8]>> bitcoin_io::Read for bitcoin_io::Cursor<T>
 impl<T: core::convert::AsRef<[u8]>> bitcoin_io::Read for std::io::cursor::Cursor<T>
+impl<T: core::default::Default> core::default::Default for bitcoin_io::Cursor<T>
 impl<T: core::fmt::Debug> core::fmt::Debug for bitcoin_io::Cursor<T>
 impl<T: core::fmt::Debug> core::fmt::Debug for bitcoin_io::FromStd<T>
 impl<T: core::fmt::Debug> core::fmt::Debug for bitcoin_io::ToStd<T>
@@ -124,6 +131,7 @@ impl<T> core::marker::Freeze for bitcoin_io::ToStd<T> where T: core::marker::Fre
 impl<T> core::marker::Send for bitcoin_io::Cursor<T> where T: core::marker::Send
 impl<T> core::marker::Send for bitcoin_io::FromStd<T> where T: core::marker::Send
 impl<T> core::marker::Send for bitcoin_io::ToStd<T> where T: core::marker::Send
+impl<T> core::marker::StructuralPartialEq for bitcoin_io::Cursor<T>
 impl<T> core::marker::Sync for bitcoin_io::Cursor<T> where T: core::marker::Sync
 impl<T> core::marker::Sync for bitcoin_io::FromStd<T> where T: core::marker::Sync
 impl<T> core::marker::Sync for bitcoin_io::ToStd<T> where T: core::marker::Sync
@@ -217,7 +225,10 @@ pub fn alloc::vec::Vec<u8>::flush(&mut self) -> bitcoin_io::Result<()>
 pub fn alloc::vec::Vec<u8>::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
 pub fn bitcoin_io::BufRead::consume(&mut self, amount: usize)
 pub fn bitcoin_io::BufRead::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn bitcoin_io::Cursor<T>::clone(&self) -> bitcoin_io::Cursor<T>
 pub fn bitcoin_io::Cursor<T>::consume(&mut self, amount: usize)
+pub fn bitcoin_io::Cursor<T>::default() -> bitcoin_io::Cursor<T>
+pub fn bitcoin_io::Cursor<T>::eq(&self, other: &bitcoin_io::Cursor<T>) -> bool
 pub fn bitcoin_io::Cursor<T>::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
 pub fn bitcoin_io::Cursor<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_io::Cursor<T>::get_mut(&mut self) -> &mut T
@@ -268,6 +279,8 @@ pub fn bitcoin_io::Read::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<u
 pub fn bitcoin_io::Read::read_exact(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<()>
 pub fn bitcoin_io::Read::read_to_limit(&mut self, buf: &mut alloc::vec::Vec<u8>, limit: u64) -> bitcoin_io::Result<usize>
 pub fn bitcoin_io::Read::take(&mut self, limit: u64) -> bitcoin_io::Take<'_, Self>
+pub fn bitcoin_io::Sink::clone(&self) -> bitcoin_io::Sink
+pub fn bitcoin_io::Sink::default() -> bitcoin_io::Sink
 pub fn bitcoin_io::Sink::flush(&mut self) -> bitcoin_io::Result<()>
 pub fn bitcoin_io::Sink::flush(&mut self) -> std::io::error::Result<()>
 pub fn bitcoin_io::Sink::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result

--- a/api/io/alloc-only.txt
+++ b/api/io/alloc-only.txt
@@ -8,16 +8,19 @@ impl bitcoin_io::Write for &mut [u8]
 impl bitcoin_io::Write for alloc::vec::Vec<u8>
 impl bitcoin_io::Write for bitcoin_io::Sink
 impl core::clone::Clone for bitcoin_io::ErrorKind
+impl core::clone::Clone for bitcoin_io::Sink
 impl core::cmp::Eq for bitcoin_io::ErrorKind
 impl core::cmp::PartialEq for bitcoin_io::ErrorKind
 impl core::convert::From<bitcoin_io::ErrorKind> for bitcoin_io::Error
 impl core::convert::From<core::convert::Infallible> for bitcoin_io::ErrorKind
+impl core::default::Default for bitcoin_io::Sink
 impl core::fmt::Debug for bitcoin_io::Error
 impl core::fmt::Debug for bitcoin_io::ErrorKind
 impl core::fmt::Debug for bitcoin_io::Sink
 impl core::fmt::Display for bitcoin_io::Error
 impl core::hash::Hash for bitcoin_io::ErrorKind
 impl core::marker::Copy for bitcoin_io::ErrorKind
+impl core::marker::Copy for bitcoin_io::Sink
 impl core::marker::Freeze for bitcoin_io::Error
 impl core::marker::Freeze for bitcoin_io::ErrorKind
 impl core::marker::Freeze for bitcoin_io::Sink
@@ -47,12 +50,17 @@ impl<R: bitcoin_io::Read + ?core::marker::Sized> bitcoin_io::Take<'_, R>
 impl<T: bitcoin_io::BufRead> bitcoin_io::BufRead for &mut T
 impl<T: bitcoin_io::Read> bitcoin_io::Read for &mut T
 impl<T: bitcoin_io::Write> bitcoin_io::Write for &mut T
+impl<T: core::clone::Clone> core::clone::Clone for bitcoin_io::Cursor<T>
+impl<T: core::cmp::Eq> core::cmp::Eq for bitcoin_io::Cursor<T>
+impl<T: core::cmp::PartialEq> core::cmp::PartialEq for bitcoin_io::Cursor<T>
 impl<T: core::convert::AsRef<[u8]>> bitcoin_io::BufRead for bitcoin_io::Cursor<T>
 impl<T: core::convert::AsRef<[u8]>> bitcoin_io::Cursor<T>
 impl<T: core::convert::AsRef<[u8]>> bitcoin_io::Read for bitcoin_io::Cursor<T>
+impl<T: core::default::Default> core::default::Default for bitcoin_io::Cursor<T>
 impl<T: core::fmt::Debug> core::fmt::Debug for bitcoin_io::Cursor<T>
 impl<T> core::marker::Freeze for bitcoin_io::Cursor<T> where T: core::marker::Freeze
 impl<T> core::marker::Send for bitcoin_io::Cursor<T> where T: core::marker::Send
+impl<T> core::marker::StructuralPartialEq for bitcoin_io::Cursor<T>
 impl<T> core::marker::Sync for bitcoin_io::Cursor<T> where T: core::marker::Sync
 impl<T> core::marker::Unpin for bitcoin_io::Cursor<T> where T: core::marker::Unpin
 impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::Cursor<T> where T: core::panic::unwind_safe::RefUnwindSafe
@@ -92,7 +100,10 @@ pub fn alloc::vec::Vec<u8>::flush(&mut self) -> bitcoin_io::Result<()>
 pub fn alloc::vec::Vec<u8>::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
 pub fn bitcoin_io::BufRead::consume(&mut self, amount: usize)
 pub fn bitcoin_io::BufRead::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn bitcoin_io::Cursor<T>::clone(&self) -> bitcoin_io::Cursor<T>
 pub fn bitcoin_io::Cursor<T>::consume(&mut self, amount: usize)
+pub fn bitcoin_io::Cursor<T>::default() -> bitcoin_io::Cursor<T>
+pub fn bitcoin_io::Cursor<T>::eq(&self, other: &bitcoin_io::Cursor<T>) -> bool
 pub fn bitcoin_io::Cursor<T>::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
 pub fn bitcoin_io::Cursor<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_io::Cursor<T>::get_mut(&mut self) -> &mut T
@@ -118,6 +129,8 @@ pub fn bitcoin_io::Read::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<u
 pub fn bitcoin_io::Read::read_exact(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<()>
 pub fn bitcoin_io::Read::read_to_limit(&mut self, buf: &mut alloc::vec::Vec<u8>, limit: u64) -> bitcoin_io::Result<usize>
 pub fn bitcoin_io::Read::take(&mut self, limit: u64) -> bitcoin_io::Take<'_, Self>
+pub fn bitcoin_io::Sink::clone(&self) -> bitcoin_io::Sink
+pub fn bitcoin_io::Sink::default() -> bitcoin_io::Sink
 pub fn bitcoin_io::Sink::flush(&mut self) -> bitcoin_io::Result<()>
 pub fn bitcoin_io::Sink::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_io::Sink::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>

--- a/api/io/no-features.txt
+++ b/api/io/no-features.txt
@@ -7,16 +7,19 @@ impl bitcoin_io::Read for &[u8]
 impl bitcoin_io::Write for &mut [u8]
 impl bitcoin_io::Write for bitcoin_io::Sink
 impl core::clone::Clone for bitcoin_io::ErrorKind
+impl core::clone::Clone for bitcoin_io::Sink
 impl core::cmp::Eq for bitcoin_io::ErrorKind
 impl core::cmp::PartialEq for bitcoin_io::ErrorKind
 impl core::convert::From<bitcoin_io::ErrorKind> for bitcoin_io::Error
 impl core::convert::From<core::convert::Infallible> for bitcoin_io::ErrorKind
+impl core::default::Default for bitcoin_io::Sink
 impl core::fmt::Debug for bitcoin_io::Error
 impl core::fmt::Debug for bitcoin_io::ErrorKind
 impl core::fmt::Debug for bitcoin_io::Sink
 impl core::fmt::Display for bitcoin_io::Error
 impl core::hash::Hash for bitcoin_io::ErrorKind
 impl core::marker::Copy for bitcoin_io::ErrorKind
+impl core::marker::Copy for bitcoin_io::Sink
 impl core::marker::Freeze for bitcoin_io::Error
 impl core::marker::Freeze for bitcoin_io::ErrorKind
 impl core::marker::Freeze for bitcoin_io::Sink
@@ -45,12 +48,17 @@ impl<R: bitcoin_io::Read + ?core::marker::Sized> bitcoin_io::Read for bitcoin_io
 impl<T: bitcoin_io::BufRead> bitcoin_io::BufRead for &mut T
 impl<T: bitcoin_io::Read> bitcoin_io::Read for &mut T
 impl<T: bitcoin_io::Write> bitcoin_io::Write for &mut T
+impl<T: core::clone::Clone> core::clone::Clone for bitcoin_io::Cursor<T>
+impl<T: core::cmp::Eq> core::cmp::Eq for bitcoin_io::Cursor<T>
+impl<T: core::cmp::PartialEq> core::cmp::PartialEq for bitcoin_io::Cursor<T>
 impl<T: core::convert::AsRef<[u8]>> bitcoin_io::BufRead for bitcoin_io::Cursor<T>
 impl<T: core::convert::AsRef<[u8]>> bitcoin_io::Cursor<T>
 impl<T: core::convert::AsRef<[u8]>> bitcoin_io::Read for bitcoin_io::Cursor<T>
+impl<T: core::default::Default> core::default::Default for bitcoin_io::Cursor<T>
 impl<T: core::fmt::Debug> core::fmt::Debug for bitcoin_io::Cursor<T>
 impl<T> core::marker::Freeze for bitcoin_io::Cursor<T> where T: core::marker::Freeze
 impl<T> core::marker::Send for bitcoin_io::Cursor<T> where T: core::marker::Send
+impl<T> core::marker::StructuralPartialEq for bitcoin_io::Cursor<T>
 impl<T> core::marker::Sync for bitcoin_io::Cursor<T> where T: core::marker::Sync
 impl<T> core::marker::Unpin for bitcoin_io::Cursor<T> where T: core::marker::Unpin
 impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::Cursor<T> where T: core::panic::unwind_safe::RefUnwindSafe
@@ -88,7 +96,10 @@ pub fn &mut [u8]::flush(&mut self) -> bitcoin_io::Result<()>
 pub fn &mut [u8]::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>
 pub fn bitcoin_io::BufRead::consume(&mut self, amount: usize)
 pub fn bitcoin_io::BufRead::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
+pub fn bitcoin_io::Cursor<T>::clone(&self) -> bitcoin_io::Cursor<T>
 pub fn bitcoin_io::Cursor<T>::consume(&mut self, amount: usize)
+pub fn bitcoin_io::Cursor<T>::default() -> bitcoin_io::Cursor<T>
+pub fn bitcoin_io::Cursor<T>::eq(&self, other: &bitcoin_io::Cursor<T>) -> bool
 pub fn bitcoin_io::Cursor<T>::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
 pub fn bitcoin_io::Cursor<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_io::Cursor<T>::get_mut(&mut self) -> &mut T
@@ -111,6 +122,8 @@ pub fn bitcoin_io::ErrorKind::hash<__H: core::hash::Hasher>(&self, state: &mut _
 pub fn bitcoin_io::Read::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
 pub fn bitcoin_io::Read::read_exact(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<()>
 pub fn bitcoin_io::Read::take(&mut self, limit: u64) -> bitcoin_io::Take<'_, Self>
+pub fn bitcoin_io::Sink::clone(&self) -> bitcoin_io::Sink
+pub fn bitcoin_io::Sink::default() -> bitcoin_io::Sink
 pub fn bitcoin_io::Sink::flush(&mut self) -> bitcoin_io::Result<()>
 pub fn bitcoin_io::Sink::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_io::Sink::write(&mut self, buf: &[u8]) -> bitcoin_io::Result<usize>

--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -192,7 +192,7 @@ impl BufRead for &[u8] {
 }
 
 /// Wraps an in memory reader providing the `position` function.
-#[derive(Debug)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Cursor<T> {
     inner: T,
     pos: u64,
@@ -331,7 +331,7 @@ impl Write for &mut [u8] {
 /// A sink to which all writes succeed. See [`std::io::Sink`] for more info.
 ///
 /// Created using `io::sink()`.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Sink;
 
 impl Write for Sink {


### PR DESCRIPTION
So that our `io` crate is not surprising it seems we should generally, unless there is a good reason not to, follow `std::io`.

Copy the derived trait implementations from `std::io` for `Cursor`, and `Sink`. `Take` is correct already, just `Debug`.

Done while investigating C-COMMON-TRAITS