### PR TITLE
units: Add support for add/sub assign

### DIFF
--- a/units/src/amount/result.rs
+++ b/units/src/amount/result.rs
@@ -187,57 +187,6 @@ crate::internal_macros::impl_op_for_references! {
 
         fn rem(self, modulus: i64) -> Self::Output { self.and_then(|lhs| lhs % modulus) }
     }
-
-    impl<T> ops::Add<NumOpResult<T>> for NumOpResult<T>
-    where
-        (T: Copy + ops::Add<Output = NumOpResult<T>>)
-    {
-        type Output = NumOpResult<T>;
-
-        fn add(self, rhs: Self) -> Self::Output {
-            match (self, rhs) {
-                (R::Valid(lhs), R::Valid(rhs)) => lhs + rhs,
-                (_, _) => R::Error(NumOpError::while_doing(MathOp::Add)),
-            }
-        }
-    }
-
-    impl<T> ops::Add<T> for NumOpResult<T>
-    where
-        (T: Copy + ops::Add<NumOpResult<T>, Output = NumOpResult<T>>)
-    {
-        type Output = NumOpResult<T>;
-
-        fn add(self, rhs: T) -> Self::Output { rhs + self }
-    }
-
-    impl<T> ops::Sub<NumOpResult<T>> for NumOpResult<T>
-    where
-        (T: Copy + ops::Sub<Output = NumOpResult<T>>)
-    {
-        type Output = NumOpResult<T>;
-
-        fn sub(self, rhs: Self) -> Self::Output {
-            match (self, rhs) {
-                (R::Valid(lhs), R::Valid(rhs)) => lhs - rhs,
-                (_, _) => R::Error(NumOpError::while_doing(MathOp::Sub)),
-            }
-        }
-    }
-
-    impl<T> ops::Sub<T> for NumOpResult<T>
-    where
-        (T: Copy + ops::Sub<Output = NumOpResult<T>>)
-    {
-        type Output = NumOpResult<T>;
-
-        fn sub(self, rhs: T) -> Self::Output {
-            match self {
-                R::Valid(amount) => amount - rhs,
-                R::Error(_) => self,
-            }
-        }
-    }
 }
 
 impl_mul_assign!(NumOpResult<Amount>, u64);

--- a/units/src/amount/tests.rs
+++ b/units/src/amount/tests.rs
@@ -1404,6 +1404,12 @@ fn num_op_result_ops() {
     let res: NumOpResult<Amount> = sat + sat;
     let sres: NumOpResult<SignedAmount> = ssat + ssat;
 
+    let mut x = res;
+    x += sat;
+
+    let mut x = sres;
+    x += ssat;
+
     macro_rules! check_op {
         ($(let _ = $lhs:ident $op:tt $rhs:ident);* $(;)?) => {
             $(

--- a/units/src/result.rs
+++ b/units/src/result.rs
@@ -3,7 +3,7 @@
 //! Provides a monodic type returned by mathematical operations (`core::ops`).
 
 use core::convert::Infallible;
-use core::fmt;
+use core::{fmt, ops};
 
 use NumOpResult as R;
 
@@ -203,6 +203,59 @@ impl<T: fmt::Debug> NumOpResult<T> {
     /// Returns `true` if the numeric result is invalid.
     #[inline]
     pub fn is_error(&self) -> bool { !self.is_valid() }
+}
+
+crate::internal_macros::impl_op_for_references! {
+    impl<T> ops::Add<NumOpResult<T>> for NumOpResult<T>
+    where
+        (T: Copy + ops::Add<Output = NumOpResult<T>>)
+    {
+        type Output = NumOpResult<T>;
+
+        fn add(self, rhs: Self) -> Self::Output {
+            match (self, rhs) {
+                (R::Valid(lhs), R::Valid(rhs)) => lhs + rhs,
+                (_, _) => R::Error(NumOpError::while_doing(MathOp::Add)),
+            }
+        }
+    }
+
+    impl<T> ops::Add<T> for NumOpResult<T>
+    where
+        (T: Copy + ops::Add<NumOpResult<T>, Output = NumOpResult<T>>)
+    {
+        type Output = NumOpResult<T>;
+
+        fn add(self, rhs: T) -> Self::Output { rhs + self }
+    }
+
+    impl<T> ops::Sub<NumOpResult<T>> for NumOpResult<T>
+    where
+        (T: Copy + ops::Sub<Output = NumOpResult<T>>)
+    {
+        type Output = NumOpResult<T>;
+
+        fn sub(self, rhs: Self) -> Self::Output {
+            match (self, rhs) {
+                (R::Valid(lhs), R::Valid(rhs)) => lhs - rhs,
+                (_, _) => R::Error(NumOpError::while_doing(MathOp::Sub)),
+            }
+        }
+    }
+
+    impl<T> ops::Sub<T> for NumOpResult<T>
+    where
+        (T: Copy + ops::Sub<Output = NumOpResult<T>>)
+    {
+        type Output = NumOpResult<T>;
+
+        fn sub(self, rhs: T) -> Self::Output {
+            match self {
+                R::Valid(amount) => amount - rhs,
+                R::Error(_) => self,
+            }
+        }
+    }
 }
 
 pub(crate) trait OptionExt<T> {

--- a/units/src/result.rs
+++ b/units/src/result.rs
@@ -258,6 +258,20 @@ crate::internal_macros::impl_op_for_references! {
     }
 }
 
+impl<T> ops::AddAssign<T> for NumOpResult<T>
+where
+    NumOpResult<T>: Copy + ops::Add<T, Output = NumOpResult<T>>
+{
+    fn add_assign(&mut self, rhs: T) { *self = *self + rhs }
+}
+
+impl<T> ops::SubAssign<T> for NumOpResult<T>
+where
+    NumOpResult<T>: Copy + ops::Sub<T, Output = NumOpResult<T>>
+{
+    fn sub_assign(&mut self, rhs: T) { *self = *self - rhs }
+}
+
 pub(crate) trait OptionExt<T> {
     fn valid_or_error(self, op: MathOp) -> NumOpResult<T>;
 }


### PR DESCRIPTION
Add support for `amount += amount` - signed and unsigned.

- Patch 1 is preparatory code move
- Patch 2 adds impls of `AddAssign` and `SubAssign`

Fix: #4031