### PR TITLE
Make `hex` in `internals` optional

### DIFF
--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -29,7 +29,7 @@ base58 = { package = "base58ck", version = "0.2.0", default-features = false, fe
 bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
 hashes = { package = "bitcoin_hashes", version = "0.16.0", default-features = false, features = ["alloc", "hex"] }
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false, features = ["alloc"] }
-internals = { package = "bitcoin-internals", version = "0.4.0", features = ["alloc"] }
+internals = { package = "bitcoin-internals", version = "0.4.0", features = ["alloc", "hex"] }
 io = { package = "bitcoin-io", version = "0.2.0", default-features = false, features = ["alloc", "hashes"] }
 primitives = { package = "bitcoin-primitives", version = "0.101.0", default-features = false, features = ["alloc"] }
 secp256k1 = { version = "0.30.0", default-features = false, features = ["hashes", "alloc", "rand"] }

--- a/internals/Cargo.toml
+++ b/internals/Cargo.toml
@@ -15,13 +15,13 @@ exclude = ["tests", "contrib"]
 
 [features]
 default = []
-std = ["alloc", "hex/std"]
-alloc = ["hex/alloc"]
+std = ["alloc", "hex?/std"]
+alloc = ["hex?/alloc"]
 
 test-serde = ["serde", "serde_json", "bincode"]
 
 [dependencies]
-hex = { package = "hex-conservative", version = "0.3.0", default-features = false }
+hex = { package = "hex-conservative", version = "0.3.0", default-features = false, optional = true }
 serde = { version = "1.0.103", default-features = false, optional = true }
 
 # Don't enable these directly, use `test-serde` feature instead.

--- a/internals/src/serde.rs
+++ b/internals/src/serde.rs
@@ -310,9 +310,11 @@ macro_rules! serde_round_trip (
     })
 );
 
+#[cfg(feature = "hex")]
 /// Serializes a byte slice using the `hex` crate.
 pub struct SerializeBytesAsHex<'a>(pub &'a [u8]);
 
+#[cfg(feature = "hex")]
 impl serde::Serialize for SerializeBytesAsHex<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -24,7 +24,7 @@ arbitrary = ["dep:arbitrary", "units/arbitrary"]
 [dependencies]
 hashes = { package = "bitcoin_hashes", version = "0.16.0", default-features = false, features = ["hex"] }
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false }
-internals = { package = "bitcoin-internals", version = "0.4.0" }
+internals = { package = "bitcoin-internals", version = "0.4.0", features = ["hex"] }
 units = { package = "bitcoin-units", version = "0.2.0", default-features = false }
 
 arbitrary = { version = "1.4", optional = true }


### PR DESCRIPTION
The `hex` crate is not always desirable - e.g. when the consumer wants to work with raw data only. We already had this optional in `hashes` but if `hashes` is going to depend on `internals` it would break this property.

This change makes `hash` optional, since it's easy: there's just one struct that depends on it.