### PR TITLE
primitives: replace error propagation with `expect`

### DIFF
--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -223,7 +223,7 @@ impl fmt::Display for Header {
             self.time.to_u32().to_le_bytes().as_hex(),
             self.bits.to_consensus().to_le_bytes().as_hex(),
             self.nonce.to_le_bytes().as_hex(),
-        )?;
+        ).expect("total length of written objects is 160 characters");
         fmt::Display::fmt(&buf, f)
     }
 }


### PR DESCRIPTION
This error path cannot happen, and if it could, failing formatting is not the correct source of action, because the std docs say that formatting may only fail if the formatter says so.

Fixes comment in #4269