### PR TITLE
Improve `Hmac` API

### DIFF
--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -10,7 +10,7 @@ use core::ops::Index;
 use core::str::FromStr;
 use core::{fmt, slice};
 
-use hashes::{hash160, hash_newtype, sha512, GeneralHash, HashEngine, Hmac, HmacEngine};
+use hashes::{hash160, hash_newtype, sha512, HashEngine, Hmac, HmacEngine};
 use internals::write_err;
 use secp256k1::{Secp256k1, XOnlyPublicKey};
 

--- a/hashes/src/hmac/mod.rs
+++ b/hashes/src/hmac/mod.rs
@@ -35,6 +35,30 @@ impl<T: GeneralHash> Hmac<T> {
     {
         HmacEngine::new(key)
     }
+
+    /// Hashes some bytes.
+    pub fn hash(key: &[u8], data: &[u8]) -> Self
+    where
+        <T as GeneralHash>::Engine: Default,
+    {
+        let mut engine = HmacEngine::new(key);
+        engine.input(data);
+        Self::from_engine(engine)
+    }
+
+    /// Hashes all the byte slices retrieved from the iterator together.
+    pub fn hash_byte_chunks<B, I>(key: &[u8], byte_slices: I) -> Self
+    where
+        <T as GeneralHash>::Engine: Default,
+        B: AsRef<[u8]>,
+        I: IntoIterator<Item = B>,
+    {
+        let mut engine = HmacEngine::new(key);
+        for slice in byte_slices {
+            engine.input(slice.as_ref());
+        }
+        Self::from_engine(engine)
+    }
 }
 
 impl<T: GeneralHash + str::FromStr> str::FromStr for Hmac<T> {

--- a/hashes/tests/regression.rs
+++ b/hashes/tests/regression.rs
@@ -8,7 +8,7 @@
 
 use bitcoin_hashes::{
     hash160, ripemd160, sha1, sha256, sha256d, sha256t, sha384, sha512, sha512_256, siphash24,
-    GeneralHash as _, HashEngine as _, Hmac, HmacEngine,
+    HashEngine as _, Hmac, HmacEngine,
 };
 
 const DATA: &str = "arbitrary data to hash as a regression test";


### PR DESCRIPTION
Done as part of #4196. These are the easy ones, all the other missing things require knowing the length of the inner array I believe. Patch 2 is already tricky enough to warrant a PR.