### PR TITLE
Remove a bunch of `try_into().expect()`

### DIFF
--- a/bitcoin/src/bip152.rs
+++ b/bitcoin/src/bip152.rs
@@ -10,7 +10,7 @@ use core::{convert, fmt, mem};
 use std::error;
 
 use hashes::{sha256, siphash24};
-use internals::ToU64 as _;
+use internals::{ToU64 as _, array::ArrayExt as _};
 use io::{BufRead, Write};
 
 use crate::consensus::encode::{self, Decodable, Encodable, ReadExt, WriteExt};
@@ -117,8 +117,8 @@ impl ShortId {
         // 2. Running SipHash-2-4 with the input being the transaction ID and the keys (k0/k1)
         // set to the first two little-endian 64-bit integers from the above hash, respectively.
         (
-            u64::from_le_bytes(h.as_byte_array()[0..8].try_into().expect("8 byte slice")),
-            u64::from_le_bytes(h.as_byte_array()[8..16].try_into().expect("8 byte slice")),
+            u64::from_le_bytes(*h.as_byte_array().sub_array::<0, 8>()),
+            u64::from_le_bytes(*h.as_byte_array().sub_array::<8, 8>()),
         )
     }
 

--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -42,7 +42,7 @@ use core::convert::Infallible;
 use core::fmt;
 
 use hashes::{sha256d, siphash24, HashEngine as _};
-use internals::{write_err, ToU64 as _};
+use internals::{write_err, ToU64 as _, array::ArrayExt as _};
 use io::{BufRead, Write};
 
 use crate::block::{Block, BlockHash, Checked};
@@ -195,8 +195,8 @@ impl<'a, W: Write> BlockFilterWriter<'a, W> {
     /// Constructs a new [`BlockFilterWriter`] from `block`.
     pub fn new(writer: &'a mut W, block: &'a Block<Checked>) -> BlockFilterWriter<'a, W> {
         let block_hash_as_int = block.block_hash().to_byte_array();
-        let k0 = u64::from_le_bytes(block_hash_as_int[0..8].try_into().expect("8 byte slice"));
-        let k1 = u64::from_le_bytes(block_hash_as_int[8..16].try_into().expect("8 byte slice"));
+        let k0 = u64::from_le_bytes(*block_hash_as_int.sub_array::<0, 8>());
+        let k1 = u64::from_le_bytes(*block_hash_as_int.sub_array::<8, 8>());
         let writer = GcsFilterWriter::new(writer, k0, k1, M, P);
         BlockFilterWriter { block, writer }
     }
