### PR TITLE
fix: typo in io lib-level documentation

### DIFF
--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! The `std::io` module is not exposed in `no-std` Rust so building `no-std` applications which
 //! require reading and writing objects via standard traits is not generally possible. Thus, this
-//! library exists to export a minmal version of `std::io`'s traits which we use in `rust-bitcoin`
+//! library exists to export a minimal version of `std::io`'s traits which we use in `rust-bitcoin`
 //! so that we can support `no-std` applications.
 //!
 //! These traits are not one-for-one drop-ins, but are as close as possible while still implementing


### PR DESCRIPTION
Fixes a typo in io lib-level documentation.