### PR TITLE
Derive `PartialOrd` and `Ord` for `Denomination`

### DIFF
--- a/api/units/all-features.txt
+++ b/api/units/all-features.txt
@@ -99,6 +99,7 @@ impl core::cmp::Eq for bitcoin_units::parse::UnprefixedHexError
 impl core::cmp::Eq for bitcoin_units::weight::Weight
 impl core::cmp::Ord for bitcoin_units::Amount
 impl core::cmp::Ord for bitcoin_units::SignedAmount
+impl core::cmp::Ord for bitcoin_units::amount::Denomination
 impl core::cmp::Ord for bitcoin_units::block::BlockHeight
 impl core::cmp::Ord for bitcoin_units::block::BlockInterval
 impl core::cmp::Ord for bitcoin_units::fee_rate::FeeRate
@@ -140,6 +141,7 @@ impl core::cmp::PartialEq for bitcoin_units::parse::UnprefixedHexError
 impl core::cmp::PartialEq for bitcoin_units::weight::Weight
 impl core::cmp::PartialOrd for bitcoin_units::Amount
 impl core::cmp::PartialOrd for bitcoin_units::SignedAmount
+impl core::cmp::PartialOrd for bitcoin_units::amount::Denomination
 impl core::cmp::PartialOrd for bitcoin_units::block::BlockHeight
 impl core::cmp::PartialOrd for bitcoin_units::block::BlockInterval
 impl core::cmp::PartialOrd for bitcoin_units::fee_rate::FeeRate
@@ -912,10 +914,12 @@ pub fn bitcoin_units::SignedAmount::unsigned_abs(self) -> bitcoin_units::Amount
 pub fn bitcoin_units::amount::CheckedSum::checked_sum(self) -> core::option::Option<R>
 pub fn bitcoin_units::amount::Denomination::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
 pub fn bitcoin_units::amount::Denomination::clone(&self) -> bitcoin_units::amount::Denomination
+pub fn bitcoin_units::amount::Denomination::cmp(&self, other: &bitcoin_units::amount::Denomination) -> core::cmp::Ordering
 pub fn bitcoin_units::amount::Denomination::eq(&self, other: &bitcoin_units::amount::Denomination) -> bool
 pub fn bitcoin_units::amount::Denomination::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_units::amount::Denomination::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin_units::amount::Denomination::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::amount::Denomination::partial_cmp(&self, other: &bitcoin_units::amount::Denomination) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_units::amount::Display::clone(&self) -> bitcoin_units::amount::Display
 pub fn bitcoin_units::amount::Display::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_units::amount::Display::show_denomination(self) -> Self

--- a/api/units/alloc-only.txt
+++ b/api/units/alloc-only.txt
@@ -92,6 +92,7 @@ impl core::cmp::Eq for bitcoin_units::parse::UnprefixedHexError
 impl core::cmp::Eq for bitcoin_units::weight::Weight
 impl core::cmp::Ord for bitcoin_units::Amount
 impl core::cmp::Ord for bitcoin_units::SignedAmount
+impl core::cmp::Ord for bitcoin_units::amount::Denomination
 impl core::cmp::Ord for bitcoin_units::block::BlockHeight
 impl core::cmp::Ord for bitcoin_units::block::BlockInterval
 impl core::cmp::Ord for bitcoin_units::fee_rate::FeeRate
@@ -132,6 +133,7 @@ impl core::cmp::PartialEq for bitcoin_units::parse::UnprefixedHexError
 impl core::cmp::PartialEq for bitcoin_units::weight::Weight
 impl core::cmp::PartialOrd for bitcoin_units::Amount
 impl core::cmp::PartialOrd for bitcoin_units::SignedAmount
+impl core::cmp::PartialOrd for bitcoin_units::amount::Denomination
 impl core::cmp::PartialOrd for bitcoin_units::block::BlockHeight
 impl core::cmp::PartialOrd for bitcoin_units::block::BlockInterval
 impl core::cmp::PartialOrd for bitcoin_units::fee_rate::FeeRate
