### PR TITLE
primitives: Increase test coverage in `Script`

### DIFF
--- a/primitives/src/script/mod.rs
+++ b/primitives/src/script/mod.rs
@@ -632,30 +632,48 @@ mod tests {
         let script_buf = ScriptBuf::from(vec![0x51, 0x52, 0x53]);
         let script_ref: &[u8] = script_buf.as_ref();
         assert_eq!(script_ref, &[0x51, 0x52, 0x53]);
+
+        let script_ref: &Script = script_buf.as_ref();
+        assert_eq!(script_ref.as_bytes(), &[0x51, 0x52, 0x53]);
     }
 
     #[test]
     fn scriptbuf_as_mut() {
         let mut script_buf = ScriptBuf::from(vec![0x51, 0x52, 0x53]);
+
         let script_mut: &mut [u8] = script_buf.as_mut();
         script_mut[0] = 0x50;
         assert_eq!(script_mut, [0x50, 0x52, 0x53]);
+
+        let script_mut: &mut Script = script_buf.as_mut();
+        script_mut.as_mut_bytes()[1] = 0x51;
+        assert_eq!(script_buf.as_bytes(), &[0x50, 0x51, 0x53]);
     }
 
     #[test]
+    #[allow(clippy::useless_asref)]
     fn script_as_ref() {
         let script = Script::from_bytes(&[0x51, 0x52, 0x53]);
         let script_ref: &[u8] = script.as_ref();
         assert_eq!(script_ref, &[0x51, 0x52, 0x53]);
+
+        let script_ref: &Script = script.as_ref();
+        assert_eq!(script_ref.as_bytes(), &[0x51, 0x52, 0x53]);
     }
 
     #[test]
+    #[allow(clippy::useless_asref)]
     fn script_as_mut() {
         let bytes = &mut [0x51, 0x52, 0x53];
         let script = Script::from_bytes_mut(bytes);
+
         let script_mut: &mut [u8] = script.as_mut();
         script_mut[0] = 0x50;
         assert_eq!(script_mut, [0x50, 0x52, 0x53]);
+
+        let script_mut: &mut Script = script.as_mut();
+        script_mut.as_mut_bytes()[1] = 0x51;
+        assert_eq!(script.as_bytes(), &[0x50, 0x51, 0x53]);
     }
 
     #[test]

--- a/primitives/src/script/mod.rs
+++ b/primitives/src/script/mod.rs
@@ -725,6 +725,7 @@ mod tests {
         let script = ScriptBuf::from(vec![0x51; 521]);
         assert!(ScriptHash::try_from(&script).is_err());
     }
+
     #[test]
     fn try_from_script_for_scripthash() {
         let script = Script::from_bytes(&[0x51; 520]);
@@ -751,7 +752,6 @@ mod tests {
         let script = ScriptBuf::from(vec![0x51; 10_001]);
         assert!(WScriptHash::try_from(&script).is_err());
     }
-
 
     #[test]
     fn try_from_script_for_wscript_hash() {

--- a/primitives/src/script/mod.rs
+++ b/primitives/src/script/mod.rs
@@ -782,26 +782,28 @@ mod tests {
 
     #[test]
     fn script_display() {
-        let script = Script::from_bytes(&[0xa1, 0xb2, 0xc3]);
-        assert_eq!(format!("{}", script), "OP_LESSTHANOREQUAL OP_CSV OP_RETURN_195");
+        let script = Script::from_bytes(&[0x00, 0xa1, 0xb2]);
+        assert_eq!(format!("{}", script), "OP_0 OP_LESSTHANOREQUAL OP_CSV");
 
         #[cfg(feature = "hex")]
         {
-            assert_eq!(format!("{:x}", script), "a1b2c3");
-            assert_eq!(format!("{:X}", script), "A1B2C3");
+            assert_eq!(format!("{:x}", script), "00a1b2");
+            assert_eq!(format!("{:X}", script), "00A1B2");
         }
+        assert!(!format!("{:?}", script).is_empty());
     }
 
     #[test]
     fn scriptbuf_display() {
-        let script_buf = ScriptBuf::from(vec![0xa1, 0xb2, 0xc3]);
-        assert_eq!(format!("{}", script_buf), "OP_LESSTHANOREQUAL OP_CSV OP_RETURN_195");
+        let script_buf = ScriptBuf::from(vec![0x00, 0xa1, 0xb2]);
+        assert_eq!(format!("{}", script_buf), "OP_0 OP_LESSTHANOREQUAL OP_CSV");
 
         #[cfg(feature = "hex")]
         {
-            assert_eq!(format!("{:x}", script_buf), "a1b2c3");
-            assert_eq!(format!("{:X}", script_buf), "A1B2C3");
+            assert_eq!(format!("{:x}", script_buf), "00a1b2");
+            assert_eq!(format!("{:X}", script_buf), "00A1B2");
         }
+        assert!(!format!("{:?}", script_buf).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Expand existing tests and add new ones to increase the test coverage in `primitives/src/script/` to 100% excluding `serde` and `arbitrary` features.