### PR TITLE
fix(taproot): raname `from_key_and_tweak` to `from_key_and_merkle_root`

### DIFF
--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -940,7 +940,7 @@ impl TapTweak for UntweakedPublicKey {
         secp: &Secp256k1<C>,
         merkle_root: Option<TapNodeHash>,
     ) -> (TweakedPublicKey, Parity) {
-        let tweak = TapTweakHash::from_key_and_tweak(self, merkle_root).to_scalar();
+        let tweak = TapTweakHash::from_key_and_merkle_root(self, merkle_root).to_scalar();
         let (output_key, parity) = self.add_tweak(secp, &tweak).expect("Tap tweak failed");
 
         debug_assert!(self.tweak_add_check(secp, &output_key, parity, tweak));
@@ -970,7 +970,7 @@ impl TapTweak for UntweakedKeypair {
         merkle_root: Option<TapNodeHash>,
     ) -> TweakedKeypair {
         let (pubkey, _parity) = XOnlyPublicKey::from_keypair(&self);
-        let tweak = TapTweakHash::from_key_and_tweak(pubkey, merkle_root).to_scalar();
+        let tweak = TapTweakHash::from_key_and_merkle_root(pubkey, merkle_root).to_scalar();
         let tweaked = self.add_xonly_tweak(secp, &tweak).expect("Tap tweak failed");
         TweakedKeypair(tweaked)
     }

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -2009,7 +2009,7 @@ mod tests {
             // tests
             let keypair = secp256k1::Keypair::from_secret_key(secp, &internal_priv_key);
             let (internal_key, _parity) = XOnlyPublicKey::from_keypair(&keypair);
-            let tweak = TapTweakHash::from_key_and_tweak(internal_key, merkle_root);
+            let tweak = TapTweakHash::from_key_and_merkle_root(internal_key, merkle_root);
             let tweaked_keypair = keypair.add_xonly_tweak(secp, &tweak.to_scalar()).unwrap();
             let mut sig_msg = Vec::new();
             cache

--- a/bitcoin/src/taproot/mod.rs
+++ b/bitcoin/src/taproot/mod.rs
@@ -95,9 +95,9 @@ impl From<TapLeafHash> for TapNodeHash {
 }
 
 impl TapTweakHash {
-    /// Constructs a new BIP341 [`TapTweakHash`] from key and tweak. Produces `H_taptweak(P||R)` where
+    /// Constructs a new BIP341 [`TapTweakHash`] from key and Merkle root. Produces `H_taptweak(P||R)` where
     /// `P` is the internal key and `R` is the Merkle root.
-    pub fn from_key_and_tweak<K: Into<UntweakedPublicKey>>(
+    pub fn from_key_and_merkle_root<K: Into<UntweakedPublicKey>>(
         internal_key: K,
         merkle_root: Option<TapNodeHash>,
     ) -> TapTweakHash {
@@ -293,7 +293,7 @@ impl TaprootSpendInfo {
     /// Returns the `TapTweakHash` for this [`TaprootSpendInfo`] i.e., the tweak using `internal_key`
     /// and `merkle_root`.
     pub fn tap_tweak(&self) -> TapTweakHash {
-        TapTweakHash::from_key_and_tweak(self.internal_key, self.merkle_root)
+        TapTweakHash::from_key_and_merkle_root(self.internal_key, self.merkle_root)
     }
 
     /// Returns the internal key for this [`TaprootSpendInfo`].
@@ -1305,7 +1305,7 @@ impl<Branch: AsRef<TaprootMerkleBranch> + ?Sized> ControlBlock<Branch> {
         }
         // compute the taptweak
         let tweak =
-            TapTweakHash::from_key_and_tweak(self.internal_key, Some(curr_hash)).to_scalar();
+            TapTweakHash::from_key_and_merkle_root(self.internal_key, Some(curr_hash)).to_scalar();
         self.internal_key.tweak_add_check(secp, &output_key, self.output_key_parity, tweak)
     }
 }
@@ -2103,7 +2103,7 @@ mod test {
                 .unwrap()
                 .assume_checked();
 
-            let tweak = TapTweakHash::from_key_and_tweak(internal_key, merkle_root);
+            let tweak = TapTweakHash::from_key_and_merkle_root(internal_key, merkle_root);
             let (output_key, _parity) = internal_key.tap_tweak(secp, merkle_root);
             let addr = Address::p2tr(secp, internal_key, merkle_root, KnownHrp::Mainnet);
             let spk = addr.script_pubkey();


### PR DESCRIPTION
Closes #4236.

### Changelog
- Rename `TapTweakHash::from_key_and_tweak` to `TapTweakHash::from_key_and_merkle_root`. The naming was just wrong, since a TapTweak takes in a the public key and a Merkle root to produce a tweak.