### PR TITLE
Policy: Relax MIN_STANDARD_TX_NONWITNESS_SIZE to 65

### DIFF
--- a/bitcoin/src/policy.rs
+++ b/bitcoin/src/policy.rs
@@ -18,8 +18,8 @@ use super::constants::{MAX_BLOCK_SIGOPS_COST, WITNESS_SCALE_FACTOR};
 /// Maximum weight of a transaction for it to be relayed by most nodes on the network
 pub const MAX_STANDARD_TX_WEIGHT: u32 = 400_000;
 
-/// Minimum non-witness size for a standard transaction (1 SegWit input + 1 P2WPKH output = 82 bytes)
-pub const MIN_STANDARD_TX_NONWITNESS_SIZE: u32 = 82;
+/// Minimum non-witness size for a standard transaction, set to 65 bytes.
+pub const MIN_STANDARD_TX_NONWITNESS_SIZE: u32 = 65;
 
 /// Maximum number of sigops in a standard tx.
 pub const MAX_STANDARD_TX_SIGOPS_COST: u32 = MAX_BLOCK_SIGOPS_COST as u32 / 5;


### PR DESCRIPTION
Align with Bitcoin Core's policy by reducing the minimum non-witness transaction size from 82 to 65 bytes. 
This will allow for more minimal transaction cases (eg: 1 input with 1 OP_RETURN output) while maintaining protection against CVE-2017-12842.

The 65-byte minimum consists of:
- 60 bytes: minimal tx (10B skeleton + 41B input + 9B output)
```
# Tx Skeleton: 4 [Version] + 1 [InCount] + 1 [OutCount] + 4 [LockTime] = 10 bytes
# Blank Input: 32 [PrevTxHash] + 4 [Index] + 1 [scriptSigLen] + 4 [SeqNo] = 41 bytes
# Output:      8 [Amount] + 1 [scriptPubKeyLen] = 9 bytes
```

- 5 bytes: minimum `scriptPubKey`

Closes https://github.com/rust-bitcoin/rust-bitcoin/issues/4108