### PR TITLE
Add additional re-exports

### DIFF
--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -120,14 +120,15 @@ pub mod taproot;
 pub use primitives::{
     block::{
         Block, BlockHash, Checked as BlockChecked, Header as BlockHeader,
-        Unchecked as BlockUnchecked, Validation as BlockValidation, WitnessCommitment,
+        Unchecked as BlockUnchecked, Validation as BlockValidation, Version as BlockVersion,
+        WitnessCommitment,
     },
     merkle_tree::{TxMerkleNode, WitnessMerkleNode},
     opcodes::Opcode,
     pow::CompactTarget, // No `pow` module outside of `primitives`.
     script::{Script, ScriptBuf},
     sequence::{self, Sequence}, // No `sequence` module outside of `primitives`.
-    transaction::{OutPoint, Transaction, TxIn, TxOut, Txid, Wtxid},
+    transaction::{OutPoint, Transaction, TxIn, TxOut, Txid, Version as TransactionVersion, Wtxid},
     witness::Witness,
 };
 #[doc(inline)]

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -73,13 +73,13 @@ pub use self::{
 };
 #[doc(inline)]
 pub use self::{
-    block::{BlockHash, Header as BlockHeader, WitnessCommitment},
+    block::{BlockHash, Header as BlockHeader, Version as BlockVersion, WitnessCommitment},
     locktime::{absolute, relative},
     merkle_tree::{TxMerkleNode, WitnessMerkleNode},
     opcodes::Opcode,
     pow::CompactTarget,
     sequence::Sequence,
-    transaction::{OutPoint, Txid, Wtxid},
+    transaction::{OutPoint, Txid, Version as TransactionVersion, Wtxid},
 };
 
 #[rustfmt::skip]


### PR DESCRIPTION
As we do for other types add two new alias' at the crate root of `primitives` and mirror it in `bitcoin`:
    
- `BlockVersion`
- `TransactionVersion`
