### PR TITLE
Saturate to `Amount::MAX` when calculating fee

### DIFF
--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -785,11 +785,7 @@ pub fn effective_value(
     value: Amount,
 ) -> NumOpResult<SignedAmount> {
     let weight = input_weight_prediction.total_weight();
-
-    fee_rate
-        .to_fee(weight)
-        .map(Amount::to_signed)
-        .and_then(|fee| value.to_signed() - fee)    // Cannot overflow.
+    value.to_signed() - fee_rate.to_fee(weight).to_signed()
 }
 
 /// Predicts the weight of a to-be-constructed transaction.
@@ -1674,7 +1670,7 @@ mod tests {
     fn effective_value_fee_rate_does_not_overflow() {
         let eff_value =
             effective_value(FeeRate::MAX, InputWeightPrediction::P2WPKH_MAX, Amount::ZERO);
-        assert!(eff_value.is_error());
+        assert_eq!(eff_value.unwrap(), SignedAmount::MIN);
     }
 
     #[test]

--- a/units/src/result.rs
+++ b/units/src/result.rs
@@ -91,23 +91,6 @@ impl<T> NumOpResult<T> {
 
     /// Maps a `NumOpResult<T>` to `NumOpResult<U>` by applying a function to a
     /// contained [`NumOpResult::Valid`] value, leaving a [`NumOpResult::Error`] value untouched.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use bitcoin_units::{FeeRate, Amount, Weight, SignedAmount};
-    ///
-    /// let fee_rate = FeeRate::from_sat_per_vb(1).unwrap();
-    /// let weight = Weight::from_wu(1000);
-    /// let amount = Amount::from_sat_u32(1_000_000);
-    ///
-    /// let amount_after_fee = fee_rate
-    ///     .to_fee(weight) // (1 sat/ 4 wu) * (1000 wu) = 250 sat fee
-    ///     .map(|fee| fee.to_signed())
-    ///     .and_then(|fee| amount.to_signed() - fee);
-    ///
-    /// assert_eq!(amount_after_fee.unwrap(), SignedAmount::from_sat_i32(999_750))
-    /// ```
     #[inline]
     pub fn map<U, F: FnOnce(T) -> U>(self, op: F) -> NumOpResult<U> {
         match self {


### PR DESCRIPTION
Currently we return an error if a fee calculation overflows. Observe however that anytime one calculates a fee the next logic step is check if there are funds enough to pay the fee. Since one can never pay `Amount::MAX` the error will always be hit.

We can therefore use saturating mul when calculating fees.

Sadly, this patch removes the reason we added `NumOpResult::map` which  included some very nice docs - remove them.
   

Close: #4497