### PR TITLE
Manually implement `PartialOrd` and `Ord` for `Denomination`

### DIFF
--- a/api/units/all-features.txt
+++ b/api/units/all-features.txt
@@ -99,6 +99,7 @@ impl core::cmp::Eq for bitcoin_units::parse::UnprefixedHexError
 impl core::cmp::Eq for bitcoin_units::weight::Weight
 impl core::cmp::Ord for bitcoin_units::Amount
 impl core::cmp::Ord for bitcoin_units::SignedAmount
+impl core::cmp::Ord for bitcoin_units::amount::Denomination
 impl core::cmp::Ord for bitcoin_units::block::BlockHeight
 impl core::cmp::Ord for bitcoin_units::block::BlockInterval
 impl core::cmp::Ord for bitcoin_units::fee_rate::FeeRate
@@ -140,6 +141,7 @@ impl core::cmp::PartialEq for bitcoin_units::parse::UnprefixedHexError
 impl core::cmp::PartialEq for bitcoin_units::weight::Weight
 impl core::cmp::PartialOrd for bitcoin_units::Amount
 impl core::cmp::PartialOrd for bitcoin_units::SignedAmount
+impl core::cmp::PartialOrd for bitcoin_units::amount::Denomination
 impl core::cmp::PartialOrd for bitcoin_units::block::BlockHeight
 impl core::cmp::PartialOrd for bitcoin_units::block::BlockInterval
 impl core::cmp::PartialOrd for bitcoin_units::fee_rate::FeeRate
@@ -914,10 +916,12 @@ pub fn bitcoin_units::SignedAmount::unsigned_abs(self) -> bitcoin_units::Amount
 pub fn bitcoin_units::amount::CheckedSum::checked_sum(self) -> core::option::Option<R>
 pub fn bitcoin_units::amount::Denomination::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
 pub fn bitcoin_units::amount::Denomination::clone(&self) -> bitcoin_units::amount::Denomination
+pub fn bitcoin_units::amount::Denomination::cmp(&self, other: &Self) -> core::cmp::Ordering
 pub fn bitcoin_units::amount::Denomination::eq(&self, other: &bitcoin_units::amount::Denomination) -> bool
 pub fn bitcoin_units::amount::Denomination::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_units::amount::Denomination::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin_units::amount::Denomination::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::amount::Denomination::partial_cmp(&self, other: &Self) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_units::amount::Display::clone(&self) -> bitcoin_units::amount::Display
 pub fn bitcoin_units::amount::Display::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_units::amount::Display::show_denomination(self) -> Self

--- a/api/units/alloc-only.txt
+++ b/api/units/alloc-only.txt
@@ -92,6 +92,7 @@ impl core::cmp::Eq for bitcoin_units::parse::UnprefixedHexError
 impl core::cmp::Eq for bitcoin_units::weight::Weight
 impl core::cmp::Ord for bitcoin_units::Amount
 impl core::cmp::Ord for bitcoin_units::SignedAmount
+impl core::cmp::Ord for bitcoin_units::amount::Denomination
 impl core::cmp::Ord for bitcoin_units::block::BlockHeight
 impl core::cmp::Ord for bitcoin_units::block::BlockInterval
 impl core::cmp::Ord for bitcoin_units::fee_rate::FeeRate
@@ -132,6 +133,7 @@ impl core::cmp::PartialEq for bitcoin_units::parse::UnprefixedHexError
 impl core::cmp::PartialEq for bitcoin_units::weight::Weight
 impl core::cmp::PartialOrd for bitcoin_units::Amount
 impl core::cmp::PartialOrd for bitcoin_units::SignedAmount
+impl core::cmp::PartialOrd for bitcoin_units::amount::Denomination
 impl core::cmp::PartialOrd for bitcoin_units::block::BlockHeight
 impl core::cmp::PartialOrd for bitcoin_units::block::BlockInterval
 impl core::cmp::PartialOrd for bitcoin_units::fee_rate::FeeRate
