### PR TITLE
Mark method as constant

### DIFF
--- a/units/src/fee.rs
+++ b/units/src/fee.rs
@@ -118,7 +118,7 @@ impl FeeRate {
     /// [`NumOpResult::Error`] if an overflow occurred.
     ///
     /// This is equivalent to `Self::checked_mul_by_weight()`.
-    pub fn to_fee(self, weight: Weight) -> NumOpResult<Amount> {
+    pub const fn to_fee(self, weight: Weight) -> NumOpResult<Amount> {
         self.checked_mul_by_weight(weight)
     }
 


### PR DESCRIPTION
Allow external const calls to access this method

Followup from https://github.com/rust-bitcoin/rust-bitcoin/pull/4428