### PR TITLE
sighash: Document `witness_script` in p2wsh

### DIFF
--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -886,6 +886,9 @@ impl<R: Borrow<Transaction>> SighashCache<R> {
     }
 
     /// Computes the BIP143 sighash to spend a p2wsh transaction for any flag type.
+    ///
+    /// `witness_script` is the script that goes into the [`Witness`],
+    /// not the one that goes into `script_pubkey` of a [`TxOut`].
     pub fn p2wsh_signature_hash(
         &mut self,
         input_index: usize,


### PR DESCRIPTION
A note suggestion for the `p2wsh_signature_hash` in the same vein as the one in the "sister" function `p2wpkh_signature_hash`: https://github.com/rust-bitcoin/rust-bitcoin/blob/33f5e5a6acddc34d6c436a9d73bb50988c067b29/bitcoin/src/crypto/sighash.rs#L863-L867

Any better wordings are welcomed. Not married to my sentences.