### PR TITLE
Demo: trivially pluralise all fields

### DIFF
--- a/bitcoin/examples/ecdsa-psbt-simple.rs
+++ b/bitcoin/examples/ecdsa-psbt-simple.rs
@@ -174,8 +174,8 @@ fn main() {
     let unsigned_tx = Transaction {
         version: transaction::Version::TWO,  // Post BIP 68.
         lock_time: absolute::LockTime::ZERO, // Ignore the locktime.
-        input: inputs,                       // Input is 0-indexed.
-        output: vec![spend, change],         // Outputs, order does not matter.
+        inputs: inputs,                       // Input is 0-indexed.
+        outputs: vec![spend, change],         // Outputs, order does not matter.
     };
 
     // Now we'll start the PSBT workflow.

--- a/bitcoin/examples/ecdsa-psbt.rs
+++ b/bitcoin/examples/ecdsa-psbt.rs
@@ -185,13 +185,13 @@ impl WatchOnly {
         let tx = Transaction {
             version: transaction::Version::TWO,
             lock_time: absolute::LockTime::ZERO,
-            input: vec![TxIn {
+            inputs: vec![TxIn {
                 previous_output: OutPoint { txid: INPUT_UTXO_TXID.parse()?, vout: INPUT_UTXO_VOUT },
                 script_sig: ScriptBuf::new(),
                 sequence: Sequence::MAX, // Disable LockTime and RBF.
                 witness: Witness::default(),
             }],
-            output: vec![
+            outputs: vec![
                 TxOut { value: to_amount, script_pubkey: to_address.script_pubkey() },
                 TxOut { value: change_amount, script_pubkey: change_address.script_pubkey() },
             ],

--- a/bitcoin/examples/sighash.rs
+++ b/bitcoin/examples/sighash.rs
@@ -22,7 +22,7 @@ use hex_lit::hex;
 /// * `amount` - ref tx output value in sats
 fn compute_sighash_p2wpkh(raw_tx: &[u8], inp_idx: usize, amount: Amount) {
     let tx: Transaction = consensus::deserialize(raw_tx).unwrap();
-    let inp = &tx.input[inp_idx];
+    let inp = &tx.inputs[inp_idx];
     let witness = &inp.witness;
     println!("Witness: {:?}", witness);
 
@@ -61,7 +61,7 @@ fn compute_sighash_p2wpkh(raw_tx: &[u8], inp_idx: usize, amount: Amount) {
 /// * `script_pubkey_bytes_opt` - Option with scriptPubKey bytes. If None, it's p2sh case, i.e., reftx output's scriptPubKey.type is "scripthash". In this case scriptPubkey is extracted from the spending transaction's scriptSig. If Some(), it's p2ms case, i.e., reftx output's scriptPubKey.type is "multisig", and the scriptPubkey is supplied from the referenced output.
 fn compute_sighash_legacy(raw_tx: &[u8], inp_idx: usize, script_pubkey_bytes_opt: Option<&[u8]>) {
     let tx: Transaction = consensus::deserialize(raw_tx).unwrap();
-    let inp = &tx.input[inp_idx];
+    let inp = &tx.inputs[inp_idx];
     let script_sig = &inp.script_sig;
     println!("scriptSig is: {}", script_sig);
     let cache = sighash::SighashCache::new(&tx);
@@ -107,7 +107,7 @@ fn compute_sighash_legacy(raw_tx: &[u8], inp_idx: usize, script_pubkey_bytes_opt
 /// * `amount` - ref tx output value in sats
 fn compute_sighash_p2wsh(raw_tx: &[u8], inp_idx: usize, amount: Amount) {
     let tx: Transaction = consensus::deserialize(raw_tx).unwrap();
-    let inp = &tx.input[inp_idx];
+    let inp = &tx.inputs[inp_idx];
     let witness = &inp.witness;
     println!("witness {:?}", witness);
 

--- a/bitcoin/examples/sign-tx-segwit-v0.rs
+++ b/bitcoin/examples/sign-tx-segwit-v0.rs
@@ -51,8 +51,8 @@ fn main() {
     let mut unsigned_tx = Transaction {
         version: transaction::Version::TWO,  // Post BIP-68.
         lock_time: absolute::LockTime::ZERO, // Ignore the locktime.
-        input: vec![input],                  // Input goes into index 0.
-        output: vec![spend, change],         // Outputs, order does not matter.
+        inputs: vec![input],                  // Input goes into index 0.
+        outputs: vec![spend, change],         // Outputs, order does not matter.
     };
     let input_index = 0;
 

--- a/bitcoin/examples/sign-tx-taproot.rs
+++ b/bitcoin/examples/sign-tx-taproot.rs
@@ -52,8 +52,8 @@ fn main() {
     let mut unsigned_tx = Transaction {
         version: transaction::Version::TWO,  // Post BIP-68.
         lock_time: absolute::LockTime::ZERO, // Ignore the locktime.
-        input: vec![input],                  // Input goes into index 0.
-        output: vec![spend, change],         // Outputs, order does not matter.
+        inputs: vec![input],                  // Input goes into index 0.
+        outputs: vec![spend, change],         // Outputs, order does not matter.
     };
     let input_index = 0;
 

--- a/bitcoin/examples/taproot-psbt-simple.rs
+++ b/bitcoin/examples/taproot-psbt-simple.rs
@@ -194,8 +194,8 @@ fn main() {
     let unsigned_tx = Transaction {
         version: transaction::Version::TWO,  // Post BIP 68.
         lock_time: absolute::LockTime::ZERO, // Ignore the locktime.
-        input: inputs,                       // Input is 0-indexed.
-        output: vec![spend, change],         // Outputs, order does not matter.
+        inputs: inputs,                       // Input is 0-indexed.
+        outputs: vec![spend, change],         // Outputs, order does not matter.
     };
 
     // Now we'll start the PSBT workflow.

--- a/bitcoin/examples/taproot-psbt.rs
+++ b/bitcoin/examples/taproot-psbt.rs
@@ -233,13 +233,13 @@ fn generate_bip86_key_spend_tx(
     let tx1 = Transaction {
         version: transaction::Version::TWO,
         lock_time: absolute::LockTime::ZERO,
-        input: vec![TxIn {
+        inputs: vec![TxIn {
             previous_output: OutPoint { txid: input_utxo.txid.parse()?, vout: input_utxo.vout },
             script_sig: ScriptBuf::new(),
             sequence: bitcoin::Sequence(0xFFFFFFFF), // Ignore nSequence.
             witness: Witness::default(),
         }],
-        output: outputs,
+        outputs: outputs,
     };
     let mut psbt = Psbt::from_unsigned_tx(tx1)?;
 
@@ -426,13 +426,13 @@ impl BenefactorWallet {
         let next_tx = Transaction {
             version: transaction::Version::TWO,
             lock_time,
-            input: vec![TxIn {
+            inputs: vec![TxIn {
                 previous_output: OutPoint { txid: tx.compute_txid(), vout: 0 },
                 script_sig: ScriptBuf::new(),
                 sequence: bitcoin::Sequence(0xFFFFFFFD), // enable locktime and opt-in RBF
                 witness: Witness::default(),
             }],
-            output: vec![],
+            outputs: vec![],
         };
         let mut next_psbt = Psbt::from_unsigned_tx(next_tx)?;
         let mut origins = BTreeMap::new();
@@ -511,7 +511,7 @@ impl BenefactorWallet {
                 taproot_spend_info.merkle_root(),
             );
 
-            psbt.unsigned_tx.output =
+            psbt.unsigned_tx.outputs =
                 vec![TxOut { script_pubkey: output_script_pubkey.clone(), value: output_value }];
             psbt.outputs = vec![Output::default()];
             psbt.unsigned_tx.lock_time = absolute::LockTime::ZERO;
@@ -574,13 +574,13 @@ impl BenefactorWallet {
             let next_tx = Transaction {
                 version: transaction::Version::TWO,
                 lock_time,
-                input: vec![TxIn {
+                inputs: vec![TxIn {
                     previous_output: OutPoint { txid: tx.compute_txid(), vout: 0 },
                     script_sig: ScriptBuf::new(),
                     sequence: bitcoin::Sequence(0xFFFFFFFD), // enable locktime and opt-in RBF
                     witness: Witness::default(),
                 }],
-                output: vec![],
+                outputs: vec![],
             };
             let mut next_psbt = Psbt::from_unsigned_tx(next_tx)?;
             let mut origins = BTreeMap::new();
@@ -647,7 +647,7 @@ impl BeneficiaryWallet {
         let input_script_pubkey =
             psbt.inputs[0].witness_utxo.as_ref().unwrap().script_pubkey.clone();
         psbt.unsigned_tx.lock_time = lock_time;
-        psbt.unsigned_tx.output = vec![TxOut {
+        psbt.unsigned_tx.outputs = vec![TxOut {
             script_pubkey: to_address.script_pubkey(),
             value: input_value - ABSOLUTE_FEES,
         }];

--- a/bitcoin/src/bip152.rs
+++ b/bitcoin/src/bip152.rs
@@ -239,7 +239,7 @@ impl HeaderAndShortIds {
                         1 => {
                             // strip witness for version 1
                             let mut no_witness = tx.clone();
-                            no_witness.input.iter_mut().for_each(|i| i.witness.clear());
+                            no_witness.inputs.iter_mut().for_each(|i| i.witness.clear());
                             no_witness
                         }
                         // > Transactions inside cmpctblock messages (both those used as direct
@@ -422,13 +422,13 @@ mod test {
         Transaction {
             version: transaction::Version::ONE,
             lock_time: absolute::LockTime::from_consensus(2),
-            input: vec![TxIn {
+            inputs: vec![TxIn {
                 previous_output: OutPoint::new(dummy_txid, 0),
                 script_sig: ScriptBuf::new(),
                 sequence: Sequence(1),
                 witness: Witness::new(),
             }],
-            output: vec![TxOut { value: Amount::ONE_SAT, script_pubkey: ScriptBuf::new() }],
+            outputs: vec![TxOut { value: Amount::ONE_SAT, script_pubkey: ScriptBuf::new() }],
         }
     }
 

--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -204,7 +204,7 @@ impl<'a, W: Write> BlockFilterWriter<'a, W> {
     /// Adds output scripts of the block to filter (excluding OP_RETURN scripts).
     pub fn add_output_scripts(&mut self) {
         for transaction in self.block.transactions() {
-            for output in &transaction.output {
+            for output in &transaction.outputs {
                 if !output.script_pubkey.is_op_return() {
                     self.add_element(output.script_pubkey.as_bytes());
                 }
@@ -223,7 +223,7 @@ impl<'a, W: Write> BlockFilterWriter<'a, W> {
             .transactions()
             .iter()
             .skip(1) // skip coinbase
-            .flat_map(|t| t.input.iter().map(|i| &i.previous_output))
+            .flat_map(|t| t.inputs.iter().map(|i| &i.previous_output))
             .map(script_for_coin)
         {
             match script {
@@ -605,7 +605,7 @@ mod test {
             let mut txmap = HashMap::new();
             let mut si = scripts.iter();
             for tx in block.transactions().iter().skip(1) {
-                for input in tx.input.iter() {
+                for input in tx.inputs.iter() {
                     txmap.insert(
                         input.previous_output,
                         ScriptBuf::from(hex!(si.next().unwrap().as_str().unwrap())),

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -160,7 +160,7 @@ fn check_merkle_root(header: &Header, transactions: &[Transaction]) -> bool {
 // Returns the Merkle root if it was computed (so it can be cached in `assume_checked`).
 fn check_witness_commitment(transactions: &[Transaction]) -> (bool, Option<WitnessMerkleNode>) {
     // Witness commitment is optional if there are no transactions using SegWit in the block.
-    if transactions.iter().all(|t| t.input.iter().all(|i| i.witness.is_empty())) {
+    if transactions.iter().all(|t| t.inputs.iter().all(|i| i.witness.is_empty())) {
         return (true, None);
     }
 
@@ -172,7 +172,7 @@ fn check_witness_commitment(transactions: &[Transaction]) -> (bool, Option<Witne
         let coinbase = transactions[0].clone();
         if let Some(commitment) = witness_commitment_from_coinbase(&coinbase) {
             // Witness reserved value is in coinbase input witness.
-            let witness_vec: Vec<_> = coinbase.input[0].witness.iter().collect();
+            let witness_vec: Vec<_> = coinbase.inputs[0].witness.iter().collect();
             if witness_vec.len() == 1 && witness_vec[0].len() == 32 {
                 if let Some((witness_root, witness_commitment)) =
                     compute_witness_commitment(transactions, witness_vec[0])
@@ -198,12 +198,12 @@ fn witness_commitment_from_coinbase(coinbase: &Transaction) -> Option<WitnessCom
 
     // Commitment is in the last output that starts with magic bytes.
     if let Some(pos) = coinbase
-        .output
+        .outputs
         .iter()
         .rposition(|o| o.script_pubkey.len() >= 38 && o.script_pubkey.as_bytes()[0..6] == MAGIC)
     {
         let bytes =
-            <[u8; 32]>::try_from(&coinbase.output[pos].script_pubkey.as_bytes()[6..38]).unwrap();
+            <[u8; 32]>::try_from(&coinbase.outputs[pos].script_pubkey.as_bytes()[6..38]).unwrap();
         Some(WitnessCommitment::from_byte_array(bytes))
     } else {
         None
@@ -295,7 +295,7 @@ impl BlockCheckedExt for Block<Checked> {
         }
 
         let cb = self.coinbase().ok_or(Bip34Error::NotPresent)?;
-        let input = cb.input.first().ok_or(Bip34Error::NotPresent)?;
+        let input = cb.inputs.first().ok_or(Bip34Error::NotPresent)?;
         let push = input
             .script_sig
             .instructions_minimal()

--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -79,8 +79,8 @@ fn bitcoin_genesis_tx(params: &Params) -> Transaction {
     let mut ret = Transaction {
         version: transaction::Version::ONE,
         lock_time: absolute::LockTime::ZERO,
-        input: vec![],
-        output: vec![],
+        inputs: vec![],
+        outputs: vec![],
     };
 
     let (in_script, out_script) = {
@@ -105,14 +105,14 @@ fn bitcoin_genesis_tx(params: &Params) -> Transaction {
         }
     };
 
-    ret.input.push(TxIn {
+    ret.inputs.push(TxIn {
         previous_output: OutPoint::COINBASE_PREVOUT,
         script_sig: in_script,
         sequence: Sequence::MAX,
         witness: Witness::default(),
     });
 
-    ret.output.push(TxOut { value: Amount::FIFTY_BTC, script_pubkey: out_script });
+    ret.outputs.push(TxOut { value: Amount::FIFTY_BTC, script_pubkey: out_script });
 
     // end
     ret
@@ -278,17 +278,17 @@ mod test {
         let gen = bitcoin_genesis_tx(&Params::MAINNET);
 
         assert_eq!(gen.version, transaction::Version::ONE);
-        assert_eq!(gen.input.len(), 1);
-        assert_eq!(gen.input[0].previous_output.txid, Txid::COINBASE_PREVOUT);
-        assert_eq!(gen.input[0].previous_output.vout, 0xFFFFFFFF);
-        assert_eq!(serialize(&gen.input[0].script_sig),
+        assert_eq!(gen.inputs.len(), 1);
+        assert_eq!(gen.inputs[0].previous_output.txid, Txid::COINBASE_PREVOUT);
+        assert_eq!(gen.inputs[0].previous_output.vout, 0xFFFFFFFF);
+        assert_eq!(serialize(&gen.inputs[0].script_sig),
                    hex!("4d04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73"));
 
-        assert_eq!(gen.input[0].sequence, Sequence::MAX);
-        assert_eq!(gen.output.len(), 1);
-        assert_eq!(serialize(&gen.output[0].script_pubkey),
+        assert_eq!(gen.inputs[0].sequence, Sequence::MAX);
+        assert_eq!(gen.outputs.len(), 1);
+        assert_eq!(serialize(&gen.outputs[0].script_pubkey),
                    hex!("434104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac"));
-        assert_eq!(gen.output[0].value, "50 BTC".parse::<Amount>().unwrap());
+        assert_eq!(gen.outputs[0].value, "50 BTC".parse::<Amount>().unwrap());
         assert_eq!(gen.lock_time, absolute::LockTime::ZERO);
 
         assert_eq!(

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -349,11 +349,11 @@ impl TransactionExt for Transaction {
     fn base_size(&self) -> usize {
         let mut size: usize = 4; // Serialized length of a u32 for the version number.
 
-        size += compact_size::encoded_size(self.input.len());
-        size += self.input.iter().map(|input| input.base_size()).sum::<usize>();
+        size += compact_size::encoded_size(self.inputs.len());
+        size += self.inputs.iter().map(|input| input.base_size()).sum::<usize>();
 
-        size += compact_size::encoded_size(self.output.len());
-        size += self.output.iter().map(|output| output.size()).sum::<usize>();
+        size += compact_size::encoded_size(self.outputs.len());
+        size += self.outputs.iter().map(|output| output.size()).sum::<usize>();
 
         size + absolute::LockTime::SIZE
     }
@@ -367,15 +367,15 @@ impl TransactionExt for Transaction {
             size += 2; // 1 byte for the marker and 1 for the flag.
         }
 
-        size += compact_size::encoded_size(self.input.len());
+        size += compact_size::encoded_size(self.inputs.len());
         size += self
-            .input
+            .inputs
             .iter()
             .map(|input| if uses_segwit { input.total_size() } else { input.base_size() })
             .sum::<usize>();
 
-        size += compact_size::encoded_size(self.output.len());
-        size += self.output.iter().map(|output| output.size()).sum::<usize>();
+        size += compact_size::encoded_size(self.outputs.len());
+        size += self.outputs.iter().map(|output| output.size()).sum::<usize>();
 
         size + absolute::LockTime::SIZE
     }
@@ -388,10 +388,10 @@ impl TransactionExt for Transaction {
 
     #[doc(alias = "is_coin_base")] // method previously had this name
     fn is_coinbase(&self) -> bool {
-        self.input.len() == 1 && self.input[0].previous_output == OutPoint::COINBASE_PREVOUT
+        self.inputs.len() == 1 && self.inputs[0].previous_output == OutPoint::COINBASE_PREVOUT
     }
 
-    fn is_explicitly_rbf(&self) -> bool { self.input.iter().any(|input| input.sequence.is_rbf()) }
+    fn is_explicitly_rbf(&self) -> bool { self.inputs.iter().any(|input| input.sequence.is_rbf()) }
 
     fn is_absolute_timelock_satisfied(&self, height: Height, time: Time) -> bool {
         if !self.is_lock_time_enabled() {
@@ -400,10 +400,10 @@ impl TransactionExt for Transaction {
         self.lock_time.is_satisfied_by(height, time)
     }
 
-    fn is_lock_time_enabled(&self) -> bool { self.input.iter().any(|i| i.enables_lock_time()) }
+    fn is_lock_time_enabled(&self) -> bool { self.inputs.iter().any(|i| i.enables_lock_time()) }
 
     fn script_pubkey_lens(&self) -> TxOutToScriptPubkeyLengthIter {
-        TxOutToScriptPubkeyLengthIter { inner: self.output.iter() }
+        TxOutToScriptPubkeyLengthIter { inner: self.outputs.iter() }
     }
 
     fn total_sigop_cost<S>(&self, mut spent: S) -> usize
@@ -419,16 +419,16 @@ impl TransactionExt for Transaction {
 
     #[inline]
     fn tx_in(&self, input_index: usize) -> Result<&TxIn, InputsIndexError> {
-        self.input
+        self.inputs
             .get(input_index)
-            .ok_or(IndexOutOfBoundsError { index: input_index, length: self.input.len() }.into())
+            .ok_or(IndexOutOfBoundsError { index: input_index, length: self.inputs.len() }.into())
     }
 
     #[inline]
     fn tx_out(&self, output_index: usize) -> Result<&TxOut, OutputsIndexError> {
-        self.output
+        self.outputs
             .get(output_index)
-            .ok_or(IndexOutOfBoundsError { index: output_index, length: self.output.len() }.into())
+            .ok_or(IndexOutOfBoundsError { index: output_index, length: self.outputs.len() }.into())
     }
 }
 
@@ -470,11 +470,11 @@ impl TransactionExtPriv for Transaction {
     /// Gets the sigop count.
     fn count_p2pk_p2pkh_sigops(&self) -> usize {
         let mut count: usize = 0;
-        for input in &self.input {
+        for input in &self.inputs {
             // 0 for p2wpkh, p2wsh, and p2sh (including wrapped SegWit).
             count = count.saturating_add(input.script_sig.count_sigops_legacy());
         }
-        for output in &self.output {
+        for output in &self.outputs {
             count = count.saturating_add(output.script_pubkey.count_sigops_legacy());
         }
         count
@@ -497,7 +497,7 @@ impl TransactionExtPriv for Transaction {
         }
 
         let mut count: usize = 0;
-        for input in &self.input {
+        for input in &self.inputs {
             if let Some(prevout) = spent(&input.previous_output) {
                 count = count.saturating_add(count_sigops(&prevout, input));
             }
@@ -548,7 +548,7 @@ impl TransactionExtPriv for Transaction {
         }
 
         let mut count: usize = 0;
-        for input in &self.input {
+        for input in &self.inputs {
             if let Some(prevout) = spent(&input.previous_output) {
                 count = count.saturating_add(count_sigops(prevout, input));
             }
@@ -559,12 +559,12 @@ impl TransactionExtPriv for Transaction {
     /// Returns whether or not to serialize transaction as specified in BIP-144.
     // This is duplicated in `primitives`, if you change it please do so in both places.
     fn uses_segwit_serialization(&self) -> bool {
-        if self.input.iter().any(|input| !input.witness.is_empty()) {
+        if self.inputs.iter().any(|input| !input.witness.is_empty()) {
             return true;
         }
         // To avoid serialization ambiguity, no inputs means we use BIP141 serialization (see
         // `Transaction` docs for full explanation).
-        self.input.is_empty()
+        self.inputs.is_empty()
     }
 }
 
@@ -709,15 +709,15 @@ impl Encodable for Transaction {
 
         // Legacy transaction serialization format only includes inputs and outputs.
         if !self.uses_segwit_serialization() {
-            len += self.input.consensus_encode(w)?;
-            len += self.output.consensus_encode(w)?;
+            len += self.inputs.consensus_encode(w)?;
+            len += self.outputs.consensus_encode(w)?;
         } else {
             // BIP-141 (SegWit) transaction serialization also includes marker, flag, and witness data.
             len += SEGWIT_MARKER.consensus_encode(w)?;
             len += SEGWIT_FLAG.consensus_encode(w)?;
-            len += self.input.consensus_encode(w)?;
-            len += self.output.consensus_encode(w)?;
-            for input in &self.input {
+            len += self.inputs.consensus_encode(w)?;
+            len += self.outputs.consensus_encode(w)?;
+            for input in &self.inputs {
                 len += input.witness.consensus_encode(w)?;
             }
         }
@@ -731,27 +731,27 @@ impl Decodable for Transaction {
         r: &mut R,
     ) -> Result<Self, encode::Error> {
         let version = Version::consensus_decode_from_finite_reader(r)?;
-        let input = Vec::<TxIn>::consensus_decode_from_finite_reader(r)?;
+        let inputs = Vec::<TxIn>::consensus_decode_from_finite_reader(r)?;
         // SegWit
-        if input.is_empty() {
+        if inputs.is_empty() {
             let segwit_flag = u8::consensus_decode_from_finite_reader(r)?;
             match segwit_flag {
                 // BIP144 input witnesses
                 1 => {
-                    let mut input = Vec::<TxIn>::consensus_decode_from_finite_reader(r)?;
-                    let output = Vec::<TxOut>::consensus_decode_from_finite_reader(r)?;
-                    for txin in input.iter_mut() {
+                    let mut inputs = Vec::<TxIn>::consensus_decode_from_finite_reader(r)?;
+                    let outputs = Vec::<TxOut>::consensus_decode_from_finite_reader(r)?;
+                    for txin in inputs.iter_mut() {
                         txin.witness = Decodable::consensus_decode_from_finite_reader(r)?;
                     }
-                    if !input.is_empty() && input.iter().all(|input| input.witness.is_empty()) {
+                    if !inputs.is_empty() && inputs.iter().all(|input| input.witness.is_empty()) {
                         Err(consensus::parse_failed_error(
                             "witness flag set but no witnesses present",
                         ))
                     } else {
                         Ok(Transaction {
                             version,
-                            input,
-                            output,
+                            inputs,
+                            outputs,
                             lock_time: Decodable::consensus_decode_from_finite_reader(r)?,
                         })
                     }
@@ -763,8 +763,8 @@ impl Decodable for Transaction {
         } else {
             Ok(Transaction {
                 version,
-                input,
-                output: Decodable::consensus_decode_from_finite_reader(r)?,
+                inputs,
+                outputs: Decodable::consensus_decode_from_finite_reader(r)?,
                 lock_time: Decodable::consensus_decode_from_finite_reader(r)?,
             })
         }
@@ -1266,15 +1266,15 @@ mod tests {
         // All these tests aren't really needed because if they fail, the hash check at the end
         // will also fail. But these will show you where the failure is so I'll leave them in.
         assert_eq!(realtx.version, Version::ONE);
-        assert_eq!(realtx.input.len(), 1);
+        assert_eq!(realtx.inputs.len(), 1);
         // In particular this one is easy to get backward -- in bitcoin hashes are encoded
         // as little-endian 256-bit numbers rather than as data strings.
         assert_eq!(
-            format!("{:x}", realtx.input[0].previous_output.txid),
+            format!("{:x}", realtx.inputs[0].previous_output.txid),
             "ce9ea9f6f5e422c6a9dbcddb3b9a14d1c78fab9ab520cb281aa2a74a09575da1".to_string()
         );
-        assert_eq!(realtx.input[0].previous_output.vout, 1);
-        assert_eq!(realtx.output.len(), 1);
+        assert_eq!(realtx.inputs[0].previous_output.vout, 1);
+        assert_eq!(realtx.outputs.len(), 1);
         assert_eq!(realtx.lock_time, absolute::LockTime::ZERO);
 
         assert_eq!(
@@ -1314,15 +1314,15 @@ mod tests {
         // All these tests aren't really needed because if they fail, the hash check at the end
         // will also fail. But these will show you where the failure is so I'll leave them in.
         assert_eq!(realtx.version, Version::TWO);
-        assert_eq!(realtx.input.len(), 1);
+        assert_eq!(realtx.inputs.len(), 1);
         // In particular this one is easy to get backward -- in bitcoin hashes are encoded
         // as little-endian 256-bit numbers rather than as data strings.
         assert_eq!(
-            format!("{:x}", realtx.input[0].previous_output.txid),
+            format!("{:x}", realtx.inputs[0].previous_output.txid),
             "7cac3cf9a112cf04901a51d605058615d56ffe6d04b45270e89d1720ea955859".to_string()
         );
-        assert_eq!(realtx.input[0].previous_output.vout, 1);
-        assert_eq!(realtx.output.len(), 1);
+        assert_eq!(realtx.inputs[0].previous_output.vout, 1);
+        assert_eq!(realtx.outputs.len(), 1);
         assert_eq!(realtx.lock_time, absolute::LockTime::ZERO);
 
         assert_eq!(
@@ -1343,7 +1343,7 @@ mod tests {
 
         // Construct a transaction without the witness data.
         let mut tx_without_witness = realtx;
-        tx_without_witness.input.iter_mut().for_each(|input| input.witness.clear());
+        tx_without_witness.inputs.iter_mut().for_each(|input| input.witness.clear());
         assert_eq!(tx_without_witness.total_size(), tx_without_witness.total_size());
         assert_eq!(tx_without_witness.total_size(), expected_strippedsize);
     }
@@ -1383,8 +1383,8 @@ mod tests {
         );
         let tx: Transaction = deserialize(&tx_bytes).expect("deserialize tx");
 
-        assert_eq!(tx.input.len(), 0);
-        assert_eq!(tx.output.len(), 1);
+        assert_eq!(tx.inputs.len(), 0);
+        assert_eq!(tx.outputs.len(), 1);
 
         let reser = serialize(&tx);
         assert_eq!(tx_bytes, reser);
@@ -1401,10 +1401,10 @@ mod tests {
             "c3573dbea28ce24425c59a189391937e00d255150fa973d59d61caf3a06b601d"
         );
         // changing sigs does not affect it
-        tx.input[0].script_sig = ScriptBuf::new();
+        tx.inputs[0].script_sig = ScriptBuf::new();
         assert_eq!(old_ntxid, tx.compute_ntxid());
         // changing pks does
-        tx.output[0].script_pubkey = ScriptBuf::new();
+        tx.outputs[0].script_pubkey = ScriptBuf::new();
         assert!(old_ntxid != tx.compute_ntxid());
     }
 
@@ -1565,7 +1565,7 @@ mod tests {
         spending
             .verify(|point: &OutPoint| {
                 if let Some(tx) = spent.remove(&point.txid) {
-                    return tx.output.get(point.vout as usize).cloned();
+                    return tx.outputs.get(point.vout as usize).cloned();
                 }
                 None
             })
@@ -1573,27 +1573,27 @@ mod tests {
 
         // test that we fail with repeated use of same input
         let mut double_spending = spending.clone();
-        let re_use = double_spending.input[0].clone();
-        double_spending.input.push(re_use);
+        let re_use = double_spending.inputs[0].clone();
+        double_spending.inputs.push(re_use);
 
         assert!(double_spending
             .verify(|point: &OutPoint| {
                 if let Some(tx) = spent2.remove(&point.txid) {
-                    return tx.output.get(point.vout as usize).cloned();
+                    return tx.outputs.get(point.vout as usize).cloned();
                 }
                 None
             })
             .is_err());
 
         // test that we get a failure if we corrupt a signature
-        let mut witness = spending.input[1].witness.to_vec();
+        let mut witness = spending.inputs[1].witness.to_vec();
         witness[0][10] = 42;
-        spending.input[1].witness = Witness::from_slice(&witness);
+        spending.inputs[1].witness = Witness::from_slice(&witness);
 
         let error = spending
             .verify(|point: &OutPoint| {
                 if let Some(tx) = spent3.remove(&point.txid) {
-                    return tx.output.get(point.vout as usize).cloned();
+                    return tx.outputs.get(point.vout as usize).cloned();
                 }
                 None
             })
@@ -1704,8 +1704,8 @@ mod tests {
         let empty_transaction_weight = Transaction {
             version: Version::TWO,
             lock_time: absolute::LockTime::ZERO,
-            input: vec![],
-            output: vec![],
+            inputs: vec![],
+            outputs: vec![],
         }
         .weight();
 
@@ -1715,8 +1715,8 @@ mod tests {
             assert_eq!(*is_segwit, tx.uses_segwit_serialization());
 
             let mut calculated_weight = empty_transaction_weight
-                + tx.input.iter().fold(Weight::ZERO, |sum, i| sum + txin_weight(i))
-                + tx.output.iter().fold(Weight::ZERO, |sum, o| sum + o.weight());
+                + tx.inputs.iter().fold(Weight::ZERO, |sum, i| sum + txin_weight(i))
+                + tx.outputs.iter().fold(Weight::ZERO, |sum, o| sum + o.weight());
 
             // The empty tx uses SegWit serialization but a legacy tx does not.
             if !tx.uses_segwit_serialization() {

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -393,19 +393,19 @@ mod test {
         let tx: Transaction = deserialize(&tx_bytes).unwrap();
 
         let expected_wit = ["304502210084622878c94f4c356ce49c8e33a063ec90f6ee9c0208540888cfab056cd1fca9022014e8dbfdfa46d318c6887afd92dcfa54510e057565e091d64d2ee3a66488f82c01", "026e181ffb98ebfe5a64c983073398ea4bcd1548e7b971b4c175346a25a1c12e95"];
-        for (i, wit_el) in tx.input[0].witness.iter().enumerate() {
+        for (i, wit_el) in tx.inputs[0].witness.iter().enumerate() {
             assert_eq!(expected_wit[i], wit_el.to_lower_hex_string());
         }
-        assert_eq!(expected_wit[1], tx.input[0].witness.last().unwrap().to_lower_hex_string());
+        assert_eq!(expected_wit[1], tx.inputs[0].witness.last().unwrap().to_lower_hex_string());
         assert_eq!(
             expected_wit[0],
-            tx.input[0].witness.second_to_last().unwrap().to_lower_hex_string()
+            tx.inputs[0].witness.second_to_last().unwrap().to_lower_hex_string()
         );
-        assert_eq!(expected_wit[0], tx.input[0].witness.nth(0).unwrap().to_lower_hex_string());
-        assert_eq!(expected_wit[1], tx.input[0].witness.nth(1).unwrap().to_lower_hex_string());
-        assert_eq!(None, tx.input[0].witness.nth(2));
-        assert_eq!(expected_wit[0], tx.input[0].witness[0].to_lower_hex_string());
-        assert_eq!(expected_wit[1], tx.input[0].witness[1].to_lower_hex_string());
+        assert_eq!(expected_wit[0], tx.inputs[0].witness.nth(0).unwrap().to_lower_hex_string());
+        assert_eq!(expected_wit[1], tx.inputs[0].witness.nth(1).unwrap().to_lower_hex_string());
+        assert_eq!(None, tx.inputs[0].witness.nth(2));
+        assert_eq!(expected_wit[0], tx.inputs[0].witness[0].to_lower_hex_string());
+        assert_eq!(expected_wit[1], tx.inputs[0].witness[1].to_lower_hex_string());
 
         let tx_bytes_back = serialize(&tx);
         assert_eq!(tx_bytes_back, tx_bytes);

--- a/bitcoin/src/consensus_validation.rs
+++ b/bitcoin/src/consensus_validation.rs
@@ -101,7 +101,7 @@ where
 {
     let serialized_tx = encode::serialize(tx);
     let flags: u32 = flags.into();
-    for (idx, input) in tx.input.iter().enumerate() {
+    for (idx, input) in tx.inputs.iter().enumerate() {
         if let Some(output) = spent(&input.previous_output) {
             verify_script_with_flags(
                 &output.script_pubkey,

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -231,7 +231,7 @@ where
 {
     fn check_all(&self, tx: &Transaction) -> Result<(), PrevoutsSizeError> {
         if let Prevouts::All(prevouts) = self {
-            if prevouts.len() != tx.input.len() {
+            if prevouts.len() != tx.inputs.len() {
                 return Err(PrevoutsSizeError);
             }
         }
@@ -702,11 +702,11 @@ impl<R: Borrow<Transaction>> SighashCache<R> {
             let mut enc = sha256::Hash::engine();
             self.tx
                 .borrow()
-                .output
+                .outputs
                 .get(input_index)
                 .ok_or(TaprootError::SingleMissingOutput(SingleMissingOutputError {
                     input_index,
-                    outputs_length: self.tx.borrow().output.len(),
+                    outputs_length: self.tx.borrow().outputs.len(),
                 }))
                 .map_err(SigningDataError::Sighash)?
                 .consensus_encode(&mut enc)?;
@@ -845,10 +845,10 @@ impl<R: Borrow<Transaction>> SighashCache<R> {
 
         if sighash != EcdsaSighashType::Single && sighash != EcdsaSighashType::None {
             self.segwit_cache().outputs.consensus_encode(writer)?;
-        } else if sighash == EcdsaSighashType::Single && input_index < self.tx.borrow().output.len()
+        } else if sighash == EcdsaSighashType::Single && input_index < self.tx.borrow().outputs.len()
         {
             let mut single_enc = LegacySighash::engine();
-            self.tx.borrow().output[input_index].consensus_encode(&mut single_enc)?;
+            self.tx.borrow().outputs[input_index].consensus_encode(&mut single_enc)?;
             let hash = LegacySighash::from_engine(single_enc);
             writer.write_all(hash.as_byte_array())?;
         } else {
@@ -943,7 +943,7 @@ impl<R: Borrow<Transaction>> SighashCache<R> {
         if is_invalid_use_of_sighash_single(
             sighash_type,
             input_index,
-            self.tx.borrow().output.len(),
+            self.tx.borrow().outputs.len(),
         ) {
             // We cannot correctly handle the SIGHASH_SINGLE bug here because usage of this function
             // will result in the data written to the writer being hashed, however the correct
@@ -968,12 +968,12 @@ impl<R: Borrow<Transaction>> SighashCache<R> {
             // Add all inputs necessary..
             if anyone_can_pay {
                 writer.emit_compact_size(1u8)?;
-                self_.input[input_index].previous_output.consensus_encode(writer)?;
+                self_.inputs[input_index].previous_output.consensus_encode(writer)?;
                 script_pubkey.consensus_encode(writer)?;
-                self_.input[input_index].sequence.consensus_encode(writer)?;
+                self_.inputs[input_index].sequence.consensus_encode(writer)?;
             } else {
-                writer.emit_compact_size(self_.input.len())?;
-                for (n, input) in self_.input.iter().enumerate() {
+                writer.emit_compact_size(self_.inputs.len())?;
+                for (n, input) in self_.inputs.iter().enumerate() {
                     input.previous_output.consensus_encode(writer)?;
                     if n == input_index {
                         script_pubkey.consensus_encode(writer)?;
@@ -993,19 +993,19 @@ impl<R: Borrow<Transaction>> SighashCache<R> {
             // ..then all outputs
             match sighash {
                 EcdsaSighashType::All => {
-                    self_.output.consensus_encode(writer)?;
+                    self_.outputs.consensus_encode(writer)?;
                 }
                 EcdsaSighashType::Single => {
                     // sign all outputs up to and including this one, but erase
                     // all of them except for this one
-                    let count = input_index.min(self_.output.len() - 1);
+                    let count = input_index.min(self_.outputs.len() - 1);
                     writer.emit_compact_size(count + 1)?;
                     for _ in 0..count {
                         // consensus encoding of the "NULL txout" - max amount, empty script_pubkey
                         writer
                             .write_all(&[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00])?;
                     }
-                    self_.output[count].consensus_encode(writer)?;
+                    self_.outputs[count].consensus_encode(writer)?;
                 }
                 EcdsaSighashType::None => {
                     writer.emit_compact_size(0u8)?;
@@ -1077,7 +1077,7 @@ impl<R: Borrow<Transaction>> SighashCache<R> {
         common_cache.get_or_insert_with(|| {
             let mut enc_prevouts = sha256::Hash::engine();
             let mut enc_sequences = sha256::Hash::engine();
-            for txin in tx.input.iter() {
+            for txin in tx.inputs.iter() {
                 txin.previous_output.consensus_encode(&mut enc_prevouts).unwrap();
                 txin.sequence.consensus_encode(&mut enc_sequences).unwrap();
             }
@@ -1086,7 +1086,7 @@ impl<R: Borrow<Transaction>> SighashCache<R> {
                 sequences: sha256::Hash::from_engine(enc_sequences),
                 outputs: {
                     let mut enc = sha256::Hash::engine();
-                    for txout in tx.output.iter() {
+                    for txout in tx.outputs.iter() {
                         txout.consensus_encode(&mut enc).unwrap();
                     }
                     sha256::Hash::from_engine(enc)
@@ -1155,7 +1155,7 @@ impl<R: BorrowMut<Transaction>> SighashCache<R> {
     /// [`SegWit v0`]: <https://github.com/rust-bitcoin/rust-bitcoin/blob/master/bitcoin/examples/sign-tx-segwit-v0.rs>
     /// [`taproot`]: <https://github.com/rust-bitcoin/rust-bitcoin/blob/master/bitcoin/examples/sign-tx-taproot.rs>
     pub fn witness_mut(&mut self, input_index: usize) -> Option<&mut Witness> {
-        self.tx.borrow_mut().input.get_mut(input_index).map(|i| &mut i.witness)
+        self.tx.borrow_mut().inputs.get_mut(input_index).map(|i| &mut i.witness)
     }
 }
 
@@ -1541,8 +1541,8 @@ mod tests {
         let tx = Transaction {
             version: transaction::Version::ONE,
             lock_time: absolute::LockTime::ZERO,
-            input: vec![TxIn::EMPTY_COINBASE, TxIn::EMPTY_COINBASE],
-            output: vec![DUMMY_TXOUT],
+            inputs: vec![TxIn::EMPTY_COINBASE, TxIn::EMPTY_COINBASE],
+            outputs: vec![DUMMY_TXOUT],
         };
         let script = ScriptBuf::new();
         let cache = SighashCache::new(&tx);
@@ -1731,8 +1731,8 @@ mod tests {
         let dumb_tx = Transaction {
             version: transaction::Version::TWO,
             lock_time: absolute::LockTime::ZERO,
-            input: vec![TxIn::EMPTY_COINBASE],
-            output: vec![],
+            inputs: vec![TxIn::EMPTY_COINBASE],
+            outputs: vec![],
         };
         let mut c = SighashCache::new(&dumb_tx);
 

--- a/bitcoin/src/psbt/map/global.rs
+++ b/bitcoin/src/psbt/map/global.rs
@@ -31,8 +31,8 @@ impl Map for Psbt {
                 // without witnesses.
                 let mut ret = Vec::new();
                 ret.extend(encode::serialize(&self.unsigned_tx.version));
-                ret.extend(encode::serialize(&self.unsigned_tx.input));
-                ret.extend(encode::serialize(&self.unsigned_tx.output));
+                ret.extend(encode::serialize(&self.unsigned_tx.inputs));
+                ret.extend(encode::serialize(&self.unsigned_tx.outputs));
                 ret.extend(encode::serialize(&self.unsigned_tx.lock_time));
                 ret
             },
@@ -96,8 +96,8 @@ impl Psbt {
                                     // properly.
                                     tx = Some(Transaction {
                                         version: Decodable::consensus_decode(&mut decoder)?,
-                                        input: Decodable::consensus_decode(&mut decoder)?,
-                                        output: Decodable::consensus_decode(&mut decoder)?,
+                                        inputs: Decodable::consensus_decode(&mut decoder)?,
+                                        outputs: Decodable::consensus_decode(&mut decoder)?,
                                         lock_time: Decodable::consensus_decode(&mut decoder)?,
                                     });
 

--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -98,7 +98,7 @@ impl Psbt {
         global.unsigned_tx_checks()?;
 
         let inputs: Vec<Input> = {
-            let inputs_len: usize = (global.unsigned_tx.input).len();
+            let inputs_len: usize = (global.unsigned_tx.inputs).len();
 
             let mut inputs: Vec<Input> = Vec::with_capacity(inputs_len);
 
@@ -110,7 +110,7 @@ impl Psbt {
         };
 
         let outputs: Vec<Output> = {
-            let outputs_len: usize = (global.unsigned_tx.output).len();
+            let outputs_len: usize = (global.unsigned_tx.outputs).len();
 
             let mut outputs: Vec<Output> = Vec::with_capacity(outputs_len);
 

--- a/bitcoin/tests/bip_174.rs
+++ b/bitcoin/tests/bip_174.rs
@@ -157,7 +157,7 @@ fn create_transaction() -> Transaction {
     Transaction {
         version: transaction::Version::TWO,
         lock_time: absolute::LockTime::ZERO,
-        input: vec![
+        inputs: vec![
             TxIn {
                 previous_output: OutPoint {
                     txid: input_0.txid.parse().expect("failed to parse txid"),
@@ -177,7 +177,7 @@ fn create_transaction() -> Transaction {
                 witness: Witness::default(),
             },
         ],
-        output: vec![
+        outputs: vec![
             TxOut {
                 value: Amount::from_str_in(output_0.amount, Denomination::Bitcoin)
                     .expect("failed to parse amount"),
@@ -243,7 +243,7 @@ fn update_psbt(mut psbt: Psbt, fingerprint: Fingerprint) -> Psbt {
 
     let v = Vec::from_hex(previous_tx_0).unwrap();
     let tx: Transaction = deserialize(&v).unwrap();
-    input_1.witness_utxo = Some(tx.output[1].clone());
+    input_1.witness_utxo = Some(tx.outputs[1].clone());
 
     input_1.redeem_script = Some(hex_script(redeem_script_1));
     input_1.witness_script = Some(hex_script(witness_script));

--- a/bitcoin/tests/psbt-sign-taproot.rs
+++ b/bitcoin/tests/psbt-sign-taproot.rs
@@ -213,13 +213,13 @@ fn create_psbt_for_taproot_key_path_spend(
     let transaction = Transaction {
         version: Version(2),
         lock_time: absolute::LockTime::ZERO,
-        input: vec![TxIn {
+        inputs: vec![TxIn {
             previous_output: OutPoint { txid: prev_tx_id.parse().unwrap(), vout: 0 },
             script_sig: ScriptBuf::new(),
             sequence: Sequence(0xFFFFFFFF), // Ignore nSequence.
             witness: Witness::default(),
         }],
-        output: out_puts,
+        outputs: out_puts,
     };
 
     let mut psbt = Psbt::from_unsigned_tx(transaction).unwrap();
@@ -290,13 +290,13 @@ fn create_psbt_for_taproot_script_path_spend(
     let transaction = Transaction {
         version: Version(2),
         lock_time: absolute::LockTime::ZERO,
-        input: vec![TxIn {
+        inputs: vec![TxIn {
             previous_output: OutPoint { txid: prev_tx_id.parse().unwrap(), vout: 0 },
             script_sig: ScriptBuf::new(),
             sequence: Sequence(0xFFFFFFFF), // Ignore nSequence.
             witness: Witness::default(),
         }],
-        output: out_puts,
+        outputs: out_puts,
     };
 
     let mut psbt = Psbt::from_unsigned_tx(transaction).unwrap();

--- a/bitcoin/tests/serde.rs
+++ b/bitcoin/tests/serde.rs
@@ -220,7 +220,7 @@ fn serde_regression_psbt() {
     let tx = Transaction {
         version: transaction::Version::ONE,
         lock_time: absolute::LockTime::ZERO,
-        input: vec![TxIn {
+        inputs: vec![TxIn {
             previous_output: OutPoint {
                 txid: "e567952fb6cc33857f392efa3a46c995a28f69cca4bb1b37e0204dab1ec7a389"
                     .parse::<Txid>()
@@ -235,7 +235,7 @@ fn serde_regression_psbt() {
             )
             .unwrap()]),
         }],
-        output: vec![TxOut {
+        outputs: vec![TxOut {
             value: Amount::from_sat_unchecked(190_303_501_938),
             script_pubkey: ScriptBuf::from_hex("a914339725ba21efd62ac753a9bcd067d6c7a6a39d0587")
                 .unwrap(),
@@ -273,8 +273,8 @@ fn serde_regression_psbt() {
         },
         unsigned_tx: {
             let mut unsigned = tx.clone();
-            unsigned.input[0].script_sig = ScriptBuf::new();
-            unsigned.input[0].witness = Witness::default();
+            unsigned.inputs[0].script_sig = ScriptBuf::new();
+            unsigned.inputs[0].witness = Witness::default();
             unsigned
         },
         proprietary: proprietary.clone(),

--- a/fuzz/fuzz_targets/bitcoin/deserialize_transaction.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_transaction.rs
@@ -11,7 +11,7 @@ fn do_test(data: &[u8]) {
             assert_eq!(&ser[..], data);
             let len = ser.len();
             let calculated_weight = tx.weight().to_wu() as usize;
-            for input in &mut tx.input {
+            for input in &mut tx.inputs {
                 input.witness = bitcoin::witness::Witness::default();
             }
             let no_witness_len = bitcoin::consensus::encode::serialize(&tx).len();
@@ -19,7 +19,7 @@ fn do_test(data: &[u8]) {
             // we serialize as SegWit even after "stripping the witnesses". We need
             // to drop two bytes (i.e. eight weight). Similarly, calculated_weight is
             // incorrect and needs 2 wu removing for the marker/flag bytes.
-            if tx.input.is_empty() {
+            if tx.inputs.is_empty() {
                 assert_eq!(no_witness_len * 3 + len - 8, calculated_weight - 2);
             } else {
                 assert_eq!(no_witness_len * 3 + len, calculated_weight);


### PR DESCRIPTION
We'd like to have the `input` and `output` fields named `inputs` and outputs` but that's a significant breaking change in terms of changed LOC. Thankfully, the change can be almost entirely automated (read below). If the only breaking change is the names of the fields then it's practically certain that the compiler suggestions are correct - aside from the fact that the words "input" and "inputs" are closer than "input" and "output", the types are different so even if the compiler messed them up it'd not cause any bugs.

Thus we can use the built-in `cargo` feature to automatically apply the suggestions. There's only one weird edge case: if `Transaction` is being constructed by first defining variables called `input` and `output` and then the short syntax `input,` is used (instead of `input: input`) the compiler doesn't produce an applicable suggestion. However this is rare enough for manual fix to be acceptable. One can simply type `inputs: input` or, preferably, rename the variable together with the field and run `cargo fix` again to patch up the other uses of the variables. This commit uses the latter option.

All this being said, `rustc` is unable to tell for sure that this transformation is correct so it marks the suggestions as `MaybeInvalid` which in practice means `cargo fix` refuses to apply them unless you pass the hidden YOLO env var. The full invocation used here is:

`__CARGO_FIX_YOLO=1 cargo fix --allow-dirty --broken-code --workspace --all-features`