### PR TITLE
units: Bump version to `1.0.0-alpha.0`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-units"
-version = "0.2.0"
+version = "1.0.0-alpha.0"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-units"
-version = "0.2.0"
+version = "1.0.0-alpha.0"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -33,7 +33,7 @@ internals = { package = "bitcoin-internals", version = "0.4.0", features = ["all
 io = { package = "bitcoin-io", version = "0.2.0", default-features = false, features = ["alloc", "hashes"] }
 primitives = { package = "bitcoin-primitives", version = "0.101.0", default-features = false, features = ["alloc"] }
 secp256k1 = { version = "0.30.0", default-features = false, features = ["hashes", "alloc", "rand"] }
-units = { package = "bitcoin-units", version = "0.2.0", default-features = false, features = ["alloc"] }
+units = { package = "bitcoin-units", version = "1.0.0-alpha.0", default-features = false, features = ["alloc"] }
 
 arbitrary = { version = "1.4", optional = true }
 base64 = { version = "0.22.0", optional = true }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -25,7 +25,7 @@ arbitrary = ["dep:arbitrary", "units/arbitrary"]
 hashes = { package = "bitcoin_hashes", version = "0.16.0", default-features = false, features = ["hex"] }
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false }
 internals = { package = "bitcoin-internals", version = "0.4.0" }
-units = { package = "bitcoin-units", version = "0.2.0", default-features = false }
+units = { package = "bitcoin-units", version = "1.0.0-alpha.0", default-features = false }
 
 arbitrary = { version = "1.4", optional = true }
 serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"], optional = true }

--- a/units/CHANGELOG.md
+++ b/units/CHANGELOG.md
@@ -1,8 +1,29 @@
-# Unreleased
+# 1.0.0 - 2025-02-24
 
-- TODO: Make a comment about `Amount::MAX_MONEY` including breaking serde
+BOOM! A long time in the making but here goes, our first 1.0 crate release.
 
-- Use MAX_MONEY in serde regression test [#3950](https://github.com/rust-bitcoin/rust-bitcoin/pull/3950)
+This changelog is a rolling description of everything that will eventually end up in `v1.0`.
+
+* Remove `InputString` from the public API [#3905](https://github.com/rust-bitcoin/rust-bitcoin/pull/3905)
+* Hide the remaining public macros [#3867](https://github.com/rust-bitcoin/rust-bitcoin/pull/3867)
+* Change method return type for `to_unsigned()` [#3769](https://github.com/rust-bitcoin/rust-bitcoin/pull/3769)
+* Change paramater type used for whole bitcoin [#3744](https://github.com/rust-bitcoin/rust-bitcoin/pull/3744)
+* Add `Weight::to_kwu_ceil` [#3740](https://github.com/rust-bitcoin/rust-bitcoin/pull/3740)
+* Replace `String` with `InputString` [#3559](https://github.com/rust-bitcoin/rust-bitcoin/pull/3559)
+* Add `FeeRate` addition and subtraction traits [#3381](https://github.com/rust-bitcoin/rust-bitcoin/pull/3381)
+
+## Changes relate to error types
+
+* Close the hex parse errors [#3673](https://github.com/rust-bitcoin/rust-bitcoin/pull/3673)
+
+## Changes related to `serde`
+
+* Implement `serde` modules for `FeeRate` [#3666](https://github.com/rust-bitcoin/rust-bitcoin/pull/3666)
+
+## Improved support for `Arbitrary`
+
+* Implement `Arbitrary` for `units` types [#3777](https://github.com/rust-bitcoin/rust-bitcoin/pull/3777)
+* Add `Arbitrary` to `Weight` [#3257](https://github.com/rust-bitcoin/rust-bitcoin/pull/3257)
 
 # 0.2.0 - 2024-09-18
 

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-units"
-version = "0.2.0"
+version = "1.0.0-alpha.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"


### PR DESCRIPTION
In preparation for doing the first 1.0 alpha release set the version number, add a changelog entry, and update the lock files.

Depend on the new version repo wide.