### PR TITLE
Move `p2p::Magic` to `network`

### DIFF
--- a/bitcoin/src/network/mod.rs
+++ b/bitcoin/src/network/mod.rs
@@ -23,13 +23,15 @@ pub mod params;
 use core::fmt;
 use core::str::FromStr;
 
-use internals::write_err;
+use hex::FromHex;
+use internals::{impl_to_hex_from_lower_hex, write_err};
+use io::{BufRead, Write};
 #[cfg(feature = "serde")]
 use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 
+use crate::consensus::encode::{self, Decodable, Encodable};
 use crate::constants::ChainHash;
-use crate::p2p::Magic;
-use crate::prelude::{String, ToOwned};
+use crate::prelude::{Borrow, BorrowMut, String, ToOwned};
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
@@ -129,7 +131,7 @@ impl Network {
     /// # Examples
     ///
     /// ```rust
-    /// use bitcoin::p2p::Magic;
+    /// use bitcoin::network::Magic;
     /// use bitcoin::Network;
     ///
     /// assert_eq!(Ok(Network::Bitcoin), Network::try_from(Magic::from_bytes([0xF9, 0xBE, 0xB4, 0xD9])));
@@ -143,7 +145,7 @@ impl Network {
     /// # Examples
     ///
     /// ```rust
-    /// use bitcoin::p2p::Magic;
+    /// use bitcoin::network::Magic;
     /// use bitcoin::Network;
     ///
     /// let network = Network::Bitcoin;
@@ -360,9 +362,192 @@ impl TryFrom<ChainHash> for Network {
     }
 }
 
+/// Network magic bytes to identify the cryptocurrency network the message was intended for.
+#[derive(Copy, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
+pub struct Magic([u8; 4]);
+
+impl Magic {
+    /// Bitcoin mainnet network magic bytes.
+    pub const BITCOIN: Self = Self([0xF9, 0xBE, 0xB4, 0xD9]);
+    /// Bitcoin testnet3 network magic bytes.
+    #[deprecated(since = "0.33.0", note = "use `TESTNET3` instead")]
+    pub const TESTNET: Self = Self([0x0B, 0x11, 0x09, 0x07]);
+    /// Bitcoin testnet3 network magic bytes.
+    pub const TESTNET3: Self = Self([0x0B, 0x11, 0x09, 0x07]);
+    /// Bitcoin testnet4 network magic bytes.
+    pub const TESTNET4: Self = Self([0x1c, 0x16, 0x3f, 0x28]);
+    /// Bitcoin signet network magic bytes.
+    pub const SIGNET: Self = Self([0x0A, 0x03, 0xCF, 0x40]);
+    /// Bitcoin regtest network magic bytes.
+    pub const REGTEST: Self = Self([0xFA, 0xBF, 0xB5, 0xDA]);
+
+    /// Construct a new network magic from bytes.
+    pub const fn from_bytes(bytes: [u8; 4]) -> Magic { Magic(bytes) }
+
+    /// Get network magic bytes.
+    pub fn to_bytes(self) -> [u8; 4] { self.0 }
+
+    /// Returns the magic bytes for the network defined by `params`.
+    pub fn from_params(params: impl AsRef<Params>) -> Self { params.as_ref().network.into() }
+}
+
+impl FromStr for Magic {
+    type Err = ParseMagicError;
+
+    fn from_str(s: &str) -> Result<Magic, Self::Err> {
+        match <[u8; 4]>::from_hex(s) {
+            Ok(magic) => Ok(Magic::from_bytes(magic)),
+            Err(e) => Err(ParseMagicError { error: e, magic: s.to_owned() }),
+        }
+    }
+}
+
+macro_rules! generate_network_magic_conversion {
+    ($(Network::$network:ident$((TestnetVersion::$testnet_version:ident))? => Magic::$magic:ident,)*) => {
+        impl From<Network> for Magic {
+            fn from(network: Network) -> Magic {
+                match network {
+                    $(
+                        Network::$network$((TestnetVersion::$testnet_version))? => Magic::$magic,
+                    )*
+                }
+            }
+        }
+
+        impl TryFrom<Magic> for Network {
+            type Error = UnknownMagicError;
+
+            fn try_from(magic: Magic) -> Result<Self, Self::Error> {
+                match magic {
+                    $(
+                        Magic::$magic => Ok(Network::$network$((TestnetVersion::$testnet_version))?),
+                    )*
+                    _ => Err(UnknownMagicError(magic)),
+                }
+            }
+        }
+    };
+}
+// Generate conversion functions for all known networks.
+// `Network -> Magic` and `Magic -> Network`
+generate_network_magic_conversion! {
+    Network::Bitcoin => Magic::BITCOIN,
+    Network::Testnet(TestnetVersion::V3) => Magic::TESTNET3,
+    Network::Testnet(TestnetVersion::V4) => Magic::TESTNET4,
+    Network::Signet => Magic::SIGNET,
+    Network::Regtest => Magic::REGTEST,
+}
+
+impl fmt::Display for Magic {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        hex::fmt_hex_exact!(f, 4, &self.0, hex::Case::Lower)?;
+        Ok(())
+    }
+}
+
+impl fmt::Debug for Magic {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> { fmt::Display::fmt(self, f) }
+}
+
+impl fmt::LowerHex for Magic {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        hex::fmt_hex_exact!(f, 4, &self.0, hex::Case::Lower)?;
+        Ok(())
+    }
+}
+impl_to_hex_from_lower_hex!(Magic, |_| 8);
+
+impl fmt::UpperHex for Magic {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        hex::fmt_hex_exact!(f, 4, &self.0, hex::Case::Upper)?;
+        Ok(())
+    }
+}
+
+impl Encodable for Magic {
+    fn consensus_encode<W: Write + ?Sized>(&self, writer: &mut W) -> Result<usize, io::Error> {
+        self.0.consensus_encode(writer)
+    }
+}
+
+impl Decodable for Magic {
+    fn consensus_decode<R: BufRead + ?Sized>(reader: &mut R) -> Result<Self, encode::Error> {
+        Ok(Magic(Decodable::consensus_decode(reader)?))
+    }
+}
+
+impl AsRef<[u8]> for Magic {
+    fn as_ref(&self) -> &[u8] { &self.0 }
+}
+
+impl AsRef<[u8; 4]> for Magic {
+    fn as_ref(&self) -> &[u8; 4] { &self.0 }
+}
+
+impl AsMut<[u8]> for Magic {
+    fn as_mut(&mut self) -> &mut [u8] { &mut self.0 }
+}
+
+impl AsMut<[u8; 4]> for Magic {
+    fn as_mut(&mut self) -> &mut [u8; 4] { &mut self.0 }
+}
+
+impl Borrow<[u8]> for Magic {
+    fn borrow(&self) -> &[u8] { &self.0 }
+}
+
+impl Borrow<[u8; 4]> for Magic {
+    fn borrow(&self) -> &[u8; 4] { &self.0 }
+}
+
+impl BorrowMut<[u8]> for Magic {
+    fn borrow_mut(&mut self) -> &mut [u8] { &mut self.0 }
+}
+
+impl BorrowMut<[u8; 4]> for Magic {
+    fn borrow_mut(&mut self) -> &mut [u8; 4] { &mut self.0 }
+}
+
+/// An error in parsing magic bytes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ParseMagicError {
+    /// The error that occurred when parsing the string.
+    error: hex::HexToArrayError,
+    /// The byte string that failed to parse.
+    magic: String,
+}
+
+impl fmt::Display for ParseMagicError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write_err!(f, "failed to parse {} as network magic", self.magic; self.error)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ParseMagicError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.error) }
+}
+
+/// Error in creating a Network from Magic bytes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct UnknownMagicError(Magic);
+
+impl fmt::Display for UnknownMagicError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "unknown network magic {}", self.0)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for UnknownMagicError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{Network, TestnetVersion};
+    use super::{Magic, Network, TestnetVersion};
     use crate::consensus::encode::{deserialize, serialize};
     use crate::p2p::ServiceFlags;
 
