### PR TITLE
Fix argument check in labeler script

### DIFF
--- a/contrib/gen_label_config.sh
+++ b/contrib/gen_label_config.sh
@@ -10,7 +10,7 @@ config=.github/labeler.yml
 # Define a default value for SCAN_DIR if not set
 : "${SCAN_DIR:=.}"
 
-if [ "${1:-default}" '!=' "--force" ] && ! git diff --exit-code "$config";
+if [ "${1:-default}" != "--force" ] && ! git diff --exit-code "$config";
 then
 	echo "Error: $config is not committed."
 	echo "Refusing to overwrite it to prevent disaster."


### PR DESCRIPTION
### Description

Removed unnecessary quotes around the `!=` operator in the Bash test expression, so the `--force` flag is now evaluated correctly instead of always passing.