### PR TITLE
Grammar fix

### DIFF
--- a/units/src/amount/result.rs
+++ b/units/src/amount/result.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! Provides a monodic numeric result type that is used to return the result of
-//! doing mathematical operations (`core::ops`) on amount types.
+//! Provides a monodic numeric type used to return the result of mathematical
+//! operations (`core::ops`) on `Amount` types.
 
 use core::{fmt, ops};
 


### PR DESCRIPTION
Pulled https://github.com/rust-bitcoin/rust-bitcoin/commit/f19ff22adc99c997934ae2eba6a1560427351d88 from https://github.com/rust-bitcoin/rust-bitcoin/pull/4158.  We can change the author of the commit but it's so minor I don't think it matters.

Also couldn't help but suggest some improvements to the title while I'm here:

* Use backticks around Amount since it's a type.
* The use of result is unnecessarily used twice when referring to the
  return.
* The use of "doing" and "that is" makes the sentence very verbose.