### PR TITLE
Remove `unwrap` from `fee_rate` unit tests

### DIFF
--- a/units/src/fee_rate/mod.rs
+++ b/units/src/fee_rate/mod.rs
@@ -309,7 +309,7 @@ mod tests {
     #[test]
     fn fee_rate_from_sat_per_vb() {
         let fee_rate = FeeRate::from_sat_per_vb(10).expect("expected feerate in sat/kwu");
-        assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(2500).unwrap());
+        assert_eq!(fee_rate, FeeRate::from_sat_per_mvb(10_000_000));
     }
 
     #[test]
@@ -327,7 +327,7 @@ mod tests {
     #[test]
     fn from_sat_per_vb_u32() {
         let fee_rate = FeeRate::from_sat_per_vb_u32(10);
-        assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(2500).unwrap());
+        assert_eq!(fee_rate, FeeRate::from_sat_per_mvb(10_000_000));
     }
 
     #[test]
@@ -336,33 +336,32 @@ mod tests {
 
     #[test]
     fn raw_feerate() {
-        let fee_rate = FeeRate::from_sat_per_kwu(749).unwrap();
-        assert_eq!(fee_rate.to_sat_per_kwu_floor(), 749);
-        assert_eq!(fee_rate.to_sat_per_vb_floor(), 2);
-        assert_eq!(fee_rate.to_sat_per_vb_ceil(), 3);
+        let fee_rate = FeeRate::from_sat_per_mvb(1_234_567);
+        assert_eq!(fee_rate.to_sat_per_kwu_floor(), 308);
+        assert_eq!(fee_rate.to_sat_per_kwu_ceil(), 309);
+        assert_eq!(fee_rate.to_sat_per_vb_floor(), 1);
+        assert_eq!(fee_rate.to_sat_per_vb_ceil(), 2);
     }
 
     #[test]
     fn checked_mul() {
-        let fee_rate = FeeRate::from_sat_per_kwu(10)
-            .unwrap()
+        let fee_rate = FeeRate::from_sat_per_mvb(10)
             .checked_mul(10)
-            .expect("expected feerate in sat/kwu");
-        assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(100).unwrap());
+            .unwrap();
+        assert_eq!(fee_rate, FeeRate::from_sat_per_mvb(100));
 
-        let fee_rate = FeeRate::from_sat_per_kwu(10).unwrap().checked_mul(u64::MAX);
+        let fee_rate = FeeRate::from_sat_per_mvb(10).checked_mul(u64::MAX);
         assert!(fee_rate.is_none());
     }
 
     #[test]
     fn checked_div() {
-        let fee_rate = FeeRate::from_sat_per_kwu(10)
-            .unwrap()
+        let fee_rate = FeeRate::from_sat_per_mvb(10)
             .checked_div(10)
-            .expect("expected feerate in sat/kwu");
-        assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(1).unwrap());
+            .unwrap();
+        assert_eq!(fee_rate, FeeRate::from_sat_per_mvb(1));
 
-        let fee_rate = FeeRate::from_sat_per_kwu(10).unwrap().checked_div(0);
+        let fee_rate = FeeRate::from_sat_per_mvb(10).checked_div(0);
         assert!(fee_rate.is_none());
     }
 

