### PR TITLE
fix: typos in documentation files

### DIFF
--- a/bitcoin/examples/sighash.rs
+++ b/bitcoin/examples/sighash.rs
@@ -155,7 +155,7 @@ fn sighash_p2wpkh() {
 }
 
 fn sighash_p2sh_multisig_2x2() {
-    //Spending transactoin:
+    //Spending transaction:
     //bitcoin-cli getrawtransaction 214646c4b563cd8c788754ec94468ab71602f5ed07d5e976a2b0e41a413bcc0e  3
     //after decoding ScriptSig from the input:0, its last ASM element is the scriptpubkey:
     //bitcoin-cli decodescript 5221032d7306898e980c66aefdfb6b377eaf71597c449bf9ce741a3380c5646354f6de2103e8c742e1f283ef810c1cd0c8875e5c2998a05fc5b23c30160d3d33add7af565752ae

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -999,7 +999,7 @@ impl InputWeightPrediction {
     ///
     /// # Panics
     ///
-    /// The funcion panics in const context and debug builds if `bytes_to_grind` is higher than 62.
+    /// The function panics in const context and debug builds if `bytes_to_grind` is higher than 62.
     ///
     /// [signature grinding]: https://bitcoin.stackexchange.com/questions/111660/what-is-signature-grinding
     pub const fn ground_p2wpkh(bytes_to_grind: usize) -> Self {
@@ -1019,7 +1019,7 @@ impl InputWeightPrediction {
     ///
     /// # Panics
     ///
-    /// The funcion panics in const context and debug builds if `bytes_to_grind` is higher than 62.
+    /// The function panics in const context and debug builds if `bytes_to_grind` is higher than 62.
     ///
     /// [nested P2WPKH]: https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#p2wpkh-nested-in-bip16-p2sh
     /// [signature grinding]: https://bitcoin.stackexchange.com/questions/111660/what-is-signature-grinding
@@ -1040,7 +1040,7 @@ impl InputWeightPrediction {
     ///
     /// # Panics
     ///
-    /// The funcion panics in const context and debug builds if `bytes_to_grind` is higher than 62.
+    /// The function panics in const context and debug builds if `bytes_to_grind` is higher than 62.
     ///
     /// [signature grinding]: https://bitcoin.stackexchange.com/questions/111660/what-is-signature-grinding
     pub const fn ground_p2pkh_compressed(bytes_to_grind: usize) -> Self {

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -324,7 +324,7 @@ impl CompressedPublicKey {
 
     /// Serializes the public key.
     ///
-    /// As the type name suggests, the key is serialzied in compressed format.
+    /// As the type name suggests, the key is serialized in compressed format.
     ///
     /// Note that this can be used as a sort key to get BIP67-compliant sorting.
     /// That's why this type doesn't have the `to_sort_key` method - it would duplicate this one.

--- a/internals/src/error/input_string.rs
+++ b/internals/src/error/input_string.rs
@@ -95,7 +95,7 @@ impl_from!(&str);
 ///
 /// This is created by `display_cannot_parse` method and should be used as
 /// `write_err!("{}", self.input.display_cannot_parse("what is parsed"); self.source)` in parse
-/// error [`Display`](fmt::Display) imlementation if the error has source. If the error doesn't
+/// error [`Display`](fmt::Display) implementation if the error has source. If the error doesn't
 /// have a source just use regular `write!` with same formatting arguments.
 pub struct CannotParse<'a, T: fmt::Display + ?Sized> {
     input: &'a InputString,


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.
- Corrected typos in multiple files (e.g., `transacton` → `transaction`, `function panics` formatting).
- Improved readability of comments in `transaction.rs`, `key.rs`, and `input_string.rs.`
- No functional code changes, only documentation updates.

This message provides a clear summary of what was done and why the changes were made. Let me know if you need any modifications!