### PR TITLE
Update to latest maintainer-tools

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
-          ref: 4f17a059a2f57c1b99b7c240a1467a5c0acebdc3
+          ref: c3324024ced9bb1eb854397686919c3ff7d97e1e
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@stable
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
-          ref: 4f17a059a2f57c1b99b7c240a1467a5c0acebdc3
+          ref: c3324024ced9bb1eb854397686919c3ff7d97e1e
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@v1
@@ -83,7 +83,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
-          ref: 4f17a059a2f57c1b99b7c240a1467a5c0acebdc3
+          ref: c3324024ced9bb1eb854397686919c3ff7d97e1e
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@stable
@@ -109,7 +109,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
-          ref: 4f17a059a2f57c1b99b7c240a1467a5c0acebdc3
+          ref: c3324024ced9bb1eb854397686919c3ff7d97e1e
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@v1
@@ -136,7 +136,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
-          ref: 4f17a059a2f57c1b99b7c240a1467a5c0acebdc3
+          ref: c3324024ced9bb1eb854397686919c3ff7d97e1e
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@stable
@@ -160,7 +160,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
-          ref: 4f17a059a2f57c1b99b7c240a1467a5c0acebdc3
+          ref: c3324024ced9bb1eb854397686919c3ff7d97e1e
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@v1
@@ -186,7 +186,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
-          ref: 4f17a059a2f57c1b99b7c240a1467a5c0acebdc3
+          ref: c3324024ced9bb1eb854397686919c3ff7d97e1e
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@v1


### PR DESCRIPTION
We have made a couple of improvements to the `run_task` script lately (*cough* actually test code with `--all-features`).

Lets update to use it.

This PR explicitly tests https://github.com/rust-bitcoin/rust-bitcoin-maintainer-tools/pull/20 because it uses the commit hash created in that PR.