### PR TITLE
fuzz: add coverage for Display for Script

### DIFF
--- a/fuzz/fuzz_targets/bitcoin/deserialize_script.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_script.rs
@@ -9,6 +9,7 @@ fn do_test(data: &[u8]) {
     if let Ok(script) = s {
         let _: Result<Vec<script::Instruction>, script::Error> = script.instructions().collect();
 
+        let _ = script.to_string();
         let mut b = script::Builder::new();
         for ins in script.instructions_minimal() {
             if ins.is_err() {


### PR DESCRIPTION
We currently have the `script_bytes_to_asm_fmt` which fuzzes the `fmt_asm` function. However, this function is deprecated and the script's Display impl should be used instead. This PR adds fuzz coverage for it.