### PR TITLE
chacha20: add benchmarks

### DIFF
--- a/chacha20_poly1305/Cargo.toml
+++ b/chacha20_poly1305/Cargo.toml
@@ -22,3 +22,6 @@ hex = { package = "hex-conservative", version = "0.3.0", default-features = fals
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+[lints.rust]
+unexpected_cfgs = { level = "deny", check-cfg = ['cfg(bench)'] }

--- a/chacha20_poly1305/src/benches.rs
+++ b/chacha20_poly1305/src/benches.rs
@@ -1,0 +1,45 @@
+use test::Bencher;
+
+use crate::{ChaCha20, Key, Nonce};
+
+#[bench]
+pub fn chacha20_10(bh: &mut Bencher) {
+  let key =
+      Key::new([0u8; 32]);
+  let nonce = Nonce::new([0u8; 12]);
+  let count = 1;
+  let mut chacha = ChaCha20::new(key, nonce, count);
+  let mut bytes = [0u8; 10];
+  bh.iter(|| {
+    chacha.apply_keystream(&mut bytes[..]);
+  });
+  bh.bytes = bytes.len() as u64;
+}
+
+#[bench]
+pub fn chacha20_1k(bh: &mut Bencher) {
+  let key =
+      Key::new([0u8; 32]);
+  let nonce = Nonce::new([0u8; 12]);
+  let count = 1;
+  let mut chacha = ChaCha20::new(key, nonce, count);
+  let mut bytes = [0u8; 1024];
+  bh.iter(|| {
+    chacha.apply_keystream(&mut bytes[..]);
+  });
+  bh.bytes = bytes.len() as u64;
+}
+
+#[bench]
+pub fn chacha20_64k(bh: &mut Bencher) {
+  let key =
+      Key::new([0u8; 32]);
+  let nonce = Nonce::new([0u8; 12]);
+  let count = 1;
+  let mut chacha = ChaCha20::new(key, nonce, count);
+  let mut bytes = [0u8; 65536];
+  bh.iter(|| {
+    chacha.apply_keystream(&mut bytes[..]);
+  });
+  bh.bytes = bytes.len() as u64;
+}

--- a/chacha20_poly1305/src/lib.rs
+++ b/chacha20_poly1305/src/lib.rs
@@ -5,6 +5,7 @@
 #![no_std]
 // Experimental features we need.
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(bench, feature(test))]
 // Coding conventions.
 #![warn(missing_docs)]
 #![warn(deprecated_in_future)]
@@ -18,6 +19,10 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+#[cfg(bench)]
+mod benches;
+#[cfg(bench)]
+extern crate test;
 pub mod chacha20;
 pub mod poly1305;
 


### PR DESCRIPTION
Add benchmarks for chacha20. These could be useful to understand future improvements.

I copied the same 10, 1k and 64k sizes as used in the sha256 benchmark. Some of the lines changed here, such as in `Config.toml`, are a little mysterious to me as I am new to rust, so please check.

```
➜  chacha20_poly1305 git:(jr_chachabench) RUSTFLAGS='--cfg=bench' cargo +nightly bench
...
test benches::chacha20_10  ... bench:         188.67 ns/iter (+/- 2.70) = 53 MB/s
test benches::chacha20_1k  ... bench:       2,885.83 ns/iter (+/- 90.06) = 354 MB/s
test benches::chacha20_64k ... bench:     186,493.88 ns/iter (+/- 5,074.53) = 351 MB/s
```