### PR TITLE
Add macro for defining an error

### DIFF
--- a/bitcoin/src/address/error.rs
+++ b/bitcoin/src/address/error.rs
@@ -6,6 +6,8 @@ use core::fmt;
 use internals::write_err;
 
 use crate::address::{Address, NetworkUnchecked};
+#[cfg(feature = "std")]
+use crate::internal_macros::impl_sourceless_error;
 use crate::prelude::String;
 use crate::script::{witness_program, witness_version};
 use crate::Network;
@@ -71,9 +73,7 @@ impl fmt::Display for UnknownAddressTypeError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for UnknownAddressTypeError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
-}
+impl_sourceless_error!(UnknownAddressTypeError);
 
 /// Address parsing error.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -142,9 +142,7 @@ impl fmt::Display for UnknownHrpError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for UnknownHrpError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
-}
+impl_sourceless_error!(UnknownHrpError);
 
 /// Address's network differs from required one.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -239,9 +237,7 @@ impl fmt::Display for ParseBech32Error {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for ParseBech32Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
-}
+impl_sourceless_error!(ParseBech32Error);
 
 /// Base58 related error.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/bitcoin/src/blockdata/script/push_bytes.rs
+++ b/bitcoin/src/blockdata/script/push_bytes.rs
@@ -4,6 +4,8 @@
 
 use core::ops::{Deref, DerefMut};
 
+#[cfg(feature = "std")]
+use crate::internal_macros::impl_sourceless_error;
 use crate::prelude::{Borrow, BorrowMut};
 use crate::script;
 
@@ -453,6 +455,4 @@ mod error {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for PushBytesError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
-}
+impl_sourceless_error!(PushBytesError);

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -21,6 +21,8 @@ use units::NumOpResult;
 use super::Weight;
 use crate::consensus::{self, encode, Decodable, Encodable};
 use crate::internal_macros::{impl_consensus_encoding, impl_hashencode};
+#[cfg(feature = "std")]
+use crate::internal_macros::impl_sourceless_error;
 use crate::locktime::absolute::{self, Height, MedianTimePast};
 use crate::prelude::{Borrow, Vec};
 use crate::script::{Script, ScriptBuf, ScriptExt as _, ScriptExtPriv as _};
@@ -580,9 +582,7 @@ impl fmt::Display for InputsIndexError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for InputsIndexError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
-}
+impl_sourceless_error!(InputsIndexError);
 
 impl From<IndexOutOfBoundsError> for InputsIndexError {
     fn from(e: IndexOutOfBoundsError) -> Self { Self(e) }
@@ -599,9 +599,7 @@ impl fmt::Display for OutputsIndexError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for OutputsIndexError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
-}
+impl_sourceless_error!(OutputsIndexError);
 
 impl From<IndexOutOfBoundsError> for OutputsIndexError {
     fn from(e: IndexOutOfBoundsError) -> Self { Self(e) }
@@ -624,9 +622,7 @@ impl fmt::Display for IndexOutOfBoundsError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for IndexOutOfBoundsError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
-}
+impl_sourceless_error!(IndexOutOfBoundsError);
 
 impl Encodable for Version {
     fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {

--- a/bitcoin/src/consensus_validation.rs
+++ b/bitcoin/src/consensus_validation.rs
@@ -14,6 +14,8 @@ use crate::consensus::encode;
 #[cfg(doc)]
 use crate::consensus_validation;
 use crate::internal_macros::define_extension_trait;
+#[cfg(feature = "std")]
+use crate::internal_macros::impl_sourceless_error;
 use crate::script::Script;
 use crate::transaction::{OutPoint, Transaction, TxOut};
 
@@ -224,9 +226,7 @@ impl fmt::Display for BitcoinconsensusError {
 }
 
 #[cfg(all(feature = "std", feature = "bitcoinconsensus"))]
-impl std::error::Error for BitcoinconsensusError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
-}
+impl_sourceless_error!(BitcoinconsensusError);
 
 /// An error during transaction validation.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -19,6 +19,8 @@ use io::{Read, Write};
 
 use crate::crypto::ecdsa;
 use crate::internal_macros::impl_asref_push_bytes;
+#[cfg(feature = "std")]
+use crate::internal_macros::impl_sourceless_error;
 use crate::network::NetworkKind;
 use crate::prelude::{DisplayHex, String, Vec};
 use crate::script::{self, ScriptBuf};
@@ -1279,9 +1281,7 @@ impl fmt::Display for UncompressedPublicKeyError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for UncompressedPublicKeyError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
-}
+impl_sourceless_error!(UncompressedPublicKeyError);
 
 /// Decoded base58 data was an invalid length.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -27,6 +27,8 @@ use crate::taproot::{LeafVersion, TapLeafHash, TapLeafTag, TAPROOT_ANNEX_PREFIX}
 use crate::transaction::TransactionExt as _;
 use crate::witness::Witness;
 use crate::{transaction, Amount, Script, Sequence, Transaction, TxOut};
+#[cfg(feature = "std")]
+use crate::internal_macros::impl_sourceless_error;
 
 /// Used for signature hash for invalid use of SIGHASH_SINGLE.
 #[rustfmt::skip]
