### PR TITLE
Add missing re-exports to primitives crate root

### DIFF
--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -68,6 +68,7 @@ pub use self::{
     block::{
         Block, Checked as BlockChecked, Unchecked as BlockUnchecked, Validation as BlockValidation,
     },
+    script::{Script, ScriptBuf},
     transaction::{Transaction, TxIn, TxOut},
     witness::Witness,
 };
@@ -76,10 +77,11 @@ pub use self::{
     block::{BlockHash, Header as BlockHeader, WitnessCommitment},
     locktime::{absolute, relative},
     merkle_tree::{TxMerkleNode, WitnessMerkleNode},
+    opcodes::Opcode,
     pow::CompactTarget,
     sequence::Sequence,
     taproot::{TapBranchTag, TapLeafHash, TapLeafTag, TapNodeHash, TapTweakHash, TapTweakTag},
-    transaction::{Txid, Wtxid},
+    transaction::{OutPoint, Txid, Wtxid},
 };
 
 #[rustfmt::skip]


### PR DESCRIPTION
There are re-exports in the bitcoin root from primitives that were not re-exported in the primitives crate root.

Add the missing re-exports to primitives crate root.

First mentioned here https://github.com/rust-bitcoin/rust-bitcoin/pull/4012#discussion_r1943895283