### PR TITLE
units: Refactor Send/Sync api test

### DIFF
--- a/io/tests/api.rs
+++ b/io/tests/api.rs
@@ -129,12 +129,12 @@ fn api_all_non_error_types_have_non_empty_debug() {
     assert!(!debug.is_empty());
 }
 
-//  Types are `Send` and `Sync` where possible (C-SEND-SYNC).
 #[test]
 fn all_non_error_tyes_implement_send_sync() {
     fn assert_send<T: Send>() {}
-    assert_send::<Types>();
-
     fn assert_sync<T: Sync>() {}
+
+    //  Types are `Send` and `Sync` where possible (C-SEND-SYNC).
+    assert_send::<Types>();
     assert_sync::<Types>();
 }

--- a/units/tests/api.rs
+++ b/units/tests/api.rs
@@ -221,16 +221,16 @@ fn api_all_non_error_types_have_non_empty_debug() {
 }
 
 #[test]
-fn send() {
+fn all_types_implement_send_sync() {
     fn assert_send<T: Send>() {}
-    assert_send::<Types>();
-    assert_send::<Errors>();
-}
-
-#[test]
-fn sync() {
     fn assert_sync<T: Sync>() {}
+
+    //  Types are `Send` and `Sync` where possible (C-SEND-SYNC).
+    assert_send::<Types>();
     assert_sync::<Types>();
+
+    // Error types should implement the Send and Sync traits (C-GOOD-ERR).
+    assert_send::<Errors>();
     assert_sync::<Errors>();
 }
 


### PR DESCRIPTION
The `api` test for types implementing `Send` and `Sync` is part of both C-SEND-SYNC and also C-GOOD-ERR (for error types).

Refactor the two tests into a single one and document appropriately. This is mirrors how we do it in `io/tests/api.rs`.