### PR TITLE
units: Implement privacy boundaries

### DIFF
--- a/primitives/src/script/borrowed.rs
+++ b/primitives/src/script/borrowed.rs
@@ -92,7 +92,7 @@ impl Script {
     /// Returns the script data as a byte slice.
     ///
     /// This is just the script bytes **not** consensus encoding (which includes a length prefix).
-   #[inline]
+    #[inline]
     pub const fn as_bytes(&self) -> &[u8] { &self.0 }
 
     /// Returns the script data as a mutable byte slice.

--- a/primitives/src/script/mod.rs
+++ b/primitives/src/script/mod.rs
@@ -752,7 +752,6 @@ mod tests {
         assert!(WScriptHash::try_from(&script).is_err());
     }
 
-
     #[test]
     fn try_from_script_for_wscript_hash() {
         let script = Script::from_bytes(&[0x51; 10_000]);

--- a/units/src/amount/mod.rs
+++ b/units/src/amount/mod.rs
@@ -604,9 +604,7 @@ impl<T> CheckedSum<Amount> for T
 where
     T: Iterator<Item = Amount>,
 {
-    fn checked_sum(mut self) -> Option<Amount> {
-        self.try_fold(Amount::ZERO, Amount::checked_add)
-    }
+    fn checked_sum(mut self) -> Option<Amount> { self.try_fold(Amount::ZERO, Amount::checked_add) }
 }
 
 impl<T> CheckedSum<SignedAmount> for T

--- a/units/src/fee.rs
+++ b/units/src/fee.rs
@@ -13,9 +13,9 @@
 
 use core::ops;
 
-use crate::{Amount, FeeRate, MathOp, NumOpResult, OptionExt, Weight};
-
 use NumOpResult as R;
+
+use crate::{Amount, FeeRate, MathOp, NumOpResult, OptionExt, Weight};
 
 impl Amount {
     /// Checked weight ceiling division.

--- a/units/src/fee_rate/mod.rs
+++ b/units/src/fee_rate/mod.rs
@@ -13,8 +13,8 @@ use arbitrary::{Arbitrary, Unstructured};
 mod encapsulate {
     /// Fee rate.
     ///
-    /// This is an integer newtype representing fee rate in `sat/kwu`. It provides protection against
-    /// mixing up the types as well as basic formatting features.
+    /// This is an integer newtype representing fee rate in `sat/kwu`. It provides protection
+    /// against mixing up the types as well as basic formatting features.
     #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
     pub struct FeeRate(u64);
 

--- a/units/src/fee_rate/mod.rs
+++ b/units/src/fee_rate/mod.rs
@@ -66,7 +66,9 @@ impl FeeRate {
     }
 
     /// Constructs a new [`FeeRate`] from satoshis per virtual bytes without overflow check.
-    pub const fn from_sat_per_vb_unchecked(sat_vb: u64) -> Self { FeeRate::from_sat_per_kwu(sat_vb * (1000 / 4)) }
+    pub const fn from_sat_per_vb_unchecked(sat_vb: u64) -> Self {
+        FeeRate::from_sat_per_kwu(sat_vb * (1000 / 4))
+    }
 
     /// Constructs a new [`FeeRate`] from satoshis per kilo virtual bytes (1,000 vbytes).
     pub const fn from_sat_per_kvb(sat_kvb: u64) -> Self { FeeRate::from_sat_per_kwu(sat_kvb / 4) }
@@ -75,7 +77,9 @@ impl FeeRate {
     pub const fn to_sat_per_vb_floor(self) -> u64 { self.to_sat_per_kwu() / (1000 / 4) }
 
     /// Converts to sat/vB rounding up.
-    pub const fn to_sat_per_vb_ceil(self) -> u64 { (self.to_sat_per_kwu() + (1000 / 4 - 1)) / (1000 / 4) }
+    pub const fn to_sat_per_vb_ceil(self) -> u64 {
+        (self.to_sat_per_kwu() + (1000 / 4 - 1)) / (1000 / 4)
+    }
 
     /// Checked multiplication.
     ///
@@ -315,7 +319,8 @@ mod tests {
 
     #[test]
     fn checked_mul() {
-        let fee_rate = FeeRate::from_sat_per_kwu(10).checked_mul(10).expect("expected feerate in sat/kwu");
+        let fee_rate =
+            FeeRate::from_sat_per_kwu(10).checked_mul(10).expect("expected feerate in sat/kwu");
         assert_eq!(FeeRate::from_sat_per_kwu(100), fee_rate);
 
         let fee_rate = FeeRate::from_sat_per_kwu(10).checked_mul(u64::MAX);
@@ -324,7 +329,8 @@ mod tests {
 
     #[test]
     fn checked_div() {
-        let fee_rate = FeeRate::from_sat_per_kwu(10).checked_div(10).expect("expected feerate in sat/kwu");
+        let fee_rate =
+            FeeRate::from_sat_per_kwu(10).checked_div(10).expect("expected feerate in sat/kwu");
         assert_eq!(FeeRate::from_sat_per_kwu(1), fee_rate);
 
         let fee_rate = FeeRate::from_sat_per_kwu(10).checked_div(0);

--- a/units/src/time.rs
+++ b/units/src/time.rs
@@ -9,34 +9,39 @@
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
 
-/// A Bitcoin block timestamp.
-///
-/// > Each block contains a Unix time timestamp. In addition to serving as a source of variation for
-/// > the block hash, they also make it more difficult for an adversary to manipulate the block chain.
-/// >
-/// > A timestamp is accepted as valid if it is greater than the median timestamp of previous 11
-/// > blocks, and less than the network-adjusted time + 2 hours. "Network-adjusted time" is the
-/// > median of the timestamps returned by all nodes connected to you. As a result block timestamps
-/// > are not exactly accurate, and they do not need to be. Block times are accurate only to within
-/// > an hour or two.
-///
-/// ref: <https://en.bitcoin.it/wiki/Block_timestamp>
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct BlockTime(u32);
+mod encapsulate {
+    #[cfg(feature = "serde")]
+    use serde::{Deserialize, Serialize};
 
-impl BlockTime {
-    /// Constructs a new [`BlockTime`] from an unsigned 32 bit integer value.
-    #[inline]
-    pub const fn from_u32(t: u32) -> Self { BlockTime(t) }
+    /// A Bitcoin block timestamp.
+    ///
+    /// > Each block contains a Unix time timestamp. In addition to serving as a source of variation for
+    /// > the block hash, they also make it more difficult for an adversary to manipulate the block chain.
+    /// >
+    /// > A timestamp is accepted as valid if it is greater than the median timestamp of previous 11
+    /// > blocks, and less than the network-adjusted time + 2 hours. "Network-adjusted time" is the
+    /// > median of the timestamps returned by all nodes connected to you. As a result block timestamps
+    /// > are not exactly accurate, and they do not need to be. Block times are accurate only to within
+    /// > an hour or two.
+    ///
+    /// ref: <https://en.bitcoin.it/wiki/Block_timestamp>
+    #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+    pub struct BlockTime(u32);
 
-    /// Returns the inner `u32` value.
-    #[inline]
-    pub const fn to_u32(self) -> u32 { self.0 }
+    impl BlockTime {
+        /// Constructs a new [`BlockTime`] from an unsigned 32 bit integer value.
+        #[inline]
+        pub const fn from_u32(t: u32) -> Self { BlockTime(t) }
+
+        /// Returns the inner `u32` value.
+        #[inline]
+        pub const fn to_u32(self) -> u32 { self.0 }
+    }
 }
+#[doc(inline)]
+pub use encapsulate::BlockTime;
 
 impl From<u32> for BlockTime {
     #[inline]

--- a/units/src/weight.rs
+++ b/units/src/weight.rs
@@ -16,8 +16,8 @@ mod encapsulate {
 
     /// The weight of a transaction or block.
     ///
-    /// This is an integer newtype representing [`Weight`] in `wu`. It provides protection against mixing
-    /// up types as well as basic formatting features.
+    /// This is an integer newtype representing [`Weight`] in `wu`. It provides protection
+    /// against mixing up types as well as basic formatting features.
     #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     #[cfg_attr(feature = "serde", serde(transparent))]

--- a/units/src/weight.rs
+++ b/units/src/weight.rs
@@ -226,21 +226,15 @@ crate::internal_macros::impl_add_assign!(Weight);
 crate::internal_macros::impl_sub_assign!(Weight);
 
 impl ops::MulAssign<u64> for Weight {
-    fn mul_assign(&mut self, rhs: u64) {
-        *self = Weight::from_wu(self.to_wu() * rhs);
-    }
+    fn mul_assign(&mut self, rhs: u64) { *self = Weight::from_wu(self.to_wu() * rhs); }
 }
 
 impl ops::DivAssign<u64> for Weight {
-    fn div_assign(&mut self, rhs: u64) {
-        *self = Weight::from_wu(self.to_wu() / rhs );
-    }
+    fn div_assign(&mut self, rhs: u64) { *self = Weight::from_wu(self.to_wu() / rhs); }
 }
 
 impl ops::RemAssign<u64> for Weight {
-    fn rem_assign(&mut self, rhs: u64) {
-        *self = Weight::from_wu(self.to_wu() % rhs);
-    }
+    fn rem_assign(&mut self, rhs: u64) { *self = Weight::from_wu(self.to_wu() % rhs); }
 }
 
 impl core::iter::Sum for Weight {


### PR DESCRIPTION
Add privacy boundary for `FeeRate`, `BlockTime`, and `Weight`. The lock times are a bit curly so just doing these ones for now.