### PR TITLE
Release tracking for chacha20-poly1305 v0.1.2

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -182,7 +182,7 @@ checksum = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 
 [[package]]
 name = "chacha20-poly1305"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "hex-conservative 0.3.0",
 ]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -184,7 +184,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20-poly1305"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "hex-conservative 0.3.0",
 ]

--- a/chacha20_poly1305/CHANGELOG.md
+++ b/chacha20_poly1305/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.2 - 2025-05-15
+
+* Fixed a bug which was doubling the amount of work, performance should be improved [#4083](https://github.com/rust-bitcoin/rust-bitcoin/pull/4083).
+
 # 0.1.1 - 2024-11-07
 
 * The crate is now `no_std`.

--- a/chacha20_poly1305/Cargo.toml
+++ b/chacha20_poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20-poly1305"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Nick Johnson <nick@yonson.dev>", "Robert Netzke <rustaceanrob@protonmail.com>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"


### PR DESCRIPTION
Getting out this big bug fix for performance: https://github.com/rust-bitcoin/rust-bitcoin/pull/4083