@@ -250,8 +250,8 @@ impl BlockFilterReader {
     /// Constructs a new [`BlockFilterReader`] from `block_hash`.
     pub fn new(block_hash: BlockHash) -> BlockFilterReader {
         let block_hash_as_int = block_hash.to_byte_array();
-        let k0 = u64::from_le_bytes(block_hash_as_int[0..8].try_into().expect("8 byte slice"));
-        let k1 = u64::from_le_bytes(block_hash_as_int[8..16].try_into().expect("8 byte slice"));
+        let k0 = u64::from_le_bytes(*block_hash_as_int.sub_array::<0, 8>());
+        let k1 = u64::from_le_bytes(*block_hash_as_int.sub_array::<8, 8>());
         BlockFilterReader { reader: GcsFilterReader::new(k0, k1, M, P) }
     }
 

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -1410,4 +1410,33 @@ mod tests {
         let xpriv_str = "xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzFAzHGBP2UuGCqWLTAPLcMtD9y5gkZ6Eq3Rjuahrv17fENZ3QzxW";
         xpriv_str.parse::<Xpriv>().unwrap();
     }
+
+    #[test]
+    fn official_vectors_5() {
+        let invalid_keys = [
+            "xpub661MyMwAqRbcEYS8w7XLSVeEsBXy79zSzH1J8vCdxAZningWLdN3zgtU6LBpB85b3D2yc8sfvZU521AAwdZafEz7mnzBBsz4wKY5fTtTQBm",
+            "xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzFGTQQD3dC4H2D5GBj7vWvSQaaBv5cxi9gafk7NF3pnBju6dwKvH",
+            "xpub661MyMwAqRbcEYS8w7XLSVeEsBXy79zSzH1J8vCdxAZningWLdN3zgtU6Txnt3siSujt9RCVYsx4qHZGc62TG4McvMGcAUjeuwZdduYEvFn",
+            "xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzFGpWnsj83BHtEy5Zt8CcDr1UiRXuWCmTQLxEK9vbz5gPstX92JQ",
+            "xpub661MyMwAqRbcEYS8w7XLSVeEsBXy79zSzH1J8vCdxAZningWLdN3zgtU6N8ZMMXctdiCjxTNq964yKkwrkBJJwpzZS4HS2fxvyYUA4q2Xe4",
+            "xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzFAzHGBP2UuGCqWLTAPLcMtD9y5gkZ6Eq3Rjuahrv17fEQ3Qen6J",
+            "xprv9s2SPatNQ9Vc6GTbVMFPFo7jsaZySyzk7L8n2uqKXJen3KUmvQNTuLh3fhZMBoG3G4ZW1N2kZuHEPY53qmbZzCHshoQnNf4GvELZfqTUrcv",
+            "xpub661no6RGEX3uJkY4bNnPcw4URcQTrSibUZ4NqJEw5eBkv7ovTwgiT91XX27VbEXGENhYRCf7hyEbWrR3FewATdCEebj6znwMfQkhRYHRLpJ",
+            "xprv9s21ZrQH4r4TsiLvyLXqM9P7k1K3EYhA1kkD6xuquB5i39AU8KF42acDyL3qsDbU9NmZn6MsGSUYZEsuoePmjzsB3eFKSUEh3Gu1N3cqVUN",
+            "xpub661MyMwAuDcm6CRQ5N4qiHKrJ39Xe1R1NyfouMKTTWcguwVcfrZJaNvhpebzGerh7gucBvzEQWRugZDuDXjNDRmXzSZe4c7mnTK97pTvGS8",
+            "DMwo58pR1QLEFihHiXPVykYB6fJmsTeHvyTp7hRThAtCX8CvYzgPcn8XnmdfHGMQzT7ayAmfo4z3gY5KfbrZWZ6St24UVf2Qgo6oujFktLHdHY4",
+            "DMwo58pR1QLEFihHiXPVykYB6fJmsTeHvyTp7hRThAtCX8CvYzgPcn8XnmdfHPmHJiEDXkTiJTVV9rHEBUem2mwVbbNfvT2MTcAqj3nesx8uBf9",
+            "xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzF93Y5wvzdUayhgkkFoicQZcP3y52uPPxFnfoLZB21Teqt1VvEHx",
+            "xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzFAzHGBP2UuGCqWLTAPLcMtD5SDKr24z3aiUvKr9bJpdrcLg1y3G",
+            "xpub661MyMwAqRbcEYS8w7XLSVeEsBXy79zSzH1J8vCdxAZningWLdN3zgtU6Q5JXayek4PRsn35jii4veMimro1xefsM58PgBMrvdYre8QyULY",
+            "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHL",
+        ];
+        for key in invalid_keys {
+            if key.starts_with("xpub") {
+                key.parse::<Xpub>().unwrap_err();
+            } else {
+                key.parse::<Xpriv>().unwrap_err();
+            }
+        }
+    }
 }

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -38,6 +38,7 @@
 // Exclude lints we don't think are valuable.
 #![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
 #![allow(clippy::manual_range_contains)] // More readable than clippy's format.
+#![allow(clippy::incompatible_msrv)] // Has FPs and we're testing it which is more reliable anyway.
 
 // We only support machines with index size of 4 bytes or more.
 //

