### PR TITLE
Derive `Clone`on consensus errors

### DIFF
--- a/bitcoin/src/consensus/error.rs
+++ b/bitcoin/src/consensus/error.rs
@@ -13,7 +13,7 @@ use internals::write_err;
 use super::IterReader;
 
 /// Error deserializing from a slice.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum DeserializeError {
     /// Error parsing encoded object.
@@ -149,7 +149,7 @@ impl From<ParseError> for Error {
 }
 
 /// Encoding is invalid.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ParseError {
     /// Missing data (early end of file or slice too short).


### PR DESCRIPTION
All error types in the repo use either [0]:

- `#[derive(Debug, Clone, PartialEq, Eq)]``
- `#[derive(Debug)]`

However the `consensus` error types do not have `Clone` derived.

Derive `Clone` on `consensus::ParseError` and `consensus::Error`.

[0] Excluding `PushBytesError`, fixed in #3879