### PR TITLE
chore: remove explicit into iteration

### DIFF
--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -206,7 +206,7 @@ impl Serialize for KeySource {
 
         rv.append(&mut self.0.to_byte_array().to_vec());
 
-        for cnum in self.1.into_iter() {
+        for cnum in &self.1 {
             rv.append(&mut serialize(&u32::from(*cnum)))
         }
 


### PR DESCRIPTION
```
warning: it is more concise to loop over containers instead of using explicit iteration methods
   --> bitcoin/src/psbt/serialize.rs:209:21
    |
209 |         for cnum in self.1.into_iter() {
    |                     ^^^^^^^^^^^^^^^^^^ help: to write this more concisely, try: `&self.1`
```