### PR TITLE
Improve `FeeRate` constructors

### DIFF
--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -751,7 +751,7 @@ fn default_dust_value() {
     assert!(script_p2wpkh.is_p2wpkh());
     assert_eq!(script_p2wpkh.minimal_non_dust(), Amount::from_sat_u32(294));
     assert_eq!(
-        script_p2wpkh.minimal_non_dust_custom(FeeRate::from_sat_per_vb_u32(6)),
+        script_p2wpkh.minimal_non_dust_custom(FeeRate::from_sat_per_vb(6)),
         Some(Amount::from_sat_u32(588))
     );
 
@@ -765,7 +765,7 @@ fn default_dust_value() {
     assert!(script_p2pkh.is_p2pkh());
     assert_eq!(script_p2pkh.minimal_non_dust(), Amount::from_sat_u32(546));
     assert_eq!(
-        script_p2pkh.minimal_non_dust_custom(FeeRate::from_sat_per_vb_u32(6)),
+        script_p2pkh.minimal_non_dust_custom(FeeRate::from_sat_per_vb(6)),
         Some(Amount::from_sat_u32(1092))
     );
 }

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -1689,7 +1689,7 @@ mod tests {
     #[test]
     fn effective_value_happy_path() {
         let value = "1 cBTC".parse::<Amount>().unwrap();
-        let fee_rate = FeeRate::from_sat_per_kwu(10).unwrap();
+        let fee_rate = FeeRate::from_sat_per_kwu(10);
         let effective_value = effective_value(fee_rate, InputWeightPrediction::P2WPKH_MAX, value);
 
         // 10 sat/kwu * 272 wu = 3 sats (rounding up)

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -128,7 +128,7 @@ impl Psbt {
     /// 1000 sats/vByte. 25k sats/vByte is obviously a mistake at this point.
     ///
     /// [`extract_tx`]: Psbt::extract_tx
-    pub const DEFAULT_MAX_FEE_RATE: FeeRate = FeeRate::from_sat_per_vb_u32(25_000);
+    pub const DEFAULT_MAX_FEE_RATE: FeeRate = FeeRate::from_sat_per_vb(25_000);
 
     /// An alias for [`extract_tx_fee_rate_limit`].
     ///
@@ -1445,7 +1445,7 @@ mod tests {
         // Large fee rate errors if we pass in 1 sat/vb so just use this to get the error fee rate returned.
         let error_fee_rate = psbt
             .clone()
-            .extract_tx_with_fee_rate_limit(FeeRate::from_sat_per_vb_u32(1))
+            .extract_tx_with_fee_rate_limit(FeeRate::from_sat_per_vb(1))
             .map_err(|e| match e {
                 ExtractTxError::AbsurdFeeRate { fee_rate, .. } => fee_rate,
                 _ => panic!(""),

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -213,11 +213,14 @@ impl Psbt {
                 if fee_rate > max_fee_rate {
                     return Err(ExtractTxError::AbsurdFeeRate { fee_rate, tx });
                 }
+                Ok(tx)
             }
-            NumOpResult::Error(_) => unreachable!("weight() is always non-zero"),
+            // We hit this if fee * 4,000 overflows.
+            NumOpResult::Error(_) => Err(ExtractTxError::AbsurdFeeRate {
+                fee_rate: FeeRate::MAX,
+                tx,
+            }),
         }
-
-        Ok(tx)
     }
 
     /// Combines this [`Psbt`] with `other` PSBT as described by BIP 174.

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -1358,17 +1358,6 @@ mod tests {
     use crate::witness::Witness;
     use crate::Sequence;
 
-    /// Fee rate in sat/kwu for a high-fee PSBT with an input=5_000_000_000_000, output=1000
-    const ABSURD_FEE_RATE: FeeRate = match FeeRate::from_sat_per_kwu(15_060_240_960_843) {
-        Some(fee_rate) => fee_rate,
-        None => panic!("unreachable - no unwrap in Rust 1.63 in const"),
-    };
-    const JUST_BELOW_ABSURD_FEE_RATE: FeeRate = match FeeRate::from_sat_per_kwu(15_060_240_960_842)
-    {
-        Some(fee_rate) => fee_rate,
-        None => panic!("unreachable - no unwrap in Rust 1.63 in const"),
-    };
-
     #[track_caller]
     pub fn hex_psbt(s: &str) -> Result<Psbt, crate::psbt::error::Error> {
         let r = Vec::from_hex(s);
@@ -1452,31 +1441,46 @@ mod tests {
 
     #[test]
     fn psbt_high_fee_checks() {
-        let psbt = psbt_with_values(5_000_000_000_000, 1000);
+        let psbt = psbt_with_values(Amount::MAX.to_sat(), 1000);
+
+        // We cannot create an expected fee rate to test against because `FeeRate::from_sat_per_mvb` is private.
+        // Large fee rate errors if we pass in 1 sat/vb so just use this to get the error fee rate returned.
+        let error_fee_rate = psbt.clone().extract_tx_with_fee_rate_limit(FeeRate::from_sat_per_vb_u32(1)).map_err(|e| {
+            match e {
+                ExtractTxError::AbsurdFeeRate { fee_rate, .. } => fee_rate,
+                _ => panic!(""),
+            }
+        }).unwrap_err();
+
+        // These all error because of overflow when calculating the fee / weight. 
         assert_eq!(
             psbt.clone().extract_tx().map_err(|e| match e {
                 ExtractTxError::AbsurdFeeRate { fee_rate, .. } => fee_rate,
                 _ => panic!(""),
             }),
-            Err(ABSURD_FEE_RATE)
+            Err(error_fee_rate)
         );
         assert_eq!(
             psbt.clone().extract_tx_fee_rate_limit().map_err(|e| match e {
                 ExtractTxError::AbsurdFeeRate { fee_rate, .. } => fee_rate,
                 _ => panic!(""),
             }),
-            Err(ABSURD_FEE_RATE)
+            Err(error_fee_rate)
         );
         assert_eq!(
-            psbt.clone().extract_tx_with_fee_rate_limit(JUST_BELOW_ABSURD_FEE_RATE).map_err(|e| {
+            psbt.clone().extract_tx_with_fee_rate_limit(FeeRate::MAX).map_err(|e| {
                 match e {
                     ExtractTxError::AbsurdFeeRate { fee_rate, .. } => fee_rate,
                     _ => panic!(""),
                 }
             }),
-            Err(ABSURD_FEE_RATE)
+            Err(FeeRate::MAX)
         );
-        assert!(psbt.extract_tx_with_fee_rate_limit(ABSURD_FEE_RATE).is_ok());
+
+        // No one is using an ~50 BTC fee so if we can handle this
+        // then the `FeeRate` restrictions are fine for PSBT usage.
+        let psbt = psbt_with_values(Amount::from_btc_u16(50).to_sat(), 1000); // fee = 50 BTC - 1000 sats
+        assert!(psbt.extract_tx_with_fee_rate_limit(FeeRate::MAX).is_ok());
 
         // Testing that extract_tx will error at 25k sat/vbyte (6250000 sat/kwu)
         assert_eq!(

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -216,10 +216,8 @@ impl Psbt {
                 Ok(tx)
             }
             // We hit this if fee * 4,000 overflows.
-            NumOpResult::Error(_) => Err(ExtractTxError::AbsurdFeeRate {
-                fee_rate: FeeRate::MAX,
-                tx,
-            }),
+            NumOpResult::Error(_) =>
+                Err(ExtractTxError::AbsurdFeeRate { fee_rate: FeeRate::MAX, tx }),
         }
     }
 
@@ -1445,14 +1443,16 @@ mod tests {
 
         // We cannot create an expected fee rate to test against because `FeeRate::from_sat_per_mvb` is private.
         // Large fee rate errors if we pass in 1 sat/vb so just use this to get the error fee rate returned.
-        let error_fee_rate = psbt.clone().extract_tx_with_fee_rate_limit(FeeRate::from_sat_per_vb_u32(1)).map_err(|e| {
-            match e {
+        let error_fee_rate = psbt
+            .clone()
+            .extract_tx_with_fee_rate_limit(FeeRate::from_sat_per_vb_u32(1))
+            .map_err(|e| match e {
                 ExtractTxError::AbsurdFeeRate { fee_rate, .. } => fee_rate,
                 _ => panic!(""),
-            }
-        }).unwrap_err();
+            })
+            .unwrap_err();
 
-        // These all error because of overflow when calculating the fee / weight. 
+        // These all error because of overflow when calculating the fee / weight.
         assert_eq!(
             psbt.clone().extract_tx().map_err(|e| match e {
                 ExtractTxError::AbsurdFeeRate { fee_rate, .. } => fee_rate,
@@ -1488,7 +1488,7 @@ mod tests {
                 ExtractTxError::AbsurdFeeRate { fee_rate, .. } => fee_rate,
                 _ => panic!(""),
             }),
-            Err(FeeRate::from_sat_per_kwu(6250003).unwrap()) // 6250000 is 25k sat/vbyte
+            Err(FeeRate::from_sat_per_kwu(6250003)) // 6250000 is 25k sat/vbyte
         );
 
         // Lowering the input satoshis by 1 lowers the sat/kwu by 3

--- a/fuzz/fuzz_targets/bitcoin/deserialize_script.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_script.rs
@@ -2,7 +2,7 @@ use bitcoin::address::Address;
 use bitcoin::consensus::encode;
 use bitcoin::script::{self, ScriptExt as _};
 use bitcoin::{FeeRate, Network};
-use bitcoin_fuzz::fuzz_utils::{consume_random_bytes, consume_u64};
+use bitcoin_fuzz::fuzz_utils::{consume_random_bytes, consume_u32};
 use honggfuzz::fuzz;
 
 fn do_test(data: &[u8]) {
@@ -17,7 +17,7 @@ fn do_test(data: &[u8]) {
         let _ = script.count_sigops_legacy();
         let _ = script.minimal_non_dust();
 
-        let fee_rate = FeeRate::from_sat_per_kwu(consume_u64(&mut new_data)).unwrap();
+        let fee_rate = FeeRate::from_sat_per_kwu(consume_u32(&mut new_data));
         let _ = script.minimal_non_dust_custom(fee_rate);
 
         let mut b = script::Builder::new();

--- a/fuzz/src/fuzz_utils.rs
+++ b/fuzz/src/fuzz_utils.rs
@@ -35,3 +35,16 @@ pub fn consume_u64(data: &mut &[u8]) -> u64 {
         u64_bytes[7],
     ])
 }
+
+#[allow(dead_code)]
+pub fn consume_u32(data: &mut &[u8]) -> u32 {
+    // We need at least 4 bytes to read a u32
+    if data.len() < 4 {
+        return 0;
+    }
+
+    let (u32_bytes, rest) = data.split_at(4);
+    *data = rest;
+
+    u32::from_le_bytes([u32_bytes[0], u32_bytes[1], u32_bytes[2], u32_bytes[3]])
+}

--- a/units/src/amount/tests.rs
+++ b/units/src/amount/tests.rs
@@ -270,13 +270,13 @@ fn amount_checked_div_by_weight_ceil() {
     let weight = Weight::from_kwu(1).unwrap();
     let fee_rate = sat(1).div_by_weight_ceil(weight).unwrap();
     // 1 sats / 1,000 wu = 1 sats/kwu
-    assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(1).unwrap());
+    assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(1));
 
     let weight = Weight::from_wu(381);
     let fee_rate = sat(329).div_by_weight_ceil(weight).unwrap();
     // 329 sats / 381 wu = 863.5 sats/kwu
     // round up to 864
-    assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(864).unwrap());
+    assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(864));
 
     let fee_rate = Amount::ONE_SAT.div_by_weight_ceil(Weight::ZERO);
     assert!(fee_rate.unwrap_err().is_div_by_zero());
@@ -288,13 +288,13 @@ fn amount_div_by_weight_floor() {
     let weight = Weight::from_kwu(1).unwrap();
     let fee_rate = sat(1).div_by_weight_floor(weight).unwrap();
     // 1 sats / 1,000 wu = 1 sats/kwu
-    assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(1).unwrap());
+    assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(1));
 
     let weight = Weight::from_wu(381);
     let fee_rate = sat(329).div_by_weight_floor(weight).unwrap();
     // 329 sats / 381 wu = 863.5 sats/kwu
     // round down to 863
-    assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(863).unwrap());
+    assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(863));
 
     let fee_rate = Amount::ONE_SAT.div_by_weight_floor(Weight::ZERO);
     assert!(fee_rate.unwrap_err().is_div_by_zero());
@@ -307,7 +307,7 @@ fn amount_div_by_weight_floor() {
 #[test]
 fn amount_checked_div_by_fee_rate() {
     let amount = sat(1000);
-    let fee_rate = FeeRate::from_sat_per_kwu(2).unwrap();
+    let fee_rate = FeeRate::from_sat_per_kwu(2);
 
     // Test floor division
     let weight = amount.div_by_fee_rate_floor(fee_rate).unwrap();
@@ -320,20 +320,20 @@ fn amount_checked_div_by_fee_rate() {
 
     // Test truncation behavior
     let amount = sat(1000);
-    let fee_rate = FeeRate::from_sat_per_kwu(3).unwrap();
+    let fee_rate = FeeRate::from_sat_per_kwu(3);
     let floor_weight = amount.div_by_fee_rate_floor(fee_rate).unwrap();
     let ceil_weight = amount.div_by_fee_rate_ceil(fee_rate).unwrap();
     assert_eq!(floor_weight, Weight::from_wu(333_333));
     assert_eq!(ceil_weight, Weight::from_wu(333_334));
 
     // Test division by zero
-    let zero_fee_rate = FeeRate::from_sat_per_kwu(0).unwrap();
+    let zero_fee_rate = FeeRate::from_sat_per_kwu(0);
     assert!(amount.div_by_fee_rate_floor(zero_fee_rate).is_error());
     assert!(amount.div_by_fee_rate_ceil(zero_fee_rate).is_error());
 
     // Test with maximum amount
     let max_amount = Amount::MAX;
-    let small_fee_rate = FeeRate::from_sat_per_kwu(1).unwrap();
+    let small_fee_rate = FeeRate::from_sat_per_kwu(1);
     let weight = max_amount.div_by_fee_rate_floor(small_fee_rate).unwrap();
     // 21_000_000_0000_0000 sats / (1 sat/kwu) = 2_100_000_000_000_000_000 wu
     assert_eq!(weight, Weight::from_wu(2_100_000_000_000_000_000));

--- a/units/src/amount/tests.rs
+++ b/units/src/amount/tests.rs
@@ -268,36 +268,39 @@ fn positive_sub() {
 #[test]
 fn amount_checked_div_by_weight_ceil() {
     let weight = Weight::from_kwu(1).unwrap();
-    let fee_rate = sat(1).checked_div_by_weight_ceil(weight).unwrap();
+    let fee_rate = sat(1).div_by_weight_ceil(weight).unwrap();
     // 1 sats / 1,000 wu = 1 sats/kwu
     assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(1).unwrap());
 
     let weight = Weight::from_wu(381);
-    let fee_rate = sat(329).checked_div_by_weight_ceil(weight).unwrap();
+    let fee_rate = sat(329).div_by_weight_ceil(weight).unwrap();
     // 329 sats / 381 wu = 863.5 sats/kwu
     // round up to 864
     assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(864).unwrap());
 
-    let fee_rate = Amount::ONE_SAT.checked_div_by_weight_ceil(Weight::ZERO);
-    assert!(fee_rate.is_none());
+    let fee_rate = Amount::ONE_SAT.div_by_weight_ceil(Weight::ZERO);
+    assert!(fee_rate.unwrap_err().is_div_by_zero());
 }
 
 #[cfg(feature = "alloc")]
 #[test]
-fn amount_checked_div_by_weight_floor() {
+fn amount_div_by_weight_floor() {
     let weight = Weight::from_kwu(1).unwrap();
-    let fee_rate = sat(1).checked_div_by_weight_floor(weight).unwrap();
+    let fee_rate = sat(1).div_by_weight_floor(weight).unwrap();
     // 1 sats / 1,000 wu = 1 sats/kwu
     assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(1).unwrap());
 
     let weight = Weight::from_wu(381);
-    let fee_rate = sat(329).checked_div_by_weight_floor(weight).unwrap();
+    let fee_rate = sat(329).div_by_weight_floor(weight).unwrap();
     // 329 sats / 381 wu = 863.5 sats/kwu
     // round down to 863
     assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(863).unwrap());
 
-    let fee_rate = Amount::ONE_SAT.checked_div_by_weight_floor(Weight::ZERO);
-    assert!(fee_rate.is_none());
+    let fee_rate = Amount::ONE_SAT.div_by_weight_floor(Weight::ZERO);
+    assert!(fee_rate.unwrap_err().is_div_by_zero());
+
+    let fee_rate = Amount::MAX.div_by_weight_floor(Weight::ZERO);
+    assert!(fee_rate.unwrap_err().is_div_by_zero());
 }
 
 #[cfg(feature = "alloc")]
@@ -307,31 +310,31 @@ fn amount_checked_div_by_fee_rate() {
     let fee_rate = FeeRate::from_sat_per_kwu(2).unwrap();
 
     // Test floor division
-    let weight = amount.checked_div_by_fee_rate_floor(fee_rate).unwrap();
+    let weight = amount.div_by_fee_rate_floor(fee_rate).unwrap();
     // 1000 sats / (2 sats/kwu) = 500,000 wu
     assert_eq!(weight, Weight::from_wu(500_000));
 
     // Test ceiling division
-    let weight = amount.checked_div_by_fee_rate_ceil(fee_rate).unwrap();
+    let weight = amount.div_by_fee_rate_ceil(fee_rate).unwrap();
     assert_eq!(weight, Weight::from_wu(500_000)); // Same result for exact division
 
     // Test truncation behavior
     let amount = sat(1000);
     let fee_rate = FeeRate::from_sat_per_kwu(3).unwrap();
-    let floor_weight = amount.checked_div_by_fee_rate_floor(fee_rate).unwrap();
-    let ceil_weight = amount.checked_div_by_fee_rate_ceil(fee_rate).unwrap();
+    let floor_weight = amount.div_by_fee_rate_floor(fee_rate).unwrap();
+    let ceil_weight = amount.div_by_fee_rate_ceil(fee_rate).unwrap();
     assert_eq!(floor_weight, Weight::from_wu(333_333));
     assert_eq!(ceil_weight, Weight::from_wu(333_334));
 
     // Test division by zero
     let zero_fee_rate = FeeRate::from_sat_per_kwu(0).unwrap();
-    assert!(amount.checked_div_by_fee_rate_floor(zero_fee_rate).is_none());
-    assert!(amount.checked_div_by_fee_rate_ceil(zero_fee_rate).is_none());
+    assert!(amount.div_by_fee_rate_floor(zero_fee_rate).is_error());
+    assert!(amount.div_by_fee_rate_ceil(zero_fee_rate).is_error());
 
     // Test with maximum amount
     let max_amount = Amount::MAX;
     let small_fee_rate = FeeRate::from_sat_per_kwu(1).unwrap();
-    let weight = max_amount.checked_div_by_fee_rate_floor(small_fee_rate).unwrap();
+    let weight = max_amount.div_by_fee_rate_floor(small_fee_rate).unwrap();
     // 21_000_000_0000_0000 sats / (1 sat/kwu) = 2_100_000_000_000_000_000 wu
     assert_eq!(weight, Weight::from_wu(2_100_000_000_000_000_000));
 }

--- a/units/src/fee.rs
+++ b/units/src/fee.rs
@@ -360,7 +360,7 @@ mod tests {
 
     #[test]
     fn fee_wu() {
-        let fee_rate = FeeRate::from_sat_per_vb(2).unwrap();
+        let fee_rate = FeeRate::from_sat_per_vb(2);
         let weight = Weight::from_vb(3).unwrap();
         assert_eq!(fee_rate.to_fee(weight), Amount::from_sat_u32(6));
     }
@@ -369,7 +369,6 @@ mod tests {
     fn checked_weight_mul() {
         let weight = Weight::from_vb(10).unwrap();
         let fee: Amount = FeeRate::from_sat_per_vb(10)
-            .unwrap()
             .checked_mul_by_weight(weight)
             .expect("expected Amount");
         assert_eq!(Amount::from_sat_u32(100), fee);
@@ -378,7 +377,7 @@ mod tests {
         assert!(fee.is_none());
 
         let weight = Weight::from_vb(3).unwrap();
-        let fee_rate = FeeRate::from_sat_per_vb(3).unwrap();
+        let fee_rate = FeeRate::from_sat_per_vb(3);
         let fee = fee_rate.checked_mul_by_weight(weight).unwrap();
         assert_eq!(Amount::from_sat_u32(9), fee);
 
@@ -393,7 +392,7 @@ mod tests {
     #[test]
     #[allow(clippy::op_ref)]
     fn multiply() {
-        let two = FeeRate::from_sat_per_vb(2).unwrap();
+        let two = FeeRate::from_sat_per_vb(2);
         let three = Weight::from_vb(3).unwrap();
         let six = Amount::from_sat_u32(6);
 

--- a/units/src/fee_rate/mod.rs
+++ b/units/src/fee_rate/mod.rs
@@ -10,10 +10,9 @@ use core::ops;
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
-
 use NumOpResult as R;
 
-use crate::{Amount,MathOp, NumOpError as E, NumOpResult};
+use crate::{Amount, MathOp, NumOpError as E, NumOpResult};
 
 mod encapsulate {
     /// Fee rate.
@@ -56,14 +55,10 @@ impl FeeRate {
     /// The fee rate used to compute dust amount.
     pub const DUST: FeeRate = FeeRate::from_sat_per_vb_u32(3);
 
-    /// Constructs a new [`FeeRate`] from satoshis per 1000 weight units,
-    /// returning `None` if overflow occurred.
-    pub const fn from_sat_per_kwu(sat_kwu: u64) -> Option<Self> {
-        // No `map()` in const context.
-        match (sat_kwu as u64).checked_mul(4_000) {
-            Some(fee_rate) => Some(FeeRate::from_sat_per_mvb(fee_rate)),
-            None => None,
-        }
+    /// Constructs a new [`FeeRate`] from satoshis per 1000 weight units.
+    pub const fn from_sat_per_kwu(sat_kwu: u32) -> Self {
+        let fee_rate = (sat_kwu as u64) * 4_000; // No `Into` in const context.
+        FeeRate::from_sat_per_mvb(fee_rate)
     }
 
     /// Constructs a new [`FeeRate`] from amount per 1000 weight units.
@@ -249,18 +244,18 @@ mod tests {
     #[test]
     #[allow(clippy::op_ref)]
     fn feerate_div_nonzero() {
-        let rate = FeeRate::from_sat_per_kwu(200).unwrap();
+        let rate = FeeRate::from_sat_per_kwu(200);
         let divisor = NonZeroU64::new(2).unwrap();
-        assert_eq!(rate / divisor, FeeRate::from_sat_per_kwu(100).unwrap());
-        assert_eq!(&rate / &divisor, FeeRate::from_sat_per_kwu(100).unwrap());
+        assert_eq!(rate / divisor, FeeRate::from_sat_per_kwu(100));
+        assert_eq!(&rate / &divisor, FeeRate::from_sat_per_kwu(100));
     }
 
     #[test]
     #[allow(clippy::op_ref)]
     fn addition() {
-        let one = FeeRate::from_sat_per_kwu(1).unwrap();
-        let two = FeeRate::from_sat_per_kwu(2).unwrap();
-        let three = FeeRate::from_sat_per_kwu(3).unwrap();
+        let one = FeeRate::from_sat_per_kwu(1);
+        let two = FeeRate::from_sat_per_kwu(2);
+        let three = FeeRate::from_sat_per_kwu(3);
 
         assert!(one + two == three);
         assert!(&one + two == three);
@@ -271,9 +266,9 @@ mod tests {
     #[test]
     #[allow(clippy::op_ref)]
     fn subtract() {
-        let three = FeeRate::from_sat_per_kwu(3).unwrap();
-        let seven = FeeRate::from_sat_per_kwu(7).unwrap();
-        let ten = FeeRate::from_sat_per_kwu(10).unwrap();
+        let three = FeeRate::from_sat_per_kwu(3);
+        let seven = FeeRate::from_sat_per_kwu(7);
+        let ten = FeeRate::from_sat_per_kwu(10);
 
         assert_eq!(ten - seven, three);
         assert_eq!(&ten - seven, three);
@@ -283,31 +278,31 @@ mod tests {
 
     #[test]
     fn add_assign() {
-        let mut f = FeeRate::from_sat_per_kwu(1).unwrap();
-        f += FeeRate::from_sat_per_kwu(2).unwrap();
-        assert_eq!(f, FeeRate::from_sat_per_kwu(3).unwrap());
+        let mut f = FeeRate::from_sat_per_kwu(1);
+        f += FeeRate::from_sat_per_kwu(2);
+        assert_eq!(f, FeeRate::from_sat_per_kwu(3));
 
-        let mut f = FeeRate::from_sat_per_kwu(1).unwrap();
-        f += &FeeRate::from_sat_per_kwu(2).unwrap();
-        assert_eq!(f, FeeRate::from_sat_per_kwu(3).unwrap());
+        let mut f = FeeRate::from_sat_per_kwu(1);
+        f += &FeeRate::from_sat_per_kwu(2);
+        assert_eq!(f, FeeRate::from_sat_per_kwu(3));
     }
 
     #[test]
     fn sub_assign() {
-        let mut f = FeeRate::from_sat_per_kwu(3).unwrap();
-        f -= FeeRate::from_sat_per_kwu(2).unwrap();
-        assert_eq!(f, FeeRate::from_sat_per_kwu(1).unwrap());
+        let mut f = FeeRate::from_sat_per_kwu(3);
+        f -= FeeRate::from_sat_per_kwu(2);
+        assert_eq!(f, FeeRate::from_sat_per_kwu(1));
 
-        let mut f = FeeRate::from_sat_per_kwu(3).unwrap();
-        f -= &FeeRate::from_sat_per_kwu(2).unwrap();
-        assert_eq!(f, FeeRate::from_sat_per_kwu(1).unwrap());
+        let mut f = FeeRate::from_sat_per_kwu(3);
+        f -= &FeeRate::from_sat_per_kwu(2);
+        assert_eq!(f, FeeRate::from_sat_per_kwu(1));
     }
 
     #[test]
     fn checked_add() {
-        let one = FeeRate::from_sat_per_kwu(1).unwrap();
-        let two = FeeRate::from_sat_per_kwu(2).unwrap();
-        let three = FeeRate::from_sat_per_kwu(3).unwrap();
+        let one = FeeRate::from_sat_per_kwu(1);
+        let two = FeeRate::from_sat_per_kwu(2);
+        let three = FeeRate::from_sat_per_kwu(3);
 
         assert_eq!(one.checked_add(two).unwrap(), three);
 
@@ -318,9 +313,9 @@ mod tests {
 
     #[test]
     fn checked_sub() {
-        let one = FeeRate::from_sat_per_kwu(1).unwrap();
-        let two = FeeRate::from_sat_per_kwu(2).unwrap();
-        let three = FeeRate::from_sat_per_kwu(3).unwrap();
+        let one = FeeRate::from_sat_per_kwu(1);
+        let two = FeeRate::from_sat_per_kwu(2);
+        let three = FeeRate::from_sat_per_kwu(3);
         assert_eq!(three.checked_sub(two).unwrap(), one);
 
         let fee_rate = FeeRate::ZERO.checked_sub(one);
@@ -339,7 +334,7 @@ mod tests {
     #[test]
     fn fee_rate_from_sat_per_vb() {
         let fee_rate = FeeRate::from_sat_per_vb(10).expect("expected feerate in sat/kwu");
-        assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(2500).unwrap());
+        assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(2500));
     }
 
     #[test]
@@ -357,7 +352,7 @@ mod tests {
     #[test]
     fn from_sat_per_vb_u32() {
         let fee_rate = FeeRate::from_sat_per_vb_u32(10);
-        assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(2500).unwrap());
+        assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(2500));
     }
 
     #[test]
@@ -366,7 +361,7 @@ mod tests {
 
     #[test]
     fn raw_feerate() {
-        let fee_rate = FeeRate::from_sat_per_kwu(749).unwrap();
+        let fee_rate = FeeRate::from_sat_per_kwu(749);
         assert_eq!(fee_rate.to_sat_per_kwu_floor(), 749);
         assert_eq!(fee_rate.to_sat_per_vb_floor(), 2);
         assert_eq!(fee_rate.to_sat_per_vb_ceil(), 3);
@@ -374,25 +369,21 @@ mod tests {
 
     #[test]
     fn checked_mul() {
-        let fee_rate = FeeRate::from_sat_per_kwu(10)
-            .unwrap()
-            .checked_mul(10)
-            .expect("expected feerate in sat/kwu");
-        assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(100).unwrap());
+        let fee_rate =
+            FeeRate::from_sat_per_kwu(10).checked_mul(10).expect("expected feerate in sat/kwu");
+        assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(100));
 
-        let fee_rate = FeeRate::from_sat_per_kwu(10).unwrap().checked_mul(u64::MAX);
+        let fee_rate = FeeRate::from_sat_per_kwu(10).checked_mul(u64::MAX);
         assert!(fee_rate.is_none());
     }
 
     #[test]
     fn checked_div() {
-        let fee_rate = FeeRate::from_sat_per_kwu(10)
-            .unwrap()
-            .checked_div(10)
-            .expect("expected feerate in sat/kwu");
-        assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(1).unwrap());
+        let fee_rate =
+            FeeRate::from_sat_per_kwu(10).checked_div(10).expect("expected feerate in sat/kwu");
+        assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(1));
 
-        let fee_rate = FeeRate::from_sat_per_kwu(10).unwrap().checked_div(0);
+        let fee_rate = FeeRate::from_sat_per_kwu(10).checked_div(0);
         assert!(fee_rate.is_none());
     }
 

--- a/units/src/fee_rate/mod.rs
+++ b/units/src/fee_rate/mod.rs
@@ -50,10 +50,10 @@ impl FeeRate {
     /// The minimum fee rate required to broadcast a transaction.
     ///
     /// The value matches the default Bitcoin Core policy at the time of library release.
-    pub const BROADCAST_MIN: FeeRate = FeeRate::from_sat_per_vb_u32(1);
+    pub const BROADCAST_MIN: FeeRate = FeeRate::from_sat_per_vb(1);
 
     /// The fee rate used to compute dust amount.
-    pub const DUST: FeeRate = FeeRate::from_sat_per_vb_u32(3);
+    pub const DUST: FeeRate = FeeRate::from_sat_per_vb(3);
 
     /// Constructs a new [`FeeRate`] from satoshis per 1000 weight units.
     pub const fn from_sat_per_kwu(sat_kwu: u32) -> Self {
@@ -70,14 +70,10 @@ impl FeeRate {
         }
     }
 
-    /// Constructs a new [`FeeRate`] from satoshis per virtual byte,
-    /// returning `None` if overflow occurred.
-    pub const fn from_sat_per_vb(sat_vb: u64) -> Option<Self> {
-        // No `map()` in const context.
-        match sat_vb.checked_mul(1_000_000) {
-            Some(fee_rate) => Some(FeeRate::from_sat_per_mvb(fee_rate)),
-            None => None,
-        }
+    /// Constructs a new [`FeeRate`] from satoshis per virtual byte.
+    pub const fn from_sat_per_vb(sat_vb: u32) -> Self {
+        let fee_rate = (sat_vb as u64) * 1_000_000; // No `Into` in const context.
+        FeeRate::from_sat_per_mvb(fee_rate)
     }
 
     /// Constructs a new [`FeeRate`] from amount per virtual byte.
@@ -87,12 +83,6 @@ impl FeeRate {
             Some(per_mvb) => R::Valid(FeeRate::from_sat_per_mvb(per_mvb.to_sat())),
             None => R::Error(E::while_doing(MathOp::Mul)),
         }
-    }
-
-    /// Constructs a new [`FeeRate`] from satoshis per virtual bytes.
-    pub const fn from_sat_per_vb_u32(sat_vb: u32) -> Self {
-        let sat_vb = sat_vb as u64; // No `Into` in const context.
-        FeeRate::from_sat_per_mvb(sat_vb * 1_000_000)
     }
 
     /// Constructs a new [`FeeRate`] from satoshis per kilo virtual bytes (1,000 vbytes),
@@ -333,7 +323,7 @@ mod tests {
 
     #[test]
     fn fee_rate_from_sat_per_vb() {
-        let fee_rate = FeeRate::from_sat_per_vb(10).expect("expected feerate in sat/kwu");
+        let fee_rate = FeeRate::from_sat_per_vb(10);
         assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(2500));
     }
 
@@ -344,20 +334,14 @@ mod tests {
     }
 
     #[test]
-    fn fee_rate_from_sat_per_vb_overflow() {
-        let fee_rate = FeeRate::from_sat_per_vb(u64::MAX);
-        assert!(fee_rate.is_none());
-    }
-
-    #[test]
-    fn from_sat_per_vb_u32() {
-        let fee_rate = FeeRate::from_sat_per_vb_u32(10);
+    fn from_sat_per_vb() {
+        let fee_rate = FeeRate::from_sat_per_vb(10);
         assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(2500));
     }
 
     #[test]
     #[cfg(debug_assertions)]
-    fn from_sat_per_vb_u32_cannot_panic() { FeeRate::from_sat_per_vb_u32(u32::MAX); }
+    fn from_sat_per_vb_cannot_panic() { FeeRate::from_sat_per_vb(u32::MAX); }
 
     #[test]
     fn raw_feerate() {

--- a/units/src/fee_rate/mod.rs
+++ b/units/src/fee_rate/mod.rs
@@ -60,7 +60,7 @@ impl FeeRate {
     /// returning `None` if overflow occurred.
     pub const fn from_sat_per_kwu(sat_kwu: u64) -> Option<Self> {
         // No `map()` in const context.
-        match sat_kwu.checked_mul(4_000) {
+        match (sat_kwu as u64).checked_mul(4_000) {
             Some(fee_rate) => Some(FeeRate::from_sat_per_mvb(fee_rate)),
             None => None,
         }

--- a/units/src/fee_rate/mod.rs
+++ b/units/src/fee_rate/mod.rs
@@ -87,12 +87,9 @@ impl FeeRate {
 
     /// Constructs a new [`FeeRate`] from satoshis per kilo virtual bytes (1,000 vbytes),
     /// returning `None` if overflow occurred.
-    pub const fn from_sat_per_kvb(sat_kvb: u64) -> Option<Self> {
-        // No `map()` in const context.
-        match sat_kvb.checked_mul(1_000) {
-            Some(fee_rate) => Some(FeeRate::from_sat_per_mvb(fee_rate)),
-            None => None,
-        }
+    pub const fn from_sat_per_kvb(sat_kvb: u32) -> Self {
+        let fee_rate = (sat_kvb as u64) * 1_000; // No `Into` in const context.
+        FeeRate::from_sat_per_mvb(fee_rate)
     }
 
     /// Constructs a new [`FeeRate`] from satoshis per kilo virtual bytes (1,000 vbytes).
@@ -296,7 +293,6 @@ mod tests {
 
         assert_eq!(one.checked_add(two).unwrap(), three);
 
-        assert!(FeeRate::from_sat_per_kvb(u64::MAX).is_none()); // sanity check.
         let fee_rate = FeeRate::from_sat_per_mvb(u64::MAX).checked_add(one);
         assert!(fee_rate.is_none());
     }
@@ -329,7 +325,7 @@ mod tests {
 
     #[test]
     fn fee_rate_from_sat_per_kvb() {
-        let fee_rate = FeeRate::from_sat_per_kvb(11).unwrap();
+        let fee_rate = FeeRate::from_sat_per_kvb(11);
         assert_eq!(fee_rate, FeeRate::from_sat_per_mvb(11_000));
     }
 

--- a/units/src/fee_rate/mod.rs
+++ b/units/src/fee_rate/mod.rs
@@ -62,7 +62,7 @@ impl FeeRate {
         }
     }
 
-    /// Constructs a new [`FeeRate`] from satoshis per virtual bytes,
+    /// Constructs a new [`FeeRate`] from satoshis per virtual byte,
     /// returning `None` if overflow occurred.
     pub const fn from_sat_per_vb(sat_vb: u64) -> Option<Self> {
         // No `map()` in const context.

--- a/units/src/fee_rate/mod.rs
+++ b/units/src/fee_rate/mod.rs
@@ -11,6 +11,10 @@ use core::ops;
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
 
+use NumOpResult as R;
+
+use crate::{Amount,MathOp, NumOpError as E, NumOpResult};
+
 mod encapsulate {
     /// Fee rate.
     ///
@@ -62,6 +66,15 @@ impl FeeRate {
         }
     }
 
+    /// Constructs a new [`FeeRate`] from amount per 1000 weight units.
+    pub const fn from_per_kwu(rate: Amount) -> NumOpResult<Self> {
+        // No `map()` in const context.
+        match rate.checked_mul(4_000) {
+            Some(per_mvb) => R::Valid(FeeRate::from_sat_per_mvb(per_mvb.to_sat())),
+            None => R::Error(E::while_doing(MathOp::Mul)),
+        }
+    }
+
     /// Constructs a new [`FeeRate`] from satoshis per virtual byte,
     /// returning `None` if overflow occurred.
     pub const fn from_sat_per_vb(sat_vb: u64) -> Option<Self> {
@@ -69,6 +82,15 @@ impl FeeRate {
         match sat_vb.checked_mul(1_000_000) {
             Some(fee_rate) => Some(FeeRate::from_sat_per_mvb(fee_rate)),
             None => None,
+        }
+    }
+
+    /// Constructs a new [`FeeRate`] from amount per virtual byte.
+    pub const fn from_per_vb(rate: Amount) -> NumOpResult<Self> {
+        // No `map()` in const context.
+        match rate.checked_mul(1_000_000) {
+            Some(per_mvb) => R::Valid(FeeRate::from_sat_per_mvb(per_mvb.to_sat())),
+            None => R::Error(E::while_doing(MathOp::Mul)),
         }
     }
 
@@ -85,6 +107,15 @@ impl FeeRate {
         match sat_kvb.checked_mul(1_000) {
             Some(fee_rate) => Some(FeeRate::from_sat_per_mvb(fee_rate)),
             None => None,
+        }
+    }
+
+    /// Constructs a new [`FeeRate`] from satoshis per kilo virtual bytes (1,000 vbytes).
+    pub const fn from_per_kvb(rate: Amount) -> NumOpResult<Self> {
+        // No `map()` in const context.
+        match rate.checked_mul(1_000) {
+            Some(per_mvb) => R::Valid(FeeRate::from_sat_per_mvb(per_mvb.to_sat())),
+            None => R::Error(E::while_doing(MathOp::Mul)),
         }
     }
 

--- a/units/src/fee_rate/serde.rs
+++ b/units/src/fee_rate/serde.rs
@@ -104,8 +104,7 @@ pub mod as_sat_per_vb_floor {
 
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-    use crate::fee_rate::serde::OverflowError;
-    use crate::fee_rate::FeeRate;
+    use crate::{Amount, FeeRate};
 
     pub fn serialize<S: Serializer>(f: &FeeRate, s: S) -> Result<S::Ok, S::Error> {
         u64::serialize(&f.to_sat_per_vb_floor(), s)
@@ -113,9 +112,12 @@ pub mod as_sat_per_vb_floor {
 
     // Errors on overflow.
     pub fn deserialize<'d, D: Deserializer<'d>>(d: D) -> Result<FeeRate, D::Error> {
-        FeeRate::from_sat_per_vb(u64::deserialize(d)?)
-            .ok_or(OverflowError)
-            .map_err(serde::de::Error::custom)
+        let sat = u64::deserialize(d)?;
+        FeeRate::from_per_vb(
+            Amount::from_sat(sat).map_err(|_| serde::de::Error::custom("overflowed amount"))?,
+        )
+        .into_result()
+        .map_err(|_| serde::de::Error::custom("overflowed amount calculating sats/vb"))
     }
 
     pub mod opt {
@@ -175,8 +177,7 @@ pub mod as_sat_per_vb_ceil {
 
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-    use crate::fee_rate::serde::OverflowError;
-    use crate::fee_rate::FeeRate;
+    use crate::{Amount, FeeRate};
 
     pub fn serialize<S: Serializer>(f: &FeeRate, s: S) -> Result<S::Ok, S::Error> {
         u64::serialize(&f.to_sat_per_vb_ceil(), s)
@@ -184,9 +185,12 @@ pub mod as_sat_per_vb_ceil {
 
     // Errors on overflow.
     pub fn deserialize<'d, D: Deserializer<'d>>(d: D) -> Result<FeeRate, D::Error> {
-        FeeRate::from_sat_per_vb(u64::deserialize(d)?)
-            .ok_or(OverflowError)
-            .map_err(serde::de::Error::custom)
+        let sat = u64::deserialize(d)?;
+        FeeRate::from_per_vb(
+            Amount::from_sat(sat).map_err(|_| serde::de::Error::custom("overflowed amount"))?,
+        )
+        .into_result()
+        .map_err(|_| serde::de::Error::custom("overflowed amount calculating sats/vb"))
     }
 
     pub mod opt {

--- a/units/src/fee_rate/serde.rs
+++ b/units/src/fee_rate/serde.rs
@@ -41,9 +41,11 @@ pub mod as_sat_per_kwu_floor {
 
     pub fn deserialize<'d, D: Deserializer<'d>>(d: D) -> Result<FeeRate, D::Error> {
         let sat = u64::deserialize(d)?;
-        FeeRate::from_per_kwu(Amount::from_sat(sat).map_err(|_| serde::de::Error::custom("overflowed amount"))?)
-            .into_result()
-            .map_err(|_| serde::de::Error::custom("overflowed amount calculating sats/kwu"))
+        FeeRate::from_per_kwu(
+            Amount::from_sat(sat).map_err(|_| serde::de::Error::custom("overflowed amount"))?,
+        )
+        .into_result()
+        .map_err(|_| serde::de::Error::custom("overflowed amount calculating sats/kwu"))
     }
 
     pub mod opt {

--- a/units/src/result.rs
+++ b/units/src/result.rs
@@ -58,7 +58,7 @@ use crate::{Amount, FeeRate, SignedAmount, Weight};
 /// let a = Amount::from_sat(123).expect("valid amount");
 /// let b = Amount::from_sat(467).expect("valid amount");
 /// // Fee rate for transaction.
-/// let fee_rate = FeeRate::from_sat_per_vb(1).unwrap();
+/// let fee_rate = FeeRate::from_sat_per_vb(1);
 ///
 /// // Somewhat contrived example to show addition operator chained with division.
 /// let max_fee = a + b;


### PR DESCRIPTION
Improve `FeeRate` constructors by adding a set that takes `Amount` as arg and then make all the ones that take sats use `u32` so they are infallible (removing overflow). 

Note commit: `14dc950b Return NumOpResult when calculating fee` touches `fee.rs` because the internals of the checked div functions on `Amount` are entangled with the constructors. Does a rename that removes the `checked_` prefix and returns `NumOpResult` instead of `Option`.

Close: #4374
Close: #4608