### PR TITLE
Implementing Div<NonZeroU64|I64> for Amount, SignedAmount, FeeRate, and and Weight

### DIFF
--- a/units/src/amount/result.rs
+++ b/units/src/amount/result.rs
@@ -2,6 +2,7 @@
 
 //! Provides a monodic type returned by mathematical operations (`core::ops`).
 
+use core::num::{NonZeroI64, NonZeroU64};
 use core::ops;
 
 use NumOpResult as R;
@@ -90,7 +91,11 @@ crate::internal_macros::impl_op_for_references! {
             self.to_sat().checked_div(rhs.to_sat()).valid_or_error(MathOp::Div)
         }
     }
+    impl ops::Div<NonZeroU64> for Amount {
+        type Output = Amount;
 
+        fn div(self, rhs: NonZeroU64) -> Self::Output { Self::from_sat(self.to_sat() / rhs.get()).expect("construction after division cannot fail") }
+    }
     impl ops::Rem<u64> for Amount {
         type Output = NumOpResult<Amount>;
 
@@ -167,7 +172,11 @@ crate::internal_macros::impl_op_for_references! {
             self.to_sat().checked_div(rhs.to_sat()).valid_or_error(MathOp::Div)
         }
     }
+    impl ops::Div<NonZeroI64> for SignedAmount {
+        type Output = SignedAmount;
 
+        fn div(self, rhs: NonZeroI64) -> Self::Output { Self::from_sat(self.to_sat() / rhs.get()).expect("construction after division cannot fail") }
+    }
     impl ops::Rem<i64> for SignedAmount {
         type Output = NumOpResult<SignedAmount>;
 

--- a/units/src/amount/tests.rs
+++ b/units/src/amount/tests.rs
@@ -6,6 +6,7 @@
 use alloc::format;
 #[cfg(feature = "alloc")]
 use alloc::string::{String, ToString};
+use core::num::{NonZeroI64, NonZeroU64};
 #[cfg(feature = "std")]
 use std::panic;
 
@@ -1529,4 +1530,27 @@ fn math_op_errors() {
     } else {
         panic!("Expected a division by zero error, but got a valid result");
     }
+}
+
+#[test]
+#[allow(clippy::op_ref)]
+fn amount_div_nonzero() {
+    let amount = Amount::from_sat(100).unwrap();
+    let divisor = NonZeroU64::new(4).unwrap();
+    let result = amount / divisor;
+    assert_eq!(result, Amount::from_sat(25).unwrap());
+    //checking also for &T/&U variant
+    assert_eq!(&amount / &divisor, Amount::from_sat(25).unwrap());
+}
+
+#[test]
+#[allow(clippy::op_ref)]
+fn signed_amount_div_nonzero() {
+    let signed = SignedAmount::from_sat(-100).unwrap();
+    let divisor = NonZeroI64::new(4).unwrap();
+    let result = signed / divisor;
+    assert_eq!(result, SignedAmount::from_sat(-25).unwrap());
+    //checking also for &T/U, T/&Uvariant
+    assert_eq!(&signed / divisor, SignedAmount::from_sat(-25).unwrap());
+    assert_eq!(signed / &divisor, SignedAmount::from_sat(-25).unwrap());
 }


### PR DESCRIPTION
The pr implements `Div<NonZeroU64>` and `Div<NonZeroI64>` for the following types in `units` crate: `Amount`, `SignedAmount`, `FeeRate`, `Weight`

For handling owned/borrowed variants, each impl is wrapped in the existing `impl_op_for_references!` macro, which generates: `T  / NonZero*` , `&T / NonZero*`, `T  / &NonZero*`, `&T / &NonZero*`

close: #4442
