### PR TITLE
fuzz: cover more stuff for Script

### DIFF
--- a/fuzz/fuzz_targets/bitcoin/deserialize_psbt.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_psbt.rs
@@ -1,16 +1,7 @@
 use honggfuzz::fuzz;
 
-fn consume_random_bytes<'a>(data: &mut &'a [u8]) -> &'a [u8] {
-    if data.is_empty() {
-        return &[];
-    }
-
-    let length = (data[0] as usize) % (data.len() + 1);
-    let (bytes, rest) = data.split_at(length);
-    *data = rest;
-
-    bytes
-}
+mod fuzz_utils;
+use fuzz_utils::consume_random_bytes;
 
 fn do_test(data: &[u8]) {
     let mut new_data = data;

--- a/fuzz/fuzz_targets/bitcoin/deserialize_script.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_script.rs
@@ -12,6 +12,7 @@ fn do_test(data: &[u8]) {
         let _ = script.to_string();
         let _ = script.count_sigops();
         let _ = script.count_sigops_legacy();
+        let _ = script.minimal_non_dust();
 
         let mut b = script::Builder::new();
         for ins in script.instructions_minimal() {

--- a/fuzz/fuzz_targets/bitcoin/deserialize_script.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_script.rs
@@ -10,6 +10,9 @@ fn do_test(data: &[u8]) {
         let _: Result<Vec<script::Instruction>, script::Error> = script.instructions().collect();
 
         let _ = script.to_string();
+        let _ = script.count_sigops();
+        let _ = script.count_sigops_legacy();
+
         let mut b = script::Builder::new();
         for ins in script.instructions_minimal() {
             if ins.is_err() {

--- a/fuzz/fuzz_targets/bitcoin/deserialize_script.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_script.rs
@@ -1,11 +1,16 @@
 use bitcoin::address::Address;
 use bitcoin::consensus::encode;
 use bitcoin::script::{self, ScriptExt as _};
-use bitcoin::Network;
+use bitcoin::{FeeRate, Network};
 use honggfuzz::fuzz;
 
+mod fuzz_utils;
+use fuzz_utils::{consume_random_bytes, consume_u64};
+
 fn do_test(data: &[u8]) {
-    let s: Result<script::ScriptBuf, _> = encode::deserialize(data);
+    let mut new_data = data;
+    let bytes = consume_random_bytes(&mut new_data);
+    let s: Result<script::ScriptBuf, _> = encode::deserialize(bytes);
     if let Ok(script) = s {
         let _: Result<Vec<script::Instruction>, script::Error> = script.instructions().collect();
 
@@ -13,6 +18,9 @@ fn do_test(data: &[u8]) {
         let _ = script.count_sigops();
         let _ = script.count_sigops_legacy();
         let _ = script.minimal_non_dust();
+
+        let fee_rate = FeeRate::from_sat_per_kwu(consume_u64(&mut new_data));
+        let _ = script.minimal_non_dust_custom(fee_rate);
 
         let mut b = script::Builder::new();
         for ins in script.instructions_minimal() {

--- a/fuzz/fuzz_targets/bitcoin/fuzz_utils.rs
+++ b/fuzz/fuzz_targets/bitcoin/fuzz_utils.rs
@@ -1,0 +1,11 @@
+pub fn consume_random_bytes<'a>(data: &mut &'a [u8]) -> &'a [u8] {
+    if data.is_empty() {
+        return &[];
+    }
+
+    let length = (data[0] as usize) % (data.len() + 1);
+    let (bytes, rest) = data.split_at(length);
+    *data = rest;
+
+    bytes
+}

--- a/fuzz/fuzz_targets/bitcoin/fuzz_utils.rs
+++ b/fuzz/fuzz_targets/bitcoin/fuzz_utils.rs
@@ -9,3 +9,25 @@ pub fn consume_random_bytes<'a>(data: &mut &'a [u8]) -> &'a [u8] {
 
     bytes
 }
+
+#[allow(dead_code)]
+pub fn consume_u64(data: &mut &[u8]) -> u64 {
+    // We need at least 8 bytes to read a u64
+    if data.len() < 8 {
+        return 0;
+    }
+
+    let (u64_bytes, rest) = data.split_at(8);
+    *data = rest;
+
+    u64::from_le_bytes([
+        u64_bytes[0],
+        u64_bytes[1],
+        u64_bytes[2],
+        u64_bytes[3],
+        u64_bytes[4],
+        u64_bytes[5],
+        u64_bytes[6],
+        u64_bytes[7],
+    ])
+}


### PR DESCRIPTION
This PR adds fuzz coverage for `count_sigops`, `count_sigops_legacy`, `minimal_non_dust` and `minimal_non_dust_custom`. In order to not duplicate `consume_random_bytes`, it moves it to a util file and adds a `consume_u64` function to be used in the `deserialize_script` target to fuzz `minimal_non_dust_custom`.