### PR TITLE
Add `LockTime` examples

### DIFF
--- a/primitives/src/locktime/absolute.rs
+++ b/primitives/src/locktime/absolute.rs
@@ -91,12 +91,34 @@ impl LockTime {
     pub const SIZE: usize = 4; // Serialized length of a u32.
 
     /// Constructs a new `LockTime` from a prefixed hex string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bitcoin_primitives::absolute::LockTime;
+    /// let hex_str = "0x61cf9980"; // Unix timestamp for January 1, 2022
+    /// let lock_time = LockTime::from_hex(hex_str)?;
+    /// assert_eq!(lock_time.to_consensus_u32(), 0x61cf9980);
+    ///
+    /// # Ok::<_, units::parse::PrefixedHexError>(())
+    /// ```
     pub fn from_hex(s: &str) -> Result<Self, PrefixedHexError> {
         let lock_time = parse::hex_u32_prefixed(s)?;
         Ok(Self::from_consensus(lock_time))
     }
 
     /// Constructs a new `LockTime` from an unprefixed hex string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bitcoin_primitives::absolute::LockTime;
+    /// let hex_str = "61cf9980"; // Unix timestamp for January 1, 2022
+    /// let lock_time = LockTime::from_unprefixed_hex(hex_str)?;
+    /// assert_eq!(lock_time.to_consensus_u32(), 0x61cf9980);
+    ///
+    /// # Ok::<_, units::parse::UnprefixedHexError>(())
+    /// ```
     pub fn from_unprefixed_hex(s: &str) -> Result<Self, UnprefixedHexError> {
         let lock_time = parse::hex_u32_unprefixed(s)?;
         Ok(Self::from_consensus(lock_time))

--- a/primitives/src/locktime/relative.rs
+++ b/primitives/src/locktime/relative.rs
@@ -77,10 +77,19 @@ impl LockTime {
     /// ```rust
     /// # use bitcoin_primitives::relative::LockTime;
     ///
-    /// // `from_consensus` roundtrips with `to_consensus_u32` for small values.
-    /// let n_lock_time: u32 = 7000;
-    /// let lock_time = LockTime::from_consensus(n_lock_time).unwrap();
-    /// assert_eq!(lock_time.to_consensus_u32(), n_lock_time);
+    /// // Values with bit 22 set to 0 will be interpreted as height-based lock times.
+    /// let height: u32 = 144; // 144 blocks, approx 24h.
+    /// let lock_time = LockTime::from_consensus(height)?;
+    /// assert!(lock_time.is_block_height());
+    /// assert_eq!(lock_time.to_consensus_u32(), height);
+    ///
+    /// // Values with bit 22 set to 1 will be interpreted as time-based lock times.
+    /// let time: u32 = 168 | (1 << 22) ; // Bit 22 is 1 with time approx 24h.
+    /// let lock_time = LockTime::from_consensus(time)?;
+    /// assert!(lock_time.is_block_time());
+    /// assert_eq!(lock_time.to_consensus_u32(), time);
+    ///
+    /// # Ok::<_, bitcoin_primitives::relative::DisabledLockTimeError>(())
     /// ```
     pub fn from_consensus(n: u32) -> Result<Self, DisabledLockTimeError> {
         let sequence = crate::Sequence::from_consensus(n);


### PR DESCRIPTION
To conform to API guidelines add examples to both `relative` and `absolute` `LockTime`.

As discussed in #3967 add an example that doesn't round trip in `relative::LockTime::from_consensus`.