### PR TITLE
bitcoin: Remove hash type re-exports

### DIFF
--- a/bitcoin/examples/ecdsa-psbt-simple.rs
+++ b/bitcoin/examples/ecdsa-psbt-simple.rs
@@ -26,13 +26,14 @@ use std::collections::BTreeMap;
 
 use bitcoin::address::script_pubkey::ScriptBufExt as _;
 use bitcoin::bip32::{ChildNumber, DerivationPath, Fingerprint, IntoDerivationPath, Xpriv, Xpub};
+use bitcoin::key::WPubkeyHash;
 use bitcoin::locktime::absolute;
 use bitcoin::psbt::Input;
 use bitcoin::secp256k1::{Secp256k1, Signing};
 use bitcoin::witness::WitnessExt as _;
 use bitcoin::{
     consensus, transaction, Address, Amount, EcdsaSighashType, Network, OutPoint, Psbt, ScriptBuf,
-    Sequence, Transaction, TxIn, TxOut, Txid, WPubkeyHash, Witness,
+    Sequence, Transaction, TxIn, TxOut, Txid, Witness,
 };
 
 // The master xpriv, from which we derive the keys we control.

--- a/bitcoin/examples/sign-tx-segwit-v0.rs
+++ b/bitcoin/examples/sign-tx-segwit-v0.rs
@@ -3,13 +3,14 @@
 //! Demonstrate creating a transaction that spends to and from p2wpkh outputs.
 
 use bitcoin::address::script_pubkey::ScriptBufExt as _;
+use bitcoin::key::WPubkeyHash;
 use bitcoin::locktime::absolute;
 use bitcoin::secp256k1::{rand, Message, Secp256k1, SecretKey, Signing};
 use bitcoin::sighash::{EcdsaSighashType, SighashCache};
 use bitcoin::witness::WitnessExt as _;
 use bitcoin::{
     transaction, Address, Amount, Network, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut,
-    Txid, WPubkeyHash, Witness,
+    Txid, Witness,
 };
 
 const DUMMY_UTXO_AMOUNT: Amount = Amount::from_sat_unchecked(20_000_000);

--- a/bitcoin/src/hash_types.rs
+++ b/bitcoin/src/hash_types.rs
@@ -13,10 +13,9 @@ pub use crate::{
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        LegacySighash, PubkeyHash, ScriptHash, SegwitV0Sighash, TapSighash, WPubkeyHash,
-        WScriptHash, XKeyIdentifier,
-    };
+    use crate::key::{PubkeyHash, WPubkeyHash};
+    use crate::script::{ScriptHash, WScriptHash};
+    use crate::{LegacySighash, SegwitV0Sighash, TapSighash, XKeyIdentifier};
 
     #[rustfmt::skip]
     /// sha256d of the empty string

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -144,9 +144,7 @@ pub use crate::{
     bip158::{FilterHash, FilterHeader},
     bip32::XKeyIdentifier,
     crypto::ecdsa,
-    crypto::key::{
-        self, CompressedPublicKey, PrivateKey, PubkeyHash, PublicKey, WPubkeyHash, XOnlyPublicKey,
-    },
+    crypto::key::{self, CompressedPublicKey, PrivateKey, PublicKey, XOnlyPublicKey},
     crypto::sighash::{self, LegacySighash, SegwitV0Sighash, TapSighash, TapSighashTag},
     merkle_tree::MerkleBlock,
     network::params::{self, Params},
@@ -163,7 +161,6 @@ pub use crate::{
     blockdata::locktime::{absolute, relative},
     blockdata::script::witness_program::{self, WitnessProgram},
     blockdata::script::witness_version::{self, WitnessVersion},
-    blockdata::script::{ScriptHash, WScriptHash}, // TODO: Move these down below after they are in primitives.
     // These modules also re-export all the respective `primitives` types.
     blockdata::{
         block, constants, fee_rate, locktime, opcodes, script, transaction, weight, witness,


### PR DESCRIPTION
The `{W}PubkeyHash` and `{W}ScriptHash` types are not likely to be used directly by consumers of the library because we have other function that return them and are more ergonomic to use. There is therefor no good reason to re-export them from the crate root.
 
