### PR TITLE
ci: update Kani GitHub Actions runners to ubuntu-24.04

### DIFF
--- a/.github/workflows/cron-daily-kani.yml
+++ b/.github/workflows/cron-daily-kani.yml
@@ -5,7 +5,7 @@ on:
     - cron: '59 23 * * *'       # midnight every day.
 jobs:
   run-kani:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: 'Checkout your code.'
         uses: actions/checkout@v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -296,7 +296,7 @@ jobs:
 
   Kani:
     name: Kani codegen - stable toolchain
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: "Checkout repo"
         uses: actions/checkout@v4


### PR DESCRIPTION
GitHub is deprecating the ubuntu-20.04 runner, with removal scheduled for 2025-04-01 (see [GitHub Issue #11101](https://github.com/actions/runner-images/issues/11101)).

This PR updates the CI/CD workflows to use ubuntu-24.04 instead of ubuntu-20.04 for the following workflows:

- cron-daily-kani.yml
- rust.yml (Kani codegen job)

This change should resolve the CI/CD error in the Kani codegen - stable toolchain job triggered by pull requests.