### PR TITLE
Remove bip158 types from crate root

### DIFF
--- a/bitcoin/src/hash_types.rs
+++ b/bitcoin/src/hash_types.rs
@@ -6,9 +6,11 @@
 
 #[deprecated(since = "TBD", note = "use `crate::T` instead")]
 pub use crate::{
-    BlockHash, FilterHash, FilterHeader, TxMerkleNode, Txid, WitnessCommitment, WitnessMerkleNode,
+    BlockHash, TxMerkleNode, Txid, WitnessCommitment, WitnessMerkleNode,
     Wtxid,
 };
+#[deprecated(since = "TBD", note = "use `crate::T` instead")]
+pub use crate::bip158::{FilterHash, FilterHeader};
 
 #[cfg(test)]
 mod tests {

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -141,7 +141,6 @@ pub use units::{
 #[doc(inline)]
 pub use crate::{
     address::{Address, AddressType, KnownHrp},
-    bip158::{FilterHash, FilterHeader},
     bip32::XKeyIdentifier,
     crypto::ecdsa,
     crypto::key::{


### PR DESCRIPTION
BIP-158 (Compact Block Filters for Light Clients) is not so common as to require re-exorting its types at the crate root - remove them.