### PR TITLE
Resolve direct minimal versions in Cargo-minimal.lock on dependency changes

### DIFF
--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -35,15 +35,15 @@ primitives = { package = "bitcoin-primitives", path = "../primitives", default-f
 secp256k1 = { version = "0.30.0", default-features = false, features = ["hashes", "alloc", "rand"] }
 units = { package = "bitcoin-units", path = "../units", default-features = false, features = ["alloc"] }
 
-arbitrary = { version = "1.4", optional = true }
+arbitrary = { version = "1.4.1", optional = true }
 base64 = { version = "0.22.0", optional = true }
 # `bitcoinconsensus` version includes metadata which indicates the version of Core. Use `cargo tree` to see it.
 bitcoinconsensus = { version = "0.106.0", default-features = false, optional = true }
-serde = { version = "1.0.103", default-features = false, features = [ "derive", "alloc" ], optional = true }
+serde = { version = "1.0.156", default-features = false, features = [ "derive", "alloc" ], optional = true }
 
 [dev-dependencies]
 internals = { package = "bitcoin-internals", path = "../internals", features = ["test-serde"] }
-serde_json = "1.0.0"
+serde_json = "1.0.68"
 serde_test = "1.0.19"
 bincode = "1.3.1"
 hex_lit = "0.1.1"

--- a/contrib/update-lock-files.sh
+++ b/contrib/update-lock-files.sh
@@ -1,11 +1,22 @@
 #!/usr/bin/env bash
 #
-# Update the minimal/recent lock file
+# Update the minimal and recent lockfiles.
 
 set -euo pipefail
 
-for file in Cargo-minimal.lock Cargo-recent.lock; do
-    cp -f "$file" Cargo.lock
-    cargo check
-    cp -f Cargo.lock "$file"
-done
+
+NIGHTLY=$(cat nightly-version)
+
+# direct-minimal-versions overrides check's already
+# conservative dependecy resolving to force
+# consistent minimal versions for direct dependencies
+# of the workspace. Transitive dependencies are only
+# updated if they must be due to manifest changes.
+cp -f Cargo-minimal.lock Cargo.lock
+cargo +"$NIGHTLY" check -Z direct-minimal-versions
+cp -f Cargo.lock Cargo-minimal.lock
+
+# Conservatively bump of recent dependencies.
+cp -f Cargo-recent.lock Cargo.lock
+cargo check
+cp -f Cargo.lock Cargo-recent.lock

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,8 +12,8 @@ cargo-fuzz = true
 honggfuzz = { version = "0.5.56", default-features = false }
 bitcoin = { path = "../bitcoin", features = [ "serde" ] }
 
-serde = { version = "1.0.103", features = [ "derive" ] }
-serde_json = "1.0"
+serde = { version = "1.0.156", features = [ "derive" ] }
+serde_json = "1.0.68"
 
 [lints.rust]
 unexpected_cfgs = { level = "deny", check-cfg = ['cfg(fuzzing)'] }

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -24,10 +24,10 @@ small-hash = []
 [dependencies]
 internals = { package = "bitcoin-internals", path = "../internals" }
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false, optional = true }
-serde = { version = "1.0.103", default-features = false, optional = true }
+serde = { version = "1.0.156", default-features = false, optional = true }
 
 [dev-dependencies]
-serde_test = "1.0"
+serde_test = "1.0.19"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/internals/Cargo.toml
+++ b/internals/Cargo.toml
@@ -22,7 +22,7 @@ test-serde = ["serde", "serde_json", "bincode"]
 
 [dependencies]
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false, optional = true }
-serde = { version = "1.0.103", default-features = false, optional = true }
+serde = { version = "1.0.156", default-features = false, optional = true }
 
 # Don't enable these directly, use `test-serde` feature instead.
 serde_json = { version = "1.0.68", optional = true }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -28,12 +28,12 @@ internals = { package = "bitcoin-internals", path = "../internals" }
 units = { package = "bitcoin-units", path = "../units", default-features = false }
 arrayvec = { version = "0.7", default-features = false }
 
-arbitrary = { version = "1.4", optional = true }
+arbitrary = { version = "1.4.1", optional = true }
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false, optional = true }
-serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"], optional = true }
+serde = { version = "1.0.156", default-features = false, features = ["derive", "alloc"], optional = true }
 
 [dev-dependencies]
-serde_json = "1.0.0"
+serde_json = "1.0.68"
 bincode = "1.3.1"
 
 [package.metadata.docs.rs]

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -20,14 +20,14 @@ alloc = ["internals/alloc","serde?/alloc"]
 [dependencies]
 internals = { package = "bitcoin-internals", path = "../internals" }
 
