### PR TITLE
`Witness` api improvements and test cleanups

### DIFF
--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -387,14 +387,8 @@ mod test {
         // annex starting with 0x50 causes the branching logic.
         let annex = hex!("50");
 
-        let witness_vec = vec![tapscript.clone(), control_block.clone()];
-        let witness_vec_annex = vec![tapscript.clone(), control_block, annex];
-
-        let witness_serialized: Vec<u8> = serialize(&witness_vec);
-        let witness_serialized_annex: Vec<u8> = serialize(&witness_vec_annex);
-
-        let witness = deserialize::<Witness>(&witness_serialized[..]).unwrap();
-        let witness_annex = deserialize::<Witness>(&witness_serialized_annex[..]).unwrap();
+        let witness = Witness::from([&*tapscript, &control_block]);
+        let witness_annex = Witness::from([&*tapscript, &control_block, &annex]);
 
         // With or without annex, the tapscript should be returned.
         assert_eq!(witness.tapscript(), Some(Script::from_bytes(&tapscript[..])));
@@ -409,14 +403,8 @@ mod test {
         // annex starting with 0x50 causes the branching logic.
         let annex = hex!("50");
 
-        let witness_vec = vec![tapscript.clone(), control_block.clone()];
-        let witness_vec_annex = vec![tapscript.clone(), control_block, annex];
-
-        let witness_serialized: Vec<u8> = serialize(&witness_vec);
-        let witness_serialized_annex: Vec<u8> = serialize(&witness_vec_annex);
-
-        let witness = deserialize::<Witness>(&witness_serialized[..]).unwrap();
-        let witness_annex = deserialize::<Witness>(&witness_serialized_annex[..]).unwrap();
+        let witness = Witness::from([&*tapscript, &control_block]);
+        let witness_annex = Witness::from([&*tapscript, &control_block, &annex]);
 
         let expected_leaf_script =
             LeafScript { version: LeafVersion::TapScript, script: Script::from_bytes(&tapscript) };
@@ -432,14 +420,8 @@ mod test {
         // annex starting with 0x50 causes the branching logic.
         let annex = hex!("50");
 
-        let witness_vec = vec![signature.clone()];
-        let witness_vec_annex = vec![signature.clone(), annex];
-
-        let witness_serialized: Vec<u8> = serialize(&witness_vec);
-        let witness_serialized_annex: Vec<u8> = serialize(&witness_vec_annex);
-
-        let witness = deserialize::<Witness>(&witness_serialized[..]).unwrap();
-        let witness_annex = deserialize::<Witness>(&witness_serialized_annex[..]).unwrap();
+        let witness = Witness::from([&*signature]);
+        let witness_annex = Witness::from([&*signature, &annex]);
 
         // With or without annex, no tapscript should be returned.
         assert_eq!(witness.tapscript(), None);
@@ -454,18 +436,9 @@ mod test {
         let annex = hex!("50");
         let signature = vec![0xff; 64];
 
-        let witness_vec = vec![tapscript.clone(), control_block.clone()];
-        let witness_vec_annex = vec![tapscript.clone(), control_block.clone(), annex.clone()];
-        let witness_vec_key_spend_annex = vec![signature, annex];
-
-        let witness_serialized: Vec<u8> = serialize(&witness_vec);
-        let witness_serialized_annex: Vec<u8> = serialize(&witness_vec_annex);
-        let witness_serialized_key_spend_annex: Vec<u8> = serialize(&witness_vec_key_spend_annex);
-
-        let witness = deserialize::<Witness>(&witness_serialized[..]).unwrap();
-        let witness_annex = deserialize::<Witness>(&witness_serialized_annex[..]).unwrap();
-        let witness_key_spend_annex =
-            deserialize::<Witness>(&witness_serialized_key_spend_annex[..]).unwrap();
+        let witness = Witness::from([&*tapscript, &control_block]);
+        let witness_annex = Witness::from([&*tapscript, &control_block, &annex]);
+        let witness_key_spend_annex = Witness::from([&*signature, &annex]);
 
         // With or without annex, the tapscript should be returned.
         assert_eq!(witness.taproot_control_block(), Some(&control_block[..]));
@@ -480,14 +453,8 @@ mod test {
         // annex starting with 0x50 causes the branching logic.
         let annex = hex!("50");
 
-        let witness_vec = vec![tapscript.clone(), control_block.clone()];
-        let witness_vec_annex = vec![tapscript.clone(), control_block.clone(), annex.clone()];
-
-        let witness_serialized: Vec<u8> = serialize(&witness_vec);
-        let witness_serialized_annex: Vec<u8> = serialize(&witness_vec_annex);
-
-        let witness = deserialize::<Witness>(&witness_serialized[..]).unwrap();
-        let witness_annex = deserialize::<Witness>(&witness_serialized_annex[..]).unwrap();
+        let witness = Witness::from([&*tapscript, &control_block]);
+        let witness_annex = Witness::from([&*tapscript, &control_block, &annex]);
 
         // With or without annex, the tapscript should be returned.
         assert_eq!(witness.taproot_annex(), None);
@@ -498,14 +465,8 @@ mod test {
         // annex starting with 0x50 causes the branching logic.
         let annex = hex!("50");
 
-        let witness_vec = vec![signature.clone()];
-        let witness_vec_annex = vec![signature.clone(), annex.clone()];
-
-        let witness_serialized: Vec<u8> = serialize(&witness_vec);
-        let witness_serialized_annex: Vec<u8> = serialize(&witness_vec_annex);
-
-        let witness = deserialize::<Witness>(&witness_serialized[..]).unwrap();
-        let witness_annex = deserialize::<Witness>(&witness_serialized_annex[..]).unwrap();
+        let witness = Witness::from([&*signature]);
+        let witness_annex = Witness::from([&*signature, &annex]);
 
         // With or without annex, the tapscript should be returned.
         assert_eq!(witness.taproot_annex(), None);

--- a/primitives/src/witness.rs
+++ b/primitives/src/witness.rs
@@ -581,11 +581,7 @@ mod test {
 
     // A witness with a single element that is empty (zero length).
     fn single_empty_element() -> Witness {
-        // The first is 0 serialized as a compact size integer.
-        // The last four bytes represent start at index 0.
-        let content = [0_u8; 5];
-
-        Witness { witness_elements: 1, content: content.to_vec(), indices_start: 1 }
+        Witness::from([[0u8; 0]])
     }
 
     #[test]
@@ -620,13 +616,7 @@ mod test {
         witness.push(push);
         assert!(!witness.is_empty());
 
-        let elements = [1u8, 11];
-        let expected = Witness {
-            witness_elements: 1,
-            content: append_u32_vec(&elements, &[0]), // Start at index 0.
-            indices_start: elements.len(),
-        };
-        assert_eq!(witness, expected);
+        assert_eq!(witness, [[11_u8]]);
 
         let element_0 = push.as_slice();
         assert_eq!(element_0, &witness[0]);
@@ -643,13 +633,7 @@ mod test {
         let push = [21u8, 22u8];
         witness.push(push);
 
-        let elements = [1u8, 11, 2, 21, 22];
-        let expected = Witness {
-            witness_elements: 2,
-            content: append_u32_vec(&elements, &[0, 2]),
-            indices_start: elements.len(),
-        };
-        assert_eq!(witness, expected);
+        assert_eq!(witness, [&[11_u8] as &[_], &[21, 22]]);
 
         let element_1 = push.as_slice();
         assert_eq!(element_1, &witness[1]);
@@ -666,13 +650,7 @@ mod test {
         let push = [31u8, 32u8];
         witness.push(push);
 
-        let elements = [1u8, 11, 2, 21, 22, 2, 31, 32];
-        let expected = Witness {
-            witness_elements: 3,
-            content: append_u32_vec(&elements, &[0, 2, 5]),
-            indices_start: elements.len(),
-        };
-        assert_eq!(witness, expected);
+        assert_eq!(witness, [&[11_u8] as &[_], &[21, 22], &[31, 32]]);
 
         let element_2 = push.as_slice();
         assert_eq!(element_2, &witness[2]);

--- a/primitives/src/witness.rs
+++ b/primitives/src/witness.rs
@@ -410,6 +410,46 @@ impl From<Vec<&[u8]>> for Witness {
     fn from(vec: Vec<&[u8]>) -> Self { Witness::from_slice(&vec) }
 }
 
+impl<const N: usize> From<[&[u8]; N]> for Witness {
+    #[inline]
+    fn from(arr: [&[u8]; N]) -> Self { Witness::from_slice(&arr) }
+}
+
+impl<const N: usize> From<&[&[u8]; N]> for Witness {
+    #[inline]
+    fn from(arr: &[&[u8]; N]) -> Self { Witness::from_slice(arr) }
+}
+
+impl<const N: usize> From<&[[u8; N]]> for Witness {
+    #[inline]
+    fn from(slice: &[[u8; N]]) -> Self { Witness::from_slice(slice) }
+}
+
+impl<const N: usize> From<&[&[u8; N]]> for Witness {
+    #[inline]
+    fn from(slice: &[&[u8; N]]) -> Self { Witness::from_slice(slice) }
+}
+
+impl<const N: usize, const M: usize> From<[[u8; M]; N]> for Witness {
+    #[inline]
+    fn from(slice: [[u8; M]; N]) -> Self { Witness::from_slice(&slice) }
+}
+
+impl<const N: usize, const M: usize> From<&[[u8; M]; N]> for Witness {
+    #[inline]
+    fn from(slice: &[[u8; M]; N]) -> Self { Witness::from_slice(slice) }
+}
+
+impl<const N: usize, const M: usize> From<[&[u8; M]; N]> for Witness {
+    #[inline]
+    fn from(slice: [&[u8; M]; N]) -> Self { Witness::from_slice(&slice) }
+}
+
+impl<const N: usize, const M: usize> From<&[&[u8; M]; N]> for Witness {
+    #[inline]
+    fn from(slice: &[&[u8; M]; N]) -> Self { Witness::from_slice(slice) }
+}
+
 impl Default for Witness {
     #[inline]
     fn default() -> Self { Self::new() }


### PR DESCRIPTION
This is supposed to go in front of #4250 

`Witness` lacked a bunch of APIs that were making it harder to use and test, so this also adds them in addition to cleaning up tests. (I only realized they are missing when I tried to clean up tests and got a bunch of errors.)