### PR TITLE
Saturate iwp constructors to u32 max

### DIFF
--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -1126,11 +1126,17 @@ impl InputWeightPrediction {
 
     /// Computes the **signature weight** added to a transaction by an input with this weight prediction,
     /// not counting the prevout (txid, index), sequence, potential witness flag bytes or the witness count varint.
+    ///
+    /// This function's internal arithmetic saturates at u32::MAX, so the return value of this
+    /// function may be inaccurate for extremely large witness predictions.
     #[deprecated(since = "TBD", note = "use `InputWeightPrediction::witness_weight()` instead")]
     pub const fn weight(&self) -> Weight { Self::witness_weight(self) }
 
     /// Computes the signature, prevout (txid, index), and sequence weights of this weight
     /// prediction.
+    ///
+    /// This function's internal arithmetic saturates at u32::MAX, so the return value of this
+    /// function may be inaccurate for extremely large witness predictions.
     ///
     /// See also [`InputWeightPrediction::witness_weight`]
     pub const fn total_weight(&self) -> Weight {
@@ -1142,6 +1148,9 @@ impl InputWeightPrediction {
 
     /// Computes the **signature weight** added to a transaction by an input with this weight prediction,
     /// not counting the prevout (txid, index), sequence, potential witness flag bytes or the witness count varint.
+    /// 
+    /// This function's internal arithmetic saturates at u32::MAX, so the return value of this
+    /// function may be inaccurate for extremely large witness predictions.
     ///
     /// See also [`InputWeightPrediction::total_weight`]
     pub const fn witness_weight(&self) -> Weight {

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -1165,22 +1165,6 @@ mod sealed {
 #[cfg(feature = "arbitrary")]
 impl<'a> Arbitrary<'a> for InputWeightPrediction {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        // limit script size to 4Mwu block size.
-        let max_block = Weight::MAX_BLOCK.to_wu() as usize;
-        let input_script_len = u.int_in_range(0..=max_block)?;
-        let remaining = max_block - input_script_len;
-
-        // create witness data if there is remaining space.
-        let mut witness_length = u.int_in_range(0..=remaining)?;
-        let mut witness_element_lengths = Vec::new();
-
-        // build vec of random witness element lengths.
-        while witness_length > 0 {
-            let elem = u.int_in_range(1..=witness_length)?;
-            witness_element_lengths.push(elem);
-            witness_length -= elem;
-        }
-
         match u.int_in_range(0..=7)? {
             0 => Ok(InputWeightPrediction::P2WPKH_MAX),
             1 => Ok(InputWeightPrediction::NESTED_P2WPKH_MAX),
@@ -1188,8 +1172,16 @@ impl<'a> Arbitrary<'a> for InputWeightPrediction {
             3 => Ok(InputWeightPrediction::P2PKH_UNCOMPRESSED_MAX),
             4 => Ok(InputWeightPrediction::P2TR_KEY_DEFAULT_SIGHASH),
             5 => Ok(InputWeightPrediction::P2TR_KEY_NON_DEFAULT_SIGHASH),
-            6 => Ok(InputWeightPrediction::new(input_script_len, witness_element_lengths)),
-            _ => Ok(InputWeightPrediction::from_slice(input_script_len, &witness_element_lengths)),
+            6 => {
+                let input_script_len = usize::arbitrary(u)?;
+                let witness_element_lengths: Vec<usize> = Vec::arbitrary(u)?;
+                Ok(InputWeightPrediction::new(input_script_len, witness_element_lengths))
+            }
+            _ => {
+                let input_script_len = usize::arbitrary(u)?;
+                let witness_element_lengths: Vec<usize> = Vec::arbitrary(u)?;
+                Ok(InputWeightPrediction::from_slice(input_script_len, &witness_element_lengths))
+            }
         }
     }
 }


### PR DESCRIPTION
Use u32 for struct and member variables in InputWeightPrediction (saturating to u32::MAX).  To avoid panics during construction and while using auxiliary methods such as `total_size()`, support saturating operations.

closes: https://github.com/rust-bitcoin/rust-bitcoin/issues/4547