### PR TITLE
Move `p2p` into a crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["addresses", "base58", "bitcoin", "chacha20_poly1305", "fuzz", "hashes", "internals", "io", "primitives", "units"]
+members = ["addresses", "base58", "bitcoin", "chacha20_poly1305", "fuzz", "hashes", "internals", "io", "primitives", "p2p", "units"]
 resolver = "2"
 
 # Keep this patch for hashes because secp256k1 depends on bitcoin-hashes via crates.io

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -56,10 +56,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 name = "bip32"
 
 [[example]]
-name = "handshake"
-required-features = ["rand-std"]
-
-[[example]]
 name = "ecdsa-psbt"
 required-features = ["std", "bitcoinconsensus"]
 

--- a/bitcoin/src/consensus/encode.rs
+++ b/bitcoin/src/consensus/encode.rs
@@ -26,11 +26,6 @@ use crate::bip152::{PrefilledTransaction, ShortId};
 use crate::bip158::{FilterHash, FilterHeader};
 use crate::block::{self, BlockHash};
 use crate::merkle_tree::TxMerkleNode;
-#[cfg(feature = "std")]
-use crate::p2p::{
-    address::{AddrV2Message, Address},
-    message_blockdata::Inventory,
-};
 use crate::prelude::{rc, sync, Box, Cow, String, Vec};
 use crate::taproot::TapLeafHash;
 use crate::transaction::{Transaction, TxIn, TxOut};
@@ -552,13 +547,6 @@ impl_vec!(TapLeafHash);
 impl_vec!(ShortId);
 impl_vec!(PrefilledTransaction);
 
