### PR TITLE
primitives: Make hex optional

### DIFF
--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -15,19 +15,20 @@ rust-version = "1.63.0"
 exclude = ["tests", "contrib"]
 
 [features]
-default = ["std"]
-std = ["alloc", "hashes/std", "hex/std", "internals/std", "units/std"]
-alloc = ["hashes/alloc", "hex/alloc", "internals/alloc", "units/alloc"]
-serde = ["dep:serde", "hashes/serde", "internals/serde", "units/serde", "alloc"]
+default = ["std", "hex"]
+std = ["alloc", "hashes/std", "hex?/std", "internals/std", "units/std"]
+alloc = ["hashes/alloc", "hex?/alloc", "internals/alloc", "units/alloc"]
+serde = ["dep:serde", "hashes/serde", "internals/serde", "units/serde", "alloc", "hex"]
 arbitrary = ["dep:arbitrary", "units/arbitrary"]
+hex = ["dep:hex", "internals/hex", "hashes/hex"]
 
 [dependencies]
-hashes = { package = "bitcoin_hashes", version = "0.16.0", default-features = false, features = ["hex"] }
-hex = { package = "hex-conservative", version = "0.3.0", default-features = false }
-internals = { package = "bitcoin-internals", version = "0.4.0", features = ["hex"] }
+hashes = { package = "bitcoin_hashes", version = "0.16.0", default-features = false, features = [] }
+internals = { package = "bitcoin-internals", version = "0.4.0", features = [] }
 units = { package = "bitcoin-units", version = "0.2.0", default-features = false }
 
 arbitrary = { version = "1.4", optional = true }
+hex = { package = "hex-conservative", version = "0.3.0", default-features = false, optional = true }
 serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"], optional = true }
 
 [dev-dependencies]

--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -310,7 +310,10 @@ hashes::hash_newtype! {
     pub struct WitnessCommitment(sha256d::Hash);
 }
 
+#[cfg(feature = "hex")]
 hashes::impl_hex_for_newtype!(BlockHash, WitnessCommitment);
+#[cfg(not(feature = "hex"))]
+hashes::impl_debug_only_for_newtype!(BlockHash, WitnessCommitment);
 #[cfg(feature = "serde")]
 hashes::impl_serde_for_newtype!(BlockHash, WitnessCommitment);
 

--- a/primitives/src/merkle_tree.rs
+++ b/primitives/src/merkle_tree.rs
@@ -11,6 +11,9 @@ hashes::hash_newtype! {
     pub struct WitnessMerkleNode(sha256d::Hash);
 }
 
+#[cfg(feature = "hex")]
 hashes::impl_hex_for_newtype!(TxMerkleNode, WitnessMerkleNode);
+#[cfg(not(feature = "hex"))]
+hashes::impl_debug_only_for_newtype!(TxMerkleNode, WitnessMerkleNode);
 #[cfg(feature = "serde")]
 hashes::impl_serde_for_newtype!(TxMerkleNode, WitnessMerkleNode);

--- a/primitives/src/script/mod.rs
+++ b/primitives/src/script/mod.rs
@@ -10,6 +10,7 @@ use core::convert::Infallible;
 use core::fmt;
 
 use hashes::{hash160, sha256};
+#[cfg(feature = "hex")]
 use hex::DisplayHex;
 use internals::script::{self, PushDataLenLen};
 
@@ -49,7 +50,10 @@ hashes::hash_newtype! {
     pub struct WScriptHash(sha256::Hash);
 }
 
+#[cfg(feature = "hex")]
 hashes::impl_hex_for_newtype!(ScriptHash, WScriptHash);
+#[cfg(not(feature = "hex"))]
+hashes::impl_debug_only_for_newtype!(ScriptHash, WScriptHash);
 #[cfg(feature = "serde")]
 hashes::impl_serde_for_newtype!(ScriptHash, WScriptHash);
 
@@ -439,6 +443,7 @@ impl fmt::Display for ScriptBuf {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(self.as_script(), f) }
 }
 
+#[cfg(feature = "hex")]
 impl fmt::LowerHex for Script {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -446,15 +451,19 @@ impl fmt::LowerHex for Script {
     }
 }
 #[cfg(feature = "alloc")]
+#[cfg(feature = "hex")]
 internals::impl_to_hex_from_lower_hex!(Script, |script: &Self| script.len() * 2);
 
+#[cfg(feature = "hex")]
 impl fmt::LowerHex for ScriptBuf {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(self.as_script(), f) }
 }
 #[cfg(feature = "alloc")]
+#[cfg(feature = "hex")]
 internals::impl_to_hex_from_lower_hex!(ScriptBuf, |script_buf: &Self| script_buf.len() * 2);
 
+#[cfg(feature = "hex")]
 impl fmt::UpperHex for Script {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -462,6 +471,7 @@ impl fmt::UpperHex for Script {
     }
 }
 
+#[cfg(feature = "hex")]
 impl fmt::UpperHex for ScriptBuf {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::UpperHex::fmt(self.as_script(), f) }

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -389,6 +389,7 @@ impl OutPoint {
     pub const COINBASE_PREVOUT: Self = Self { txid: Txid::COINBASE_PREVOUT, vout: u32::MAX };
 }
 
+#[cfg(feature = "hex")]
 impl fmt::Display for OutPoint {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -500,7 +501,10 @@ hashes::hash_newtype! {
     pub struct Wtxid(sha256d::Hash);
 }
 
+#[cfg(feature = "hex")]
 hashes::impl_hex_for_newtype!(Txid, Wtxid);
+#[cfg(not(feature = "hex"))]
+hashes::impl_debug_only_for_newtype!(Txid, Wtxid);
 #[cfg(feature = "serde")]
 hashes::impl_serde_for_newtype!(Txid, Wtxid);
 


### PR DESCRIPTION
Make the `hex` dependency optional. This means not implementing `Display` for some types if `hex` is not enabled and only implementing `Debug`.

Note: this is Tobin's commit edited by Martin Habovstiak. The edits are fixes to depend on `hex?/` rather than `hex/`.

Rationale for this approach: this increases compile time and possibly even binary size but the other solutions are worse: turning it into a runtime check (based on serializer being human readable or not) can cause surprising errors and using
`all(feature = "serde, feature = "hex")` everywhere is tedious and hard to understand.

Alternative to #4262