### PR TITLE
Implement `Display` for `block::Header`

### DIFF
--- a/bitcoin/src/bip152.rs
+++ b/bitcoin/src/bip152.rs
@@ -413,8 +413,8 @@ mod test {
     use crate::merkle_tree::TxMerkleNode;
     use crate::transaction::OutPointExt;
     use crate::{
-        transaction, Amount, BlockChecked, BlockTime, CompactTarget, OutPoint, ScriptBuf, Sequence,
-        TxIn, TxOut, Txid, Witness,
+        transaction, Amount, BlockChecked, BlockTime, CompactTarget, Nonce, OutPoint, ScriptBuf,
+        Sequence, TxIn, TxOut, Txid, Witness,
     };
 
     fn dummy_tx(nonce: &[u8]) -> Transaction {
@@ -439,7 +439,7 @@ mod test {
             merkle_root: TxMerkleNode::from_byte_array([0x77; 32]),
             time: BlockTime::from_u32(2),
             bits: CompactTarget::from_consensus(3),
-            nonce: 4,
+            nonce: Nonce::from_u32(4),
         };
         let transactions = vec![dummy_tx(&[2]), dummy_tx(&[3]), dummy_tx(&[4])];
         Block::new_unchecked(header, transactions).assume_checked(None)

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -13,7 +13,7 @@ use core::fmt;
 use hashes::{sha256d, HashEngine};
 use internals::{compact_size, ToU64};
 use io::{BufRead, Write};
-use units::BlockTime;
+use units::{BlockTime, Nonce};
 
 use super::Weight;
 use crate::consensus::encode::WriteExt as _;
@@ -71,6 +71,18 @@ crate::internal_macros::define_extension_trait! {
 
         /// Returns the total work of the block.
         fn work(&self) -> Work { self.target().to_work() }
+    }
+}
+
+impl Encodable for Nonce {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        self.to_u32().consensus_encode(w)
+    }
+}
+
+impl Decodable for Nonce {
+    fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        Decodable::consensus_decode(r).map(Nonce::from_u32)
     }
 }
 
@@ -611,7 +623,7 @@ mod tests {
         assert_eq!(serialize(&real_decode.header().merkle_root), merkle);
         assert_eq!(real_decode.header().time, BlockTime::from_u32(1231965655));
         assert_eq!(real_decode.header().bits, CompactTarget::from_consensus(486604799));
-        assert_eq!(real_decode.header().nonce, 2067413810);
+        assert_eq!(real_decode.header().nonce, Nonce::from_u32(2067413810));
         assert_eq!(real_decode.header().work(), work);
 
         assert_eq!(real_decode.header().difficulty(&params), 1);
@@ -662,7 +674,7 @@ mod tests {
         );
         assert_eq!(real_decode.header().time, BlockTime::from_u32(1472004949));
         assert_eq!(real_decode.header().bits, CompactTarget::from_consensus(0x1a06d450));
-        assert_eq!(real_decode.header().nonce, 1879759182);
+        assert_eq!(real_decode.header().nonce, Nonce::from_u32(1879759182));
         assert_eq!(real_decode.header().work(), work);
         assert_eq!(real_decode.header().difficulty(&params), 2456598);
         assert_eq!(real_decode.header().difficulty_float(&params), 2456598.4399242126);

--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -16,7 +16,7 @@ use crate::opcodes::all::*;
 use crate::pow::CompactTarget;
 use crate::transaction::{self, OutPoint, Transaction, TxIn, TxOut};
 use crate::witness::Witness;
-use crate::{script, Amount, BlockHash, BlockTime, Sequence, TestnetVersion};
+use crate::{script, Amount, BlockHash, BlockTime, Nonce, Sequence, TestnetVersion};
 
 /// How many seconds between blocks we expect on average.
 pub const TARGET_BLOCK_SPACING: u32 = 600;
@@ -136,7 +136,7 @@ pub fn genesis_block(params: impl AsRef<Params>) -> Block<Checked> {
                 merkle_root,
                 time: BlockTime::from_u32(1231006505),
                 bits: CompactTarget::from_consensus(0x1d00ffff),
-                nonce: 2083236893,
+                nonce: Nonce::from_u32(2083236893),
             },
             transactions,
         )
