### PR TITLE
Fix `block::Version` soft fork bit value test

### DIFF
--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -349,8 +349,9 @@ mod tests {
 
     #[test]
     fn version_is_not_signalling_with_invalid_bit() {
-        let arbitrary_version = Version::from_consensus(1234567890);
+        let arbitrary_version = Version::from_consensus(0b00111111111111111111111111111111);
         // The max bit number to signal is 28.
+        assert!(Version::is_signalling_soft_fork(&arbitrary_version, 28));
         assert!(!Version::is_signalling_soft_fork(&arbitrary_version, 29));
     }
 


### PR DESCRIPTION
Cargo mutants found `primitives/src/block.rs:274:16: replace > with == in Version::is_signalling_soft_fork`.

There was a test but it passed for any value of bit.  There is also a redundant check in `is_signalling_soft_fork(&self, bit: u8)` to check that `bit` is not greater than 28.  The existing bit mask in the function only looks at bits from 0 to 28, so having another check is redundant.

Remove the redundant check and add a comment to the bit mask code to clarify how it works.

Fix the test so that the version being checked would signal a soft fork for any bit value less than 29, and has bit 29 on.