### PR TITLE
feat(p2p): add AddrV2 <> IpAddr conversions

### DIFF
--- a/.github/workflows/cron-daily-fuzz.yml
+++ b/.github/workflows/cron-daily-fuzz.yml
@@ -27,6 +27,7 @@ jobs:
           bitcoin_deserialize_witness,
           bitcoin_deser_net_msg,
           bitcoin_outpoint_string,
+          bitcoin_p2p_address_roundtrip,
           bitcoin_script_bytes_to_asm_fmt,
           hashes_json,
           hashes_ripemd160,

--- a/bitcoin/src/p2p/address.rs
+++ b/bitcoin/src/p2p/address.rs
@@ -833,4 +833,162 @@ mod test {
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), AddrV2ToSocketAddrError::UnknownNotSupported);
     }
+
+    #[test]
+    fn addrv2_to_ipaddr_ipv4() {
+        let addr = AddrV2::Ipv4(Ipv4Addr::new(192, 168, 1, 1));
+        let ip_addr = IpAddr::try_from(addr).unwrap();
+
+        assert_eq!(ip_addr, IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)));
+    }
+
+    #[test]
+    fn addrv2_to_ipaddr_ipv6() {
+        let addr = AddrV2::Ipv6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1));
+        let ip_addr = IpAddr::try_from(addr).unwrap();
+
+        assert_eq!(ip_addr, IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)));
+    }
+
+    #[test]
+    fn addrv2_to_ipaddr_cjdns() {
+        let addr = AddrV2::Cjdns(Ipv6Addr::new(0xfc00, 0, 0, 0, 0, 0, 0, 1));
+        let result = IpAddr::try_from(addr);
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), AddrV2ToIpAddrError::Cjdns);
+    }
+
+    #[test]
+    fn addrv2_to_ipaddr_torv3() {
+        let addr = AddrV2::TorV3([0; 32]);
+        let result = IpAddr::try_from(addr);
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), AddrV2ToIpAddrError::TorV3);
+    }
+
+    #[test]
+    fn addrv2_to_ipaddr_i2p() {
+        let addr = AddrV2::I2p([0; 32]);
+        let result = IpAddr::try_from(addr);
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), AddrV2ToIpAddrError::I2p);
+    }
+
+    #[test]
+    fn addrv2_to_ipaddr_unknown() {
+        let addr = AddrV2::Unknown(42, vec![1, 2, 3, 4]);
+        let result = IpAddr::try_from(addr);
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), AddrV2ToIpAddrError::Unknown);
+    }
+
+    #[test]
+    fn addrv2_to_ipv4addr_ipv4() {
+        let addr = AddrV2::Ipv4(Ipv4Addr::new(192, 168, 1, 1));
+        let ip_addr = Ipv4Addr::try_from(addr).unwrap();
+
+        assert_eq!(ip_addr, Ipv4Addr::new(192, 168, 1, 1));
+    }
+
+    #[test]
+    fn addrv2_to_ipv4addr_ipv6() {
+        let addr = AddrV2::Ipv6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1));
+        let result = Ipv4Addr::try_from(addr);
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), AddrV2ToIpv4AddrError::Ipv6);
+    }
+
+    #[test]
+    fn addrv2_to_ipv4addr_cjdns() {
+        let addr = AddrV2::Cjdns(Ipv6Addr::new(0xfc00, 0, 0, 0, 0, 0, 0, 1));
+        let result = Ipv4Addr::try_from(addr);
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), AddrV2ToIpv4AddrError::Cjdns);
+    }
+
+    #[test]
+    fn addrv2_to_ipv4addr_torv3() {
+        let addr = AddrV2::TorV3([0; 32]);
+        let result = Ipv4Addr::try_from(addr);
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), AddrV2ToIpv4AddrError::TorV3);
+    }
+
+    #[test]
+    fn addrv2_to_ipv4addr_i2p() {
+        let addr = AddrV2::I2p([0; 32]);
+        let result = Ipv4Addr::try_from(addr);
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), AddrV2ToIpv4AddrError::I2p);
+    }
+
+    #[test]
+    fn addrv2_to_ipv4addr_unknown() {
+        let addr = AddrV2::Unknown(42, vec![1, 2, 3, 4]);
+        let result = Ipv4Addr::try_from(addr);
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), AddrV2ToIpv4AddrError::Unknown);
+    }
+
+    #[test]
+    fn addrv2_to_ipv6addr_ipv4() {
+        let addr = AddrV2::Ipv4(Ipv4Addr::new(192, 168, 1, 1));
+        let result = Ipv6Addr::try_from(addr);
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), AddrV2ToIpv6AddrError::Ipv4);
+    }
+
+    #[test]
+    fn addrv2_to_ipv6addr_ipv6() {
+        let addr = AddrV2::Ipv6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1));
+        let ip_addr = Ipv6Addr::try_from(addr).unwrap();
+
+        assert_eq!(ip_addr, Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1));
+    }
+
+    #[test]
+    fn addrv2_to_ipv6addr_cjdns() {
+        let addr = AddrV2::Cjdns(Ipv6Addr::new(0xfc00, 0, 0, 0, 0, 0, 0, 1));
+        let result = Ipv6Addr::try_from(addr);
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), AddrV2ToIpv6AddrError::Cjdns);
+    }
+
+    #[test]
+    fn addrv2_to_ipv6addr_torv3() {
+        let addr = AddrV2::TorV3([0; 32]);
+        let result = Ipv6Addr::try_from(addr);
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), AddrV2ToIpv6AddrError::TorV3);
+    }
+
+    #[test]
+    fn addrv2_to_ipv6addr_i2p() {
+        let addr = AddrV2::I2p([0; 32]);
+        let result = Ipv6Addr::try_from(addr);
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), AddrV2ToIpv6AddrError::I2p);
+    }
+
+    #[test]
+    fn addrv2_to_ipv6addr_unknown() {
+        let addr = AddrV2::Unknown(42, vec![1, 2, 3, 4]);
+        let result = Ipv6Addr::try_from(addr);
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), AddrV2ToIpv6AddrError::Unknown);
+    }
 }

