### PR TITLE
units: Hide the remaining public macros

### DIFF
--- a/api/units/all-features.txt
+++ b/api/units/all-features.txt
@@ -1220,8 +1220,6 @@ pub fn u32::from(height: bitcoin_units::block::BlockInterval) -> Self
 pub fn u64::from(value: bitcoin_units::fee_rate::FeeRate) -> Self
 pub fn u64::from(value: bitcoin_units::weight::Weight) -> Self
 pub fn u64::mul(self, rhs: bitcoin_units::weight::Weight) -> Self::Output
-pub macro bitcoin_units::impl_parse_str!
-pub macro bitcoin_units::impl_parse_str_from_int_infallible!
 pub mod bitcoin_units
 pub mod bitcoin_units::amount
 pub mod bitcoin_units::amount::serde

--- a/api/units/alloc-only.txt
+++ b/api/units/alloc-only.txt
@@ -1064,8 +1064,6 @@ pub fn u32::from(height: bitcoin_units::block::BlockInterval) -> Self
 pub fn u64::from(value: bitcoin_units::fee_rate::FeeRate) -> Self
 pub fn u64::from(value: bitcoin_units::weight::Weight) -> Self
 pub fn u64::mul(self, rhs: bitcoin_units::weight::Weight) -> Self::Output
-pub macro bitcoin_units::impl_parse_str!
-pub macro bitcoin_units::impl_parse_str_from_int_infallible!
 pub mod bitcoin_units
 pub mod bitcoin_units::amount
 pub mod bitcoin_units::block

--- a/api/units/no-features.txt
+++ b/api/units/no-features.txt
@@ -1018,8 +1018,6 @@ pub fn u32::from(height: bitcoin_units::block::BlockInterval) -> Self
 pub fn u64::from(value: bitcoin_units::fee_rate::FeeRate) -> Self
 pub fn u64::from(value: bitcoin_units::weight::Weight) -> Self
 pub fn u64::mul(self, rhs: bitcoin_units::weight::Weight) -> Self::Output
-pub macro bitcoin_units::impl_parse_str!
-pub macro bitcoin_units::impl_parse_str_from_int_infallible!
 pub mod bitcoin_units
 pub mod bitcoin_units::amount
 pub mod bitcoin_units::block

--- a/units/src/parse.rs
+++ b/units/src/parse.rs
@@ -117,6 +117,7 @@ pub fn int<T: Integer, S: AsRef<str> + Into<InputString>>(s: S) -> Result<T, Par
 ///
 /// If parsing the string fails then a `units::parse::ParseIntError` is returned.
 #[macro_export]
+#[doc(hidden)] // This is an 'internal' macro that should not be used outside of the `rust-bitcoin` crate.
 macro_rules! impl_parse_str_from_int_infallible {
     ($to:ident, $inner:ident, $fn:ident) => {
         $crate::impl_tryfrom_str_from_int_infallible!(&str, $to, $inner, $fn);
@@ -174,6 +175,7 @@ macro_rules! impl_tryfrom_str_from_int_infallible {
 ///
 /// All functions use the error returned by `$inner_fn`.
 #[macro_export]
+#[doc(hidden)] // This is an 'internal' macro that should not be used outside of the `rust-bitcoin` crate.
 macro_rules! impl_parse_str {
     ($to:ty, $err:ty, $inner_fn:expr) => {
         $crate::impl_tryfrom_str!(&str, $to, $err, $inner_fn);


### PR DESCRIPTION
We do not want to commit to any public macros in `units`. Recently we (I at least) learned that adding `doc(hidden)` signals to users that the macro is unstable and should not be relied upon.

Hide the remaining two macros so we can release 1.0 and not worry about later breaking them.

With this applied there are no exported macros that are not hidden. Verify using `git grep -A 1 macro_export`.