### PR TITLE
units: Prevent casting pub enums as ints

### DIFF
--- a/units/src/amount/mod.rs
+++ b/units/src/amount/mod.rs
@@ -91,6 +91,10 @@ pub enum Denomination {
     Bit,
     /// satoshi (1 BTC = 100,000,000 satoshi).
     Satoshi,
+    /// Stops users from casting this enum to an integer.
+    // May get removed if one day Rust supports disabling casts natively.
+    #[doc(hidden)]
+    _DoNotUse(Infallible),
 }
 
 impl Denomination {
@@ -109,6 +113,7 @@ impl Denomination {
             Denomination::MicroBitcoin => -2,
             Denomination::Bit => -2,
             Denomination::Satoshi => 0,
+            Denomination::_DoNotUse(infallible) => match infallible {}
         }
     }
 
@@ -121,6 +126,7 @@ impl Denomination {
             Denomination::MicroBitcoin => "uBTC",
             Denomination::Bit => "bits",
             Denomination::Satoshi => "satoshi",
+            Denomination::_DoNotUse(infallible) => match infallible {}
         }
     }
 


### PR DESCRIPTION
A public enum with simple variants gets an automatic integer variant that can be cast by library consumers. This puts a unnecessary maintenance burden upon us because we cannot then add variants in the middle of others.

Add a hidden variant to the single public non-error enum in `units`.