### PR TITLE
fix err `P2WPKH` to `P2WSH` witness_version.rs

### DIFF
--- a/bitcoin/src/blockdata/script/witness_version.rs
+++ b/bitcoin/src/blockdata/script/witness_version.rs
@@ -28,7 +28,7 @@ use crate::script::Instruction;
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 #[repr(u8)]
 pub enum WitnessVersion {
-    /// Initial version of witness program. Used for P2WPKH and P2WPK outputs
+    /// Initial version of witness program. Used for P2WPKH and P2WSH outputs
     V0 = 0,
     /// Version of witness program used for Taproot P2TR outputs.
     V1 = 1,


### PR DESCRIPTION
The correction is important because “P2WPK” is not a valid name. In the BIP141 specifications, the correct terms are “P2WPKH” and “P2WSH”.
