### PR TITLE
Fix documentation error for `TweakedPublicKey::serialize`

### DIFF
--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -899,9 +899,7 @@ impl TweakedPublicKey {
     #[inline]
     pub fn as_x_only_public_key(&self) -> &XOnlyPublicKey { &self.0 }
 
-    /// Serializes the key as a byte-encoded pair of values. In compressed form
-    /// the y-coordinate is represented by only a single bit, as x determines
-    /// it up to one bit.
+    /// Serializes the key as a byte-encoded x coordinate value (32 bytes).
     #[inline]
     pub fn serialize(&self) -> [u8; constants::SCHNORR_PUBLIC_KEY_SIZE] { self.0.serialize() }
 }


### PR DESCRIPTION
Fixes an ancient copy/paste error in documentation ( `secp256k1::schnorrsig::PublicKey::serialize()` docs copied from ECDSA docs, which was copied into rust-bitcoin)

Is there a threshold beneath which a PR is too trivial?