### PR TITLE
Improve examples on `Denomination`

### DIFF
--- a/units/src/amount/mod.rs
+++ b/units/src/amount/mod.rs
@@ -58,12 +58,20 @@ pub use self::{
 /// ```
 /// # use bitcoin_units::Amount;
 ///
-/// assert_eq!("1 BTC".parse::<Amount>().unwrap(), Amount::from_sat(100_000_000));
-/// assert_eq!("1 cBTC".parse::<Amount>().unwrap(), Amount::from_sat(1_000_000));
-/// assert_eq!("1 mBTC".parse::<Amount>().unwrap(), Amount::from_sat(100_000));
-/// assert_eq!("1 uBTC".parse::<Amount>().unwrap(), Amount::from_sat(100));
-/// assert_eq!("1 bit".parse::<Amount>().unwrap(), Amount::from_sat(100));
-/// assert_eq!("1 sat".parse::<Amount>().unwrap(), Amount::from_sat(1));
+/// let equal = [
+///     ("1 BTC", 100_000_000),
+///     ("1 cBTC", 1_000_000),
+///     ("1 mBTC", 100_000),
+///     ("1 uBTC", 100),
+///     ("1 bit", 100),
+///     ("1 sat", 1),
+/// ];
+/// for (string, sats) in equal {
+///     assert_eq!(
+///         string.parse::<Amount>().expect("valid bitcoin amount string"),
+///         Amount::from_sat(sats),
+///     )
+/// }
 /// ```
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 #[non_exhaustive]


### PR DESCRIPTION
Reduce the noise in the examples.