### PR TITLE
Add `fee_rate::serde` re-export

### DIFF
--- a/bitcoin/src/blockdata/mod.rs
+++ b/bitcoin/src/blockdata/mod.rs
@@ -23,6 +23,8 @@ pub use self::{
 pub mod fee_rate {
     /// Re-export everything from the [`units::fee_rate`] module.
     pub use units::fee_rate::FeeRate;
+    #[cfg(feature = "serde")]
+    pub use units::fee_rate::serde;
 }
 
 /// Provides absolute and relative locktimes.


### PR DESCRIPTION
When we added the `fee_rate::serde` module we forgot to re-export it. This is needed so downstream can do specify serde attributes on struct fields.

```rust
    #[serde(with = "bitcoin::fee_rate::serde::as_sat_per_kwu")]
    rate: FeeRate,
```