### PR TITLE
Deprecate `sha256t_tag` macro

### DIFF
--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -16,7 +16,7 @@ use core::{fmt, str};
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
-use hashes::{hash_newtype, sha256, sha256d, sha256t, sha256t_tag};
+use hashes::{hash_newtype, sha256, sha256d, sha256t};
 use internals::write_err;
 use io::Write;
 
@@ -76,8 +76,12 @@ impl SegwitV0Sighash {
     fn from_engine(e: sha256d::HashEngine) -> Self { Self(sha256d::Hash::from_engine(e)) }
 }
 
-sha256t_tag! {
-    pub struct TapSighashTag = hash_str("TapSighash");
+/// Tag for the `TapSighash`.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum TapSighashTag {}
+
+impl sha256t::Tag for TapSighashTag {
+    const MIDSTATE: sha256::Midstate = sha256::Midstate::hash_tag("TapSighash".as_bytes());
 }
 
 hash_newtype! {

--- a/hashes/src/hkdf/mod.rs
+++ b/hashes/src/hkdf/mod.rs
@@ -108,7 +108,7 @@ where
 
 impl<T: GeneralHash> fmt::Debug for Hkdf<T> {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        use crate::{sha256t, sha256t_tag};
+        use crate::{sha256t, sha256};
 
         struct Fingerprint([u8; 8]); // Print 16 hex characters as a fingerprint.
 
@@ -116,8 +116,11 @@ impl<T: GeneralHash> fmt::Debug for Hkdf<T> {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { crate::debug_hex(&self.0, f) }
         }
 
-        sha256t_tag! {
-            pub struct Tag = hash_str("bitcoin_hashes1DEBUG");
+        #[derive(Debug, Clone)]
+        enum Tag {}
+
+        impl sha256t::Tag for Tag {
+            const MIDSTATE: sha256::Midstate = sha256::Midstate::hash_tag("bitcoin_hashes1DEBUG".as_bytes());
         }
 
         let hash = sha256t::Hash::<Tag>::hash(self.prk.as_ref());

--- a/hashes/src/macros.rs
+++ b/hashes/src/macros.rs
@@ -28,6 +28,7 @@
 /// may use `raw(MIDSTATE_BYTES, HASHED_BYTES_LENGTH)` instead, note that HASHED_BYTES_LENGTH must
 /// be a multiple of 64.
 #[macro_export]
+#[deprecated(since = "TBD", note = "create an empty enum and implement Tag on it")]
 macro_rules! sha256t_tag {
     ($(#[$($tag_attr:tt)*])* $tag_vis:vis struct $tag:ident = $constructor:tt($($tag_value:tt)+);) => {
         $crate::sha256t_tag_struct!($tag_vis, $tag, stringify!($hash_name), $(#[$($tag_attr)*])*);
@@ -579,21 +580,22 @@ mod test {
     }
 
     #[test]
-    fn macros_work_in_function_scope() {
+    fn macro_works_in_function_scope() {
         use crate::sha256t;
 
-        sha256t_tag! {
-            #[repr(align(2))] // This tests that we can add additional attributes.
-            pub struct FunctionScopeTag = hash_str("It works");
+        #[derive(Debug, Clone)]
+        enum FunctionScopeTag {}
+
+        impl sha256t::Tag for FunctionScopeTag {
+            const MIDSTATE: sha256::Midstate = sha256::Midstate::hash_tag("It  works".as_bytes());
         }
 
         hash_newtype! {
             /// Some docs.
             #[repr(align(4))] // This tests that we can add additional attributes.
-            pub struct FunctionScopeHash(pub(crate) sha256t::Hash<FunctionScopeTag>);
+            struct FunctionScopeHash(pub(crate) sha256t::Hash<FunctionScopeTag>);
         }
 
-        assert_eq!(2, core::mem::align_of::<FunctionScopeTag>());
         assert_eq!(4, core::mem::align_of::<FunctionScopeHash>());
     }
 

--- a/hashes/src/sha256t/mod.rs
+++ b/hashes/src/sha256t/mod.rs
@@ -213,11 +213,13 @@ mod tests {
         assert_eq!(TestHash::hash(&[0]).to_string(), HASH_ZERO_FORWARD);
     }
 
-    // We also provide macros to create the tag and the hash type.
-    sha256t_tag! {
-        /// Test detailed explanation.
-        struct NewTypeTagBackward = raw(TEST_MIDSTATE, 64);
+    #[derive(Debug, Clone)]
+    enum NewTypeTagBackward {}
+
+    impl sha256t::Tag for NewTypeTagBackward {
+        const MIDSTATE: sha256::Midstate = sha256::Midstate::new(TEST_MIDSTATE, 64);
     }
+
     hash_newtype! {
         /// A test hash.
         #[hash_newtype(backward)]
@@ -241,11 +243,13 @@ mod tests {
         assert_eq!(sha256t::Hash::<NewTypeTagBackward>::hash(&[0]).to_string(), HASH_ZERO_FORWARD);
     }
 
-    // We also provide a macro to create the tag and the hash type.
-    sha256t_tag! {
-        /// Test detailed explanation.
-        struct NewTypeTagForward = raw(TEST_MIDSTATE, 64);
+    #[derive(Debug, Clone)]
+    enum NewTypeTagForward {}
+
+    impl sha256t::Tag for NewTypeTagForward {
+        const MIDSTATE: sha256::Midstate = sha256::Midstate::new(TEST_MIDSTATE, 64);
     }
+
     hash_newtype! {
         /// A test hash.
         #[hash_newtype(forward)]

--- a/primitives/src/taproot.rs
+++ b/primitives/src/taproot.rs
@@ -4,11 +4,15 @@
 //!
 //! This module provides support for Taproot tagged hashes.
 
-use hashes::{hash_newtype, sha256t, sha256t_tag};
+use hashes::{hash_newtype, sha256t, sha256};
 
+/// Tag for the `TapLeafHash`.
 // Taproot test vectors from BIP-341 state the hashes without any reversing
-sha256t_tag! {
-    pub struct TapLeafTag = hash_str("TapLeaf");
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum TapLeafTag {}
+
+impl sha256t::Tag for TapLeafTag {
+    const MIDSTATE: sha256::Midstate = sha256::Midstate::hash_tag("TapLeaf".as_bytes());
 }
 
 hash_newtype! {
@@ -22,8 +26,12 @@ hashes::impl_hex_for_newtype!(TapLeafHash);
 #[cfg(feature = "serde")]
 hashes::impl_serde_for_newtype!(TapLeafHash);
 
-sha256t_tag! {
-    pub struct TapBranchTag = hash_str("TapBranch");
+/// Tag for the `TapNodeHash`.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum TapBranchTag {}
+
+impl sha256t::Tag for TapBranchTag {
+    const MIDSTATE: sha256::Midstate = sha256::Midstate::hash_tag("TapBranch".as_bytes());
 }
 
 hash_newtype! {
@@ -37,8 +45,12 @@ hashes::impl_hex_for_newtype!(TapNodeHash);
 #[cfg(feature = "serde")]
 hashes::impl_serde_for_newtype!(TapNodeHash);
 
-sha256t_tag! {
-    pub struct TapTweakTag = hash_str("TapTweak");
+/// Tag for the `TapTweakHash`.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum TapTweakTag {}
+
+impl sha256t::Tag for TapTweakTag {
+    const MIDSTATE: sha256::Midstate = sha256::Midstate::hash_tag("TapTweak".as_bytes());
 }
 
 hash_newtype! {


### PR DESCRIPTION
Now that we added the associated const to the `Tag` trait to hold the midstate the `sha256t_tag` macro is not adding that much value.

In an effort to reduce the API surface of `hashes` lets get rid of it.

Deprecate the `sha256t_tag` macro so we can remove it in `v1.0`.