### PR TITLE
Check mul opt

### DIFF
--- a/units/src/fee.rs
+++ b/units/src/fee.rs
@@ -15,7 +15,7 @@ use core::ops;
 
 use NumOpResult as R;
 
-use crate::{Amount, FeeRate, MathOp, NumOpError as E, NumOpResult, OptionExt, Weight};
+use crate::{Amount, FeeRate, MathOp, NumOpError, NumOpResult, OptionExt, Weight};
 
 impl Amount {
     /// Checked weight ceiling division.
@@ -158,7 +158,7 @@ impl FeeRate {
                 }
             }
         }
-        NumOpResult::Error(E::while_doing(MathOp::Mul))
+        NumOpResult::Error(NumOpError::while_doing(MathOp::Mul))
     }
 }
 


### PR DESCRIPTION
A few follwups from https://github.com/rust-bitcoin/rust-bitcoin/pull/4428

I reworked Kix's  suggestion for optimizing `checked_mul_by_weight`, so I ask that he be one of the reviewers before merging.

There are a few minor changes to the optimization Kix originally suggested. A mul by 1000 was changed to an add by 1 since I believe it was a mistake and a few other trivial changes to appease the compiler.

I'm convinced this is probably more performant in that two checked arithmetic are removed, although one of them was replaced with a greater than less than comparison, which I'm not sure is more efficient.