--- a/internals/src/array.rs
+++ b/internals/src/array.rs
@@ -1,0 +1,105 @@
+//! Contains extensions related to arrays.
+
+/// Extension trait for arrays.
+pub trait ArrayExt {
+    /// The item type the array is storing.
+    type Item;
+
+    /// Just like the slicing operation, this returns an array `LEN` items long at position
+    /// `OFFSET`.
+    ///
+    /// The correctness of this operation is compile-time checked.
+    ///
+    /// Note that unlike slicing where the second number is the end index, here the second number
+    /// is array length!
+    fn sub_array<const OFFSET: usize, const LEN: usize>(&self) -> &[Self::Item; LEN];
+
+    /// Returns an item at given statically-known index.
+    ///
+    /// This is just like normal indexing except the check happens at compile time.
+    fn get_static<const INDEX: usize>(&self) -> &Self::Item {
+        &self.sub_array::<INDEX, 1>()[0]
+    }
+
+    /// Returns the first item in an array.
+    ///
+    /// Fails to compile if the array is empty.
+    ///
+    /// Note that this method's name is intentionally shadowing the `std`'s `first` method which
+    /// returns `Option`. The rationale is that given the known length of the array, we always know
+    /// that this will not return `None` so trying to keep the `std` method around is pointless.
+    /// Importing the trait will also cause compile failures - that's also intentional to expose
+    /// the places where useless checks are made.
+    fn first(&self) -> &Self::Item {
+        self.get_static::<0>()
+    }
+
+    /// Splits the array into two, non-overlaping smaller arrays covering the entire range.
+    ///
+    /// This is almost equivalent to just calling [`sub_array`](Self::sub_array) twice, except it also
+    /// checks that the arrays don't overlap and that they cover the full range. This is very useful
+    /// for demonstrating correctness, especially when chained. Using this technique even revealed
+    /// a bug in the past. ([#4195](https://github.com/rust-bitcoin/rust-bitcoin/issues/4195))
+    fn split_array<const LEFT: usize, const RIGHT: usize>(&self) -> (&[Self::Item; LEFT], &[Self::Item; RIGHT]);
+
+    /// Splits the array into the first element and the remaining, one element shorter, array.
+    ///
+    /// Fails to compile if the array is empty.
+    ///
+    /// Note that this method's name is intentionally shadowing the `std`'s `split_first` method which
+    /// returns `Option`. The rationale is that given the known length of the array, we always know
+    /// that this will not return `None` so trying to keep the `std` method around is pointless.
+    /// Importing the trait will also cause compile failures - that's also intentional to expose
+    /// the places where useless checks are made.
+    fn split_first<const RIGHT: usize>(&self) -> (&Self::Item, &[Self::Item; RIGHT]) {
+        let (first, remaining) = self.split_array::<1, RIGHT>();
+        (&first[0], remaining)
+    }
+
+    /// Splits the array into the last element and the remaining, one element shorter, array.
+    ///
+    /// Fails to compile if the array is empty.
+    ///
+    /// Note that this method's name is intentionally shadowing the `std`'s `split_last` method which
+    /// returns `Option`. The rationale is that given the known length of the array, we always know
+    /// that this will not return `None` so trying to keep the `std` method around is pointless.
+    /// Importing the trait will also cause compile failures - that's also intentional to expose
+    /// the places where useless checks are made.
+    ///
+    /// The returned tuple is also reversed just as `std` for consistency and simpler diffs when
+    /// migrating.
+    fn split_last<const LEFT: usize>(&self) -> (&Self::Item, &[Self::Item; LEFT]) {
+        let (remaining, last) = self.split_array::<LEFT, 1>();
+        (&last[0], remaining)
+    }
+}
+
+impl<const N: usize, T> ArrayExt for [T; N] {
+    type Item = T;
+
+    fn sub_array<const OFFSET: usize, const LEN: usize>(&self) -> &[Self::Item; LEN] {
+        #[allow(clippy::let_unit_value)]
+        let _ = Hack::<N, OFFSET, LEN>::IS_VALID_RANGE;
+
+        self[OFFSET..(OFFSET + LEN)].try_into().expect("this is also compiler-checked above")
+    }
+
+    fn split_array<const LEFT: usize, const RIGHT: usize>(&self) -> (&[Self::Item; LEFT], &[Self::Item; RIGHT]) {
+        #[allow(clippy::let_unit_value)]
+        let _ = Hack2::<N, LEFT, RIGHT>::IS_FULL_RANGE;
+
+        (self.sub_array::<0, LEFT>(), self.sub_array::<LEFT, RIGHT>())
+    }
+}
+
+struct Hack<const N: usize, const OFFSET: usize, const LEN: usize>;
+
+impl<const N: usize, const OFFSET: usize, const LEN: usize> Hack<N, OFFSET, LEN> {
+    const IS_VALID_RANGE: () = assert!(OFFSET + LEN <= N);
+}
+
+struct Hack2<const N: usize, const LEFT: usize, const RIGHT: usize>;
+
+impl<const N: usize, const LEFT: usize, const RIGHT: usize> Hack2<N, LEFT, RIGHT> {
+    const IS_FULL_RANGE: () = assert!(LEFT + RIGHT == N);
+}

--- a/internals/src/lib.rs
+++ b/internals/src/lib.rs
@@ -35,6 +35,7 @@ pub mod rust_version {
     include!(concat!(env!("OUT_DIR"), "/rust_version.rs"));
 }
 
+pub mod array;
 pub mod array_vec;
 pub mod compact_size;
 pub mod const_tools;

--- a/primitives/src/witness.rs
+++ b/primitives/src/witness.rs
@@ -12,6 +12,7 @@ use arbitrary::{Arbitrary, Unstructured};
 use hex::DisplayHex;
 use internals::compact_size;
 use internals::wrap_debug::WrapDebug;
+use internals::slice::SliceExt;
 
 use crate::prelude::Vec;
 
@@ -234,12 +235,7 @@ fn encode_cursor(bytes: &mut [u8], start_of_indices: usize, index: usize, value:
 #[inline]
 fn decode_cursor(bytes: &[u8], start_of_indices: usize, index: usize) -> Option<usize> {
     let start = start_of_indices + index * 4;
-    let end = start + 4;
-    if end > bytes.len() {
-        None
-    } else {
-        Some(u32::from_ne_bytes(bytes[start..end].try_into().expect("is u32 size")) as usize)
-    }
+    bytes.get_array::<4>(start).map(|index_bytes| u32::from_ne_bytes(*index_bytes) as usize)
 }
 
 /// Debug implementation that displays the witness as a structured output containing:


### PR DESCRIPTION
Previously we've used `try_into().expect()` because const generics wer
unavailable. Then they become available but we didn't realize we could
already convert a bunch of code to not use panicking conversions. But we
can (and could for a while).

This adds an extension trait for arrays to provide basic non-panicking
operations retutning arrays, so they can be composed with other
functions accepting arrays without any conversions. It also refactors a
bunch of code to use the non-panicking constructs but it's certainly not
all of it. That could be done later. This just aims at removing the
ugliest offenders and demonstrate the usefulness of this approach.