### PR TITLE
documentation: update instructions for building lock files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -209,12 +209,9 @@ in Bitcoin Core, with the following exceptions:
 If your change requires a dependency to be upgraded you must do the following:
 
 1. Modify `Cargo.toml`
-2. Copy `Cargo-minimal.lock` to `Cargo.lock`
-3. Trigger cargo to update the required entries in the lock file - use `--precise` using the minimum version number that works
-4. Test your change
-5. Copy `Cargo.lock` to `Cargo-minimal.lock`
-6. Update `Cargo-recent.lock` if it is also behind
-7. Commit both lock files together with `Cargo.toml` and your code changes
+2. Run `just update-lock-files`, if necessary install `just` first with `cargo install just`.
+3. Test your change
+4. Commit both `Cargo-minimal.lock` and `Cargo-recent.lock` together with `Cargo.toml` and your code changes
 
 ### Unsafe code
 

--- a/contrib/update-lock-files.sh
+++ b/contrib/update-lock-files.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 for file in Cargo-minimal.lock Cargo-recent.lock; do
-    cp --force "$file" Cargo.lock
+    cp -f "$file" Cargo.lock
     cargo check
-    cp --force Cargo.lock "$file"
+    cp -f Cargo.lock "$file"
 done


### PR DESCRIPTION
1. Updates `CONTRIBUTING.md` with latest instructions on using `just` to create new lock files. See discussion [here](https://github.com/rust-bitcoin/rust-bitcoin/pull/4045/files).
2. For the command `cp`,  `--force` is not an option on the Mac. Changed to `-f` which as far as I can tell is equivalent.

```
➜  rust-bitcoin git:(jr_update_contrib) ✗ cp --force
cp: illegal option -- -
```