### PR TITLE
hashes: Derive `Debug` for all hash engines

### DIFF
--- a/hashes/src/hash160/mod.rs
+++ b/hashes/src/hash160/mod.rs
@@ -25,7 +25,7 @@ fn from_engine(e: HashEngine) -> Hash {
 }
 
 /// Engine to compute HASH160 hash function.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct HashEngine(sha256::HashEngine);
 
 impl HashEngine {

--- a/hashes/src/hmac/mod.rs
+++ b/hashes/src/hmac/mod.rs
@@ -35,7 +35,7 @@ impl<T: GeneralHash + str::FromStr> str::FromStr for Hmac<T> {
 }
 
 /// Pair of underlying hash engines, used for the inner and outer hash of HMAC.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct HmacEngine<T: GeneralHash> {
     iengine: T::Engine,
     oengine: T::Engine,

--- a/hashes/src/ripemd160/mod.rs
+++ b/hashes/src/ripemd160/mod.rs
@@ -48,7 +48,7 @@ fn from_engine(e: HashEngine) -> Hash {
 const BLOCK_SIZE: usize = 64;
 
 /// Engine to compute RIPEMD160 hash function.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct HashEngine {
     buffer: [u8; BLOCK_SIZE],
     h: [u32; 5],

--- a/hashes/src/sha1/mod.rs
+++ b/hashes/src/sha1/mod.rs
@@ -40,7 +40,7 @@ fn from_engine(mut e: HashEngine) -> Hash {
 const BLOCK_SIZE: usize = 64;
 
 /// Engine to compute SHA1 hash function.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct HashEngine {
     buffer: [u8; BLOCK_SIZE],
     h: [u32; 5],

--- a/hashes/src/sha256/mod.rs
+++ b/hashes/src/sha256/mod.rs
@@ -54,7 +54,7 @@ fn from_engine(e: HashEngine) -> Hash {
 const BLOCK_SIZE: usize = 64;
 
 /// Engine to compute SHA256 hash function.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct HashEngine {
     buffer: [u8; BLOCK_SIZE],
     h: [u32; 8],

--- a/hashes/src/sha256d/mod.rs
+++ b/hashes/src/sha256d/mod.rs
@@ -20,7 +20,7 @@ fn from_engine(e: HashEngine) -> Hash {
 }
 
 /// Engine to compute SHA256d hash function.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct HashEngine(sha256::HashEngine);
 
 impl HashEngine {

--- a/hashes/src/sha384/mod.rs
+++ b/hashes/src/sha384/mod.rs
@@ -17,7 +17,7 @@ fn from_engine(e: HashEngine) -> Hash {
 }
 
 /// Engine to compute SHA384 hash function.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct HashEngine(sha512::HashEngine);
 
 impl HashEngine {

--- a/hashes/src/sha512/mod.rs
+++ b/hashes/src/sha512/mod.rs
@@ -49,7 +49,7 @@ pub(crate) fn from_engine(e: HashEngine) -> Hash {
 pub(crate) const BLOCK_SIZE: usize = 128;
 
 /// Engine to compute SHA512 hash function.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct HashEngine {
     h: [u64; 8],
     bytes_hashed: u64,

--- a/hashes/src/sha512_256/mod.rs
+++ b/hashes/src/sha512_256/mod.rs
@@ -27,7 +27,7 @@ fn from_engine(e: HashEngine) -> Hash {
 /// the output to 256 bits. It has different initial constants than sha512 so it
 /// produces an entirely different hash compared to sha512. More information at
 /// <https://eprint.iacr.org/2010/548.pdf>.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct HashEngine(sha512::HashEngine);
 
 impl HashEngine {


### PR DESCRIPTION
Public types typically should implement `Debug`.

Derive `Debug` for all the hash engines.