### PR TITLE
chore: fix grammatical errors

### DIFF
--- a/base58/src/error.rs
+++ b/base58/src/error.rs
@@ -141,7 +141,7 @@ impl fmt::Display for TooShortError {
 #[cfg(feature = "std")]
 impl std::error::Error for TooShortError {}
 
-/// Found a invalid ASCII byte while decoding base58 string.
+/// Found an invalid ASCII byte while decoding base58 string.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InvalidCharacterError(pub(super) InvalidCharacterErrorInner);
 

--- a/bitcoin/CHANGELOG.md
+++ b/bitcoin/CHANGELOG.md
@@ -311,7 +311,7 @@ In particular consider having some type that implements `AsRef<Params>`, we have
   - Rename `ExtendedPubKey` to `Xpub` [#2019](https://github.com/rust-bitcoin/rust-bitcoin/pull/2019)
   - Rename `ExtendedPrivKey` to `Xpriv` [#2019](https://github.com/rust-bitcoin/rust-bitcoin/pull/2019)
   - Remove `_v0` from various function names (eg, `new_v0_p2wpkh`) [#1994](https://github.com/rust-bitcoin/rust-bitcoin/pull/1994)
-  - Remove `SighashCache::segwit_signature_hash` (add `p2wpkh_signiture_hash` and `p2wsh_signature_hash`) [#1995](https://github.com/rust-bitcoin/rust-bitcoin/pull/1995)
+  - Remove `SighashCache::segwit_signature_hash` (add `p2wpkh_signature_hash` and `p2wsh_signature_hash`) [#1995](https://github.com/rust-bitcoin/rust-bitcoin/pull/1995)
   - Reexport all the hash types from the crate root [#1998](https://github.com/rust-bitcoin/rust-bitcoin/pull/1998)
   - Rename `opcodes::All` to `Opcode` [#1995](https://github.com/rust-bitcoin/rust-bitcoin/pull/1995)
   - Removed `TxOut::default()`, the same logic now exists as `TxOut::NULL` [#1811](https://github.com/rust-bitcoin/rust-bitcoin/pull/1811) and [#1838](https://github.com/rust-bitcoin/rust-bitcoin/pull/1838)

--- a/units/src/amount/error.rs
+++ b/units/src/amount/error.rs
@@ -176,7 +176,7 @@ impl OutOfRangeError {
         }
     }
 
-    /// Returns true if the input value was large than the maximum allowed value.
+    /// Returns true if the input value was larger than the maximum allowed value.
     pub fn is_above_max(self) -> bool { self.is_greater_than_max }
 
     /// Returns true if the input value was smaller than the minimum allowed value.

--- a/units/src/fee_rate/mod.rs
+++ b/units/src/fee_rate/mod.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! Implements `FeeRate` and assoctiated features.
+//! Implements `FeeRate` and associated features.
 
 #[cfg(feature = "serde")]
 pub mod serde;

--- a/units/tests/api.rs
+++ b/units/tests/api.rs
@@ -2,7 +2,7 @@
 
 //! Test the API surface of `units`.
 //!
-//! The point of these tests are to check the API surface as opposed to test the API functionality.
+//! The point of these tests is to check the API surface as opposed to test the API functionality.
 //!
 //! ref: <https://rust-lang.github.io/api-guidelines/about.html>
 


### PR DESCRIPTION
base58/src/error.rs:

- Corrected grammar in error comment: "Found a invalid ASCII byte" → "Found an invalid ASCII byte".

bitcoin/CHANGELOG.md:

- Fixed typo in function name: p2wpkh_signiture_hash → p2wpkh_signature_hash.

units/src/amount/error.rs:

- Fixed grammar: "was large than" → "was larger than".

units/src/fee_rate/mod.rs:

- Corrected typo: "assoctiated" → "associated".

units/tests/api.rs:

- Grammar fix: "THE POINT of tests are" → "THE POINT of tests is".