### PR TITLE
Add `Coinbase(Transaction)` newtype to distinguish coinbase transactions

### DIFF
--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -15,6 +15,7 @@ use internals::{compact_size, ToU64};
 use io::{BufRead, Write};
 use units::BlockTime;
 
+use super::transaction::Coinbase;
 use super::Weight;
 use crate::consensus::encode::WriteExt as _;
 use crate::consensus::{encode, Decodable, Encodable};
@@ -259,7 +260,7 @@ pub trait BlockCheckedExt: sealed::Sealed {
     fn total_size(&self) -> usize;
 
     /// Returns the coinbase transaction, if one is present.
-    fn coinbase(&self) -> Option<&Transaction>;
+    fn coinbase(&self) -> Result<&Coinbase, CoinbaseError>;
 
     /// Returns the block height, as encoded in the coinbase transaction according to BIP34.
     fn bip34_block_height(&self) -> Result<u64, Bip34Error>;
@@ -294,7 +295,10 @@ impl BlockCheckedExt for Block<Checked> {
     }
 
     /// Returns the coinbase transaction, if one is present.
-    fn coinbase(&self) -> Option<&Transaction> { self.transactions().first() }
+    fn coinbase(&self) -> Result<&Coinbase, CoinbaseError> {
+        let first_tx = self.transactions().first().ok_or(CoinbaseError::NoTransactions)?;
+        first_tx.try_into().map_err(|_| CoinbaseError::InvalidCoinbase)
+    }
 
     /// Returns the block height, as encoded in the coinbase transaction according to BIP34.
     fn bip34_block_height(&self) -> Result<u64, Bip34Error> {
@@ -311,7 +315,7 @@ impl BlockCheckedExt for Block<Checked> {
             return Err(Bip34Error::Unsupported);
         }
 
-        let cb = self.coinbase().ok_or(Bip34Error::NotPresent)?;
+        let cb = self.coinbase().map_err(|_| Bip34Error::NotPresent)?;
         let input = cb.input.first().ok_or(Bip34Error::NotPresent)?;
         let push = input
             .script_sig

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -315,7 +315,7 @@ impl BlockCheckedExt for Block<Checked> {
             return Err(Bip34Error::Unsupported);
         }
 
-        let cb = self.coinbase().map_err(|_| Bip34Error::NotPresent)?;
+        let cb = self.coinbase().map_err(|_| Bip34Error::NoCoinbase)?;
         let input = cb.input.first().ok_or(Bip34Error::NotPresent)?;
         let push = input
             .script_sig
@@ -429,6 +429,8 @@ impl std::error::Error for InvalidBlockError {}
 pub enum Bip34Error {
     /// The block does not support BIP34 yet.
     Unsupported,
+    /// Block has no valid coinbase transaction.
+    NoCoinbase,
     /// No push was present where the BIP34 push was expected.
     NotPresent,
     /// The BIP34 push was not minimally encoded.
@@ -447,6 +449,7 @@ impl fmt::Display for Bip34Error {
 
         match *self {
             Unsupported => write!(f, "block doesn't support BIP34"),
+            NoCoinbase => write!(f, "block has no valid coinbase transaction"),
             NotPresent => write!(f, "BIP34 push not present in block's coinbase"),
             NonMinimalPush => write!(f, "byte push not minimally encoded"),
             NegativeHeight => write!(f, "negative BIP34 height"),
@@ -460,7 +463,7 @@ impl std::error::Error for Bip34Error {
         use Bip34Error::*;
 
         match *self {
-            Unsupported | NotPresent | NonMinimalPush | NegativeHeight => None,
+            Unsupported | NoCoinbase | NotPresent | NonMinimalPush | NegativeHeight => None,
         }
     }
 }

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -505,6 +505,42 @@ impl std::error::Error for ValidationError {
     }
 }
 
+/// An error when accessing the coinbase transaction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CoinbaseError {
+    /// Block has no transactions.
+    NoTransactions,
+    /// Transaction is not a valid coinbase transaction.
+    InvalidCoinbase,
+}
+
+impl From<Infallible> for CoinbaseError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+impl fmt::Display for CoinbaseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use CoinbaseError::*;
+
+        match *self {
+            NoTransactions => write!(f, "block has no transactions"),
+            InvalidCoinbase => write!(f, "transaction is not a valid coinbase transaction"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for CoinbaseError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use CoinbaseError::*;
+
+        match *self {
+            NoTransactions | InvalidCoinbase => None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use hex_lit::hex;

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -11,6 +11,7 @@
 //! This module provides the structures and functions needed to support transactions.
 
 use core::fmt;
+use core::ops::Deref;
 
 use hashes::sha256d;
 use internals::{compact_size, write_err, ToU64};
@@ -28,6 +29,7 @@ use crate::script::{Script, ScriptBuf, ScriptExt as _, ScriptExtPriv as _};
 use crate::sighash::{EcdsaSighashType, TapSighashType};
 use crate::witness::Witness;
 use crate::{Amount, FeeRate, SignedAmount};
+use crate::blockdata::block::CoinbaseError;
 
 #[rustfmt::skip]            // Keep public re-exports separate.
 #[doc(inline)]
@@ -1127,6 +1129,46 @@ impl InputWeightPrediction {
         let wu = self.script_size * 4 + self.witness_size;
         let wu = wu as u64; // Can't use `ToU64` in const context.
         Weight::from_wu(wu)
+    }
+}
+
+/// A wrapper type for the coinbase transaction of a block.
+///
+/// This type exists to distinguish coinbase transactions from regular ones at the type level.
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
+#[repr(transparent)]
+pub struct Coinbase(Transaction);
+
+impl Coinbase {
+    /// Computes the [`Txid`] of this coinbase transaction.
+    pub fn compute_txid(&self) -> Txid {
+        self.0.compute_txid()
+    }
+
+    /// Computes the [`Wtxid`] of this coinbase transaction.
+    pub fn compute_wtxid(&self) -> Wtxid {
+        self.0.compute_wtxid()
+    }
+}
+
+impl Deref for Coinbase {
+    type Target = Transaction;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+
+impl<'a> TryFrom<&'a Transaction> for &'a Coinbase {
+    type Error = CoinbaseError;
+
+    fn try_from(tx: &'a Transaction) -> Result<Self, Self::Error> {
+        if tx.is_coinbase() {
+            Ok(unsafe { &*(tx as *const Transaction as *const Coinbase) })
+        } else {
+            Err(CoinbaseError::InvalidCoinbase)
+        }
     }
 }
 

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -2062,6 +2062,35 @@ mod tests {
         let pretty_txid = "0x0000000000000000000000000000000000000000000000000000000000000000";
         assert_eq!(pretty_txid, format!("{:#}", &outpoint.txid));
     }
+
+    #[test]
+    fn coinbase_try_from_valid_coinbase() {
+        use crate::constants;
+        use crate::network::Network;
+
+        let genesis = constants::genesis_block(Network::Bitcoin);
+        let coinbase_tx = &genesis.transactions()[0];
+        
+        // Test that we can convert a valid coinbase transaction
+        let coinbase_ref: Result<&Coinbase, _> = coinbase_tx.try_into();
+        assert!(coinbase_ref.is_ok());
+        
+        let coinbase = coinbase_ref.unwrap();
+        assert_eq!(coinbase.compute_txid(), coinbase_tx.compute_txid());
+        assert_eq!(coinbase.compute_wtxid(), coinbase_tx.compute_wtxid());
+    }
+
+    #[test]
+    fn coinbase_try_from_invalid_coinbase() {
+        let tx_bytes = hex!("0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000");
+        let tx: Transaction = deserialize(&tx_bytes).unwrap();
+        assert!(!tx.is_coinbase());
+        
+        // Test that we get an error when trying to convert a non-coinbase transaction
+        let coinbase_ref: Result<&Coinbase, _> = (&tx).try_into();
+        assert!(coinbase_ref.is_err());
+        assert_eq!(coinbase_ref.unwrap_err(), CoinbaseError::InvalidCoinbase);
+    }
 }
 
 #[cfg(bench)]

--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -76,6 +76,12 @@ impl Block<Unchecked> {
         Block { header, transactions, witness_root: None, marker: PhantomData::<Unchecked> }
     }
 
+    /// Adds a transaction to the block.
+    #[inline]
+    pub fn push_transaction(&mut self, transaction: Transaction) {
+        self.transactions.push(transaction);
+    }
+
     /// Ignores block validation logic and just assumes you know what you are doing.
     ///
     /// You should only use this function if you trust the block i.e., it comes from a trusted node.


### PR DESCRIPTION
Coinbase transactions are structurally and semantically different from normal transactions.

We introduce a distinct `Coinbase(Transaction)` newtype to make this distinction explicit at the type level, helping to catch logic that shouldn't apply to coinbases (e.g attempting to look up coinbase inputs in the UTXO set).

This PR is split into several patches to keep changes reviewable and to document the rationale behind each step.

- Closes #4437 
- Closes #4543