### PR TITLE
chore: remove needless question mark

### DIFF
--- a/units/src/fee_rate/serde.rs
+++ b/units/src/fee_rate/serde.rs
@@ -108,9 +108,9 @@ pub mod as_sat_per_vb_floor {
 
     // Errors on overflow.
     pub fn deserialize<'d, D: Deserializer<'d>>(d: D) -> Result<FeeRate, D::Error> {
-        Ok(FeeRate::from_sat_per_vb(u64::deserialize(d)?)
+        FeeRate::from_sat_per_vb(u64::deserialize(d)?)
             .ok_or(OverflowError)
-            .map_err(serde::de::Error::custom)?)
+            .map_err(serde::de::Error::custom)
     }
 
     pub mod opt {
@@ -184,9 +184,9 @@ pub mod as_sat_per_vb_ceil {
 
     // Errors on overflow.
     pub fn deserialize<'d, D: Deserializer<'d>>(d: D) -> Result<FeeRate, D::Error> {
-        Ok(FeeRate::from_sat_per_vb(u64::deserialize(d)?)
+        FeeRate::from_sat_per_vb(u64::deserialize(d)?)
             .ok_or(OverflowError)
-            .map_err(serde::de::Error::custom)?)
+            .map_err(serde::de::Error::custom)
     }
 
     pub mod opt {

--- a/units/src/locktime/absolute.rs
+++ b/units/src/locktime/absolute.rs
@@ -111,7 +111,7 @@ impl<'de> serde::Deserialize<'de> for Height {
         D: serde::Deserializer<'de>,
     {
         let u = u32::deserialize(deserializer)?;
-        Ok(Height::from_consensus(u).map_err(serde::de::Error::custom)?)
+        Height::from_consensus(u).map_err(serde::de::Error::custom)
     }
 }
 
@@ -191,7 +191,7 @@ impl<'de> serde::Deserialize<'de> for Time {
         D: serde::Deserializer<'de>,
     {
         let u = u32::deserialize(deserializer)?;
-        Ok(Time::from_consensus(u).map_err(serde::de::Error::custom)?)
+        Time::from_consensus(u).map_err(serde::de::Error::custom)
     }
 }
 

--- a/units/src/parse.rs
+++ b/units/src/parse.rs
@@ -284,7 +284,7 @@ pub fn hex_check_unprefixed(s: &str) -> Result<&str, UnprefixedHexError> {
 /// If the input string is not a valid hex encoding of a `u32`.
 pub fn hex_u32(s: &str) -> Result<u32, ParseIntError> {
     let unchecked = hex_remove_optional_prefix(s);
-    Ok(hex_u32_unchecked(unchecked)?)
+    hex_u32_unchecked(unchecked)
 }
 
 /// Parses a `u32` from a prefixed hex string.
@@ -333,7 +333,7 @@ pub fn hex_u32_unchecked(s: &str) -> Result<u32, ParseIntError> {
 /// If the input string is not a valid hex encoding of a `u128`.
 pub fn hex_u128(s: &str) -> Result<u128, ParseIntError> {
     let unchecked = hex_remove_optional_prefix(s);
-    Ok(hex_u128_unchecked(unchecked)?)
+    hex_u128_unchecked(unchecked)
 }
 
 /// Parses a `u128` from a prefixed hex string.


### PR DESCRIPTION
There’s no reason to use ? to short-circuit when execution of the body will end there anyway.