### PR TITLE
Use `path = [bala]` for `rust-bitcoin`'s workspace members dependencies. remove `[patch.crates-io.balab]` 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,26 +2,8 @@
 members = ["addresses", "base58", "bitcoin", "chacha20_poly1305", "fuzz", "hashes", "internals", "io", "primitives", "units"]
 resolver = "2"
 
-[patch.crates-io.bitcoin-addresses]
-path = "addresses"
-
-[patch.crates-io.base58ck]
-path = "base58"
-
-[patch.crates-io.bitcoin]
-path = "bitcoin"
-
+# Keep this patch for hashes because secp256k1 depends on bitcoin-hashes via crates.io
+# This allows testing changes to hashes with secp256k1
+# See https://github.com/rust-bitcoin/rust-bitcoin/pull/4284#pullrequestreview-2714442229
 [patch.crates-io.bitcoin_hashes]
 path = "hashes"
-
-[patch.crates-io.bitcoin-internals]
-path = "internals"
-
-[patch.crates-io.bitcoin-io]
-path = "io"
-
-[patch.crates-io.bitcoin-primitives]
-path = "primitives"
-
-[patch.crates-io.bitcoin-units]
-path = "units"

--- a/base58/Cargo.toml
+++ b/base58/Cargo.toml
@@ -18,8 +18,8 @@ std = ["alloc", "hashes/std", "internals/std"]
 alloc = ["hashes/alloc", "internals/alloc"]
 
 [dependencies]
-hashes = { package = "bitcoin_hashes", version = "0.16.0", default-features = false }
-internals = { package = "bitcoin-internals", version = "0.4.0" }
+hashes = { package = "bitcoin_hashes", path = "../hashes", default-features = false }
+internals = { package = "bitcoin-internals", path = "../internals" }
 
 [dev-dependencies]
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false, features = ["alloc"] }

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -25,15 +25,15 @@ secp-recovery = ["secp256k1/recovery"]
 arbitrary = ["dep:arbitrary", "units/arbitrary", "primitives/arbitrary"]
 
 [dependencies]
-base58 = { package = "base58ck", version = "0.2.0", default-features = false, features = ["alloc"] }
+base58 = { package = "base58ck", path = "../base58", default-features = false, features = ["alloc"] }
 bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
-hashes = { package = "bitcoin_hashes", version = "0.16.0", default-features = false, features = ["alloc", "hex"] }
+hashes = { package = "bitcoin_hashes", path = "../hashes", default-features = false, features = ["alloc", "hex"] }
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false, features = ["alloc"] }
-internals = { package = "bitcoin-internals", version = "0.4.0", features = ["alloc", "hex"] }
-io = { package = "bitcoin-io", version = "0.2.0", default-features = false, features = ["alloc", "hashes"] }
-primitives = { package = "bitcoin-primitives", version = "0.101.0", default-features = false, features = ["alloc"] }
+internals = { package = "bitcoin-internals", path = "../internals", features = ["alloc", "hex"] }
+io = { package = "bitcoin-io", path = "../io", default-features = false, features = ["alloc", "hashes"] }
+primitives = { package = "bitcoin-primitives", path = "../primitives", default-features = false, features = ["alloc"] }
 secp256k1 = { version = "0.30.0", default-features = false, features = ["hashes", "alloc", "rand"] }
-units = { package = "bitcoin-units", version = "0.2.0", default-features = false, features = ["alloc"] }
+units = { package = "bitcoin-units", path = "../units", default-features = false, features = ["alloc"] }
 
 arbitrary = { version = "1.4", optional = true }
 base64 = { version = "0.22.0", optional = true }
