### PR TITLE
units: Kill mutants found in weekly mutation testing

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -21,6 +21,7 @@ exclude_re = [
     "Time::to_consensus_u32", # Mutant from replacing | with ^, this returns the same value since the XOR is taken against the u16 with an all-zero bitmask
     "FeeRate::fee_vb", # Deprecated
     "FeeRate::fee_wu", # Deprecated
+    "SignedAmount::checked_abs", # Deprecated
 
     # primitives
     "Sequence::from_512_second_intervals", # Mutant from replacing | with ^, this returns the same value since the XOR is taken against the u16 with an all-zero bitmask

--- a/units/src/amount/tests.rs
+++ b/units/src/amount/tests.rs
@@ -104,7 +104,12 @@ fn from_str_zero_without_denomination() {
 fn from_int_btc() {
     let amt = Amount::from_btc_u16(2);
     assert_eq!(sat(200_000_000), amt);
+    let amt = Amount::from_int_btc(2_u16);
+    assert_eq!(sat(200_000_000), amt);
+
     let amt = SignedAmount::from_btc_i16(-2);
+    assert_eq!(ssat(-200_000_000), amt);
+    let amt = SignedAmount::from_int_btc(-2_i16);
     assert_eq!(ssat(-200_000_000), amt);
 }
 

--- a/units/src/time.rs
+++ b/units/src/time.rs
@@ -56,3 +56,14 @@ impl<'a> Arbitrary<'a> for BlockTime {
         Ok(BlockTime::from(t))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn block_time_round_trip() {
+        let t = BlockTime::from(1_742_979_600); // 26 Mar 2025 9:00 UTC
+        assert_eq!(u32::from(t), 1_742_979_600);
+    }
+}


### PR DESCRIPTION
Weekly mutation testing found mutants in `Amount` and `BlockTime`.

Add a test to `BlockTime`.
Add two asserts to `Amount` tests.
Exclude deprecated function from mutation testing.

Closes #4225, #4243, #4278