### PR TITLE
Fix off-by-one-bug in absolute timelock

### DIFF
--- a/units/src/locktime/absolute.rs
+++ b/units/src/locktime/absolute.rs
@@ -83,6 +83,17 @@ impl Height {
     /// Converts this [`Height`] to a raw `u32` value.
     #[inline]
     pub const fn to_u32(self) -> u32 { self.0 }
+
+    /// Returns true if a transaction with this locktime can be included in the next block.
+    ///
+    /// `self` is value of the `LockTime` and if `height` is the current chain tip then
+    /// a transaction with this lock can be broadcast for inclusion in the next block.
+    #[inline]
+    pub fn is_satisfied_by(self, height: Height) -> bool {
+        // Use u64 so that there can be no overflow.
+        let next_block_height = u64::from(height.to_u32()) + 1;
+        u64::from(self.to_u32()) <= next_block_height
+    }
 }
 
 impl fmt::Display for Height {
@@ -217,6 +228,18 @@ impl MedianTimePast {
     /// Converts this [`MedianTimePast`] to a raw `u32` value.
     #[inline]
     pub const fn to_u32(self) -> u32 { self.0 }
+
+    /// Returns true if a transaction with this locktime can be included in the next block.
+    ///
+    /// `self`is the value of the `LockTime` and if `time` is the median time past of the block at
+    /// the chain tip then a transaction with this lock can be broadcast for inclusion in the next
+    /// block.
+    #[inline]
+    pub fn is_satisfied_by(self, time: MedianTimePast) -> bool {
+        // The locktime check in Core during block validation uses the MTP
+        // of the previous block - which is the expected to be `time` here.
+        self <= time
+    }
 }
 
 impl fmt::Display for MedianTimePast {


### PR DESCRIPTION
We just fixed this in relative locktime (#4448) and forgot to check the absolute lock time where the exact same bug exists - face palm.
    
When checking a locktime against block height we add 1 because when the next block is being validated that is what the height will be and `is_satisfied_by` is defined to return true if a transaction with this locktime can be included in the next block.
    
As we have in `relative`, and for the same reasons, add an API to the absolute `Height` and `MedianTimePast`: `is_satisfied_by`. Also add `is_satisfied_by_{height, time}` variants to `absolute::LockTime`. Call through to the new functions in `units`.
