### PR TITLE
Introduce empty p2p messages crate

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -107,6 +107,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin-p2p-messages"
+version = "0.1.0"
+
+[[package]]
 name = "bitcoin-primitives"
 version = "0.101.0"
 dependencies = [

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -106,6 +106,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin-p2p-messages"
+version = "0.1.0"
+
+[[package]]
 name = "bitcoin-primitives"
 version = "0.101.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["addresses", "base58", "bitcoin", "chacha20_poly1305", "fuzz", "hashes", "internals", "io", "primitives", "units"]
+members = ["addresses", "base58", "bitcoin", "chacha20_poly1305", "fuzz", "hashes", "internals", "io", "p2p", "primitives", "units"]
 resolver = "2"
 
 # Keep this patch for hashes because secp256k1 depends on bitcoin-hashes via crates.io

--- a/p2p/CHANGELOG.md
+++ b/p2p/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.1.0 - 2025-05-27
+
+* Initial release of the `github.com/rust-bitcoin/rust-bitcoin/p2p` crate as `bitcoin-p2p-messages`.

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "bitcoin-p2p-messages"
+version = "0.1.0"
+authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
+license = "CC0-1.0"
+repository = "https://github.com/rust-bitcoin/rust-bitcoin"
+description = "Peer-to-peer messages defined by the Bitcoin protocol"
+categories = ["cryptography::cryptocurrencies"]
+keywords = ["bitcoin", "peer-to-peer"]
+readme = "README.md"
+edition = "2021"
+rust-version = "1.63.0"
+exclude = ["tests", "contrib"]
+
+[dependencies]
+
+[dev-dependencies]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/p2p/README.md
+++ b/p2p/README.md
@@ -1,0 +1,12 @@
+# Rust Bitcoin Peer to Peer Message Types
+
+This crate provides data types used in the Bitcoin peer-to-peer protocol.
+
+## Minimum Supported Rust Version (MSRV)
+
+This library should always compile with any combination of features on **Rust 1.63.0**.
+
+## Licensing
+
+The code in this project is licensed under the [Creative Commons CC0 1.0 Universal license](LICENSE).
+We use the [SPDX license list](https://spdx.org/licenses/) and [SPDX IDs](https://spdx.dev/ids/).

--- a/p2p/contrib/test_vars.sh
+++ b/p2p/contrib/test_vars.sh
@@ -1,0 +1,14 @@
+# No shebang, this file should not be executed.
+# shellcheck disable=SC2148
+#
+# disable verify unused vars, despite the fact that they are used when sourced
+# shellcheck disable=SC2034
+
+# Test all these features with "std" enabled.
+FEATURES_WITH_STD=""
+
+# Test all these features without "std" enabled.
+FEATURES_WITHOUT_STD=""
+
+# Run these examples.
+EXAMPLES=""

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! # Rust Bitcoin Peer to Peer Message Types
+
+// Experimental features we need.
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+// Coding conventions.
+#![warn(missing_docs)]
+#![warn(deprecated_in_future)]
+#![doc(test(attr(warn(unused))))]
+// Pedantic lints that we enforce.
+#![warn(clippy::return_self_not_must_use)]
+// Exclude lints we don't think are valuable.
+#![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
+#![allow(clippy::manual_range_contains)] // More readable than clippy's format.
+#![allow(clippy::uninlined_format_args)] // Allow `format!("{}", x)`instead of enforcing `format!("{x}")`


### PR DESCRIPTION
Peer to peer messages change on occasion, and we would like to add messages as they are released from Bitcoin Core. Add an empty crate to take the crate name.