### PR TITLE
Implement `ops::Mul` and `ops::Div` operations for `Amount` and `SignedAmount`

### DIFF
--- a/units/src/amount/tests.rs
+++ b/units/src/amount/tests.rs
@@ -138,7 +138,7 @@ fn neg() {
 fn overflows() {
     let result = Amount::MAX + Amount::from_sat_unchecked(1);
     assert!(result.is_error());
-    let result = Amount::from_sat_unchecked(8_446_744_073_709_551_615) * 3;
+    let result: NumOpResult<Amount> = Amount::from_sat_unchecked(8_446_744_073_709_551_615) * 3;
     assert!(result.is_error());
 }
 


### PR DESCRIPTION
Implement `ops::Mul` and `ops::Div` operations for `Amount` and  `SignedAmount` with common integer types (usize, isize, u64, i32) using macros to reduce code duplication.

We handle both `owned` and `reference`  impls.

Also we focus primarly on these types: (usize, isize, u64, i32), Other integer types (u8, u16, etc) can be easily added to the macro implementations if needed in the future. 

**Note on type selection**: Added i32 support after finding  compilation errors in `amount/tests.rs` where untyped literals like `amount * 3` no longer worked with just u64 implementation as we have before (Rust couldn t automatically coerce to u64 with multiple type implementations)

Closes #4030