@@ -148,7 +148,7 @@ pub fn genesis_block(params: impl AsRef<Params>) -> Block<Checked> {
                 merkle_root,
                 time: BlockTime::from_u32(1296688602),
                 bits: CompactTarget::from_consensus(0x1d00ffff),
-                nonce: 414098458,
+                nonce: Nonce::from_u32(414098458),
             },
             transactions,
         )
@@ -160,7 +160,7 @@ pub fn genesis_block(params: impl AsRef<Params>) -> Block<Checked> {
                 merkle_root,
                 time: BlockTime::from_u32(1714777860),
                 bits: CompactTarget::from_consensus(0x1d00ffff),
-                nonce: 393743547,
+                nonce: Nonce::from_u32(393743547),
             },
             transactions,
         )
@@ -172,7 +172,7 @@ pub fn genesis_block(params: impl AsRef<Params>) -> Block<Checked> {
                 merkle_root,
                 time: BlockTime::from_u32(1598918400),
                 bits: CompactTarget::from_consensus(0x1e0377ae),
-                nonce: 52613770,
+                nonce: Nonce::from_u32(52613770),
             },
             transactions,
         )
@@ -184,7 +184,7 @@ pub fn genesis_block(params: impl AsRef<Params>) -> Block<Checked> {
                 merkle_root,
                 time: BlockTime::from_u32(1296688602),
                 bits: CompactTarget::from_consensus(0x207fffff),
-                nonce: 2,
+                nonce: Nonce::from_u32(2),
             },
             transactions,
         )
