### PR TITLE
Fix typo in transaction.rs

### DIFF
--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -1506,7 +1506,7 @@ mod tests {
             "SIGHASH_SINGLE| SIGHASH_ANYONECANPAY",
             "SIGHASH_ALL SIGHASH_ANYONECANPAY",
             "SIGHASH_NONE |",
-            "SIGHASH_SIGNLE",
+            "SIGHASH_SINGLE",
             "sighash_none",
             "Sighash_none",
             "SigHash_None",


### PR DESCRIPTION
This PR fixes a typo in the transaction.rs file where "SIGHASH_SIGNLE" was incorrectly spelled. The correct spelling is "SIGHASH_SINGLE".

The typo was in the signature hash flags enumeration which could potentially cause confusion for developers working with the codebase.