### PR TITLE
Implement `Display` for  `Header`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -111,6 +111,7 @@ name = "bitcoin-primitives"
 version = "0.101.0"
 dependencies = [
  "arbitrary",
+ "arrayvec",
  "bincode",
  "bitcoin-internals",
  "bitcoin-units",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -110,6 +110,7 @@ name = "bitcoin-primitives"
 version = "0.101.0"
 dependencies = [
  "arbitrary",
+ "arrayvec",
  "bincode",
  "bitcoin-internals",
  "bitcoin-units",

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["tests", "contrib"]
 
 [features]
 default = ["std", "hex"]
-std = ["alloc", "hashes/std", "hex?/std", "internals/std", "units/std"]
+std = ["alloc", "hashes/std", "hex?/std", "internals/std", "units/std", "arrayvec/std"]
 alloc = ["hashes/alloc", "hex?/alloc", "internals/alloc", "units/alloc"]
 serde = ["dep:serde", "hashes/serde", "hex?/serde", "internals/serde", "units/serde", "alloc", "hex"]
 arbitrary = ["dep:arbitrary", "units/arbitrary"]
@@ -26,6 +26,7 @@ hex = ["dep:hex", "hashes/hex", "internals/hex"]
 hashes = { package = "bitcoin_hashes", path = "../hashes", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals" }
 units = { package = "bitcoin-units", path = "../units", default-features = false }
+arrayvec = { version = "0.7", default-features = false }
 
 arbitrary = { version = "1.4", optional = true }
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false, optional = true }


### PR DESCRIPTION
Not all the fields within `block::Header` implement `Display` however a block header can reasonably be displayed by using 160 hex characters.

Implement `Display` for `block::Header` by printing the header in hex in the same layout as we hash it in `block_hash`.

Close: #3658