### PR TITLE
Remove Option return from `minimal_non_dust`

### DIFF
--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -261,7 +261,7 @@ crate::internal_macros::define_extension_trait! {
         /// Returns the minimum value an output with this script should have in order to be
         /// broadcastable on today’s Bitcoin network.
         #[deprecated(since = "0.32.0", note = "use `minimal_non_dust` etc. instead")]
-        fn dust_value(&self) -> Option<Amount> { self.minimal_non_dust() }
+        fn dust_value(&self) -> Amount { self.minimal_non_dust() }
 
         /// Returns the minimum value an output with this script should have in order to be
         /// broadcastable on today's Bitcoin network.
@@ -272,8 +272,9 @@ crate::internal_macros::define_extension_trait! {
         /// To use a custom value, use [`minimal_non_dust_custom`].
         ///
         /// [`minimal_non_dust_custom`]: Script::minimal_non_dust_custom
-        fn minimal_non_dust(&self) -> Option<Amount> {
+        fn minimal_non_dust(&self) -> Amount {
             self.minimal_non_dust_internal(DUST_RELAY_TX_FEE.into())
+                .expect("dust_relay_fee or script length should not be absurdly large")
         }
 
         /// Returns the minimum value an output with this script should have in order to be

--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -684,7 +684,7 @@ fn default_dust_value() {
     // well-known scriptPubKey types.
     let script_p2wpkh = Builder::new().push_int_unchecked(0).push_slice([42; 20]).into_script();
     assert!(script_p2wpkh.is_p2wpkh());
-    assert_eq!(script_p2wpkh.minimal_non_dust(), Some(Amount::from_sat_u32(294)));
+    assert_eq!(script_p2wpkh.minimal_non_dust(), Amount::from_sat_u32(294));
     assert_eq!(
         script_p2wpkh.minimal_non_dust_custom(FeeRate::from_sat_per_vb_unchecked(6)),
         Some(Amount::from_sat_u32(588))
@@ -698,7 +698,7 @@ fn default_dust_value() {
         .push_opcode(OP_CHECKSIG)
         .into_script();
     assert!(script_p2pkh.is_p2pkh());
-    assert_eq!(script_p2pkh.minimal_non_dust(), Some(Amount::from_sat_u32(546)));
+    assert_eq!(script_p2pkh.minimal_non_dust(), Amount::from_sat_u32(546));
     assert_eq!(
         script_p2pkh.minimal_non_dust_custom(FeeRate::from_sat_per_vb_unchecked(6)),
         Some(Amount::from_sat_u32(1092))

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -183,8 +183,8 @@ crate::internal_macros::define_extension_trait! {
         /// To use a custom value, use [`minimal_non_dust_custom`].
         ///
         /// [`minimal_non_dust_custom`]: TxOut::minimal_non_dust_custom
-        fn minimal_non_dust(script_pubkey: ScriptBuf) -> Option<TxOut> {
-            Some(TxOut { value: script_pubkey.minimal_non_dust()?, script_pubkey })
+        fn minimal_non_dust(script_pubkey: ScriptBuf) -> TxOut {
+            TxOut { value: script_pubkey.minimal_non_dust(), script_pubkey }
         }
 
         /// Constructs a new `TxOut` with given script and the smallest possible `value` that is **not** dust


### PR DESCRIPTION
Closes #4221 

This removes the `Option` return type from `minimal_non_dust

Overflow is only possible in 2 cases:
- `dust_relay_fee` would need to be excessively high
- script size would have to exceed ~6.15 × 10¹⁵ bytes (≈ 6 petabytes)

we now panic with the same message we had before in  https://github.com/rust-bitcoin/rust-bitcoin/blob/cf12ba262a646a6341098ee3f4c178a52fc90211/bitcoin/src/blockdata/script/borrowed.rs#L412