--- a/units/src/fee_rate/mod.rs
+++ b/units/src/fee_rate/mod.rs
@@ -219,18 +219,18 @@ mod tests {
     #[test]
     #[allow(clippy::op_ref)]
     fn feerate_div_nonzero() {
-        let rate = FeeRate::from_sat_per_kwu(200).unwrap();
+        let rate = FeeRate::from_sat_per_mvb(200);
         let divisor = NonZeroU64::new(2).unwrap();
-        assert_eq!(rate / divisor, FeeRate::from_sat_per_kwu(100).unwrap());
-        assert_eq!(&rate / &divisor, FeeRate::from_sat_per_kwu(100).unwrap());
+        assert_eq!(rate / divisor, FeeRate::from_sat_per_mvb(100));
+        assert_eq!(&rate / &divisor, FeeRate::from_sat_per_mvb(100));
     }
 
     #[test]
     #[allow(clippy::op_ref)]
     fn addition() {
-        let one = FeeRate::from_sat_per_kwu(1).unwrap();
-        let two = FeeRate::from_sat_per_kwu(2).unwrap();
-        let three = FeeRate::from_sat_per_kwu(3).unwrap();
+        let one = FeeRate::from_sat_per_mvb(1);
+        let two = FeeRate::from_sat_per_mvb(2);
+        let three = FeeRate::from_sat_per_mvb(3);
 
         assert!(one + two == three);
         assert!(&one + two == three);
@@ -241,9 +241,9 @@ mod tests {
     #[test]
     #[allow(clippy::op_ref)]
     fn subtract() {
-        let three = FeeRate::from_sat_per_kwu(3).unwrap();
-        let seven = FeeRate::from_sat_per_kwu(7).unwrap();
-        let ten = FeeRate::from_sat_per_kwu(10).unwrap();
+        let three = FeeRate::from_sat_per_mvb(3);
+        let seven = FeeRate::from_sat_per_mvb(7);
+        let ten = FeeRate::from_sat_per_mvb(10);
 
         assert_eq!(ten - seven, three);
         assert_eq!(&ten - seven, three);
@@ -253,31 +253,31 @@ mod tests {
 
     #[test]
     fn add_assign() {
-        let mut f = FeeRate::from_sat_per_kwu(1).unwrap();
-        f += FeeRate::from_sat_per_kwu(2).unwrap();
-        assert_eq!(f, FeeRate::from_sat_per_kwu(3).unwrap());
+        let mut f = FeeRate::from_sat_per_mvb(1);
+        f += FeeRate::from_sat_per_mvb(2);
+        assert_eq!(f, FeeRate::from_sat_per_mvb(3));
 
-        let mut f = FeeRate::from_sat_per_kwu(1).unwrap();
-        f += &FeeRate::from_sat_per_kwu(2).unwrap();
-        assert_eq!(f, FeeRate::from_sat_per_kwu(3).unwrap());
+        let mut f = FeeRate::from_sat_per_mvb(1);
+        f += &FeeRate::from_sat_per_mvb(2);
+        assert_eq!(f, FeeRate::from_sat_per_mvb(3));
     }
 
     #[test]
     fn sub_assign() {
-        let mut f = FeeRate::from_sat_per_kwu(3).unwrap();
-        f -= FeeRate::from_sat_per_kwu(2).unwrap();
-        assert_eq!(f, FeeRate::from_sat_per_kwu(1).unwrap());
+        let mut f = FeeRate::from_sat_per_mvb(3);
+        f -= FeeRate::from_sat_per_mvb(2);
+        assert_eq!(f, FeeRate::from_sat_per_mvb(1));
 
-        let mut f = FeeRate::from_sat_per_kwu(3).unwrap();
-        f -= &FeeRate::from_sat_per_kwu(2).unwrap();
-        assert_eq!(f, FeeRate::from_sat_per_kwu(1).unwrap());
+        let mut f = FeeRate::from_sat_per_mvb(3);
+        f -= &FeeRate::from_sat_per_mvb(2);
+        assert_eq!(f, FeeRate::from_sat_per_mvb(1));
     }
 
     #[test]
     fn checked_add() {
-        let one = FeeRate::from_sat_per_kwu(1).unwrap();
-        let two = FeeRate::from_sat_per_kwu(2).unwrap();
-        let three = FeeRate::from_sat_per_kwu(3).unwrap();
+        let one = FeeRate::from_sat_per_mvb(1);
+        let two = FeeRate::from_sat_per_mvb(2);
+        let three = FeeRate::from_sat_per_mvb(3);
 
         assert_eq!(one.checked_add(two).unwrap(), three);
 
@@ -288,9 +288,9 @@ mod tests {
 
     #[test]
     fn checked_sub() {
-        let one = FeeRate::from_sat_per_kwu(1).unwrap();
-        let two = FeeRate::from_sat_per_kwu(2).unwrap();
-        let three = FeeRate::from_sat_per_kwu(3).unwrap();
+        let one = FeeRate::from_sat_per_mvb(1);
+        let two = FeeRate::from_sat_per_mvb(2);
+        let three = FeeRate::from_sat_per_mvb(3);
         assert_eq!(three.checked_sub(two).unwrap(), one);
 
         let fee_rate = FeeRate::ZERO.checked_sub(one);


### PR DESCRIPTION
Remove all the `unwraps` in unit tests introduced in #4534.

- Patch 1: Brain dead to review.
- Patch 2: Needs a tiny bit of thought.