### PR TITLE
units: Test for dyn compatibility

### DIFF
--- a/units/src/parse.rs
+++ b/units/src/parse.rs
@@ -53,6 +53,7 @@ impl AsRef<core::num::ParseIntError> for ParseIntError {
 
 /// Not strictly necessary but serves as a lint - avoids weird behavior if someone accidentally
 /// passes non-integer to the `parse()` function.
+// This trait is not dyn-compatible because `FromStr` is not dyn-compatible.
 pub trait Integer:
     FromStr<Err = core::num::ParseIntError> + TryFrom<i8> + Sized + sealed::Sealed
 {

--- a/units/tests/api.rs
+++ b/units/tests/api.rs
@@ -247,6 +247,18 @@ fn regression_default() {
     assert_eq!(got, want);
 }
 
+#[test]
+fn dyn_compatible() {
+    // If this builds then traits are dyn compatible.
+    struct Traits {
+        a: Box<dyn amount::CheckedSum<Amount>>,
+        // These traits are explicitly not dyn compatible.
+        // b: Box<dyn amount::serde::SerdeAmount>,
+        // c: Box<dyn amount::serde::SerdeAmountForOpt>,
+        // d: Box<dyn parse::Integer>,
+    }
+}
+
 #[cfg(feature = "arbitrary")]
 impl<'a> Arbitrary<'a> for Types {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {


### PR DESCRIPTION
Phew! dyn compatibility is a non-trivial concept. There are four public traits in `units`, only one is dyn compatible.

This patch is done in order to check off C-OBJECT from the Rust API guidelines checklist.

Add a test to check the public traits in `units` for dyn compatibility.

While we are at it add a code comment on `Integer` stating why its not dyn-compatible.

ref: https://rust-lang.github.io/api-guidelines/flexibility.html#c-object