### PR TITLE
units: Improve code comment on macros

### DIFF
--- a/units/src/parse.rs
+++ b/units/src/parse.rs
@@ -149,7 +149,7 @@ fn int<T: Integer, S: AsRef<str> + Into<InputString>>(s: S) -> Result<T, ParseIn
 ///
 /// If parsing the string fails then a `units::parse::ParseIntError` is returned.
 #[macro_export]
-#[doc(hidden)] // This is an 'internal' macro that should not be used outside of the `rust-bitcoin` crate.
+#[doc(hidden)] // This macro is stable but is considered internal to the `rust-bitcoin` repository.
 macro_rules! impl_parse_str_from_int_infallible {
     ($to:ident, $inner:ident, $fn:ident) => {
         impl $crate::_export::_core::str::FromStr for $to {
@@ -214,7 +214,7 @@ macro_rules! impl_parse_str_from_int_infallible {
 ///
 /// All functions use the error returned by `$inner_fn`.
 #[macro_export]
-#[doc(hidden)] // This is an 'internal' macro that should not be used outside of the `rust-bitcoin` crate.
+#[doc(hidden)] // This macro is stable but is considered internal to the `rust-bitcoin` repository.
 macro_rules! impl_parse_str {
     ($to:ty, $err:ty, $inner_fn:expr) => {
         $crate::impl_tryfrom_str!(&str, $to, $err, $inner_fn);


### PR DESCRIPTION
We have two macros that are hidden because they are code de-duplication tools. However the output they produce is, and has to be, stable so that we can use them in `units` and `primitives` without inadvertently breaking semver in `primitives`.