### PR TITLE
chore: delete unused `.actrc`

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,1 +1,0 @@
--e contrib/act/event.json


### PR DESCRIPTION
Closes #4531.

Removes the useless and unused `.actrc` file.