### PR TITLE
Assert num op error

### DIFF
--- a/units/src/fee.rs
+++ b/units/src/fee.rs
@@ -344,8 +344,11 @@ mod tests {
 
     #[test]
     fn fee_wu() {
-        let fee_overflow = FeeRate::from_sat_per_kwu(10).to_fee(Weight::MAX);
-        assert!(fee_overflow.is_error());
+        let operation = FeeRate::from_sat_per_kwu(10)
+            .to_fee(Weight::MAX)
+            .unwrap_err()
+            .operation();
+        assert!(operation.is_multiplication());
 
         let fee_rate = FeeRate::from_sat_per_vb(2).unwrap();
         let weight = Weight::from_vb(3).unwrap();

--- a/units/src/result.rs
+++ b/units/src/result.rs
@@ -254,6 +254,18 @@ impl MathOp {
 
     /// Returns `true` if this operation error'ed due to division by zero.
     pub fn is_div_by_zero(self) -> bool { !self.is_overflow() }
+
+    /// Returns `true` if this operation error'ed due to addition.
+    pub fn is_addition(self) -> bool { self == MathOp::Add }
+
+    /// Returns `true` if this operation error'ed due to subtraction.
+    pub fn is_subtraction(self) -> bool { self == MathOp::Sub }
+
+    /// Returns `true` if this operation error'ed due to multiplication.
+    pub fn is_multiplication(self) -> bool { self == MathOp::Mul }
+
+    /// Returns `true` if this operation error'ed due to negation.
+    pub fn is_negation(self) -> bool { self == MathOp::Neg }
 }
 
 impl fmt::Display for MathOp {


### PR DESCRIPTION
Follow up from https://github.com/rust-bitcoin/rust-bitcoin/pull/4428 to assert the error type which I agree improves the test.

Added some helper functions since it can be nice to see what type of overflow happened.