### PR TITLE
Add fee rate constructors that take `Amount` as arg

### DIFF
--- a/units/src/fee_rate/mod.rs
+++ b/units/src/fee_rate/mod.rs
@@ -62,7 +62,7 @@ impl FeeRate {
         }
     }
 
-    /// Constructs a new [`FeeRate`] from satoshis per virtual bytes,
+    /// Constructs a new [`FeeRate`] from satoshis per virtual byte,
     /// returning `None` if overflow occurred.
     pub const fn from_sat_per_vb(sat_vb: u64) -> Option<Self> {
         // No `map()` in const context.

--- a/units/src/fee_rate/mod.rs
+++ b/units/src/fee_rate/mod.rs
@@ -11,6 +11,10 @@ use core::ops;
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
 
+use NumOpResult as R;
+
+use crate::{Amount,MathOp, NumOpError as E, NumOpResult};
+
 mod encapsulate {
     /// Fee rate.
     ///
@@ -62,6 +66,15 @@ impl FeeRate {
         }
     }
 
+    /// Constructs a new [`FeeRate`] from amount per 1000 weight units.
+    pub const fn from_per_kwu(rate: Amount) -> NumOpResult<Self> {
+        // No `map()` in const context.
+        match rate.checked_mul(4_000) {
+            Some(per_mvb) => R::Valid(FeeRate::from_sat_per_mvb(per_mvb.to_sat())),
+            None => R::Error(E::while_doing(MathOp::Mul)),
+        }
+    }
+
     /// Constructs a new [`FeeRate`] from satoshis per virtual byte,
     /// returning `None` if overflow occurred.
     pub const fn from_sat_per_vb(sat_vb: u64) -> Option<Self> {
@@ -69,6 +82,15 @@ impl FeeRate {
         match sat_vb.checked_mul(1_000_000) {
             Some(fee_rate) => Some(FeeRate::from_sat_per_mvb(fee_rate)),
             None => None,
+        }
+    }
+
+    /// Constructs a new [`FeeRate`] from amount per virtual byte.
+    pub const fn from_per_vb(rate: Amount) -> NumOpResult<Self> {
+        // No `map()` in const context.
+        match rate.checked_mul(1_000_000) {
+            Some(per_mvb) => R::Valid(FeeRate::from_sat_per_mvb(per_mvb.to_sat())),
+            None => R::Error(E::while_doing(MathOp::Mul)),
         }
     }
 
@@ -85,6 +107,15 @@ impl FeeRate {
         match sat_kvb.checked_mul(1_000) {
             Some(fee_rate) => Some(FeeRate::from_sat_per_mvb(fee_rate)),
             None => None,
+        }
+    }
+
+    /// Constructs a new [`FeeRate`] from satoshis per kilo virtual bytes (1,000 vbytes).
+    pub const fn from_per_kvb(rate: Amount) -> NumOpResult<Self> {
+        // No `map()` in const context.
+        match rate.checked_mul(1_000) {
+            Some(per_mvb) => R::Valid(FeeRate::from_sat_per_mvb(per_mvb.to_sat())),
+            None => R::Error(E::while_doing(MathOp::Mul)),
         }
     }
 


### PR DESCRIPTION
Some users may find it more ergonomic to pass in an `Amount` when constructing fee rates. Also the strong type adds some semantic meaning as well as imposes the `Amount::MAX` limit.

Add an equivalent constructor for each of the existing ones that uses an argument of type `Amount` instead of `u64` sats.

(This was pulled out of #4610.)

Close: #4734