### PR TITLE
Improve docs on absolute::LockTime::is_implied_by

### DIFF
--- a/primitives/src/locktime/absolute.rs
+++ b/primitives/src/locktime/absolute.rs
@@ -253,9 +253,15 @@ impl LockTime {
     /// two lock times (same unit) then the larger lock time being satisfied implies (in a
     /// mathematical sense) the smaller one being satisfied.
     ///
-    /// This function is useful if you wish to check a lock time against various other locks e.g.,
-    /// filtering out locks which cannot be satisfied. Can also be used to remove the smaller value
-    /// of two `OP_CHECKLOCKTIMEVERIFY` operations within one branch of the script.
+    /// This function serves multiple purposes:
+    ///
+    /// * When evaluating `OP_CHECKLOCKTIMEVERIFY` the argument must be less than or equal to the
+    ///   transactions nLockTime. If using this function to validate a script `self` is the argument
+    ///   to `CLTV` and `other` is the transaction nLockTime.
+    ///
+    /// * If you wish to check a lock time against various other locks e.g., filtering out locks
+    ///   which cannot be satisfied. Can also be used to remove the smaller value of two
+    ///   `OP_CHECKLOCKTIMEVERIFY` operations within one branch of the script.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
If one wishes to verify a script that contains CLTV is valid in a transaction then one must compare the argument to CLTV (the locktime) to the transaction locktime. And to be valid the CLTV locktime must be less than or equal to the transaction locktime. This usage kind of lends itself to the term 'implied by' and we have a function already `is_implied_by` that does exactly this.

Improve the docs by adding a section mentioning this usecase.