@@ -42,7 +42,7 @@ bitcoinconsensus = { version = "0.106.0", default-features = false, optional = t
 serde = { version = "1.0.103", default-features = false, features = [ "derive", "alloc" ], optional = true }
 
 [dev-dependencies]
-internals = { package = "bitcoin-internals", version = "0.4.0", features = ["test-serde"] }
+internals = { package = "bitcoin-internals", path = "../internals", features = ["test-serde"] }
 serde_json = "1.0.0"
 serde_test = "1.0.19"
 bincode = "1.3.1"

--- a/bitcoin/embedded/Cargo.toml
+++ b/bitcoin/embedded/Cargo.toml
@@ -27,20 +27,6 @@ codegen-units = 1 # better optimizations
 debug = true # symbols are nice and they don't increase the size on Flash
 lto = true # better optimizations
 
-[patch.crates-io.base58ck]
-path = "../../base58"
 
 [patch.crates-io.bitcoin_hashes]
 path = "../../hashes"
-
-[patch.crates-io.bitcoin-internals]
-path = "../../internals"
-
-[patch.crates-io.bitcoin-io]
-path = "../../io"
-
-[patch.crates-io.bitcoin-primitives]
-path = "../../primitives"
-
-[patch.crates-io.bitcoin-units]
-path = "../../units"

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -22,7 +22,7 @@ serde = ["dep:serde", "hex"]
 small-hash = []
 
 [dependencies]
-internals = { package = "bitcoin-internals", version = "0.4.0" }
+internals = { package = "bitcoin-internals", path = "../internals" }
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
 

--- a/hashes/embedded/Cargo.toml
+++ b/hashes/embedded/Cargo.toml
@@ -34,12 +34,3 @@ lto = true # better optimizations
 
 [patch.crates-io.bitcoin_hashes]
 path = "../../hashes"
-
-[patch.crates-io.bitcoin-internals]
-path = "../../internals"
-
-[patch.crates-io.bitcoin-io]
-path = "../../io"
-
-[patch.crates-io.bitcoin-units]
-path = "../../units"

--- a/io/Cargo.toml
+++ b/io/Cargo.toml
@@ -19,12 +19,12 @@ std = ["alloc", "hashes?/std"]
 alloc = ["hashes?/alloc"]
 
 [dependencies]
-internals = { package = "bitcoin-internals", version = "0.4.0" }
+internals = { package = "bitcoin-internals", path = "../internals" }
 
-hashes = { package = "bitcoin_hashes", version = "0.16.0", default-features = false, optional = true }
+hashes = { package = "bitcoin_hashes", path = "../hashes", default-features = false, optional = true }
 
 [dev-dependencies]
-hashes = { package = "bitcoin_hashes", version = "0.16.0", default-features = false, features = ["hex"] }
+hashes = { package = "bitcoin_hashes", path = "../hashes", default-features = false, features = ["hex"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -22,10 +22,10 @@ serde = ["dep:serde", "hashes/serde", "internals/serde", "units/serde", "alloc"]
 arbitrary = ["dep:arbitrary", "units/arbitrary"]
 
 [dependencies]
-hashes = { package = "bitcoin_hashes", version = "0.16.0", default-features = false, features = ["hex"] }
+hashes = { package = "bitcoin_hashes", path = "../hashes", default-features = false, features = ["hex"] }
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false }
-internals = { package = "bitcoin-internals", version = "0.4.0", features = ["hex"] }
-units = { package = "bitcoin-units", version = "0.2.0", default-features = false }
+internals = { package = "bitcoin-internals", path = "../internals", features = ["hex"] }
+units = { package = "bitcoin-units", path = "../units", default-features = false }
 
 arbitrary = { version = "1.4", optional = true }
 serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"], optional = true }

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -18,13 +18,13 @@ std = ["alloc", "internals/std"]
 alloc = ["internals/alloc","serde?/alloc"]
 
 [dependencies]
-internals = { package = "bitcoin-internals", version = "0.4.0" }
+internals = { package = "bitcoin-internals", path = "../internals" }
 
 serde = { version = "1.0.103", default-features = false, features = ["derive"], optional = true }
 arbitrary = { version = "1.4", optional = true }
 
 [dev-dependencies]
-internals = { package = "bitcoin-internals", version = "0.4.0", features = ["test-serde"] }
+internals = { package = "bitcoin-internals", path = "../internals", features = ["test-serde"] }
 bincode = "1.3.1"
 serde_test = "1.0"
 serde_json = "1.0"


### PR DESCRIPTION
This PR want to:

1. make all workspace members use `workspace = true` syntax to import dependencies.
2. use `path = [balabala]` to define dependencies, instead of useing `[patch.crates-io.balabala]` , fix: https://github.com/rust-bitcoin/rust-bitcoin/issues/4283
