### PR TITLE
feat: add max size of push bytes error

### DIFF
--- a/bitcoin/src/blockdata/script/push_bytes.rs
+++ b/bitcoin/src/blockdata/script/push_bytes.rs
@@ -31,7 +31,7 @@ mod primitive {
         if len < 0x100000000 {
             Ok(())
         } else {
-            Err(PushBytesError { len })
+            Err(PushBytesError { len, max: 0x100000000 })
         }
     }
 
@@ -439,6 +439,8 @@ mod error {
     pub struct PushBytesError {
         /// How long the input was.
         pub(super) len: usize,
+        /// How long the input can be.
+        pub(super) max: usize,
     }
 
     impl super::PushBytesErrorReport for PushBytesError {


### PR DESCRIPTION
Related issue: https://github.com/rust-bitcoin/rust-bitcoin/issues/3530
While the issue talks about adding new constant to know the max limit of push bytes, I'm not sure whether it's important enough to have the constant for, as 2^32 is just the maximum able to express with `OP_PUSHDATA4`(https://bitcoin.stackexchange.com/questions/43693/pushdata4-unnecessary), but not able to be included in block as block size limit is much smaller.
However, I do agree with that API is unclear to know the limit in case of fail, so add it in error message.