### PR TITLE
Add `µBTC` as a recognized `str` form of a MicroBitcoin Denomination

### DIFF
--- a/units/src/amount/mod.rs
+++ b/units/src/amount/mod.rs
@@ -42,7 +42,7 @@ pub use self::{
 ///
 /// # Accepted Denominations
 ///
-/// All upper or lower case, excluding SI prefix (c, m, u) which must be lower case.
+/// All upper or lower case, excluding SI prefixes c, m and u (or µ) which must be lower case.
 /// - Singular: BTC, cBTC, mBTC, uBTC
 /// - Plural or singular: sat, satoshi, bit
 ///
@@ -119,7 +119,7 @@ impl Denomination {
             "BTC" | "btc" => Some(Denomination::Bitcoin),
             "cBTC" | "cbtc" => Some(Denomination::CentiBitcoin),
             "mBTC" | "mbtc" => Some(Denomination::MilliBitcoin),
-            "uBTC" | "ubtc" => Some(Denomination::MicroBitcoin),
+            "uBTC" | "ubtc" | "µBTC" | "µbtc" => Some(Denomination::MicroBitcoin),
             "bit" | "bits" | "BIT" | "BITS" => Some(Denomination::Bit),
             "SATOSHI" | "satoshi" | "SATOSHIS" | "satoshis" | "SAT" | "sat" | "SATS" | "sats" =>
                 Some(Denomination::Satoshi),

--- a/units/src/amount/mod.rs
+++ b/units/src/amount/mod.rs
@@ -67,6 +67,7 @@ pub use self::{
 /// ```
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 #[non_exhaustive]
+#[allow(clippy::doc_markdown)]
 pub enum Denomination {
     /// BTC (1 BTC = 100,000,000 satoshi).
     Bitcoin,
@@ -74,9 +75,9 @@ pub enum Denomination {
     CentiBitcoin,
     /// mBTC (1 mBTC = 100,000 satoshi).
     MilliBitcoin,
-    /// uBTC (1 uBTC = 100 satoshi).
+    /// µBTC (1 µBTC = 100 satoshi).
     MicroBitcoin,
-    /// bits (bits = uBTC).
+    /// bits (bits = µBTC).
     Bit,
     /// satoshi (1 BTC = 100,000,000 satoshi).
     Satoshi,

--- a/units/src/amount/tests.rs
+++ b/units/src/amount/tests.rs
@@ -1013,8 +1013,9 @@ fn checked_sum_amounts() {
 fn denomination_string_acceptable_forms() {
     // Exhaustive list of valid forms.
     let valid = [
-        "BTC", "btc", "cBTC", "cbtc", "mBTC", "mbtc", "uBTC", "ubtc", "bit", "bits", "BIT", "BITS",
-        "SATOSHI", "satoshi", "SATOSHIS", "satoshis", "SAT", "sat", "SATS", "sats",
+        "BTC", "btc", "cBTC", "cbtc", "mBTC", "mbtc", "uBTC", "ubtc", "µBTC", "µbtc", "bit",
+        "bits", "BIT", "BITS", "SATOSHI", "satoshi", "SATOSHIS", "satoshis", "SAT", "sat", "SATS",
+        "sats",
     ];
     for denom in valid {
         assert!(denom.parse::<Denomination>().is_ok());


### PR DESCRIPTION
`µ` is the correct letter for the SI unit micro but is not on most standard keyboards.  `u` was used instead because it looks similar.

Add `µBTC` to the list of recognized strings for MicroBitcoin.  This is an addition only, `uBTC` still works as normal.

Change `uBTC` to `µBTC` in the rustdocs.  The examples have been left as `uBTC` since this is easier for most people to use.

Add `µBTC` and `µbtc` to the tests.

Close #3941