--- a/bitcoin/src/p2p/address.rs
+++ b/bitcoin/src/p2p/address.rs
@@ -169,16 +169,7 @@ impl From<SocketAddr> for AddrV2 {
     fn from(addr: SocketAddr) -> Self {
         match addr {
             SocketAddr::V4(sock) => AddrV2::Ipv4(*sock.ip()),
-            SocketAddr::V6(sock) => {
-                // CJDNS uses the IPv6 network `fc00::/8`
-                // All CJDNS addresses must have `0xfc00` as the first and second octets
-                let ip = *sock.ip();
-                if ip.octets()[0] == 0xfc && ip.octets()[1] == 0x00 {
-                    AddrV2::Cjdns(ip)
-                } else {
-                    AddrV2::Ipv6(ip)
-                }
-            }
+            SocketAddr::V6(sock) => AddrV2::Ipv6(*sock.ip()),
         }
     }
 }
@@ -759,19 +750,6 @@ mod test {
         let addr = AddrV2::from(socket);
 
         assert_eq!(addr, AddrV2::Ipv6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)));
-    }
-
-    #[test]
-    fn socketaddr_to_addrv2_cjdns() {
-        let socket = SocketAddr::V6(SocketAddrV6::new(
-            Ipv6Addr::new(0xfc00, 0, 0, 0, 0, 0, 0, 1),
-            8333,
-            0,
-            0,
-        ));
-        let addr = AddrV2::from(socket);
-
-        assert_eq!(addr, AddrV2::Cjdns(Ipv6Addr::new(0xfc00, 0, 0, 0, 0, 0, 0, 1)));
     }
 
     #[test]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -85,3 +85,7 @@ path = "fuzz_targets/hashes/sha512.rs"
 [[bin]]
 name = "units_deserialize_amount"
 path = "fuzz_targets/units/deserialize_amount.rs"
+
+[[bin]]
+name = "bitcoin_p2p_address_roundtrip"
+path = "fuzz_targets/bitcoin/p2p_address_roundtrip.rs"

