### PR TITLE
Respect new MAX for Amount and SignedAmount for Arbitrary types

### DIFF
--- a/units/src/amount/signed.rs
+++ b/units/src/amount/signed.rs
@@ -513,7 +513,9 @@ impl From<Amount> for SignedAmount {
 #[cfg(feature = "arbitrary")]
 impl<'a> Arbitrary<'a> for SignedAmount {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let s = i64::arbitrary(u)?;
+        let min = SignedAmount::MIN.to_sat();
+        let max = SignedAmount::MAX.to_sat();
+        let s = u.int_in_range(min..=max)?;
         Ok(Self(s))
     }
 }

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -455,7 +455,9 @@ impl TryFrom<SignedAmount> for Amount {
 #[cfg(feature = "arbitrary")]
 impl<'a> Arbitrary<'a> for Amount {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let a = u64::arbitrary(u)?;
+        let min = Amount::MIN.to_sat();
+        let max = Amount::MAX.to_sat();
+        let a:u64 = u.int_in_range(min..=max)?;
         Ok(Self(a))
     }
 }


### PR DESCRIPTION
The MAX for both Amount and SignedAmount was adjusted, however Arbitrary types still used the previous MAX of u64::MAX.  Change the bounds of the generated arbitrary type to be the actual MAX of the type.