### PR TITLE
units: Change `create` to `construct` in rustdocs

### DIFF
--- a/units/src/parse.rs
+++ b/units/src/parse.rs
@@ -121,7 +121,7 @@ fn int<T: Integer, S: AsRef<str> + Into<InputString>>(s: S) -> Result<T, ParseIn
 /// Implements standard parsing traits for `$type` by calling `parse::int`.
 ///
 /// Once the string is converted to an integer the infallible conversion function `fn` is used to
-/// create the type `to`.
+/// construct the type `to`.
 ///
 /// Implements:
 ///


### PR DESCRIPTION
In preparation for units 1.0 address #3868 and make sure "constructs" is used instead of "creates" in rustdocs.