### PR TITLE
Change `#[must_use]` to be the same as stdlib

### DIFF
--- a/primitives/src/witness.rs
+++ b/primitives/src/witness.rs
@@ -103,7 +103,7 @@ impl Witness {
     pub fn is_empty(&self) -> bool { self.witness_elements == 0 }
 
     /// Returns a struct implementing [`Iterator`].
-    #[must_use = "returned iterator should be used"]
+    #[must_use = "iterators are lazy and do nothing unless consumed"]
     pub fn iter(&self) -> Iter {
         Iter { inner: self.content.as_slice(), indices_start: self.indices_start, current_index: 0 }
     }


### PR DESCRIPTION
Change the iterator `#[must_use]` message to be the same as stdlib uses.

Message taken from https://doc.rust-lang.org/src/core/iter/traits/iterator.rs.html#38

Close #3962