### PR TITLE
Iterate on the script hex APIs

### DIFF
--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -376,12 +376,19 @@ crate::internal_macros::define_extension_trait! {
         fn to_asm_string(&self) -> String { self.to_string() }
 
         /// Consensus encodes the script as lower-case hex.
-        fn to_hex_string(&self) -> String { consensus::encode::serialize_hex(self) }
+        #[deprecated(since = "TBD", note = "use `to_hex_string_prefixed()` instead")]
+        fn to_hex_string(&self) -> String { self.to_hex_string_prefixed() }
+
+        /// Consensus encodes the script as lower-case hex.
+        fn to_hex_string_prefixed(&self) -> String { consensus::encode::serialize_hex(self) }
 
         /// Consensus encodes the script as lower-case hex.
         ///
-        /// This is **not** consensus encoding, you likely want to use `to_hex_string`. The returned
-        /// hex string will not include the length prefix.
+        /// This is **not** consensus encoding, you likely want to use `to_hex_string_prefixed`.
+        ///
+        /// # Returns
+        ///
+        /// The returned hex string will not include the length prefix.
         fn to_hex_string_no_length_prefix(&self) -> String {
             self.as_bytes().to_lower_hex_string()
         }

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -30,8 +30,16 @@ crate::internal_macros::define_extension_trait! {
         /// Constructs a new [`ScriptBuf`] from a hex string.
         ///
         /// The input string is expected to be consensus encoded i.e., includes the length prefix.
-        fn from_hex(s: &str) -> Result<ScriptBuf, consensus::FromHexError> {
+        fn from_hex_prefixed(s: &str) -> Result<ScriptBuf, consensus::FromHexError> {
             consensus::encode::deserialize_hex(s)
+        }
+
+        /// Constructs a new [`ScriptBuf`] from a hex string.
+        ///
+        /// The input string is expected to be consensus encoded i.e., includes the length prefix.
+        #[deprecated(since = "TBD", note = "use `from_hex_string_prefixed()` instead")]
+        fn from_hex(s: &str) -> Result<ScriptBuf, consensus::FromHexError> {
+            Self::from_hex_prefixed(s)
         }
 
         /// Constructs a new [`ScriptBuf`] from a hex string.

--- a/primitives/src/script/borrowed.rs
+++ b/primitives/src/script/borrowed.rs
@@ -49,6 +49,14 @@ internals::transparent_newtype! {
     /// The type is `#[repr(transparent)]` for internal purposes only!
     /// No consumer crate may rely on the representation of the struct!
     ///
+    /// # Hexadecimal strings
+    ///
+    /// Scripts are consensus encoded with a length prefix and as a result of this in some places in
+    /// the eccosystem one will encounter hex strings that include the prefix while in other places
+    /// the prefix is excluded. To support parsing and formatting scripts as hex we provide a bunch
+    /// of different APIs and trait implementations. Please see [`examples/script.rs`] for a
+    /// thorough example of all the APIs.
+    ///
     /// # Bitcoin Core References
     ///
     /// * [CScript definition](https://github.com/bitcoin/bitcoin/blob/d492dc1cdaabdc52b0766bf4cba4bd73178325d0/src/script/script.h#L410)

--- a/primitives/src/script/mod.rs
+++ b/primitives/src/script/mod.rs
@@ -431,12 +431,9 @@ impl fmt::Display for ScriptBuf {
 
 #[cfg(feature = "hex")]
 impl fmt::LowerHex for Script {
-    // Currently we drop all formatter options.
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let compact = internals::compact_size::encode(self.as_bytes().len());
-        write!(f, "{:x}", compact.as_slice().as_hex())?;
-        write!(f, "{:x}", self.as_bytes().as_hex())
+        fmt::LowerHex::fmt(&self.as_bytes().as_hex(), f)
     }
 }
 #[cfg(feature = "alloc")]
@@ -454,12 +451,9 @@ internals::impl_to_hex_from_lower_hex!(ScriptBuf, |script_buf: &Self| script_buf
 
 #[cfg(feature = "hex")]
 impl fmt::UpperHex for Script {
-    // Currently we drop all formatter options.
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let compact = internals::compact_size::encode(self.as_bytes().len());
-        write!(f, "{:X}", compact.as_slice().as_hex())?;
-        write!(f, "{:X}", self.as_bytes().as_hex())
+        fmt::UpperHex::fmt(&self.as_bytes().as_hex(), f)
     }
 }
 
@@ -511,8 +505,7 @@ impl serde::Serialize for Script {
         S: serde::Serializer,
     {
         if serializer.is_human_readable() {
-            // Do not call LowerHex because we don't want to add the len prefix.
-            serializer.collect_str(&format_args!("{}", self.as_bytes().as_hex()))
+            serializer.collect_str(&format_args!("{:x}", self))
         } else {
             serializer.serialize_bytes(self.as_bytes())
         }
@@ -803,8 +796,8 @@ mod tests {
 
         #[cfg(feature = "hex")]
         {
-            assert_eq!(format!("{:x}", script), "0300a1b2");
-            assert_eq!(format!("{:X}", script), "0300A1B2");
+            assert_eq!(format!("{:x}", script), "00a1b2");
+            assert_eq!(format!("{:X}", script), "00A1B2");
         }
         assert!(!format!("{:?}", script).is_empty());
     }
@@ -816,8 +809,8 @@ mod tests {
 
         #[cfg(feature = "hex")]
         {
-            assert_eq!(format!("{:x}", script_buf), "0300a1b2");
-            assert_eq!(format!("{:X}", script_buf), "0300A1B2");
+            assert_eq!(format!("{:x}", script_buf), "00a1b2");
+            assert_eq!(format!("{:X}", script_buf), "00A1B2");
         }
         assert!(!format!("{:?}", script_buf).is_empty());
     }
@@ -935,7 +928,7 @@ mod tests {
     fn script_to_hex() {
         let script = Script::from_bytes(&[0xa1, 0xb2, 0xc3]);
         let hex = script.to_hex();
-        assert_eq!(hex, "03a1b2c3");
+        assert_eq!(hex, "a1b2c3");
     }
 
     #[test]
@@ -944,6 +937,6 @@ mod tests {
     fn scriptbuf_to_hex() {
         let script = ScriptBuf::from_bytes(vec![0xa1, 0xb2, 0xc3]);
         let hex = script.to_hex();
-        assert_eq!(hex, "03a1b2c3");
+        assert_eq!(hex, "a1b2c3");
     }
 }

--- a/primitives/src/script/owned.rs
+++ b/primitives/src/script/owned.rs
@@ -16,6 +16,15 @@ use crate::prelude::{Box, Vec};
 /// Just as other similar types, this implements [`Deref`], so [deref coercions] apply. Also note
 /// that all the safety/validity restrictions that apply to [`Script`] apply to `ScriptBuf` as well.
 ///
+/// # Hexadecimal strings
+///
+/// Scripts are consensus encoded with a length prefix and as a result of this in some places in the
+/// eccosystem one will encounter hex strings that include the prefix while in other places the
+/// prefix is excluded. To support parsing and formatting scripts as hex we provide a bunch of
+/// different APIs and trait implementations. Please see [`examples/script.rs`] for a thorough
+/// example of all the APIs.
+///
+/// [`examples/script.rs`]: <https://github.com/rust-bitcoin/rust-bitcoin/blob/master/bitcoin/examples/script.rs>
 /// [deref coercions]: https://doc.rust-lang.org/std/ops/trait.Deref.html#more-on-deref-coercion
 #[derive(Default, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct ScriptBuf(Vec<u8>);


### PR DESCRIPTION
In #4316 we made some 'improvements' to what script functions and trait implementations do and do not include the length prefix. Iterate again on it as described here: https://github.com/rust-bitcoin/rust-bitcoin/pull/4316#issuecomment-2847710436

- Patch 1 does the changes
- Patch 2 adds some more docs, requires a grammarian to check Aussie lingua