### PR TITLE
Fix up script to/from hex

### DIFF
--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -376,19 +376,19 @@ crate::internal_macros::define_extension_trait! {
         fn to_asm_string(&self) -> String { self.to_string() }
 
         /// Consensus encodes the script as lower-case hex.
-        #[deprecated(since = "TBD", note = "use `to_hex_string_prefixed()` instead")]
-        fn to_hex_string(&self) -> String { self.to_hex_string_prefixed() }
+        #[deprecated(since = "TBD", note = "use `to_hex_string_no_length_prefix` instead")]
+        fn to_hex_string(&self) -> String { self.to_hex_string_no_length_prefix() }
 
         /// Consensus encodes the script as lower-case hex.
+        ///
+        /// Consensus encoding includes a length prefix. To hex encode without the length prefix use
+        /// `to_hex_string_no_length_prefix`.
         fn to_hex_string_prefixed(&self) -> String { consensus::encode::serialize_hex(self) }
 
-        /// Consensus encodes the script as lower-case hex.
+        /// Encodes the script as lower-case hex.
         ///
-        /// This is **not** consensus encoding, you likely want to use `to_hex_string_prefixed`.
-        ///
-        /// # Returns
-        ///
-        /// The returned hex string will not include the length prefix.
+        /// This is **not** consensus encoding. The returned hex string will not include the length
+        /// prefix. See `to_hex_string_prefixed`.
         fn to_hex_string_no_length_prefix(&self) -> String {
             self.as_bytes().to_lower_hex_string()
         }

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -35,17 +35,15 @@ crate::internal_macros::define_extension_trait! {
         }
 
         /// Constructs a new [`ScriptBuf`] from a hex string.
-        ///
-        /// The input string is expected to be consensus encoded i.e., includes the length prefix.
-        #[deprecated(since = "TBD", note = "use `from_hex_string_prefixed()` instead")]
-        fn from_hex(s: &str) -> Result<ScriptBuf, consensus::FromHexError> {
-            Self::from_hex_prefixed(s)
+        #[deprecated(since = "TBD", note = "use `from_hex_string_no_length_prefix()` instead")]
+        fn from_hex(s: &str) -> Result<ScriptBuf, hex::HexToBytesError> {
+            Self::from_hex_no_length_prefix(s)
         }
 
         /// Constructs a new [`ScriptBuf`] from a hex string.
         ///
-        /// This is **not** consensus encoding. If your hex string is a consensus encode script then
-        /// use `ScriptBuf::from_hex`.
+        /// This is **not** consensus encoding. If your hex string is a consensus encoded script
+        /// then use `ScriptBuf::from_hex_prefixed`.
         fn from_hex_no_length_prefix(s: &str) -> Result<ScriptBuf, hex::HexToBytesError> {
             let v = Vec::from_hex(s)?;
             Ok(ScriptBuf::from_bytes(v))


### PR DESCRIPTION
We (I) have recently done to PRs patching the way we handle converting scripts to and from hex.

In doing these I made a mess of the deprecation because after both PRs were in I had managed to change the return type and the behaviour of the deprecated function.

On top of that the docs were either outright wrong or not that clear.

Props to Kix for doing post merge review and finding my mistakes.

Close #4498