### PR TITLE
chore: remove unused serde_json dep

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -149,7 +149,6 @@ dependencies = [
  "bitcoin-internals",
  "hex-conservative 0.3.0",
  "serde",
- "serde_json",
  "serde_test",
 ]
 

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -148,7 +148,6 @@ dependencies = [
  "bitcoin-internals",
  "hex-conservative 0.3.0",
  "serde",
- "serde_json",
  "serde_test",
 ]
 

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -28,7 +28,6 @@ serde = { version = "1.0", default-features = false, optional = true }
 
 [dev-dependencies]
 serde_test = "1.0"
-serde_json = "1.0"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
checked by [shear](https://github.com/boshen/cargo-shear)
```
bitcoin_hashes -- hashes/Cargo.toml:
  serde_json

Fixed 1 dependencies!
```

cargo +nightly build  in local env is ok, local cargo.lock  is ok(not include serde_json) so no need update cargo.lock
```
[[package]]
name = "bitcoin_hashes"
version = "0.16.0"
dependencies = [
 "bitcoin-internals",
 "hex-conservative 0.3.0",
 "serde",
 "serde_test",
]
```

but check CI seems need update 
`error: the lock file /home/runner/work/rust-bitcoin/rust-bitcoin/Cargo.lock needs to be updated but --locked was passed to prevent this
If you want to try to generate the lock file without accessing the network, remove the --locked flag and use --offline instead.`