### PR TITLE
fix: fix a serious typo in method name `invalid_legcay_address_length`

### DIFF
--- a/bitcoin/src/address/error.rs
+++ b/bitcoin/src/address/error.rs
@@ -338,7 +338,7 @@ impl LegacyAddressTooLongError {
 
     #[doc(hidden)]
     #[deprecated = "Use invalid_legacy_address_length() instead"]
-    pub fn invalid_legcay_address_length(&self) -> usize { self.invalid_legacy_address_length() }
+    pub fn invalid_legacy_address_length(&self) -> usize { self.invalid_legacy_address_length() }
 }
 
 impl fmt::Display for LegacyAddressTooLongError {


### PR DESCRIPTION
The method `invalid_legcay_address_length` has been renamed to `invalid_legacy_address_length_deprecated` due to a typo in the name.
The old name was misspelled (`legcay` instead of `legacy`), now it is correct.
The actual method remains `invalid_legacy_address_length()`.