### PR TITLE
units: Make error constructor private

### DIFF
--- a/primitives/src/sequence.rs
+++ b/primitives/src/sequence.rs
@@ -20,7 +20,7 @@ use core::fmt;
 use arbitrary::{Arbitrary, Unstructured};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use units::locktime::relative::TimeOverflowError;
+use units::locktime::relative::{NumberOf512Seconds, TimeOverflowError};
 use units::parse::{self, PrefixedHexError, UnprefixedHexError};
 
 use crate::locktime::relative;
@@ -156,11 +156,8 @@ impl Sequence {
     /// Will return an error if the input cannot be encoded in 16 bits.
     #[inline]
     pub fn from_seconds_floor(seconds: u32) -> Result<Self, TimeOverflowError> {
-        if let Ok(interval) = u16::try_from(seconds / 512) {
-            Ok(Sequence::from_512_second_intervals(interval))
-        } else {
-            Err(TimeOverflowError::new(seconds))
-        }
+        let intervals = NumberOf512Seconds::from_seconds_floor(seconds)?;
+        Ok(Sequence::from_512_second_intervals(intervals.to_512_second_intervals()))
     }
 
     /// Constructs a new relative lock-time from seconds, converting the seconds into 512 second
@@ -169,11 +166,8 @@ impl Sequence {
     /// Will return an error if the input cannot be encoded in 16 bits.
     #[inline]
     pub fn from_seconds_ceil(seconds: u32) -> Result<Self, TimeOverflowError> {
-        if let Ok(interval) = u16::try_from((seconds + 511) / 512) {
-            Ok(Sequence::from_512_second_intervals(interval))
-        } else {
-            Err(TimeOverflowError::new(seconds))
-        }
+        let intervals = NumberOf512Seconds::from_seconds_ceil(seconds)?;
+        Ok(Sequence::from_512_second_intervals(intervals.to_512_second_intervals()))
     }
 
     /// Constructs a new sequence from a u32 value.

--- a/units/src/locktime/relative.rs
+++ b/units/src/locktime/relative.rs
@@ -211,18 +211,6 @@ pub struct TimeOverflowError {
     pub(crate) seconds: u32,
 }
 
-impl TimeOverflowError {
-    /// Constructs a new `TimeOverflowError` using `seconds`.
-    ///
-    /// # Panics
-    ///
-    /// If `seconds` would not actually overflow a `u16`.
-    pub fn new(seconds: u32) -> Self {
-        assert!(u16::try_from((seconds + 511) / 512).is_err());
-        Self { seconds }
-    }
-}
-
 impl fmt::Display for TimeOverflowError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(


### PR DESCRIPTION
We typically do not want to have public constructors on error types. Currently we do on the `TimeOverflowError` so that we can call it in `primitives` but it turns out we can just use `NumberOf512Seconds` constructors instead.