### PR TITLE
Allow using the 'base64' feature in `no_std` environments

### DIFF
--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["tests", "contrib"]
 # If you change features or optional dependencies in any way please update the "# Cargo features" section in lib.rs as well.
 [features]
 default = [ "std", "secp-recovery" ]
-std = ["base58/std", "bech32/std", "hashes/std", "hex/std", "internals/std", "io/std", "primitives/std", "secp256k1/std", "units/std", "bitcoinconsensus?/std"]
+std = ["base58/std", "bech32/std", "hashes/std", "hex/std", "internals/std", "io/std", "primitives/std", "secp256k1/std", "units/std", "base64?/std", "bitcoinconsensus?/std"]
 rand-std = ["secp256k1/rand", "std"]
 rand = ["secp256k1/rand"]
 serde = ["dep:serde", "hashes/serde", "internals/serde", "primitives/serde", "secp256k1/serde", "units/serde"]
@@ -36,7 +36,7 @@ secp256k1 = { version = "0.30.0", default-features = false, features = ["hashes"
 units = { package = "bitcoin-units", path = "../units", default-features = false, features = ["alloc"] }
 
 arbitrary = { version = "1.4", optional = true }
-base64 = { version = "0.22.0", optional = true }
+base64 = { version = "0.22.0", optional = true, default-features = false, features = ["alloc"] }
 # `bitcoinconsensus` version includes metadata which indicates the version of Core. Use `cargo tree` to see it.
 bitcoinconsensus = { version = "0.106.0", default-features = false, optional = true }
 serde = { version = "1.0.103", default-features = false, features = [ "derive", "alloc" ], optional = true }


### PR DESCRIPTION
Gating like the other features should do the trick.