@@ -829,10 +831,12 @@ pub fn bitcoin_units::SignedAmount::unchecked_sub(self, rhs: bitcoin_units::Sign
 pub fn bitcoin_units::SignedAmount::unsigned_abs(self) -> bitcoin_units::Amount
 pub fn bitcoin_units::amount::CheckedSum::checked_sum(self) -> core::option::Option<R>
 pub fn bitcoin_units::amount::Denomination::clone(&self) -> bitcoin_units::amount::Denomination
+pub fn bitcoin_units::amount::Denomination::cmp(&self, other: &Self) -> core::cmp::Ordering
 pub fn bitcoin_units::amount::Denomination::eq(&self, other: &bitcoin_units::amount::Denomination) -> bool
 pub fn bitcoin_units::amount::Denomination::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_units::amount::Denomination::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin_units::amount::Denomination::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::amount::Denomination::partial_cmp(&self, other: &Self) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_units::amount::Display::clone(&self) -> bitcoin_units::amount::Display
 pub fn bitcoin_units::amount::Display::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_units::amount::Display::show_denomination(self) -> Self

--- a/api/units/no-features.txt
+++ b/api/units/no-features.txt
@@ -92,6 +92,7 @@ impl core::cmp::Eq for bitcoin_units::parse::UnprefixedHexError
 impl core::cmp::Eq for bitcoin_units::weight::Weight
 impl core::cmp::Ord for bitcoin_units::Amount
 impl core::cmp::Ord for bitcoin_units::SignedAmount
+impl core::cmp::Ord for bitcoin_units::amount::Denomination
 impl core::cmp::Ord for bitcoin_units::block::BlockHeight
 impl core::cmp::Ord for bitcoin_units::block::BlockInterval
 impl core::cmp::Ord for bitcoin_units::fee_rate::FeeRate
@@ -132,6 +133,7 @@ impl core::cmp::PartialEq for bitcoin_units::parse::UnprefixedHexError
 impl core::cmp::PartialEq for bitcoin_units::weight::Weight
 impl core::cmp::PartialOrd for bitcoin_units::Amount
 impl core::cmp::PartialOrd for bitcoin_units::SignedAmount
+impl core::cmp::PartialOrd for bitcoin_units::amount::Denomination
 impl core::cmp::PartialOrd for bitcoin_units::block::BlockHeight
 impl core::cmp::PartialOrd for bitcoin_units::block::BlockInterval
 impl core::cmp::PartialOrd for bitcoin_units::fee_rate::FeeRate
@@ -799,10 +801,12 @@ pub fn bitcoin_units::SignedAmount::unchecked_sub(self, rhs: bitcoin_units::Sign
 pub fn bitcoin_units::SignedAmount::unsigned_abs(self) -> bitcoin_units::Amount
 pub fn bitcoin_units::amount::CheckedSum::checked_sum(self) -> core::option::Option<R>
 pub fn bitcoin_units::amount::Denomination::clone(&self) -> bitcoin_units::amount::Denomination
+pub fn bitcoin_units::amount::Denomination::cmp(&self, other: &Self) -> core::cmp::Ordering
 pub fn bitcoin_units::amount::Denomination::eq(&self, other: &bitcoin_units::amount::Denomination) -> bool
 pub fn bitcoin_units::amount::Denomination::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_units::amount::Denomination::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin_units::amount::Denomination::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::amount::Denomination::partial_cmp(&self, other: &Self) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_units::amount::Display::clone(&self) -> bitcoin_units::amount::Display
 pub fn bitcoin_units::amount::Display::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_units::amount::Display::show_denomination(self) -> Self


### PR DESCRIPTION
Currently `units::amount::Denomination` does not implement `PartialOrd` or `Ord`. This prevents any type that includes a Denomination from being used in contexts that require these traits (e.g. as key to a `BTreeMap`). This is an unnecessary restriction.

We had an extensive discussion in #3865 about whether the order of enum variants with no inner data matters.

This patch manually implements the traits on `Denomination`. Even though I started all this writing this patch feels a bit silly.

This is an alternative to #3866. I personally think we should do 3866 and not this one.