### PR TITLE
hashes: Only enable hex/std, and hex/alloc when hex is

### DIFF
--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -15,8 +15,8 @@ exclude = ["tests", "contrib"]
 
 [features]
 default = ["std"]
-std = ["alloc", "hex/std"]
-alloc = ["hex/alloc"]
+std = ["alloc", "hex?/std"]
+alloc = ["hex?/alloc"]
 serde = ["dep:serde", "hex"]
 # Smaller (but slower) implementation of sha256, sha512 and ripemd160
 small-hash = []

--- a/hashes/src/cmp.rs
+++ b/hashes/src/cmp.rs
@@ -95,6 +95,7 @@ mod tests {
 }
 
 #[cfg(bench)]
+#[cfg(feature = "hex")]
 mod benches {
     use test::Bencher;
 

--- a/hashes/src/hash160/mod.rs
+++ b/hashes/src/hash160/mod.rs
@@ -47,6 +47,7 @@ impl crate::HashEngine for HashEngine {
 mod tests {
     #[test]
     #[cfg(feature = "alloc")]
+    #[cfg(feature = "hex")]
     fn test() {
         use alloc::string::ToString;
 

--- a/hashes/src/hkdf/mod.rs
+++ b/hashes/src/hkdf/mod.rs
@@ -107,6 +107,7 @@ where
 
 #[cfg(test)]
 #[cfg(feature = "alloc")]
+#[cfg(feature = "hex")]
 mod tests {
     use hex::prelude::{DisplayHex, FromHex};
 

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -326,6 +326,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "alloc")]
+    #[cfg(feature = "hex")]
     fn newtype_fmt_roundtrip() {
         use alloc::format;
 

--- a/hashes/src/ripemd160/tests.rs
+++ b/hashes/src/ripemd160/tests.rs
@@ -1,5 +1,6 @@
 #[test]
 #[cfg(feature = "alloc")]
+#[cfg(feature = "hex")]
 fn test() {
     use alloc::string::ToString;
 

--- a/hashes/src/sha1/tests.rs
+++ b/hashes/src/sha1/tests.rs
@@ -1,5 +1,6 @@
 #[test]
 #[cfg(feature = "alloc")]
+#[cfg(feature = "hex")]
 fn test() {
     use alloc::string::ToString;
 

--- a/hashes/src/sha256/tests.rs
+++ b/hashes/src/sha256/tests.rs
@@ -5,6 +5,7 @@ use crate::{sha256, HashEngine};
 
 #[test]
 #[cfg(feature = "alloc")]
+#[cfg(feature = "hex")]
 fn test() {
     use alloc::string::ToString;
 
@@ -70,6 +71,7 @@ fn test() {
 
 #[test]
 #[cfg(feature = "alloc")]
+#[cfg(feature = "hex")]
 fn fmt_roundtrips() {
     use alloc::format;
 

--- a/hashes/src/sha256d/mod.rs
+++ b/hashes/src/sha256d/mod.rs
@@ -45,6 +45,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "alloc")]
+    #[cfg(feature = "hex")]
     fn test() {
         use alloc::string::ToString;
 
@@ -98,6 +99,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "alloc")]
+    #[cfg(feature = "hex")]
     fn fmt_roundtrips() {
         use alloc::format;
 

--- a/hashes/src/sha256t/mod.rs
+++ b/hashes/src/sha256t/mod.rs
@@ -182,10 +182,12 @@ mod tests {
 
     // The digest created by sha256 hashing `&[0]` starting with `TEST_MIDSTATE`.
     #[cfg(feature = "alloc")]
+    #[cfg(feature = "hex")]
     const HASH_ZERO_BACKWARD: &str =
         "29589d5122ec666ab5b4695070b6debc63881a4f85d88d93ddc90078038213ed";
     // And the same thing, forward.
     #[cfg(feature = "alloc")]
+    #[cfg(feature = "hex")]
     const HASH_ZERO_FORWARD: &str =
         "ed1382037800c9dd938dd8854f1a8863bcdeb6705069b4b56a66ec22519d5829";
 
@@ -198,10 +200,12 @@ mod tests {
 
     // We support manually implementing `Tag` and creating a tagged hash from it.
     #[cfg(feature = "alloc")]
+    #[cfg(feature = "hex")]
     pub type TestHash = sha256t::Hash<TestHashTag>;
 
     #[test]
     #[cfg(feature = "alloc")]
+    #[cfg(feature = "hex")]
     fn manually_created_sha256t_hash_type() {
         use alloc::string::ToString;
 

--- a/hashes/src/sha384/mod.rs
+++ b/hashes/src/sha384/mod.rs
@@ -41,6 +41,7 @@ impl crate::HashEngine for HashEngine {
 mod tests {
     #[test]
     #[cfg(feature = "alloc")]
+    #[cfg(feature = "hex")]
     fn test() {
         use alloc::string::ToString;
 

--- a/hashes/src/sha512/tests.rs
+++ b/hashes/src/sha512/tests.rs
@@ -1,5 +1,6 @@
 #[test]
 #[cfg(feature = "alloc")]
+#[cfg(feature = "hex")]
 fn test() {
     use alloc::string::ToString;
 

--- a/hashes/src/sha512_256/mod.rs
+++ b/hashes/src/sha512_256/mod.rs
@@ -51,6 +51,7 @@ impl crate::HashEngine for HashEngine {
 mod tests {
     #[test]
     #[cfg(feature = "alloc")]
+    #[cfg(feature = "hex")]
     fn test() {
         use alloc::string::ToString;
 

--- a/io/Cargo.toml
+++ b/io/Cargo.toml
@@ -23,6 +23,9 @@ internals = { package = "bitcoin-internals", version = "0.4.0" }
 
 hashes = { package = "bitcoin_hashes", version = "0.16.0", default-features = false, optional = true }
 
+[dev-dependencies]
+hashes = { package = "bitcoin_hashes", version = "0.16.0", default-features = false, features = ["hex"] }
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
`hex/std` and `hex/alloc` should only be included if optional dependency `hex` is enabled.  A bunch of tests that need `hex` relied on an `alloc` feature gate to ensure `hex/alloc` was enabled.  

Add feature gates to the tests that require `hex`.

Add `?` so `hex/alloc` or `hex/std` are only included if the optional feature `hex` is enabled.

Audit rest of crates `Cargo.toml` files: no other cases found.

Close #4035