### PR TITLE
Demo the `hex-conservative-errors` crate

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -202,11 +202,14 @@ dependencies = [
 [[package]]
 name = "hex-conservative"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afe881d0527571892c4034822e59bb10c6c991cce6abe8199b6f5cf10766f55"
 dependencies = [
  "arrayvec",
+ "hex-conservative-errors",
 ]
+
+[[package]]
+name = "hex-conservative-errors"
+version = "1.0.0-alpha.0"
 
 [[package]]
 name = "hex_lit"

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -204,11 +204,14 @@ dependencies = [
 [[package]]
 name = "hex-conservative"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afe881d0527571892c4034822e59bb10c6c991cce6abe8199b6f5cf10766f55"
 dependencies = [
  "arrayvec",
+ "hex-conservative-errors",
 ]
+
+[[package]]
+name = "hex-conservative-errors"
+version = "1.0.0-alpha.0"
 
 [[package]]
 name = "hex_lit"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,7 @@ path = "primitives"
 path = "units"
 
 [patch.crates-io.hex-conservative]
-path = "/home/tobin/build/github.com/tcharding/hex-conservative/master"
+path = "/home/tobin/build/github.com/tcharding/hex-conservative/02-21-demo-error-crate"
+
+[patch.crates-io.hex-conservative-errors]
+path = "/home/tobin/build/github.com/tcharding/hex-conservative/02-21-demo-error-crate/errors"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,6 @@ path = "primitives"
 
 [patch.crates-io.bitcoin-units]
 path = "units"
+
+[patch.crates-io.hex-conservative]
+path = "/home/tobin/build/github.com/tcharding/hex-conservative/master"

--- a/base58/src/lib.rs
+++ b/base58/src/lib.rs
@@ -253,7 +253,7 @@ where
 mod tests {
     use alloc::vec;
 
-    use hex::test_hex_unwrap as hex;
+    macro_rules! hex (($hex:expr) => (<Vec<u8> as hex::FromHex>::from_hex($hex).unwrap()));
 
     use super::*;
 

--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -577,12 +577,13 @@ impl<'a, W: Write> BitStreamWriter<'a, W> {
 mod test {
     use std::collections::HashMap;
 
-    use hex::test_hex_unwrap as hex;
     use serde_json::Value;
 
     use super::*;
     use crate::consensus::encode::deserialize;
     use crate::ScriptBuf;
+
+    macro_rules! hex (($hex:expr) => (<Vec<u8> as hex::FromHex>::from_hex($hex).unwrap()));
 
     #[test]
     fn blockfilters() {

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -969,12 +969,13 @@ impl std::error::Error for InvalidBase58PayloadLengthError {}
 
 #[cfg(test)]
 mod tests {
-    use hex::test_hex_unwrap as hex;
     #[cfg(feature = "serde")]
     use internals::serde_round_trip;
 
     use super::ChildNumber::{Hardened, Normal};
     use super::*;
+
+    macro_rules! hex (($hex:expr) => (<Vec<u8> as hex::FromHex>::from_hex($hex).unwrap()));
 
     #[test]
     fn parse_derivation_path() {

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -490,13 +490,14 @@ impl std::error::Error for ValidationError {
 
 #[cfg(test)]
 mod tests {
-    use hex::test_hex_unwrap as hex;
     use internals::ToU64 as _;
 
     use super::*;
     use crate::consensus::encode::{deserialize, serialize};
     use crate::pow::test_utils::{u128_to_work, u64_to_work};
     use crate::{block, CompactTarget, Network, TestnetVersion};
+
+    macro_rules! hex (($hex:expr) => (<Vec<u8> as hex::FromHex>::from_hex($hex).unwrap()));
 
     #[test]
     fn static_vector() {

--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -266,12 +266,12 @@ impl ChainHash {
 
 #[cfg(test)]
 mod test {
-    use hex::test_hex_unwrap as hex;
-
     use super::*;
     use crate::consensus::encode::serialize;
     use crate::network::params;
     use crate::Txid;
+
+    macro_rules! hex (($hex:expr) => (<Vec<u8> as hex::FromHex>::from_hex($hex).unwrap()));
 
     #[test]
     fn bitcoin_genesis_first_transaction() {

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -1148,7 +1148,7 @@ mod sealed {
 
 #[cfg(test)]
 mod tests {
-    use hex::{test_hex_unwrap as hex, FromHex};
+    use hex::FromHex;
     #[cfg(feature = "serde")]
     use internals::serde_round_trip;
     use units::parse;
@@ -1157,6 +1157,8 @@ mod tests {
     use crate::consensus::encode::{deserialize, serialize};
     use crate::constants::WITNESS_SCALE_FACTOR;
     use crate::sighash::EcdsaSighashType;
+
+    macro_rules! hex (($hex:expr) => (<Vec<u8> as hex::FromHex>::from_hex($hex).unwrap()));
 
     const SOME_TX: &str = "0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000";
 

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -223,13 +223,13 @@ fn encode_cursor(bytes: &mut [u8], start_of_indices: usize, index: usize, value:
 
 #[cfg(test)]
 mod test {
-    use hex::test_hex_unwrap as hex;
-
     use super::*;
     use crate::consensus::{deserialize, encode, serialize};
     use crate::hex::DisplayHex;
     use crate::sighash::EcdsaSighashType;
     use crate::Transaction;
+
+    macro_rules! hex (($hex:expr) => (<Vec<u8> as hex::FromHex>::from_hex($hex).unwrap()));
 
     #[test]
     fn exact_sized_iterator() {

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -11,7 +11,7 @@ use core::ops;
 use core::str::FromStr;
 
 use hashes::hash160;
-use hex::{FromHex, HexToArrayError};
+use hex::FromHex;
 use internals::array_vec::ArrayVec;
 use internals::{impl_to_hex_from_lower_hex, write_err};
 use io::{Read, Write};
@@ -237,20 +237,20 @@ impl fmt::Display for PublicKey {
 impl FromStr for PublicKey {
     type Err = ParsePublicKeyError;
     fn from_str(s: &str) -> Result<PublicKey, ParsePublicKeyError> {
-        use HexToArrayError::*;
+        use hex::ToArrayError as E;
 
         match s.len() {
             66 => {
-                let bytes = <[u8; 33]>::from_hex(s).map_err(|e| match e {
-                    InvalidChar(e) => ParsePublicKeyError::InvalidChar(e),
-                    InvalidLength(_) => unreachable!("length checked already"),
+                let bytes = <[u8; 33]>::from_hex(s).map_err(|e| match e.parse_error() {
+                    E::InvalidChar(e) => ParsePublicKeyError::InvalidChar(e),
+                    E::InvalidLength(_) => unreachable!("length checked already"),
                 })?;
                 Ok(PublicKey::from_slice(&bytes)?)
             }
             130 => {
-                let bytes = <[u8; 65]>::from_hex(s).map_err(|e| match e {
-                    InvalidChar(e) => ParsePublicKeyError::InvalidChar(e),
-                    InvalidLength(_) => unreachable!("length checked already"),
+                let bytes = <[u8; 65]>::from_hex(s).map_err(|e| match e.parse_error() {
+                    E::InvalidChar(e) => ParsePublicKeyError::InvalidChar(e),
+                    E::InvalidLength(_) => unreachable!("length checked already"),
                 })?;
                 Ok(PublicKey::from_slice(&bytes)?)
             }

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -1521,7 +1521,7 @@ impl<'a> Arbitrary<'a> for TapSighashType {
 #[cfg(test)]
 mod tests {
     use hashes::HashEngine;
-    use hex::{test_hex_unwrap as hex, FromHex};
+    use hex::FromHex;
 
     use super::*;
     use crate::consensus::deserialize;
@@ -1532,6 +1532,8 @@ mod tests {
     extern crate serde_json;
 
     const DUMMY_TXOUT: TxOut = TxOut { value: Amount::MIN, script_pubkey: ScriptBuf::new() };
+
+    macro_rules! hex (($hex:expr) => (<Vec<u8> as hex::FromHex>::from_hex($hex).unwrap()));
 
     #[test]
     fn sighash_single_bug() {

--- a/bitcoin/src/merkle_tree/block.rs
+++ b/bitcoin/src/merkle_tree/block.rs
@@ -519,7 +519,9 @@ mod tests {
     use crate::block::{BlockUncheckedExt as _, Unchecked};
     use crate::consensus::encode;
     use crate::hash_types::Txid;
-    use crate::hex::{test_hex_unwrap as hex, DisplayHex, FromHex};
+    use crate::hex::{DisplayHex, FromHex};
+
+    macro_rules! hex (($hex:expr) => (<Vec<u8> as hex::FromHex>::from_hex($hex).unwrap()));
 
     #[cfg(feature = "rand-std")]
     macro_rules! pmt_tests {

--- a/bitcoin/src/p2p/address.rs
+++ b/bitcoin/src/p2p/address.rs
@@ -301,10 +301,12 @@ impl ToSocketAddrs for AddrV2Message {
 mod test {
     use std::net::IpAddr;
 
-    use hex::{test_hex_unwrap as hex, FromHex};
+    use hex::FromHex;
 
     use super::*;
     use crate::consensus::encode::{deserialize, serialize};
+
+    macro_rules! hex (($hex:expr) => (<Vec<u8> as hex::FromHex>::from_hex($hex).unwrap()));
 
     #[test]
     fn serialize_address() {

--- a/bitcoin/src/p2p/message.rs
+++ b/bitcoin/src/p2p/message.rs
@@ -697,7 +697,6 @@ impl Decodable for V2NetworkMessage {
 mod test {
     use std::net::Ipv4Addr;
 
-    use hex::test_hex_unwrap as hex;
     use units::BlockHeight;
 
     use super::*;
@@ -715,6 +714,8 @@ mod test {
     use crate::p2p::ServiceFlags;
     use crate::script::ScriptBuf;
     use crate::transaction::Transaction;
+
+    macro_rules! hex (($hex:expr) => (<Vec<u8> as hex::FromHex>::from_hex($hex).unwrap()));
 
     fn hash(array: [u8; 32]) -> sha256d::Hash { sha256d::Hash::from_byte_array(array) }
 

--- a/bitcoin/src/p2p/message_blockdata.rs
+++ b/bitcoin/src/p2p/message_blockdata.rs
@@ -144,10 +144,10 @@ impl_consensus_encoding!(GetHeadersMessage, version, locator_hashes, stop_hash);
 
 #[cfg(test)]
 mod tests {
-    use hex::test_hex_unwrap as hex;
-
     use super::*;
     use crate::consensus::encode::{deserialize, serialize};
+
+    macro_rules! hex (($hex:expr) => (<Vec<u8> as hex::FromHex>::from_hex($hex).unwrap()));
 
     #[test]
     fn getblocks_message() {

--- a/bitcoin/src/p2p/message_network.rs
+++ b/bitcoin/src/p2p/message_network.rs
@@ -148,10 +148,10 @@ impl_consensus_encoding!(Reject, message, ccode, reason, hash);
 
 #[cfg(test)]
 mod tests {
-    use hex::test_hex_unwrap as hex;
-
     use super::*;
     use crate::consensus::encode::{deserialize, serialize};
+
+    macro_rules! hex (($hex:expr) => (<Vec<u8> as hex::FromHex>::from_hex($hex).unwrap()));
 
     #[test]
     fn version_message_test() {

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -1222,7 +1222,7 @@ pub use self::display_from_str::PsbtParseError;
 #[cfg(test)]
 mod tests {
     use hashes::{hash160, ripemd160, sha256};
-    use hex::{test_hex_unwrap as hex, FromHex};
+    use hex::FromHex;
     #[cfg(feature = "rand-std")]
     use secp256k1::{All, SecretKey};
 
@@ -1236,6 +1236,8 @@ mod tests {
     use crate::transaction::{self, OutPoint, TxIn};
     use crate::witness::Witness;
     use crate::Sequence;
+
+    macro_rules! hex (($hex:expr) => (<Vec<u8> as hex::FromHex>::from_hex($hex).unwrap()));
 
     #[track_caller]
     pub fn hex_psbt(s: &str) -> Result<Psbt, crate::psbt::error::Error> {

--- a/primitives/src/witness.rs
+++ b/primitives/src/witness.rs
@@ -344,8 +344,7 @@ impl<'de> serde::Deserialize<'de> for Witness {
                 self,
                 mut a: A,
             ) -> Result<Self::Value, A::Error> {
-                use hex::FromHex;
-                use hex::HexToBytesError::*;
+                use hex::{FromHex as _, ToBytesError};
                 use serde::de::{self, Unexpected};
 
                 let mut ret = match a.size_hint() {
@@ -354,8 +353,8 @@ impl<'de> serde::Deserialize<'de> for Witness {
                 };
 
                 while let Some(elem) = a.next_element::<String>()? {
-                    let vec = Vec::<u8>::from_hex(&elem).map_err(|e| match e {
-                        InvalidChar(ref e) => match core::char::from_u32(e.invalid_char().into()) {
+                    let vec = Vec::<u8>::from_hex(&elem).map_err(|e| match e.parse_error() {
+                        ToBytesError::InvalidChar(ref e) => match core::char::from_u32(e.invalid_char().into()) {
                             Some(c) => de::Error::invalid_value(
                                 Unexpected::Char(c),
                                 &"a valid hex character",
@@ -365,7 +364,7 @@ impl<'de> serde::Deserialize<'de> for Witness {
                                 &"a valid hex character",
                             ),
                         },
-                        OddLengthString(ref e) =>
+                        ToBytesError::OddLengthString(ref e) =>
                             de::Error::invalid_length(e.length(), &"an even length string"),
                     })?;
                     ret.push(vec);


### PR DESCRIPTION
Wild Friday afternoon hacking session led to: https://github.com/rust-bitcoin/hex-conservative/pull/161

This PR demos its usage.