### PR TITLE
primitives: Document script to/from bytes

### DIFF
--- a/primitives/src/script/borrowed.rs
+++ b/primitives/src/script/borrowed.rs
@@ -90,14 +90,20 @@ impl Script {
     pub const fn new() -> &'static Self { Self::from_bytes(&[]) }
 
     /// Returns the script data as a byte slice.
-    #[inline]
+    ///
+    /// This is just the script bytes **not** consensus encoding (which includes a length prefix).
+   #[inline]
     pub const fn as_bytes(&self) -> &[u8] { &self.0 }
 
     /// Returns the script data as a mutable byte slice.
+    ///
+    /// This is just the script bytes **not** consensus encoding (which includes a length prefix).
     #[inline]
     pub fn as_mut_bytes(&mut self) -> &mut [u8] { &mut self.0 }
 
     /// Returns a copy of the script data.
+    ///
+    /// This is just the script bytes **not** consensus encoding (which includes a length prefix).
     #[inline]
     pub fn to_vec(&self) -> Vec<u8> { self.as_bytes().to_owned() }
 

--- a/primitives/src/script/owned.rs
+++ b/primitives/src/script/owned.rs
@@ -27,7 +27,8 @@ impl ScriptBuf {
 
     /// Converts byte vector into script.
     ///
-    /// This method doesn't (re)allocate.
+    /// This method doesn't (re)allocate. `bytes` is just the script bytes **not** consensus
+    /// encoding (i.e no length prefix).
     #[inline]
     pub const fn from_bytes(bytes: Vec<u8>) -> Self { Self(bytes) }
 
@@ -42,6 +43,10 @@ impl ScriptBuf {
     /// Converts the script into a byte vector.
     ///
     /// This method doesn't (re)allocate.
+    ///
+    /// # Returns
+    ///
+    /// Just the script bytes **not** consensus encoding (which includes a length prefix).
     #[inline]
     pub fn into_bytes(self) -> Vec<u8> { self.0 }
 


### PR DESCRIPTION
The byte slice/vector in the to/from methods for the script types does not include the length prefix that is used when consensus encoding.

Add docs to make this more clear.