### PR TITLE
Implement `Rem` for `Weight`

### DIFF
--- a/units/src/weight.rs
+++ b/units/src/weight.rs
@@ -198,6 +198,16 @@ crate::internal_macros::impl_op_for_references! {
 
         fn div(self, rhs: Weight) -> Self::Output { self.to_wu() / rhs.to_wu() }
     }
+    impl ops::Rem<u64> for Weight {
+        type Output = Weight;
+
+        fn rem(self, rhs: u64) -> Self::Output { Weight(self.0 % rhs) }
+    }
+    impl ops::Rem<Weight> for Weight {
+        type Output = u64;
+
+        fn rem(self, rhs: Weight) -> Self::Output { self.0 % rhs.0 }
+    }
 }
 crate::internal_macros::impl_add_assign!(Weight);
 crate::internal_macros::impl_sub_assign!(Weight);
@@ -208,6 +218,10 @@ impl ops::MulAssign<u64> for Weight {
 
 impl ops::DivAssign<u64> for Weight {
     fn div_assign(&mut self, rhs: u64) { self.0 /= rhs }
+}
+
+impl ops::RemAssign<u64> for Weight {
+    fn rem_assign(&mut self, rhs: u64) { self.0 %= rhs }
 }
 
 impl core::iter::Sum for Weight {

--- a/units/src/weight.rs
+++ b/units/src/weight.rs
@@ -453,4 +453,23 @@ mod tests {
         w /= Weight(4).into();
         assert_eq!(w, Weight(2));
     }
+
+    #[test]
+    fn remainder() {
+        let weight10 = Weight(10);
+        let weight3 = Weight(3);
+
+        let remainder = weight10 % weight3;
+        assert_eq!(remainder, 1);
+
+        let remainder = weight10 % 3;
+        assert_eq!(remainder, Weight(1));
+    }
+
+    #[test]
+    fn remainder_assign() {
+        let mut weight = Weight(10);
+        weight %= 3;
+        assert_eq!(weight, Weight(1));
+    }
 }


### PR DESCRIPTION
Weight implements `Div` but not `Rem`.

Add the `Rem` implementation.

Add a test for the remainder operation on `Weight`

Close #4171