### PR TITLE
units: Test generic `Add` and `Sub`

### DIFF
--- a/units/src/amount/tests.rs
+++ b/units/src/amount/tests.rs
@@ -227,6 +227,10 @@ fn add() {
     assert!(ssat(-127) + ssat(179) == ssat(52).into());
     assert!(ssat(127) + ssat(-179) == ssat(-52).into());
     assert!(ssat(-127) + ssat(-179) == ssat(-306).into());
+
+    // Implemented using generic impl.
+    assert!(res(127) + sat(179) == sat(306).into());
+    assert!(sres(127) + ssat(179) == ssat(306).into());
 }
 
 #[test]
@@ -240,6 +244,10 @@ fn sub() {
     assert!(ssat(-127) - ssat(179) == ssat(-306).into());
     assert!(ssat(127) - ssat(-179) == ssat(306).into());
     assert!(ssat(-127) - ssat(-179) == ssat(52).into());
+
+    // Implemented using generic impl.
+    assert!(res(179) - sat(127) == sat(52).into());
+    assert!(sres(179) - ssat(127) == ssat(52).into());
 }
 
 #[test]


### PR DESCRIPTION
We have `Add` and `Sub` implemented for `NumOpResult<T>` but because the impls are generic they are not grouped in the file with the other add/sub impls. This makes it hard to see if they are supported.

Add to the `add` and `sub` unit tests to verify support is implemented.