### PR TITLE
Use NumOpResult instead of Option

### DIFF
--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -779,7 +779,7 @@ pub fn effective_value(
     value: Amount,
 ) -> Option<SignedAmount> {
     let weight = input_weight_prediction.total_weight();
-    let signed_input_fee = fee_rate.to_fee(weight)?.to_signed();
+    let signed_input_fee = fee_rate.to_fee(weight).ok()?.to_signed();
     value.to_signed().checked_sub(signed_input_fee)
 }
 

--- a/units/src/result.rs
+++ b/units/src/result.rs
@@ -203,7 +203,7 @@ pub struct NumOpError(MathOp);
 
 impl NumOpError {
     /// Creates a [`NumOpError`] caused by `op`.
-    pub(crate) fn while_doing(op: MathOp) -> Self { NumOpError(op) }
+    pub(crate) const fn while_doing(op: MathOp) -> Self { NumOpError(op) }
 
     /// Returns `true` if this operation error'ed due to overflow.
     pub fn is_overflow(self) -> bool { self.0.is_overflow() }


### PR DESCRIPTION
Prefer the more descriptive NumOpResult return type over Option where return types are fallible.

Closes https://github.com/rust-bitcoin/rust-bitcoin/issues/4419