### PR TITLE
units: Make minor improvements to `MathOp`

### DIFF
--- a/units/src/result.rs
+++ b/units/src/result.rs
@@ -3,6 +3,7 @@
 //! Provides a monodic type returned by mathematical operations (`core::ops`).
 
 use core::fmt;
+use core::convert::Infallible;
 
 use NumOpResult as R;
 
@@ -134,7 +135,7 @@ pub struct NumOpError(MathOp);
 
 impl NumOpError {
     /// Creates a [`NumOpError`] caused by `op`.
-    pub fn while_doing(op: MathOp) -> Self { NumOpError(op) }
+    pub(crate) fn while_doing(op: MathOp) -> Self { NumOpError(op) }
 
     /// Returns the [`MathOp`] that caused this error.
     pub fn operation(self) -> MathOp { self.0 }
@@ -165,6 +166,10 @@ pub enum MathOp {
     Rem,
     /// Negation failed ([`core::ops::Neg`] resulted in an invalid value).
     Neg,
+    /// Stops users from casting this enum to an integer.
+    // May get removed if one day Rust supports disabling casts natively.
+    #[doc(hidden)]
+    _DoNotUse(Infallible),
 }
 
 impl MathOp {
@@ -179,13 +184,14 @@ impl MathOp {
 
 impl fmt::Display for MathOp {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
+        match *self {
             MathOp::Add => write!(f, "add"),
             MathOp::Sub => write!(f, "sub"),
             MathOp::Mul => write!(f, "mul"),
             MathOp::Div => write!(f, "div"),
             MathOp::Rem => write!(f, "rem"),
             MathOp::Neg => write!(f, "neg"),
+            MathOp::_DoNotUse(infallible) => match infallible {},
         }
     }
 }


### PR DESCRIPTION
Follow up from #4312, improve the `MathOp` type by:

- Do not provide public constructor
- Add cast protection