### PR TITLE
Kill new mutants

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -25,6 +25,8 @@ exclude_re = [
     "SignedAmount::checked_abs", # Deprecated
     "NumberOfBlocks::value", # Deprecated
     "NumberOf512Seconds::to_consensus_u32", # Deprecated
+    "MedianTimePast::to_consensus_u32", # Deprecated
+    "Height::to_consensus_u32", # Deprecated
 
     # primitives
     "Sequence::from_512_second_intervals", # Mutant from replacing | with ^, this returns the same value since the XOR is taken against the u16 with an all-zero bitmask

--- a/primitives/src/script/mod.rs
+++ b/primitives/src/script/mod.rs
@@ -803,6 +803,21 @@ mod tests {
     }
 
     #[test]
+    fn script_display_pushdata() {
+        // OP_PUSHDATA1
+        let script = Script::from_bytes(&[0x4c, 0x02, 0xab, 0xcd]);
+        assert_eq!(format!("{}", script), "OP_PUSHDATA1 abcd");
+
+        // OP_PUSHDATA2
+        let script = Script::from_bytes(&[0x4d, 0x02, 0x00, 0x12, 0x34]);
+        assert_eq!(format!("{}", script), "OP_PUSHDATA2 1234");
+
+        // OP_PUSHDATA4
+        let script = Script::from_bytes(&[0x4e, 0x02, 0x00, 0x00, 0x00, 0x56, 0x78]);
+        assert_eq!(format!("{}", script), "OP_PUSHDATA4 5678");
+    }
+
+    #[test]
     fn scriptbuf_display() {
         let script_buf = ScriptBuf::from(vec![0x00, 0xa1, 0xb2]);
         assert_eq!(format!("{}", script_buf), "OP_0 OP_LESSTHANOREQUAL OP_CSV");

--- a/units/src/amount/tests.rs
+++ b/units/src/amount/tests.rs
@@ -52,8 +52,14 @@ fn sanity_check() {
 
 #[test]
 fn check_if_num_is_too_precise() {
-    assert_eq!(is_too_precise("1234", 3).unwrap(), 3);
-    assert_eq!(is_too_precise("1234.1234", 3).unwrap(), 3);
+    // Has decimal, not too precise
+    assert_eq!(is_too_precise("1234.5678", 4), Some(0));
+    // Has decimal, is too precise
+    assert_eq!(is_too_precise("1234.5678", 3), Some(3));
+    // No decimal, not too precise
+    assert_eq!(is_too_precise("1234", 4), Some(0));
+    // No decimal, is too precise
+    assert_eq!(is_too_precise("1234", 2), Some(3));
 }
 
 #[test]


### PR DESCRIPTION
Weekly mutation found new mutants. There are also some untested mutants in match statements that will be included in future mutation testing once #4654 goes in.

- Add a regression test for the mutants in the `Display` impl for `Script`.
- Improve the existing test for `is_too_precise` to check all four cases.
- Exclude the two deprecated functions that have untested mutants.

Closes #4646