### PR TITLE
Fix fuzz targets

### DIFF
--- a/fuzz/fuzz_targets/bitcoin/deserialize_psbt.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_psbt.rs
@@ -1,7 +1,6 @@
 use honggfuzz::fuzz;
 
-mod fuzz_utils;
-use fuzz_utils::consume_random_bytes;
+use bitcoin_fuzz::fuzz_utils::consume_random_bytes;
 
 fn do_test(data: &[u8]) {
     let mut new_data = data;

--- a/fuzz/fuzz_targets/bitcoin/deserialize_script.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_script.rs
@@ -4,8 +4,7 @@ use bitcoin::script::{self, ScriptExt as _};
 use bitcoin::{FeeRate, Network};
 use honggfuzz::fuzz;
 
-mod fuzz_utils;
-use fuzz_utils::{consume_random_bytes, consume_u64};
+use bitcoin_fuzz::fuzz_utils::{consume_random_bytes, consume_u64};
 
 fn do_test(data: &[u8]) {
     let mut new_data = data;

--- a/fuzz/src/fuzz_utils.rs
+++ b/fuzz/src/fuzz_utils.rs
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Helper functions for fuzzing.
+
 pub fn consume_random_bytes<'a>(data: &mut &'a [u8]) -> &'a [u8] {
     if data.is_empty() {
         return &[];

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! # Fuzzing
+
+pub mod fuzz_utils;


### PR DESCRIPTION
#4185 introduced a new file `fuzz/fuzz_targets/bitcoin/fuzz_utils.rs` which is not a valid fuzz target.  This causes the daily fuzz workflow to fail on `verify-execution`.

Move the module to the `src/` directory. Create a `lib.rs` file.