### PR TITLE
primitives: Add additional Debug derives

### DIFF
--- a/primitives/src/taproot.rs
+++ b/primitives/src/taproot.rs
@@ -8,6 +8,7 @@ use hashes::{hash_newtype, sha256t, sha256t_tag};
 
 // Taproot test vectors from BIP-341 state the hashes without any reversing
 sha256t_tag! {
+    #[derive(Debug)]
     pub struct TapLeafTag = hash_str("TapLeaf");
 }
 
@@ -23,6 +24,7 @@ hashes::impl_hex_for_newtype!(TapLeafHash);
 hashes::impl_serde_for_newtype!(TapLeafHash);
 
 sha256t_tag! {
+    #[derive(Debug)]
     pub struct TapBranchTag = hash_str("TapBranch");
 }
 
@@ -38,6 +40,7 @@ hashes::impl_hex_for_newtype!(TapNodeHash);
 hashes::impl_serde_for_newtype!(TapNodeHash);
 
 sha256t_tag! {
+    #[derive(Debug)]
     pub struct TapTweakTag = hash_str("TapTweak");
 }
 

--- a/primitives/src/witness.rs
+++ b/primitives/src/witness.rs
@@ -258,6 +258,7 @@ impl fmt::Debug for Witness {
 }
 
 /// An iterator returning individual witness elements.
+#[derive(Debug)]
 pub struct Iter<'a> {
     inner: &'a [u8],
     indices_start: usize,


### PR DESCRIPTION
As part of C-DEBUG derive `Debug` on our sha256t tags as well as on the `witness::Iter`.