### PR TITLE
primitives: Add additional re-exports

### DIFF
--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -120,14 +120,15 @@ pub mod taproot;
 pub use primitives::{
     block::{
         Block, BlockHash, Checked as BlockChecked, Header as BlockHeader,
-        Unchecked as BlockUnchecked, Validation as BlockValidation, WitnessCommitment,
+        Unchecked as BlockUnchecked, Validation as BlockValidation, Version as BlockVersion,
+        WitnessCommitment,
     },
     merkle_tree::{TxMerkleNode, WitnessMerkleNode},
     opcodes::Opcode,
     pow::CompactTarget, // No `pow` module outside of `primitives`.
     script::{Script, ScriptBuf, ScriptHash, WScriptHash},
     sequence::{self, Sequence}, // No `sequence` module outside of `primitives`.
-    transaction::{OutPoint, Transaction, TxIn, TxOut, Txid, Wtxid},
+    transaction::{OutPoint, Transaction, TxIn, TxOut, Txid, Version as TxVersion, Wtxid},
     witness::Witness,
 };
 #[doc(inline)]

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -125,7 +125,7 @@ pub use primitives::{
     merkle_tree::{TxMerkleNode, WitnessMerkleNode},
     opcodes::Opcode,
     pow::CompactTarget, // No `pow` module outside of `primitives`.
-    script::{Script, ScriptBuf},
+    script::{Script, ScriptBuf, ScriptHash, WScriptHash},
     sequence::{self, Sequence}, // No `sequence` module outside of `primitives`.
     transaction::{OutPoint, Transaction, TxIn, TxOut, Txid, Wtxid},
     witness::Witness,
@@ -163,7 +163,6 @@ pub use crate::{
     blockdata::locktime::{absolute, relative},
     blockdata::script::witness_program::{self, WitnessProgram},
     blockdata::script::witness_version::{self, WitnessVersion},
-    blockdata::script::{ScriptHash, WScriptHash}, // TODO: Move these down below after they are in primitives.
     // These modules also re-export all the respective `primitives` types.
     blockdata::{
         block, constants, fee_rate, locktime, opcodes, script, transaction, weight, witness,

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -68,7 +68,7 @@ pub use self::{
     block::{
         Block, Checked as BlockChecked, Unchecked as BlockUnchecked, Validation as BlockValidation,
     },
-    script::{Script, ScriptBuf},
+    script::{Script, ScriptBuf, ScriptHash, WScriptHash},
     transaction::{Transaction, TxIn, TxOut},
     witness::Witness,
 };

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -74,14 +74,14 @@ pub use self::{
 };
 #[doc(inline)]
 pub use self::{
-    block::{BlockHash, Header as BlockHeader, WitnessCommitment},
+    block::{BlockHash, Header as BlockHeader, Version as BlockVersion, WitnessCommitment},
     locktime::{absolute, relative},
     merkle_tree::{TxMerkleNode, WitnessMerkleNode},
     opcodes::Opcode,
     pow::CompactTarget,
     sequence::Sequence,
     taproot::{TapBranchTag, TapLeafHash, TapLeafTag, TapNodeHash, TapTweakHash, TapTweakTag},
-    transaction::{OutPoint, Txid, Wtxid},
+    transaction::{OutPoint, Txid, Version as TxVersion, Wtxid},
 };
 
 #[rustfmt::skip]


### PR DESCRIPTION
We have a few types that can reasonably be re-exported at the root of both `primitives` and `bitcoin`.
    
- `ScriptHash` and `WScriptHash`
- `BlockVersion` alias to `block::Version`
- `TxVersion` alias to `transaction::Version`

EDIT: Note that `ScriptHash` and `WScritpHash` are already re-exported at `bitcoin` crate root, this just removes the indirection and re-exports them directly from `primitives` now that they live there.
