### PR TITLE
ci: Update GitHub workflows to use ubuntu-24.04 instead of ubuntu-latest

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -7,7 +7,7 @@ name: Code coverage with llvm-cov
 jobs:
   Coveralls:
     name: Code coverage - stable toolchain
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
     steps:

--- a/.github/workflows/cron-daily-fuzz.yml
+++ b/.github/workflows/cron-daily-fuzz.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   fuzz:
     if: ${{ !github.event.act }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -67,7 +67,7 @@ jobs:
   verify-execution:
     if: ${{ !github.event.act }}
     needs: fuzz
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4

--- a/.github/workflows/cron-weekly-cargo-mutants.yml
+++ b/.github/workflows/cron-weekly-cargo-mutants.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch: # allows manual triggering
 jobs:
   cargo-mutants:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: taiki-e/install-action@v2

--- a/.github/workflows/cron-weekly-rustfmt.yml
+++ b/.github/workflows/cron-weekly-rustfmt.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   format:
     name: Nightly rustfmt
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/cron-weekly-update-cargo-semver-checks.yml
+++ b/.github/workflows/cron-weekly-update-cargo-semver-checks.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   format:
     name: Update cargo-semver-checks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Update semver-checks to use latest crates.io published version

--- a/.github/workflows/cron-weekly-update-nightly.yml
+++ b/.github/workflows/cron-weekly-update-nightly.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   format:
     name: Update nightly rustc
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/cron-weekly-update-stable.yml
+++ b/.github/workflows/cron-weekly-update-stable.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   format:
     name: Update stable rustc
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - uses: ncipollo/release-action@v1

--- a/.github/workflows/manage-pr.yml
+++ b/.github/workflows/manage-pr.yml
@@ -7,7 +7,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout master
         uses: actions/checkout@v4

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -11,7 +11,7 @@ name: Miri
 jobs:
   Miri:
     name: Miri
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ name: Release
 jobs:
   release:
     name: Release - dry-run
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Crate
         uses: actions/checkout@v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,7 @@ name: Continuous integration
 
 jobs:
   Prepare:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       nightly_version: ${{ steps.read_toolchain.outputs.nightly_version }}
     steps:
@@ -22,7 +22,7 @@ jobs:
 
   Stable:                       # 2 jobs, one per manifest.
     name: Test - stable toolchain
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -46,7 +46,7 @@ jobs:
   Nightly:                      # 2 jobs, one per manifest.
     name: Test - nightly toolchain
     needs: Prepare
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -71,7 +71,7 @@ jobs:
 
   MSRV:                         # 2 jobs, one per manifest.
     name: Test - MSRV toolchain
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -97,7 +97,7 @@ jobs:
   Lint:
     name: Lint - nightly toolchain
     needs: Prepare
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -124,7 +124,7 @@ jobs:
 
   Docs:
     name: Docs - stable toolchain
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -148,7 +148,7 @@ jobs:
   Docsrs:
     name: Docs - nightly toolchain
     needs: Prepare
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -174,7 +174,7 @@ jobs:
   Bench:
     name: Bench - nightly toolchain
     needs: Prepare
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -199,7 +199,7 @@ jobs:
 
   Arch32bit:
     name: Test 32-bit version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: "Checkout repo"
         uses: actions/checkout@v4
@@ -217,7 +217,7 @@ jobs:
   Cross:
     name: Cross test - stable toolchain
     if: ${{ !github.event.act }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: "Checkout repo"
         uses: actions/checkout@v4
@@ -233,7 +233,7 @@ jobs:
   Embedded:
     name: Embedded - nightly toolchain
     needs: Prepare
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       RUSTFLAGS: "-C link-arg=-Tlink.x"
       CARGO_TARGET_THUMBV7M_NONE_EABI_RUNNER: "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"
@@ -261,7 +261,7 @@ jobs:
   ASAN:                         # hashes crate only.
     name: ASAN - nightly toolchain
     needs: Prepare
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -282,7 +282,7 @@ jobs:
 
   WASM:                         # hashes crate only.
     name: WASM - stable toolchain
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       # Note we do not use the recent lock file for wasm testing.

--- a/.github/workflows/semver-checks-pr-label.yml
+++ b/.github/workflows/semver-checks-pr-label.yml
@@ -8,7 +8,7 @@ name: Check semver breaks - Label and Comment PR
 jobs:
   Download:
     name: Download, Unzip and Add Labels/Comments
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -6,7 +6,7 @@ name: Check semver breaks
 jobs:
   PR:
     name: PR Semver - stable toolchain
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
     steps:
@@ -45,7 +45,7 @@ jobs:
 
   Feature:
     name: Non additive cargo features - stable toolchain
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
     steps:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   shellcheck:
     name: Shellcheck
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: Run ShellCheck

--- a/fuzz/generate-files.sh
+++ b/fuzz/generate-files.sh
@@ -57,7 +57,7 @@ on:
 jobs:
   fuzz:
     if: \${{ !github.event.act }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -97,7 +97,7 @@ $(for name in $(listTargetNames); do echo "          $name,"; done)
   verify-execution:
     if: \${{ !github.event.act }}
     needs: fuzz
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
This PR updates all GitHub workflow files to use `ubuntu-24.04` instead of `ubuntu-latest`. 

This change improves CI reliability by:
- Pinning to a specific Ubuntu version instead of a floating reference
- Preventing unexpected CI failures when GitHub updates the `ubuntu-latest` alias
- Ensuring consistent build environments and reproducible CI results
- Allowing for controlled migration to newer Ubuntu versions when ready

The modification affects all workflow files in the `.github/workflows/` directory and the fuzz generation script.

Context:

> Yeah, I prefer the explicit version (and would prefer changing the other `-latest` ones to use the explicit version too). But I don't feel strongly.

_Originally posted by apoelstra in https://github.com/rust-bitcoin/rust-bitcoin/pull/4188#discussion_r1980549662_

 > I think an explicit version would be a bit better. It wouldn't suddenly and unexpectedly change and if GH does something like this again, it'll be a few years into the future. Also an explicit version is nicer for troubleshooting.

_Originally posted by Kixunil in https://github.com/rust-bitcoin/rust-bitcoin/pull/4188#discussion_r1979872413_
            
