### PR TITLE
Introduce and use `test_hex_unwrap` macro in `internals`

### DIFF
--- a/base58/src/lib.rs
+++ b/base58/src/lib.rs
@@ -251,8 +251,7 @@ where
 #[cfg(test)]
 mod tests {
     use alloc::vec;
-
-    use hex::test_hex_unwrap as hex;
+    use hex::FromHex as _;
 
     use super::*;
 
@@ -281,7 +280,7 @@ mod tests {
         assert_eq!(&res, exp);
 
         // Addresses
-        let addr = hex!("00f8917303bfa8ef24f292e8fa1419b20460ba064d");
+        let addr = Vec::from_hex("00f8917303bfa8ef24f292e8fa1419b20460ba064d").unwrap();
         assert_eq!(&encode_check(&addr[..]), "1PfJpZsjreyVrqeoAfabrRwwjQyoSQMmHH");
     }
 
@@ -300,7 +299,7 @@ mod tests {
         // Addresses
         assert_eq!(
             decode_check("1PfJpZsjreyVrqeoAfabrRwwjQyoSQMmHH").ok(),
-            Some(hex!("00f8917303bfa8ef24f292e8fa1419b20460ba064d"))
+            Some(Vec::from_hex("00f8917303bfa8ef24f292e8fa1419b20460ba064d").unwrap())
         );
         // Non Base58 char.
         assert_eq!(decode("¢").unwrap_err(), InvalidCharacterError::new(194));

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -1019,7 +1019,7 @@ impl Common {
 
 #[cfg(test)]
 mod tests {
-    use hex::test_hex_unwrap as hex;
+    use hex_lit::hex;
     #[cfg(feature = "serde")]
     use internals::serde_round_trip;
 

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -503,7 +503,7 @@ impl std::error::Error for ValidationError {
 
 #[cfg(test)]
 mod tests {
-    use hex::test_hex_unwrap as hex;
+    use hex_lit::hex;
     use internals::ToU64 as _;
 
     use super::*;

--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -265,7 +265,7 @@ impl ChainHash {
 
 #[cfg(test)]
 mod test {
-    use hex::test_hex_unwrap as hex;
+    use hex_lit::hex;
 
     use super::*;
     use crate::consensus::encode::serialize;

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -1137,7 +1137,8 @@ mod sealed {
 
 #[cfg(test)]
 mod tests {
-    use hex::{test_hex_unwrap as hex, FromHex};
+    use hex::FromHex;
+    use hex_lit::hex;
     #[cfg(feature = "serde")]
     use internals::serde_round_trip;
     use units::parse;
@@ -1376,7 +1377,7 @@ mod tests {
         assert_eq!(tx.output.len(), 1);
 
         let reser = serialize(&tx);
-        assert_eq!(tx_bytes, reser);
+        assert_eq!(tx_bytes, *reser);
     }
 
     #[test]
@@ -1522,8 +1523,8 @@ mod tests {
 
     #[test]
     fn huge_witness() {
-        deserialize::<Transaction>(&hex!(include_str!("../../tests/data/huge_witness.hex").trim()))
-            .unwrap();
+        let hex = Vec::from_hex(include_str!("../../tests/data/huge_witness.hex").trim()).unwrap();
+        deserialize::<Transaction>(&hex).unwrap();
     }
 
     #[test]
@@ -1858,7 +1859,7 @@ mod tests {
         fn return_none(_outpoint: &OutPoint) -> Option<TxOut> { None }
 
         for (hx, expected, spent_fn, expected_none) in tx_hexes.iter() {
-            let tx_bytes = hex!(hx);
+            let tx_bytes = Vec::from_hex(hx).unwrap();
             let tx: Transaction = deserialize(&tx_bytes).unwrap();
             assert_eq!(tx.total_sigop_cost(spent_fn), *expected);
             assert_eq!(tx.total_sigop_cost(return_none), *expected_none);
@@ -2007,6 +2008,7 @@ mod benches {
 
     #[bench]
     pub fn bench_transaction_deserialize(bh: &mut Bencher) {
+        // hex_lit does not work in bench code for some reason. Perhaps criterion fixes this.
         let raw_tx = <Vec<u8> as hex::FromHex>::from_hex(SOME_TX).unwrap();
 
         bh.iter(|| {

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -1966,20 +1966,17 @@ mod tests {
 
 #[cfg(bench)]
 mod benches {
-    use hex::test_hex_unwrap as hex;
     use io::sink;
     use test::{black_box, Bencher};
 
     use super::*;
-    use crate::consensus::{deserialize, Encodable};
+    use crate::consensus::{encode, Encodable};
 
     const SOME_TX: &str = "0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000";
 
     #[bench]
     pub fn bench_transaction_size(bh: &mut Bencher) {
-        let raw_tx = hex!(SOME_TX);
-
-        let mut tx: Transaction = deserialize(&raw_tx).unwrap();
+        let mut tx: Transaction = encode::deserialize_hex(SOME_TX).unwrap();
 
         bh.iter(|| {
             black_box(black_box(&mut tx).total_size());
@@ -1988,10 +1985,8 @@ mod benches {
 
     #[bench]
     pub fn bench_transaction_serialize(bh: &mut Bencher) {
-        let raw_tx = hex!(SOME_TX);
-        let tx: Transaction = deserialize(&raw_tx).unwrap();
-
-        let mut data = Vec::with_capacity(raw_tx.len());
+        let tx: Transaction = encode::deserialize_hex(SOME_TX).unwrap();
+        let mut data = Vec::with_capacity(SOME_TX.len());
 
         bh.iter(|| {
             let result = tx.consensus_encode(&mut data);
@@ -2002,8 +1997,7 @@ mod benches {
 
     #[bench]
     pub fn bench_transaction_serialize_logic(bh: &mut Bencher) {
-        let raw_tx = hex!(SOME_TX);
-        let tx: Transaction = deserialize(&raw_tx).unwrap();
+        let tx: Transaction = encode::deserialize_hex(SOME_TX).unwrap();
 
         bh.iter(|| {
             let size = tx.consensus_encode(&mut sink());
@@ -2013,10 +2007,18 @@ mod benches {
 
     #[bench]
     pub fn bench_transaction_deserialize(bh: &mut Bencher) {
-        let raw_tx = hex!(SOME_TX);
+        let raw_tx = <Vec<u8> as hex::FromHex>::from_hex(SOME_TX).unwrap();
 
         bh.iter(|| {
-            let tx: Transaction = deserialize(&raw_tx).unwrap();
+            let tx: Transaction = encode::deserialize(&raw_tx).unwrap();
+            black_box(&tx);
+        });
+    }
+
+    #[bench]
+    pub fn bench_transaction_deserialize_hex(bh: &mut Bencher) {
+        bh.iter(|| {
+            let tx: Transaction = encode::deserialize_hex(SOME_TX).unwrap();
             black_box(&tx);
         });
     }

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -321,7 +321,7 @@ fn encode_cursor(bytes: &mut [u8], start_of_indices: usize, index: usize, value:
 
 #[cfg(test)]
 mod test {
-    use hex::test_hex_unwrap as hex;
+    use hex_lit::hex;
 
     use super::*;
     use crate::consensus::{deserialize, encode, serialize};
@@ -361,14 +361,14 @@ mod test {
 
     #[test]
     fn consensus_serialize() {
-        let el_0 = hex!("03d2e15674941bad4a996372cb87e1856d3652606d98562fe39c5e9e7e413f2105");
-        let el_1 = hex!("000000");
+        let el_0 = hex!("03d2e15674941bad4a996372cb87e1856d3652606d98562fe39c5e9e7e413f2105").to_vec();
+        let el_1 = hex!("000000").to_vec();
 
         let mut want_witness = Witness::default();
         want_witness.push(&el_0);
         want_witness.push(&el_1);
 
-        let vec = vec![el_0.clone(), el_1.clone()];
+        let vec = vec![el_0, el_1];
 
         // Puts a CompactSize at the front as well as one at the front of each element.
         let want_ser: Vec<u8> = encode::serialize(&vec);
@@ -392,8 +392,8 @@ mod test {
         // annex starting with 0x50 causes the branching logic.
         let annex = hex!("50");
 
-        let witness = Witness::from([&*tapscript, &control_block]);
-        let witness_annex = Witness::from([&*tapscript, &control_block, &annex]);
+        let witness = Witness::from([tapscript.as_slice(), &control_block]);
+        let witness_annex = Witness::from([tapscript.as_slice(), &control_block, &annex]);
 
         // With or without annex, the tapscript should be returned.
         assert_eq!(witness.tapscript(), Some(Script::from_bytes(&tapscript[..])));
@@ -408,8 +408,8 @@ mod test {
         // annex starting with 0x50 causes the branching logic.
         let annex = hex!("50");
 
-        let witness = Witness::from([&*tapscript, &control_block]);
-        let witness_annex = Witness::from([&*tapscript, &control_block, &annex]);
+        let witness = Witness::from([tapscript.as_slice(), &control_block]);
+        let witness_annex = Witness::from([tapscript.as_slice(), &control_block, &annex]);
 
         let expected_leaf_script =
             LeafScript { version: LeafVersion::TapScript, script: Script::from_bytes(&tapscript) };
@@ -425,8 +425,8 @@ mod test {
         // annex starting with 0x50 causes the branching logic.
         let annex = hex!("50");
 
-        let witness = Witness::from([&*signature]);
-        let witness_annex = Witness::from([&*signature, &annex]);
+        let witness = Witness::from([signature]);
+        let witness_annex = Witness::from([signature.as_slice(), &annex]);
 
         // With or without annex, no tapscript should be returned.
         assert_eq!(witness.tapscript(), None);
@@ -443,9 +443,9 @@ mod test {
         let annex = hex!("50");
         let signature = vec![0xff; 64];
 
-        let witness = Witness::from([&*tapscript, &control_block]);
-        let witness_annex = Witness::from([&*tapscript, &control_block, &annex]);
-        let witness_key_spend_annex = Witness::from([&*signature, &annex]);
+        let witness = Witness::from([tapscript.as_slice(), &control_block]);
+        let witness_annex = Witness::from([tapscript.as_slice(), &control_block, &annex]);
+        let witness_key_spend_annex = Witness::from([signature.as_slice(), &annex]);
 
         // With or without annex, the tapscript should be returned.
         assert_eq!(witness.taproot_control_block().unwrap(), expected_control_block);
@@ -461,8 +461,8 @@ mod test {
         // annex starting with 0x50 causes the branching logic.
         let annex = hex!("50");
 
-        let witness = Witness::from([&*tapscript, &control_block]);
-        let witness_annex = Witness::from([&*tapscript, &control_block, &annex]);
+        let witness = Witness::from([tapscript.as_slice(), &control_block]);
+        let witness_annex = Witness::from([tapscript.as_slice(), &control_block, &annex]);
 
         // With or without annex, the tapscript should be returned.
         assert_eq!(witness.taproot_annex(), None);
@@ -473,8 +473,8 @@ mod test {
         // annex starting with 0x50 causes the branching logic.
         let annex = hex!("50");
 
-        let witness = Witness::from([&*signature]);
-        let witness_annex = Witness::from([&*signature, &annex]);
+        let witness = Witness::from([signature]);
+        let witness_annex = Witness::from([signature.as_slice(), &annex]);
 
         // With or without annex, the tapscript should be returned.
         assert_eq!(witness.taproot_annex(), None);

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -1532,7 +1532,8 @@ impl<'a> Arbitrary<'a> for TapSighashType {
 #[cfg(test)]
 mod tests {
     use hashes::HashEngine;
-    use hex::{test_hex_unwrap as hex, FromHex};
+    use hex::FromHex;
+    use hex_lit::hex;
 
     use super::*;
     use crate::consensus::deserialize;

--- a/bitcoin/src/merkle_tree/block.rs
+++ b/bitcoin/src/merkle_tree/block.rs
@@ -519,7 +519,8 @@ mod tests {
     use crate::block::{BlockUncheckedExt as _, Unchecked};
     use crate::consensus::encode;
     use crate::hash_types::Txid;
-    use crate::hex::{test_hex_unwrap as hex, DisplayHex, FromHex};
+    use hex::{DisplayHex, FromHex};
+    use hex_lit::hex;
 
     #[cfg(feature = "rand-std")]
     macro_rules! pmt_tests {
@@ -649,7 +650,8 @@ mod tests {
         // `gettxoutproof '["220ebc64e21abece964927322cba69180ed853bb187fbc6923bac7d010b9d87a"]'`
         let mb_hex = include_str!("../../tests/data/merkle_block.hex");
 
-        let mb: MerkleBlock = encode::deserialize(&hex!(mb_hex)).unwrap();
+        let bytes = Vec::from_hex(mb_hex).unwrap();
+        let mb: MerkleBlock = encode::deserialize(&bytes).unwrap();
         assert_eq!(get_block_13b8a().block_hash(), mb.header.block_hash());
         assert_eq!(
             mb.header.merkle_root,

--- a/bitcoin/src/p2p/address.rs
+++ b/bitcoin/src/p2p/address.rs
@@ -301,7 +301,8 @@ impl ToSocketAddrs for AddrV2Message {
 mod test {
     use std::net::IpAddr;
 
-    use hex::{test_hex_unwrap as hex, FromHex};
+    use hex::FromHex;
+    use hex_lit::hex;
 
     use super::*;
     use crate::consensus::encode::{deserialize, serialize};
@@ -422,7 +423,7 @@ mod test {
         let ip = AddrV2::Cjdns("fc01:1:2:3:4:5:6:7".parse::<Ipv6Addr>().unwrap());
         assert_eq!(serialize(&ip), hex!("0610fc010001000200030004000500060007"));
 
-        let ip = AddrV2::Unknown(170, hex!("01020304"));
+        let ip = AddrV2::Unknown(170, hex!("01020304").to_vec());
         assert_eq!(serialize(&ip), hex!("aa0401020304"));
     }
 
@@ -517,7 +518,7 @@ mod test {
 
         // Unknown, with reasonable length.
         let ip: AddrV2 = deserialize(&hex!("aa0401020304")).unwrap();
-        assert_eq!(ip, AddrV2::Unknown(170, hex!("01020304")));
+        assert_eq!(ip, AddrV2::Unknown(170, hex!("01020304").to_vec()));
 
         // Unknown, with zero length.
         let ip: AddrV2 = deserialize(&hex!("aa00")).unwrap();
@@ -536,7 +537,7 @@ mod test {
                     services: ServiceFlags::NETWORK,
                     time: 0x4966bc61,
                     port: 8333,
-                    addr: AddrV2::Unknown(153, hex!("abab"))
+                    addr: AddrV2::Unknown(153, hex!("abab").to_vec())
                 },
                 AddrV2Message {
                     services: ServiceFlags::NETWORK_LIMITED

--- a/bitcoin/src/p2p/message.rs
+++ b/bitcoin/src/p2p/message.rs
@@ -697,7 +697,7 @@ impl Decodable for V2NetworkMessage {
 mod test {
     use std::net::Ipv4Addr;
 
-    use hex::test_hex_unwrap as hex;
+    use hex_lit::hex;
     use units::BlockHeight;
 
     use super::*;
@@ -769,7 +769,7 @@ mod test {
             NetworkMessage::Pong(23),
             NetworkMessage::MerkleBlock(merkle_block),
             NetworkMessage::FilterLoad(FilterLoad {
-                filter: hex!("03614e9b050000000000000001"),
+                filter: hex!("03614e9b050000000000000001").to_vec(),
                 hash_funcs: 1,
                 tweak: 2,
                 flags: BloomFlags::All,

--- a/bitcoin/src/p2p/message_blockdata.rs
+++ b/bitcoin/src/p2p/message_blockdata.rs
@@ -144,7 +144,7 @@ impl_consensus_encoding!(GetHeadersMessage, version, locator_hashes, stop_hash);
 
 #[cfg(test)]
 mod tests {
-    use hex::test_hex_unwrap as hex;
+    use hex_lit::hex;
 
     use super::*;
     use crate::consensus::encode::{deserialize, serialize};

--- a/bitcoin/src/p2p/message_network.rs
+++ b/bitcoin/src/p2p/message_network.rs
@@ -148,7 +148,7 @@ impl_consensus_encoding!(Reject, message, ccode, reason, hash);
 
 #[cfg(test)]
 mod tests {
-    use hex::test_hex_unwrap as hex;
+    use hex_lit::hex;
 
     use super::*;
     use crate::consensus::encode::{deserialize, serialize};

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -1285,7 +1285,8 @@ pub use self::display_from_str::PsbtParseError;
 #[cfg(test)]
 mod tests {
     use hashes::{hash160, ripemd160, sha256};
-    use hex::{test_hex_unwrap as hex, FromHex};
+    use hex::FromHex;
+    use hex_lit::hex;
     #[cfg(feature = "rand-std")]
     use {
         crate::address::script_pubkey::ScriptBufExt as _,
@@ -1772,8 +1773,8 @@ mod tests {
                                     script_sig: ScriptBuf::from_hex("160014be18d152a9b012039daf3da7de4f53349eecb985").unwrap(),
                                     sequence: Sequence::MAX,
                                     witness: Witness::from_slice(&[
-                                        hex!("304402202712be22e0270f394f568311dc7ca9a68970b8025fdd3b240229f07f8a5f3a240220018b38d7dcd314e734c9276bd6fb40f673325bc4baa144c800d2f2f02db2765c01"),
-                                        hex!("03d2e15674941bad4a996372cb87e1856d3652606d98562fe39c5e9e7e413f2105"),
+                                        hex!("304402202712be22e0270f394f568311dc7ca9a68970b8025fdd3b240229f07f8a5f3a240220018b38d7dcd314e734c9276bd6fb40f673325bc4baa144c800d2f2f02db2765c01").as_slice(),
+                                        hex!("03d2e15674941bad4a996372cb87e1856d3652606d98562fe39c5e9e7e413f2105").as_slice(),
                                     ]),
                                 },
                                 TxIn {
@@ -1784,8 +1785,8 @@ mod tests {
                                     script_sig: ScriptBuf::from_hex("160014fe3e9ef1a745e974d902c4355943abcb34bd5353").unwrap(),
                                     sequence: Sequence::MAX,
                                     witness: Witness::from_slice(&[
-                                        hex!("3045022100d12b852d85dcd961d2f5f4ab660654df6eedcc794c0c33ce5cc309ffb5fce58d022067338a8e0e1725c197fb1a88af59f51e44e4255b20167c8684031c05d1f2592a01"),
-                                        hex!("0223b72beef0965d10be0778efecd61fcac6f79a4ea169393380734464f84f2ab3"),
+                                        hex!("3045022100d12b852d85dcd961d2f5f4ab660654df6eedcc794c0c33ce5cc309ffb5fce58d022067338a8e0e1725c197fb1a88af59f51e44e4255b20167c8684031c05d1f2592a01").as_slice(),
+                                        hex!("0223b72beef0965d10be0778efecd61fcac6f79a4ea169393380734464f84f2ab3").as_slice(),
                                     ]),
                                 }
                             ],
@@ -1935,8 +1936,8 @@ mod tests {
 
             let mut unknown: BTreeMap<raw::Key, Vec<u8>> = BTreeMap::new();
             let key: raw::Key =
-                raw::Key { type_value: 0x0fu64, key_data: hex!("010203040506070809") };
-            let value: Vec<u8> = hex!("0102030405060708090a0b0c0d0e0f");
+                raw::Key { type_value: 0x0fu64, key_data: hex!("010203040506070809").to_vec() };
+            let value = hex!("0102030405060708090a0b0c0d0e0f").to_vec();
 
             unknown.insert(key, value);
 
@@ -2105,8 +2106,8 @@ mod tests {
                                 script_sig: ScriptBuf::from_hex("160014be18d152a9b012039daf3da7de4f53349eecb985").unwrap(),
                                 sequence: Sequence::MAX,
                                 witness: Witness::from_slice(&[
-                                    hex!("304402202712be22e0270f394f568311dc7ca9a68970b8025fdd3b240229f07f8a5f3a240220018b38d7dcd314e734c9276bd6fb40f673325bc4baa144c800d2f2f02db2765c01"),
-                                    hex!("03d2e15674941bad4a996372cb87e1856d3652606d98562fe39c5e9e7e413f2105"),
+                                    hex!("304402202712be22e0270f394f568311dc7ca9a68970b8025fdd3b240229f07f8a5f3a240220018b38d7dcd314e734c9276bd6fb40f673325bc4baa144c800d2f2f02db2765c01").as_slice(),
+                                    hex!("03d2e15674941bad4a996372cb87e1856d3652606d98562fe39c5e9e7e413f2105").as_slice(),
                                 ]),
                             },
                             TxIn {
@@ -2117,8 +2118,8 @@ mod tests {
                                 script_sig: ScriptBuf::from_hex("160014fe3e9ef1a745e974d902c4355943abcb34bd5353").unwrap(),
                                 sequence: Sequence::MAX,
                                 witness: Witness::from_slice(&[
-                                    hex!("3045022100d12b852d85dcd961d2f5f4ab660654df6eedcc794c0c33ce5cc309ffb5fce58d022067338a8e0e1725c197fb1a88af59f51e44e4255b20167c8684031c05d1f2592a01"),
-                                    hex!("0223b72beef0965d10be0778efecd61fcac6f79a4ea169393380734464f84f2ab3"),
+                                    hex!("3045022100d12b852d85dcd961d2f5f4ab660654df6eedcc794c0c33ce5cc309ffb5fce58d022067338a8e0e1725c197fb1a88af59f51e44e4255b20167c8684031c05d1f2592a01").as_slice(),
+                                    hex!("0223b72beef0965d10be0778efecd61fcac6f79a4ea169393380734464f84f2ab3").as_slice(),
                                 ]),
                             }
                         ],


### PR DESCRIPTION
We have the `hex_lit` dependency for converting a hex string literal to an array.

Currently we have a `test_hex_unwrap` macro in the `hex v0.3.0` release but not on either `master`
or the upcoming `v1.0.0-alpha.0` release. This is making PRs around releasing and depending on the
release more noisy than required.

Introduce a `test_hex_unwrap` macro in internals for usage when the input is not a string literal.

Use `hex_lit::hex` where possible (often needing an additional call to
