### PR TITLE
Update mutants.toml

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,5 +1,5 @@
 additional_cargo_args = ["--all-features"]
-examine_globs = ["units/src/**/*.rs"]
+examine_globs = ["units/src/**/*.rs", "primitives/src/**/*.rs"]
 exclude_globs = [
     "units/src/amount/verification.rs" # kani tests
 ]
@@ -9,6 +9,7 @@ exclude_re = [
     "impl Display",
     ".*Error",
     "deserialize", # Skip serde mutation tests
+    "Iterator", # Mutating operations in an iterator can result in an infinite loop
 
     # ----------------------------------Crate-specific exclusions----------------------------------
     # Units
@@ -18,4 +19,14 @@ exclude_re = [
     "dec_width", # Replacing num /= 10 with num %=10 in a loop causes a timeout due to infinite loop
     # src/locktime/relative.rs
     "Time::to_consensus_u32", # Mutant from replacing | with ^, this returns the same value since the XOR is taken against the u16 with an all-zero bitmask
+
+    # primitives
+    "Sequence::from_512_second_intervals", # Mutant from replacing | with ^, this returns the same value since the XOR is taken against the u16 with an all-zero bitmask
+    "Opcode::classify", # Not possible to kill all mutants without individually checking every opcode classification
+    "Block<Checked>::cached_witness_root", # Skip getters
+    "Block<Checked>::transactions", # Skip getters
+    "Script::to_bytes", # Deprecated
+    "decode_cursor", # Mutating operations in decode_cursor can result in an infinite loop
+    "fmt_debug", # Mutants from formatting/display changes
+    "fmt_debug_pretty", # Mutants from formatting/display changes
 ]

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -8,20 +8,14 @@ exclude_re = [
     "impl Arbitrary",
     "impl Display",
     ".*Error",
-    # --------------------------------------------Crate-specific exclusions--------------------------------------------
+    "deserialize", # Skip serde mutation tests
+
+    # ----------------------------------Crate-specific exclusions----------------------------------
     # Units
     # src/amount/mod.rs
     "parse_signed_to_satoshi", # Can't kill all mutants since there is no denomination smaller than Satoshi
     "fmt_satoshi_in", # Related to formatting/display
     "dec_width", # Replacing num /= 10 with num %=10 in a loop causes a timeout due to infinite loop
-    # src/fee_rate/serde.rs
-    "as_sat_per_kwu::opt::deserialize::<impl Visitor for VisitOpt>.*", # Replaces return value with Ok(Default::default()), which is the same as Ok(None)
-    "as_sat_per_vb_floor::opt::deserialize::<impl Visitor for VisitOpt>.*", # Replaces return value with Ok(Default::default()), which is the same as Ok(None)
-    "as_sat_per_vb_ceil::opt::deserialize::<impl Visitor for VisitOpt>.*", # Replaces return value with Ok(Default::default()), which is the same as Ok(None)
-    # src/amount/serde.rs
-    "as_sat::opt::deserialize::<impl Visitor for VisitOptAmt<X>>.*", # Replaces return value with Ok(Default::default()), which is the same as Ok(None)
-    "as_btc::opt::deserialize::<impl Visitor for VisitOptAmt<X>>.*", # Replaces return value with Ok(Default::default()), which is the same as Ok(None)
-    "as_str::opt::deserialize::<impl Visitor for VisitOptAmt<X>>.*", # Replaces return value with Ok(Default::default()), which is the same as Ok(None)
     # src/locktime/relative.rs
-    "Time::to_consensus_u32" # It will replace | with ^, which will return the same value since the XOR is always taken against the u16 and an all-zero bitmask
+    "Time::to_consensus_u32", # Mutant from replacing | with ^, this returns the same value since the XOR is taken against the u16 with an all-zero bitmask
 ]


### PR DESCRIPTION
All of the mutants found by `cargo mutants` in primitives have been killed in: #3948, #3971, #3987, #4012, #4019, #4020, #4024, #4033, #4036, #4037.

Add `deserialize` as a general exception.  The mutant is changing the return value to Ok(Default::default()), and a test to kill it doesn't prove anything other than the function can return something.

Reword comments to make them clearer.

Add the required exceptions for cases in primitives that need to be skipped.

Add primitives to the examine paths.