### PR TITLE
Fix typos in code comments and documentation

### DIFF
--- a/bitcoin/src/blockdata/script/instruction.rs
+++ b/bitcoin/src/blockdata/script/instruction.rs
@@ -31,7 +31,7 @@ impl Instruction<'_> {
         }
     }
 
-    /// Returns the number interpretted by the script parser
+    /// Returns the number interpreted by the script parser
     /// if it can be coerced into a number.
     ///
     /// This does not require the script num to be minimal.

--- a/bitcoin/src/p2p/message.rs
+++ b/bitcoin/src/p2p/message.rs
@@ -27,7 +27,7 @@ use crate::{block, consensus, transaction};
 pub const MAX_INV_SIZE: usize = 50_000;
 
 /// Maximum size, in bytes, of an encoded message
-/// This by neccessity should be larger tham `MAX_VEC_SIZE`
+/// This by necessity should be larger tham `MAX_VEC_SIZE`
 pub const MAX_MSG_SIZE: usize = 5_000_000;
 
 /// Serializer for command string

--- a/bitcoin/src/taproot/serialized_signature.rs
+++ b/bitcoin/src/taproot/serialized_signature.rs
@@ -217,7 +217,7 @@ mod into_iter {
 
         #[inline]
         fn size_hint(&self) -> (usize, Option<usize>) {
-            // can't underlflow thanks to the invariant
+            // can't underflow thanks to the invariant
             let len = self.signature.len() - self.pos;
             (len, Some(len))
         }

--- a/units/src/amount/mod.rs
+++ b/units/src/amount/mod.rs
@@ -139,7 +139,7 @@ impl Denomination {
     }
 }
 
-/// These form are ambigous and could have many meanings.  For example, M could denote Mega or Milli.
+/// These form are ambiguous and could have many meanings.  For example, M could denote Mega or Milli.
 /// If any of these forms are used, an error type `PossiblyConfusingDenomination` is returned.
 const CONFUSING_FORMS: [&str; 6] = ["CBTC", "Cbtc", "MBTC", "Mbtc", "UBTC", "Ubtc"];
 


### PR DESCRIPTION
This PR fixes several typos in comments across multiple files:

- Fixed typo `interpretted` -> `interpreted` in `blockdata/script/instruction.rs`
- Fixed typo `neccessity` -> `necessity` in `p2p/message.rs` 
- Fixed typo `underlflow` -> `underflow` in `taproot/serialized_signature.rs`
- Fixed typo `ambigous` -> `ambiguous"` in `units/src/amount/mod.rs`

These changes only affect comments and documentation, no functional code changes.