### PR TITLE
hashes: update serde dependency to match workspace

### DIFF
--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -24,7 +24,7 @@ small-hash = []
 [dependencies]
 internals = { package = "bitcoin-internals", path = "../internals" }
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false, optional = true }
-serde = { version = "1.0", default-features = false, optional = true }
+serde = { version = "1.0.103", default-features = false, optional = true }
 
 [dev-dependencies]
 serde_test = "1.0"


### PR DESCRIPTION
Update serde from 1.0 to 1.0.103 to align with versions used in other workspace crates. This makes the dependency constraint match reality since it was almost always implicitly raised by the other crates.

I ran the `update-lock-files`, but no changes, which makes sense since other crates in the workspace bumped the version.

A bit more info in https://github.com/rust-bitcoin/rust-bitcoin/issues/4313#issuecomment-2786281653 with talk about minimal version testing.