### PR TITLE
primitives: Add regression tests for `Display` implementations

### DIFF
--- a/primitives/src/sequence.rs
+++ b/primitives/src/sequence.rs
@@ -354,4 +354,11 @@ mod tests {
         let sequence_u32: u32 = sequence.into();
         assert_eq!(sequence_u32, 0x7FFF_FFFF);
     }
+
+    #[test]
+    fn sequence_display() {
+        let sequence = Sequence(0x7FFF_FFFF);
+        let want: u32 = 0x7FFF_FFFF;
+        assert_eq!(format!("{}", sequence), want.to_string());
+    }
 }

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -748,4 +748,19 @@ mod tests {
         assert!(parse_vout("01").is_err()); // Leading zero not allowed
         assert!(parse_vout("+1").is_err()); // Non digits not allowed
     }
+
+    #[test]
+    #[cfg(feature = "alloc")]
+    #[cfg(feature = "hex")]
+    fn outpoint_display_roundtrip() {
+        let outpoint_str = "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20:1";
+        let outpoint: OutPoint = outpoint_str.parse().unwrap();
+        assert_eq!(format!("{}", outpoint), outpoint_str);
+    }
+
+    #[test]
+    fn version_display() {
+        let version = Version(123);
+        assert_eq!(format!("{}", version), "123");
+    }
 }


### PR DESCRIPTION
The output of `Display` should not change in stable crates for types that have well defined formatting and ones that implement `FromStr`. Error types do not need to be tested. Discussed in #4415.

Add missing tests for all implementations in `primitives` and round trips for types that implement `FromStr`.