-#[cfg(feature = "std")]
-impl_vec!(Inventory);
-#[cfg(feature = "std")]
-impl_vec!((u32, Address));
-#[cfg(feature = "std")]
-impl_vec!(AddrV2Message);
-
 pub(crate) fn consensus_encode_with_size<W: Write + ?Sized>(
     data: &[u8],
     w: &mut W,
@@ -765,8 +753,6 @@ mod tests {
     use core::mem::discriminant;
 
     use super::*;
-    #[cfg(feature = "std")]
-    use crate::p2p::{message_blockdata::Inventory, Address};
 
     #[test]
     fn serialize_int() {
@@ -1049,10 +1035,6 @@ mod tests {
         test_len_is_max_vec::<TxIn>();
         test_len_is_max_vec::<Vec<u8>>();
         test_len_is_max_vec::<u64>();
-        #[cfg(feature = "std")]
-        test_len_is_max_vec::<(u32, Address)>();
-        #[cfg(feature = "std")]
-        test_len_is_max_vec::<Inventory>();
     }
 
     fn test_len_is_max_vec<T>()

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -94,7 +94,6 @@ extern crate serde;
 mod internal_macros;
 
 #[macro_use]
-pub mod p2p;
 pub mod address;
 pub mod bip152;
 pub mod bip158;

--- a/bitcoin/src/network/mod.rs
+++ b/bitcoin/src/network/mod.rs
@@ -5,18 +5,6 @@
 //! The term "network" is overloaded, here [`Network`] refers to the specific
 //! Bitcoin network we are operating on e.g., signet, regtest. The terms
 //! "network" and "chain" are often used interchangeably for this concept.
-//!
-//! # Example: encoding a network's magic bytes
-//!
-//! ```rust
-//! use bitcoin::Network;
-//! use bitcoin::consensus::encode::serialize;
-//!
-//! let network = Network::Bitcoin;
-//! let bytes = serialize(&network.magic());
-//!
-//! assert_eq!(&bytes[..], &[0xF9, 0xBE, 0xB4, 0xD9]);
-//! ```
 
 pub mod params;
 
@@ -28,7 +16,6 @@ use internals::write_err;
 use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::constants::ChainHash;
-use crate::p2p::Magic;
 use crate::prelude::{String, ToOwned};
 
 #[rustfmt::skip]                // Keep public re-exports separate.
@@ -124,33 +111,6 @@ impl<'de> Deserialize<'de> for Network {
 }
 
 impl Network {
-    /// Constructs a new `Network` from the magic bytes.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use bitcoin::p2p::Magic;
-    /// use bitcoin::Network;
-    ///
-    /// assert_eq!(Ok(Network::Bitcoin), Network::try_from(Magic::from_bytes([0xF9, 0xBE, 0xB4, 0xD9])));
-    /// assert_eq!(None, Network::from_magic(Magic::from_bytes([0xFF, 0xFF, 0xFF, 0xFF])));
-    /// ```
-    pub fn from_magic(magic: Magic) -> Option<Network> { Network::try_from(magic).ok() }
-
-    /// Return the network magic bytes, which should be encoded little-endian
-    /// at the start of every message
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use bitcoin::p2p::Magic;
-    /// use bitcoin::Network;
-    ///
-    /// let network = Network::Bitcoin;
-    /// assert_eq!(network.magic(), Magic::from_bytes([0xF9, 0xBE, 0xB4, 0xD9]));
-    /// ```
-    pub fn magic(self) -> Magic { Magic::from(self) }
-
     /// Converts a `Network` to its equivalent `bitcoind -chain` argument name.
     ///
     /// ```bash
@@ -363,35 +323,6 @@ impl TryFrom<ChainHash> for Network {
 #[cfg(test)]
 mod tests {
     use super::{Network, TestnetVersion};
-    use crate::consensus::encode::{deserialize, serialize};
-    use crate::p2p::ServiceFlags;
-
-    #[test]
-    fn serialize_deserialize() {
-        assert_eq!(serialize(&Network::Bitcoin.magic()), &[0xf9, 0xbe, 0xb4, 0xd9]);
-        assert_eq!(
-            serialize(&Network::Testnet(TestnetVersion::V3).magic()),
-            &[0x0b, 0x11, 0x09, 0x07]
-        );
-        assert_eq!(
-            serialize(&Network::Testnet(TestnetVersion::V4).magic()),
-            &[0x1c, 0x16, 0x3f, 0x28]
-        );
-        assert_eq!(serialize(&Network::Signet.magic()), &[0x0a, 0x03, 0xcf, 0x40]);
-        assert_eq!(serialize(&Network::Regtest.magic()), &[0xfa, 0xbf, 0xb5, 0xda]);
-
-        assert_eq!(deserialize(&[0xf9, 0xbe, 0xb4, 0xd9]).ok(), Some(Network::Bitcoin.magic()));
-        assert_eq!(
-            deserialize(&[0x0b, 0x11, 0x09, 0x07]).ok(),
-            Some(Network::Testnet(TestnetVersion::V3).magic())
-        );
-        assert_eq!(
-            deserialize(&[0x1c, 0x16, 0x3f, 0x28]).ok(),
-            Some(Network::Testnet(TestnetVersion::V4).magic())
-        );
-        assert_eq!(deserialize(&[0x0a, 0x03, 0xcf, 0x40]).ok(), Some(Network::Signet.magic()));
-        assert_eq!(deserialize(&[0xfa, 0xbf, 0xb5, 0xda]).ok(), Some(Network::Regtest.magic()));
-    }
 
     #[test]
     fn string() {
@@ -409,47 +340,7 @@ mod tests {
         assert!("fakenet".parse::<Network>().is_err());
     }
 
-    #[test]
-    fn service_flags() {
-        let all = [
-            ServiceFlags::NETWORK,
-            ServiceFlags::GETUTXO,
-            ServiceFlags::BLOOM,
-            ServiceFlags::WITNESS,
-            ServiceFlags::COMPACT_FILTERS,
-            ServiceFlags::NETWORK_LIMITED,
-            ServiceFlags::P2P_V2,
-        ];
-
-        let mut flags = ServiceFlags::NONE;
-        for f in all.iter() {
-            assert!(!flags.has(*f));
-        }
-
-        flags |= ServiceFlags::WITNESS;
-        assert_eq!(flags, ServiceFlags::WITNESS);
-
-        let mut flags2 = flags | ServiceFlags::GETUTXO;
-        for f in all.iter() {
-            assert_eq!(flags2.has(*f), *f == ServiceFlags::WITNESS || *f == ServiceFlags::GETUTXO);
-        }
-
-        flags2 ^= ServiceFlags::WITNESS;
-        assert_eq!(flags2, ServiceFlags::GETUTXO);
-
-        flags2 |= ServiceFlags::COMPACT_FILTERS;
-        flags2 ^= ServiceFlags::GETUTXO;
-        assert_eq!(flags2, ServiceFlags::COMPACT_FILTERS);
-
-        // Test formatting.
-        assert_eq!("ServiceFlags(NONE)", ServiceFlags::NONE.to_string());
-        assert_eq!("ServiceFlags(WITNESS)", ServiceFlags::WITNESS.to_string());
-        let flag = ServiceFlags::WITNESS | ServiceFlags::BLOOM | ServiceFlags::NETWORK;
-        assert_eq!("ServiceFlags(NETWORK|BLOOM|WITNESS)", flag.to_string());
-        let flag = ServiceFlags::WITNESS | 0xf0.into();
-        assert_eq!("ServiceFlags(WITNESS|COMPACT_FILTERS|0xb0)", flag.to_string());
-    }
-
+    
     #[test]
     #[cfg(feature = "serde")]
     fn serde_roundtrip() {

--- a/bitcoin/src/network/params.rs
+++ b/bitcoin/src/network/params.rs
@@ -12,7 +12,7 @@
 //!
 //! ```
 //! use bitcoin::network::Params;
-//! use bitcoin::{p2p, Script, ScriptBuf, Network, Target};
+//! use bitcoin::{Script, ScriptBuf, Network, Target};
 //!
 //! const POW_TARGET_SPACING: u64 = 120; // Two minutes.
 //! const MAGIC: [u8; 4] = [1, 2, 3, 4];
@@ -39,9 +39,6 @@
 //!         }
 //!     }
 //!
-//!     /// Returns the custom magic bytes.
-//!     pub fn magic(&self) -> p2p::Magic { p2p::Magic::from_bytes(self.magic) }
-//!
 //!     /// Returns the custom signet challenge script.
 //!     pub fn challenge_script(&self) -> &Script { &self.challenge_script }
 //! }
@@ -61,7 +58,6 @@
 //! #    let _ = target.difficulty(signet);
 //! #
 //! #    let custom = CustomParams::new();
-//! #    let _ = custom.magic();
 //! #    let _ = custom.challenge_script();
 //! #    let _ = target.difficulty(custom);
 //! # }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,6 +11,7 @@ cargo-fuzz = true
 [dependencies]
 honggfuzz = { version = "0.5.56", default-features = false }
 bitcoin = { path = "../bitcoin", features = [ "serde" ] }
+p2p = { path = "../p2p/", package = "bitcoin_p2p" }
 
 serde = { version = "1.0.103", features = [ "derive" ] }
 serde_json = "1.0"

--- a/fuzz/fuzz_targets/bitcoin/deser_net_msg.rs
+++ b/fuzz/fuzz_targets/bitcoin/deser_net_msg.rs
@@ -1,7 +1,7 @@
 use honggfuzz::fuzz;
 
 fn do_test(data: &[u8]) {
-    let _: Result<bitcoin::p2p::message::RawNetworkMessage, _> =
+    let _: Result<p2p::message::RawNetworkMessage, _> =
         bitcoin::consensus::encode::deserialize(data);
 }
 

--- a/fuzz/fuzz_targets/bitcoin/p2p_address_roundtrip.rs
+++ b/fuzz/fuzz_targets/bitcoin/p2p_address_roundtrip.rs
@@ -2,7 +2,7 @@ use std::convert::TryFrom;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
 use bitcoin::consensus::Decodable;
-use bitcoin::p2p::address::AddrV2;
+use p2p::address::AddrV2;
 use honggfuzz::fuzz;
 
 fn do_test(data: &[u8]) {

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "bitcoin_p2p"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+bitcoin = { path = "../bitcoin/" }
+hashes = { package = "bitcoin_hashes", path = "../hashes", default-features = false, features = ["alloc", "hex"] }
+hex = { package = "hex-conservative", version = "0.3.0", default-features = false, features = ["alloc"] }
+internals = { package = "bitcoin-internals", path = "../internals", features = ["alloc", "hex"] }
+io = { package = "bitcoin-io", path = "../io", default-features = false, features = ["alloc", "hashes"] }
+units = { package = "bitcoin-units", path = "../units", default-features = false, features = ["alloc"] }
+
+[dev-dependencies]
+hex_lit = "0.1.1"
+
+[[example]]
+name = "handshake"
+
+[lib]
+path = "src/lib.rs"

--- a/p2p/examples/handshake.rs
+++ b/p2p/examples/handshake.rs
@@ -4,8 +4,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use std::{env, process};
 
 use bitcoin::consensus::{encode, Decodable};
-use bitcoin::p2p::{self, address, message, message_network};
-use bitcoin::secp256k1::rand::Rng;
+use bitcoin_p2p::{self, address, message, message_network, Magic};
 
 fn main() {
     // This example establishes a connection to a Bitcoin node, sends the initial
@@ -26,7 +25,7 @@ fn main() {
     let version_message = build_version_message(address);
 
     let first_message =
-        message::RawNetworkMessage::new(bitcoin::Network::Bitcoin.magic(), version_message);
+        message::RawNetworkMessage::new(Magic::BITCOIN, version_message);
 
     if let Ok(mut stream) = TcpStream::connect(address) {
         // Send the message
@@ -44,7 +43,7 @@ fn main() {
                     println!("Received version message: {:?}", reply.payload());
 
                     let second_message = message::RawNetworkMessage::new(
-                        bitcoin::Network::Bitcoin.magic(),
+                        Magic::BITCOIN,
                         message::NetworkMessage::Verack,
                     );
 
@@ -72,19 +71,19 @@ fn build_version_message(address: SocketAddr) -> message::NetworkMessage {
     let my_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 0);
 
     // "bitfield of features to be enabled for this connection"
-    let services = p2p::ServiceFlags::NONE;
+    let services = bitcoin_p2p::ServiceFlags::NONE;
 
     // "standard UNIX timestamp in seconds"
     let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).expect("Time error").as_secs();
 
     // "The network address of the node receiving this message"
-    let addr_recv = address::Address::new(&address, p2p::ServiceFlags::NONE);
+    let addr_recv = address::Address::new(&address, bitcoin_p2p::ServiceFlags::NONE);
 
     // "The network address of the node emitting this message"
-    let addr_from = address::Address::new(&my_address, p2p::ServiceFlags::NONE);
+    let addr_from = address::Address::new(&my_address, bitcoin_p2p::ServiceFlags::NONE);
 
     // "Node random nonce, randomly generated every time a version packet is sent. This nonce is used to detect connections to self."
-    let nonce: u64 = secp256k1::rand::thread_rng().gen();
+    let nonce: u64 = 42;
 
     // "User Agent (0x00 if string is 0 bytes long)"
     let user_agent = String::from("rust-example");

--- a/p2p/src/message_blockdata.rs
+++ b/p2p/src/message_blockdata.rs
@@ -7,11 +7,10 @@
 
 use io::{BufRead, Write};
 
-use crate::block::BlockHash;
-use crate::consensus::encode::{self, Decodable, Encodable};
-use crate::internal_macros::impl_consensus_encoding;
-use crate::p2p;
-use crate::transaction::{Txid, Wtxid};
+use bitcoin::block::BlockHash;
+use bitcoin::consensus::encode::{self, Decodable, Encodable};
+use bitcoin::transaction::{Txid, Wtxid};
+use crate::impl_consensus_encoding;
 
 /// An inventory item.
 #[derive(PartialEq, Eq, Clone, Debug, Copy, Hash, PartialOrd, Ord)]
@@ -127,7 +126,7 @@ pub struct GetHeadersMessage {
 impl GetBlocksMessage {
     /// Construct a new `getblocks` message
     pub fn new(locator_hashes: Vec<BlockHash>, stop_hash: BlockHash) -> GetBlocksMessage {
-        GetBlocksMessage { version: p2p::PROTOCOL_VERSION, locator_hashes, stop_hash }
+        GetBlocksMessage { version: crate::PROTOCOL_VERSION, locator_hashes, stop_hash }
     }
 }
 
@@ -136,7 +135,7 @@ impl_consensus_encoding!(GetBlocksMessage, version, locator_hashes, stop_hash);
 impl GetHeadersMessage {
     /// Construct a new `getheaders` message
     pub fn new(locator_hashes: Vec<BlockHash>, stop_hash: BlockHash) -> GetHeadersMessage {
-        GetHeadersMessage { version: p2p::PROTOCOL_VERSION, locator_hashes, stop_hash }
+        GetHeadersMessage { version: crate::PROTOCOL_VERSION, locator_hashes, stop_hash }
     }
 }
 
@@ -147,7 +146,7 @@ mod tests {
     use hex_lit::hex;
 
     use super::*;
-    use crate::consensus::encode::{deserialize, serialize};
+    use bitcoin::consensus::encode::{deserialize, serialize};
 
     #[test]
     fn getblocks_message() {

--- a/p2p/src/message_bloom.rs
+++ b/p2p/src/message_bloom.rs
@@ -6,8 +6,8 @@
 
 use io::{BufRead, Write};
 
-use crate::consensus::{self, encode, Decodable, Encodable, ReadExt};
-use crate::internal_macros::impl_consensus_encoding;
+use bitcoin::consensus::{encode, Decodable, Encodable, ReadExt};
+use crate::impl_consensus_encoding;
 
 /// `filterload` message sets the current bloom filter
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -52,7 +52,7 @@ impl Decodable for BloomFlags {
             0 => BloomFlags::None,
             1 => BloomFlags::All,
             2 => BloomFlags::PubkeyOnly,
-            _ => return Err(consensus::parse_failed_error("unknown bloom flag")),
+            _ => return Err(crate::parse_failed_error("unknown bloom flag")),
         })
     }
 }

--- a/p2p/src/message_compact_blocks.rs
+++ b/p2p/src/message_compact_blocks.rs
@@ -3,8 +3,8 @@
 //!
 //! BIP152  Compact Blocks network messages
 
-use crate::bip152;
-use crate::internal_macros::impl_consensus_encoding;
+use bitcoin::bip152;
+use crate::impl_consensus_encoding;
 
 /// sendcmpct message
 #[derive(PartialEq, Eq, Clone, Debug, Copy, PartialOrd, Ord, Hash)]

--- a/p2p/src/message_filter.rs
+++ b/p2p/src/message_filter.rs
@@ -6,9 +6,9 @@
 
 use units::BlockHeight;
 
-use crate::bip158::{FilterHash, FilterHeader};
-use crate::block::BlockHash;
-use crate::internal_macros::impl_consensus_encoding;
+use bitcoin::bip158::{FilterHash, FilterHeader};
+use bitcoin::block::BlockHash;
+use crate::impl_consensus_encoding;
 
 /// getcfilters message
 #[derive(PartialEq, Eq, Clone, Debug)]

--- a/p2p/src/message_network.rs
+++ b/p2p/src/message_network.rs
@@ -8,11 +8,10 @@
 use hashes::sha256d;
 use io::{BufRead, Write};
 
-use crate::consensus::{self, encode, Decodable, Encodable, ReadExt};
-use crate::internal_macros::impl_consensus_encoding;
-use crate::p2p;
-use crate::p2p::address::Address;
-use crate::p2p::ServiceFlags;
+use bitcoin::consensus::{encode, Decodable, Encodable, ReadExt};
+use crate::impl_consensus_encoding;
+use crate::address::Address;
+use crate::ServiceFlags;
 use crate::prelude::{Cow, String};
 
 // Some simple messages
@@ -61,7 +60,7 @@ impl VersionMessage {
         start_height: i32,
     ) -> VersionMessage {
         VersionMessage {
-            version: p2p::PROTOCOL_VERSION,
+            version: crate::PROTOCOL_VERSION,
             services,
             timestamp,
             receiver,
@@ -126,7 +125,7 @@ impl Decodable for RejectReason {
             0x41 => RejectReason::Dust,
             0x42 => RejectReason::Fee,
             0x43 => RejectReason::Checkpoint,
-            _ => return Err(consensus::parse_failed_error("unknown reject code")),
+            _ => return Err(crate::parse_failed_error("unknown reject code")),
         })
     }
 }
@@ -151,7 +150,7 @@ mod tests {
     use hex_lit::hex;
 
     use super::*;
-    use crate::consensus::encode::{deserialize, serialize};
+    use bitcoin::consensus::encode::{deserialize, serialize};
 
     #[test]
     fn version_message_test() {


### PR DESCRIPTION
New peer-to-peer messages are added to Bitcoin Core occasionally. Including `p2p` in the general `bitcoin` crate restricts changes in its API to the SemVer semantics of `bitcoin`. This would generally prevent new peer-to-peer messages in the `p2p` module. Except for a few types, `bitcoin` does not depend on `p2p`, so `p2p` can have an independent release cycle of `bitcoin`.

Caveats:
- The `Network` type included some methods that depended on `p2p::Magic`. These are removed, as `TryFrom` is implemented to and from magic/network
- `Encodable` is no longer defined within `p2p`, so encodable vector types violate the orphan rule when attempting to implement `Encodable` for `Vec<T: Encodable>`. Instead of introducing a generic implementation for `Vec<T>`, I used wrapper types and implemented encodable for those
- `Network` is no longer defined at the crate level so the match arm becomes non-exhaustive. This requires `TryFrom` for Network to Magic now
- The only types available in `no-std` were `Magic` and `ServiceFlags`. It simplifies the crate greatly to assume a standard environment. One can implement their own concept of magic without this crate.
- `ServiceFlags` appeared to have a duplicate test

It looks like `impl_consensus_encoding` and `parse_failed_error` would be useful in `internals`.
