### PR TITLE
 Remove marker traits from network validation traits

### DIFF
--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -1526,4 +1526,31 @@ mod tests {
         assert_eq!(&rinsed.address, foo_checked.address.as_unchecked());
         assert_eq!(rinsed, foo_unchecked);
     }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn serde_serialize_generic() {
+        use serde::Serialize;
+
+        // Note no `Deserialize`.
+        #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+        struct Foo<V>
+        where
+            V: NetworkValidation,
+        {
+            address: Address<V>,
+        }
+
+        let addr_str = "33iFwdLuRpW1uK1RTRqsoi8rR4NpDzk66k";
+        let unchecked = addr_str.parse::<Address<NetworkUnchecked>>().unwrap();
+
+        // Serialize with an unchecked address.
+        let foo_unchecked = Foo { address: unchecked.clone() };
+        let _ = serde_json::to_string(&foo_unchecked).expect("failed to serialize");
+
+        // Serialize with an checked address.
+        let foo_checked = Foo { address: unchecked.clone().assume_checked() };
+        let _ = serde_json::to_string(&foo_checked).expect("failed to serialize");
+
+    }
 }

--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -130,7 +130,7 @@ mod sealed {
 
 /// Marker of status of address's network validation. See section [*Parsing addresses*](Address#parsing-addresses)
 /// on [`Address`] for details.
-pub trait NetworkValidation: sealed::NetworkValidation + Sync + Send + Sized + Unpin {
+pub trait NetworkValidation: sealed::NetworkValidation {
     /// Indicates whether this `NetworkValidation` is `NetworkChecked` or not.
     const IS_CHECKED: bool;
 }
@@ -140,7 +140,7 @@ pub trait NetworkValidation: sealed::NetworkValidation + Sync + Send + Sized + U
 /// This allows users to use `V: NetworkValidation` in conjunction with derives. Is only ever
 /// implemented for `NetworkUnchecked`.
 pub trait NetworkValidationUnchecked:
-    NetworkValidation + sealed::NetworkValidationUnchecked + Sync + Send + Sized + Unpin
+    NetworkValidation + sealed::NetworkValidationUnchecked
 {
 }
 


### PR DESCRIPTION
In PR #1785 it was claimed that we needed marker traits in order for `Serialize` to be derived because of the `NetworkValidation` trait bound.

I can't work out why. Note I ack'd the PR so that is my bad.

We have a unit test that derives `Serialize` on a type that includes an address with generic trait bound. So the fact that unit tests pass with this patch applied shows we do not need the marker trait bounds - I think.
