### PR TITLE
Improved error message when parsing ScriptBuf from hex

### DIFF
--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -30,8 +30,11 @@ crate::internal_macros::define_extension_trait! {
         /// Constructs a new [`ScriptBuf`] from a hex string.
         ///
         /// The input string is expected to be consensus encoded i.e., includes the length prefix.
-        fn from_hex(s: &str) -> Result<ScriptBuf, consensus::FromHexError> {
-            consensus::encode::deserialize_hex(s)
+        fn from_hex(s: &str) -> Result<ScriptBuf, consensus::ScriptHexError> {
+            match consensus::encode::deserialize_hex(s) {
+                Ok(script) => Ok(script),
+                Err(e) => Err(e.into()),
+            }
         }
 
         /// Constructs a new [`ScriptBuf`] from a hex string.

--- a/bitcoin/src/consensus/error.rs
+++ b/bitcoin/src/consensus/error.rs
@@ -257,3 +257,33 @@ impl From<OddLengthStringError> for FromHexError {
 pub(crate) fn parse_failed_error(msg: &'static str) -> Error {
     Error::Parse(ParseError::ParseFailed(msg))
 }
+
+/// Custom error type for ScriptBuf hex parsing
+#[derive(Debug)]
+pub struct ScriptHexError {
+    error: FromHexError,
+}
+
+impl fmt::Display for ScriptHexError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use FromHexError::*;
+        match &self.error {
+            Decode(DecodeError::Parse(ParseError::MissingData)) => {
+                write!(
+                    f,
+                    "MissingData: consider using ScriptBuf::from_hex_no_length_prefix() instead"
+                )
+            }
+            other => write!(f, "{}", other),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ScriptHexError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.error) }
+}
+
+impl From<FromHexError> for ScriptHexError {
+    fn from(error: FromHexError) -> Self { ScriptHexError { error } }
+}

--- a/bitcoin/src/consensus/mod.rs
+++ b/bitcoin/src/consensus/mod.rs
@@ -20,7 +20,7 @@ use crate::consensus;
 #[doc(inline)]
 pub use self::{
     encode::{deserialize, deserialize_partial, serialize, Decodable, Encodable, ReadExt, WriteExt},
-    error::{Error, FromHexError, DecodeError, ParseError, DeserializeError},
+    error::{Error, FromHexError, DecodeError, ParseError, DeserializeError, ScriptHexError},
 };
 pub(crate) use self::error::parse_failed_error;
 


### PR DESCRIPTION
Improve the error message of `ScriptBuf::from_hex` by returning a richer error type (ScriptHexError) that wraps the underlying parse error, produces a clear, actionable hint directing users to either include the prefix or call `from_hex_no_length_prefix()` instead of the generic MissingData message.

**Changes**
- New Error Type
- Debug Formatting
- Updated `from_hex`

Closes #4356 