@@ -273,9 +275,7 @@ impl fmt::Display for PrevoutsSizeError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for PrevoutsSizeError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
-}
+impl_sourceless_error!(PrevoutsSizeError);
 
 /// A single prevout was been provided but all prevouts are needed without `ANYONECANPAY`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -289,9 +289,7 @@ impl fmt::Display for PrevoutsKindError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for PrevoutsKindError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
-}
+impl_sourceless_error!(PrevoutsKindError);
 
 /// [`Prevouts`] index related errors.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -553,9 +551,7 @@ impl fmt::Display for InvalidSighashTypeError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for InvalidSighashTypeError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
-}
+impl_sourceless_error!(InvalidSighashTypeError);
 
 /// This type is consensus valid but an input including it would prevent the transaction from
 /// being relayed on today's Bitcoin network.
@@ -569,9 +565,7 @@ impl fmt::Display for NonStandardSighashTypeError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for NonStandardSighashTypeError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
-}
+impl_sourceless_error!(NonStandardSighashTypeError);
 
 /// Error returned for failure during parsing one of the sighash types.
 ///
@@ -590,9 +584,7 @@ impl fmt::Display for SighashTypeParseError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for SighashTypeParseError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
-}
+impl_sourceless_error!(SighashTypeParseError);
 
 impl<R: Borrow<Transaction>> SighashCache<R> {
     /// Constructs a new `SighashCache` from an unsigned transaction.
@@ -1328,9 +1320,7 @@ impl fmt::Display for SingleMissingOutputError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for SingleMissingOutputError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
-}
+impl_sourceless_error!(SingleMissingOutputError);
 
 /// Annex must be at least one byte long and the first bytes must be `0x50`.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/bitcoin/src/internal_macros.rs
+++ b/bitcoin/src/internal_macros.rs
@@ -400,3 +400,15 @@ macro_rules! impl_array_newtype {
     };
 }
 pub(crate) use impl_array_newtype;
+
+#[cfg(feature = "std")]
+macro_rules! impl_sourceless_error {
+    ($e:ident) => {
+        impl std::error::Error for $e {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+        }
+    };
+}
+
+#[cfg(feature = "std")]
+pub(crate) use impl_sourceless_error;

--- a/bitcoin/src/network/mod.rs
+++ b/bitcoin/src/network/mod.rs
@@ -26,6 +26,8 @@ use core::str::FromStr;
 use internals::write_err;
 #[cfg(feature = "serde")]
 use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
+#[cfg(feature = "std")]
+use crate::internal_macros::impl_sourceless_error;
 
 use crate::constants::ChainHash;
 use crate::p2p::Magic;
@@ -301,9 +303,7 @@ impl fmt::Display for ParseNetworkError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for ParseNetworkError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
-}
+impl_sourceless_error!(ParseNetworkError);
 
 impl FromStr for Network {
     type Err = ParseNetworkError;
@@ -340,9 +340,7 @@ impl fmt::Display for UnknownChainHashError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for UnknownChainHashError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
-}
+impl_sourceless_error!(UnknownChainHashError);
 
 impl TryFrom<ChainHash> for Network {
     type Error = UnknownChainHashError;

--- a/bitcoin/src/p2p/message.rs
+++ b/bitcoin/src/p2p/message.rs
@@ -12,6 +12,7 @@ use internals::ToU64 as _;
 use io::{BufRead, Write};
 
 use crate::consensus::encode::{self, CheckedData, Decodable, Encodable, ReadExt, WriteExt};
+use crate::internal_macros::impl_sourceless_error;
 use crate::merkle_tree::MerkleBlock;
 use crate::p2p::address::{AddrV2Message, Address};
 use crate::p2p::{
@@ -144,9 +145,7 @@ impl fmt::Display for CommandStringError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for CommandStringError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
-}
+impl_sourceless_error!(CommandStringError);
 
 /// A Network message using the v1 p2p protocol.
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/bitcoin/src/p2p/mod.rs
+++ b/bitcoin/src/p2p/mod.rs
@@ -26,6 +26,8 @@ use core::{fmt, ops};
 use hex::FromHex;
 use internals::{impl_to_hex_from_lower_hex, write_err};
 use io::{BufRead, Write};
+#[cfg(feature = "std")]
+use crate::internal_macros::impl_sourceless_error;
 
 use crate::consensus::encode::{self, Decodable, Encodable};
 use crate::network::{Network, Params, TestnetVersion};
@@ -372,9 +374,7 @@ impl fmt::Display for ParseMagicError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for ParseMagicError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.error) }
-}
+impl_sourceless_error!(ParseMagicError);
 
 /// Error in creating a Network from Magic bytes.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -388,9 +388,7 @@ impl fmt::Display for UnknownMagicError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for UnknownMagicError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
-}
+impl_sourceless_error!(UnknownMagicError);
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Errors with no sources have the same implementation body. This can be automated for many error types across the crate. I use this in my personal projects and thought it may be useful here, but none taken if it isn't seen as a net benefit.

For the sake of easy review, I replaced the direct occurances where an error explicitly defined the `source` method. There are also empty `std::error::Error` implementations that could make use of the macro, but I omitted them to preserve the exact API that was present before. This can be used to implement `Error` for the blank impl block cases as well.