### PR TITLE
rustdoc: Fix unused lint warnings

### DIFF
--- a/primitives/src/locktime/relative.rs
+++ b/primitives/src/locktime/relative.rs
@@ -225,7 +225,6 @@ impl LockTime {
     /// # Examples
     ///
     /// ```rust
-    /// # use bitcoin_primitives::locktime::relative::HeightInterval;
     /// # use bitcoin_primitives::relative::Time;
     /// # use units::mtp_height::MtpAndHeight;
     /// # use bitcoin_primitives::BlockHeight;

--- a/units/src/lib.rs
+++ b/units/src/lib.rs
@@ -14,7 +14,7 @@
 //! // Exactly the same as `use bitcoin::{amount, Amount}`.
 //! use bitcoin_units::{amount, Amount};
 //!
-//! let amount = Amount::from_sat(1_000)?;
+//! let _amount = Amount::from_sat(1_000)?;
 //! # Ok::<_, amount::OutOfRangeError>(())
 //! ```
 

--- a/units/src/result.rs
+++ b/units/src/result.rs
@@ -39,12 +39,12 @@ use crate::{Amount, FeeRate, SignedAmount, Weight};
 /// //
 /// // For example if the `spend` value comes from the user and the `change` value is later
 /// // used then overflow here could be an attack vector.
-/// let change = (a1 + a2 - spend - fee).into_result().expect("handle this error");
+/// let _change = (a1 + a2 - spend - fee).into_result().expect("handle this error");
 ///
 /// // Or if we control all the values and know they are sane we can just `unwrap`.
-/// let change = (a1 + a2 - spend - fee).unwrap();
+/// let _change = (a1 + a2 - spend - fee).unwrap();
 /// // `NumOpResult` also implements `expect`.
-/// let change = (a1 + a2 - spend - fee).expect("we know values don't overflow");
+/// let _change = (a1 + a2 - spend - fee).expect("we know values don't overflow");
 /// # Ok::<_, amount::OutOfRangeError>(())
 /// ```
 ///

--- a/units/src/result.rs
+++ b/units/src/result.rs
@@ -53,7 +53,7 @@ use crate::{Amount, FeeRate, SignedAmount, Weight};
 /// In some instances one may wish to differentiate div-by-zero from overflow.
 ///
 /// ```
-/// # use bitcoin_units::{amount, Amount, FeeRate, NumOpResult, NumOpError};
+/// # use bitcoin_units::{Amount, FeeRate, NumOpResult, NumOpError};
 /// // Two amounts that will be added to calculate the max fee.
 /// let a = Amount::from_sat(123).expect("valid amount");
 /// let b = Amount::from_sat(467).expect("valid amount");


### PR DESCRIPTION
There is a lint warning about unused variables and imports in the rustdoc examples.

Remove the unused imports and prefix the unused variables with an underscore.