### PR TITLE
Fix amount whole btc constructors

### DIFF
--- a/api/units/all-features.txt
+++ b/api/units/all-features.txt
@@ -740,7 +740,7 @@ pub const fn bitcoin_units::SignedAmount::checked_div(self, rhs: i64) -> core::o
 pub const fn bitcoin_units::SignedAmount::checked_mul(self, rhs: i64) -> core::option::Option<bitcoin_units::SignedAmount>
 pub const fn bitcoin_units::SignedAmount::checked_rem(self, rhs: i64) -> core::option::Option<bitcoin_units::SignedAmount>
 pub const fn bitcoin_units::SignedAmount::checked_sub(self, rhs: bitcoin_units::SignedAmount) -> core::option::Option<bitcoin_units::SignedAmount>
-pub const fn bitcoin_units::SignedAmount::from_int_btc_const(whole_bitcoin: i64) -> bitcoin_units::SignedAmount
+pub const fn bitcoin_units::SignedAmount::from_int_btc_const(whole_bitcoin: i32) -> bitcoin_units::SignedAmount
 pub const fn bitcoin_units::SignedAmount::from_sat(satoshi: i64) -> bitcoin_units::SignedAmount
 pub const fn bitcoin_units::SignedAmount::from_sat_unchecked(satoshi: i64) -> bitcoin_units::SignedAmount
 pub const fn bitcoin_units::SignedAmount::to_sat(self) -> i64
