### PR TITLE
Add FeeRate getters/setters using Amount

### DIFF
--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -290,7 +290,7 @@ crate::internal_macros::define_extension_trait! {
         ///
         /// [`minimal_non_dust`]: Script::minimal_non_dust
         fn minimal_non_dust_custom(&self, dust_relay_fee: FeeRate) -> Option<Amount> {
-            self.minimal_non_dust_internal(dust_relay_fee.to_sat_per_kwu() * 4)
+            self.minimal_non_dust_internal(dust_relay_fee.to_sat_per_kwu_ceil() * 4)
         }
 
         /// Counts the sigops for this Script using accurate counting.

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -290,7 +290,7 @@ crate::internal_macros::define_extension_trait! {
         ///
         /// [`minimal_non_dust`]: Script::minimal_non_dust
         fn minimal_non_dust_custom(&self, dust_relay: FeeRate) -> Option<Amount> {
-            self.minimal_non_dust_internal(dust_relay.to_sat_per_kvb())
+            self.minimal_non_dust_internal(dust_relay.to_sat_per_kvb_ceil())
         }
 
         /// Counts the sigops for this Script using accurate counting.

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -289,8 +289,8 @@ crate::internal_macros::define_extension_trait! {
         /// To use the default Bitcoin Core value, use [`minimal_non_dust`].
         ///
         /// [`minimal_non_dust`]: Script::minimal_non_dust
-        fn minimal_non_dust_custom(&self, dust_relay_fee: FeeRate) -> Option<Amount> {
-            self.minimal_non_dust_internal(dust_relay_fee.to_sat_per_kwu_ceil() * 4)
+        fn minimal_non_dust_custom(&self, dust_relay: FeeRate) -> Option<Amount> {
+            self.minimal_non_dust_internal(dust_relay.to_sat_per_kvb())
         }
 
         /// Counts the sigops for this Script using accurate counting.
@@ -407,10 +407,10 @@ mod sealed {
 
 crate::internal_macros::define_extension_trait! {
     pub(crate) trait ScriptExtPriv impl for Script {
-        fn minimal_non_dust_internal(&self, dust_relay_fee: u64) -> Option<Amount> {
+        fn minimal_non_dust_internal(&self, dust_relay_fee_rate_per_kvb: u64) -> Option<Amount> {
             // This must never be lower than Bitcoin Core's GetDustThreshold() (as of v0.21) as it may
             // otherwise allow users to create transactions which likely can never be broadcast/confirmed.
-            let sats = dust_relay_fee
+            let sats = dust_relay_fee_rate_per_kvb
                 .checked_mul(if self.is_op_return() {
                     0
                 } else if self.is_witness_program() {

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -1653,7 +1653,7 @@ mod tests {
     #[test]
     fn effective_value_happy_path() {
         let value = "1 cBTC".parse::<Amount>().unwrap();
-        let fee_rate = FeeRate::from_sat_per_kwu(10);
+        let fee_rate = FeeRate::from_sat_per_kwu(10).unwrap();
         let effective_value = effective_value(fee_rate, InputWeightPrediction::P2WPKH_MAX, value);
 
         // 10 sat/kwu * 272 wu = 4 sats (rounding up)

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -1656,7 +1656,7 @@ mod tests {
         let fee_rate = FeeRate::from_sat_per_kwu(10).unwrap();
         let effective_value = effective_value(fee_rate, InputWeightPrediction::P2WPKH_MAX, value);
 
-        // 10 sat/kwu * 272 wu = 4 sats (rounding up)
+        // 10 sat/kwu * 272 wu = 3 sats (rounding up)
         let expected_fee = "3 sats".parse::<SignedAmount>().unwrap();
         let expected_effective_value = (value.to_signed() - expected_fee).unwrap();
         assert_eq!(effective_value, expected_effective_value);

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -774,6 +774,7 @@ impl Decodable for Transaction {
 ///
 /// * `fee_rate` - the fee rate of the transaction being created.
 /// * `input_weight_prediction` - the predicted input weight.
+/// * `value` - The value of the output we are spending.
 ///
 /// # Returns
 ///

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -1666,7 +1666,8 @@ mod tests {
     fn effective_value_fee_rate_does_not_overflow() {
         let eff_value =
             effective_value(FeeRate::MAX, InputWeightPrediction::P2WPKH_MAX, Amount::ZERO);
-        assert_eq!(eff_value, SignedAmount::MIN)
+        let want = SignedAmount::from_sat(-1254378597012250).unwrap(); // U64::MAX / 4_000 because of FeeRate::MAX
+        assert_eq!(eff_value, want)
     }
 
     #[test]

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -1178,8 +1178,11 @@ impl fmt::Display for ExtractTxError {
         use ExtractTxError::*;
 
         match *self {
-            AbsurdFeeRate { fee_rate, .. } =>
-                write!(f, "an absurdly high fee rate of {} sat/kwu", fee_rate.to_sat_per_kwu()),
+            AbsurdFeeRate { fee_rate, .. } => write!(
+                f,
+                "an absurdly high fee rate of {} sat/kwu",
+                fee_rate.to_sat_per_kwu_floor()
+            ),
             MissingInputValue { .. } => write!(
                 f,
                 "one of the inputs lacked value information (witness_utxo or non_witness_utxo)"

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -1354,9 +1354,15 @@ mod tests {
     use crate::Sequence;
 
     /// Fee rate in sat/kwu for a high-fee PSBT with an input=5_000_000_000_000, output=1000
-    const ABSURD_FEE_RATE: FeeRate = FeeRate::from_sat_per_kwu(15_060_240_960_843);
-    /// Fee rate which is just below absurd threshold (1 sat/kwu less)
-    const JUST_BELOW_ABSURD_FEE_RATE: FeeRate = FeeRate::from_sat_per_kwu(15_060_240_960_842);
+    const ABSURD_FEE_RATE: FeeRate = match FeeRate::from_sat_per_kwu(15_060_240_960_843) {
+        Some(fee_rate) => fee_rate,
+        None => panic!("unreachable - no unwrap in Rust 1.63 in const"),
+    };
+    const JUST_BELOW_ABSURD_FEE_RATE: FeeRate = match FeeRate::from_sat_per_kwu(15_060_240_960_842)
+    {
+        Some(fee_rate) => fee_rate,
+        None => panic!("unreachable - no unwrap in Rust 1.63 in const"),
+    };
 
     #[track_caller]
     pub fn hex_psbt(s: &str) -> Result<Psbt, crate::psbt::error::Error> {
@@ -1473,7 +1479,7 @@ mod tests {
                 ExtractTxError::AbsurdFeeRate { fee_rate, .. } => fee_rate,
                 _ => panic!(""),
             }),
-            Err(FeeRate::from_sat_per_kwu(6250003)) // 6250000 is 25k sat/vbyte
+            Err(FeeRate::from_sat_per_kwu(6250003).unwrap()) // 6250000 is 25k sat/vbyte
         );
 
         // Lowering the input satoshis by 1 lowers the sat/kwu by 3

--- a/fuzz/fuzz_targets/bitcoin/deserialize_script.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_script.rs
@@ -17,7 +17,7 @@ fn do_test(data: &[u8]) {
         let _ = script.count_sigops_legacy();
         let _ = script.minimal_non_dust();
 
-        let fee_rate = FeeRate::from_sat_per_kwu(consume_u64(&mut new_data));
+        let fee_rate = FeeRate::from_sat_per_kwu(consume_u64(&mut new_data)).unwrap();
         let _ = script.minimal_non_dust_custom(fee_rate);
 
         let mut b = script::Builder::new();

--- a/units/src/amount/tests.rs
+++ b/units/src/amount/tests.rs
@@ -270,13 +270,13 @@ fn amount_checked_div_by_weight_ceil() {
     let weight = Weight::from_kwu(1).unwrap();
     let fee_rate = sat(1).checked_div_by_weight_ceil(weight).unwrap();
     // 1 sats / 1,000 wu = 1 sats/kwu
-    assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(1));
+    assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(1).unwrap());
 
     let weight = Weight::from_wu(381);
     let fee_rate = sat(329).checked_div_by_weight_ceil(weight).unwrap();
     // 329 sats / 381 wu = 863.5 sats/kwu
     // round up to 864
-    assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(864));
+    assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(864).unwrap());
 
     let fee_rate = Amount::ONE_SAT.checked_div_by_weight_ceil(Weight::ZERO);
     assert!(fee_rate.is_none());
@@ -288,13 +288,13 @@ fn amount_checked_div_by_weight_floor() {
     let weight = Weight::from_kwu(1).unwrap();
     let fee_rate = sat(1).checked_div_by_weight_floor(weight).unwrap();
     // 1 sats / 1,000 wu = 1 sats/kwu
-    assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(1));
+    assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(1).unwrap());
 
     let weight = Weight::from_wu(381);
     let fee_rate = sat(329).checked_div_by_weight_floor(weight).unwrap();
     // 329 sats / 381 wu = 863.5 sats/kwu
     // round down to 863
-    assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(863));
+    assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(863).unwrap());
 
     let fee_rate = Amount::ONE_SAT.checked_div_by_weight_floor(Weight::ZERO);
     assert!(fee_rate.is_none());
@@ -304,7 +304,7 @@ fn amount_checked_div_by_weight_floor() {
 #[test]
 fn amount_checked_div_by_fee_rate() {
     let amount = sat(1000);
-    let fee_rate = FeeRate::from_sat_per_kwu(2);
+    let fee_rate = FeeRate::from_sat_per_kwu(2).unwrap();
 
     // Test floor division
     let weight = amount.checked_div_by_fee_rate_floor(fee_rate).unwrap();
@@ -317,20 +317,20 @@ fn amount_checked_div_by_fee_rate() {
 
     // Test truncation behavior
     let amount = sat(1000);
-    let fee_rate = FeeRate::from_sat_per_kwu(3);
+    let fee_rate = FeeRate::from_sat_per_kwu(3).unwrap();
     let floor_weight = amount.checked_div_by_fee_rate_floor(fee_rate).unwrap();
     let ceil_weight = amount.checked_div_by_fee_rate_ceil(fee_rate).unwrap();
     assert_eq!(floor_weight, Weight::from_wu(333_333));
     assert_eq!(ceil_weight, Weight::from_wu(333_334));
 
     // Test division by zero
-    let zero_fee_rate = FeeRate::from_sat_per_kwu(0);
+    let zero_fee_rate = FeeRate::from_sat_per_kwu(0).unwrap();
     assert!(amount.checked_div_by_fee_rate_floor(zero_fee_rate).is_none());
     assert!(amount.checked_div_by_fee_rate_ceil(zero_fee_rate).is_none());
 
     // Test with maximum amount
     let max_amount = Amount::MAX;
-    let small_fee_rate = FeeRate::from_sat_per_kwu(1);
+    let small_fee_rate = FeeRate::from_sat_per_kwu(1).unwrap();
     let weight = max_amount.checked_div_by_fee_rate_floor(small_fee_rate).unwrap();
     // 21_000_000_0000_0000 sats / (1 sat/kwu) = 2_100_000_000_000_000_000 wu
     assert_eq!(weight, Weight::from_wu(2_100_000_000_000_000_000));

--- a/units/src/fee.rs
+++ b/units/src/fee.rs
@@ -55,7 +55,7 @@ impl Amount {
     /// # Ok::<_, amount::OutOfRangeError>(())
     /// ```
     #[must_use]
-    pub const fn checked_div_by_weight_ceil(self, weight: Weight) -> Option<FeeRate> {
+    pub fn checked_div_by_weight_ceil(self, weight: Weight) -> Option<FeeRate> {
         let wu = weight.to_wu();
         // No `?` operator in const context.
         if let Some(sats) = self.to_sat().checked_mul(1_000) {
@@ -78,7 +78,7 @@ impl Amount {
     ///
     /// Returns [`None`] if overflow occurred or if `fee_rate` is zero.
     #[must_use]
-    pub const fn checked_div_by_fee_rate_floor(self, fee_rate: FeeRate) -> Option<Weight> {
+    pub fn checked_div_by_fee_rate_floor(self, fee_rate: FeeRate) -> Option<Weight> {
         match self.to_sat().checked_mul(1000) {
             Some(amount_msats) => match amount_msats.checked_div(fee_rate.to_sat_per_kwu_ceil()) {
                 Some(wu) => Some(Weight::from_wu(wu)),
@@ -95,7 +95,7 @@ impl Amount {
     ///
     /// Returns [`None`] if overflow occurred or if `fee_rate` is zero.
     #[must_use]
-    pub const fn checked_div_by_fee_rate_ceil(self, fee_rate: FeeRate) -> Option<Weight> {
+    pub fn checked_div_by_fee_rate_ceil(self, fee_rate: FeeRate) -> Option<Weight> {
         // Use ceil because result is used as the divisor.
         let rate = fee_rate.to_sat_per_kwu_ceil();
         match self.to_sat().checked_mul(1000) {
@@ -119,7 +119,7 @@ impl FeeRate {
     /// [`NumOpResult::Error`] if an overflow occurred.
     ///
     /// This is equivalent to `Self::checked_mul_by_weight()`.
-    pub const fn to_fee(self, weight: Weight) -> NumOpResult<Amount> {
+    pub fn to_fee(self, weight: Weight) -> NumOpResult<Amount> {
         self.checked_mul_by_weight(weight)
     }
 
@@ -151,7 +151,7 @@ impl FeeRate {
     /// enough instead of falling short if rounded down.
     ///
     /// Returns [`NumOpResult::Error`] if overflow occurred.
-    pub const fn checked_mul_by_weight(self, weight: Weight) -> NumOpResult<Amount> {
+    pub fn checked_mul_by_weight(self, weight: Weight) -> NumOpResult<Amount> {
         if let Some(fee) = self.to_sat_per_kwu_floor().checked_mul(weight.to_wu()) {
             if let Some(round_up) = fee.checked_add(999) {
                 if let Ok(ret) = Amount::from_sat(round_up / 1_000) {
@@ -329,7 +329,7 @@ impl Weight {
     /// enough instead of falling short if rounded down.
     ///
     /// Returns [`None`] if overflow occurred.
-    pub const fn checked_mul_by_fee_rate(self, fee_rate: FeeRate) -> NumOpResult<Amount> {
+    pub fn checked_mul_by_fee_rate(self, fee_rate: FeeRate) -> NumOpResult<Amount> {
         fee_rate.checked_mul_by_weight(self)
     }
 }

--- a/units/src/fee.rs
+++ b/units/src/fee.rs
@@ -56,16 +56,21 @@ impl Amount {
     /// # Ok::<_, amount::OutOfRangeError>(())
     /// ```
     #[must_use]
-    pub fn checked_div_by_weight_ceil(self, weight: Weight) -> Option<FeeRate> {
+    pub const fn checked_div_by_weight_ceil(self, weight: Weight) -> Option<FeeRate> {
         let wu = weight.to_wu();
         if wu == 0 {
             return None;
         }
 
-        let sats = self.to_sat() * 1_000; // Because we use per/kwu.
-        let fee_rate = (sats + wu - 1) / wu;
-
-        FeeRate::from_sat_per_kwu(fee_rate)
+        // Mul by 1,000 because we use per/kwu.
+        if let Some(sats) = self.to_sat().checked_mul(1_000) {
+            // No need to used checked arithmetic because wu is non-zero.
+            if let Some(bump) = sats.checked_add(wu - 1) {
+                let fee_rate = bump / wu;
+                return FeeRate::from_sat_per_kwu(fee_rate);
+            }
+        }
+        None
     }
 
     /// Checked fee rate floor division.
@@ -76,7 +81,7 @@ impl Amount {
     ///
     /// Returns [`None`] if overflow occurred or if `fee_rate` is zero.
     #[must_use]
-    pub fn checked_div_by_fee_rate_floor(self, fee_rate: FeeRate) -> Option<Weight> {
+    pub const fn checked_div_by_fee_rate_floor(self, fee_rate: FeeRate) -> Option<Weight> {
         match self.to_sat().checked_mul(1000) {
             Some(amount_msats) => match amount_msats.checked_div(fee_rate.to_sat_per_kwu_ceil()) {
                 Some(wu) => Some(Weight::from_wu(wu)),
@@ -93,7 +98,7 @@ impl Amount {
     ///
     /// Returns [`None`] if overflow occurred or if `fee_rate` is zero.
     #[must_use]
-    pub fn checked_div_by_fee_rate_ceil(self, fee_rate: FeeRate) -> Option<Weight> {
+    pub const fn checked_div_by_fee_rate_ceil(self, fee_rate: FeeRate) -> Option<Weight> {
         // Use ceil because result is used as the divisor.
         let rate = fee_rate.to_sat_per_kwu_ceil();
         match self.to_sat().checked_mul(1000) {
@@ -117,8 +122,12 @@ impl FeeRate {
     /// [`NumOpResult::Error`] if an overflow occurred.
     ///
     /// This is equivalent to `Self::checked_mul_by_weight()`.
-    pub fn to_fee(self, weight: Weight) -> Amount {
-        self.checked_mul_by_weight(weight).unwrap_or(Amount::MAX)
+    pub const fn to_fee(self, weight: Weight) -> Amount {
+        // No `unwrap_or()` in const context.
+        match self.checked_mul_by_weight(weight) {
+            Some(fee) => fee,
+            None => Amount::MAX,
+        }
     }
 
     /// Calculates the fee by multiplying this fee rate by weight, in weight units, returning [`None`]
@@ -145,13 +154,18 @@ impl FeeRate {
     /// enough instead of falling short if rounded down.
     ///
     /// Returns [`None`] if overflow occurred.
-    pub fn checked_mul_by_weight(self, weight: Weight) -> Option<Amount> {
+    pub const fn checked_mul_by_weight(self, weight: Weight) -> Option<Amount> {
         let wu = weight.to_wu();
-        let fee_kwu = self.to_sat_per_kwu_floor().checked_mul(wu)?;
-        let bump = fee_kwu.checked_add(999)?; // We do ceil division.
-        let fee = bump / 1_000;
-
-        Amount::from_sat(fee).ok()
+        if let Some(fee_kwu) = self.to_sat_per_kwu_floor().checked_mul(wu) {
+            // Bump by 999 to do ceil division using kwu.
+            if let Some(bump) = fee_kwu.checked_add(999) {
+                let fee = bump / 1_000;
+                if let Ok(fee_amount) = Amount::from_sat(fee) {
+                    return Some(fee_amount);
+                }
+            }
+        }
+        None
     }
 }
 
@@ -327,7 +341,7 @@ impl Weight {
     /// enough instead of falling short if rounded down.
     ///
     /// Returns [`None`] if overflow occurred.
-    pub fn checked_mul_by_fee_rate(self, fee_rate: FeeRate) -> Option<Amount> {
+    pub const fn checked_mul_by_fee_rate(self, fee_rate: FeeRate) -> Option<Amount> {
         fee_rate.checked_mul_by_weight(self)
     }
 }

--- a/units/src/fee_rate/mod.rs
+++ b/units/src/fee_rate/mod.rs
@@ -31,25 +31,25 @@ mod encapsulate {
 pub use encapsulate::FeeRate;
 
 impl FeeRate {
-    /// 0 sat/kwu.
+    /// The zero fee rate.
     ///
     /// Equivalent to [`MIN`](Self::MIN), may better express intent in some contexts.
     pub const ZERO: FeeRate = FeeRate::from_sat_per_mvb(0);
 
-    /// Minimum possible value (0 sat/kwu).
+    /// The minimum possible value.
     ///
     /// Equivalent to [`ZERO`](Self::ZERO), may better express intent in some contexts.
     pub const MIN: FeeRate = FeeRate::ZERO;
 
-    /// Maximum possible value.
+    /// The maximum possible value.
     pub const MAX: FeeRate = FeeRate::from_sat_per_mvb(u64::MAX);
 
-    /// Minimum fee rate required to broadcast a transaction.
+    /// The minimum fee rate required to broadcast a transaction.
     ///
     /// The value matches the default Bitcoin Core policy at the time of library release.
     pub const BROADCAST_MIN: FeeRate = FeeRate::from_sat_per_vb_u32(1);
 
-    /// Fee rate used to compute dust amount.
+    /// The fee rate used to compute dust amount.
     pub const DUST: FeeRate = FeeRate::from_sat_per_vb_u32(3);
 
     /// Constructs a new [`FeeRate`] from satoshis per 1000 weight units.

--- a/units/src/fee_rate/mod.rs
+++ b/units/src/fee_rate/mod.rs
@@ -30,7 +30,7 @@ impl FeeRate {
     pub const MIN: FeeRate = FeeRate::ZERO;
 
     /// Maximum possible value.
-    pub const MAX: FeeRate = FeeRate::from_sat_per_kwu(u64::MAX);
+    pub const MAX: FeeRate = FeeRate::from_sat_per_kwu(u64::MAX / 4_000);
 
     /// Minimum fee rate required to broadcast a transaction.
     ///
@@ -271,7 +271,7 @@ mod tests {
     fn fee_rate_const() {
         assert_eq!(FeeRate::ZERO.to_sat_per_kwu_floor(), 0);
         assert_eq!(FeeRate::MIN.to_sat_per_kwu_floor(), u64::MIN);
-        assert_eq!(FeeRate::MAX.to_sat_per_kwu_floor(), u64::MAX);
+        assert_eq!(FeeRate::MAX.to_sat_per_kwu_floor(), u64::MAX / 4_000);
         assert_eq!(FeeRate::BROADCAST_MIN.to_sat_per_kwu_floor(), 250);
         assert_eq!(FeeRate::DUST.to_sat_per_kwu_floor(), 750);
     }

--- a/units/src/fee_rate/mod.rs
+++ b/units/src/fee_rate/mod.rs
@@ -11,26 +11,12 @@ use core::ops;
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
 
-mod encapsulate {
-    /// Fee rate.
-    ///
-    /// This is an integer newtype representing fee rate in `sat/kwu`. It provides protection
-    /// against mixing up the types as well as basic formatting features.
-    #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
-    pub struct FeeRate(u64);
-
-    impl FeeRate {
-        /// Constructs a new [`FeeRate`] from satoshis per 1000 weight units.
-        pub const fn from_sat_per_kwu(sat_kwu: u64) -> Self { FeeRate(sat_kwu) }
-
-        /// Returns raw fee rate.
-        ///
-        /// Can be used instead of `into()` to avoid inference issues.
-        pub const fn to_sat_per_kwu(self) -> u64 { self.0 }
-    }
-}
-#[doc(inline)]
-pub use encapsulate::FeeRate;
+/// Fee rate.
+///
+/// This is an integer newtype representing fee rate in `sat/kwu`. It provides protection
+/// against mixing up the types as well as basic formatting features.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct FeeRate(u64);
 
 impl FeeRate {
     /// 0 sat/kwu.
@@ -54,6 +40,9 @@ impl FeeRate {
     /// Fee rate used to compute dust amount.
     pub const DUST: FeeRate = FeeRate::from_sat_per_vb_u32(3);
 
+    /// Constructs a new [`FeeRate`] from satoshis per 1000 weight units.
+    pub const fn from_sat_per_kwu(sat_kwu: u64) -> Self { FeeRate(sat_kwu) }
+
     /// Constructs a new [`FeeRate`] from satoshis per virtual bytes.
     ///
     /// # Errors
@@ -74,6 +63,9 @@ impl FeeRate {
 
     /// Constructs a new [`FeeRate`] from satoshis per kilo virtual bytes (1,000 vbytes).
     pub const fn from_sat_per_kvb(sat_kvb: u64) -> Self { FeeRate::from_sat_per_kwu(sat_kvb / 4) }
+
+    /// Returns raw fee rate.
+    pub const fn to_sat_per_kwu(self) -> u64 { self.0 }
 
     /// Converts to sat/vB rounding down.
     pub const fn to_sat_per_vb_floor(self) -> u64 { self.to_sat_per_kwu() / (1000 / 4) }

--- a/units/src/fee_rate/mod.rs
+++ b/units/src/fee_rate/mod.rs
@@ -11,12 +11,24 @@ use core::ops;
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
 
-/// Fee rate.
-///
-/// This is an integer newtype representing fee rate in `sat/kwu`. It provides protection
-/// against mixing up the types as well as basic formatting features.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub struct FeeRate(u64);
+mod encapsulate {
+    /// Fee rate.
+    ///
+    /// This is an integer newtype representing fee rate. It provides protection
+    /// against mixing up the types, conversion functions, and basic formatting.
+    #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+    pub struct FeeRate(u64);
+
+    impl FeeRate {
+        /// Constructs a new [`FeeRate`] from satoshis per 1,000,000 virtual bytes.
+        pub(crate) const fn from_sat_per_mvb(sat_mvb: u64) -> Self { Self(sat_mvb) }
+
+        /// Converts to sat/MvB.
+        pub(crate) const fn to_sat_per_mvb(self) -> u64 { self.0 }
+    }
+}
+#[doc(inline)]
+pub use encapsulate::FeeRate;
 
 impl FeeRate {
     /// 0 sat/kwu.
@@ -39,9 +51,6 @@ impl FeeRate {
 
     /// Fee rate used to compute dust amount.
     pub const DUST: FeeRate = FeeRate::from_sat_per_vb_u32(3);
-
-    /// Constructs a new [`FeeRate`] from satoshis per 1,000,000 virtual bytes.
-    pub(crate) const fn from_sat_per_mvb(sat_mvb: u64) -> Self { Self(sat_mvb) }
 
     /// Constructs a new [`FeeRate`] from satoshis per 1000 weight units.
     pub const fn from_sat_per_kwu(sat_kwu: u64) -> Option<Self> {
@@ -79,9 +88,6 @@ impl FeeRate {
             None => None,
         }
     }
-
-    /// Converts to sat/MvB.
-    pub(crate) const fn to_sat_per_mvb(self) -> u64 { self.0 }
 
     /// Converts to sat/kwu rounding down.
     pub const fn to_sat_per_kwu_floor(self) -> u64 { self.to_sat_per_mvb() / 4_000 }

--- a/units/src/fee_rate/mod.rs
+++ b/units/src/fee_rate/mod.rs
@@ -78,6 +78,9 @@ impl FeeRate {
         (self.to_sat_per_kwu_floor() + (1000 / 4 - 1)) / (1000 / 4)
     }
 
+    /// Converts to sat/kvb.
+    pub const fn to_sat_per_kvb(self) -> u64 { self.to_sat_per_kwu_floor() * 4 }
+
     /// Checked multiplication.
     ///
     /// Computes `self * rhs` returning [`None`] if overflow occurred.

--- a/units/src/fee_rate/serde.rs
+++ b/units/src/fee_rate/serde.rs
@@ -18,7 +18,7 @@
 //!
 //! #[derive(Serialize, Deserialize)]
 //! pub struct Foo {
-//!     #[serde(with = "fee_rate::serde::as_sat_per_kwu")]
+//!     #[serde(with = "fee_rate::serde::as_sat_per_kwu_floor")]
 //!     pub fee_rate: FeeRate,
 //! }
 //! ```
@@ -26,7 +26,7 @@
 use core::convert::Infallible;
 use core::fmt;
 
-pub mod as_sat_per_kwu {
+pub mod as_sat_per_kwu_floor {
     //! Serialize and deserialize [`FeeRate`] denominated in satoshis per 1000 weight units.
     //!
     //! Use with `#[serde(with = "fee_rate::serde::as_sat_per_kwu")]`.
@@ -40,7 +40,8 @@ pub mod as_sat_per_kwu {
     }
 
     pub fn deserialize<'d, D: Deserializer<'d>>(d: D) -> Result<FeeRate, D::Error> {
-        Ok(FeeRate::from_sat_per_kwu(u64::deserialize(d)?))
+        FeeRate::from_sat_per_kwu(u64::deserialize(d)?)
+            .ok_or_else(|| serde::de::Error::custom("overflowed sats/kwu"))
     }
 
     pub mod opt {

--- a/units/src/fee_rate/serde.rs
+++ b/units/src/fee_rate/serde.rs
@@ -36,7 +36,7 @@ pub mod as_sat_per_kwu {
     use crate::FeeRate;
 
     pub fn serialize<S: Serializer>(f: &FeeRate, s: S) -> Result<S::Ok, S::Error> {
-        u64::serialize(&f.to_sat_per_kwu(), s)
+        u64::serialize(&f.to_sat_per_kwu_floor(), s)
     }
 
     pub fn deserialize<'d, D: Deserializer<'d>>(d: D) -> Result<FeeRate, D::Error> {
@@ -57,7 +57,7 @@ pub mod as_sat_per_kwu {
         #[allow(clippy::ref_option)] // API forced by serde.
         pub fn serialize<S: Serializer>(f: &Option<FeeRate>, s: S) -> Result<S::Ok, S::Error> {
             match *f {
-                Some(f) => s.serialize_some(&f.to_sat_per_kwu()),
+                Some(f) => s.serialize_some(&f.to_sat_per_kwu_floor()),
                 None => s.serialize_none(),
             }
         }

--- a/units/src/result.rs
+++ b/units/src/result.rs
@@ -90,23 +90,6 @@ pub enum NumOpResult<T> {
 impl<T> NumOpResult<T> {
     /// Maps a `NumOpResult<T>` to `NumOpResult<U>` by applying a function to a
     /// contained [`NumOpResult::Valid`] value, leaving a [`NumOpResult::Error`] value untouched.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use bitcoin_units::{FeeRate, Amount, Weight, SignedAmount};
-    ///
-    /// let fee_rate = FeeRate::from_sat_per_vb(1).unwrap();
-    /// let weight = Weight::from_wu(1000);
-    /// let amount = Amount::from_sat_u32(1_000_000);
-    ///
-    /// let amount_after_fee = fee_rate
-    ///     .to_fee(weight) // (1 sat/ 4 wu) * (1000 wu) = 250 sat fee
-    ///     .map(|fee| fee.to_signed())
-    ///     .and_then(|fee| amount.to_signed() - fee);
-    ///
-    /// assert_eq!(amount_after_fee.unwrap(), SignedAmount::from_sat_i32(999_750))
-    /// ```
     #[inline]
     pub fn map<U, F: FnOnce(T) -> U>(self, op: F) -> NumOpResult<U> {
         match self {

--- a/units/tests/serde.rs
+++ b/units/tests/serde.rs
@@ -37,13 +37,13 @@ struct Serde {
     vb_floor: FeeRate,
     #[serde(with = "fee_rate::serde::as_sat_per_vb_ceil")]
     vb_ceil: FeeRate,
-    #[serde(with = "fee_rate::serde::as_sat_per_kwu")]
+    #[serde(with = "fee_rate::serde::as_sat_per_kwu_floor")]
     kwu: FeeRate,
     #[serde(with = "fee_rate::serde::as_sat_per_vb_floor::opt")]
     opt_vb_floor: Option<FeeRate>,
     #[serde(with = "fee_rate::serde::as_sat_per_vb_ceil::opt")]
     opt_vb_ceil: Option<FeeRate>,
-    #[serde(with = "fee_rate::serde::as_sat_per_kwu::opt")]
+    #[serde(with = "fee_rate::serde::as_sat_per_kwu_floor::opt")]
     opt_kwu: Option<FeeRate>,
 
     a: BlockHeight,


### PR DESCRIPTION
Draft because on top of #4534. This PR is just the last patch.

Instead of using the word sat in the identifier and taking/returning a `u64` we can use an `Amount`.

Close: #4374