### PR TITLE
Implement `Ord` for `absolute::LockTime`

### DIFF
--- a/api/primitives/all-features.txt
+++ b/api/primitives/all-features.txt
@@ -158,6 +158,7 @@ impl core::cmp::Ord for bitcoin_primitives::block::Header
 impl core::cmp::Ord for bitcoin_primitives::block::Unchecked
 impl core::cmp::Ord for bitcoin_primitives::block::Version
 impl core::cmp::Ord for bitcoin_primitives::block::WitnessCommitment
+impl core::cmp::Ord for bitcoin_primitives::locktime::absolute::LockTime
 impl core::cmp::Ord for bitcoin_primitives::merkle_tree::TxMerkleNode
 impl core::cmp::Ord for bitcoin_primitives::merkle_tree::WitnessMerkleNode
 impl core::cmp::Ord for bitcoin_primitives::opcodes::ClassifyContext
@@ -806,7 +807,6 @@ impl core::str::traits::FromStr for bitcoin_primitives::taproot::TapTweakHash
 impl core::str::traits::FromStr for bitcoin_primitives::transaction::OutPoint
 impl core::str::traits::FromStr for bitcoin_primitives::transaction::Txid
 impl core::str::traits::FromStr for bitcoin_primitives::transaction::Wtxid
-impl ordered::ArbitraryOrd for bitcoin_primitives::locktime::absolute::LockTime
 impl ordered::ArbitraryOrd for bitcoin_primitives::locktime::relative::LockTime
 impl serde::ser::Serialize for bitcoin_primitives::block::BlockHash
 impl serde::ser::Serialize for bitcoin_primitives::block::Header