-serde = { version = "1.0.103", default-features = false, features = ["derive"], optional = true }
-arbitrary = { version = "1.4", optional = true }
+serde = { version = "1.0.156", default-features = false, features = ["derive"], optional = true }
+arbitrary = { version = "1.4.1", optional = true }
 
 [dev-dependencies]
 internals = { package = "bitcoin-internals", path = "../internals", features = ["test-serde"] }
 bincode = "1.3.1"
-serde_test = "1.0"
-serde_json = "1.0"
+serde_test = "1.0.19"
+serde_json = "1.0.68"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Strategy to close #4313.

The first patch has a handful of necessary dependency upgrades in order to use the `direct-minimal-versions` flag.

* Standardize the `serde_json` and `serde_test` dev dependencies. The `direct-minimal-versions` flag requires one version for all direct dependencies in a workspace.
* Makes `serde`'s minimal version explicit with `1.0.156`. I originally tried to make `1.0.103` work, but at the very least requires quite a bit of lint config tweaks to build that code. I never got `1.0.103` to actually work.
* Bumps `arbitrary` from `1.4.0` to `1.4.1`, `1.4.0` does not work with the `1.63.0` MSRV due to `core::error::Error` usage.

The second patch has the tweak for generating `Cargo-minimal.lock` with direct dependency versions. In the linked issue, Kix suggests a CI check to make sure the `Cargo-minimal.lock` file isn't drifting. I don't think that would play nice with the `direct-minimal-versions` flag since transitive dependency updates would break CI. Another possibility is to just calculate `Cargo-minimal.lock` on the fly in CI, but I assume having a checked in version is still desired by the maintainers.

After running `just update-lock-files`with the new strategy, there are only upgrades in `Cargo-minimal.lock`. The upgrades are due to the `direct-minimal-versions` flag allowing transitive dependency versions to update like normal so that this workspace is not blocked from testing its minimal versions just because the minimal versions of a dependency are broken. No downgrades are listed because `serde` and `arbitrary`, the two drifters, required upgrades to actually build addressed in the first patch.

Calling out one potential pain-point to this strategy, as seen with the `serde_json` and `serde_test` dev dependencies in patch 1, `direct-minimal-versions` requires just one minimum constraint definition per-dependency in a workspace. So all the crates in rust-bitcoin need to move in lockstep for each dep. This is more strict than it has been, but I think if a crate needs a dramatically different version of a dep, it might just be a good sign it should be moved outside of the workspace.

## Maximums?

`Cargo-recent.lock` could be resolved with a more aggressive `cargo update`, where everything goes to its "max" version (minor and patch updates) given the constraints. This would test a wider window of direct dependency versions, but I do not know if it is in the original spirit of what `Cargo-recent.lock` was meant to capture. Here are the changes if updated with `cargo update`.

```
  +---------------------+------------+----------+------------+
  | Package             | Recent     | Change   | Maximum    |
  +---------------------+------------+----------+------------+
  | ADDED/REMOVED       |            |          |            |
  +---------------------+------------+----------+------------+
  | byteorder           | 1.5.0      | --->     | N/A        |
  +---------------------+------------+----------+------------+
  | MINOR CHANGES       |            |          |            |
  +---------------------+------------+----------+------------+
  | cc                  | 1.1.22     | --->     | 1.2.19     |
  | zerocopy            | 0.7.35     | --->     | 0.8.24     |
  | zerocopy-derive     | 0.7.35     | --->     | 0.8.24     |
  +---------------------+------------+----------+------------+
  | PATCH CHANGES       |            |          |            |
  +---------------------+------------+----------+------------+
  | honggfuzz           | 0.5.56     | --->     | 0.5.57     |
  | itoa                | 1.0.11     | --->     | 1.0.15     |
  | libc                | 0.2.159    | --->     | 0.2.172    |
  | ppv-lite86          | 0.2.20     | --->     | 0.2.21     |
  | proc-macro2         | 1.0.86     | --->     | 1.0.94     |
  | quote               | 1.0.37     | --->     | 1.0.40     |
  | ryu                 | 1.0.18     | --->     | 1.0.20     |
  | semver              | 1.0.23     | --->     | 1.0.26     |
  | serde               | 1.0.210    | --->     | 1.0.219    |
  | serde_derive        | 1.0.210    | --->     | 1.0.219    |
  | serde_json          | 1.0.128    | --->     | 1.0.140    |
  | syn                 | 2.0.79     | --->     | 2.0.100    |
  | unicode-ident       | 1.0.13     | --->     | 1.0.18     |
  +---------------------+------------+----------+------------+
```