### PR TITLE
units: macroize the op implementations

### DIFF
--- a/units/src/amount/result.rs
+++ b/units/src/amount/result.rs
@@ -135,269 +135,117 @@ crate::internal_macros::impl_op_for_references! {
 
         fn add(self, rhs: NumOpResult<Amount>) -> Self::Output { rhs.and_then(|a| a + self) }
     }
-}
 
-crate::internal_macros::impl_op_for_references! {
     impl ops::Sub<Amount> for Amount {
         type Output = NumOpResult<Amount>;
 
         fn sub(self, rhs: Amount) -> Self::Output { self.checked_sub(rhs).valid_or_error() }
     }
-}
 
-impl ops::Sub<NumOpResult<Amount>> for Amount {
-    type Output = NumOpResult<Amount>;
+    impl ops::Sub<NumOpResult<Amount>> for Amount {
+        type Output = NumOpResult<Amount>;
 
-    fn sub(self, rhs: NumOpResult<Amount>) -> Self::Output {
-        match rhs {
-            R::Valid(amount) => self - amount,
-            R::Error(_) => rhs,
+        fn sub(self, rhs: NumOpResult<Amount>) -> Self::Output {
+            match rhs {
+                R::Valid(amount) => self - amount,
+                R::Error(_) => rhs,
+            }
         }
     }
-}
-impl ops::Sub<NumOpResult<Amount>> for &Amount {
-    type Output = NumOpResult<Amount>;
 
-    fn sub(self, rhs: NumOpResult<Amount>) -> Self::Output {
-        match rhs {
-            R::Valid(amount) => self - amount,
-            R::Error(_) => rhs,
+    impl ops::Mul<u64> for Amount {
+        type Output = NumOpResult<Amount>;
+
+        fn mul(self, rhs: u64) -> Self::Output { self.checked_mul(rhs).valid_or_error() }
+    }
+    impl ops::Div<u64> for Amount {
+        type Output = NumOpResult<Amount>;
+
+        fn div(self, rhs: u64) -> Self::Output { self.checked_div(rhs).valid_or_error() }
+    }
+    impl ops::Rem<u64> for Amount {
+        type Output = NumOpResult<Amount>;
+
+        fn rem(self, modulus: u64) -> Self::Output { self.checked_rem(modulus).valid_or_error() }
+    }
+
+    // FIXME these two should be covered by generic impls below
+    impl ops::Add<Amount> for NumOpResult<Amount> {
+        type Output = NumOpResult<Amount>;
+
+        fn add(self, rhs: Amount) -> Self::Output { rhs + self }
+    }
+    impl ops::Sub<Amount> for NumOpResult<Amount> {
+        type Output = NumOpResult<Amount>;
+
+        fn sub(self, rhs: Amount) -> Self::Output {
+            match self {
+                R::Valid(amount) => amount - rhs,
+                R::Error(_) => self,
+            }
         }
     }
-}
-impl ops::Sub<Amount> for NumOpResult<Amount> {
-    type Output = NumOpResult<Amount>;
 
-    fn sub(self, rhs: Amount) -> Self::Output {
-        match self {
-            R::Valid(amount) => amount - rhs,
-            R::Error(_) => self,
+    impl ops::Add<SignedAmount> for SignedAmount {
+        type Output = NumOpResult<SignedAmount>;
+
+        fn add(self, rhs: SignedAmount) -> Self::Output { self.checked_add(rhs).valid_or_error() }
+    }
+
+    impl ops::Add<NumOpResult<SignedAmount>> for SignedAmount {
+        type Output = NumOpResult<SignedAmount>;
+
+        fn add(self, rhs: NumOpResult<SignedAmount>) -> Self::Output { rhs.and_then(|a| a + self) }
+    }
+
+    impl ops::Sub<SignedAmount> for SignedAmount {
+        type Output = NumOpResult<SignedAmount>;
+
+        fn sub(self, rhs: SignedAmount) -> Self::Output { self.checked_sub(rhs).valid_or_error() }
+    }
+    impl ops::Sub<NumOpResult<SignedAmount>> for SignedAmount {
+        type Output = NumOpResult<SignedAmount>;
+
+        fn sub(self, rhs: NumOpResult<SignedAmount>) -> Self::Output {
+            match rhs {
+                R::Valid(amount) => amount - rhs,
+                R::Error(_) => rhs,
+            }
         }
     }
-}
-impl ops::Sub<&Amount> for NumOpResult<Amount> {
-    type Output = NumOpResult<Amount>;
 
-    fn sub(self, rhs: &Amount) -> Self::Output {
-        match self {
-            R::Valid(amount) => amount - (*rhs),
-            R::Error(_) => self,
+    impl ops::Add<SignedAmount> for NumOpResult<SignedAmount> {
+        type Output = NumOpResult<SignedAmount>;
+
+        fn add(self, rhs: SignedAmount) -> Self::Output { rhs + self }
+    }
+
+    impl ops::Sub<SignedAmount> for NumOpResult<SignedAmount> {
+        type Output = NumOpResult<SignedAmount>;
+
+        fn sub(self, rhs: SignedAmount) -> Self::Output {
+            match self {
+                R::Valid(amount) => amount - rhs,
+                R::Error(_) => self,
+            }
         }
     }
-}
 
-impl ops::Mul<u64> for Amount {
-    type Output = NumOpResult<Amount>;
+    impl ops::Mul<i64> for SignedAmount {
+        type Output = NumOpResult<SignedAmount>;
 
-    fn mul(self, rhs: u64) -> Self::Output { self.checked_mul(rhs).valid_or_error() }
-}
-impl ops::Mul<&u64> for Amount {
-    type Output = NumOpResult<Amount>;
-
-    fn mul(self, rhs: &u64) -> Self::Output { self.mul(*rhs) }
-}
-impl ops::Mul<u64> for &Amount {
-    type Output = NumOpResult<Amount>;
-
-    fn mul(self, rhs: u64) -> Self::Output { (*self).mul(rhs) }
-}
-impl ops::Mul<&u64> for &Amount {
-    type Output = NumOpResult<Amount>;
-
-    fn mul(self, rhs: &u64) -> Self::Output { self.mul(*rhs) }
-}
-
-impl ops::Div<u64> for Amount {
-    type Output = NumOpResult<Amount>;
-
-    fn div(self, rhs: u64) -> Self::Output { self.checked_div(rhs).valid_or_error() }
-}
-impl ops::Div<&u64> for Amount {
-    type Output = NumOpResult<Amount>;
-
-    fn div(self, rhs: &u64) -> Self::Output { self.div(*rhs) }
-}
-impl ops::Div<u64> for &Amount {
-    type Output = NumOpResult<Amount>;
-
-    fn div(self, rhs: u64) -> Self::Output { (*self).div(rhs) }
-}
-impl ops::Div<&u64> for &Amount {
-    type Output = NumOpResult<Amount>;
-
-    fn div(self, rhs: &u64) -> Self::Output { (*self).div(*rhs) }
-}
-
-impl ops::Rem<u64> for Amount {
-    type Output = NumOpResult<Amount>;
-
-    fn rem(self, modulus: u64) -> Self::Output { self.checked_rem(modulus).valid_or_error() }
-}
-impl ops::Rem<&u64> for Amount {
-    type Output = NumOpResult<Amount>;
-
-    fn rem(self, modulus: &u64) -> Self::Output { self.rem(*modulus) }
-}
-impl ops::Rem<u64> for &Amount {
-    type Output = NumOpResult<Amount>;
-
-    fn rem(self, modulus: u64) -> Self::Output { (*self).rem(modulus) }
-}
-impl ops::Rem<&u64> for &Amount {
-    type Output = NumOpResult<Amount>;
-
-    fn rem(self, modulus: &u64) -> Self::Output { (*self).rem(*modulus) }
-}
-
-// FIXME these two should be covered by generic impls below
-impl ops::Add<Amount> for NumOpResult<Amount> {
-    type Output = NumOpResult<Amount>;
-
-    fn add(self, rhs: Amount) -> Self::Output { rhs + self }
-}
-impl ops::Add<&Amount> for NumOpResult<Amount> {
-    type Output = NumOpResult<Amount>;
-
-    fn add(self, rhs: &Amount) -> Self::Output { rhs + self }
-}
-
-impl ops::Add<SignedAmount> for SignedAmount {
-    type Output = NumOpResult<SignedAmount>;
-
-    fn add(self, rhs: SignedAmount) -> Self::Output { self.checked_add(rhs).valid_or_error() }
-}
-crate::internal_macros::impl_add_for_amount_references!(SignedAmount);
-
-impl ops::Add<NumOpResult<SignedAmount>> for SignedAmount {
-    type Output = NumOpResult<SignedAmount>;
-
-    fn add(self, rhs: NumOpResult<SignedAmount>) -> Self::Output { rhs.and_then(|a| a + self) }
-}
-impl ops::Add<NumOpResult<SignedAmount>> for &SignedAmount {
-    type Output = NumOpResult<SignedAmount>;
-
-    fn add(self, rhs: NumOpResult<SignedAmount>) -> Self::Output { rhs.and_then(|a| a + self) }
-}
-impl ops::Add<SignedAmount> for NumOpResult<SignedAmount> {
-    type Output = NumOpResult<SignedAmount>;
-
-    fn add(self, rhs: SignedAmount) -> Self::Output { rhs + self }
-}
-impl ops::Add<&SignedAmount> for NumOpResult<SignedAmount> {
-    type Output = NumOpResult<SignedAmount>;
-
-    fn add(self, rhs: &SignedAmount) -> Self::Output { rhs + self }
-}
-
-impl ops::Sub<SignedAmount> for SignedAmount {
-    type Output = NumOpResult<SignedAmount>;
-
-    fn sub(self, rhs: SignedAmount) -> Self::Output { self.checked_sub(rhs).valid_or_error() }
-}
-crate::internal_macros::impl_sub_for_amount_references!(SignedAmount);
-
-impl ops::Sub<NumOpResult<SignedAmount>> for SignedAmount {
-    type Output = NumOpResult<SignedAmount>;
-
-    fn sub(self, rhs: NumOpResult<SignedAmount>) -> Self::Output {
-        match rhs {
-            R::Valid(amount) => amount - rhs,
-            R::Error(_) => rhs,
-        }
+        fn mul(self, rhs: i64) -> Self::Output { self.checked_mul(rhs).valid_or_error() }
     }
-}
-impl ops::Sub<NumOpResult<SignedAmount>> for &SignedAmount {
-    type Output = NumOpResult<SignedAmount>;
+    impl ops::Div<i64> for SignedAmount {
+        type Output = NumOpResult<SignedAmount>;
 
-    fn sub(self, rhs: NumOpResult<SignedAmount>) -> Self::Output {
-        match rhs {
-            R::Valid(amount) => amount - rhs,
-            R::Error(_) => rhs,
-        }
+        fn div(self, rhs: i64) -> Self::Output { self.checked_div(rhs).valid_or_error() }
     }
-}
-impl ops::Sub<SignedAmount> for NumOpResult<SignedAmount> {
-    type Output = NumOpResult<SignedAmount>;
+    impl ops::Rem<i64> for SignedAmount {
+        type Output = NumOpResult<SignedAmount>;
 
-    fn sub(self, rhs: SignedAmount) -> Self::Output {
-        match self {
-            R::Valid(amount) => amount - rhs,
-            R::Error(_) => self,
-        }
+        fn rem(self, modulus: i64) -> Self::Output { self.checked_rem(modulus).valid_or_error() }
     }
-}
-impl ops::Sub<&SignedAmount> for NumOpResult<SignedAmount> {
-    type Output = NumOpResult<SignedAmount>;
-
-    fn sub(self, rhs: &SignedAmount) -> Self::Output {
-        match self {
-            R::Valid(amount) => amount - *rhs,
-            R::Error(_) => self,
-        }
-    }
-}
-
-impl ops::Mul<i64> for SignedAmount {
-    type Output = NumOpResult<SignedAmount>;
-
-    fn mul(self, rhs: i64) -> Self::Output { self.checked_mul(rhs).valid_or_error() }
-}
-impl ops::Mul<&i64> for SignedAmount {
-    type Output = NumOpResult<SignedAmount>;
-
-    fn mul(self, rhs: &i64) -> Self::Output { self.mul(*rhs) }
-}
-impl ops::Mul<i64> for &SignedAmount {
-    type Output = NumOpResult<SignedAmount>;
-
-    fn mul(self, rhs: i64) -> Self::Output { (*self).mul(rhs) }
-}
-impl ops::Mul<&i64> for &SignedAmount {
-    type Output = NumOpResult<SignedAmount>;
-
-    fn mul(self, rhs: &i64) -> Self::Output { self.mul(*rhs) }
-}
-
-impl ops::Div<i64> for SignedAmount {
-    type Output = NumOpResult<SignedAmount>;
-
-    fn div(self, rhs: i64) -> Self::Output { self.checked_div(rhs).valid_or_error() }
-}
-impl ops::Div<&i64> for SignedAmount {
-    type Output = NumOpResult<SignedAmount>;
-
-    fn div(self, rhs: &i64) -> Self::Output { self.div(*rhs) }
-}
-impl ops::Div<i64> for &SignedAmount {
-    type Output = NumOpResult<SignedAmount>;
-
-    fn div(self, rhs: i64) -> Self::Output { (*self).div(rhs) }
-}
-impl ops::Div<&i64> for &SignedAmount {
-    type Output = NumOpResult<SignedAmount>;
-
-    fn div(self, rhs: &i64) -> Self::Output { (*self).div(*rhs) }
-}
-
-impl ops::Rem<i64> for SignedAmount {
-    type Output = NumOpResult<SignedAmount>;
-
-    fn rem(self, modulus: i64) -> Self::Output { self.checked_rem(modulus).valid_or_error() }
-}
-impl ops::Rem<&i64> for SignedAmount {
-    type Output = NumOpResult<SignedAmount>;
-
-    fn rem(self, modulus: &i64) -> Self::Output { self.rem(*modulus) }
-}
-impl ops::Rem<i64> for &SignedAmount {
-    type Output = NumOpResult<SignedAmount>;
-
-    fn rem(self, modulus: i64) -> Self::Output { (*self).rem(modulus) }
-}
-impl ops::Rem<&i64> for &SignedAmount {
-    type Output = NumOpResult<SignedAmount>;
-
-    fn rem(self, modulus: &i64) -> Self::Output { (*self).rem(*modulus) }
 }
 
 impl ops::Neg for SignedAmount {

--- a/units/src/amount/result.rs
+++ b/units/src/amount/result.rs
@@ -246,65 +246,26 @@ crate::internal_macros::impl_op_for_references! {
 
         fn rem(self, modulus: i64) -> Self::Output { self.checked_rem(modulus).valid_or_error() }
     }
+
+    impl<T> ops::Add<NumOpResult<T>> for NumOpResult<T>
+    where
+        (T: Copy + ops::Add<Output = NumOpResult<T>>)
+    {
+        type Output = NumOpResult<T>;
+
+        fn add(self, rhs: Self) -> Self::Output {
+            match (self, rhs) {
+                (R::Valid(lhs), R::Valid(rhs)) => lhs + rhs,
+                (_, _) => R::Error(NumOpError {}),
+            }
+        }
+    }
 }
 
 impl ops::Neg for SignedAmount {
     type Output = Self;
 
     fn neg(self) -> Self::Output { Self::from_sat(self.to_sat().neg()) }
-}
-
-impl<T> ops::Add for NumOpResult<T>
-where
-    T: ops::Add<Output = NumOpResult<T>>,
-{
-    type Output = NumOpResult<T>;
-
-    fn add(self, rhs: Self) -> Self::Output {
-        match (self, rhs) {
-            (R::Valid(lhs), R::Valid(rhs)) => lhs + rhs,
-            (_, _) => R::Error(NumOpError {}),
-        }
-    }
-}
-impl<T> ops::Add<NumOpResult<T>> for &NumOpResult<T>
-where
-    T: ops::Add<Output = NumOpResult<T>> + Copy,
-{
-    type Output = NumOpResult<T>;
-
-    fn add(self, rhs: NumOpResult<T>) -> Self::Output {
-        match (self, rhs) {
-            (R::Valid(lhs), R::Valid(rhs)) => *lhs + rhs,
-            (_, _) => R::Error(NumOpError {}),
-        }
-    }
-}
-impl<T> ops::Add<&NumOpResult<T>> for NumOpResult<T>
-where
-    T: ops::Add<Output = NumOpResult<T>> + Copy,
-{
-    type Output = NumOpResult<T>;
-
-    fn add(self, rhs: &NumOpResult<T>) -> Self::Output {
-        match (self, rhs) {
-            (R::Valid(lhs), R::Valid(rhs)) => lhs + *rhs,
-            (_, _) => R::Error(NumOpError {}),
-        }
-    }
-}
-impl<T> ops::Add for &NumOpResult<T>
-where
-    T: ops::Add<Output = NumOpResult<T>> + Copy,
-{
-    type Output = NumOpResult<T>;
-
-    fn add(self, rhs: &NumOpResult<T>) -> Self::Output {
-        match (self, rhs) {
-            (R::Valid(lhs), R::Valid(rhs)) => *lhs + *rhs,
-            (_, _) => R::Error(NumOpError {}),
-        }
-    }
 }
 
 impl<T> ops::Sub for NumOpResult<T>

--- a/units/src/amount/result.rs
+++ b/units/src/amount/result.rs
@@ -123,23 +123,23 @@ impl From<&SignedAmount> for NumOpResult<SignedAmount> {
     fn from(a: &SignedAmount) -> Self { Self::Valid(*a) }
 }
 
-impl ops::Add for Amount {
-    type Output = NumOpResult<Amount>;
+crate::internal_macros::impl_op_for_references! {
+    impl ops::Add<Amount> for Amount {
+        type Output = NumOpResult<Amount>;
 
-    fn add(self, rhs: Amount) -> Self::Output { self.checked_add(rhs).valid_or_error() }
+        fn add(self, rhs: Amount) -> Self::Output { self.checked_add(rhs).valid_or_error() }
+    }
 }
-crate::internal_macros::impl_add_for_amount_references!(Amount);
 
-impl ops::Add<NumOpResult<Amount>> for Amount {
-    type Output = NumOpResult<Amount>;
+crate::internal_macros::impl_op_for_references! {
+    impl ops::Add<NumOpResult<Amount>> for Amount {
+        type Output = NumOpResult<Amount>;
 
-    fn add(self, rhs: NumOpResult<Amount>) -> Self::Output { rhs.and_then(|a| a + self) }
+        fn add(self, rhs: NumOpResult<Amount>) -> Self::Output { rhs.and_then(|a| a + self) }
+    }
 }
-impl ops::Add<NumOpResult<Amount>> for &Amount {
-    type Output = NumOpResult<Amount>;
 
-    fn add(self, rhs: NumOpResult<Amount>) -> Self::Output { rhs.and_then(|a| a + self) }
-}
+// FIXME these two should be covered by generic impls below
 impl ops::Add<Amount> for NumOpResult<Amount> {
     type Output = NumOpResult<Amount>;
 
@@ -151,12 +151,13 @@ impl ops::Add<&Amount> for NumOpResult<Amount> {
     fn add(self, rhs: &Amount) -> Self::Output { rhs + self }
 }
 
-impl ops::Sub for Amount {
-    type Output = NumOpResult<Amount>;
+crate::internal_macros::impl_op_for_references! {
+    impl ops::Sub<Amount> for Amount {
+        type Output = NumOpResult<Amount>;
 
-    fn sub(self, rhs: Amount) -> Self::Output { self.checked_sub(rhs).valid_or_error() }
+        fn sub(self, rhs: Amount) -> Self::Output { self.checked_sub(rhs).valid_or_error() }
+    }
 }
-crate::internal_macros::impl_sub_for_amount_references!(Amount);
 
 impl ops::Sub<NumOpResult<Amount>> for Amount {
     type Output = NumOpResult<Amount>;

--- a/units/src/amount/result.rs
+++ b/units/src/amount/result.rs
@@ -137,18 +137,6 @@ crate::internal_macros::impl_op_for_references! {
     }
 }
 
-// FIXME these two should be covered by generic impls below
-impl ops::Add<Amount> for NumOpResult<Amount> {
-    type Output = NumOpResult<Amount>;
-
-    fn add(self, rhs: Amount) -> Self::Output { rhs + self }
-}
-impl ops::Add<&Amount> for NumOpResult<Amount> {
-    type Output = NumOpResult<Amount>;
-
-    fn add(self, rhs: &Amount) -> Self::Output { rhs + self }
-}
-
 crate::internal_macros::impl_op_for_references! {
     impl ops::Sub<Amount> for Amount {
         type Output = NumOpResult<Amount>;
@@ -261,7 +249,19 @@ impl ops::Rem<&u64> for &Amount {
     fn rem(self, modulus: &u64) -> Self::Output { (*self).rem(*modulus) }
 }
 
-impl ops::Add for SignedAmount {
+// FIXME these two should be covered by generic impls below
+impl ops::Add<Amount> for NumOpResult<Amount> {
+    type Output = NumOpResult<Amount>;
+
+    fn add(self, rhs: Amount) -> Self::Output { rhs + self }
+}
+impl ops::Add<&Amount> for NumOpResult<Amount> {
+    type Output = NumOpResult<Amount>;
+
+    fn add(self, rhs: &Amount) -> Self::Output { rhs + self }
+}
+
+impl ops::Add<SignedAmount> for SignedAmount {
     type Output = NumOpResult<SignedAmount>;
 
     fn add(self, rhs: SignedAmount) -> Self::Output { self.checked_add(rhs).valid_or_error() }
@@ -289,7 +289,7 @@ impl ops::Add<&SignedAmount> for NumOpResult<SignedAmount> {
     fn add(self, rhs: &SignedAmount) -> Self::Output { rhs + self }
 }
 
-impl ops::Sub for SignedAmount {
+impl ops::Sub<SignedAmount> for SignedAmount {
     type Output = NumOpResult<SignedAmount>;
 
     fn sub(self, rhs: SignedAmount) -> Self::Output { self.checked_sub(rhs).valid_or_error() }

--- a/units/src/amount/result.rs
+++ b/units/src/amount/result.rs
@@ -129,7 +129,6 @@ crate::internal_macros::impl_op_for_references! {
 
         fn add(self, rhs: Amount) -> Self::Output { self.checked_add(rhs).valid_or_error() }
     }
-
     impl ops::Add<NumOpResult<Amount>> for Amount {
         type Output = NumOpResult<Amount>;
 
@@ -141,7 +140,6 @@ crate::internal_macros::impl_op_for_references! {
 
         fn sub(self, rhs: Amount) -> Self::Output { self.checked_sub(rhs).valid_or_error() }
     }
-
     impl ops::Sub<NumOpResult<Amount>> for Amount {
         type Output = NumOpResult<Amount>;
 
@@ -158,15 +156,32 @@ crate::internal_macros::impl_op_for_references! {
 
         fn mul(self, rhs: u64) -> Self::Output { self.checked_mul(rhs).valid_or_error() }
     }
+    impl ops::Mul<u64> for NumOpResult<Amount> {
+        type Output = NumOpResult<Amount>;
+
+        fn mul(self, rhs: u64) -> Self::Output { self.and_then(|lhs| lhs * rhs) }
+    }
+
     impl ops::Div<u64> for Amount {
         type Output = NumOpResult<Amount>;
 
         fn div(self, rhs: u64) -> Self::Output { self.checked_div(rhs).valid_or_error() }
     }
+    impl ops::Div<u64> for NumOpResult<Amount> {
+        type Output = NumOpResult<Amount>;
+
+        fn div(self, rhs: u64) -> Self::Output { self.and_then(|lhs| lhs / rhs) }
+    }
+
     impl ops::Rem<u64> for Amount {
         type Output = NumOpResult<Amount>;
 
         fn rem(self, modulus: u64) -> Self::Output { self.checked_rem(modulus).valid_or_error() }
+    }
+    impl ops::Rem<u64> for NumOpResult<Amount> {
+        type Output = NumOpResult<Amount>;
+
+        fn rem(self, modulus: u64) -> Self::Output { self.and_then(|lhs| lhs % modulus) }
     }
 
     impl ops::Add<SignedAmount> for SignedAmount {
@@ -174,7 +189,6 @@ crate::internal_macros::impl_op_for_references! {
 
         fn add(self, rhs: SignedAmount) -> Self::Output { self.checked_add(rhs).valid_or_error() }
     }
-
     impl ops::Add<NumOpResult<SignedAmount>> for SignedAmount {
         type Output = NumOpResult<SignedAmount>;
 
@@ -202,15 +216,32 @@ crate::internal_macros::impl_op_for_references! {
 
         fn mul(self, rhs: i64) -> Self::Output { self.checked_mul(rhs).valid_or_error() }
     }
+    impl ops::Mul<i64> for NumOpResult<SignedAmount> {
+        type Output = NumOpResult<SignedAmount>;
+
+        fn mul(self, rhs: i64) -> Self::Output { self.and_then(|lhs| lhs * rhs) }
+    }
+
     impl ops::Div<i64> for SignedAmount {
         type Output = NumOpResult<SignedAmount>;
 
         fn div(self, rhs: i64) -> Self::Output { self.checked_div(rhs).valid_or_error() }
     }
+    impl ops::Div<i64> for NumOpResult<SignedAmount> {
+        type Output = NumOpResult<SignedAmount>;
+
+        fn div(self, rhs: i64) -> Self::Output { self.and_then(|lhs| lhs / rhs) }
+    }
+
     impl ops::Rem<i64> for SignedAmount {
         type Output = NumOpResult<SignedAmount>;
 
         fn rem(self, modulus: i64) -> Self::Output { self.checked_rem(modulus).valid_or_error() }
+    }
+    impl ops::Rem<i64> for NumOpResult<SignedAmount> {
+        type Output = NumOpResult<SignedAmount>;
+
+        fn rem(self, modulus: i64) -> Self::Output { self.and_then(|lhs| lhs % modulus) }
     }
 
     impl<T> ops::Add<NumOpResult<T>> for NumOpResult<T>

--- a/units/src/amount/result.rs
+++ b/units/src/amount/result.rs
@@ -129,9 +129,7 @@ crate::internal_macros::impl_op_for_references! {
 
         fn add(self, rhs: Amount) -> Self::Output { self.checked_add(rhs).valid_or_error() }
     }
-}
 
-crate::internal_macros::impl_op_for_references! {
     impl ops::Add<NumOpResult<Amount>> for Amount {
         type Output = NumOpResult<Amount>;
 

--- a/units/src/amount/result.rs
+++ b/units/src/amount/result.rs
@@ -12,7 +12,7 @@ use super::{Amount, SignedAmount};
 /// Result of an operation on [`Amount`] or [`SignedAmount`].
 ///
 /// The type parameter `T` should be normally `Amout` or `SignedAmount`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[must_use]
 pub enum NumOpResult<T> {
     /// Result of a successful mathematical operation.
@@ -584,7 +584,7 @@ impl OptionExt<SignedAmount> for Option<SignedAmount> {
 }
 
 /// An error occurred while doing a mathematical operation.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct NumOpError;
 

--- a/units/src/amount/tests.rs
+++ b/units/src/amount/tests.rs
@@ -1329,44 +1329,44 @@ fn amount_op_result_all_ops() {
     // let sres: NumOpResult<SignedAmount> = ssat + ssat;
 
     // Operations that where RHS is the result of another operation.
-    let _ = sat + res.clone();
-    let _ = &sat + res.clone();
-    // let _ = sat + &res.clone();
-    // let _ = &sat + &res.clone();
+    let _ = sat + res;
+    let _ = &sat + res;
+    // let _ = sat + &res;
+    // let _ = &sat + &res;
 
-    let _ = sat - res.clone();
-    let _ = &sat - res.clone();
-    // let _ = sat - &res.clone();
-    // let _ = &sat - &res.clone();
+    let _ = sat - res;
+    let _ = &sat - res;
+    // let _ = sat - &res;
+    // let _ = &sat - &res;
 
     // Operations that where LHS is the result of another operation.
-    let _ = res.clone() + sat;
-    // let _ = &res.clone() + sat;
-    let _ = res.clone() + &sat;
-    // let _ = &res.clone() + &sat;
+    let _ = res + sat;
+    // let _ = &res + sat;
+    let _ = res + &sat;
+    // let _ = &res + &sat;
 
-    let _ = res.clone() - sat;
-    // let _ = &res.clone() - sat;
-    let _ = res.clone() - &sat;
-    // let _ = &res.clone() - &sat;
+    let _ = res - sat;
+    // let _ = &res - sat;
+    let _ = res - &sat;
+    // let _ = &res - &sat;
 
     // Operations that where both sides are the result of another operation.
-    let _ = res.clone() + res.clone();
-    // let _ = &res.clone() + res.clone();
-    // let _ = res.clone() + &res.clone();
-    // let _ = &res.clone() + &res.clone();
+    let _ = res + res;
+    // let _ = &res + res;
+    // let _ = res + &res;
+    // let _ = &res + &res;
 
-    let _ = res.clone() - res.clone();
-    // let _ = &res.clone() - res.clone();
-    // let _ = res.clone() - &res.clone();
-    // let _ = &res.clone() - &res.clone();
+    let _ = res - res;
+    // let _ = &res - res;
+    // let _ = res - &res;
+    // let _ = &res - &res;
 }
 
 // Verify we have implemented all `Sum` for the `NumOpResult` type.
 #[test]
 fn amount_op_result_sum() {
     let res = Amount::from_sat(1) + Amount::from_sat(1);
-    let amounts = [res.clone(), res.clone()];
+    let amounts = [res, res];
     let amount_refs = [&res, &res];
 
     // Sum iterators.

--- a/units/src/fee_rate/mod.rs
+++ b/units/src/fee_rate/mod.rs
@@ -135,20 +135,20 @@ impl From<FeeRate> for u64 {
     fn from(value: FeeRate) -> Self { value.to_sat_per_kwu() }
 }
 
-impl ops::Add for FeeRate {
+impl ops::Add<FeeRate> for FeeRate {
     type Output = FeeRate;
 
     fn add(self, rhs: FeeRate) -> Self::Output { FeeRate(self.0 + rhs.0) }
 }
 crate::internal_macros::impl_add_for_references!(FeeRate);
-crate::internal_macros::impl_add_assign!(FeeRate);
 
-impl ops::Sub for FeeRate {
+impl ops::Sub<FeeRate> for FeeRate {
     type Output = FeeRate;
 
     fn sub(self, rhs: FeeRate) -> Self::Output { FeeRate(self.0 - rhs.0) }
 }
 crate::internal_macros::impl_sub_for_references!(FeeRate);
+crate::internal_macros::impl_add_assign!(FeeRate);
 crate::internal_macros::impl_sub_assign!(FeeRate);
 
 impl core::iter::Sum for FeeRate {

--- a/units/src/fee_rate/mod.rs
+++ b/units/src/fee_rate/mod.rs
@@ -135,19 +135,19 @@ impl From<FeeRate> for u64 {
     fn from(value: FeeRate) -> Self { value.to_sat_per_kwu() }
 }
 
-impl ops::Add<FeeRate> for FeeRate {
-    type Output = FeeRate;
+crate::internal_macros::impl_op_for_references! {
+    impl ops::Add<FeeRate> for FeeRate {
+        type Output = FeeRate;
 
-    fn add(self, rhs: FeeRate) -> Self::Output { FeeRate(self.0 + rhs.0) }
+        fn add(self, rhs: FeeRate) -> Self::Output { FeeRate(self.0 + rhs.0) }
+    }
+
+    impl ops::Sub<FeeRate> for FeeRate {
+        type Output = FeeRate;
+
+        fn sub(self, rhs: FeeRate) -> Self::Output { FeeRate(self.0 - rhs.0) }
+    }
 }
-crate::internal_macros::impl_add_for_references!(FeeRate);
-
-impl ops::Sub<FeeRate> for FeeRate {
-    type Output = FeeRate;
-
-    fn sub(self, rhs: FeeRate) -> Self::Output { FeeRate(self.0 - rhs.0) }
-}
-crate::internal_macros::impl_sub_for_references!(FeeRate);
 crate::internal_macros::impl_add_assign!(FeeRate);
 crate::internal_macros::impl_sub_assign!(FeeRate);
 

--- a/units/src/internal_macros.rs
+++ b/units/src/internal_macros.rs
@@ -4,6 +4,59 @@
 //!
 //! Macros meant to be used inside the `bitcoin-units` library.
 
+/// Implements an opcode for various reference combinations.
+///
+/// Given `$ty`, assumes the `$op_trait<$other_ty>` trait is implemented on it,
+/// and implements the same trait with the full matrix of `&$ty` and `&$other_ty`:
+///
+/// - `Add<$other_ty> for &$ty`
+/// - `Add<&$other_ty> for $ty`
+/// - `Add<&$other_ty> for &$ty`
+///
+/// # Limitations
+///
+/// You must specify `$other_ty` and you may not use `Self`. So e.g. you need
+/// to write `impl ops::Add<Amount> for Amount { ... }` when calling this macro.
+macro_rules! impl_op_for_references {
+    (
+        impl $($op_trait:ident)::+<$other_ty:ty> for $ty:ty {
+            type Output = $($main_output:ty)*;
+            fn $op:ident($($main_args:tt)*) -> Self::Output {
+                $($main_impl:tt)*
+            }
+        }
+    ) => {
+        impl $($op_trait)::+<$other_ty> for $ty {
+            type Output = $($main_output)*;
+            fn $op($($main_args)*) -> Self::Output {
+                $($main_impl)*
+            }
+        }
+
+        impl $($op_trait)::+<$other_ty> for &$ty {
+            type Output = <$ty as $($op_trait)::+<$other_ty>>::Output;
+            fn $op(self, rhs: $other_ty) -> Self::Output {
+                (*self).$op(rhs)
+            }
+        }
+
+        impl $($op_trait)::+<&$other_ty> for $ty {
+            type Output = <$ty as $($op_trait)::+<$other_ty>>::Output;
+            fn $op(self, rhs: &$other_ty) -> Self::Output {
+                self.$op(*rhs)
+            }
+        }
+
+        impl<'a> $($op_trait)::+<&'a $other_ty> for &$ty {
+            type Output = <$ty as $($op_trait)::+<$other_ty>>::Output;
+            fn $op(self, rhs: &$other_ty) -> Self::Output {
+                (*self).$op(*rhs)
+            }
+        }
+    };
+}
+pub(crate) use impl_op_for_references;
+
 /// Implements `ops::Add` for various references.
 ///
 /// Requires `$ty` it implement `Add` e.g. 'impl Add<T> for T'. Adds impls of:

--- a/units/src/internal_macros.rs
+++ b/units/src/internal_macros.rs
@@ -18,14 +18,14 @@
 /// You must specify `$other_ty` and you may not use `Self`. So e.g. you need
 /// to write `impl ops::Add<Amount> for Amount { ... }` when calling this macro.
 macro_rules! impl_op_for_references {
-    (
+    ($(
         impl $($op_trait:ident)::+<$other_ty:ty> for $ty:ty {
             type Output = $($main_output:ty)*;
             fn $op:ident($($main_args:tt)*) -> Self::Output {
                 $($main_impl:tt)*
             }
         }
-    ) => {
+    )+) => {$(
         impl $($op_trait)::+<$other_ty> for $ty {
             type Output = $($main_output)*;
             fn $op($($main_args)*) -> Self::Output {
@@ -53,7 +53,7 @@ macro_rules! impl_op_for_references {
                 (*self).$op(*rhs)
             }
         }
-    };
+    )+};
 }
 pub(crate) use impl_op_for_references;
 

--- a/units/src/internal_macros.rs
+++ b/units/src/internal_macros.rs
@@ -57,66 +57,6 @@ macro_rules! impl_op_for_references {
 }
 pub(crate) use impl_op_for_references;
 
-/// Implements `ops::Add` for various references.
-///
-/// Requires `$ty` it implement `Add` e.g. 'impl Add<T> for T'. Adds impls of:
-///
-/// - Add<T> for &T
-/// - Add<&T> for T
-/// - Add<&T> for &T
-macro_rules! impl_add_for_references {
-    ($ty:ident) => {
-        impl core::ops::Add<$ty> for &$ty {
-            type Output = $ty;
-
-            fn add(self, rhs: $ty) -> Self::Output { *self + rhs }
-        }
-
-        impl core::ops::Add<&$ty> for $ty {
-            type Output = $ty;
-
-            fn add(self, rhs: &$ty) -> Self::Output { self + *rhs }
-        }
-
-        impl<'a> core::ops::Add<&'a $ty> for &$ty {
-            type Output = $ty;
-
-            fn add(self, rhs: &'a $ty) -> Self::Output { *self + *rhs }
-        }
-    };
-}
-pub(crate) use impl_add_for_references;
-
-/// Implements `ops::Add` for various amount references.
-///
-/// Requires `$ty` it implement `Add` e.g. 'impl Add<T> for T'. Adds impls of:
-///
-/// - Add<T> for &T
-/// - Add<&T> for T
-/// - Add<&T> for &T
-macro_rules! impl_add_for_amount_references {
-    ($ty:ident) => {
-        impl core::ops::Add<$ty> for &$ty {
-            type Output = NumOpResult<$ty>;
-
-            fn add(self, rhs: $ty) -> Self::Output { *self + rhs }
-        }
-
-        impl core::ops::Add<&$ty> for $ty {
-            type Output = NumOpResult<$ty>;
-
-            fn add(self, rhs: &$ty) -> Self::Output { self + *rhs }
-        }
-
-        impl<'a> core::ops::Add<&'a $ty> for &$ty {
-            type Output = NumOpResult<$ty>;
-
-            fn add(self, rhs: &'a $ty) -> Self::Output { *self + *rhs }
-        }
-    };
-}
-pub(crate) use impl_add_for_amount_references;
-
 /// Implement `ops::AddAssign` for `$ty` and `&$ty`.
 macro_rules! impl_add_assign {
     ($ty:ident) => {
@@ -130,66 +70,6 @@ macro_rules! impl_add_assign {
     };
 }
 pub(crate) use impl_add_assign;
-
-/// Implement `ops::Sub` for various references.
-///
-/// Requires `$ty` it implement `Sub` e.g. 'impl Sub<T> for T'. Adds impls of:
-///
-/// - Sub<T> for &T
-/// - Sub<&T> for T
-/// - Sub<&T> for &T
-macro_rules! impl_sub_for_references {
-    ($ty:ident) => {
-        impl core::ops::Sub<$ty> for &$ty {
-            type Output = $ty;
-
-            fn sub(self, rhs: $ty) -> Self::Output { *self - rhs }
-        }
-
-        impl core::ops::Sub<&$ty> for $ty {
-            type Output = $ty;
-
-            fn sub(self, rhs: &$ty) -> Self::Output { self - *rhs }
-        }
-
-        impl<'a> core::ops::Sub<&'a $ty> for &$ty {
-            type Output = $ty;
-
-            fn sub(self, rhs: &'a $ty) -> Self::Output { *self - *rhs }
-        }
-    };
-}
-pub(crate) use impl_sub_for_references;
-
-/// Implement `ops::Sub` for various amount references.
-///
-/// Requires `$ty` it implement `Sub` e.g. 'impl Sub<T> for T'. Adds impls of:
-///
-/// - Sub<T> for &T
-/// - Sub<&T> for T
-/// - Sub<&T> for &T
-macro_rules! impl_sub_for_amount_references {
-    ($ty:ident) => {
-        impl core::ops::Sub<$ty> for &$ty {
-            type Output = NumOpResult<$ty>;
-
-            fn sub(self, rhs: $ty) -> Self::Output { *self - rhs }
-        }
-
-        impl core::ops::Sub<&$ty> for $ty {
-            type Output = NumOpResult<$ty>;
-
-            fn sub(self, rhs: &$ty) -> Self::Output { self - *rhs }
-        }
-
-        impl<'a> core::ops::Sub<&'a $ty> for &$ty {
-            type Output = NumOpResult<$ty>;
-
-            fn sub(self, rhs: &'a $ty) -> Self::Output { *self - *rhs }
-        }
-    };
-}
-pub(crate) use impl_sub_for_amount_references;
 
 /// Implement `ops::SubAssign` for `$ty` and `&$ty`.
 macro_rules! impl_sub_assign {

--- a/units/src/internal_macros.rs
+++ b/units/src/internal_macros.rs
@@ -17,37 +17,49 @@
 ///
 /// You must specify `$other_ty` and you may not use `Self`. So e.g. you need
 /// to write `impl ops::Add<Amount> for Amount { ... }` when calling this macro.
+///
+/// Your where clause must include extra parenthesis, like `where (T: Copy)`.
 macro_rules! impl_op_for_references {
     ($(
-        impl $($op_trait:ident)::+<$other_ty:ty> for $ty:ty {
+        impl$(<$gen:ident>)? $($op_trait:ident)::+<$other_ty:ty> for $ty:ty
+        $(where ($($bounds:tt)*))?
+        {
             type Output = $($main_output:ty)*;
             fn $op:ident($($main_args:tt)*) -> Self::Output {
                 $($main_impl:tt)*
             }
         }
     )+) => {$(
-        impl $($op_trait)::+<$other_ty> for $ty {
+        impl$(<$gen>)?  $($op_trait)::+<$other_ty> for $ty
+        $(where $($bounds)*)?
+        {
             type Output = $($main_output)*;
             fn $op($($main_args)*) -> Self::Output {
                 $($main_impl)*
             }
         }
 
-        impl $($op_trait)::+<$other_ty> for &$ty {
+        impl$(<$gen>)?  $($op_trait)::+<$other_ty> for &$ty
+        $(where $($bounds)*)?
+        {
             type Output = <$ty as $($op_trait)::+<$other_ty>>::Output;
             fn $op(self, rhs: $other_ty) -> Self::Output {
                 (*self).$op(rhs)
             }
         }
 
-        impl $($op_trait)::+<&$other_ty> for $ty {
+        impl$(<$gen>)?  $($op_trait)::+<&$other_ty> for $ty
+        $(where $($bounds)*)?
+        {
             type Output = <$ty as $($op_trait)::+<$other_ty>>::Output;
             fn $op(self, rhs: &$other_ty) -> Self::Output {
                 self.$op(*rhs)
             }
         }
 
-        impl<'a> $($op_trait)::+<&'a $other_ty> for &$ty {
+        impl<'a, $($gen)?> $($op_trait)::+<&'a $other_ty> for &$ty
+        $(where $($bounds)*)?
+        {
             type Output = <$ty as $($op_trait)::+<$other_ty>>::Output;
             fn $op(self, rhs: &$other_ty) -> Self::Output {
                 (*self).$op(*rhs)

--- a/units/src/weight.rs
+++ b/units/src/weight.rs
@@ -166,48 +166,44 @@ impl From<Weight> for u64 {
     fn from(value: Weight) -> Self { value.to_wu() }
 }
 
-impl ops::Add<Weight> for Weight {
-    type Output = Weight;
+crate::internal_macros::impl_op_for_references! {
+    impl ops::Add<Weight> for Weight {
+        type Output = Weight;
 
-    fn add(self, rhs: Weight) -> Self::Output { Weight(self.0 + rhs.0) }
+        fn add(self, rhs: Weight) -> Self::Output { Weight(self.0 + rhs.0) }
+    }
+    impl ops::Sub<Weight> for Weight {
+        type Output = Weight;
+
+        fn sub(self, rhs: Weight) -> Self::Output { Weight(self.0 - rhs.0) }
+    }
+
+    impl ops::Mul<u64> for Weight {
+        type Output = Weight;
+
+        fn mul(self, rhs: u64) -> Self::Output { Weight(self.0 * rhs) }
+    }
+    impl ops::Mul<Weight> for u64 {
+        type Output = Weight;
+
+        fn mul(self, rhs: Weight) -> Self::Output { Weight(self * rhs.0) }
+    }
+    impl ops::Div<u64> for Weight {
+        type Output = Weight;
+
+        fn div(self, rhs: u64) -> Self::Output { Weight(self.0 / rhs) }
+    }
+    impl ops::Div<Weight> for Weight {
+        type Output = u64;
+
+        fn div(self, rhs: Weight) -> Self::Output { self.to_wu() / rhs.to_wu() }
+    }
 }
-crate::internal_macros::impl_add_for_references!(Weight);
-
-impl ops::Sub<Weight> for Weight {
-    type Output = Weight;
-
-    fn sub(self, rhs: Weight) -> Self::Output { Weight(self.0 - rhs.0) }
-}
-crate::internal_macros::impl_sub_for_references!(Weight);
 crate::internal_macros::impl_add_assign!(Weight);
 crate::internal_macros::impl_sub_assign!(Weight);
 
-impl ops::Mul<u64> for Weight {
-    type Output = Weight;
-
-    fn mul(self, rhs: u64) -> Self::Output { Weight(self.0 * rhs) }
-}
-
-impl ops::Mul<Weight> for u64 {
-    type Output = Weight;
-
-    fn mul(self, rhs: Weight) -> Self::Output { Weight(self * rhs.0) }
-}
-
 impl ops::MulAssign<u64> for Weight {
     fn mul_assign(&mut self, rhs: u64) { self.0 *= rhs }
-}
-
-impl ops::Div<u64> for Weight {
-    type Output = Weight;
-
-    fn div(self, rhs: u64) -> Self::Output { Weight(self.0 / rhs) }
-}
-
-impl ops::Div<Weight> for Weight {
-    type Output = u64;
-
-    fn div(self, rhs: Weight) -> Self::Output { self.to_wu() / rhs.to_wu() }
 }
 
 impl ops::DivAssign<u64> for Weight {

--- a/units/src/weight.rs
+++ b/units/src/weight.rs
@@ -166,20 +166,20 @@ impl From<Weight> for u64 {
     fn from(value: Weight) -> Self { value.to_wu() }
 }
 
-impl ops::Add for Weight {
+impl ops::Add<Weight> for Weight {
     type Output = Weight;
 
     fn add(self, rhs: Weight) -> Self::Output { Weight(self.0 + rhs.0) }
 }
 crate::internal_macros::impl_add_for_references!(Weight);
-crate::internal_macros::impl_add_assign!(Weight);
 
-impl ops::Sub for Weight {
+impl ops::Sub<Weight> for Weight {
     type Output = Weight;
 
     fn sub(self, rhs: Weight) -> Self::Output { Weight(self.0 - rhs.0) }
 }
 crate::internal_macros::impl_sub_for_references!(Weight);
+crate::internal_macros::impl_add_assign!(Weight);
 crate::internal_macros::impl_sub_assign!(Weight);
 
 impl ops::Mul<u64> for Weight {


### PR DESCRIPTION
This introduces a general macro which takes some number of `impl ops::Whatever<A> for <B>` and replicates them with all the permutations of references. It also takes a syntax which resembles the code for the initial impl block.

Uses it for all the binary opcodes on `Amount`, `SignedAmount`, `Weight`, `FeeRate`, as well as the numeric mul/div on those types, as well as generic impls on `NumResultOp<T>` (which are expanded to cover more cases).