### PR TITLE
Delete `TxOut::NULL`

### DIFF
--- a/api/primitives/all-features.txt
+++ b/api/primitives/all-features.txt
@@ -46,7 +46,6 @@ impl bitcoin_primitives::taproot::TapTweakHash
 impl bitcoin_primitives::transaction::OutPoint
 impl bitcoin_primitives::transaction::Transaction
 impl bitcoin_primitives::transaction::TxIn
-impl bitcoin_primitives::transaction::TxOut
 impl bitcoin_primitives::transaction::Txid
 impl bitcoin_primitives::transaction::Version
 impl bitcoin_primitives::transaction::Wtxid
@@ -1258,7 +1257,6 @@ pub const bitcoin_primitives::transaction::OutPoint::COINBASE_PREVOUT: Self
 pub const bitcoin_primitives::transaction::OutPoint::SIZE: usize
 pub const bitcoin_primitives::transaction::Transaction::MAX_STANDARD_WEIGHT: bitcoin_units::weight::Weight
 pub const bitcoin_primitives::transaction::TxIn::EMPTY_COINBASE: bitcoin_primitives::transaction::TxIn
-pub const bitcoin_primitives::transaction::TxOut::NULL: Self
 pub const bitcoin_primitives::transaction::Txid::COINBASE_PREVOUT: Self
 pub const bitcoin_primitives::transaction::Txid::DISPLAY_BACKWARD: bool
 pub const bitcoin_primitives::transaction::Version::ONE: Self

--- a/api/primitives/alloc-only.txt
+++ b/api/primitives/alloc-only.txt
@@ -46,7 +46,6 @@ impl bitcoin_primitives::taproot::TapTweakHash
 impl bitcoin_primitives::transaction::OutPoint
 impl bitcoin_primitives::transaction::Transaction
 impl bitcoin_primitives::transaction::TxIn
-impl bitcoin_primitives::transaction::TxOut
 impl bitcoin_primitives::transaction::Txid
 impl bitcoin_primitives::transaction::Version
 impl bitcoin_primitives::transaction::Wtxid
@@ -1184,7 +1183,6 @@ pub const bitcoin_primitives::transaction::OutPoint::COINBASE_PREVOUT: Self
 pub const bitcoin_primitives::transaction::OutPoint::SIZE: usize
 pub const bitcoin_primitives::transaction::Transaction::MAX_STANDARD_WEIGHT: bitcoin_units::weight::Weight
 pub const bitcoin_primitives::transaction::TxIn::EMPTY_COINBASE: bitcoin_primitives::transaction::TxIn
-pub const bitcoin_primitives::transaction::TxOut::NULL: Self
 pub const bitcoin_primitives::transaction::Txid::COINBASE_PREVOUT: Self
 pub const bitcoin_primitives::transaction::Txid::DISPLAY_BACKWARD: bool
 pub const bitcoin_primitives::transaction::Version::ONE: Self

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -1530,6 +1530,8 @@ mod tests {
 
     extern crate serde_json;
 
+    const DUMMY_TXOUT: TxOut = TxOut { value: Amount::MIN, script_pubkey: ScriptBuf::new() };
+
     #[test]
     fn sighash_single_bug() {
         const SIGHASH_SINGLE: u32 = 3;
@@ -1539,7 +1541,7 @@ mod tests {
             version: transaction::Version::ONE,
             lock_time: absolute::LockTime::ZERO,
             input: vec![TxIn::EMPTY_COINBASE, TxIn::EMPTY_COINBASE],
-            output: vec![TxOut::NULL],
+            output: vec![DUMMY_TXOUT],
         };
         let script = ScriptBuf::new();
         let cache = SighashCache::new(&tx);
@@ -1740,13 +1742,13 @@ mod tests {
             c.taproot_signature_hash(0, &empty_prevouts, None, None, TapSighashType::All),
             Err(TaprootError::PrevoutsSize(PrevoutsSizeError))
         );
-        let two = [TxOut::NULL, TxOut::NULL];
+        let two = [DUMMY_TXOUT, DUMMY_TXOUT];
         let too_many_prevouts = Prevouts::All(&two);
         assert_eq!(
             c.taproot_signature_hash(0, &too_many_prevouts, None, None, TapSighashType::All),
             Err(TaprootError::PrevoutsSize(PrevoutsSizeError))
         );
-        let tx_out = TxOut::NULL;
+        let tx_out = DUMMY_TXOUT;
         let prevout = Prevouts::One(1, &tx_out);
         assert_eq!(
             c.taproot_signature_hash(0, &prevout, None, None, TapSighashType::All),

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -2279,7 +2279,7 @@ mod tests {
             version: transaction::Version::TWO,
             lock_time: absolute::LockTime::ZERO,
             input: vec![TxIn::EMPTY_COINBASE, TxIn::EMPTY_COINBASE],
-            output: vec![TxOut::NULL],
+            output: vec![TxOut { value: Amount::from_sat(0), script_pubkey: ScriptBuf::new() }],
         };
         let mut psbt = Psbt::from_unsigned_tx(unsigned_tx).unwrap();
 

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -350,13 +350,6 @@ pub struct TxOut {
     pub script_pubkey: ScriptBuf,
 }
 
-#[cfg(feature = "alloc")]
-impl TxOut {
-    /// This is used as a "null txout" in consensus signing code.
-    pub const NULL: Self =
-        TxOut { value: Amount::from_sat(0xffffffffffffffff), script_pubkey: ScriptBuf::new() };
-}
-
 /// A reference to a transaction output.
 ///
 /// ### Bitcoin Core References


### PR DESCRIPTION
This removes `TxOut::NULL` from our API and replaces the very few occurrences in our code. The PR has three commits so that the first one provably doesn't break anything, and the second one could be dropped if anyone complains about not deprecating but I really hope that won't happen.

As a side effect this also improves signing performance.

Closes #3975 