### PR TITLE
Make transaction::Version field private

### DIFF
--- a/bitcoin/tests/psbt-sign-taproot.rs
+++ b/bitcoin/tests/psbt-sign-taproot.rs
@@ -211,7 +211,7 @@ fn create_psbt_for_taproot_key_path_spend(
     let prev_tx_id = "06980ca116f74c7845a897461dd0e1d15b114130176de5004957da516b4dee3a";
 
     let transaction = Transaction {
-        version: Version(2),
+        version: Version::TWO,
         lock_time: absolute::LockTime::ZERO,
         input: vec![TxIn {
             previous_output: OutPoint { txid: prev_tx_id.parse().unwrap(), vout: 0 },
@@ -288,7 +288,7 @@ fn create_psbt_for_taproot_script_path_spend(
     }];
     let prev_tx_id = "9d7c6770fca57285babab60c51834cfcfd10ad302119cae842d7216b4ac9a376";
     let transaction = Transaction {
-        version: Version(2),
+        version: Version::TWO,
         lock_time: absolute::LockTime::ZERO,
         input: vec![TxIn {
             previous_output: OutPoint { txid: prev_tx_id.parse().unwrap(), vout: 0 },

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -518,7 +518,7 @@ impl Wtxid {
 /// [BIP-431]: https://github.com/bitcoin/bips/blob/master/bip-0431.mediawiki
 #[derive(Copy, PartialEq, Eq, Clone, Debug, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Version(pub u32);
+pub struct Version(u32);
 
 impl Version {
     /// The original Bitcoin transaction version (pre-BIP-68).
@@ -529,10 +529,33 @@ impl Version {
 
     /// The third Bitcoin transaction version (post-BIP-431).
     pub const THREE: Self = Self(3);
+
+    /// Constructs a potentially non-standard transaction version.
+    ///
+    /// This can accept both standard and non-standard versions.
+    #[inline]
+    pub fn maybe_non_standard(version: u32) -> Version { Self(version) }
+
+    /// Returns the inner `u32` value of this `Version`.
+    #[inline]
+    pub const fn to_u32(self) -> u32 { self.0 }
+
+    /// Returns true if this transaction version number is considered standard.
+    ///
+    /// The behavior of this method matches whatever Bitcoin Core considers standard at the time
+    /// of the release and may change in future versions to accommodate new standard versions.
+    /// As of Bitcoin Core 28.0 ([release notes](https://bitcoincore.org/en/releases/28.0/)),
+    /// versions 1, 2, and 3 are considered standard.
+    #[inline]
+    pub fn is_standard(&self) -> bool { *self == Version::ONE || *self == Version::TWO || *self == Version::THREE }
 }
 
 impl fmt::Display for Version {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { fmt::Display::fmt(&self.0, f) }
+}
+
+impl From<Version> for u32 {
+    fn from(version: Version) -> Self { version.0 }
 }
 
 #[cfg(feature = "arbitrary")]


### PR DESCRIPTION
This commit addresses #4041 by making the `transaction::Version` field private. 

This forces people to either use the associated constants (`Version::ONE/TWO/THREE`) or the `non_standard`/`from_consensus` methods for any other transaction version.

This aligns with our approach to `block::Version`