### PR TITLE
Remove unnecessary closure

### DIFF
--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -187,9 +187,7 @@ impl Serialize for Vec<secp256k1::PublicKey> {
 impl Deserialize for Vec<secp256k1::PublicKey> {
     fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
         bytes.chunks(secp256k1::constants::PUBLIC_KEY_SIZE)
-            .map(|pubkey_bytes| {
-                secp256k1::PublicKey::deserialize(pubkey_bytes)
-            })
+            .map(secp256k1::PublicKey::deserialize)
             .collect()
     }
 }


### PR DESCRIPTION
We can just pass the function directly. Found by clippy bizarrely after running `rustfmt` (in bot-created PR #4586).

Internal change only, no logic change.