### PR TITLE
Make `Cursor` methods const

### DIFF
--- a/api/io/all-features.txt
+++ b/api/io/all-features.txt
@@ -164,6 +164,9 @@ pub bitcoin_io::ErrorKind::TimedOut
 pub bitcoin_io::ErrorKind::UnexpectedEof
 pub bitcoin_io::ErrorKind::WouldBlock
 pub bitcoin_io::ErrorKind::WriteZero
+pub const fn bitcoin_io::Cursor<T>::get_ref(&self) -> &T
+pub const fn bitcoin_io::Cursor<T>::new(inner: T) -> Self
+pub const fn bitcoin_io::Cursor<T>::position(&self) -> u64
 pub const fn bitcoin_io::FromStd<T>::new(inner: T) -> Self
 pub const fn bitcoin_io::ToStd<T>::new(inner: T) -> Self
 pub const fn bitcoin_io::from_std<T>(std_io: T) -> bitcoin_io::FromStd<T>
@@ -232,11 +235,8 @@ pub fn bitcoin_io::Cursor<T>::eq(&self, other: &bitcoin_io::Cursor<T>) -> bool
 pub fn bitcoin_io::Cursor<T>::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
 pub fn bitcoin_io::Cursor<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_io::Cursor<T>::get_mut(&mut self) -> &mut T
-pub fn bitcoin_io::Cursor<T>::get_ref(&self) -> &T
 pub fn bitcoin_io::Cursor<T>::inner(&self) -> &T
 pub fn bitcoin_io::Cursor<T>::into_inner(self) -> T
-pub fn bitcoin_io::Cursor<T>::new(inner: T) -> Self
-pub fn bitcoin_io::Cursor<T>::position(&self) -> u64
 pub fn bitcoin_io::Cursor<T>::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
 pub fn bitcoin_io::Cursor<T>::set_position(&mut self, position: u64)
 pub fn bitcoin_io::Error::cause(&self) -> core::option::Option<&dyn core::error::Error>

--- a/api/io/alloc-only.txt
+++ b/api/io/alloc-only.txt
@@ -83,6 +83,9 @@ pub bitcoin_io::ErrorKind::TimedOut
 pub bitcoin_io::ErrorKind::UnexpectedEof
 pub bitcoin_io::ErrorKind::WouldBlock
 pub bitcoin_io::ErrorKind::WriteZero
+pub const fn bitcoin_io::Cursor<T>::get_ref(&self) -> &T
+pub const fn bitcoin_io::Cursor<T>::new(inner: T) -> Self
+pub const fn bitcoin_io::Cursor<T>::position(&self) -> u64
 pub enum bitcoin_io::ErrorKind
 pub fn &[u8]::consume(&mut self, amount: usize)
 pub fn &[u8]::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
@@ -107,11 +110,8 @@ pub fn bitcoin_io::Cursor<T>::eq(&self, other: &bitcoin_io::Cursor<T>) -> bool
 pub fn bitcoin_io::Cursor<T>::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
 pub fn bitcoin_io::Cursor<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_io::Cursor<T>::get_mut(&mut self) -> &mut T
-pub fn bitcoin_io::Cursor<T>::get_ref(&self) -> &T
 pub fn bitcoin_io::Cursor<T>::inner(&self) -> &T
 pub fn bitcoin_io::Cursor<T>::into_inner(self) -> T
-pub fn bitcoin_io::Cursor<T>::new(inner: T) -> Self
-pub fn bitcoin_io::Cursor<T>::position(&self) -> u64
 pub fn bitcoin_io::Cursor<T>::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
 pub fn bitcoin_io::Cursor<T>::set_position(&mut self, position: u64)
 pub fn bitcoin_io::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result

--- a/api/io/no-features.txt
+++ b/api/io/no-features.txt
@@ -81,6 +81,9 @@ pub bitcoin_io::ErrorKind::TimedOut
 pub bitcoin_io::ErrorKind::UnexpectedEof
 pub bitcoin_io::ErrorKind::WouldBlock
 pub bitcoin_io::ErrorKind::WriteZero
+pub const fn bitcoin_io::Cursor<T>::get_ref(&self) -> &T
+pub const fn bitcoin_io::Cursor<T>::new(inner: T) -> Self
+pub const fn bitcoin_io::Cursor<T>::position(&self) -> u64
 pub enum bitcoin_io::ErrorKind
 pub fn &[u8]::consume(&mut self, amount: usize)
 pub fn &[u8]::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
@@ -103,11 +106,8 @@ pub fn bitcoin_io::Cursor<T>::eq(&self, other: &bitcoin_io::Cursor<T>) -> bool
 pub fn bitcoin_io::Cursor<T>::fill_buf(&mut self) -> bitcoin_io::Result<&[u8]>
 pub fn bitcoin_io::Cursor<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_io::Cursor<T>::get_mut(&mut self) -> &mut T
-pub fn bitcoin_io::Cursor<T>::get_ref(&self) -> &T
 pub fn bitcoin_io::Cursor<T>::inner(&self) -> &T
 pub fn bitcoin_io::Cursor<T>::into_inner(self) -> T
-pub fn bitcoin_io::Cursor<T>::new(inner: T) -> Self
-pub fn bitcoin_io::Cursor<T>::position(&self) -> u64
 pub fn bitcoin_io::Cursor<T>::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
 pub fn bitcoin_io::Cursor<T>::set_position(&mut self, position: u64)
 pub fn bitcoin_io::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result

--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -201,11 +201,11 @@ pub struct Cursor<T> {
 impl<T: AsRef<[u8]>> Cursor<T> {
     /// Constructs a new `Cursor` by wrapping `inner`.
     #[inline]
-    pub fn new(inner: T) -> Self { Cursor { inner, pos: 0 } }
+    pub const fn new(inner: T) -> Self { Cursor { inner, pos: 0 } }
 
     /// Returns the position read up to thus far.
     #[inline]
-    pub fn position(&self) -> u64 { self.pos }
+    pub const fn position(&self) -> u64 { self.pos }
 
     /// Sets the internal position.
     ///
@@ -226,7 +226,7 @@ impl<T: AsRef<[u8]>> Cursor<T> {
     ///
     /// This is the whole wrapped buffer, including the bytes already read.
     #[inline]
-    pub fn get_ref(&self) -> &T { &self.inner }
+    pub const fn get_ref(&self) -> &T { &self.inner }
 
     /// Returns a mutable reference to the inner buffer.
     ///


### PR DESCRIPTION
Mirror the `std::io::Cursor` type by making the same methods `const`.