### PR TITLE
Add tests to kill mutants

### DIFF
--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -729,9 +729,20 @@ mod tests {
         // Check the number of bytes OutPoint contributes to the transaction is equal to SIZE
         let outpoint_size = outpoint.txid.as_byte_array().len() + outpoint.vout.to_le_bytes().len();
         assert_eq!(outpoint_size, OutPoint::SIZE);
+    }
 
-        // Check TooLong error
-        outpoint_str.push_str("0000000000");
+    #[test]
+    #[cfg(feature = "hex")]
+    fn outpoint_from_str_too_long() {
+        // Check edge case: length exactly 75
+        let mut outpoint_str = "0".repeat(64);
+        outpoint_str.push_str(":1234567890");
+        assert_eq!(outpoint_str.len(), 75);
+        assert!(outpoint_str.parse::<OutPoint>().is_ok());
+
+        // Check TooLong error (length 76)
+        outpoint_str.push('0');
+        assert_eq!(outpoint_str.len(), 76);
         let outpoint: Result<OutPoint, ParseOutPointError> = outpoint_str.parse();
         assert_eq!(outpoint, Err(ParseOutPointError::TooLong));
     }

--- a/units/src/amount/tests.rs
+++ b/units/src/amount/tests.rs
@@ -259,6 +259,7 @@ fn checked_arithmetic() {
 #[test]
 fn positive_sub() {
     assert_eq!(ssat(10).positive_sub(ssat(7)).unwrap(), ssat(3));
+    assert_eq!(ssat(10).positive_sub(ssat(10)).unwrap(), ssat(0));
     assert!(ssat(-10).positive_sub(ssat(7)).is_none());
     assert!(ssat(10).positive_sub(ssat(-7)).is_none());
     assert!(ssat(10).positive_sub(ssat(11)).is_none());

--- a/units/src/fee_rate/mod.rs
+++ b/units/src/fee_rate/mod.rs
@@ -384,12 +384,6 @@ mod tests {
     }
 
     #[test]
-    fn from_sat_per_vb() {
-        let fee_rate = FeeRate::from_sat_per_vb(10);
-        assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(2500));
-    }
-
-    #[test]
     fn raw_feerate() {
         let fee_rate = FeeRate::from_sat_per_kwu(749);
         assert_eq!(fee_rate.to_sat_per_kwu_floor(), 749);

--- a/units/src/fee_rate/mod.rs
+++ b/units/src/fee_rate/mod.rs
@@ -384,11 +384,20 @@ mod tests {
     }
 
     #[test]
-    fn raw_feerate() {
-        let fee_rate = FeeRate::from_sat_per_kwu(749);
-        assert_eq!(fee_rate.to_sat_per_kwu_floor(), 749);
+    fn fee_rate_to_sat_per_x() {
+        let fee_rate = FeeRate::from_sat_per_mvb(2_000_400);
+
+        // sat/kwu: 2_000_400 / 4_000 = 500.1
+        assert_eq!(fee_rate.to_sat_per_kwu_floor(), 500);
+        assert_eq!(fee_rate.to_sat_per_kwu_ceil(), 501);
+
+        // sat/vB: 2_000_400 / 1_000_000 = 2.0004
         assert_eq!(fee_rate.to_sat_per_vb_floor(), 2);
         assert_eq!(fee_rate.to_sat_per_vb_ceil(), 3);
+
+        // sat/kvb: 2_000_400 / 1_000 = 2_000.4
+        assert_eq!(fee_rate.to_sat_per_kvb_floor(), 2_000);
+        assert_eq!(fee_rate.to_sat_per_kvb_ceil(), 2_001);
     }
 
     #[test]

--- a/units/src/locktime/relative.rs
+++ b/units/src/locktime/relative.rs
@@ -308,6 +308,13 @@ mod tests {
     }
 
     #[test]
+    fn from_512_second_intervals_roundtrip() {
+        let intervals = 100_u16;
+        let locktime = NumberOf512Seconds::from_512_second_intervals(intervals);
+        assert_eq!(locktime.to_512_second_intervals(), intervals);
+    }
+    
+    #[test]
     fn from_seconds_ceil_success() {
         let actual = NumberOf512Seconds::from_seconds_ceil(100).unwrap();
         let expected = NumberOf512Seconds(1_u16);


### PR DESCRIPTION
Weekly mutation testing found new mutants in units and primitives.

- Add tests or improve existing tests to kill all of the mutants. 
- Remove a duplicate test in `fee_rate`

Closes #4601, Closes #4622