### PR TITLE
Correct hash algorithm name in RIPEMD160 documentation

### DIFF
--- a/hashes/src/ripemd160/mod.rs
+++ b/hashes/src/ripemd160/mod.rs
@@ -62,7 +62,7 @@ pub struct HashEngine {
 }
 
 impl HashEngine {
-    /// Constructs a new SHA256 hash engine.
+    /// Constructs a new RIPEMD160 hash engine.
     pub const fn new() -> Self {
         Self {
             h: [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476, 0xc3d2e1f0],


### PR DESCRIPTION
Corrected the documentation comment for the `new()` method in the RIPEMD160 `HashEngine` struct. The comment incorrectly stated it constructs a "SHA256 hash engine" when it actually constructs a RIPEMD160 hash engine.

