### PR TITLE
Remove the `GeneralHash` trait

### DIFF
--- a/bitcoin/src/consensus/encode.rs
+++ b/bitcoin/src/consensus/encode.rs
@@ -16,7 +16,7 @@
 
 use core::mem;
 
-use hashes::{sha256, sha256d, GeneralHash, Hash};
+use hashes::{sha256, sha256d, Hash};
 use hex::DisplayHex as _;
 use internals::{compact_size, ToU64};
 use io::{BufRead, Cursor, Read, Write};
@@ -629,7 +629,7 @@ impl Decodable for Box<[u8]> {
 
 /// Does a double-SHA256 on `data` and returns the first 4 bytes.
 fn sha2_checksum(data: &[u8]) -> [u8; 4] {
-    let checksum = <sha256d::Hash as GeneralHash>::hash(data);
+    let checksum = sha256d::hash(data);
     let checksum = checksum.to_byte_array();
     [checksum[0], checksum[1], checksum[2], checksum[3]]
 }

--- a/bitcoin/src/psbt/macros.rs
+++ b/bitcoin/src/psbt/macros.rs
@@ -113,15 +113,15 @@ macro_rules! impl_psbt_insert_pair {
 
 #[rustfmt::skip]
 macro_rules! psbt_insert_hash_pair {
-    (&mut $slf:ident.$map:ident <= $raw_key:ident|$raw_value:ident|$hash:path|$hash_type_error:path) => {
+    (&mut $slf:ident.$map:ident <= $raw_key:ident|$raw_value:ident|$hash:ident|$hash_type_error:path) => {
         if $raw_key.key_data.is_empty() {
             return Err($crate::psbt::Error::InvalidKey($raw_key));
         }
-        let key_val: $hash = Deserialize::deserialize(&$raw_key.key_data)?;
+        let key_val: $hash::Hash = Deserialize::deserialize(&$raw_key.key_data)?;
         match $slf.$map.entry(key_val) {
             btree_map::Entry::Vacant(empty_key) => {
                 let val: Vec<u8> = Deserialize::deserialize(&$raw_value)?;
-                if <$hash as hashes::GeneralHash>::hash(&val) != key_val {
+                if $hash::hash(&val) != key_val {
                     return Err($crate::psbt::Error::InvalidPreimageHashPair {
                         preimage: val.into_boxed_slice(),
                         hash: Box::from(key_val.borrow()),

--- a/bitcoin/src/psbt/map/input.rs
+++ b/bitcoin/src/psbt/map/input.rs
@@ -317,22 +317,22 @@ impl Input {
             }
             PSBT_IN_RIPEMD160 => {
                 psbt_insert_hash_pair! {
-                    &mut self.ripemd160_preimages <= raw_key|raw_value|ripemd160::Hash|error::PsbtHash::Ripemd
+                    &mut self.ripemd160_preimages <= raw_key|raw_value|ripemd160|error::PsbtHash::Ripemd
                 }
             }
             PSBT_IN_SHA256 => {
                 psbt_insert_hash_pair! {
-                    &mut self.sha256_preimages <= raw_key|raw_value|sha256::Hash|error::PsbtHash::Sha256
+                    &mut self.sha256_preimages <= raw_key|raw_value|sha256|error::PsbtHash::Sha256
                 }
             }
             PSBT_IN_HASH160 => {
                 psbt_insert_hash_pair! {
-                    &mut self.hash160_preimages <= raw_key|raw_value|hash160::Hash|error::PsbtHash::Hash160
+                    &mut self.hash160_preimages <= raw_key|raw_value|hash160|error::PsbtHash::Hash160
                 }
             }
             PSBT_IN_HASH256 => {
                 psbt_insert_hash_pair! {
-                    &mut self.hash256_preimages <= raw_key|raw_value|sha256d::Hash|error::PsbtHash::Hash256
+                    &mut self.hash256_preimages <= raw_key|raw_value|sha256d|error::PsbtHash::Hash256
                 }
             }
             PSBT_IN_TAP_KEY_SIG => {

--- a/hashes/src/hash160/mod.rs
+++ b/hashes/src/hash160/mod.rs
@@ -39,6 +39,7 @@ impl Default for HashEngine {
 
 impl crate::HashEngine for HashEngine {
     type Hash = Hash;
+    type Bytes = [u8; 20];
     const BLOCK_SIZE: usize = 64; // Same as sha256::HashEngine::BLOCK_SIZE;
 
     fn input(&mut self, data: &[u8]) { self.0.input(data) }

--- a/hashes/src/hash160/mod.rs
+++ b/hashes/src/hash160/mod.rs
@@ -38,9 +38,12 @@ impl Default for HashEngine {
 }
 
 impl crate::HashEngine for HashEngine {
+    type Hash = Hash;
     const BLOCK_SIZE: usize = 64; // Same as sha256::HashEngine::BLOCK_SIZE;
+
     fn input(&mut self, data: &[u8]) { self.0.input(data) }
     fn n_bytes_hashed(&self) -> u64 { self.0.n_bytes_hashed() }
+    fn finalize(self) -> Self::Hash { Hash::from_engine(self) }
 }
 
 #[cfg(test)]

--- a/hashes/src/hash160/mod.rs
+++ b/hashes/src/hash160/mod.rs
@@ -132,7 +132,7 @@ mod tests {
 mod benches {
     use test::Bencher;
 
-    use crate::{hash160, GeneralHash as _, Hash as _, HashEngine};
+    use crate::{hash160, Hash as _, HashEngine};
 
     #[bench]
     pub fn hash160_10(bh: &mut Bencher) {

--- a/hashes/src/hmac/mod.rs
+++ b/hashes/src/hmac/mod.rs
@@ -92,11 +92,12 @@ impl<T: GeneralHash> HmacEngine<T> {
 }
 
 impl<T: GeneralHash> HashEngine for HmacEngine<T> {
+    type Hash = Hmac<T>;
     const BLOCK_SIZE: usize = T::Engine::BLOCK_SIZE;
 
     fn n_bytes_hashed(&self) -> u64 { self.iengine.n_bytes_hashed() }
-
     fn input(&mut self, buf: &[u8]) { self.iengine.input(buf) }
+    fn finalize(self) -> Self::Hash { Hmac::from_engine(self) }
 }
 
 impl<T: GeneralHash + fmt::Debug> fmt::Debug for Hmac<T> {

--- a/hashes/src/internal_macros.rs
+++ b/hashes/src/internal_macros.rs
@@ -26,12 +26,6 @@ macro_rules! hash_trait_impls {
         #[cfg(not(feature = "hex"))]
         $crate::impl_debug_only!(Hash, { $bits / 8 }, $reverse $(, $gen: $gent)*);
 
-        impl<$($gen: $gent),*> $crate::GeneralHash for Hash<$($gen),*> {
-            type Engine = HashEngine<$($gen),*>;
-
-            fn from_engine(e: Self::Engine) -> Hash<$($gen),*> { Self::from_engine(e) }
-        }
-
         #[cfg(feature = "serde")]
         $crate::serde_impl!(Hash, { $bits / 8} $(, $gen: $gent)*);
 

--- a/hashes/src/internal_macros.rs
+++ b/hashes/src/internal_macros.rs
@@ -71,6 +71,15 @@ pub(crate) use hash_trait_impls;
 /// [`hash_trait_impls`].
 macro_rules! general_hash_type {
     ($bits:expr, $reverse:expr, $doc:literal) => {
+        /// Hashes some bytes.
+        pub fn hash(data: &[u8]) -> Hash {
+            use crate::HashEngine as _;
+
+            let mut engine = Hash::engine();
+            engine.input(data);
+            engine.finalize()
+        }
+
         $crate::internal_macros::hash_type_no_default!($bits, $reverse, $doc);
 
         impl Hash {
@@ -82,7 +91,7 @@ macro_rules! general_hash_type {
 
             /// Hashes some bytes.
             #[allow(clippy::self_named_constructors)] // Hash is a noun and a verb.
-            pub fn hash(data: &[u8]) -> Self { <Self as $crate::GeneralHash>::hash(data) }
+            pub fn hash(data: &[u8]) -> Self { hash(data) }
 
             /// Hashes all the byte slices retrieved from the iterator together.
             pub fn hash_byte_chunks<B, I>(byte_slices: I) -> Self

--- a/hashes/src/internal_macros.rs
+++ b/hashes/src/internal_macros.rs
@@ -80,6 +80,21 @@ macro_rules! general_hash_type {
             engine.finalize()
         }
 
+        /// Hashes all the byte slices retrieved from the iterator together.
+        pub fn hash_byte_chunks<B, I>(byte_slices: I) -> Hash
+        where
+            B: AsRef<[u8]>,
+            I: IntoIterator<Item = B>,
+        {
+            use crate::HashEngine as _;
+
+            let mut engine = Hash::engine();
+            for slice in byte_slices {
+                engine.input(slice.as_ref());
+            }
+            engine.finalize()
+        }
+
         $crate::internal_macros::hash_type_no_default!($bits, $reverse, $doc);
 
         impl Hash {
@@ -99,7 +114,7 @@ macro_rules! general_hash_type {
                 B: AsRef<[u8]>,
                 I: IntoIterator<Item = B>,
             {
-                <Self as $crate::GeneralHash>::hash_byte_chunks(byte_slices)
+                hash_byte_chunks(byte_slices)
             }
         }
     };

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -208,52 +208,6 @@ pub trait HashEngine: Clone {
     fn finalize(self) -> Self::Hash;
 }
 
-/// Trait describing hash digests which can be constructed by hashing arbitrary data.
-///
-/// Some methods have been bound to engines which implement Default, which is
-/// generally an unkeyed hash function.
-pub trait GeneralHash: Hash {
-    /// A hashing engine which bytes can be serialized into. It is expected
-    /// to implement the `io::Write` trait, and to never return errors under
-    /// any conditions.
-    type Engine: HashEngine;
-
-    /// Constructs a new engine.
-    fn engine() -> Self::Engine
-    where
-        Self::Engine: Default,
-    {
-        Self::Engine::default()
-    }
-
-    /// Produces a hash from the current state of a given engine.
-    fn from_engine(e: Self::Engine) -> Self;
-
-    /// Hashes some bytes.
-    fn hash(data: &[u8]) -> Self
-    where
-        Self::Engine: Default,
-    {
-        let mut engine = Self::engine();
-        engine.input(data);
-        Self::from_engine(engine)
-    }
-
-    /// Hashes all the byte slices retrieved from the iterator together.
-    fn hash_byte_chunks<B, I>(byte_slices: I) -> Self
-    where
-        B: AsRef<[u8]>,
-        I: IntoIterator<Item = B>,
-        Self::Engine: Default,
-    {
-        let mut engine = Self::engine();
-        for slice in byte_slices {
-            engine.input(slice.as_ref());
-        }
-        Self::from_engine(engine)
-    }
-}
-
 /// Trait which applies to hashes of all types.
 pub trait Hash:
     Copy + Clone + PartialEq + Eq + PartialOrd + Ord + hash::Hash + convert::AsRef<[u8]>

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -186,6 +186,9 @@ pub type HkdfSha512 = Hkdf<sha512::Hash>;
 
 /// A hashing engine which bytes can be serialized into.
 pub trait HashEngine: Clone {
+    /// The `Hash` type returned when finalizing this engine.
+    type Hash: Hash;
+
     /// Length of the hash's internal block size, in bytes.
     const BLOCK_SIZE: usize;
 
@@ -194,6 +197,9 @@ pub trait HashEngine: Clone {
 
     /// Return the number of bytes already input into the engine.
     fn n_bytes_hashed(&self) -> u64;
+
+    /// Finalizes this engine.
+    fn finalize(self) -> Self::Hash;
 }
 
 /// Trait describing hash digests which can be constructed by hashing arbitrary data.

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -189,6 +189,12 @@ pub trait HashEngine: Clone {
     /// The `Hash` type returned when finalizing this engine.
     type Hash: Hash;
 
+    /// The byte array that is used internally in `finalize`.
+    type Bytes: Copy + IsByteArray;
+
+    /// Length of the hash, in bytes.
+    const LEN: usize = Self::Bytes::LEN;
+
     /// Length of the hash's internal block size, in bytes.
     const BLOCK_SIZE: usize;
 

--- a/hashes/src/ripemd160/mod.rs
+++ b/hashes/src/ripemd160/mod.rs
@@ -88,6 +88,7 @@ impl Default for HashEngine {
 
 impl crate::HashEngine for HashEngine {
     type Hash = Hash;
+    type Bytes = [u8; 20];
     const BLOCK_SIZE: usize = 64;
 
     fn n_bytes_hashed(&self) -> u64 { self.bytes_hashed }

--- a/hashes/src/ripemd160/mod.rs
+++ b/hashes/src/ripemd160/mod.rs
@@ -87,9 +87,10 @@ impl Default for HashEngine {
 }
 
 impl crate::HashEngine for HashEngine {
+    type Hash = Hash;
     const BLOCK_SIZE: usize = 64;
 
     fn n_bytes_hashed(&self) -> u64 { self.bytes_hashed }
-
     crate::internal_macros::engine_input_impl!();
+    fn finalize(self) -> Self::Hash { Hash::from_engine(self) }
 }

--- a/hashes/src/sha1/mod.rs
+++ b/hashes/src/sha1/mod.rs
@@ -79,9 +79,12 @@ impl Default for HashEngine {
 }
 
 impl crate::HashEngine for HashEngine {
+    type Hash = Hash;
     const BLOCK_SIZE: usize = 64;
 
     fn n_bytes_hashed(&self) -> u64 { self.bytes_hashed }
 
     crate::internal_macros::engine_input_impl!();
+
+    fn finalize(self) -> Self::Hash { Hash::from_engine(self) }
 }

--- a/hashes/src/sha1/mod.rs
+++ b/hashes/src/sha1/mod.rs
@@ -80,6 +80,7 @@ impl Default for HashEngine {
 
 impl crate::HashEngine for HashEngine {
     type Hash = Hash;
+    type Bytes = [u8; 20];
     const BLOCK_SIZE: usize = 64;
 
     fn n_bytes_hashed(&self) -> u64 { self.bytes_hashed }

--- a/hashes/src/sha256/mod.rs
+++ b/hashes/src/sha256/mod.rs
@@ -140,9 +140,7 @@ impl crate::HashEngine for HashEngine {
 impl Hash {
     /// Iterate the sha256 algorithm to turn a sha256 hash into a sha256d hash
     #[must_use]
-    pub fn hash_again(&self) -> sha256d::Hash {
-        crate::Hash::from_byte_array(<Self as crate::GeneralHash>::hash(&self.0).0)
-    }
+    pub fn hash_again(&self) -> sha256d::Hash { sha256d::Hash::from_byte_array(hash(&self.0).0) }
 
     /// Computes hash from `bytes` in `const` context.
     ///

--- a/hashes/src/sha256/mod.rs
+++ b/hashes/src/sha256/mod.rs
@@ -128,11 +128,12 @@ impl Default for HashEngine {
 }
 
 impl crate::HashEngine for HashEngine {
+    type Hash = Hash;
     const BLOCK_SIZE: usize = 64;
 
     fn n_bytes_hashed(&self) -> u64 { self.bytes_hashed }
-
     crate::internal_macros::engine_input_impl!();
+    fn finalize(self) -> Self::Hash { Hash::from_engine(self) }
 }
 
 impl Hash {

--- a/hashes/src/sha256/mod.rs
+++ b/hashes/src/sha256/mod.rs
@@ -129,6 +129,7 @@ impl Default for HashEngine {
 
 impl crate::HashEngine for HashEngine {
     type Hash = Hash;
+    type Bytes = [u8; 32];
     const BLOCK_SIZE: usize = 64;
 
     fn n_bytes_hashed(&self) -> u64 { self.bytes_hashed }

--- a/hashes/src/sha256d/mod.rs
+++ b/hashes/src/sha256d/mod.rs
@@ -33,9 +33,12 @@ impl Default for HashEngine {
 }
 
 impl crate::HashEngine for HashEngine {
+    type Hash = Hash;
     const BLOCK_SIZE: usize = 64; // Same as sha256::HashEngine::BLOCK_SIZE;
+
     fn input(&mut self, data: &[u8]) { self.0.input(data) }
     fn n_bytes_hashed(&self) -> u64 { self.0.n_bytes_hashed() }
+    fn finalize(self) -> Self::Hash { Hash::from_engine(self) }
 }
 
 #[cfg(test)]

--- a/hashes/src/sha256d/mod.rs
+++ b/hashes/src/sha256d/mod.rs
@@ -34,6 +34,7 @@ impl Default for HashEngine {
 
 impl crate::HashEngine for HashEngine {
     type Hash = Hash;
+    type Bytes = [u8; 32];
     const BLOCK_SIZE: usize = 64; // Same as sha256::HashEngine::BLOCK_SIZE;
 
     fn input(&mut self, data: &[u8]) { self.0.input(data) }

--- a/hashes/src/sha256t/mod.rs
+++ b/hashes/src/sha256t/mod.rs
@@ -9,6 +9,18 @@ use core::marker::PhantomData;
 use crate::sha256::Midstate;
 use crate::{sha256, HashEngine as _};
 
+/// Hashes some bytes.
+pub fn hash<T>(data: &[u8]) -> Hash<T>
+where
+    T: Tag,
+{
+    use crate::HashEngine as _;
+
+    let mut engine = HashEngine::default();
+    engine.input(data);
+    engine.finalize()
+}
+
 /// Trait representing a tag that can be used as a context for SHA256t hashes.
 pub trait Tag {
     /// The [`Midstate`] after pre-tagging the hash engine.

--- a/hashes/src/sha256t/mod.rs
+++ b/hashes/src/sha256t/mod.rs
@@ -133,9 +133,12 @@ impl<T: Tag> Clone for HashEngine<T> {
 }
 
 impl<T: Tag> crate::HashEngine for HashEngine<T> {
+    type Hash = Hash<T>;
     const BLOCK_SIZE: usize = 64; // Same as sha256::HashEngine::BLOCK_SIZE;
+
     fn input(&mut self, data: &[u8]) { self.0.input(data) }
     fn n_bytes_hashed(&self) -> u64 { self.0.n_bytes_hashed() }
+    fn finalize(self) -> Self::Hash { Hash::from_engine(self) }
 }
 
 crate::internal_macros::impl_write!(

--- a/hashes/src/sha256t/mod.rs
+++ b/hashes/src/sha256t/mod.rs
@@ -134,6 +134,7 @@ impl<T: Tag> Clone for HashEngine<T> {
 
 impl<T: Tag> crate::HashEngine for HashEngine<T> {
     type Hash = Hash<T>;
+    type Bytes = [u8; 32];
     const BLOCK_SIZE: usize = 64; // Same as sha256::HashEngine::BLOCK_SIZE;
 
     fn input(&mut self, data: &[u8]) { self.0.input(data) }

--- a/hashes/src/sha256t/mod.rs
+++ b/hashes/src/sha256t/mod.rs
@@ -21,6 +21,22 @@ where
     engine.finalize()
 }
 
+/// Hashes all the byte slices retrieved from the iterator together.
+pub fn hash_byte_chunks<B, I, T>(byte_slices: I) -> Hash<T>
+where
+    B: AsRef<[u8]>,
+    I: IntoIterator<Item = B>,
+    T: Tag,
+{
+    use crate::HashEngine as _;
+
+    let mut engine = HashEngine::default();
+    for slice in byte_slices {
+        engine.input(slice.as_ref());
+    }
+    engine.finalize()
+}
+
 /// Trait representing a tag that can be used as a context for SHA256t hashes.
 pub trait Tag {
     /// The [`Midstate`] after pre-tagging the hash engine.

--- a/hashes/src/sha384/mod.rs
+++ b/hashes/src/sha384/mod.rs
@@ -30,11 +30,12 @@ impl Default for HashEngine {
 }
 
 impl crate::HashEngine for HashEngine {
+    type Hash = Hash;
     const BLOCK_SIZE: usize = sha512::BLOCK_SIZE;
 
     fn n_bytes_hashed(&self) -> u64 { self.0.n_bytes_hashed() }
-
     fn input(&mut self, inp: &[u8]) { self.0.input(inp); }
+    fn finalize(self) -> Self::Hash { Hash::from_engine(self) }
 }
 
 #[cfg(test)]

--- a/hashes/src/sha384/mod.rs
+++ b/hashes/src/sha384/mod.rs
@@ -31,6 +31,7 @@ impl Default for HashEngine {
 
 impl crate::HashEngine for HashEngine {
     type Hash = Hash;
+    type Bytes = [u8; 48];
     const BLOCK_SIZE: usize = sha512::BLOCK_SIZE;
 
     fn n_bytes_hashed(&self) -> u64 { self.0.n_bytes_hashed() }

--- a/hashes/src/sha512/mod.rs
+++ b/hashes/src/sha512/mod.rs
@@ -120,9 +120,10 @@ impl HashEngine {
 }
 
 impl crate::HashEngine for HashEngine {
+    type Hash = Hash;
     const BLOCK_SIZE: usize = 128;
 
     fn n_bytes_hashed(&self) -> u64 { self.bytes_hashed }
-
     crate::internal_macros::engine_input_impl!();
+    fn finalize(self) -> Self::Hash { Hash::from_engine(self) }
 }

--- a/hashes/src/sha512/mod.rs
+++ b/hashes/src/sha512/mod.rs
@@ -121,6 +121,7 @@ impl HashEngine {
 
 impl crate::HashEngine for HashEngine {
     type Hash = Hash;
+    type Bytes = [u8; 64];
     const BLOCK_SIZE: usize = 128;
 
     fn n_bytes_hashed(&self) -> u64 { self.bytes_hashed }

--- a/hashes/src/sha512_256/mod.rs
+++ b/hashes/src/sha512_256/mod.rs
@@ -41,6 +41,7 @@ impl Default for HashEngine {
 
 impl crate::HashEngine for HashEngine {
     type Hash = Hash;
+    type Bytes = [u8; 64];
     const BLOCK_SIZE: usize = sha512::BLOCK_SIZE;
 
     fn n_bytes_hashed(&self) -> u64 { self.0.n_bytes_hashed() }

--- a/hashes/src/sha512_256/mod.rs
+++ b/hashes/src/sha512_256/mod.rs
@@ -40,11 +40,12 @@ impl Default for HashEngine {
 }
 
 impl crate::HashEngine for HashEngine {
+    type Hash = Hash;
     const BLOCK_SIZE: usize = sha512::BLOCK_SIZE;
 
     fn n_bytes_hashed(&self) -> u64 { self.0.n_bytes_hashed() }
-
     fn input(&mut self, inp: &[u8]) { self.0.input(inp); }
+    fn finalize(self) -> Self::Hash { Hash::from_engine(self) }
 }
 
 #[cfg(test)]

--- a/hashes/src/siphash24/mod.rs
+++ b/hashes/src/siphash24/mod.rs
@@ -121,6 +121,7 @@ impl HashEngine {
 }
 
 impl crate::HashEngine for HashEngine {
+    type Hash = Hash;
     const BLOCK_SIZE: usize = 8;
 
     #[inline]
@@ -165,6 +166,8 @@ impl crate::HashEngine for HashEngine {
     }
 
     fn n_bytes_hashed(&self) -> u64 { self.bytes_hashed }
+
+    fn finalize(self) -> Self::Hash { Hash::from_engine(self) }
 }
 
 impl Hash {

--- a/hashes/src/siphash24/mod.rs
+++ b/hashes/src/siphash24/mod.rs
@@ -122,6 +122,7 @@ impl HashEngine {
 
 impl crate::HashEngine for HashEngine {
     type Hash = Hash;
+    type Bytes = [u8; 8];
     const BLOCK_SIZE: usize = 8;
 
     #[inline]

--- a/hashes/tests/regression.rs
+++ b/hashes/tests/regression.rs
@@ -87,3 +87,13 @@ fn regression_siphash24_with_key() {
     let want = "e823ed82311d601a";
     assert_eq!(got, want);
 }
+
+#[test]
+fn regression_sha256_hash_again() {
+    let hash = sha256::Hash::hash(b"Don't explain your philosophy. Embody it.");
+    let again = hash.hash_again();
+
+    let got = format!("{}", again);
+    let want = "28273103bcd88ab99e2b1007174770ff3f0ea91ee4b3ac942879ed1a2d264b4c";
+    assert_eq!(got, want);
+}

--- a/hashes/tests/regression.rs
+++ b/hashes/tests/regression.rs
@@ -8,7 +8,7 @@
 
 use bitcoin_hashes::{
     hash160, ripemd160, sha1, sha256, sha256d, sha256t, sha384, sha512, sha512_256, siphash24,
-    GeneralHash as _, HashEngine as _, Hmac, HmacEngine,
+    HashEngine as _, HmacEngine,
 };
 
 const DATA: &str = "arbitrary data to hash as a regression test";
@@ -57,9 +57,9 @@ fn regression_sha256t() {
 
 #[test]
 fn regression_hmac_sha256_with_key() {
-    let mut engine = HmacEngine::<sha256::Hash>::new(HMAC_KEY);
+    let mut engine = HmacEngine::<sha256::HashEngine>::new(HMAC_KEY);
     engine.input(DATA.as_bytes());
-    let hash = Hmac::from_engine(engine);
+    let hash = engine.finalize();
 
     let got = format!("{}", hash);
     let want = "d159cecaf4adf90b6a641bab767e4817d3a51c414acea3682686c35ec0b37b52";
@@ -68,9 +68,9 @@ fn regression_hmac_sha256_with_key() {
 
 #[test]
 fn regression_hmac_sha512_with_key() {
-    let mut engine = HmacEngine::<sha512::Hash>::new(HMAC_KEY);
+    let mut engine = HmacEngine::<sha512::HashEngine>::new(HMAC_KEY);
     engine.input(DATA.as_bytes());
-    let hash = Hmac::from_engine(engine);
+    let hash = engine.finalize();
 
     let got = format!("{}", hash);
     let want = "8511773748f89ba22c07fb3a2981a12c1823695119de41f4a62aead6b848bd34939acf16475c35ed7956114fead3e794cc162ecd35e447a4dabc3227d55f757b";

--- a/io/src/hash.rs
+++ b/io/src/hash.rs
@@ -128,7 +128,7 @@ impl_write!(
         Ok(buf.len())
     },
     |_us| { Ok(()) },
-    T: hashes::GeneralHash
+    T: hashes::HashEngine
 );
 
 /// Hashes data from a reader.
@@ -172,7 +172,7 @@ mod sealed {
 mod tests {
     use alloc::format;
 
-    use hashes::{hmac, Hmac};
+    use hashes::hmac;
 
     use super::*;
     use crate::{Cursor, Write as _};
@@ -257,24 +257,24 @@ mod tests {
 
     #[test]
     fn hmac() {
-        let mut engine = hmac::HmacEngine::<sha256::Hash>::new(&[0xde, 0xad, 0xbe, 0xef]);
+        let mut engine = hmac::HmacEngine::<sha256::HashEngine>::new(&[0xde, 0xad, 0xbe, 0xef]);
         engine.write_all(&[]).unwrap();
         assert_eq!(
-            format!("{}", hmac::Hmac::from_engine(engine)),
+            format!("{}", engine.finalize()),
             "bf5515149cf797955c4d3194cca42472883281951697c8375d9d9b107f384225"
         );
 
-        let mut engine = hmac::HmacEngine::<sha256::Hash>::new(&[0xde, 0xad, 0xbe, 0xef]);
+        let mut engine = hmac::HmacEngine::<sha256::HashEngine>::new(&[0xde, 0xad, 0xbe, 0xef]);
         engine.write_all(&[1; 256]).unwrap();
         assert_eq!(
-            format!("{}", hmac::Hmac::from_engine(engine)),
+            format!("{}", engine.finalize()),
             "59c9aca10c81c73cb4c196d94db741b6bf2050e0153d5a45f2526bff34675ac5"
         );
 
-        let mut engine = hmac::HmacEngine::<sha256::Hash>::new(&[0xde, 0xad, 0xbe, 0xef]);
+        let mut engine = hmac::HmacEngine::<sha256::HashEngine>::new(&[0xde, 0xad, 0xbe, 0xef]);
         engine.write_all(&[99; 64000]).unwrap();
         assert_eq!(
-            format!("{}", hmac::Hmac::from_engine(engine)),
+            format!("{}", engine.finalize()),
             "30df499717415a395379a1eaabe50038036e4abb5afc94aa55c952f4aa57be08"
         );
     }
@@ -345,9 +345,9 @@ mod tests {
 
     #[test]
     fn regression_hmac_sha256_with_key() {
-        let mut engine = HmacEngine::<sha256::Hash>::new(HMAC_KEY);
+        let mut engine = HmacEngine::<sha256::HashEngine>::new(HMAC_KEY);
         engine.input(DATA.as_bytes());
-        let hash = Hmac::from_engine(engine);
+        let hash = engine.finalize();
 
         let got = format!("{}", hash);
         let want = "d159cecaf4adf90b6a641bab767e4817d3a51c414acea3682686c35ec0b37b52";
@@ -356,9 +356,9 @@ mod tests {
 
     #[test]
     fn regression_hmac_sha512_with_key() {
-        let mut engine = HmacEngine::<sha512::Hash>::new(HMAC_KEY);
+        let mut engine = HmacEngine::<sha512::HashEngine>::new(HMAC_KEY);
         engine.input(DATA.as_bytes());
-        let hash = Hmac::from_engine(engine);
+        let hash = engine.finalize();
 
         let got = format!("{}", hash);
         let want = "8511773748f89ba22c07fb3a2981a12c1823695119de41f4a62aead6b848bd34939acf16475c35ed7956114fead3e794cc162ecd35e447a4dabc3227d55f757b";

--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -46,7 +46,7 @@ pub use bridge::{FromStd, ToStd};
 #[rustfmt::skip]                // Keep public re-exports separate.
 pub use self::error::{Error, ErrorKind};
 #[cfg(feature = "hashes")]
-pub use self::hash::GeneralHashExt;
+pub use self::hash::hash_reader;
 
 /// Result type returned by functions in this crate.
 pub type Result<T> = core::result::Result<T, Error>;


### PR DESCRIPTION
This is the done as part of #4051.

Requires some surgery on the `Hmac` and `Hkdf` types as well as a few other patches to maintain the logic that is currently provided by the trait. Final patch is a pure red diff - enjoy.