### PR TITLE
Demo hex `v1.0.0-alpha.0` usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,11 @@ path = "primitives"
 
 [patch.crates-io.bitcoin-units]
 path = "units"
+
+[patch.crates-io.hex-conservative]
+git = "https://github.com/rust-bitcoin/hex-conservative"
+# Tip of master at: Mon 24 Feb 2025 09:45:43 AEDT
+# Merge rust-bitcoin/hex-conservative#158: Remove default impl of `hex_reserve_suggestion`
+rev = "3dee66bd69743bf4d125d6a40355fdc8981caeaa"
+
+

--- a/base58/Cargo.toml
+++ b/base58/Cargo.toml
@@ -14,15 +14,16 @@ exclude = ["tests", "contrib"]
 
 [features]
 default = ["std"]
-std = ["alloc", "hashes/std", "internals/std"]
-alloc = ["hashes/alloc", "internals/alloc"]
+std = ["alloc", "hashes/std", "internals/std", "hex-stable/std", "hex-unstable/std"]
+alloc = ["hashes/alloc", "internals/alloc", "hex-stable/alloc", "hex-unstable/alloc"]
 
 [dependencies]
 hashes = { package = "bitcoin_hashes", version = "0.16.0", default-features = false }
 internals = { package = "bitcoin-internals", version = "0.4.0" }
 
 [dev-dependencies]
