### PR TITLE
script: push_int_non_minimal handles OP_0

### DIFF
--- a/bitcoin/src/blockdata/script/builder.rs
+++ b/bitcoin/src/blockdata/script/builder.rs
@@ -73,7 +73,7 @@ impl Builder {
     /// This uses the explicit encoding regardless of the availability of dedicated opcodes.
     pub(in crate::blockdata) fn push_int_non_minimal(self, data: i64) -> Builder {
         let mut buf = [0u8; 8];
-        let len = write_scriptint(&mut buf, data);
+        let len = if data == 0 { 1 } else { write_scriptint(&mut buf, data) };
         self.push_slice_non_minimal(&<&PushBytes>::from(&buf)[..len])
     }
 


### PR DESCRIPTION
`push_int_non_minimal` should push int in a non-minimal way without optimization. However, as it depends on `write_script_int` which return zero len on zero push, it unintentionally optimizes OP_0 push.