@@ -324,7 +324,7 @@ mod test {
 
         assert_eq!(gen.header().time, BlockTime::from_u32(1231006505));
         assert_eq!(gen.header().bits, CompactTarget::from_consensus(0x1d00ffff));
-        assert_eq!(gen.header().nonce, 2083236893);
+        assert_eq!(gen.header().nonce, Nonce::from_u32(2083236893));
         assert_eq!(
             gen.header().block_hash().to_string(),
             "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
@@ -342,7 +342,7 @@ mod test {
         );
         assert_eq!(gen.header().time, BlockTime::from_u32(1296688602));
         assert_eq!(gen.header().bits, CompactTarget::from_consensus(0x1d00ffff));
-        assert_eq!(gen.header().nonce, 414098458);
+        assert_eq!(gen.header().nonce, Nonce::from_u32(414098458));
         assert_eq!(
             gen.header().block_hash().to_string(),
             "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"
@@ -360,7 +360,7 @@ mod test {
         );
         assert_eq!(gen.header().time, BlockTime::from_u32(1598918400));
         assert_eq!(gen.header().bits, CompactTarget::from_consensus(0x1e0377ae));
-        assert_eq!(gen.header().nonce, 52613770);
+        assert_eq!(gen.header().nonce, Nonce::from_u32(52613770));
         assert_eq!(
             gen.header().block_hash().to_string(),
             "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6"

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -14,8 +14,8 @@ use crate::prelude::Vec;
 #[cfg(doc)]
 use crate::script::ScriptExt as _;
 use crate::taproot::{
-    self, ControlBlock, LeafScript, LeafVersion, TAPROOT_ANNEX_PREFIX, TAPROOT_CONTROL_BASE_SIZE,
-    TAPROOT_LEAF_MASK, TaprootMerkleBranch,
+    self, ControlBlock, LeafScript, LeafVersion, TaprootMerkleBranch, TAPROOT_ANNEX_PREFIX,
+    TAPROOT_CONTROL_BASE_SIZE, TAPROOT_LEAF_MASK,
 };
 use crate::Script;
 

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -135,6 +135,7 @@ pub use units::{
     amount::{Amount, Denomination, SignedAmount},
     block::{BlockHeight, BlockInterval},
     fee_rate::FeeRate,
+    nonce::{self, Nonce},
     time::{self, BlockTime},
     weight::Weight,
 };

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -1078,7 +1078,7 @@ pub mod test_utils {
 mod tests {
     use super::*;
     use crate::pow::test_utils::{u128_to_work, u32_to_target, u64_to_target};
-    use crate::BlockTime;
+    use crate::{BlockTime, Nonce};
 
     impl U256 {
         fn bit_at(&self, index: usize) -> bool {
@@ -1787,7 +1787,7 @@ mod tests {
             merkle_root: TxMerkleNode::from_byte_array([0; 32]),
             time: BlockTime::from_u32(1599332844),
             bits: starting_bits,
-            nonce: 0,
+            nonce: Nonce::from_u32(0),
         };
 
         // Block 4031, the only information used are `bits` and `time`
@@ -1797,7 +1797,7 @@ mod tests {
             merkle_root: TxMerkleNode::from_byte_array([0; 32]),
             time: BlockTime::from_u32(1600591200),
             bits: starting_bits,
-            nonce: 0,
+            nonce: Nonce::from_u32(0),
         };
         let adjustment =
             CompactTarget::from_header_difficulty_adjustment(epoch_start, current, params);

--- a/bitcoin/src/taproot/merkle_branch/borrowed.rs
+++ b/bitcoin/src/taproot/merkle_branch/borrowed.rs
@@ -1,9 +1,12 @@
 use core::borrow::{Borrow, BorrowMut};
+
 use internals::slice::SliceExt;
-
-use super::{DecodeError, InvalidMerkleBranchSizeError, InvalidMerkleTreeDepthError, TaprootMerkleBranchBuf, TapNodeHash, TAPROOT_CONTROL_MAX_NODE_COUNT, TAPROOT_CONTROL_NODE_SIZE};
-
 pub use privacy_boundary::TaprootMerkleBranch;
+
+use super::{
+    DecodeError, InvalidMerkleBranchSizeError, InvalidMerkleTreeDepthError, TapNodeHash,
+    TaprootMerkleBranchBuf, TAPROOT_CONTROL_MAX_NODE_COUNT, TAPROOT_CONTROL_NODE_SIZE,
+};
 
 /// Makes sure only the allowed conversions are accessible to external code.
 mod privacy_boundary {
@@ -24,24 +27,18 @@ mod privacy_boundary {
         pub fn as_mut_slice(&mut self) -> &mut [TapNodeHash] { &mut self.0 }
 
         pub(super) const fn from_hashes_unchecked(hashes: &[TapNodeHash]) -> &Self {
-            unsafe {
-                &*(hashes as *const _ as *const Self)
-            }
+            unsafe { &*(hashes as *const _ as *const Self) }
         }
 
         pub(super) fn from_mut_hashes_unchecked(hashes: &mut [TapNodeHash]) -> &mut Self {
-            unsafe {
-                &mut *(hashes as *mut _ as *mut Self)
-            }
+            unsafe { &mut *(hashes as *mut _ as *mut Self) }
         }
     }
 }
 
 impl TaprootMerkleBranch {
     /// Returns an empty branch.
-    pub const fn new() -> &'static Self {
-        Self::from_hashes_unchecked(&[])
-    }
+    pub const fn new() -> &'static Self { Self::from_hashes_unchecked(&[]) }
 
     /// Returns the number of nodes in this Merkle proof.
     #[inline]
@@ -97,7 +94,9 @@ impl TaprootMerkleBranch {
     /// Decodes a byte slice that is statically known to be multiple of 32.
     ///
     /// This can be used as a building block for other ways of decoding.
-    fn decode_exact(nodes: &[[u8; TAPROOT_CONTROL_NODE_SIZE]]) -> Result<&Self, InvalidMerkleTreeDepthError> {
+    fn decode_exact(
+        nodes: &[[u8; TAPROOT_CONTROL_NODE_SIZE]],
+    ) -> Result<&Self, InvalidMerkleTreeDepthError> {
         // SAFETY:
         // The lifetime of the returned reference is the same as the lifetime of the input
         // reference, the size of `TapNodeHash` is equal to `TAPROOT_CONTROL_NODE_SIZE` and the
@@ -105,7 +104,7 @@ impl TaprootMerkleBranch {
         Self::from_hashes(unsafe { &*(nodes as *const _ as *const [TapNodeHash]) })
     }
 
-    fn from_hashes(nodes: &[TapNodeHash]) -> Result<&Self, InvalidMerkleTreeDepthError>{
+    fn from_hashes(nodes: &[TapNodeHash]) -> Result<&Self, InvalidMerkleTreeDepthError> {
         if nodes.len() <= TAPROOT_CONTROL_MAX_NODE_COUNT {
             Ok(Self::from_hashes_unchecked(nodes))
         } else {
@@ -115,21 +114,15 @@ impl TaprootMerkleBranch {
 }
 
 impl Default for &'_ TaprootMerkleBranch {
-    fn default() -> Self {
-        TaprootMerkleBranch::new()
-    }
+    fn default() -> Self { TaprootMerkleBranch::new() }
 }
 
 impl AsRef<TaprootMerkleBranch> for TaprootMerkleBranch {
-    fn as_ref(&self) -> &TaprootMerkleBranch {
-        self
-    }
+    fn as_ref(&self) -> &TaprootMerkleBranch { self }
 }
 
 impl AsMut<TaprootMerkleBranch> for TaprootMerkleBranch {
-    fn as_mut(&mut self) -> &mut TaprootMerkleBranch {
-        self
-    }
+    fn as_mut(&mut self) -> &mut TaprootMerkleBranch { self }
 }
 
 impl AsRef<TaprootMerkleBranch> for TaprootMerkleBranchBuf {
@@ -254,18 +247,14 @@ impl alloc::borrow::ToOwned for TaprootMerkleBranch {
     // `Cow`.
     type Owned = TaprootMerkleBranchBuf;
 
-    fn to_owned(&self) -> Self::Owned {
-        self.into()
-    }
+    fn to_owned(&self) -> Self::Owned { self.into() }
 }
 
 impl<'a> IntoIterator for &'a TaprootMerkleBranch {
     type IntoIter = core::slice::Iter<'a, TapNodeHash>;
     type Item = &'a TapNodeHash;
 
-    fn into_iter(self) -> Self::IntoIter {
-        self.as_slice().iter()
-    }
+    fn into_iter(self) -> Self::IntoIter { self.as_slice().iter() }
 }
 
 impl<'a> IntoIterator for &'a mut TaprootMerkleBranch {
@@ -280,7 +269,10 @@ impl<'a> IntoIterator for &'a mut TaprootMerkleBranch {
 mod tests {
     #[test]
     fn alignment() {
-        assert!(core::mem::align_of_val(super::TaprootMerkleBranch::new()) == core::mem::align_of::<u8>());
+        assert!(
+            core::mem::align_of_val(super::TaprootMerkleBranch::new())
+                == core::mem::align_of::<u8>()
+        );
     }
 
     const _: () = {

--- a/bitcoin/src/taproot/merkle_branch/buf.rs
+++ b/bitcoin/src/taproot/merkle_branch/buf.rs
@@ -86,7 +86,10 @@ impl TaprootMerkleBranchBuf {
     }
 
     /// Appends elements to proof.
-    pub(in super::super) fn push(&mut self, h: TapNodeHash) -> Result<(), InvalidMerkleTreeDepthError> {
+    pub(in super::super) fn push(
+        &mut self,
+        h: TapNodeHash,
+    ) -> Result<(), InvalidMerkleTreeDepthError> {
         if self.len() >= TAPROOT_CONTROL_MAX_NODE_COUNT {
             Err(InvalidMerkleTreeDepthError(self.0.len()))
         } else {
@@ -213,9 +216,7 @@ impl BorrowMut<[TapNodeHash]> for TaprootMerkleBranchBuf {
 }
 
 impl<'a> From<&'a TaprootMerkleBranch> for TaprootMerkleBranchBuf {
-    fn from(value: &'a TaprootMerkleBranch) -> Self {
-        Self(value.as_slice().into())
-    }
+    fn from(value: &'a TaprootMerkleBranch) -> Self { Self(value.as_slice().into()) }
 }
 
 /// Iterator over node hashes within Taproot Merkle branch.

--- a/bitcoin/src/taproot/merkle_branch/mod.rs
+++ b/bitcoin/src/taproot/merkle_branch/mod.rs
@@ -1,12 +1,13 @@
 //! Contains `TaprootMerkleBranchBuf` and its associated types.
 
-mod buf;
 mod borrowed;
-
-pub use buf::TaprootMerkleBranchBuf;
-pub use borrowed::TaprootMerkleBranch;
+mod buf;
 
 use core::fmt;
+
+pub use borrowed::TaprootMerkleBranch;
+pub use buf::TaprootMerkleBranchBuf;
+
 use super::{
     InvalidMerkleBranchSizeError, InvalidMerkleTreeDepthError, TapNodeHash, TaprootError,
     TAPROOT_CONTROL_MAX_NODE_COUNT, TAPROOT_CONTROL_NODE_SIZE,
@@ -28,27 +29,30 @@ pub struct DecodeError {
 }
 
 impl From<InvalidMerkleBranchSizeError> for DecodeError {
-    fn from(value: InvalidMerkleBranchSizeError) -> Self {
-        Self {
-            num_bytes: value.0,
-        }
-    }
+    fn from(value: InvalidMerkleBranchSizeError) -> Self { Self { num_bytes: value.0 } }
 }
 
 impl From<InvalidMerkleTreeDepthError> for DecodeError {
     fn from(value: InvalidMerkleTreeDepthError) -> Self {
-        Self {
-            num_bytes: value.0 * TAPROOT_CONTROL_NODE_SIZE,
-        }
+        Self { num_bytes: value.0 * TAPROOT_CONTROL_NODE_SIZE }
     }
 }
 
 impl fmt::Display for DecodeError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.num_bytes % TAPROOT_CONTROL_NODE_SIZE == 0 {
-            write!(f, "the Merkle branch has {} nodes which is more than the limit {}", self.num_bytes / TAPROOT_CONTROL_NODE_SIZE, TAPROOT_CONTROL_MAX_NODE_COUNT)
+            write!(
+                f,
+                "the Merkle branch has {} nodes which is more than the limit {}",
+                self.num_bytes / TAPROOT_CONTROL_NODE_SIZE,
+                TAPROOT_CONTROL_MAX_NODE_COUNT
+            )
         } else {
-            write!(f, "the Merkle branch is {} bytes long which is not an integer multiple of {}", self.num_bytes, TAPROOT_CONTROL_NODE_SIZE)
+            write!(
+                f,
+                "the Merkle branch is {} bytes long which is not an integer multiple of {}",
+                self.num_bytes, TAPROOT_CONTROL_NODE_SIZE
+            )
         }
     }
 }

--- a/bitcoin/src/taproot/mod.rs
+++ b/bitcoin/src/taproot/mod.rs
@@ -27,9 +27,9 @@ use crate::{Script, ScriptBuf};
 #[doc(inline)]
 pub use crate::crypto::taproot::{SigFromSliceError, Signature};
 #[doc(inline)]
-pub use merkle_branch::TaprootMerkleBranchBuf;
-#[doc(inline)]
 pub use merkle_branch::TaprootMerkleBranch;
+#[doc(inline)]
+pub use merkle_branch::TaprootMerkleBranchBuf;
 
 type ControlBlockArrayVec = internals::array_vec::ArrayVec<u8, TAPROOT_CONTROL_MAX_SIZE>;
 
@@ -1137,7 +1137,10 @@ impl<'leaf> ScriptLeaf<'leaf> {
 /// Control block data structure used in Tapscript satisfaction.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct ControlBlock<Branch = TaprootMerkleBranchBuf> where Branch: ?Sized {
+pub struct ControlBlock<Branch = TaprootMerkleBranchBuf>
+where
+    Branch: ?Sized,
+{
     /// The tapleaf version.
     pub leaf_version: LeafVersion,
     /// The parity of the output key (NOT THE INTERNAL KEY WHICH IS ALWAYS XONLY).
@@ -1204,7 +1207,8 @@ impl<Branch: AsRef<TaprootMerkleBranch> + ?Sized> ControlBlock<Branch> {
         self.encode_inner(|bytes| -> Result<(), core::convert::Infallible> {
             result.extend_from_slice(bytes);
             Ok(())
-        }).unwrap_or_else(|never| match never {});
+        })
+        .unwrap_or_else(|never| match never {});
         result
     }
 

--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -14,7 +14,7 @@ use core::marker::PhantomData;
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
 use hashes::{sha256d, HashEngine as _};
-use units::BlockTime;
+use units::{BlockTime, Nonce};
 
 use crate::merkle_tree::TxMerkleNode;
 #[cfg(feature = "alloc")]
@@ -184,7 +184,7 @@ pub struct Header {
     /// The target value below which the blockhash must lie.
     pub bits: CompactTarget,
     /// The nonce, selected to obtain a low enough blockhash.
-    pub nonce: u32,
+    pub nonce: Nonce,
 }
 
 impl Header {
@@ -201,7 +201,7 @@ impl Header {
         engine.input(self.merkle_root.as_byte_array());
         engine.input(&self.time.to_u32().to_le_bytes());
         engine.input(&self.bits.to_consensus().to_le_bytes());
-        engine.input(&self.nonce.to_le_bytes());
+        engine.input(&self.nonce.to_u32().to_le_bytes());
 
         BlockHash::from_byte_array(sha256d::Hash::from_engine(engine).to_byte_array())
     }
@@ -368,7 +368,7 @@ mod tests {
             merkle_root: TxMerkleNode::from_byte_array([0x77; 32]),
             time: BlockTime::from(2),
             bits: CompactTarget::from_consensus(3),
-            nonce: 4,
+            nonce: Nonce::from(4),
         }
     }
 
@@ -424,7 +424,7 @@ mod tests {
             + header.merkle_root.as_byte_array().len()
             + header.time.to_u32().to_le_bytes().len()
             + header.bits.to_consensus().to_le_bytes().len()
-            + header.nonce.to_le_bytes().len();
+            + header.nonce.to_u32().to_le_bytes().len();
 
         assert_eq!(header_size, Header::SIZE);
     }

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -52,6 +52,7 @@ pub use units::{
     amount::{self, Amount, SignedAmount},
     block::{BlockHeight, BlockInterval},
     fee_rate::{self, FeeRate},
+    nonce::{self, Nonce},
     time::{self, BlockTime},
     weight::{self, Weight},
 };

--- a/primitives/src/locktime/relative.rs
+++ b/primitives/src/locktime/relative.rs
@@ -486,7 +486,7 @@ mod tests {
 
     #[test]
     fn from_seconds_ceil_and_floor() {
-        let time = 70*512+1;
+        let time = 70 * 512 + 1;
         let lock_by_time = LockTime::from_seconds_ceil(time).unwrap();
         assert_eq!(lock_by_time, LockTime::from_512_second_intervals(71));
 
@@ -494,7 +494,7 @@ mod tests {
         assert_eq!(lock_by_time, LockTime::from_512_second_intervals(70));
 
         let mut max_time = 0xffff * 512;
-        assert_eq!(LockTime::from_seconds_ceil(max_time),LockTime::from_seconds_floor(max_time));
+        assert_eq!(LockTime::from_seconds_ceil(max_time), LockTime::from_seconds_floor(max_time));
         max_time += 512;
         assert!(LockTime::from_seconds_ceil(max_time).is_err());
         assert!(LockTime::from_seconds_floor(max_time).is_err());

--- a/units/src/lib.rs
+++ b/units/src/lib.rs
@@ -33,6 +33,7 @@ pub mod amount;
 pub mod block;
 pub mod fee_rate;
 pub mod locktime;
+pub mod nonce;
 pub mod parse;
 pub mod time;
 pub mod weight;
@@ -43,6 +44,7 @@ pub use self::{
     amount::{Amount, SignedAmount},
     block::{BlockHeight, BlockInterval},
     fee_rate::FeeRate,
+    nonce::Nonce,
     time::BlockTime,
     weight::Weight
 };

--- a/units/src/nonce.rs
+++ b/units/src/nonce.rs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! An unsigned 32 bit nonce value.
+
+#[cfg(feature = "arbitrary")]
+use arbitrary::{Arbitrary, Unstructured};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+/// The bitcoin block nonce.
+///
+/// Traditionally the block header nonce was modified by miners to change the block hash while
+/// searching for a valid block.
+///
+/// Any `u32` value is valid, no invariant implied or otherwise.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct Nonce(u32);
+
+impl Nonce {
+    /// Constructs a new [`Nonce`] from an unsigned 32 bit integer value.
+    #[inline]
+    pub const fn from_u32(t: u32) -> Self { Nonce(t) }
+
+    /// Returns the inner `u32` value.
+    #[inline]
+    pub const fn to_u32(self) -> u32 { self.0 }
+}
+
+impl From<u32> for Nonce {
+    #[inline]
+    fn from(t: u32) -> Self { Self::from_u32(t) }
+}
+
+impl From<Nonce> for u32 {
+    #[inline]
+    fn from(t: Nonce) -> Self { t.to_u32() }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> Arbitrary<'a> for Nonce {
+    #[inline]
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let t: u32 = u.arbitrary()?;
+        Ok(Nonce::from(t))
+    }
+}


### PR DESCRIPTION
- Patch 1: Run the formatter
- Patch 2: Add a `block::Nonce` type (thin wrapper)
- Patch 3: Implement `Display` for `Header`

Please note that patch 3 makes a bunch of changes/improvements to `fmt` implementations for the `Header` fields. 

Close: #3658