### PR TITLE
mutants: Remove `impl Display` from mutants.toml exclusion list

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -7,8 +7,6 @@ exclude_re = [
     "impl Arbitrary",
     "impl Debug",
     "impl fmt::Debug",
-    "impl Display",
-    "impl fmt::Display",
     ".*Error",
     "deserialize", # Skip serde mutation tests
     "Iterator", # Mutating operations in an iterator can result in an infinite loop


### PR DESCRIPTION
The output of Display should not change in stable crates for types that have well defined formatting and ones that implement FromStr. Crates that are included in the mutation testing have been updated to have regression tests for all relevant Display implementations in #4420 and #4422.

Remove the exclusion so that the Display implementations are included in mutation testing.

Together with #4420 and #4422 Closes #4415