### PR TITLE
primitives: Add tests to `script::borrowed` and `script::owned`

### DIFF
--- a/primitives/src/script/borrowed.rs
+++ b/primitives/src/script/borrowed.rs
@@ -152,3 +152,62 @@ delegate_index!(
     RangeToInclusive<usize>,
     (Bound<usize>, Bound<usize>)
 );
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn script_from_bytes() {
+        let script = Script::from_bytes(&[1, 2, 3]);
+        assert_eq!(script.as_bytes(), [1, 2, 3]);
+    }
+
+    #[test]
+    fn script_from_bytes_mut() {
+        let bytes = &mut [1, 2, 3];
+        let script = Script::from_bytes_mut(bytes);
+        script.as_mut_bytes()[0] = 4;
+        assert_eq!(script.as_mut_bytes(), [4, 2, 3]);
+    }
+
+    #[test]
+    fn script_to_vec() {
+        let script = Script::from_bytes(&[1, 2, 3]);
+        assert_eq!(script.to_vec(), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn script_len() {
+        let script = Script::from_bytes(&[1, 2, 3]);
+        assert_eq!(script.len(), 3);
+    }
+
+    #[test]
+    fn script_is_empty() {
+        let script = Script::new();
+        assert!(script.is_empty());
+
+        let script = Script::from_bytes(&[1, 2, 3]);
+        assert!(!script.is_empty());
+    }
+
+    #[test]
+    fn script_to_owned() {
+        let script = Script::from_bytes(&[1, 2, 3]);
+        let script_buf = script.to_owned();
+        assert_eq!(script_buf.as_bytes(), [1, 2, 3]);
+    }
+
+    #[test]
+    fn test_index() {
+        let script = Script::from_bytes(&[1, 2, 3, 4, 5]);
+
+        assert_eq!(script[1..3].as_bytes(), &[2, 3]);
+        assert_eq!(script[2..].as_bytes(), &[3, 4, 5]);
+        assert_eq!(script[..3].as_bytes(), &[1, 2, 3]);
+        assert_eq!(script[..].as_bytes(), &[1, 2, 3, 4, 5]);
+        assert_eq!(script[1..=3].as_bytes(), &[2, 3, 4]);
+        assert_eq!(script[..=2].as_bytes(), &[1, 2, 3]);
+    }
+}

--- a/primitives/src/script/owned.rs
+++ b/primitives/src/script/owned.rs
@@ -94,3 +94,69 @@ impl<'a> Arbitrary<'a> for ScriptBuf {
         Ok(ScriptBuf(v))
     }
 }
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn script_buf_from_bytes() {
+        let bytes = vec![1, 2, 3];
+        let script = ScriptBuf::from_bytes(bytes.clone());
+        assert_eq!(script.0, bytes);
+    }
+
+    #[test]
+    fn script_buf_as_script() {
+        let bytes = vec![1, 2, 3];
+        let script = ScriptBuf::from_bytes(bytes.clone());
+        let script_ref = script.as_script();
+        assert_eq!(script_ref.as_bytes(), bytes);
+    }
+
+    #[test]
+    fn script_buf_as_mut_script() {
+        let bytes = vec![1, 2, 3];
+        let mut script = ScriptBuf::from_bytes(bytes.clone());
+        let script_mut_ref = script.as_mut_script();
+        script_mut_ref.as_mut_bytes()[0] = 4;
+        assert_eq!(script.0, vec![4, 2, 3]);
+    }
+
+    #[test]
+    fn script_buf_into_bytes() {
+        let bytes = vec![1, 2, 3];
+        let script = ScriptBuf::from_bytes(bytes.clone());
+        let result = script.into_bytes();
+        assert_eq!(result, bytes);
+    }
+
+    #[test]
+    fn script_buf_into_boxed_script() {
+        let bytes = vec![1, 2, 3];
+        let script = ScriptBuf::from_bytes(bytes.clone());
+        let boxed_script = script.into_boxed_script();
+        assert_eq!(boxed_script.as_bytes(), bytes);
+    }
+
+    #[test]
+    fn script_buf_capacity() {
+        let script = ScriptBuf::with_capacity(10);
+        assert!(script.0.capacity() >= 10);
+    }
+
+    #[test]
+    fn script_buf_reserve() {
+        let mut script = ScriptBuf::new();
+        script.reserve(10);
+        assert!(script.0.capacity() >= 10);
+    }
+
+    #[test]
+    fn script_buf_reserve_exact() {
+        let mut script = ScriptBuf::new();
+        script.reserve_exact(10);
+        assert!(script.0.capacity() >= 10);
+    }
+}


### PR DESCRIPTION
Add tests to both `primitives/src/script/borrowed.rs` and `primitives/src/script/owned.rs` to kill the mutants found by running `cargo mutants`.