### PR TITLE
Use relative import paths rather than absolute

### DIFF
--- a/bitcoin/src/network/params.rs
+++ b/bitcoin/src/network/params.rs
@@ -62,11 +62,10 @@
 
 use units::{BlockHeight, BlockHeightInterval};
 
-use crate::network::Network;
+use super::{Network, TestnetVersion};
 #[cfg(doc)]
 use crate::pow::CompactTarget;
 use crate::pow::Target;
-use crate::TestnetVersion;
 
 /// Parameters that influence chain consensus.
 #[non_exhaustive]


### PR DESCRIPTION
When doing large refactorings such as moving entire modules around referring to items defined in a parent module by mentioning `crate` is umbersome since the paths change and make the move confusing. It also obscures the fact that some concepts are related.

This changes a few paths to relative so that the refactoring in the future will be easier.