### PR TITLE
Mutation testing: Add exclusions for match arm/guard mutants

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -4,12 +4,15 @@ exclude_globs = [
     "units/src/amount/verification.rs" # kani tests
 ]
 exclude_re = [
-    "impl Debug",
     "impl Arbitrary",
+    "impl Debug",
+    "impl fmt::Debug",
     "impl Display",
+    "impl fmt::Display",
     ".*Error",
     "deserialize", # Skip serde mutation tests
     "Iterator", # Mutating operations in an iterator can result in an infinite loop
+    "match arm", "match guard", # New addition in cargo-mutants 25.0.1 deletes match arms and replaces match guards even in excluded functions
 
     # ----------------------------------Crate-specific exclusions----------------------------------
     # Units


### PR DESCRIPTION
cargo-mutants 25.0.1 introduced a new mutation pattern that deletes an arm of a match statement or replaces a match guard with true and false. These are applied in sections that have been excluded from mutation testing and cause false positives.
The match patterns are also now stricter causing previously excluded `impl` to be included.

Exclude the new match arm and guard mutation patterns.

Add `impl fmt::` versions for Debug and Display.

Closes #4402