@@ -1433,8 +1433,8 @@ pub fn bitcoin_primitives::block::WitnessCommitment::partial_cmp(&self, other: &
 pub fn bitcoin_primitives::block::WitnessCommitment::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
 pub fn bitcoin_primitives::block::WitnessCommitment::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin_primitives::locktime::absolute::LockTime::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
-pub fn bitcoin_primitives::locktime::absolute::LockTime::arbitrary_cmp(&self, other: &Self) -> core::cmp::Ordering
 pub fn bitcoin_primitives::locktime::absolute::LockTime::clone(&self) -> bitcoin_primitives::locktime::absolute::LockTime
+pub fn bitcoin_primitives::locktime::absolute::LockTime::cmp(&self, other: &bitcoin_primitives::locktime::absolute::LockTime) -> core::cmp::Ordering
 pub fn bitcoin_primitives::locktime::absolute::LockTime::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
 pub fn bitcoin_primitives::locktime::absolute::LockTime::eq(&self, other: &bitcoin_primitives::locktime::absolute::LockTime) -> bool
 pub fn bitcoin_primitives::locktime::absolute::LockTime::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -1790,7 +1790,7 @@ pub fn bitcoin_primitives::transaction::ParseOutPointError::from(never: core::co
 pub fn bitcoin_primitives::transaction::ParseOutPointError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 pub fn bitcoin_primitives::transaction::Transaction::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
 pub fn bitcoin_primitives::transaction::Transaction::clone(&self) -> bitcoin_primitives::transaction::Transaction
-pub fn bitcoin_primitives::transaction::Transaction::cmp(&self, other: &Self) -> core::cmp::Ordering
+pub fn bitcoin_primitives::transaction::Transaction::cmp(&self, other: &bitcoin_primitives::transaction::Transaction) -> core::cmp::Ordering
 pub fn bitcoin_primitives::transaction::Transaction::compute_ntxid(&self) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin_primitives::transaction::Transaction::compute_txid(&self) -> bitcoin_primitives::transaction::Txid
 pub fn bitcoin_primitives::transaction::Transaction::compute_wtxid(&self) -> bitcoin_primitives::transaction::Wtxid
@@ -1802,7 +1802,7 @@ pub fn bitcoin_primitives::transaction::Transaction::inputs(&self) -> &[bitcoin_
 pub fn bitcoin_primitives::transaction::Transaction::inputs_mut(&mut self) -> &mut [bitcoin_primitives::transaction::TxIn]
 pub fn bitcoin_primitives::transaction::Transaction::outputs(&self) -> &[bitcoin_primitives::transaction::TxOut]
 pub fn bitcoin_primitives::transaction::Transaction::outputs_mut(&mut self) -> &mut [bitcoin_primitives::transaction::TxOut]
-pub fn bitcoin_primitives::transaction::Transaction::partial_cmp(&self, other: &Self) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::Transaction::partial_cmp(&self, other: &bitcoin_primitives::transaction::Transaction) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_primitives::transaction::Transaction::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
 pub fn bitcoin_primitives::transaction::TxIn::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
 pub fn bitcoin_primitives::transaction::TxIn::clone(&self) -> bitcoin_primitives::transaction::TxIn

--- a/api/primitives/alloc-only.txt
+++ b/api/primitives/alloc-only.txt
@@ -158,6 +158,7 @@ impl core::cmp::Ord for bitcoin_primitives::block::Header
 impl core::cmp::Ord for bitcoin_primitives::block::Unchecked
 impl core::cmp::Ord for bitcoin_primitives::block::Version
 impl core::cmp::Ord for bitcoin_primitives::block::WitnessCommitment
+impl core::cmp::Ord for bitcoin_primitives::locktime::absolute::LockTime
 impl core::cmp::Ord for bitcoin_primitives::merkle_tree::TxMerkleNode
 impl core::cmp::Ord for bitcoin_primitives::merkle_tree::WitnessMerkleNode
 impl core::cmp::Ord for bitcoin_primitives::opcodes::ClassifyContext
@@ -1345,6 +1346,7 @@ pub fn bitcoin_primitives::block::WitnessCommitment::hash<__H: core::hash::Hashe
 pub fn bitcoin_primitives::block::WitnessCommitment::partial_cmp(&self, other: &bitcoin_primitives::block::WitnessCommitment) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_primitives::block::WitnessCommitment::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin_primitives::locktime::absolute::LockTime::clone(&self) -> bitcoin_primitives::locktime::absolute::LockTime
+pub fn bitcoin_primitives::locktime::absolute::LockTime::cmp(&self, other: &bitcoin_primitives::locktime::absolute::LockTime) -> core::cmp::Ordering
 pub fn bitcoin_primitives::locktime::absolute::LockTime::eq(&self, other: &bitcoin_primitives::locktime::absolute::LockTime) -> bool
 pub fn bitcoin_primitives::locktime::absolute::LockTime::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_primitives::locktime::absolute::LockTime::from(h: bitcoin_units::locktime::absolute::Height) -> Self
@@ -1666,7 +1668,7 @@ pub fn bitcoin_primitives::transaction::ParseOutPointError::eq(&self, other: &bi
 pub fn bitcoin_primitives::transaction::ParseOutPointError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_primitives::transaction::ParseOutPointError::from(never: core::convert::Infallible) -> Self
 pub fn bitcoin_primitives::transaction::Transaction::clone(&self) -> bitcoin_primitives::transaction::Transaction
-pub fn bitcoin_primitives::transaction::Transaction::cmp(&self, other: &Self) -> core::cmp::Ordering
+pub fn bitcoin_primitives::transaction::Transaction::cmp(&self, other: &bitcoin_primitives::transaction::Transaction) -> core::cmp::Ordering
 pub fn bitcoin_primitives::transaction::Transaction::compute_ntxid(&self) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin_primitives::transaction::Transaction::compute_txid(&self) -> bitcoin_primitives::transaction::Txid
 pub fn bitcoin_primitives::transaction::Transaction::compute_wtxid(&self) -> bitcoin_primitives::transaction::Wtxid
@@ -1677,7 +1679,7 @@ pub fn bitcoin_primitives::transaction::Transaction::inputs(&self) -> &[bitcoin_
 pub fn bitcoin_primitives::transaction::Transaction::inputs_mut(&mut self) -> &mut [bitcoin_primitives::transaction::TxIn]
 pub fn bitcoin_primitives::transaction::Transaction::outputs(&self) -> &[bitcoin_primitives::transaction::TxOut]
 pub fn bitcoin_primitives::transaction::Transaction::outputs_mut(&mut self) -> &mut [bitcoin_primitives::transaction::TxOut]
-pub fn bitcoin_primitives::transaction::Transaction::partial_cmp(&self, other: &Self) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::Transaction::partial_cmp(&self, other: &bitcoin_primitives::transaction::Transaction) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_primitives::transaction::TxIn::clone(&self) -> bitcoin_primitives::transaction::TxIn
 pub fn bitcoin_primitives::transaction::TxIn::cmp(&self, other: &bitcoin_primitives::transaction::TxIn) -> core::cmp::Ordering
 pub fn bitcoin_primitives::transaction::TxIn::eq(&self, other: &bitcoin_primitives::transaction::TxIn) -> bool

--- a/api/primitives/no-features.txt
+++ b/api/primitives/no-features.txt
@@ -107,6 +107,7 @@ impl core::cmp::Ord for bitcoin_primitives::block::BlockHash
 impl core::cmp::Ord for bitcoin_primitives::block::Header
 impl core::cmp::Ord for bitcoin_primitives::block::Version
 impl core::cmp::Ord for bitcoin_primitives::block::WitnessCommitment
+impl core::cmp::Ord for bitcoin_primitives::locktime::absolute::LockTime
 impl core::cmp::Ord for bitcoin_primitives::merkle_tree::TxMerkleNode
 impl core::cmp::Ord for bitcoin_primitives::merkle_tree::WitnessMerkleNode
 impl core::cmp::Ord for bitcoin_primitives::opcodes::ClassifyContext
@@ -955,6 +956,7 @@ pub fn bitcoin_primitives::block::WitnessCommitment::hash<__H: core::hash::Hashe
 pub fn bitcoin_primitives::block::WitnessCommitment::partial_cmp(&self, other: &bitcoin_primitives::block::WitnessCommitment) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_primitives::block::WitnessCommitment::to_byte_array(self) -> Self::Bytes
 pub fn bitcoin_primitives::locktime::absolute::LockTime::clone(&self) -> bitcoin_primitives::locktime::absolute::LockTime
+pub fn bitcoin_primitives::locktime::absolute::LockTime::cmp(&self, other: &bitcoin_primitives::locktime::absolute::LockTime) -> core::cmp::Ordering
 pub fn bitcoin_primitives::locktime::absolute::LockTime::eq(&self, other: &bitcoin_primitives::locktime::absolute::LockTime) -> bool
 pub fn bitcoin_primitives::locktime::absolute::LockTime::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_primitives::locktime::absolute::LockTime::from(h: bitcoin_units::locktime::absolute::Height) -> Self

--- a/primitives/src/locktime/relative.rs
+++ b/primitives/src/locktime/relative.rs
@@ -28,8 +28,8 @@ pub use units::locktime::relative::{Height, Time, TimeOverflowError};
 /// ### Note on ordering
 ///
 /// Locktimes may be height- or time-based, and these metrics are incommensurate; there is no total
-/// ordering on locktimes. We therefore have implemented [`PartialOrd`] but not [`Ord`]. We also
-/// implement [`ordered::ArbitraryOrd`] if the "ordered" feature is enabled.
+/// ordering for relative locktimes. We therefore have implemented [`PartialOrd`] but not [`Ord`].
+/// We have also implemented [`ordered::ArbitraryOrd`] if the `ordered` feature is enabled.
 ///
 /// ### Relevant BIPs
 ///


### PR DESCRIPTION
Surprise surprise, locktimes are curly AF.

The main benefit of this PR is it simplifies usage of the `absolute::LockTime` because users do not have to think about ordering implementation details or gotchas - WIN.

An absolute locktime _does_ have a total ordering because the current implementation uses the consensus value as the inner value for both variants and there is an invariant on this value that it is on the correct side of the threshold - there seems no sane reason to change this implementation.

Therefore a height-based lock time is always strictly less than a time based locktime implying the two can be compared.

Phew!

Remove the `ordered::ArbitraryOrd` implementation for `absolute::LockTime`. Add a `Ord` implementation.

In `Transaction` that means we can remove the manual implementation and just derive `PartialOrd` and `Ord` - the derived code is identical to the current manual implementation.

Clean up all the docs.

### Note on the API changes

Using `Self` for the right hand side of the comparison instead of explicitly using the type (e.g., `Transaction`) changes the output of `cargo public-api` even though the logic stays the same. The derived implementation uses `Transaction` where as the replaced implementations used `Self`. 