### PR TITLE
Remove unnecessary `doc(hidden)`

### DIFF
--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -303,7 +303,6 @@ impl<const N: usize> IsByteArray for [u8; N] {
 }
 
 mod sealed {
-    #[doc(hidden)]
     pub trait IsByteArray {}
 
     impl<const N: usize> IsByteArray for [u8; N] {}


### PR DESCRIPTION
This trait is private and is meant just for sealing. It already will not show up in public docs and cannot be used by downstream users.

Resolve: #3912