### PR TITLE
primitives: Inline `impl_to_hex_from_lower_hex` macro and deprecate

### DIFF
--- a/primitives/src/pow.rs
+++ b/primitives/src/pow.rs
@@ -30,16 +30,18 @@ impl CompactTarget {
     /// Returns the consensus encoded `u32` representation of this [`CompactTarget`].
     #[inline]
     pub fn to_consensus(self) -> u32 { self.0 }
+
+    /// Gets the hex representation of this [`CompactTarget`].
+    #[cfg(feature = "alloc")]
+    #[inline]
+    #[deprecated(since = "TBD", note = "use `format!(\"{var:x}\")` instead")]
+    pub fn to_hex(self) -> alloc::string::String { alloc::format!("{:x}", self) }
 }
 
 impl fmt::LowerHex for CompactTarget {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(&self.0, f) }
 }
-#[cfg(feature = "alloc")]
-internals::impl_to_hex_from_lower_hex!(CompactTarget, |compact_target: &CompactTarget| {
-    8 - compact_target.0.leading_zeros() as usize / 4
-});
 
 impl fmt::UpperHex for CompactTarget {
     #[inline]

--- a/primitives/src/script/borrowed.rs
+++ b/primitives/src/script/borrowed.rs
@@ -137,6 +137,18 @@ impl Script {
         let inner = unsafe { Box::from_raw(rw) };
         ScriptBuf::from_bytes(Vec::from(inner))
     }
+
+    /// Gets the hex representation of this script.
+    ///
+    /// # Returns
+    ///
+    /// Just the script bytes in hexadecimal **not** consensus encoding of the script i.e., the
+    /// string will not include a length prefix.
+    #[cfg(feature = "alloc")]
+    #[cfg(feature = "hex")]
+    #[inline]
+    #[deprecated(since = "TBD", note = "use `format!(\"{var:x}\")` instead")]
+    pub fn to_hex(&self) -> alloc::string::String { alloc::format!("{:x}", self) }
 }
 
 #[cfg(feature = "arbitrary")]

--- a/primitives/src/script/mod.rs
+++ b/primitives/src/script/mod.rs
@@ -436,18 +436,12 @@ impl fmt::LowerHex for Script {
         fmt::LowerHex::fmt(&self.as_bytes().as_hex(), f)
     }
 }
-#[cfg(feature = "alloc")]
-#[cfg(feature = "hex")]
-internals::impl_to_hex_from_lower_hex!(Script, |script: &Self| script.len() * 2);
 
 #[cfg(feature = "hex")]
 impl fmt::LowerHex for ScriptBuf {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(self.as_script(), f) }
 }
-#[cfg(feature = "alloc")]
-#[cfg(feature = "hex")]
-internals::impl_to_hex_from_lower_hex!(ScriptBuf, |script_buf: &Self| script_buf.len() * 2);
 
 #[cfg(feature = "hex")]
 impl fmt::UpperHex for Script {
@@ -942,7 +936,7 @@ mod tests {
     #[cfg(feature = "hex")]
     fn script_to_hex() {
         let script = Script::from_bytes(&[0xa1, 0xb2, 0xc3]);
-        let hex = script.to_hex();
+        let hex = alloc::format!("{script:x}");
         assert_eq!(hex, "a1b2c3");
     }
 
@@ -951,7 +945,7 @@ mod tests {
     #[cfg(feature = "hex")]
     fn scriptbuf_to_hex() {
         let script = ScriptBuf::from_bytes(vec![0xa1, 0xb2, 0xc3]);
-        let hex = script.to_hex();
+        let hex = alloc::format!("{script:x}");
         assert_eq!(hex, "a1b2c3");
     }
 }

--- a/primitives/src/script/owned.rs
+++ b/primitives/src/script/owned.rs
@@ -111,6 +111,18 @@ impl ScriptBuf {
     /// It is guaranteed that `script.capacity() >= script.len()` always holds.
     #[inline]
     pub fn capacity(&self) -> usize { self.0.capacity() }
+
+    /// Gets the hex representation of this script.
+    ///
+    /// # Returns
+    ///
+    /// Just the script bytes in hexadecimal **not** consensus encoding of the script i.e., the
+    /// string will not include a length prefix.
+    #[cfg(feature = "alloc")]
+    #[cfg(feature = "hex")]
+    #[inline]
+    #[deprecated(since = "TBD", note = "use `format!(\"{var:x}\")` instead")]
+    pub fn to_hex(&self) -> alloc::string::String { alloc::format!("{:x}", self) }
 }
 
 impl Deref for ScriptBuf {

--- a/primitives/src/sequence.rs
+++ b/primitives/src/sequence.rs
@@ -25,7 +25,7 @@ use units::parse::{self, PrefixedHexError, UnprefixedHexError};
 
 use crate::locktime::relative;
 #[cfg(all(doc, feature = "alloc"))]
-use crate::transaction::Transaction;
+use crate::Transaction;
 
 /// Bitcoin transaction input sequence number.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -178,6 +178,12 @@ impl Sequence {
     #[inline]
     pub fn to_consensus_u32(self) -> u32 { self.0 }
 
+    /// Gets the hex representation of this [`Sequence`].
+    #[cfg(feature = "alloc")]
+    #[inline]
+    #[deprecated(since = "TBD", note = "use `format!(\"{var:x}\")` instead")]
+    pub fn to_hex(self) -> alloc::string::String { alloc::format!("{:x}", self) }
+
     /// Constructs a new [`relative::LockTime`] from this [`Sequence`] number.
     #[inline]
     pub fn to_relative_lock_time(self) -> Option<relative::LockTime> {
@@ -223,10 +229,6 @@ impl fmt::LowerHex for Sequence {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(&self.0, f) }
 }
-#[cfg(feature = "alloc")]
-internals::impl_to_hex_from_lower_hex!(Sequence, |sequence: &Sequence| {
-    8 - sequence.0.leading_zeros() as usize / 4
-});
 
 impl fmt::UpperHex for Sequence {
     #[inline]


### PR DESCRIPTION
Macros are basically just a pain in the arse. This one is used to reduced code duplication/verbosity even thought the function can be written as a one-liner.

Also calling macros across crate boundries is error prone and a constant source of maintenance grief.

Note also:

- The generated docs are quite general
- `#[inline]` is missing
- The docs on the macro are wrong in regards to the no-op

Remove all calls to the macro from `primitives` and inline using terse syntax by way of the `format!` macro.

Add `deprecated` attribute and direct users to just use `format!("{var:x}")` instead.
