### PR TITLE
feature: introduce MAX_BLOCK_SERIALIZED_SIZE to check limit

### DIFF
--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -52,6 +52,8 @@ pub const SUBSIDY_HALVING_INTERVAL: u32 = 210_000;
 pub const MAX_SCRIPTNUM_VALUE: u32 = 0x80000000; // 2^31
 /// Number of blocks needed for an output from a coinbase transaction to be spendable.
 pub const COINBASE_MATURITY: u32 = 100;
+/// The maximum allowed size for a serialized block, in bytes (only for buffer size limits)
+pub const MAX_BLOCK_SERIALIZED_SIZE: usize = 4_000_000;
 
 // This is the 65 byte (uncompressed) pubkey used as the one-and-only output of the genesis transaction.
 //


### PR DESCRIPTION
fad0d9ea2d1e807806fa141238e279fddea6ae99: add `MAX_BLOCK_SERIALIZED_SIZE` as constant, which also exists in [bitcoin-core](https://github.com/bitcoin/bitcoin/blob/59ff17e5af4e382cbe16f183767beef1bdcd9131/src/consensus/consensus.h#L13).

I originally thought it would be better to use this value for checking limit of push_bytes [here](https://github.com/rust-bitcoin/rust-bitcoin/blob/0870cd1660edd21739cc94075e4b3a1c7f1a7d15/bitcoin/src/blockdata/script/push_bytes.rs#L31), as it's the actual limit(`OP_PUSHDATA4` semantic says it could allow up to 4GB though). However, I'm not sure whether there might be need to push_bytes larger than `MAX_BLOCK_SERIALIZED_SIZE`, so just let developer use this constant to check the actual limit rather than enforcing it.