### PR TITLE
bitcoin: secp256k1 global-context feature re-export

### DIFF
--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -20,6 +20,7 @@ std = ["base58/std", "bech32/std", "hashes/std", "hex/std", "internals/std", "io
 rand-std = ["secp256k1/rand", "std"]
 rand = ["secp256k1/rand"]
 serde = ["base64", "dep:serde", "hashes/serde", "internals/serde", "primitives/serde", "secp256k1/serde", "units/serde"]
+secp-global-context = ["secp256k1/global-context"]
 secp-lowmemory = ["secp256k1/lowmemory"]
 secp-recovery = ["secp256k1/recovery"]
 arbitrary = ["dep:arbitrary", "units/arbitrary", "primitives/arbitrary"]


### PR DESCRIPTION
Often we want to have the global-context feature in secp256k1 without having to add manually the secp256k1 dependency and enabling the global-context feature.

Having the ability to do that directly from bitcoin without having to add secp256k1 and do the whole tango of tightly coupling the two dependecy versions together, e.g. bitcoin 0.32.x and secp256k1 0.29.x would be really nice and would also simplify a lot code maintainability for anyone who depends on bitcoin.

This needs to be backported to 0.32.x, which I'll gladly do as well.