### PR TITLE
Remove match arm and guard mutant exclusion

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -10,7 +10,6 @@ exclude_re = [
     ".*Error",
     "deserialize", # Skip serde mutation tests
     "Iterator", # Mutating operations in an iterator can result in an infinite loop
-    "match arm", "match guard", # New addition in cargo-mutants 25.0.1 deletes match arms and replaces match guards even in excluded functions
 
     # ----------------------------------Crate-specific exclusions----------------------------------
     # Units

--- a/.github/workflows/cron-weekly-cargo-mutants.yml
+++ b/.github/workflows/cron-weekly-cargo-mutants.yml
@@ -22,13 +22,15 @@ jobs:
         run: |
           if [ -s mutants.out/missed.txt ]; then
             echo "New missed mutants found"
+            MUTANTS_VERSION=$(cargo mutants --version)
             gh issue create \
             --title "New Mutants Found" \
             --body "$(cat <<EOF
           Displaying up to the first 10 mutants:
-
+          \`\`\`
           $(head -n 10 mutants.out/missed.txt)
-
+          \`\`\`
+          Running cargo mutants version: ${MUTANTS_VERSION}
           For the complete list, please check the [mutants.out artifact](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).
           EOF
           )"


### PR DESCRIPTION
Closes #4653

This removes the delete match arm and match guard exclusion as these mutations can now be targeted individually.

~~In draft as I have yet to run the mutations locally to add any exclusions that may still need to be added~~
