### PR TITLE
Improve ops for amount types

### DIFF
--- a/units/src/amount/result.rs
+++ b/units/src/amount/result.rs
@@ -161,6 +161,16 @@ crate::internal_macros::impl_op_for_references! {
 
         fn mul(self, rhs: u64) -> Self::Output { self.and_then(|lhs| lhs * rhs) }
     }
+    impl ops::Mul<Amount> for u64 {
+        type Output = NumOpResult<Amount>;
+
+        fn mul(self, rhs: Amount) -> Self::Output { rhs.checked_mul(self).valid_or_error() }
+    }
+    impl ops::Mul<NumOpResult<Amount>> for u64 {
+        type Output = NumOpResult<Amount>;
+
+        fn mul(self, rhs: NumOpResult<Amount>) -> Self::Output { rhs.and_then(|rhs| self * rhs) }
+    }
 
     impl ops::Div<u64> for Amount {
         type Output = NumOpResult<Amount>;
@@ -220,6 +230,16 @@ crate::internal_macros::impl_op_for_references! {
         type Output = NumOpResult<SignedAmount>;
 
         fn mul(self, rhs: i64) -> Self::Output { self.and_then(|lhs| lhs * rhs) }
+    }
+    impl ops::Mul<SignedAmount> for i64 {
+        type Output = NumOpResult<SignedAmount>;
+
+        fn mul(self, rhs: SignedAmount) -> Self::Output { rhs.checked_mul(self).valid_or_error() }
+    }
+    impl ops::Mul<NumOpResult<SignedAmount>> for i64 {
+        type Output = NumOpResult<SignedAmount>;
+
+        fn mul(self, rhs: NumOpResult<SignedAmount>) -> Self::Output { rhs.and_then(|rhs| self * rhs) }
     }
 
     impl ops::Div<i64> for SignedAmount {

--- a/units/src/amount/result.rs
+++ b/units/src/amount/result.rs
@@ -182,6 +182,11 @@ crate::internal_macros::impl_op_for_references! {
 
         fn div(self, rhs: u64) -> Self::Output { self.and_then(|lhs| lhs / rhs) }
     }
+    impl ops::Div<Amount> for Amount {
+        type Output = u64;
+
+        fn div(self, rhs: Amount) -> Self::Output { self.to_sat() / rhs.to_sat() }
+    }
 
     impl ops::Rem<u64> for Amount {
         type Output = NumOpResult<Amount>;
@@ -251,6 +256,11 @@ crate::internal_macros::impl_op_for_references! {
         type Output = NumOpResult<SignedAmount>;
 
         fn div(self, rhs: i64) -> Self::Output { self.and_then(|lhs| lhs / rhs) }
+    }
+    impl ops::Div<SignedAmount> for SignedAmount {
+        type Output = i64;
+
+        fn div(self, rhs: SignedAmount) -> Self::Output { self.to_sat() / rhs.to_sat() }
     }
 
     impl ops::Rem<i64> for SignedAmount {

--- a/units/src/amount/tests.rs
+++ b/units/src/amount/tests.rs
@@ -1252,8 +1252,10 @@ fn op_int_combos() {
     assert_eq!(res(23) * 31, res(713));
     assert_eq!(sres(23) * 31, sres(713));
 
-    // assert_eq!(31 * sat(23), res(713));
-    // assert_eq!(31 * ssat(23), sres(713));
+    assert_eq!(31 * sat(23), res(713));
+    assert_eq!(31 * ssat(23), sres(713));
+    assert_eq!(31 * res(23), res(713));
+    assert_eq!(31 * sres(23), sres(713));
 
     // No remainder.
     assert_eq!(sat(1897) / 7, res(271));

--- a/units/src/amount/tests.rs
+++ b/units/src/amount/tests.rs
@@ -1283,6 +1283,38 @@ fn op_int_combos() {
 }
 
 #[test]
+fn unsigned_amount_div_by_amount() {
+    let sat = Amount::from_sat;
+
+    assert_eq!(sat(0) / sat(7), 0);
+    assert_eq!(sat(1897) / sat(7), 271);
+}
+
+#[test]
+#[should_panic(expected = "attempt to divide by zero")]
+fn unsigned_amount_div_by_amount_zero() {
+    let _ = Amount::from_sat(1897) / Amount::ZERO;
+}
+
+#[test]
+fn signed_amount_div_by_amount() {
+    let ssat = SignedAmount::from_sat;
+
+    assert_eq!(ssat(0) / ssat(7), 0);
+
+    assert_eq!(ssat(1897) / ssat(7), 271);
+    assert_eq!(ssat(1897) / ssat(-7), -271);
+    assert_eq!(ssat(-1897) / ssat(7), -271);
+    assert_eq!(ssat(-1897) / ssat(-7), 271);
+}
+
+#[test]
+#[should_panic(expected = "attempt to divide by zero")]
+fn signed_amount_div_by_amount_zero() {
+    let _ = SignedAmount::from_sat(1897) / SignedAmount::ZERO;
+}
+
+#[test]
 fn check_const() {
     assert_eq!(SignedAmount::ONE_BTC.to_sat(), 100_000_000);
     assert_eq!(Amount::ONE_BTC.to_sat(), 100_000_000);

--- a/units/src/amount/tests.rs
+++ b/units/src/amount/tests.rs
@@ -1207,7 +1207,10 @@ fn signed_addition() {
     assert_eq!(ssat(-307) + ssat(461), NumOpResult::from(ssat(154)));
     assert_eq!(ssat(307) + ssat(-461), NumOpResult::from(ssat(-154)));
     assert_eq!(ssat(-307) + ssat(-461), NumOpResult::from(ssat(-768)));
-    assert_eq!(SignedAmount::MAX_MONEY + -SignedAmount::MAX_MONEY, NumOpResult::from(SignedAmount::ZERO));
+    assert_eq!(
+        SignedAmount::MAX_MONEY + -SignedAmount::MAX_MONEY,
+        NumOpResult::from(SignedAmount::ZERO)
+    );
 }
 
 #[test]
@@ -1234,6 +1237,47 @@ fn signed_subtraction() {
     assert_eq!(ssat(-307) - ssat(461), NumOpResult::from(ssat(-768)));
     assert_eq!(ssat(307) - ssat(-461), NumOpResult::from(ssat(768)));
     assert_eq!(ssat(-307) - ssat(-461), NumOpResult::from(ssat(154)));
+}
+
+#[test]
+fn op_int_combos() {
+    let sat = Amount::from_sat;
+    let ssat = SignedAmount::from_sat;
+
+    let res = |sat| NumOpResult::from(Amount::from_sat(sat));
+    let sres = |ssat| NumOpResult::from(SignedAmount::from_sat(ssat));
+
+    assert_eq!(sat(23) * 31, res(713));
+    assert_eq!(ssat(23) * 31, sres(713));
+    assert_eq!(res(23) * 31, res(713));
+    assert_eq!(sres(23) * 31, sres(713));
+
+    // assert_eq!(31 * sat(23), res(713));
+    // assert_eq!(31 * ssat(23), sres(713));
+
+    // No remainder.
+    assert_eq!(sat(1897) / 7, res(271));
+    assert_eq!(ssat(1897) / 7, sres(271));
+    assert_eq!(res(1897) / 7, res(271));
+    assert_eq!(sres(1897) / 7, sres(271));
+
+    // Truncation works as expected.
+    assert_eq!(sat(1901) / 7, res(271));
+    assert_eq!(ssat(1901) / 7, sres(271));
+    assert_eq!(res(1901) / 7, res(271));
+    assert_eq!(sres(1901) / 7, sres(271));
+
+    // No remainder.
+    assert_eq!(sat(1897) % 7, res(0));
+    assert_eq!(ssat(1897) % 7, sres(0));
+    assert_eq!(res(1897) % 7, res(0));
+    assert_eq!(sres(1897) % 7, sres(0));
+
+    // Remainder works as expected.
+    assert_eq!(sat(1901) % 7, res(4));
+    assert_eq!(ssat(1901) % 7, sres(4));
+    assert_eq!(res(1901) % 7, res(4));
+    assert_eq!(sres(1901) % 7, sres(4));
 }
 
 #[test]

--- a/units/src/amount/tests.rs
+++ b/units/src/amount/tests.rs
@@ -1289,6 +1289,15 @@ fn num_op_result_ops_integer() {
         }
     }
     check_op! {
+        // Operations on an amount type and an integer.
+        let _ = sat * 3_u64; // Explicit type for the benefit of the reader.
+        let _ = sat / 3;
+        let _ = sat % 3;
+
+        let _ = ssat * 3_i64; // Explicit type for the benefit of the reader.
+        let _ = ssat / 3;
+        let _ = ssat % 3;
+
         // Operations on a `NumOpResult` and integer.
         let _ = res * 3_u64; // Explicit type for the benefit of the reader.
         let _ = res / 3;

--- a/units/src/amount/tests.rs
+++ b/units/src/amount/tests.rs
@@ -1182,6 +1182,61 @@ fn add_sub_combos() {
 }
 
 #[test]
+fn unsigned_addition() {
+    let sat = Amount::from_sat;
+
+    assert_eq!(sat(0) + sat(0), NumOpResult::from(sat(0)));
+    assert_eq!(sat(0) + sat(307), NumOpResult::from(sat(307)));
+    assert_eq!(sat(307) + sat(0), NumOpResult::from(sat(307)));
+    assert_eq!(sat(307) + sat(461), NumOpResult::from(sat(768)));
+    assert_eq!(sat(0) + Amount::MAX_MONEY, NumOpResult::from(Amount::MAX_MONEY));
+}
+
+#[test]
+fn signed_addition() {
+    let ssat = SignedAmount::from_sat;
+
+    assert_eq!(ssat(0) + ssat(0), NumOpResult::from(ssat(0)));
+    assert_eq!(ssat(0) + ssat(307), NumOpResult::from(ssat(307)));
+    assert_eq!(ssat(307) + ssat(0), NumOpResult::from(ssat(307)));
+    assert_eq!(ssat(307) + ssat(461), NumOpResult::from(ssat(768)));
+    assert_eq!(ssat(0) + SignedAmount::MAX_MONEY, NumOpResult::from(SignedAmount::MAX_MONEY));
+
+    assert_eq!(ssat(0) + ssat(-307), NumOpResult::from(ssat(-307)));
+    assert_eq!(ssat(-307) + ssat(0), NumOpResult::from(ssat(-307)));
+    assert_eq!(ssat(-307) + ssat(461), NumOpResult::from(ssat(154)));
+    assert_eq!(ssat(307) + ssat(-461), NumOpResult::from(ssat(-154)));
+    assert_eq!(ssat(-307) + ssat(-461), NumOpResult::from(ssat(-768)));
+    assert_eq!(SignedAmount::MAX_MONEY + -SignedAmount::MAX_MONEY, NumOpResult::from(SignedAmount::ZERO));
+}
+
+#[test]
+fn unsigned_subtraction() {
+    let sat = Amount::from_sat;
+
+    assert_eq!(sat(0) - sat(0), NumOpResult::from(sat(0)));
+    assert_eq!(sat(307) - sat(0), NumOpResult::from(sat(307)));
+    assert_eq!(sat(461) - sat(307), NumOpResult::from(sat(154)));
+}
+
+#[test]
+fn signed_subtraction() {
+    let ssat = SignedAmount::from_sat;
+
+    assert_eq!(ssat(0) - ssat(0), NumOpResult::from(ssat(0)));
+    assert_eq!(ssat(0) - ssat(307), NumOpResult::from(ssat(-307)));
+    assert_eq!(ssat(307) - ssat(0), NumOpResult::from(ssat(307)));
+    assert_eq!(ssat(307) - ssat(461), NumOpResult::from(ssat(-154)));
+    assert_eq!(ssat(0) - SignedAmount::MAX_MONEY, NumOpResult::from(-SignedAmount::MAX_MONEY));
+
+    assert_eq!(ssat(0) - ssat(-307), NumOpResult::from(ssat(307)));
+    assert_eq!(ssat(-307) - ssat(0), NumOpResult::from(ssat(-307)));
+    assert_eq!(ssat(-307) - ssat(461), NumOpResult::from(ssat(-768)));
+    assert_eq!(ssat(307) - ssat(-461), NumOpResult::from(ssat(768)));
+    assert_eq!(ssat(-307) - ssat(-461), NumOpResult::from(ssat(154)));
+}
+
+#[test]
 fn check_const() {
     assert_eq!(SignedAmount::ONE_BTC.to_sat(), 100_000_000);
     assert_eq!(Amount::ONE_BTC.to_sat(), 100_000_000);


### PR DESCRIPTION
Improve the test coverage and add missing implementations of math operations for the amount types.

Along the way close #4030.