### PR TITLE
Do not derive `Default` on `CompactTarget`

### DIFF
--- a/primitives/src/pow.rs
+++ b/primitives/src/pow.rs
@@ -18,7 +18,7 @@ use core::fmt;
 /// `CompactTarget` and `Target` is lossy *in both directions* (there are multiple `CompactTarget`
 /// values that map to the same `Target` value). Ordering and equality for this type are defined in
 /// terms of the underlying `u32`.
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CompactTarget(u32);
 


### PR DESCRIPTION
It is not immediately obvious what a zero value compact target is. Because of this and the fact that we are trying to release minimal code in `primitives 1.0` its best to remove the `Default` derive.

This is an API breaking change.