### PR TITLE
backport: Add XOnlyPublicKey support for PSBT key retrieval and improve Taproot signing

### DIFF
--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -496,6 +496,20 @@ impl PrivateKey {
             inner: secp256k1::SecretKey::from_slice(&data[1..33])?,
         })
     }
+
+    /// Returns a new private key with the negated secret value.
+    ///
+    /// The resulting key corresponds to the same x-only public key (identical x-coordinate)
+    /// but with the opposite y-coordinate parity. This is useful for ensuring compatibility
+    /// with specific public key formats and BIP-340 requirements.
+    #[inline]
+    pub fn negate(&self) -> Self {
+        PrivateKey {
+            compressed: self.compressed,
+            network: self.network,
+            inner: self.inner.negate(),
+        }
+    }
 }
 
 impl fmt::Display for PrivateKey {

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -807,7 +807,7 @@ impl GetKey for $set<Xpriv> {
             KeyRequest::Pubkey(_) => Err(GetKeyError::NotSupported),
             KeyRequest::Bip32((fingerprint, path)) => {
                 for xpriv in self.iter() {
-                    if xpriv.parent_fingerprint == fingerprint {
+                    if xpriv.fingerprint(secp) == fingerprint {
                         let k = xpriv.derive_priv(secp, &path)?;
                         return Ok(Some(k.to_priv()));
                     }

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -21,7 +21,7 @@ use std::collections::{HashMap, HashSet};
 use internals::write_err;
 use secp256k1::{Keypair, Message, Secp256k1, Signing, Verification};
 
-use crate::bip32::{self, KeySource, Xpriv, Xpub};
+use crate::bip32::{self, DerivationPath, KeySource, Xpriv, Xpub};
 use crate::blockdata::transaction::{self, Transaction, TxOut};
 use crate::crypto::key::{PrivateKey, PublicKey};
 use crate::crypto::{ecdsa, taproot};
@@ -762,6 +762,13 @@ impl GetKey for Xpriv {
             KeyRequest::Pubkey(_) => Err(GetKeyError::NotSupported),
             KeyRequest::Bip32((fingerprint, path)) => {
                 let key = if self.fingerprint(secp) == fingerprint {
+                    let k = self.derive_priv(secp, &path)?;
+                    Some(k.to_priv())
+                } else if self.parent_fingerprint == fingerprint
+                    && !path.is_empty()
+                    && path[0] == self.child_number
+                {
+                    let path = DerivationPath::from_iter(path.into_iter().skip(1).copied());
                     let k = self.derive_priv(secp, &path)?;
                     Some(k.to_priv())
                 } else {


### PR DESCRIPTION
Backport two PRs:

- #3356
- #4238

The first includes a bug fix in a `GetKey` impl and the second is a feature we want to release. And the three refactor patches touch code that #4238 builds on so I figured we should backport them all.

All 5 patches required a small amount of massaging to get in. The first 4 was just adding a `?` to the calls to `derive_priv`. The last patch needed a few calls in the unit test changing.