@@ -827,10 +829,12 @@ pub fn bitcoin_units::SignedAmount::unchecked_sub(self, rhs: bitcoin_units::Sign
 pub fn bitcoin_units::SignedAmount::unsigned_abs(self) -> bitcoin_units::Amount
 pub fn bitcoin_units::amount::CheckedSum::checked_sum(self) -> core::option::Option<R>
 pub fn bitcoin_units::amount::Denomination::clone(&self) -> bitcoin_units::amount::Denomination
+pub fn bitcoin_units::amount::Denomination::cmp(&self, other: &bitcoin_units::amount::Denomination) -> core::cmp::Ordering
 pub fn bitcoin_units::amount::Denomination::eq(&self, other: &bitcoin_units::amount::Denomination) -> bool
 pub fn bitcoin_units::amount::Denomination::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_units::amount::Denomination::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin_units::amount::Denomination::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::amount::Denomination::partial_cmp(&self, other: &bitcoin_units::amount::Denomination) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_units::amount::Display::clone(&self) -> bitcoin_units::amount::Display
 pub fn bitcoin_units::amount::Display::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_units::amount::Display::show_denomination(self) -> Self

--- a/api/units/no-features.txt
+++ b/api/units/no-features.txt
@@ -92,6 +92,7 @@ impl core::cmp::Eq for bitcoin_units::parse::UnprefixedHexError
 impl core::cmp::Eq for bitcoin_units::weight::Weight
 impl core::cmp::Ord for bitcoin_units::Amount
 impl core::cmp::Ord for bitcoin_units::SignedAmount
+impl core::cmp::Ord for bitcoin_units::amount::Denomination
 impl core::cmp::Ord for bitcoin_units::block::BlockHeight
 impl core::cmp::Ord for bitcoin_units::block::BlockInterval
 impl core::cmp::Ord for bitcoin_units::fee_rate::FeeRate
@@ -132,6 +133,7 @@ impl core::cmp::PartialEq for bitcoin_units::parse::UnprefixedHexError
 impl core::cmp::PartialEq for bitcoin_units::weight::Weight
 impl core::cmp::PartialOrd for bitcoin_units::Amount
 impl core::cmp::PartialOrd for bitcoin_units::SignedAmount
+impl core::cmp::PartialOrd for bitcoin_units::amount::Denomination
 impl core::cmp::PartialOrd for bitcoin_units::block::BlockHeight
 impl core::cmp::PartialOrd for bitcoin_units::block::BlockInterval
 impl core::cmp::PartialOrd for bitcoin_units::fee_rate::FeeRate
@@ -797,10 +799,12 @@ pub fn bitcoin_units::SignedAmount::unchecked_sub(self, rhs: bitcoin_units::Sign
 pub fn bitcoin_units::SignedAmount::unsigned_abs(self) -> bitcoin_units::Amount
 pub fn bitcoin_units::amount::CheckedSum::checked_sum(self) -> core::option::Option<R>
 pub fn bitcoin_units::amount::Denomination::clone(&self) -> bitcoin_units::amount::Denomination
+pub fn bitcoin_units::amount::Denomination::cmp(&self, other: &bitcoin_units::amount::Denomination) -> core::cmp::Ordering
 pub fn bitcoin_units::amount::Denomination::eq(&self, other: &bitcoin_units::amount::Denomination) -> bool
 pub fn bitcoin_units::amount::Denomination::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_units::amount::Denomination::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin_units::amount::Denomination::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::amount::Denomination::partial_cmp(&self, other: &bitcoin_units::amount::Denomination) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_units::amount::Display::clone(&self) -> bitcoin_units::amount::Display
 pub fn bitcoin_units::amount::Display::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_units::amount::Display::show_denomination(self) -> Self

--- a/units/src/amount/mod.rs
+++ b/units/src/amount/mod.rs
@@ -65,7 +65,7 @@ pub use self::{
 /// assert_eq!("1 bit".parse::<Amount>().unwrap(), Amount::from_sat(100));
 /// assert_eq!("1 sat".parse::<Amount>().unwrap(), Amount::from_sat(1));
 /// ```
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 pub enum Denomination {
     /// BTC


### PR DESCRIPTION
Currently units::amount::Denomination does not implement PartialOrd or Ord. This prevents any type that includes a Denomination from being used in contexts that require these traits (e.g. as key to a BTreeMap). This is an unnecessary restriction. We should either implement the traits or implement ArbitraryOrd.

Whether to derive the traits or manually implement them is an open question.

Derive `PartialOrd` and `Ord` for `Denomination`.