### PR TITLE
primitives: Add tests to CompactTarget

### DIFF
--- a/primitives/src/pow.rs
+++ b/primitives/src/pow.rs
@@ -43,3 +43,26 @@ impl fmt::UpperHex for CompactTarget {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::UpperHex::fmt(&self.0, f) }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compact_target_ordering() {
+        let lower = CompactTarget::from_consensus(0x1d00fffe);
+        let lower_copy = CompactTarget::from_consensus(0x1d00fffe);
+        let higher = CompactTarget::from_consensus(0x1d00ffff);
+
+        assert!(lower < higher);
+        assert!(lower == lower_copy);
+    }
+
+    #[test]
+    fn compact_target_formatting() {
+        let compact_target = CompactTarget::from_consensus(0x1d00ffff);
+        assert_eq!(format!("{:x}", compact_target), "1d00ffff");
+        assert_eq!(format!("{:X}", compact_target), "1D00FFFF");
+        assert_eq!(compact_target.to_consensus(), 0x1d00ffff);
+    }
+}


### PR DESCRIPTION
Add tests to pow.rs to kill the mutants found in CompactTarget.