### PR TITLE
backport: Add methods to retrieve inner types

### DIFF
--- a/bitcoin/examples/sign-tx-taproot.rs
+++ b/bitcoin/examples/sign-tx-taproot.rs
@@ -72,7 +72,7 @@ fn main() {
     // Sign the sighash using the secp256k1 library (exported by rust-bitcoin).
     let tweaked: TweakedKeypair = keypair.tap_tweak(&secp, None);
     let msg = Message::from(sighash);
-    let signature = secp.sign_schnorr(&msg, &tweaked.to_inner());
+    let signature = secp.sign_schnorr(&msg, tweaked.as_keypair());
 
     // Update the witness stack.
     let signature = bitcoin::taproot::Signature { signature, sighash_type };

--- a/bitcoin/examples/taproot-psbt.rs
+++ b/bitcoin/examples/taproot-psbt.rs
@@ -734,7 +734,7 @@ fn sign_psbt_taproot(
 ) {
     let keypair = secp256k1::Keypair::from_seckey_slice(secp, secret_key.as_ref()).unwrap();
     let keypair = match leaf_hash {
-        None => keypair.tap_tweak(secp, psbt_input.tap_merkle_root).to_inner(),
+        None => keypair.tap_tweak(secp, psbt_input.tap_merkle_root).to_keypair(),
         Some(_) => keypair, // no tweak for script spend
     };
 

--- a/bitcoin/src/blockdata/script/witness_program.rs
+++ b/bitcoin/src/blockdata/script/witness_program.rs
@@ -90,13 +90,13 @@ impl WitnessProgram {
         merkle_root: Option<TapNodeHash>,
     ) -> Self {
         let (output_key, _parity) = internal_key.tap_tweak(secp, merkle_root);
-        let pubkey = output_key.to_inner().serialize();
+        let pubkey = output_key.as_x_only_public_key().serialize();
         WitnessProgram::new_p2tr(pubkey)
     }
 
     /// Creates a pay to taproot address from a pre-tweaked output key.
     pub fn p2tr_tweaked(output_key: TweakedPublicKey) -> Self {
-        let pubkey = output_key.to_inner().serialize();
+        let pubkey = output_key.as_x_only_public_key().serialize();
         WitnessProgram::new_p2tr(pubkey)
     }
 

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -841,8 +841,17 @@ impl TweakedPublicKey {
         TweakedPublicKey(key)
     }
 
-    /// Returns the underlying public key.
+    #[doc(hidden)]
+    #[deprecated(since="0.32.6", note="use to_x_only_public_key() instead")]
     pub fn to_inner(self) -> XOnlyPublicKey { self.0 }
+
+    /// Returns the underlying x-only public key.
+    #[inline]
+    pub fn to_x_only_public_key(self) -> XOnlyPublicKey { self.0 }
+
+    /// Returns a reference to the underlying x-only public key.
+    #[inline]
+    pub fn as_x_only_public_key(&self) -> &XOnlyPublicKey { &self.0 }
 
     /// Serialize the key as a byte-encoded pair of values. In compressed form
     /// the y-coordinate is represented by only a single bit, as x determines
@@ -860,9 +869,17 @@ impl TweakedKeypair {
     #[inline]
     pub fn dangerous_assume_tweaked(pair: Keypair) -> TweakedKeypair { TweakedKeypair(pair) }
 
+    #[doc(hidden)]
+    #[deprecated(since="0.32.6", note="use to_keypair() instead")]
+    pub fn to_inner(self) -> Keypair { self.0 }
+
     /// Returns the underlying key pair.
     #[inline]
-    pub fn to_inner(self) -> Keypair { self.0 }
+    pub fn to_keypair(self) -> Keypair { self.0 }
+
+    /// Returns a reference to the underlying key pair.
+    #[inline]
+    pub fn as_keypair(&self) -> &Keypair { &self.0 }
 
     /// Returns the [`TweakedPublicKey`] and its [`Parity`] for this [`TweakedKeypair`].
     #[inline]

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -442,7 +442,7 @@ impl Psbt {
                     let (msg, sighash_type) = self.sighash_taproot(input_index, cache, None)?;
                     let key_pair = Keypair::from_secret_key(secp, &sk.inner)
                         .tap_tweak(secp, input.tap_merkle_root)
-                        .to_inner();
+                        .to_keypair();
 
                     #[cfg(feature = "rand-std")]
                     let signature = secp.sign_schnorr(&msg, &key_pair);

--- a/bitcoin/src/taproot/mod.rs
+++ b/bitcoin/src/taproot/mod.rs
@@ -1556,7 +1556,7 @@ mod test {
         let control_block =
             ControlBlock::decode(&Vec::<u8>::from_hex(control_block_hex).unwrap()).unwrap();
         assert_eq!(control_block_hex, control_block.serialize().to_lower_hex_string());
-        assert!(control_block.verify_taproot_commitment(secp, out_pk.to_inner(), &script));
+        assert!(control_block.verify_taproot_commitment(secp, out_pk.to_x_only_public_key(), &script));
     }
 
     #[test]
@@ -1663,7 +1663,7 @@ mod test {
             let ctrl_block = tree_info.control_block(&ver_script).unwrap();
             assert!(ctrl_block.verify_taproot_commitment(
                 &secp,
-                output_key.to_inner(),
+                output_key.to_x_only_public_key(),
                 &ver_script.0
             ))
         }
@@ -1738,7 +1738,7 @@ mod test {
             let ctrl_block = tree_info.control_block(&ver_script).unwrap();
             assert!(ctrl_block.verify_taproot_commitment(
                 &secp,
-                output_key.to_inner(),
+                output_key.to_x_only_public_key(),
                 &ver_script.0
             ))
         }
@@ -1854,7 +1854,7 @@ mod test {
             let addr = Address::p2tr(secp, internal_key, merkle_root, KnownHrp::Mainnet);
             let spk = addr.script_pubkey();
 
-            assert_eq!(expected_output_key, output_key.to_inner());
+            assert_eq!(expected_output_key, output_key.to_x_only_public_key());
             assert_eq!(expected_tweak, tweak);
             assert_eq!(expected_addr, addr);
             assert_eq!(expected_spk, spk);


### PR DESCRIPTION
Backport #4373, authored by Shing Him Ng.

Original gitlog:

For TweakedKeypair, `to_inner` is also renamed to `to_keypair` to maintain consistency. Similarly, `to_inner` is renamed to `to_x_only_pubkey` for TweakedPublicKey