### PR TITLE
Reword `relative::LockTime` rustdoc

### DIFF
--- a/primitives/src/locktime/relative.rs
+++ b/primitives/src/locktime/relative.rs
@@ -52,8 +52,9 @@ impl LockTime {
     /// Constructs a new `LockTime` from an nSequence value or the argument to OP_CHECKSEQUENCEVERIFY.
     ///
     /// This method will **not** round-trip with [`Self::to_consensus_u32`], because relative
-    /// locktimes only use some bits of the underlying `u32` value and discard the rest. If
-    /// you want to preserve the full value, you should use the [`Sequence`] type instead.
+    /// locktimes only use some bits of the underlying `u32` value and discard the rest. Small
+    /// values may still round-trip, but if you want to preserve the full value, you should use the
+    /// [`Sequence`] type instead.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
When writing examples I was confused by the rust docs that seemed to say `this does not round-trip` and then provide an example that round trips.

Reword to make it clearer.