### PR TITLE
Fix typos

### DIFF
--- a/base58/README.md
+++ b/base58/README.md
@@ -8,7 +8,7 @@ obviously named ones differ from this crate because:
 
 1. [bitcoin-base58](https://crates.io/crates/bitcoin-base58) is transpiled from the C++ code in
    Bitcoin Core as part of a large long-term transpilation project, whereas this crate is a pure
-   Rust implementation intended to be production-ready and to provide an Rust-idiomatic API.
+   Rust implementation intended to be production-ready and to provide a Rust-idiomatic API.
 
 2. [base58](https://crates.io/crates/base58) implements parsing but does not validate checksums (see
    `base58check`). It may be appropriate in cases where performance is more important than safety.

--- a/io/README.md
+++ b/io/README.md
@@ -5,5 +5,5 @@ reading and writing objects via standard traits is not generally possible. Thus,
 to export a minimal version of `std::io`'s traits which we use in `rust-bitcoin` so that we can
 support `no-std` applications.
 
-These traits are not one-for-one drop-ins, but are as close as possible while still implementing
+These traits are not one-to-one drop-ins, but are as close as possible while still implementing
 `std::io`'s traits without unnecessary complexity.


### PR DESCRIPTION
"one-for-one" → "one-to-one"
"an Rust-idiomatic API" → "a Rust-idiomatic API"