### PR TITLE
drop the optional sighash in taproot::Signature::from_slice()

### DIFF
--- a/bitcoin/src/crypto/taproot.rs
+++ b/bitcoin/src/crypto/taproot.rs
@@ -36,7 +36,10 @@ impl Signature {
             Ok(Signature { signature, sighash_type: TapSighashType::Default })
         } else if let Ok(signature) = <[u8; 65]>::try_from(sl) {
             let (sighash_type, signature) = signature.split_last();
-            let sighash_type = TapSighashType::from_consensus_u8(*sighash_type)?;
+            let sighash_type = match TapSighashType::from_consensus_u8(*sighash_type)? {
+                TapSighashType::All => TapSighashType::Default,
+                t => t,
+            };
             let signature = secp256k1::schnorr::Signature::from_byte_array(*signature);
             Ok(Signature { signature, sighash_type })
         } else {


### PR DESCRIPTION
in [`async-hwi`](https://github.com/wizardsardine/async-hwi/blob/76f3ab6c903f5ed2f8644acb21943eff0476e9ee/src/specter.rs#L148-L157) we deserialize the signature from Specter DIY, and it appear that Specter DIY, in some cases [append optional `SIGHASH_ALL` to the signature](https://github.com/cryptoadvance/specter-diy/issues/302), leading to some inconsistency in Liana [fee estimation](https://github.com/wizardsardine/liana/issues/1322#issuecomment-2879557296) in some case.
 