### PR TITLE
units: Improve code enforcing privacy boundry

### DIFF
--- a/units/src/amount/signed.rs
+++ b/units/src/amount/signed.rs
@@ -57,14 +57,6 @@ mod encapsulate {
         /// The minimum value of an amount.
         pub const MIN: Self = Self(-21_000_000 * 100_000_000);
 
-        /// Constructs a new [`SignedAmount`] with satoshi precision and the given number of satoshis.
-        ///
-        /// Accepts an `i32` which is guaranteed to be in range for the type, but which can only
-        /// represent roughly -21.47 to 21.47 BTC.
-        pub const fn from_sat_i32(satoshi: i32) -> Self {
-            Self(satoshi as i64) // cannot use i64::from in a constfn
-        }
-
         /// Gets the number of satoshis in this [`SignedAmount`].
         ///
         /// # Examples
@@ -115,6 +107,18 @@ impl SignedAmount {
     pub const FIFTY_BTC: Self = Self::from_btc_i16(50);
     /// The maximum value allowed as an amount. Useful for sanity checking.
     pub const MAX_MONEY: Self = Self::MAX;
+
+    /// Constructs a new [`SignedAmount`] with satoshi precision and the given number of satoshis.
+    ///
+    /// Accepts an `i32` which is guaranteed to be in range for the type, but which can only
+    /// represent roughly -21.47 to 21.47 BTC.
+    pub const fn from_sat_i32(satoshi: i32) -> Self {
+        let sats = satoshi as i64; // cannot use i64::from in a constfn
+        match Self::from_sat(sats) {
+            Ok(amount) => amount,
+            Err(_) => panic!("unreachable - 32,767 BTC is within range"),
+        }
+    }
 
     /// Converts from a value expressing a decimal number of bitcoin to a [`SignedAmount`].
     ///

--- a/units/src/amount/signed.rs
+++ b/units/src/amount/signed.rs
@@ -152,7 +152,7 @@ impl SignedAmount {
 
         match Self::from_sat(sats) {
             Ok(amount) => amount,
-            Err(_) => panic!("unreachable - 65536 BTC is within range"),
+            Err(_) => panic!("unreachable - 32,767 BTC is within range"),
         }
     }
 

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -152,7 +152,7 @@ impl Amount {
 
         match Self::from_sat(sats) {
             Ok(amount) => amount,
-            Err(_) => panic!("unreachable - 65536 BTC is within range"),
+            Err(_) => panic!("unreachable - 65,535 BTC is within range"),
         }
     }
 

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -57,14 +57,6 @@ mod encapsulate {
         /// The minimum value of an amount.
         pub const MIN: Self = Self(0);
 
-        /// Constructs a new [`Amount`] with satoshi precision and the given number of satoshis.
-        ///
-        /// Accepts an `u32` which is guaranteed to be in range for the type, but which can only
-        /// represent roughly 0 to 42.95 BTC.
-        pub const fn from_sat_u32(satoshi: u32) -> Self {
-            Self(satoshi as u64) // cannot use u64::from in a constfn
-        }
-
         /// Gets the number of satoshis in this [`Amount`].
         ///
         /// # Examples
@@ -115,6 +107,18 @@ impl Amount {
     pub const MAX_MONEY: Self = Self::MAX;
     /// The number of bytes that an amount contributes to the size of a transaction.
     pub const SIZE: usize = 8; // Serialized length of a u64.
+
+    /// Constructs a new [`Amount`] with satoshi precision and the given number of satoshis.
+    ///
+    /// Accepts an `u32` which is guaranteed to be in range for the type, but which can only
+    /// represent roughly 0 to 42.95 BTC.
+    pub const fn from_sat_u32(satoshi: u32) -> Self {
+        let sats = satoshi as u64; // cannot use i64::from in a constfn
+        match Self::from_sat(sats) {
+            Ok(amount) => amount,
+            Err(_) => panic!("unreachable - 65,536 BTC is within range"),
+        }
+    }
 
     /// Converts from a value expressing a decimal number of bitcoin to an [`Amount`].
     ///


### PR DESCRIPTION
This is a follow up to #4256 - onwards and upwards!

- Patch 1: Fix the incorrect BTC value in panic message
- Patch 2: Strictly adhere to the sanity rules (#4090)

 Close: #4140