### PR TITLE
Do not enable `soft-float` when running `miri`

### DIFF
--- a/contrib/test-miri.sh
+++ b/contrib/test-miri.sh
@@ -6,7 +6,7 @@ cd "$(dirname "$0")/.."
 
 . contrib/test_vars.sh
 
-target_features="$(rustc --print target-features | awk '{ if ($1 == "") { exit 0 } if (NR != 1 && $1 != "crt-static") { if (NR == 2) { printf "+%s", $1 } else { printf ",+%s", $1 } } }')"
+target_features="$(rustc --print target-features | awk '{ if ($1 == "") { exit 0 } if (NR != 1 && $1 != "crt-static" && $1 != "soft-float") { if (NR == 2) { printf "+%s", $1 } else { printf ",+%s", $1 } } }')"
 
 for crate in $CRATES;
 do


### PR DESCRIPTION
To ensure that all target features are tested we simply enable all of them. However some of them are problematic. We already have an exception to not enable `crt-static`. This change also adds `soft-float` to the list because `miri` was warning about it being UB.