### PR TITLE
Shorten method names

### DIFF
--- a/units/src/fee.rs
+++ b/units/src/fee.rs
@@ -349,7 +349,7 @@ mod tests {
             .to_fee(Weight::MAX)
             .unwrap_err()
             .operation();
-        assert!(operation.is_multiplication());
+        assert!(operation.is_mul());
 
         let fee_rate = FeeRate::from_sat_per_vb(2).unwrap();
         let weight = Weight::from_vb(3).unwrap();

--- a/units/src/result.rs
+++ b/units/src/result.rs
@@ -256,16 +256,16 @@ impl MathOp {
     pub fn is_div_by_zero(self) -> bool { !self.is_overflow() }
 
     /// Returns `true` if this operation error'ed due to addition.
-    pub fn is_addition(self) -> bool { self == MathOp::Add }
+    pub fn is_add(self) -> bool { self == MathOp::Add }
 
     /// Returns `true` if this operation error'ed due to subtraction.
-    pub fn is_subtraction(self) -> bool { self == MathOp::Sub }
+    pub fn is_sub(self) -> bool { self == MathOp::Sub }
 
     /// Returns `true` if this operation error'ed due to multiplication.
-    pub fn is_multiplication(self) -> bool { self == MathOp::Mul }
+    pub fn is_mul(self) -> bool { self == MathOp::Mul }
 
     /// Returns `true` if this operation error'ed due to negation.
-    pub fn is_negation(self) -> bool { self == MathOp::Neg }
+    pub fn is_neg(self) -> bool { self == MathOp::Neg }
 }
 
 impl fmt::Display for MathOp {


### PR DESCRIPTION
Prefer brevity in names but verboseness in docs.