### PR TITLE
Fix minor typos and improve clarity in documentation and comments

### DIFF
--- a/bitcoin/src/internal_macros.rs
+++ b/bitcoin/src/internal_macros.rs
@@ -244,7 +244,7 @@ macro_rules! only_non_doc_attrs {
 }
 pub(crate) use only_non_doc_attrs;
 
-/// Defines an trait `$trait_name` and implements it for `ty`, used to define extension traits.
+/// Defines a trait `$trait_name` and implements it for `ty`, used to define extension traits.
 macro_rules! define_extension_trait {
     ($(#[$($trait_attrs:tt)*])* $trait_vis:vis trait $trait_name:ident impl for $ty:ident {
         $(

--- a/bitcoin/src/network/params.rs
+++ b/bitcoin/src/network/params.rs
@@ -8,7 +8,7 @@
 //! # Custom Signets Example
 //!
 //! In various places in this crate we take `AsRef<Params>` as a parameter, in order to create a
-//! custom type that can be used is such places you might want to do the following:
+//! custom type that can be used in such places you might want to do the following:
 //!
 //! ```
 //! use bitcoin::network::Params;

--- a/bitcoin/src/p2p/message_compact_blocks.rs
+++ b/bitcoin/src/p2p/message_compact_blocks.rs
@@ -9,7 +9,7 @@ use crate::internal_macros::impl_consensus_encoding;
 /// sendcmpct message
 #[derive(PartialEq, Eq, Clone, Debug, Copy, PartialOrd, Ord, Hash)]
 pub struct SendCmpct {
-    /// Request to be send compact blocks.
+    /// Request to be sent compact blocks.
     pub send_compact: bool,
     /// Compact Blocks protocol version number.
     pub version: u64,

--- a/bitcoin/src/psbt/error.rs
+++ b/bitcoin/src/psbt/error.rs
@@ -96,7 +96,7 @@ pub enum Error {
     InvalidLeafVersion,
     /// Parsing error indicating a Taproot error
     Taproot(&'static str),
-    /// Taproot tree deserilaization error
+    /// Taproot tree deserialization error
     TapTree(crate::taproot::IncompleteBuilderError),
     /// Error related to an xpub key
     XPubKey(&'static str),

--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -370,7 +370,7 @@ impl Serialize for TapTree {
             // safe to cast from usize to u8
             buf.push(leaf_info.merkle_branch().len() as u8);
             buf.push(leaf_info.version().to_consensus());
-            leaf_info.script().consensus_encode(&mut buf).expect("Vecs dont err");
+            leaf_info.script().consensus_encode(&mut buf).expect("Vecs don't err");
         }
         buf
     }

--- a/bitcoin/src/taproot/mod.rs
+++ b/bitcoin/src/taproot/mod.rs
@@ -1316,7 +1316,7 @@ impl FutureLeafVersion {
     ) -> Result<FutureLeafVersion, InvalidTaprootLeafVersionError> {
         match version {
             TAPROOT_LEAF_TAPSCRIPT => unreachable!(
-                "FutureLeafVersion::from_consensus should be never called for 0xC0 value"
+                "FutureLeafVersion::from_consensus should never be called for 0xC0 value"
             ),
             TAPROOT_ANNEX_PREFIX => Err(InvalidTaprootLeafVersionError(TAPROOT_ANNEX_PREFIX)),
             odd if odd & 0xFE != odd => Err(InvalidTaprootLeafVersionError(odd)),


### PR DESCRIPTION
This PR addresses several minor issues across the codebase, including:
- Fixing typographical errors in comments and documentation (e.g., "deserilaization" → "deserialization", "send" → "sent").
- Improving sentence clarity and grammar in doc comments (e.g., correcting sentence structure and word choice).
- Enhancing code readability without changing any logic or functionality.

These changes are purely cosmetic and aimed at improving maintainability and developer experience.