-hex = { package = "hex-conservative", version = "0.3.0", default-features = false, features = ["alloc"] }
+hex-unstable = { package = "hex-conservative", version = "0.4.0", git = "https://github.com/tcharding/hex-conservative", branch = "02-24-release-0.4", default-features = false }
+hex-stable = { package = "hex-conservative", version = "1.0.0-alpha.0", git = "https://github.com/tcharding/hex-conservative", branch = "02-24-release-1.0-alpha.0", default-features = false }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/base58/src/lib.rs
+++ b/base58/src/lib.rs
@@ -253,7 +253,7 @@ where
 mod tests {
     use alloc::vec;
 
-    use hex::test_hex_unwrap as hex;
+    macro_rules! hex (($hex:expr) => (<Vec<u8> as hex::FromHex>::from_hex($hex).unwrap()));
 
     use super::*;
 

--- a/base58/src/lib.rs
+++ b/base58/src/lib.rs
@@ -253,7 +253,7 @@ where
 mod tests {
     use alloc::vec;
 
-    macro_rules! hex (($hex:expr) => (<Vec<u8> as hex::FromHex>::from_hex($hex).unwrap()));
+    macro_rules! hex (($hex:expr) => (<Vec<u8> as hex_stable::FromHex>::from_hex($hex).unwrap()));
 
     use super::*;
 

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["tests", "contrib"]
 # If you change features or optional dependencies in any way please update the "# Cargo features" section in lib.rs as well.
 [features]
 default = [ "std", "secp-recovery" ]
-std = ["base58/std", "bech32/std", "hashes/std", "hex/std", "internals/std", "io/std", "primitives/std", "secp256k1/std", "units/std", "bitcoinconsensus?/std"]
+std = ["base58/std", "bech32/std", "hashes/std", "hex-stable/std", "hex-unstable/std", "internals/std", "io/std", "primitives/std", "secp256k1/std", "units/std", "bitcoinconsensus?/std"]
 rand-std = ["secp256k1/rand-std", "std"]
 rand = ["secp256k1/rand"]
 serde = ["dep:serde", "hashes/serde", "internals/serde", "primitives/serde", "secp256k1/serde", "units/serde"]
@@ -28,7 +28,8 @@ arbitrary = ["dep:arbitrary", "units/arbitrary", "primitives/arbitrary"]
 base58 = { package = "base58ck", version = "0.2.0", default-features = false, features = ["alloc"] }
 bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
 hashes = { package = "bitcoin_hashes", version = "0.16.0", default-features = false, features = ["alloc", "hex"] }
-hex = { package = "hex-conservative", version = "0.3.0", default-features = false, features = ["alloc"] }
+hex-unstable = { package = "hex-conservative", version = "0.4.0", git = "https://github.com/tcharding/hex-conservative", branch = "02-24-release-0.4", default-features = false, features = ["alloc"] }
+hex-stable = { package = "hex-conservative", version = "1.0.0-alpha.0", git = "https://github.com/tcharding/hex-conservative", branch = "02-24-release-1.0-alpha.0", default-features = false, features = ["alloc"] }
 internals = { package = "bitcoin-internals", version = "0.4.0", features = ["alloc"] }
 io = { package = "bitcoin-io", version = "0.2.0", default-features = false, features = ["alloc", "hashes"] }
 primitives = { package = "bitcoin-primitives", version = "0.101.0", default-features = false, features = ["alloc"] }

--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -577,12 +577,13 @@ impl<'a, W: Write> BitStreamWriter<'a, W> {
 mod test {
     use std::collections::HashMap;
 
-    use hex::test_hex_unwrap as hex;
     use serde_json::Value;
 
     use super::*;
     use crate::consensus::encode::deserialize;
     use crate::ScriptBuf;
+
+    macro_rules! hex (($hex:expr) => (<Vec<u8> as hex::FromHex>::from_hex($hex).unwrap()));
 
     #[test]
     fn blockfilters() {

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -969,12 +969,13 @@ impl std::error::Error for InvalidBase58PayloadLengthError {}
 
 #[cfg(test)]
 mod tests {
-    use hex::test_hex_unwrap as hex;
     #[cfg(feature = "serde")]
     use internals::serde_round_trip;
 
     use super::ChildNumber::{Hardened, Normal};
     use super::*;
+
+    macro_rules! hex (($hex:expr) => (<Vec<u8> as hex::FromHex>::from_hex($hex).unwrap()));
 
     #[test]
     fn parse_derivation_path() {

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -490,13 +490,14 @@ impl std::error::Error for ValidationError {
 
 #[cfg(test)]
 mod tests {
-    use hex::test_hex_unwrap as hex;
     use internals::ToU64 as _;
 
     use super::*;
     use crate::consensus::encode::{deserialize, serialize};
     use crate::pow::test_utils::{u128_to_work, u64_to_work};
     use crate::{block, CompactTarget, Network, TestnetVersion};
+
+    macro_rules! hex (($hex:expr) => (<Vec<u8> as hex::FromHex>::from_hex($hex).unwrap()));
 
     #[test]
     fn static_vector() {

--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -266,12 +266,12 @@ impl ChainHash {
 
 #[cfg(test)]
 mod test {
-    use hex::test_hex_unwrap as hex;
-
     use super::*;
     use crate::consensus::encode::serialize;
     use crate::network::params;
     use crate::Txid;
+
+    macro_rules! hex (($hex:expr) => (<Vec<u8> as hex::FromHex>::from_hex($hex).unwrap()));
 
     #[test]
     fn bitcoin_genesis_first_transaction() {

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -1148,7 +1148,7 @@ mod sealed {
 
 #[cfg(test)]
 mod tests {
-    use hex::{test_hex_unwrap as hex, FromHex};
+    use hex::FromHex;
     #[cfg(feature = "serde")]
     use internals::serde_round_trip;
     use units::parse;
@@ -1157,6 +1157,8 @@ mod tests {
     use crate::consensus::encode::{deserialize, serialize};
     use crate::constants::WITNESS_SCALE_FACTOR;
     use crate::sighash::EcdsaSighashType;
+
+    macro_rules! hex (($hex:expr) => (<Vec<u8> as hex::FromHex>::from_hex($hex).unwrap()));
 
     const SOME_TX: &str = "0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000";
 

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -223,13 +223,13 @@ fn encode_cursor(bytes: &mut [u8], start_of_indices: usize, index: usize, value:
 
 #[cfg(test)]
 mod test {
-    use hex::test_hex_unwrap as hex;
-
     use super::*;
     use crate::consensus::{deserialize, encode, serialize};
     use crate::hex::DisplayHex;
     use crate::sighash::EcdsaSighashType;
     use crate::Transaction;
+
+    macro_rules! hex (($hex:expr) => (<Vec<u8> as hex::FromHex>::from_hex($hex).unwrap()));
 
     #[test]
     fn exact_sized_iterator() {

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -223,9 +223,10 @@ fn encode_cursor(bytes: &mut [u8], start_of_indices: usize, index: usize, value:
 
 #[cfg(test)]
 mod test {
+    use hex_unstable::DisplayHex as _;
+
     use super::*;
     use crate::consensus::{deserialize, encode, serialize};
-    use crate::hex::DisplayHex;
     use crate::sighash::EcdsaSighashType;
     use crate::Transaction;
 

--- a/bitcoin/src/consensus/encode.rs
+++ b/bitcoin/src/consensus/encode.rs
@@ -17,7 +17,7 @@
 use core::mem;
 
 use hashes::{sha256, sha256d, GeneralHash, Hash};
-use hex::DisplayHex as _;
+use hex_unstable::DisplayHex as _;
 use internals::{compact_size, ToU64};
 use io::{BufRead, Cursor, Read, Write};
 

--- a/bitcoin/src/consensus/error.rs
+++ b/bitcoin/src/consensus/error.rs
@@ -5,8 +5,8 @@
 use core::convert::Infallible;
 use core::fmt;
 
-use hex::error::{InvalidCharError, OddLengthStringError};
-use hex::DisplayHex as _;
+use hex::{InvalidCharError, OddLengthStringError};
+use hex_unstable::DisplayHex as _;
 use internals::write_err;
 
 #[cfg(doc)]

--- a/bitcoin/src/consensus/serde.rs
+++ b/bitcoin/src/consensus/serde.rs
@@ -38,7 +38,7 @@ pub mod hex {
     use core::fmt;
     use core::marker::PhantomData;
 
-    use hex::buf_encoder::BufEncoder;
+    use hex_unstable::buf_encoder::BufEncoder;
 
     /// Marker for upper/lower case type-level flags ("type-level enum").
     ///

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -11,7 +11,7 @@ use core::ops;
 use core::str::FromStr;
 
 use hashes::hash160;
-use hex::{FromHex, HexToArrayError};
+use hex::FromHex;
 use internals::array_vec::ArrayVec;
 use internals::{impl_to_hex_from_lower_hex, write_err};
 use io::{Read, Write};
@@ -237,20 +237,20 @@ impl fmt::Display for PublicKey {
 impl FromStr for PublicKey {
     type Err = ParsePublicKeyError;
     fn from_str(s: &str) -> Result<PublicKey, ParsePublicKeyError> {
-        use HexToArrayError::*;
+        use hex::ToArrayError as E;
 
         match s.len() {
             66 => {
-                let bytes = <[u8; 33]>::from_hex(s).map_err(|e| match e {
-                    InvalidChar(e) => ParsePublicKeyError::InvalidChar(e),
-                    InvalidLength(_) => unreachable!("length checked already"),
+                let bytes = <[u8; 33]>::from_hex(s).map_err(|e| match e.parse_error() {
+                    E::InvalidChar(e) => ParsePublicKeyError::InvalidChar(e),
+                    E::InvalidLength(_) => unreachable!("length checked already"),
                 })?;
                 Ok(PublicKey::from_slice(&bytes)?)
             }
             130 => {
-                let bytes = <[u8; 65]>::from_hex(s).map_err(|e| match e {
-                    InvalidChar(e) => ParsePublicKeyError::InvalidChar(e),
-                    InvalidLength(_) => unreachable!("length checked already"),
+                let bytes = <[u8; 65]>::from_hex(s).map_err(|e| match e.parse_error() {
+                    E::InvalidChar(e) => ParsePublicKeyError::InvalidChar(e),
+                    E::InvalidLength(_) => unreachable!("length checked already"),
                 })?;
                 Ok(PublicKey::from_slice(&bytes)?)
             }

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -1847,7 +1847,7 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn bip_341_sighash_tests() {
-        use hex::DisplayHex;
+        use hex_unstable::DisplayHex;
 
         use crate::taproot::TapTweakHashExt as _;
 

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -1521,7 +1521,7 @@ impl<'a> Arbitrary<'a> for TapSighashType {
 #[cfg(test)]
 mod tests {
     use hashes::HashEngine;
-    use hex::{test_hex_unwrap as hex, FromHex};
+    use hex::FromHex;
 
     use super::*;
     use crate::consensus::deserialize;
@@ -1532,6 +1532,8 @@ mod tests {
     extern crate serde_json;
 
     const DUMMY_TXOUT: TxOut = TxOut { value: Amount::MIN, script_pubkey: ScriptBuf::new() };
+
+    macro_rules! hex (($hex:expr) => (<Vec<u8> as hex::FromHex>::from_hex($hex).unwrap()));
 
     #[test]
     fn sighash_single_bug() {

--- a/bitcoin/src/internal_macros.rs
+++ b/bitcoin/src/internal_macros.rs
@@ -62,14 +62,16 @@ macro_rules! impl_array_newtype_stringify {
 
         impl core::fmt::LowerHex for $t {
             fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-                use $crate::hex::{display, Case};
+                use $crate::hex::Case;
+                use hex_unstable::display;
                 display::fmt_hex_exact!(f, $len, &self.0, Case::Lower)
             }
         }
 
         impl core::fmt::UpperHex for $t {
             fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-                use $crate::hex::{display, Case};
+                use $crate::hex::Case;
+                use hex_unstable::display;
                 display::fmt_hex_exact!(f, $len, &self.0, Case::Upper)
             }
         }

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -74,7 +74,7 @@ pub extern crate bech32;
 pub extern crate hashes;
 
 /// Re-export the `hex-conservative` crate.
-pub extern crate hex;
+pub extern crate hex_stable as hex;
 
 /// Re-export the `bitcoin-io` crate.
 pub extern crate io;
@@ -190,7 +190,7 @@ mod prelude {
 
     pub use crate::io::sink;
 
-    pub use hex::DisplayHex;
+    pub use hex_unstable::DisplayHex;
 }
 
 pub mod amount {

--- a/bitcoin/src/merkle_tree/block.rs
+++ b/bitcoin/src/merkle_tree/block.rs
@@ -519,7 +519,9 @@ mod tests {
     use crate::block::{BlockUncheckedExt as _, Unchecked};
     use crate::consensus::encode;
     use crate::hash_types::Txid;
-    use crate::hex::{test_hex_unwrap as hex, DisplayHex, FromHex};
+    use crate::hex::{DisplayHex, FromHex};
+
+    macro_rules! hex (($hex:expr) => (<Vec<u8> as hex::FromHex>::from_hex($hex).unwrap()));
 
     #[cfg(feature = "rand-std")]
     macro_rules! pmt_tests {

--- a/bitcoin/src/merkle_tree/block.rs
+++ b/bitcoin/src/merkle_tree/block.rs
@@ -515,11 +515,13 @@ mod tests {
     #[cfg(feature = "rand-std")]
     use {core::cmp, secp256k1::rand::prelude::*};
 
+    use hex_unstable::DisplayHex as _;
+
     use super::*;
     use crate::block::{BlockUncheckedExt as _, Unchecked};
     use crate::consensus::encode;
     use crate::hash_types::Txid;
-    use crate::hex::{DisplayHex, FromHex};
+    use crate::hex::FromHex;
 
     macro_rules! hex (($hex:expr) => (<Vec<u8> as hex::FromHex>::from_hex($hex).unwrap()));
 

--- a/bitcoin/src/p2p/address.rs
+++ b/bitcoin/src/p2p/address.rs
@@ -301,10 +301,12 @@ impl ToSocketAddrs for AddrV2Message {
 mod test {
     use std::net::IpAddr;
 
-    use hex::{test_hex_unwrap as hex, FromHex};
+    use hex::FromHex;
 
     use super::*;
     use crate::consensus::encode::{deserialize, serialize};
+
+    macro_rules! hex (($hex:expr) => (<Vec<u8> as hex::FromHex>::from_hex($hex).unwrap()));
 
     #[test]
     fn serialize_address() {

--- a/bitcoin/src/p2p/message.rs
+++ b/bitcoin/src/p2p/message.rs
@@ -697,7 +697,6 @@ impl Decodable for V2NetworkMessage {
 mod test {
     use std::net::Ipv4Addr;
 
-    use hex::test_hex_unwrap as hex;
     use units::BlockHeight;
 
     use super::*;
@@ -715,6 +714,8 @@ mod test {
     use crate::p2p::ServiceFlags;
     use crate::script::ScriptBuf;
     use crate::transaction::Transaction;
+
+    macro_rules! hex (($hex:expr) => (<Vec<u8> as hex::FromHex>::from_hex($hex).unwrap()));
 
     fn hash(array: [u8; 32]) -> sha256d::Hash { sha256d::Hash::from_byte_array(array) }
 

--- a/bitcoin/src/p2p/message_blockdata.rs
+++ b/bitcoin/src/p2p/message_blockdata.rs
@@ -144,10 +144,10 @@ impl_consensus_encoding!(GetHeadersMessage, version, locator_hashes, stop_hash);
 
 #[cfg(test)]
 mod tests {
-    use hex::test_hex_unwrap as hex;
-
     use super::*;
     use crate::consensus::encode::{deserialize, serialize};
+
+    macro_rules! hex (($hex:expr) => (<Vec<u8> as hex::FromHex>::from_hex($hex).unwrap()));
 
     #[test]
     fn getblocks_message() {

--- a/bitcoin/src/p2p/message_network.rs
+++ b/bitcoin/src/p2p/message_network.rs
@@ -148,10 +148,10 @@ impl_consensus_encoding!(Reject, message, ccode, reason, hash);
 
 #[cfg(test)]
 mod tests {
-    use hex::test_hex_unwrap as hex;
-
     use super::*;
     use crate::consensus::encode::{deserialize, serialize};
+
+    macro_rules! hex (($hex:expr) => (<Vec<u8> as hex::FromHex>::from_hex($hex).unwrap()));
 
     #[test]
     fn version_message_test() {

--- a/bitcoin/src/p2p/mod.rs
+++ b/bitcoin/src/p2p/mod.rs
@@ -287,7 +287,7 @@ generate_network_magic_conversion! {
 
 impl fmt::Display for Magic {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        hex::fmt_hex_exact!(f, 4, &self.0, hex::Case::Lower)?;
+        hex_unstable::fmt_hex_exact!(f, 4, &self.0, hex::Case::Lower)?;
         Ok(())
     }
 }
@@ -298,7 +298,7 @@ impl fmt::Debug for Magic {
 
 impl fmt::LowerHex for Magic {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        hex::fmt_hex_exact!(f, 4, &self.0, hex::Case::Lower)?;
+        hex_unstable::fmt_hex_exact!(f, 4, &self.0, hex::Case::Lower)?;
         Ok(())
     }
 }
@@ -306,7 +306,7 @@ impl_to_hex_from_lower_hex!(Magic, |_| 8);
 
 impl fmt::UpperHex for Magic {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        hex::fmt_hex_exact!(f, 4, &self.0, hex::Case::Upper)?;
+        hex_unstable::fmt_hex_exact!(f, 4, &self.0, hex::Case::Upper)?;
         Ok(())
     }
 }

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -936,7 +936,7 @@ macro_rules! impl_hex {
     ($hex:path, $case:expr) => {
         impl $hex for U256 {
             fn fmt(&self, f: &mut fmt::Formatter) -> core::fmt::Result {
-                hex::fmt_hex_exact!(f, 32, &self.to_be_bytes(), $case)
+                hex_unstable::fmt_hex_exact!(f, 32, &self.to_be_bytes(), $case)
             }
         }
     };

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -1222,7 +1222,7 @@ pub use self::display_from_str::PsbtParseError;
 #[cfg(test)]
 mod tests {
     use hashes::{hash160, ripemd160, sha256};
-    use hex::{test_hex_unwrap as hex, FromHex};
+    use hex::FromHex;
     #[cfg(feature = "rand-std")]
     use secp256k1::{All, SecretKey};
 
@@ -1236,6 +1236,8 @@ mod tests {
     use crate::transaction::{self, OutPoint, TxIn};
     use crate::witness::Witness;
     use crate::Sequence;
+
+    macro_rules! hex (($hex:expr) => (<Vec<u8> as hex::FromHex>::from_hex($hex).unwrap()));
 
     #[track_caller]
     pub fn hex_psbt(s: &str) -> Result<Psbt, crate::psbt::error::Error> {

--- a/bitcoin/src/serde_utils.rs
+++ b/bitcoin/src/serde_utils.rs
@@ -11,7 +11,7 @@ impl serde::Serialize for SerializeBytesAsHex<'_> {
     where
         S: serde::Serializer,
     {
-        use hex::DisplayHex;
+        use hex_unstable::DisplayHex;
 
         serializer.collect_str(&format_args!("{:x}", self.0.as_hex()))
     }

--- a/bitcoin/src/taproot/mod.rs
+++ b/bitcoin/src/taproot/mod.rs
@@ -1564,7 +1564,8 @@ mod sealed {
 #[cfg(test)]
 mod test {
     use hashes::sha256;
-    use hex::{DisplayHex, FromHex};
+    use hex_unstable::DisplayHex;
+    use hex_stable::FromHex;
     use secp256k1::VerifyOnly;
 
     use super::*;

--- a/bitcoin/src/taproot/serialized_signature.rs
+++ b/bitcoin/src/taproot/serialized_signature.rs
@@ -28,7 +28,7 @@ impl fmt::Debug for SerializedSignature {
 
 impl fmt::Display for SerializedSignature {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        hex::fmt_hex_exact!(f, MAX_LEN, self, hex::Case::Lower)
+        hex_unstable::fmt_hex_exact!(f, MAX_LEN, self, hex::Case::Lower)
     }
 }
 

--- a/chacha20_poly1305/Cargo.toml
+++ b/chacha20_poly1305/Cargo.toml
@@ -13,11 +13,12 @@ exclude = ["tests", "contrib"]
 
 [features]
 default = ["std"]
-std = ["alloc"]
-alloc = []
+std = ["alloc", "hex-stable/std", "hex-unstable/std"]
+alloc = ["hex-stable/alloc", "hex-unstable/alloc"]
 
 [dev-dependencies]
-hex = { package = "hex-conservative", version = "0.3.0", default-features = false, features = ["alloc"] }
+hex-unstable = { package = "hex-conservative", version = "0.4.0", git = "https://github.com/tcharding/hex-conservative", branch = "02-24-release-0.4", default-features = false, features = ["alloc"] }
+hex-stable = { package = "hex-conservative", version = "1.0.0-alpha.0", git = "https://github.com/tcharding/hex-conservative", branch = "02-24-release-1.0-alpha.0", default-features = false, features = ["alloc"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/chacha20_poly1305/src/chacha20.rs
+++ b/chacha20_poly1305/src/chacha20.rs
@@ -328,7 +328,7 @@ fn keystream_at_slice(key: Key, nonce: Nonce, count: u32, seek: usize) -> [u8; 6
 mod tests {
     use alloc::vec::Vec;
 
-    use hex::prelude::*;
+    use hex_unstable::prelude::*;
 
     use super::*;
 

--- a/chacha20_poly1305/src/lib.rs
+++ b/chacha20_poly1305/src/lib.rs
@@ -165,7 +165,7 @@ fn encode_lengths(aad_len: u64, content_len: u64) -> [u8; 16] {
 mod tests {
     use alloc::vec::Vec;
 
-    use hex::prelude::*;
+    use hex_unstable::prelude::*;
 
     use super::*;
 

--- a/chacha20_poly1305/src/poly1305.rs
+++ b/chacha20_poly1305/src/poly1305.rs
@@ -225,7 +225,7 @@ fn _print_acc(num: &[u32; 5]) {
 mod tests {
     use alloc::vec::Vec;
 
-    use hex::prelude::*;
+    use hex_unstable::prelude::*;
 
     use super::*;
 

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -15,15 +15,16 @@ exclude = ["tests", "contrib"]
 
 [features]
 default = ["std"]
-std = ["alloc", "hex?/std"]
-alloc = ["hex?/alloc"]
-serde = ["dep:serde", "hex"]
+std = ["alloc", "hex-stable?/std", "hex-unstable?/std"]
+alloc = ["hex-stable?/alloc", "hex-unstable?/alloc"]
+hex = ["hex-stable", "hex-unstable"]
+serde = ["dep:serde", "hex-unstable"]
 # Smaller (but slower) implementation of sha256, sha512 and ripemd160
 small-hash = []
 
 [dependencies]
-
-hex = { package = "hex-conservative", version = "0.3.0", default-features = false, optional = true }
+hex-unstable = { package = "hex-conservative", version = "0.4.0", git = "https://github.com/tcharding/hex-conservative", branch = "02-24-release-0.4", default-features = false, optional = true }
+hex-stable = { package = "hex-conservative", version = "1.0.0-alpha.0", git = "https://github.com/tcharding/hex-conservative", branch = "02-24-release-1.0-alpha.0", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/hashes/src/hkdf/mod.rs
+++ b/hashes/src/hkdf/mod.rs
@@ -130,7 +130,8 @@ impl<T: GeneralHash> fmt::Debug for Hkdf<T> {
 #[cfg(feature = "alloc")]
 #[cfg(feature = "hex")]
 mod tests {
-    use hex::prelude::{DisplayHex, FromHex};
+    use hex_unstable::prelude::DisplayHex;
+    use hex_stable::prelude::FromHex;
 
     use super::*;
     use crate::sha256;

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -86,7 +86,10 @@ extern crate test;
 
 /// Re-export the `hex-conservative` crate.
 #[cfg(feature = "hex")]
-pub extern crate hex;
+pub extern crate hex_stable as hex;
+#[doc(hidden)]
+#[cfg(feature = "hex")]
+pub extern crate hex_unstable;
 
 #[doc(hidden)]
 pub mod _export {

--- a/hashes/src/macros.rs
+++ b/hashes/src/macros.rs
@@ -302,7 +302,7 @@ macro_rules! impl_hex_string_traits {
             }
         }
 
-        $crate::hex::impl_fmt_traits! {
+        $crate::hex_unstable::impl_fmt_traits! {
             #[display_backward($reverse)]
             impl<$($gen: $gent),*> fmt_traits for $ty<$($gen),*> {
                 const LENGTH: usize = ($len); // parens required due to rustc parser weirdness

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -16,14 +16,15 @@ exclude = ["tests", "contrib"]
 
 [features]
 default = ["std"]
-std = ["alloc", "hashes/std", "hex/std", "internals/std", "units/std"]
-alloc = ["hashes/alloc", "hex/alloc", "internals/alloc", "units/alloc"]
+std = ["alloc", "hashes/std", "hex-stable/std", "hex-unstable/std", "internals/std", "units/std"]
+alloc = ["hashes/alloc", "hex-stable/alloc", "hex-unstable/alloc", "internals/alloc", "units/alloc"]
 serde = ["dep:serde", "hashes/serde", "internals/serde", "units/serde", "alloc"]
 arbitrary = ["dep:arbitrary", "units/arbitrary"]
 
 [dependencies]
-hashes = { package = "bitcoin_hashes", version = "0.16.0", default-features = false, features = ["hex"] }
-hex = { package = "hex-conservative", version = "0.3.0", default-features = false }
+hashes = { package = "bitcoin_hashes", version = "0.16.0", default-features = false, features = ["hex-unstable"] }
+hex-unstable = { package = "hex-conservative", version = "0.4.0", git = "https://github.com/tcharding/hex-conservative", branch = "02-24-release-0.4", default-features = false }
+hex-stable = { package = "hex-conservative", version = "1.0.0-alpha.0", git = "https://github.com/tcharding/hex-conservative", branch = "02-24-release-1.0-alpha.0", default-features = false }
 internals = { package = "bitcoin-internals", version = "0.4.0" }
 units = { package = "bitcoin-units", version = "0.2.0", default-features = false }
 

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -29,6 +29,9 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+pub extern crate hex_stable as hex;
+extern crate hex_unstable;
+
 #[cfg(feature = "serde")]
 #[macro_use]
 extern crate serde;

--- a/primitives/src/script/mod.rs
+++ b/primitives/src/script/mod.rs
@@ -13,7 +13,7 @@ use core::fmt;
 use core::ops::{Deref, DerefMut};
 
 use hashes::{hash160, sha256};
-use hex::DisplayHex;
+use hex_unstable::DisplayHex;
 use internals::script::{self, PushDataLenLen};
 
 use crate::opcodes::all::*;
@@ -521,7 +521,7 @@ impl<'de> serde::Deserialize<'de> for ScriptBuf {
     {
         use core::fmt::Formatter;
 
-        use hex::FromHex;
+        use crate::hex::FromHex;
 
         if deserializer.is_human_readable() {
             struct Visitor;

--- a/primitives/src/witness.rs
+++ b/primitives/src/witness.rs
@@ -9,7 +9,7 @@ use core::ops::Index;
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
-use hex::DisplayHex;
+use hex_unstable::DisplayHex;
 use internals::compact_size;
 use internals::wrap_debug::WrapDebug;
 


### PR DESCRIPTION
We want any `hex` type that is in the public API of any of the leaf crates to come from `hex v1.0.0-alpha.0` - make it happen.

Uses branches on `hex` for the demo:

- `hex v1.0.0-alpha.0`: https://github.com/rust-bitcoin/hex-conservative/pull/162
- `hex v0.4.0`: https://github.com/rust-bitcoin/hex-conservative/pull/163

Replaces #4096
