### PR TITLE
Private key from slice fix

### DIFF
--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -468,6 +468,7 @@ impl PrivateKey {
     }
 
     /// Deserializes a private key from a slice.
+    #[deprecated(since = "TBD", note = "use from_byte_array instead")]
     pub fn from_slice(
         data: &[u8],
         network: impl Into<NetworkKind>,
@@ -1606,6 +1607,8 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // tests the deprecated function
+    #[allow(deprecated_in_future)]
     fn invalid_private_key_len() {
         use crate::Network;
         assert!(PrivateKey::from_slice(&[1u8; 31], Network::Regtest).is_err());

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -459,17 +459,21 @@ impl PrivateKey {
     /// Serializes the private key to bytes.
     pub fn to_vec(self) -> Vec<u8> { self.inner[..].to_vec() }
 
+    /// Deserializes a private key from a byte array.
+    pub fn from_byte_array(
+        data: [u8; 32],
+        network: impl Into<NetworkKind>
+    ) -> Result<PrivateKey, secp256k1::Error> {
+        Ok(PrivateKey::new(secp256k1::SecretKey::from_byte_array(&data)?, network))
+    }
+
     /// Deserializes a private key from a slice.
     pub fn from_slice(
         data: &[u8],
         network: impl Into<NetworkKind>,
     ) -> Result<PrivateKey, secp256k1::Error> {
-        Ok(PrivateKey::new(
-            secp256k1::SecretKey::from_byte_array(
-                data.try_into().map_err(|_| secp256k1::Error::InvalidSecretKey)?,
-            )?,
-            network,
-        ))
+        let array = data.try_into().map_err(|_| secp256k1::Error::InvalidSecretKey)?;
+        Self::from_byte_array(array, network)
     }
 
     /// Formats the private key to WIF format.

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -1600,4 +1600,11 @@ mod tests {
             panic!("Expected Invalid char error");
         }
     }
+
+    #[test]
+    fn invalid_private_key_len() {
+        use crate::Network;
+        assert!(PrivateKey::from_slice(&[1u8; 31], Network::Regtest).is_err());
+        assert!(PrivateKey::from_slice(&[1u8; 33], Network::Regtest).is_err());
+    }
 }

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -466,7 +466,7 @@ impl PrivateKey {
     ) -> Result<PrivateKey, secp256k1::Error> {
         Ok(PrivateKey::new(
             secp256k1::SecretKey::from_byte_array(
-                data[..32].try_into().expect("Slice should be exactly 32 bytes"),
+                data.try_into().map_err(|_| secp256k1::Error::InvalidSecretKey)?,
             )?,
             network,
         ))

--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -261,7 +261,7 @@ impl Serialize for XOnlyPublicKey {
 impl Deserialize for XOnlyPublicKey {
     fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
         XOnlyPublicKey::from_byte_array(
-            bytes[..32].try_into().expect("statistically impossible to hit"),
+            bytes.try_into().map_err(|_| Error::InvalidXOnlyPublicKey)?,
         )
         .map_err(|_| Error::InvalidXOnlyPublicKey)
     }

--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -462,6 +462,12 @@ mod tests {
     }
 
     #[test]
+    fn deserialize_xonly_public_key_len() {
+        assert!(XOnlyPublicKey::deserialize(&[1; 31]).is_err());
+        assert!(XOnlyPublicKey::deserialize(&[1; 33]).is_err());
+    }
+
+    #[test]
     #[should_panic(expected = "InvalidMagic")]
     fn invalid_vector_1() {
         let hex_psbt = b"0200000001268171371edff285e937adeea4b37b78000c0566cbb3ad64641713ca42171bf6000000006a473044022070b2245123e6bf474d60c5b50c043d4c691a5d2435f09a34a7662a9dc251790a022001329ca9dacf280bdf30740ec0390422422c81cb45839457aeb76fc12edd95b3012102657d118d3357b8e0f4c2cd46db7b39f6d9c38d9a70abcb9b2de5dc8dbfe4ce31feffffff02d3dff505000000001976a914d0c59903c5bac2868760e90fd521a4665aa7652088ac00e1f5050000000017a9143545e6e33b832c47050f24d3eeb93c9c03948bc787b32e1300";


### PR DESCRIPTION
This fixes the bug introduced in #4154 and deprecates `from_slice` method in favor of `from_byte_array` (see commits).

Closes #4191 