### PR TITLE
Take `spent` closure by value in `count_witness_sigops`

### DIFF
--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -414,7 +414,7 @@ impl TransactionExt for Transaction {
 
         // coinbase tx is correctly handled because `spent` will always returns None.
         cost = cost.saturating_add(self.count_p2sh_sigops(&mut spent).saturating_mul(4));
-        cost.saturating_add(self.count_witness_sigops(&mut spent))
+        cost.saturating_add(self.count_witness_sigops(spent))
     }
 
     #[inline]
@@ -453,12 +453,12 @@ trait TransactionExtPriv {
     fn count_p2pk_p2pkh_sigops(&self) -> usize;
 
     /// Does not include wrapped SegWit (see `count_witness_sigops`).
-    fn count_p2sh_sigops<S>(&self, spent: &mut S) -> usize
+    fn count_p2sh_sigops<S>(&self, spent: S) -> usize
     where
         S: FnMut(&OutPoint) -> Option<TxOut>;
 
     /// Includes wrapped SegWit (returns 0 for Taproot spends).
-    fn count_witness_sigops<S>(&self, spent: &mut S) -> usize
+    fn count_witness_sigops<S>(&self, spent: S) -> usize
     where
         S: FnMut(&OutPoint) -> Option<TxOut>;
 
@@ -481,7 +481,7 @@ impl TransactionExtPriv for Transaction {
     }
 
     /// Does not include wrapped SegWit (see `count_witness_sigops`).
-    fn count_p2sh_sigops<S>(&self, spent: &mut S) -> usize
+    fn count_p2sh_sigops<S>(&self, mut spent: S) -> usize
     where
         S: FnMut(&OutPoint) -> Option<TxOut>,
     {
@@ -506,7 +506,7 @@ impl TransactionExtPriv for Transaction {
     }
 
     /// Includes wrapped SegWit (returns 0 for Taproot spends).
-    fn count_witness_sigops<S>(&self, spent: &mut S) -> usize
+    fn count_witness_sigops<S>(&self, mut spent: S) -> usize
     where
         S: FnMut(&OutPoint) -> Option<TxOut>,
     {


### PR DESCRIPTION
This fixes #4141

Changed `count_witness_sigops` to take the `spent` closure by value instead of `&mut`
This removes the need for `&mut` when calling the function while still allowing mutable closure to be passed when needed