### PR TITLE
Upgrade `rust-ordered`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -257,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "ordered"
-version = "0.4.0"
+version = "1.0.0-alpha.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c12388aac4f817eae0359011d67d4072ed84cfc63b0d9a7958ef476fb74bec"
+checksum = "42b1e4dc865f301214157871d201f02f0175a7a19c248398e39669f80fde242c"
 
 [[package]]
 name = "ppv-lite86"

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -265,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "ordered"
-version = "0.4.0"
+version = "1.0.0-alpha.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c12388aac4f817eae0359011d67d4072ed84cfc63b0d9a7958ef476fb74bec"
+checksum = "42b1e4dc865f301214157871d201f02f0175a7a19c248398e39669f80fde242c"
 
 [[package]]
 name = "ppv-lite86"

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -39,7 +39,7 @@ arbitrary = { version = "1.4", optional = true }
 base64 = { version = "0.22.0", optional = true }
 # `bitcoinconsensus` version includes metadata which indicates the version of Core. Use `cargo tree` to see it.
 bitcoinconsensus = { version = "0.106.0", default-features = false, optional = true }
-ordered = { version = "0.4.0", optional = true }
+ordered = { version = "1.0.0-alpha.0", optional = true }
 serde = { version = "1.0.103", default-features = false, features = [ "derive", "alloc" ], optional = true }
 
 [dev-dependencies]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -29,7 +29,7 @@ io = { package = "bitcoin-io", version = "0.2.0", default-features = false }
 units = { package = "bitcoin-units", version = "0.2.0", default-features = false }
 
 arbitrary = { version = "1.4", optional = true }
-ordered = { version = "0.4.0", optional = true }
+ordered = { version = "1.0.0-alpha.0", optional = true }
 serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"], optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
We just released the first `v1.0` alpha release of `rust-ordered` - lets use it.

ref: https://crates.io/crates/ordered/1.0.0-alpha.0