### PR TITLE
WIP: Add standard_check fuzz test

### DIFF
--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -23,6 +23,7 @@ serde = ["dep:serde", "hashes/serde", "internals/serde", "primitives/serde", "se
 secp-lowmemory = ["secp256k1/lowmemory"]
 secp-recovery = ["secp256k1/recovery"]
 arbitrary = ["dep:arbitrary", "units/arbitrary", "primitives/arbitrary"]
+standard_test = ["dep:standard_test", "units/standard_test"]
 
 [dependencies]
 base58 = { package = "base58ck", path = "../base58", default-features = false, features = ["alloc"] }
@@ -40,6 +41,7 @@ base64 = { version = "0.22.0", optional = true }
 # `bitcoinconsensus` version includes metadata which indicates the version of Core. Use `cargo tree` to see it.
 bitcoinconsensus = { version = "0.106.0", default-features = false, optional = true }
 serde = { version = "1.0.103", default-features = false, features = [ "derive", "alloc" ], optional = true }
+standard_test = { version = "0.1.0", optional = true }
 
 [dev-dependencies]
 internals = { package = "bitcoin-internals", path = "../internals", features = ["test-serde"] }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,10 +10,11 @@ cargo-fuzz = true
 
 [dependencies]
 honggfuzz = { version = "0.5.56", default-features = false }
-bitcoin = { path = "../bitcoin", features = [ "serde" ] }
+bitcoin = { path = "../bitcoin", features = [ "serde", "arbitrary", "standard_test" ] }
 
 serde = { version = "1.0.103", features = [ "derive" ] }
 serde_json = "1.0"
+standard_test = "0.1.0"
 
 [lints.rust]
 unexpected_cfgs = { level = "deny", check-cfg = ['cfg(fuzzing)'] }
@@ -85,3 +86,7 @@ path = "fuzz_targets/hashes/sha512.rs"
 [[bin]]
 name = "units_deserialize_amount"
 path = "fuzz_targets/units/deserialize_amount.rs"
+
+[[bin]]
+name = "units_standard_checks"
+path = "fuzz_targets/units/standard_checks.rs"

--- a/fuzz/fuzz_targets/units/standard_checks.rs
+++ b/fuzz/fuzz_targets/units/standard_checks.rs
@@ -1,0 +1,42 @@
+use bitcoin::Amount;
+use honggfuzz::fuzz;
+use standard_test::StandardChecks as _;
+
+fn do_test(data: &[u8]) {
+    Amount::one_iteration(data);
+}
+
+fn main() {
+    loop {
+        fuzz!(|data| {
+            do_test(data);
+        });
+    }
+}
+
+#[cfg(all(test, fuzzing))]
+mod tests {
+    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
+        let mut b = 0;
+        for (idx, c) in hex.as_bytes().iter().enumerate() {
+            b <<= 4;
+            match *c {
+                b'A'..=b'F' => b |= c - b'A' + 10,
+                b'a'..=b'f' => b |= c - b'a' + 10,
+                b'0'..=b'9' => b |= c - b'0',
+                _ => panic!("Bad hex"),
+            }
+            if (idx & 1) == 1 {
+                out.push(b);
+                b = 0;
+            }
+        }
+    }
+
+    #[test]
+    fn duplicate_crash() {
+        let mut a = Vec::new();
+        extend_vec_from_hex("00000000", &mut a);
+        super::do_test(&a);
+    }
+}

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -22,6 +22,7 @@ internals = { package = "bitcoin-internals", path = "../internals" }
 
 serde = { version = "1.0.103", default-features = false, features = ["derive"], optional = true }
 arbitrary = { version = "1.4", optional = true }
+standard_test = { version = "0.1.0", optional = true }
 
 [dev-dependencies]
 internals = { package = "bitcoin-internals", path = "../internals", features = ["test-serde"] }
@@ -34,7 +35,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [lints.rust]
-unexpected_cfgs = { level = "deny", check-cfg = ['cfg(kani)'] }
+unexpected_cfgs = { level = "deny", check-cfg = ['cfg(kani)', 'cfg(fuzzing)'] }
 
 [lints.clippy]
 # Exclude lints we don't think are valuable.

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -459,3 +459,6 @@ impl<'a> Arbitrary<'a> for Amount {
         Ok(Self::from_sat(sats).expect("range is valid"))
     }
 }
+
+#[cfg(feature = "standard_test")]
+standard_test::standard_checks!(Amount);


### PR DESCRIPTION
Introduce fuzzing using the `standard_test` crate.

I can't work out how to correctly feature gate the `standard_checks!` macro call in `units::amount::unsigned` so that it is implemented only when fuzzing.

TODO:

- Check all types in `units` implement `Arbitrary`
- Add `standard_check!` call for all types
- Add to the fuzz test for all types

Close: #4252