### PR TITLE
Make code style consistent and fix naming in macro Array implementations

### DIFF
--- a/bitcoin/src/taproot/merkle_branch/buf.rs
+++ b/bitcoin/src/taproot/merkle_branch/buf.rs
@@ -126,7 +126,7 @@ impl_try_from!(&[TapNodeHash]);
 impl_try_from!(Vec<TapNodeHash>);
 impl_try_from!(Box<[TapNodeHash]>);
 
-macro_rules! impl_try_from_array {
+macro_rules! impl_from_array {
     ($($len:expr),* $(,)?) => {
         $(
             impl From<[TapNodeHash; $len]> for TaprootMerkleBranchBuf {
@@ -142,7 +142,7 @@ macro_rules! impl_try_from_array {
 //
 // The reason zero is included is that `TaprootMerkleBranchBuf` doesn't contain the hash of the node
 // that's being proven - it's not needed because the script is already right before control block.
-impl_try_from_array!(
+impl_from_array!(
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
     26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
     50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73,


### PR DESCRIPTION
This PR makes two main changes:

1. Standardizes the function signatures in the `Amount` and `SignedAmount` implementations by consistently using `Self` as the return type instead of the concrete type names. This improves code consistency, maintainability, and follows Rust's idiomatic practices.
2. Renames `impl_try_from_array` to `impl_from_array` to better reflect its functionality.

### Changes
**Consistent usage of Self instead of concrete types**

- Replace all occurrences of `-> Amount` with `-> Self `in unsigned.rs
- Replace all occurrences of `-> SignedAmount` with `-> Self` in signed.rs
- Make similar replacements for Option/Result return types
- Use `Self::` instead of explicit type name for static method calls

**Function rename**

Renamed `impl_try_from_array` to `impl_from_array` for better clarity

### Related Issues

Closes #4210

Closes #4241