### PR TITLE
Return `Self::Output` from `ops::Rem`

### DIFF
--- a/units/src/amount/signed.rs
+++ b/units/src/amount/signed.rs
@@ -502,7 +502,7 @@ crate::internal_macros::impl_sub_assign!(SignedAmount);
 impl ops::Rem<i64> for SignedAmount {
     type Output = SignedAmount;
 
-    fn rem(self, modulus: i64) -> Self {
+    fn rem(self, modulus: i64) -> Self::Output {
         self.checked_rem(modulus).expect("SignedAmount remainder error")
     }
 }

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -445,7 +445,7 @@ crate::internal_macros::impl_sub_assign!(Amount);
 impl ops::Rem<u64> for Amount {
     type Output = Amount;
 
-    fn rem(self, modulus: u64) -> Self {
+    fn rem(self, modulus: u64) -> Self::Output {
         self.checked_rem(modulus).expect("Amount remainder error")
     }
 }


### PR DESCRIPTION
The ops traits return `Self::Output` not `Self`. The current code builds because `Self` and `Self::Output` are both the same type.

Use `Self::Output` as the return value of `ops::Rem`.