### PR TITLE
Remove Display/FromStr for FeeRate

### DIFF
--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -1133,7 +1133,7 @@ impl fmt::Display for ExtractTxError {
 
         match *self {
             AbsurdFeeRate { fee_rate, .. } =>
-                write!(f, "an absurdly high fee rate of {}", fee_rate),
+                write!(f, "an absurdly high fee rate of {} sat/kwu", fee_rate.to_sat_per_kwu()),
             MissingInputValue { .. } => write!(
                 f,
                 "one of the inputs lacked value information (witness_utxo or non_witness_utxo)"

--- a/units/src/fee_rate/mod.rs
+++ b/units/src/fee_rate/mod.rs
@@ -6,7 +6,7 @@
 pub mod serde;
 
 use core::num::NonZeroU64;
-use core::{fmt, ops};
+use core::ops;
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
@@ -131,17 +131,6 @@ impl FeeRate {
     }
 }
 
-/// Alternative will display the unit.
-impl fmt::Display for FeeRate {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if f.alternate() {
-            write!(f, "{}.00 sat/vbyte", self.to_sat_per_vb_ceil())
-        } else {
-            fmt::Display::fmt(&self.to_sat_per_kwu(), f)
-        }
-    }
-}
-
 impl From<FeeRate> for u64 {
     fn from(value: FeeRate) -> Self { value.to_sat_per_kwu() }
 }
@@ -185,8 +174,6 @@ impl<'a> core::iter::Sum<&'a FeeRate> for FeeRate {
         FeeRate::from_sat_per_kwu(iter.map(|f| FeeRate::to_sat_per_kwu(*f)).sum())
     }
 }
-
-crate::impl_parse_str_from_int_infallible!(FeeRate, u64, from_sat_per_kwu);
 
 #[cfg(feature = "arbitrary")]
 impl<'a> Arbitrary<'a> for FeeRate {

--- a/units/tests/str.rs
+++ b/units/tests/str.rs
@@ -4,7 +4,7 @@
 
 use bitcoin_units::amount::Denomination;
 use bitcoin_units::locktime::{absolute, relative};
-use bitcoin_units::{Amount, BlockHeight, BlockInterval, FeeRate, SignedAmount, Weight};
+use bitcoin_units::{Amount, BlockHeight, BlockInterval, SignedAmount, Weight};
 
 macro_rules! check {
     ($($test_name:ident, $ty:path, $val:path, $str:literal);* $(;)?) => {
@@ -36,10 +36,6 @@ check! {
 
     block_interval_min, BlockInterval, BlockInterval::MIN, "0";
     block_interval_max, BlockInterval, BlockInterval::MAX, "4294967295";
-
-    fee_rate_min, FeeRate, FeeRate::MIN, "0";
-    fee_rate_max, FeeRate, FeeRate::MAX, "18446744073709551615";
-    fee_rate_dust, FeeRate, FeeRate::DUST, "750";
 
     lock_by_height_absolute_min, absolute::Height, absolute::Height::MIN, "0";
     lock_by_height_absolute_max, absolute::Height, absolute::Height::MAX, "499999999";


### PR DESCRIPTION
Parsing and displaying strings is a PITA. `FeeRate` is likely not that heavily used at the moment and users can always just call `to_sat_per_kwu()` to format it.

So we can get the `units-1.0-alpha.0` release out the door just remove the `Display` and `FromStr` impls for now. They can be added back in later when we have time to get #4339 in.