### PR TITLE
docs: Update README to replace use of mutagen with cargo-mutants

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Unit and integration tests are available for those interested, along with benchm
 developers, especially new contributors looking for something to work on, we do:
 
 - Fuzz testing with [`Hongfuzz`](https://github.com/rust-fuzz/honggfuzz-rs)
-- Mutation testing with [`Mutagen`](https://github.com/llogiq/mutagen)
+- Mutation testing with [`cargo-mutants`](https://github.com/sourcefrog/cargo-mutants)
 - Code verification with [`Kani`](https://github.com/model-checking/kani)
 
 There are always more tests to write and more bugs to find, contributions to our testing efforts
@@ -167,9 +167,9 @@ bench marks use: `RUSTFLAGS='--cfg=bench' cargo +nightly bench`.
 
 ### Mutation tests
 
-We have started doing mutation testing with [mutagen](https://github.com/llogiq/mutagen). To run
-these tests first install the latest dev version with `cargo +nightly install --git https://github.com/llogiq/mutagen`
-then run with `RUSTFLAGS='--cfg=mutate' cargo +nightly mutagen`.
+We are doing mutation testing with [cargo-mutants](https://github.com/sourcefrog/cargo-mutants). To run
+these tests first install with `cargo install --locked cargo-mutants` then run with `cargo mutants --in-place --no-shuffle`.
+Note that running these mutation tests will take on the order of 10's of minutes.
 
 ### Code verification
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ alias build-docs='RUSTDOCFLAGS="--cfg docsrs" cargo +nightly rustdoc --features=
 Unit and integration tests are available for those interested, along with benchmarks. For project
 developers, especially new contributors looking for something to work on, we do:
 
-- Fuzz testing with [`Hongfuzz`](https://github.com/rust-fuzz/honggfuzz-rs)
+- Fuzz testing with [`Honggfuzz`](https://github.com/rust-fuzz/honggfuzz-rs)
 - Mutation testing with [`cargo-mutants`](https://github.com/sourcefrog/cargo-mutants)
 - Code verification with [`Kani`](https://github.com/model-checking/kani)
 

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -95,4 +95,4 @@ name = "io"
 required-features = ["std"]
 
 [lints.rust]
-unexpected_cfgs = { level = "deny", check-cfg = ['cfg(bench)', 'cfg(fuzzing)', 'cfg(kani)', 'cfg(mutate)'] }
+unexpected_cfgs = { level = "deny", check-cfg = ['cfg(bench)', 'cfg(fuzzing)', 'cfg(kani)'] }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -38,9 +38,6 @@ bincode = "1.3.1"
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
-[lints.rust]
-unexpected_cfgs = { level = "deny", check-cfg = ['cfg(mutate)'] }
-
 [lints.clippy]
 # Exclude lints we don't think are valuable.
 needless_question_mark = "allow" # https://github.com/rust-bitcoin/rust-bitcoin/pull/2134


### PR DESCRIPTION
Hey there!

I am just getting up to speed with the project and in following the README discovered that there are still references to the previous mutation testing tool `mutagen`. I updated the README to refer to the new tool, `cargo-mutation`.

I'm suggesting the user use the same command, `cargo mutants --in-place --no-shuffle`, as is run in the weekly CI workflow.

I noticed that there are still references to the old `mutate` attribute in the following files. I removed these as well as per [feedback](https://github.com/rust-bitcoin/rust-bitcoin/pull/4228#issuecomment-2709407253).

`primitives/Cargo.toml`:
```
[lints.rust]
unexpected_cfgs = { level = "deny", check-cfg = ['cfg(mutate)'] }
```

and 

`bitcoin/Cargo.toml`:
```
unexpected_cfgs = { level = "deny", check-cfg = ['cfg(bench)', 'cfg(fuzzing)', 'cfg(kani)', 'cfg(mutate)'] }
```

Update to PR: removed incorrect understanding of logic in PR description as per [feedback](https://github.com/rust-bitcoin/rust-bitcoin/pull/4228#issuecomment-2709408598) and removed `cfg(mutate)` from above 2 files.