### PR TITLE
primitives: Add tests to improve coverage

### DIFF
--- a/primitives/src/script/borrowed.rs
+++ b/primitives/src/script/borrowed.rs
@@ -195,7 +195,7 @@ mod tests {
 
     #[test]
     fn script_is_empty() {
-        let script = Script::new();
+        let script: &Script = Default::default();
         assert!(script.is_empty());
 
         let script = Script::from_bytes(&[1, 2, 3]);

--- a/primitives/src/script/mod.rs
+++ b/primitives/src/script/mod.rs
@@ -708,11 +708,47 @@ mod tests {
     }
 
     #[test]
+    fn try_from_scriptbuf_ref_for_scripthash() {
+        let script = ScriptBuf::from(vec![0x51; 520]);
+        assert!(ScriptHash::try_from(&script).is_ok());
+
+        let script = ScriptBuf::from(vec![0x51; 521]);
+        assert!(ScriptHash::try_from(&script).is_err());
+    }
+    #[test]
+    fn try_from_script_for_scripthash() {
+        let script = Script::from_bytes(&[0x51; 520]);
+        assert!(ScriptHash::try_from(script).is_ok());
+
+        let script = Script::from_bytes(&[0x51; 521]);
+        assert!(ScriptHash::try_from(script).is_err());
+    }
+
+    #[test]
     fn try_from_scriptbuf_for_wscript_hash() {
         let script = ScriptBuf::from(vec![0x51; 10_000]);
         assert!(WScriptHash::try_from(script).is_ok());
 
         let script = ScriptBuf::from(vec![0x51; 10_001]);
+        assert!(WScriptHash::try_from(script).is_err());
+    }
+
+    #[test]
+    fn try_from_scriptbuf_ref_for_wscript_hash() {
+        let script = ScriptBuf::from(vec![0x51; 10_000]);
+        assert!(WScriptHash::try_from(&script).is_ok());
+
+        let script = ScriptBuf::from(vec![0x51; 10_001]);
+        assert!(WScriptHash::try_from(&script).is_err());
+    }
+
+
+    #[test]
+    fn try_from_script_for_wscript_hash() {
+        let script = Script::from_bytes(&[0x51; 10_000]);
+        assert!(WScriptHash::try_from(script).is_ok());
+
+        let script = Script::from_bytes(&[0x51; 10_001]);
         assert!(WScriptHash::try_from(script).is_err());
     }
 


### PR DESCRIPTION
Update test in borrowed to cover the `default` implementation of `Script`.

Add tests to cover all `TryFrom` implementations in `Script`