### PR TITLE
Kill mutants found by github-actions

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -19,6 +19,8 @@ exclude_re = [
     "dec_width", # Replacing num /= 10 with num %=10 in a loop causes a timeout due to infinite loop
     # src/locktime/relative.rs
     "Time::to_consensus_u32", # Mutant from replacing | with ^, this returns the same value since the XOR is taken against the u16 with an all-zero bitmask
+    "FeeRate::fee_vb", # Deprecated
+    "FeeRate::fee_wu", # Deprecated
 
     # primitives
     "Sequence::from_512_second_intervals", # Mutant from replacing | with ^, this returns the same value since the XOR is taken against the u16 with an all-zero bitmask

--- a/units/src/fee.rs
+++ b/units/src/fee.rs
@@ -254,7 +254,7 @@ mod tests {
 
         let weight = Weight::from_wu(381);
         let fee_rate = FeeRate::from_sat_per_kwu(864);
-        let fee = fee_rate.checked_mul_by_weight(weight).unwrap();
+        let fee = weight.checked_mul_by_fee_rate(fee_rate).unwrap();
         // 381 * 0.864 yields 329.18.
         // The result is then rounded up to 330.
         assert_eq!(fee, Amount::from_sat_unchecked(330));


### PR DESCRIPTION
Recent changes to units created new mutants.

Skip mutants from deprecated functions.

Modify existing test to kill `checked_mul_by_fee_rate` mutant.

Close #4026