### PR TITLE
Add absolute value

### DIFF
--- a/units/src/result.rs
+++ b/units/src/result.rs
@@ -161,6 +161,15 @@ impl<T: fmt::Debug> NumOpResult<T> {
         }
     }
 
+    /// Returns `NumOpResult` from a `Result<T, NumOpError>`.
+    #[inline]
+    pub fn from_result(r: Result<T, NumOpError>) -> Self {
+        match r {
+            Ok(x) => R::Valid(x),
+            Err(e) => NumOpResult::Error(e),
+        }
+    }
+
     /// Calls `op` if the numeric result is `Valid`, otherwise returns the `Error` value of `self`.
     #[inline]
     pub fn and_then<F>(self, op: F) -> NumOpResult<T>

--- a/units/src/result.rs
+++ b/units/src/result.rs
@@ -215,7 +215,7 @@ pub struct NumOpError(MathOp);
 
 impl NumOpError {
     /// Creates a [`NumOpError`] caused by `op`.
-    pub(crate) const fn while_doing(op: MathOp) -> Self { NumOpError(op) }
+    pub const fn while_doing(op: MathOp) -> Self { NumOpError(op) }
 
     /// Returns `true` if this operation error'ed due to overflow.
     pub fn is_overflow(self) -> bool { self.0.is_overflow() }


### PR DESCRIPTION
Not sure if there's interest in adding `absolute_value()` which is sort of the antidote to `effective_value()`.  It's useful for coin-selection and is also present in bitcoin-core.

A few things of interest in preparing this PR:
* it would be really helpful to go from a `Result` to a` NumOpResult` I think, so added  `from_result()`.  Not sure if this is "idiomatic" enough.
* Also, since this is in the bitcoin crate, `while_doing` was in-accessible since it's in the units crate with crate level visibility.  Therefore updated accessibility.