### PR TITLE
Add engine function to `siphash24::Hash`

### DIFF
--- a/api/hashes/all-features.txt
+++ b/api/hashes/all-features.txt
@@ -967,6 +967,7 @@ pub fn bitcoin_hashes::siphash24::Hash::borrow(&self) -> &[u8]
 pub fn bitcoin_hashes::siphash24::Hash::clone(&self) -> bitcoin_hashes::siphash24::Hash
 pub fn bitcoin_hashes::siphash24::Hash::cmp(&self, other: &bitcoin_hashes::siphash24::Hash) -> core::cmp::Ordering
 pub fn bitcoin_hashes::siphash24::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::siphash24::Hash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::siphash24::Hash::engine(k0: u64, k1: u64) -> bitcoin_hashes::siphash24::HashEngine
 pub fn bitcoin_hashes::siphash24::Hash::eq(&self, other: &bitcoin_hashes::siphash24::Hash) -> bool
 pub fn bitcoin_hashes::siphash24::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_hashes::siphash24::Hash::from_byte_array(bytes: Self::Bytes) -> Self

--- a/api/hashes/alloc-only.txt
+++ b/api/hashes/alloc-only.txt
@@ -831,6 +831,7 @@ pub fn bitcoin_hashes::siphash24::Hash::borrow(&self) -> &[u8; 8]
 pub fn bitcoin_hashes::siphash24::Hash::borrow(&self) -> &[u8]
 pub fn bitcoin_hashes::siphash24::Hash::clone(&self) -> bitcoin_hashes::siphash24::Hash
 pub fn bitcoin_hashes::siphash24::Hash::cmp(&self, other: &bitcoin_hashes::siphash24::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::siphash24::Hash::engine(k0: u64, k1: u64) -> bitcoin_hashes::siphash24::HashEngine
 pub fn bitcoin_hashes::siphash24::Hash::eq(&self, other: &bitcoin_hashes::siphash24::Hash) -> bool
 pub fn bitcoin_hashes::siphash24::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_hashes::siphash24::Hash::from_byte_array(bytes: Self::Bytes) -> Self

--- a/api/hashes/no-features.txt
+++ b/api/hashes/no-features.txt
@@ -780,6 +780,7 @@ pub fn bitcoin_hashes::siphash24::Hash::borrow(&self) -> &[u8; 8]
 pub fn bitcoin_hashes::siphash24::Hash::borrow(&self) -> &[u8]
 pub fn bitcoin_hashes::siphash24::Hash::clone(&self) -> bitcoin_hashes::siphash24::Hash
 pub fn bitcoin_hashes::siphash24::Hash::cmp(&self, other: &bitcoin_hashes::siphash24::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::siphash24::Hash::engine(k0: u64, k1: u64) -> bitcoin_hashes::siphash24::HashEngine
 pub fn bitcoin_hashes::siphash24::Hash::eq(&self, other: &bitcoin_hashes::siphash24::Hash) -> bool
 pub fn bitcoin_hashes::siphash24::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_hashes::siphash24::Hash::from_byte_array(bytes: Self::Bytes) -> Self

--- a/hashes/src/siphash24.rs
+++ b/hashes/src/siphash24.rs
@@ -168,6 +168,9 @@ impl crate::HashEngine for HashEngine {
 }
 
 impl Hash {
+    /// Constructs a new SipHash24 engine with keys.
+    pub fn engine(k0: u64, k1: u64) -> HashEngine { HashEngine::with_keys(k0, k1) }
+
     /// Produces a hash from the current state of a given engine.
     pub fn from_engine(e: HashEngine) -> Hash { from_engine(e) }
 


### PR DESCRIPTION
The other hashes that require initial state (keys etc) both have an `engine` function on the hash type because they cannot use the `GeneralHash::engine` function.

Add an `engine` function to the `siphash24::Hash` type.