### PR TITLE
Remove marker from `io::Error`

### DIFF
--- a/api/io/all-features.txt
+++ b/api/io/all-features.txt
@@ -1,6 +1,5 @@
 #[repr(transparent)] pub struct bitcoin_io::FromStd<T>(_)
 #[repr(transparent)] pub struct bitcoin_io::ToStd<T>(_)
-impl !core::marker::Sync for bitcoin_io::Error
 impl !core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::Error
 impl !core::panic::unwind_safe::UnwindSafe for bitcoin_io::Error
 impl bitcoin_io::BufRead for &[u8]
@@ -70,6 +69,7 @@ impl core::marker::Send for bitcoin_io::Error
 impl core::marker::Send for bitcoin_io::ErrorKind
 impl core::marker::Send for bitcoin_io::Sink
 impl core::marker::StructuralPartialEq for bitcoin_io::ErrorKind
+impl core::marker::Sync for bitcoin_io::Error
 impl core::marker::Sync for bitcoin_io::ErrorKind
 impl core::marker::Sync for bitcoin_io::Sink
 impl core::marker::Unpin for bitcoin_io::Error

--- a/api/io/alloc-only.txt
+++ b/api/io/alloc-only.txt
@@ -1,4 +1,3 @@
-impl !core::marker::Sync for bitcoin_io::Error
 impl !core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::Error
 impl !core::panic::unwind_safe::UnwindSafe for bitcoin_io::Error
 impl bitcoin_io::BufRead for &[u8]
@@ -28,6 +27,7 @@ impl core::marker::Send for bitcoin_io::Error
 impl core::marker::Send for bitcoin_io::ErrorKind
 impl core::marker::Send for bitcoin_io::Sink
 impl core::marker::StructuralPartialEq for bitcoin_io::ErrorKind
+impl core::marker::Sync for bitcoin_io::Error
 impl core::marker::Sync for bitcoin_io::ErrorKind
 impl core::marker::Sync for bitcoin_io::Sink
 impl core::marker::Unpin for bitcoin_io::Error

--- a/api/io/no-features.txt
+++ b/api/io/no-features.txt
@@ -1,6 +1,3 @@
-impl !core::marker::Sync for bitcoin_io::Error
-impl !core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::Error
-impl !core::panic::unwind_safe::UnwindSafe for bitcoin_io::Error
 impl bitcoin_io::BufRead for &[u8]
 impl bitcoin_io::Error
 impl bitcoin_io::Read for &[u8]
@@ -27,13 +24,16 @@ impl core::marker::Send for bitcoin_io::Error
 impl core::marker::Send for bitcoin_io::ErrorKind
 impl core::marker::Send for bitcoin_io::Sink
 impl core::marker::StructuralPartialEq for bitcoin_io::ErrorKind
+impl core::marker::Sync for bitcoin_io::Error
 impl core::marker::Sync for bitcoin_io::ErrorKind
 impl core::marker::Sync for bitcoin_io::Sink
 impl core::marker::Unpin for bitcoin_io::Error
 impl core::marker::Unpin for bitcoin_io::ErrorKind
 impl core::marker::Unpin for bitcoin_io::Sink
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::Error
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::ErrorKind
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_io::Sink
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_io::Error
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_io::ErrorKind
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_io::Sink
 impl<'a, R: core::fmt::Debug + bitcoin_io::Read + ?core::marker::Sized> core::fmt::Debug for bitcoin_io::Take<'a, R>

--- a/io/src/error.rs
+++ b/io/src/error.rs
@@ -6,11 +6,6 @@ use core::fmt;
 #[derive(Debug)]
 pub struct Error {
     kind: ErrorKind,
-    /// Indicates that the `struct` can pretend to own a mutable static reference
-    /// and an [`UnsafeCell`](core::cell::UnsafeCell), which are not unwind safe.
-    /// This is so that it does not introduce non-additive cargo features.
-    _not_unwind_safe: core::marker::PhantomData<(&'static mut (), core::cell::UnsafeCell<()>)>,
-
     #[cfg(feature = "std")]
     error: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
     #[cfg(all(feature = "alloc", not(feature = "std")))]
@@ -24,13 +19,13 @@ impl Error {
     where
         E: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
     {
-        Self { kind, _not_unwind_safe: core::marker::PhantomData, error: Some(error.into()) }
+        Self { kind, error: Some(error.into()) }
     }
 
     /// Constructs a new I/O error.
     #[cfg(all(feature = "alloc", not(feature = "std")))]
     pub fn new<E: sealed::IntoBoxDynDebug>(kind: ErrorKind, error: E) -> Error {
-        Self { kind, _not_unwind_safe: core::marker::PhantomData, error: Some(error.into()) }
+        Self { kind, error: Some(error.into()) }
     }
 
     /// Returns the error kind for this error.
@@ -53,7 +48,6 @@ impl From<ErrorKind> for Error {
     fn from(kind: ErrorKind) -> Error {
         Self {
             kind,
-            _not_unwind_safe: core::marker::PhantomData,
             #[cfg(any(feature = "std", feature = "alloc"))]
             error: None,
         }
@@ -96,7 +90,6 @@ impl From<std::io::Error> for Error {
     fn from(o: std::io::Error) -> Error {
         Self {
             kind: ErrorKind::from_std(o.kind()),
-            _not_unwind_safe: core::marker::PhantomData,
             error: o.into_inner(),
         }
     }

--- a/io/tests/api.rs
+++ b/io/tests/api.rs
@@ -137,4 +137,8 @@ fn all_non_error_tyes_implement_send_sync() {
     //  Types are `Send` and `Sync` where possible (C-SEND-SYNC).
     assert_send::<Types>();
     assert_sync::<Types>();
+
+    // Error types are meaningful and well-behaved (C-GOOD-ERR)
+    assert_send::<Errors>();
+    assert_sync::<Errors>();
 }


### PR DESCRIPTION
We currently have a marker that claims to prohibit introduction of non-additive features however the only difference between the `std` and `no-std` builds is that the inner error implements `std::io::Error` only in `std` builds. This is as expected, right?

We have previously discussed that we can't really guarantee our crates won't break a `no-std` build if a dependency graph contains `std` enabled crates at some place. Following on from this the fact I claim that the inner error implements a `std` trait if `std` is enabled should not be an issue.

Fix: #3883