### PR TITLE
Remove Copy from `PushBytesError`

### DIFF
--- a/bitcoin/src/blockdata/script/push_bytes.rs
+++ b/bitcoin/src/blockdata/script/push_bytes.rs
@@ -413,7 +413,7 @@ mod error {
 
     /// Error returned on attempt to create too large `PushBytes`.
     #[allow(unused)]
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct PushBytesError {
         never: core::convert::Infallible,
     }
@@ -435,7 +435,7 @@ mod error {
     use core::fmt;
 
     /// Error returned on attempt to create too large `PushBytes`.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct PushBytesError {
         /// How long the input was.
         pub(super) len: usize,


### PR DESCRIPTION
The `PushBytesError` is the only error type in the codebase to derive `Copy`. Without thinking too hard this is unusual - remove it.

Thinking a bit harder it makes the code less maintainable because we must commit to implementing `Copy`.