### PR TITLE
Fix fuzz test failure

### DIFF
--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -260,8 +260,11 @@ impl Serialize for XOnlyPublicKey {
 
 impl Deserialize for XOnlyPublicKey {
     fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
+        if bytes.len() < 32 {
+            return Err(Error::InvalidXOnlyPublicKey);
+        }
         XOnlyPublicKey::from_byte_array(
-            bytes[..32].try_into().expect("statistically impossible to hit"),
+            bytes[..32].try_into().expect("size checked above"),
         )
         .map_err(|_| Error::InvalidXOnlyPublicKey)
     }


### PR DESCRIPTION
Fuzz testing crashed with:
```
thread panicked at bitcoin/src/psbt/serialize.rs:264:18:
range end index 32 out of range for slice of length 1
```

Add a check to ensure that the range is valid.

Close #4191 