### PR TITLE
Make `Read` and `BufRead` dyn compatible

### DIFF
--- a/io/tests/api.rs
+++ b/io/tests/api.rs
@@ -142,3 +142,19 @@ fn all_non_error_tyes_implement_send_sync() {
     assert_send::<Errors>();
     assert_sync::<Errors>();
 }
+
+#[test]
+fn object_safety() {
+    // Sanity check, these are all object safe.
+    struct StdlibTraits {
+        p: Box<dyn std::io::Read>,
+        q: Box<dyn std::io::Write>,
+        r: Box<dyn std::io::BufRead>,
+    }
+    // If this builds then our three traits are object safe also.
+    struct OurTraits {
+        p: Box<dyn Read>,
+        q: Box<dyn Write>,
+        r: Box<dyn BufRead>,
+    }
+}


### PR DESCRIPTION
In order to do this we need to remove the `?Sized` trait bound from `consensus_encode` - done in patch 1. Please note I do not know why we added it in the first place (added in #1035).

Patch 2 fixes `Take` and adds a unit test to verify all `io` traits are dyn compatible (object safe).

Close: #3833