--- a/fuzz/fuzz_targets/bitcoin/p2p_address_roundtrip.rs
+++ b/fuzz/fuzz_targets/bitcoin/p2p_address_roundtrip.rs
@@ -1,0 +1,86 @@
+use std::convert::TryFrom;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+
+use bitcoin::consensus::Decodable;
+use bitcoin::p2p::address::AddrV2;
+use honggfuzz::fuzz;
+
+fn do_test(data: &[u8]) {
+    if data.len() < 2 {
+        return;
+    }
+
+    let mut cursor = std::io::Cursor::new(data);
+    let addr_v2 = if let Ok(addr) = AddrV2::consensus_decode(&mut cursor) {
+        addr
+    } else {
+        return;
+    };
+
+    if let Ok(ip_addr) = IpAddr::try_from(addr_v2.clone()) {
+        let round_trip: AddrV2 = AddrV2::from(ip_addr);
+        assert_eq!(
+            addr_v2, round_trip,
+            "AddrV2 -> IpAddr -> AddrV2 should round-trip correctly"
+        );
+    }
+
+    if let Ok(ip_addr) = Ipv4Addr::try_from(addr_v2.clone()) {
+        let round_trip: AddrV2 = AddrV2::from(ip_addr);
+        assert_eq!(
+            addr_v2, round_trip,
+            "AddrV2 -> Ipv4Addr -> AddrV2 should round-trip correctly"
+        );
+    }
+
+    if let Ok(ip_addr) = Ipv6Addr::try_from(addr_v2.clone()) {
+        let round_trip: AddrV2 = AddrV2::from(ip_addr);
+        assert_eq!(
+            addr_v2, round_trip,
+            "AddrV2 -> Ipv6Addr -> AddrV2 should round-trip correctly"
+        );
+    }
+
+    if let Ok(socket_addr) = SocketAddr::try_from(addr_v2.clone()) {
+        let round_trip: AddrV2 = AddrV2::from(socket_addr);
+        assert_eq!(
+            addr_v2, round_trip,
+            "AddrV2 -> SocketAddr -> AddrV2 should round-trip correctly"
+        );
+    }
+}
+
+fn main() {
+    loop {
+        fuzz!(|data| {
+            do_test(data);
+        });
+    }
+}
+
+#[cfg(all(test, fuzzing))]
+mod tests {
+    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
+        let mut b = 0;
+        for (idx, c) in hex.as_bytes().iter().enumerate() {
+            b <<= 4;
+            match *c {
+                b'A'..=b'F' => b |= c - b'A' + 10,
+                b'a'..=b'f' => b |= c - b'a' + 10,
+                b'0'..=b'9' => b |= c - b'0',
+                _ => panic!("Bad hex"),
+            }
+            if (idx & 1) == 1 {
+                out.push(b);
+                b = 0;
+            }
+        }
+    }
+
+    #[test]
+    fn duplicate_crash() {
+        let mut a = Vec::new();
+        extend_vec_from_hex("00", &mut a);
+        super::do_test(&a);
+    }
+}


### PR DESCRIPTION
 This PR adds conversion traits between `AddrV2` and standard IP types, inspired by #4519.

### Changelog

- Implement `From<IpAddr>` for `AddrV2`.
-  Implement `From<Ipv4Addr>` for `AddrV2`.
-  Implement `From<Ipv6Addr>` for `AddrV2.`
- Implement `TryFrom<AddrV2>` for `IpAddr`.
- Implement `TryFrom<AddrV2>` for `Ipv4Addr`.
- Implement `TryFrom<AddrV2>` for `Ipv6Addr`.
- Implement `AddrV2ToIpAddrError` enum and it's `fmt::Display`.
- Implement `AddrV2ToIpv4AddrError` enum and it's `fmt::Display`.
- Implement `AddrV2ToIpv6AddrError` enum and it's `fmt::Display`.
- Renamed `AddrV2ConversionError` to `AddrV2ToSocketAddrError`
- Tests for `TryFrom` conversions.