### PR TITLE
Move `opcodes` back to bitcoin

### DIFF
--- a/bitcoin/src/blockdata/mod.rs
+++ b/bitcoin/src/blockdata/mod.rs
@@ -7,6 +7,7 @@
 
 pub mod block;
 pub mod constants;
+pub mod opcodes;
 pub mod script;
 pub mod transaction;
 pub mod witness;
@@ -68,12 +69,6 @@ pub mod locktime {
             LockTime, Time, TimeOverflowError,
         };
     }
-}
-
-/// Bitcoin script opcodes.
-pub mod opcodes {
-    /// Re-export everything from the [`primitives::opcodes`] module.
-    pub use primitives::opcodes::*;
 }
 
 /// Implements `Weight` and associated features.

--- a/bitcoin/src/blockdata/opcodes.rs
+++ b/bitcoin/src/blockdata/opcodes.rs
@@ -6,7 +6,6 @@
 //! all of the opcodes for that language.
 
 #![allow(non_camel_case_types)]
-#![allow(dead_code)]            // This module is private and is duplicated in `bitcoin`.
 
 use core::fmt;
 

--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -61,12 +61,12 @@ use core::convert::Infallible;
 use core::fmt;
 
 use io::{BufRead, Write};
-use primitives::opcodes::all::*;
-use primitives::opcodes::Opcode;
 
 use crate::consensus::{encode, Decodable, Encodable};
 use crate::internal_macros::impl_asref_push_bytes;
 use crate::key::WPubkeyHash;
+use crate::opcodes::all::*;
+use crate::opcodes::Opcode;
 use crate::prelude::Vec;
 use crate::OutPoint;
 

--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
 use hex_lit::hex;
-use primitives::opcodes;
 
 use super::*;
 use crate::address::script_pubkey::{
@@ -9,7 +8,7 @@ use crate::address::script_pubkey::{
 };
 use crate::consensus::encode::{deserialize, serialize};
 use crate::crypto::key::{PublicKey, XOnlyPublicKey};
-use crate::{Amount, FeeRate};
+use crate::{Amount, FeeRate, opcodes};
 
 #[test]
 #[rustfmt::skip]

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -123,7 +123,6 @@ pub use primitives::{
         Unchecked as BlockUnchecked, Validation as BlockValidation, WitnessCommitment,
     },
     merkle_tree::{TxMerkleNode, WitnessMerkleNode},
-    opcodes::Opcode,
     pow::CompactTarget, // No `pow` module outside of `primitives`.
     script::{Script, ScriptBuf},
     sequence::{self, Sequence}, // No `sequence` module outside of `primitives`.
@@ -161,12 +160,13 @@ pub use crate::{
 pub use crate::{
     // Also, re-export types and modules from `blockdata` that don't come from `primitives`.
     blockdata::locktime::{absolute, relative},
+    blockdata::opcodes::{self, Opcode},
     blockdata::script::witness_program::{self, WitnessProgram},
     blockdata::script::witness_version::{self, WitnessVersion},
     blockdata::script::{ScriptHash, WScriptHash}, // TODO: Move these down below after they are in primitives.
     // These modules also re-export all the respective `primitives` types.
     blockdata::{
-        block, constants, fee_rate, locktime, opcodes, script, transaction, weight, witness,
+        block, constants, fee_rate, locktime, script, transaction, weight, witness,
     },
 };
 

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -44,7 +44,7 @@ pub mod _export {
 pub mod block;
 pub mod locktime;
 pub mod merkle_tree;
-pub mod opcodes;
+mod opcodes;
 pub mod pow;
 #[cfg(feature = "alloc")]
 pub mod script;
@@ -76,7 +76,6 @@ pub use self::{
     block::{BlockHash, Header as BlockHeader, WitnessCommitment},
     locktime::{absolute, relative},
     merkle_tree::{TxMerkleNode, WitnessMerkleNode},
-    opcodes::Opcode,
     pow::CompactTarget,
     sequence::Sequence,
     transaction::{OutPoint, Txid, Wtxid},


### PR DESCRIPTION
Duplicate `opcodes` in `bitcoin` and hide it in `primitives` so we do not have to commit to the API.

We use opcodes in `impl fmt::Display for Script`.

Close: #4144