@@ -827,7 +827,7 @@ pub fn bitcoin_units::Amount::eq(&self, other: &bitcoin_units::Amount) -> bool
 pub fn bitcoin_units::Amount::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_units::Amount::from_btc(btc: f64) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::ParseAmountError>
 pub fn bitcoin_units::Amount::from_float_in(value: f64, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::ParseAmountError>
-pub fn bitcoin_units::Amount::from_int_btc<T: core::convert::Into<u64>>(whole_bitcoin: T) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::OutOfRangeError>
+pub fn bitcoin_units::Amount::from_int_btc<T: core::convert::Into<u32>>(whole_bitcoin: T) -> bitcoin_units::Amount
 pub fn bitcoin_units::Amount::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin_units::Amount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::ParseAmountError>
 pub fn bitcoin_units::Amount::from_str_with_denomination(s: &str) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::ParseError>
@@ -879,7 +879,7 @@ pub fn bitcoin_units::SignedAmount::fmt(&self, f: &mut core::fmt::Formatter<'_>)
 pub fn bitcoin_units::SignedAmount::from(value: bitcoin_units::Amount) -> Self
 pub fn bitcoin_units::SignedAmount::from_btc(btc: f64) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::ParseAmountError>
 pub fn bitcoin_units::SignedAmount::from_float_in(value: f64, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::ParseAmountError>
-pub fn bitcoin_units::SignedAmount::from_int_btc<T: core::convert::Into<i64>>(whole_bitcoin: T) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::OutOfRangeError>
+pub fn bitcoin_units::SignedAmount::from_int_btc<T: core::convert::Into<i32>>(whole_bitcoin: T) -> bitcoin_units::SignedAmount
 pub fn bitcoin_units::SignedAmount::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin_units::SignedAmount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::ParseAmountError>
 pub fn bitcoin_units::SignedAmount::from_str_with_denomination(s: &str) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::ParseError>

--- a/api/units/alloc-only.txt
+++ b/api/units/alloc-only.txt
@@ -678,7 +678,7 @@ pub const fn bitcoin_units::SignedAmount::checked_div(self, rhs: i64) -> core::o
 pub const fn bitcoin_units::SignedAmount::checked_mul(self, rhs: i64) -> core::option::Option<bitcoin_units::SignedAmount>
 pub const fn bitcoin_units::SignedAmount::checked_rem(self, rhs: i64) -> core::option::Option<bitcoin_units::SignedAmount>
 pub const fn bitcoin_units::SignedAmount::checked_sub(self, rhs: bitcoin_units::SignedAmount) -> core::option::Option<bitcoin_units::SignedAmount>
-pub const fn bitcoin_units::SignedAmount::from_int_btc_const(whole_bitcoin: i64) -> bitcoin_units::SignedAmount
+pub const fn bitcoin_units::SignedAmount::from_int_btc_const(whole_bitcoin: i32) -> bitcoin_units::SignedAmount
 pub const fn bitcoin_units::SignedAmount::from_sat(satoshi: i64) -> bitcoin_units::SignedAmount
 pub const fn bitcoin_units::SignedAmount::from_sat_unchecked(satoshi: i64) -> bitcoin_units::SignedAmount
 pub const fn bitcoin_units::SignedAmount::to_sat(self) -> i64
@@ -761,7 +761,7 @@ pub fn bitcoin_units::Amount::eq(&self, other: &bitcoin_units::Amount) -> bool
 pub fn bitcoin_units::Amount::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_units::Amount::from_btc(btc: f64) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::ParseAmountError>
 pub fn bitcoin_units::Amount::from_float_in(value: f64, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::ParseAmountError>
-pub fn bitcoin_units::Amount::from_int_btc<T: core::convert::Into<u64>>(whole_bitcoin: T) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::OutOfRangeError>
+pub fn bitcoin_units::Amount::from_int_btc<T: core::convert::Into<u32>>(whole_bitcoin: T) -> bitcoin_units::Amount
 pub fn bitcoin_units::Amount::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin_units::Amount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::ParseAmountError>
 pub fn bitcoin_units::Amount::from_str_with_denomination(s: &str) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::ParseError>
@@ -802,7 +802,7 @@ pub fn bitcoin_units::SignedAmount::fmt(&self, f: &mut core::fmt::Formatter<'_>)
 pub fn bitcoin_units::SignedAmount::from(value: bitcoin_units::Amount) -> Self
 pub fn bitcoin_units::SignedAmount::from_btc(btc: f64) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::ParseAmountError>
 pub fn bitcoin_units::SignedAmount::from_float_in(value: f64, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::ParseAmountError>
-pub fn bitcoin_units::SignedAmount::from_int_btc<T: core::convert::Into<i64>>(whole_bitcoin: T) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::OutOfRangeError>
+pub fn bitcoin_units::SignedAmount::from_int_btc<T: core::convert::Into<i32>>(whole_bitcoin: T) -> bitcoin_units::SignedAmount
 pub fn bitcoin_units::SignedAmount::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin_units::SignedAmount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::ParseAmountError>
 pub fn bitcoin_units::SignedAmount::from_str_with_denomination(s: &str) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::ParseError>

--- a/api/units/no-features.txt
+++ b/api/units/no-features.txt
@@ -660,7 +660,7 @@ pub const fn bitcoin_units::SignedAmount::checked_div(self, rhs: i64) -> core::o
 pub const fn bitcoin_units::SignedAmount::checked_mul(self, rhs: i64) -> core::option::Option<bitcoin_units::SignedAmount>
 pub const fn bitcoin_units::SignedAmount::checked_rem(self, rhs: i64) -> core::option::Option<bitcoin_units::SignedAmount>
 pub const fn bitcoin_units::SignedAmount::checked_sub(self, rhs: bitcoin_units::SignedAmount) -> core::option::Option<bitcoin_units::SignedAmount>
-pub const fn bitcoin_units::SignedAmount::from_int_btc_const(whole_bitcoin: i64) -> bitcoin_units::SignedAmount
+pub const fn bitcoin_units::SignedAmount::from_int_btc_const(whole_bitcoin: i32) -> bitcoin_units::SignedAmount
 pub const fn bitcoin_units::SignedAmount::from_sat(satoshi: i64) -> bitcoin_units::SignedAmount
 pub const fn bitcoin_units::SignedAmount::from_sat_unchecked(satoshi: i64) -> bitcoin_units::SignedAmount
 pub const fn bitcoin_units::SignedAmount::to_sat(self) -> i64
@@ -741,7 +741,7 @@ pub fn bitcoin_units::Amount::div(self, rhs: u64) -> Self::Output
 pub fn bitcoin_units::Amount::div_assign(&mut self, rhs: u64)
 pub fn bitcoin_units::Amount::eq(&self, other: &bitcoin_units::Amount) -> bool
 pub fn bitcoin_units::Amount::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::Amount::from_int_btc<T: core::convert::Into<u64>>(whole_bitcoin: T) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::OutOfRangeError>
+pub fn bitcoin_units::Amount::from_int_btc<T: core::convert::Into<u32>>(whole_bitcoin: T) -> bitcoin_units::Amount
 pub fn bitcoin_units::Amount::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin_units::Amount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::ParseAmountError>
 pub fn bitcoin_units::Amount::from_str_with_denomination(s: &str) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::ParseError>
@@ -776,7 +776,7 @@ pub fn bitcoin_units::SignedAmount::div_assign(&mut self, rhs: i64)
 pub fn bitcoin_units::SignedAmount::eq(&self, other: &bitcoin_units::SignedAmount) -> bool
 pub fn bitcoin_units::SignedAmount::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_units::SignedAmount::from(value: bitcoin_units::Amount) -> Self
-pub fn bitcoin_units::SignedAmount::from_int_btc<T: core::convert::Into<i64>>(whole_bitcoin: T) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::OutOfRangeError>
+pub fn bitcoin_units::SignedAmount::from_int_btc<T: core::convert::Into<i32>>(whole_bitcoin: T) -> bitcoin_units::SignedAmount
 pub fn bitcoin_units::SignedAmount::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 pub fn bitcoin_units::SignedAmount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::ParseAmountError>
 pub fn bitcoin_units::SignedAmount::from_str_with_denomination(s: &str) -> core::result::Result<bitcoin_units::SignedAmount, bitcoin_units::amount::ParseError>

--- a/units/src/amount/signed.rs
+++ b/units/src/amount/signed.rs
@@ -125,18 +125,10 @@ impl SignedAmount {
         }
     }
 
-    /// Converts from a value expressing a whole number of bitcoin to a [`SignedAmount`]
-    /// in const context.
-    ///
-    /// # Panics
-    ///
-    /// The function panics if the argument multiplied by the number of sats
-    /// per bitcoin overflows an `i64` type.
-    pub const fn from_int_btc_const(whole_bitcoin: i64) -> SignedAmount {
-        match whole_bitcoin.checked_mul(100_000_000) {
-            Some(amount) => SignedAmount::from_sat(amount),
-            None => panic!("checked_mul overflowed"),
-        }
+    /// Converts from a value expressing a whole number of bitcoin to a [`SignedAmount`].
+    pub const fn from_int_btc_const(whole_bitcoin: i32) -> SignedAmount {
+        let btc = whole_bitcoin as i64; // Can't call i64::from in const context.
+        SignedAmount(btc * 100_000_000) // Don't need checked multiplication: i32::MAX * 100_000_000 < i64::MAX
     }
 
     /// Parses a decimal string as a value in the given [`Denomination`].

--- a/units/src/amount/signed.rs
+++ b/units/src/amount/signed.rs
@@ -113,16 +113,10 @@ impl SignedAmount {
     }
 
     /// Converts from a value expressing a whole number of bitcoin to a [`SignedAmount`].
-    ///
-    /// # Errors
-    ///
-    /// The function errors if the argument multiplied by the number of sats
-    /// per bitcoin overflows an `i64` type.
-    pub fn from_int_btc<T: Into<i64>>(whole_bitcoin: T) -> Result<SignedAmount, OutOfRangeError> {
-        match whole_bitcoin.into().checked_mul(100_000_000) {
-            Some(amount) => Ok(Self::from_sat(amount)),
-            None => Err(OutOfRangeError { is_signed: true, is_greater_than_max: true }),
-        }
+    pub fn from_int_btc<T: Into<i32>>(whole_bitcoin: T) -> SignedAmount {
+        let btc = i64::from(whole_bitcoin.into());
+        let satoshi = btc * 100_000_000; // Unchecked mul ok, can't overflow an `i64`.
+        Self::from_sat(satoshi)
     }
 
     /// Converts from a value expressing a whole number of bitcoin to a [`SignedAmount`].

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -116,16 +116,10 @@ impl Amount {
     }
 
     /// Converts from a value expressing a whole number of bitcoin to an [`Amount`].
-    ///
-    /// # Errors
-    ///
-    /// The function errors if the argument multiplied by the number of sats
-    /// per bitcoin overflows a `u64` type.
-    pub fn from_int_btc<T: Into<u64>>(whole_bitcoin: T) -> Result<Amount, OutOfRangeError> {
-        match whole_bitcoin.into().checked_mul(100_000_000) {
-            Some(amount) => Ok(Self::from_sat(amount)),
-            None => Err(OutOfRangeError { is_signed: false, is_greater_than_max: true }),
-        }
+    pub fn from_int_btc<T: Into<u32>>(whole_bitcoin: T) -> Amount {
+        let btc = u64::from(whole_bitcoin.into());
+        let satoshi = btc * 100_000_000; // Unchecked mul ok, can't overflow a `u64`.
+        Self::from_sat(satoshi)
     }
 
     /// Converts from a value expressing a whole number of bitcoin to an [`Amount`].

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -130,17 +130,9 @@ impl Amount {
 
     /// Converts from a value expressing a whole number of bitcoin to an [`Amount`]
     /// in const context.
-    ///
-    /// # Panics
-    ///
-    /// The function panics if the argument multiplied by the number of sats
-    /// per bitcoin overflows a `u64` type.
     pub const fn from_int_btc_const(whole_bitcoin: u32) -> Amount {
         let btc = whole_bitcoin as u64; // Can't call u64::from in const context.
-        match btc.checked_mul(100_000_000) {
-            Some(amount) => Amount::from_sat(amount),
-            None => panic!("checked_mul overflowed"),
-        }
+        Amount(btc * 100_000_000) // Don't need checked multiplication: u32::MAX * 100_000_000 < u64::MAX
     }
 
     /// Parses a decimal string as a value in the given [`Denomination`].

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -128,8 +128,7 @@ impl Amount {
         }
     }
 
-    /// Converts from a value expressing a whole number of bitcoin to an [`Amount`]
-    /// in const context.
+    /// Converts from a value expressing a whole number of bitcoin to an [`Amount`].
     pub const fn from_int_btc_const(whole_bitcoin: u32) -> Amount {
         let btc = whole_bitcoin as u64; // Can't call u64::from in const context.
         Amount(btc * 100_000_000) // Don't need checked multiplication: u32::MAX * 100_000_000 < u64::MAX


### PR DESCRIPTION
I royally botched the recent effort to make const amount constructors use a smaller type. I left in an unnecessary panic and forgot to do both of them - it is hard to get good help.

- Patch 1 is taken from #3932 - excuse the confusion.
- Patch 2 updates `SignedAmount` to mirror `Amount` - gawd damn, again.
- Patch 3 updates the non-const constructors to use `Into<X>` with a 32 bit int type.