### PR TITLE
Fix typo in githooks warning message

### DIFF
--- a/githooks/post-merge
+++ b/githooks/post-merge
@@ -22,7 +22,7 @@ do
 			>&2 cat <<- EOF
 			==================================================
 			Project githooks have changed. Please inspect the
-			changes and re-reun \`just githooks-install\` if
+			changes and re-run \`just githooks-install\` if
 			they are legitimate.
 
 			Remove $HOOKS_DIR/post-merge to skip this warning


### PR DESCRIPTION
Replaced “re-reun” with “re-run” in the post-merge hook notice to provide clear instructions for reinstalling project githooks.






