### PR TITLE
Use new type names instead of deprecated aliases

### DIFF
--- a/units/src/block.rs
+++ b/units/src/block.rs
@@ -6,7 +6,7 @@
 //!
 //! These are general types for abstracting over block heights, they are not designed to use with
 //! lock times. If you are creating lock times you should be using the
-//! [`locktime::absolute::Height`] and [`locktime::relative::Height`] types.
+//! [`locktime::absolute::Height`] and [`locktime::relative::NumberOfBlocks`] types.
 //!
 //! The difference between these types and the locktime types is that these types are thin wrappers
 //! whereas the locktime types contain more complex locktime specific abstractions.

--- a/units/tests/str.rs
+++ b/units/tests/str.rs
@@ -40,14 +40,14 @@ check! {
     lock_by_height_absolute_min, absolute::Height, absolute::Height::MIN, "0";
     lock_by_height_absolute_max, absolute::Height, absolute::Height::MAX, "499999999";
 
-    lock_by_height_relative_min, relative::Height, relative::Height::MIN, "0";
-    lock_by_height_relative_max, relative::Height, relative::Height::MAX, "65535";
+    lock_by_height_relative_min, relative::NumberOfBlocks, relative::NumberOfBlocks::MIN, "0";
+    lock_by_height_relative_max, relative::NumberOfBlocks, relative::NumberOfBlocks::MAX, "65535";
 
-    lock_by_time_absolute_min, absolute::Time, absolute::Time::MIN, "500000000";
-    lock_by_time_absolute_max, absolute::Time, absolute::Time::MAX, "4294967295";
+    lock_by_time_absolute_min, absolute::MedianTimePast, absolute::MedianTimePast::MIN, "500000000";
+    lock_by_time_absolute_max, absolute::MedianTimePast, absolute::MedianTimePast::MAX, "4294967295";
 
-    lock_by_time_relative_min, relative::Time, relative::Time::MIN, "0";
-    lock_by_time_relative_max, relative::Time, relative::Time::MAX, "65535";
+    lock_by_time_relative_min, relative::NumberOf512Seconds, relative::NumberOf512Seconds::MIN, "0";
+    lock_by_time_relative_max, relative::NumberOf512Seconds, relative::NumberOf512Seconds::MAX, "65535";
 
     weight_min, Weight, Weight::MIN, "0";
     weight_max, Weight, Weight::MAX, "18446744073709551615";


### PR DESCRIPTION
Recently we changed the names of some locktime types but kept aliases to the original names. To assist with ongoing maintenance lets use the new names already.

~Internal change only.~

Added a patch that does the same in some rustdocs.