@@ -508,5 +693,22 @@ mod tests {
                 serde_test::Token::StructEnd,
             ],
         );
+    }
+
+    #[test]
+    fn magic_from_str() {
+        let known_network_magic_strs = [
+            ("f9beb4d9", Network::Bitcoin),
+            ("0b110907", Network::Testnet(TestnetVersion::V3)),
+            ("1c163f28", Network::Testnet(TestnetVersion::V4)),
+            ("fabfb5da", Network::Regtest),
+            ("0a03cf40", Network::Signet),
+        ];
+
+        for (magic_str, network) in &known_network_magic_strs {
+            let magic: Magic = magic_str.parse::<Magic>().unwrap();
+            assert_eq!(Network::try_from(magic).unwrap(), *network);
+            assert_eq!(&magic.to_string(), magic_str);
+        }
     }
 }

--- a/bitcoin/src/network/params.rs
+++ b/bitcoin/src/network/params.rs
@@ -11,8 +11,8 @@
 //! custom type that can be used in such places you might want to do the following:
 //!
 //! ```
-//! use bitcoin::network::Params;
-//! use bitcoin::{p2p, Script, ScriptBuf, Network, Target};
+//! use bitcoin::network::{self, Params};
+//! use bitcoin::{Script, ScriptBuf, Network, Target};
 //!
 //! const POW_TARGET_SPACING: u64 = 120; // Two minutes.
 //! const MAGIC: [u8; 4] = [1, 2, 3, 4];
@@ -40,7 +40,7 @@
 //!     }
 //!
 //!     /// Returns the custom magic bytes.
-//!     pub fn magic(&self) -> p2p::Magic { p2p::Magic::from_bytes(self.magic) }
+//!     pub fn magic(&self) -> network::Magic { network::Magic::from_bytes(self.magic) }
 //!
 //!     /// Returns the custom signet challenge script.
 //!     pub fn challenge_script(&self) -> &Script { &self.challenge_script }

--- a/bitcoin/src/p2p/message.rs
+++ b/bitcoin/src/p2p/message.rs
@@ -13,10 +13,10 @@ use io::{BufRead, Write};
 
 use crate::consensus::encode::{self, CheckedData, Decodable, Encodable, ReadExt, WriteExt};
 use crate::merkle_tree::MerkleBlock;
+use crate::network::Magic;
 use crate::p2p::address::{AddrV2Message, Address};
 use crate::p2p::{
     message_blockdata, message_bloom, message_compact_blocks, message_filter, message_network,
-    Magic,
 };
 use crate::prelude::{Box, Cow, String, ToOwned, Vec};
 use crate::{block, consensus, transaction};


### PR DESCRIPTION
This is an implicit step in moving `p2p` to its own crate. Ideally nothing in `bitcoin` depends on `p2p`, but `p2p::Magic` is used as a constructor for `Network`. In my opinion, network "magic" and the cryptocurrency network are somewhat interchangable, in that a network magic is meaningless without an underlying network. This PR relocates the `Magic` struct into `network` along with the associated test.