### PR TITLE
Remove deprecated `std::error::Error` trait method impls

### DIFF
--- a/api/io/all-features.txt
+++ b/api/io/all-features.txt
@@ -239,8 +239,6 @@ pub fn bitcoin_io::Cursor<T>::inner(&self) -> &T
 pub fn bitcoin_io::Cursor<T>::into_inner(self) -> T
 pub fn bitcoin_io::Cursor<T>::read(&mut self, buf: &mut [u8]) -> bitcoin_io::Result<usize>
 pub fn bitcoin_io::Cursor<T>::set_position(&mut self, position: u64)
-pub fn bitcoin_io::Error::cause(&self) -> core::option::Option<&dyn core::error::Error>
-pub fn bitcoin_io::Error::description(&self) -> &str
 pub fn bitcoin_io::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_io::Error::fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
 pub fn bitcoin_io::Error::from(kind: bitcoin_io::ErrorKind) -> bitcoin_io::Error

--- a/io/src/error.rs
+++ b/io/src/error.rs
@@ -76,19 +76,6 @@ impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         self.error.as_ref().and_then(|e| e.as_ref().source())
     }
-
-    #[allow(deprecated)]
-    fn description(&self) -> &str {
-        match self.error.as_ref() {
-            Some(e) => e.description(),
-            None => self.kind.description(),
-        }
-    }
-
-    #[allow(deprecated)]
-    fn cause(&self) -> Option<&dyn std::error::Error> {
-        self.error.as_ref().and_then(|e| e.as_ref().cause())
-    }
 }
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
The `description` method was deprecated in Rust `v1.42`. The `cause` method was deprecated in Rust `v1.33`. Our MSRV is now Rust `v1.63`.

We do not need to implement the deprecated functions any longer.

Fix: #3869