### PR TITLE
Do not enable serde's derive feature

### DIFF
--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -30,7 +30,7 @@ arrayvec = { version = "0.7", default-features = false }
 
 arbitrary = { version = "1.4", optional = true }
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false, optional = true }
-serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"], optional = true }
+serde = { version = "1.0.103", default-features = false, features = ["alloc"], optional = true }
 
 [dev-dependencies]
 serde_json = "1.0.0"

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -20,7 +20,7 @@ alloc = ["internals/alloc","serde?/alloc"]
 [dependencies]
 internals = { package = "bitcoin-internals", path = "../internals" }
 
-serde = { version = "1.0.103", default-features = false, features = ["derive"], optional = true }
+serde = { version = "1.0.103", default-features = false, optional = true }
 arbitrary = { version = "1.4", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Turns out we no longer need the `derive` feature in `units` or `primitives`.

For `units` this should have been done as part of #4506.