### PR TITLE
Rename `bip34_block_height()` for better discoverability

### DIFF
--- a/fuzz/fuzz_targets/bitcoin/deserialize_block.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_block.rs
@@ -18,7 +18,7 @@ fn do_test(data: &[u8]) {
             block::compute_witness_root(&transactions);
 
             if let Ok(block) = Block::new_checked(header, transactions) {
-                let _ = block.bip34_block_height();
+                let _ = block.block_height();
                 block.block_hash();
                 block.weight();
             }


### PR DESCRIPTION
~~This PR extracts the block height from the coinbase transaction's scriptSig according to BIP-34~~
 
~~The new `coinbase_height` method mirrors  the existing `Block::bip34_block_height` except that we don't check block version since we're workign directly with txs~~

EDIT: Rename `bip34_block_height()` to `block_height()`.  This makes the API more discoverable for users looking for a block's height
 
Closes #4424