### PR TITLE
Add FIFTY_BTC const to the amount types

### DIFF
--- a/api/units/all-features.txt
+++ b/api/units/all-features.txt
@@ -673,6 +673,7 @@ pub bitcoin_units::amount::Denomination::MilliBitcoin
 pub bitcoin_units::amount::Denomination::Satoshi
 pub bitcoin_units::amount::ParseDenominationError::PossiblyConfusing(bitcoin_units::amount::PossiblyConfusingDenominationError)
 pub bitcoin_units::amount::ParseDenominationError::Unknown(bitcoin_units::amount::UnknownDenominationError)
+pub const bitcoin_units::Amount::FIFTY_BTC: Self
 pub const bitcoin_units::Amount::MAX: Self
 pub const bitcoin_units::Amount::MAX_MONEY: Self
 pub const bitcoin_units::Amount::MIN: Self
@@ -680,6 +681,7 @@ pub const bitcoin_units::Amount::ONE_BTC: Self
 pub const bitcoin_units::Amount::ONE_SAT: Self
 pub const bitcoin_units::Amount::SIZE: usize
 pub const bitcoin_units::Amount::ZERO: Self
+pub const bitcoin_units::SignedAmount::FIFTY_BTC: Self
 pub const bitcoin_units::SignedAmount::MAX: Self
 pub const bitcoin_units::SignedAmount::MAX_MONEY: Self
 pub const bitcoin_units::SignedAmount::MIN: Self

--- a/api/units/alloc-only.txt
+++ b/api/units/alloc-only.txt
@@ -611,6 +611,7 @@ pub bitcoin_units::amount::Denomination::MilliBitcoin
 pub bitcoin_units::amount::Denomination::Satoshi
 pub bitcoin_units::amount::ParseDenominationError::PossiblyConfusing(bitcoin_units::amount::PossiblyConfusingDenominationError)
 pub bitcoin_units::amount::ParseDenominationError::Unknown(bitcoin_units::amount::UnknownDenominationError)
+pub const bitcoin_units::Amount::FIFTY_BTC: Self
 pub const bitcoin_units::Amount::MAX: Self
 pub const bitcoin_units::Amount::MAX_MONEY: Self
 pub const bitcoin_units::Amount::MIN: Self
@@ -618,6 +619,7 @@ pub const bitcoin_units::Amount::ONE_BTC: Self
 pub const bitcoin_units::Amount::ONE_SAT: Self
 pub const bitcoin_units::Amount::SIZE: usize
 pub const bitcoin_units::Amount::ZERO: Self
+pub const bitcoin_units::SignedAmount::FIFTY_BTC: Self
 pub const bitcoin_units::SignedAmount::MAX: Self
 pub const bitcoin_units::SignedAmount::MAX_MONEY: Self
 pub const bitcoin_units::SignedAmount::MIN: Self

--- a/api/units/no-features.txt
+++ b/api/units/no-features.txt
@@ -595,6 +595,7 @@ pub bitcoin_units::amount::Denomination::MilliBitcoin
 pub bitcoin_units::amount::Denomination::Satoshi
 pub bitcoin_units::amount::ParseDenominationError::PossiblyConfusing(bitcoin_units::amount::PossiblyConfusingDenominationError)
 pub bitcoin_units::amount::ParseDenominationError::Unknown(bitcoin_units::amount::UnknownDenominationError)
+pub const bitcoin_units::Amount::FIFTY_BTC: Self
 pub const bitcoin_units::Amount::MAX: Self
 pub const bitcoin_units::Amount::MAX_MONEY: Self
 pub const bitcoin_units::Amount::MIN: Self
@@ -602,6 +603,7 @@ pub const bitcoin_units::Amount::ONE_BTC: Self
 pub const bitcoin_units::Amount::ONE_SAT: Self
 pub const bitcoin_units::Amount::SIZE: usize
 pub const bitcoin_units::Amount::ZERO: Self
+pub const bitcoin_units::SignedAmount::FIFTY_BTC: Self
 pub const bitcoin_units::SignedAmount::MAX: Self
 pub const bitcoin_units::SignedAmount::MAX_MONEY: Self
 pub const bitcoin_units::SignedAmount::MIN: Self

--- a/bitcoin/examples/taproot-psbt.rs
+++ b/bitcoin/examples/taproot-psbt.rs
@@ -49,7 +49,7 @@ const UTXO_1: P2trUtxo = P2trUtxo {
     script_pubkey: UTXO_SCRIPT_PUBKEY,
     pubkey: UTXO_PUBKEY,
     master_fingerprint: UTXO_MASTER_FINGERPRINT,
-    amount_in_sats: Amount::from_int_btc_const(50),
+    amount_in_sats: Amount::FIFTY_BTC,
     derivation_path: BIP86_DERIVATION_PATH,
 };
 
@@ -60,7 +60,7 @@ const UTXO_2: P2trUtxo = P2trUtxo {
     script_pubkey: UTXO_SCRIPT_PUBKEY,
     pubkey: UTXO_PUBKEY,
     master_fingerprint: UTXO_MASTER_FINGERPRINT,
-    amount_in_sats: Amount::from_int_btc_const(50),
+    amount_in_sats: Amount::FIFTY_BTC,
     derivation_path: BIP86_DERIVATION_PATH,
 };
 
@@ -71,7 +71,7 @@ const UTXO_3: P2trUtxo = P2trUtxo {
     script_pubkey: UTXO_SCRIPT_PUBKEY,
     pubkey: UTXO_PUBKEY,
     master_fingerprint: UTXO_MASTER_FINGERPRINT,
-    amount_in_sats: Amount::from_int_btc_const(50),
+    amount_in_sats: Amount::FIFTY_BTC,
     derivation_path: BIP86_DERIVATION_PATH,
 };
 

--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -113,7 +113,7 @@ fn bitcoin_genesis_tx(params: &Params) -> Transaction {
     });
 
     ret.output.push(TxOut {
-        value: Amount::from_sat_unchecked(50 * 100_000_000),
+        value: Amount::FIFTY_BTC,
         script_pubkey: out_script,
     });
 

--- a/units/src/amount/signed.rs
+++ b/units/src/amount/signed.rs
@@ -55,6 +55,8 @@ impl SignedAmount {
     pub const ONE_SAT: Self = SignedAmount(1);
     /// Exactly one bitcoin.
     pub const ONE_BTC: Self = SignedAmount(100_000_000);
+    /// Exactly fifty bitcoin.
+    pub const FIFTY_BTC: Self = Self::from_sat_unchecked(50 * 100_000_000);
     /// The maximum value allowed as an amount. Useful for sanity checking.
     pub const MAX_MONEY: Self = SignedAmount(21_000_000 * 100_000_000);
     /// The minimum value of an amount.

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -58,6 +58,8 @@ impl Amount {
     pub const ONE_SAT: Self = Amount(1);
     /// Exactly one bitcoin.
     pub const ONE_BTC: Self = Self::from_int_btc_const(1);
+    /// Exactly fifty bitcoin.
+    pub const FIFTY_BTC: Self = Self::from_sat_unchecked(50 * 100_000_000);
     /// The maximum value allowed as an amount. Useful for sanity checking.
     pub const MAX_MONEY: Self = Self::from_int_btc_const(21_000_000);
     /// The minimum value of an amount.


### PR DESCRIPTION
The mining reward for the first epoc is 50 bitcoin. For mainnet this is old news but for regtest it is still relevant.

Add and use a new const `FIFTY_BTC` to the `Amount` type. To keep the amount types uniform also add it to the `SignedAmount`.