### PR TITLE
bitcoin: Add public ext modules

### DIFF
--- a/bitcoin/examples/ecdsa-psbt-simple.rs
+++ b/bitcoin/examples/ecdsa-psbt-simple.rs
@@ -25,12 +25,11 @@
 use std::collections::BTreeMap;
 
 use bitcoin::bip32::{ChildNumber, DerivationPath, Fingerprint, IntoDerivationPath, Xpriv, Xpub};
+use bitcoin::ext::*;
 use bitcoin::key::WPubkeyHash;
 use bitcoin::locktime::absolute;
 use bitcoin::psbt::Input;
-use bitcoin::script::ScriptBufExt as _;
 use bitcoin::secp256k1::{Secp256k1, Signing};
-use bitcoin::witness::WitnessExt as _;
 use bitcoin::{
     consensus, transaction, Address, Amount, EcdsaSighashType, Network, OutPoint, Psbt, ScriptBuf,
     Sequence, Transaction, TxIn, TxOut, Txid, Witness,

--- a/bitcoin/examples/ecdsa-psbt.rs
+++ b/bitcoin/examples/ecdsa-psbt.rs
@@ -33,10 +33,9 @@ use std::fmt;
 
 use bitcoin::bip32::{ChildNumber, DerivationPath, Fingerprint, IntoDerivationPath, Xpriv, Xpub};
 use bitcoin::consensus::encode;
-use bitcoin::consensus_validation::TransactionExt as _;
+use bitcoin::ext::*;
 use bitcoin::locktime::absolute;
 use bitcoin::psbt::{self, Input, Psbt, PsbtSighashType};
-use bitcoin::script::ScriptBufExt as _;
 use bitcoin::secp256k1::{Secp256k1, Signing, Verification};
 use bitcoin::{
     transaction, Address, Amount, CompressedPublicKey, Network, OutPoint, ScriptBuf, Sequence,

--- a/bitcoin/examples/sighash.rs
+++ b/bitcoin/examples/sighash.rs
@@ -1,4 +1,4 @@
-use bitcoin::script::{ScriptBufExt as _, ScriptExt as _};
+use bitcoin::ext::*;
 use bitcoin::{
     consensus, ecdsa, sighash, Amount, CompressedPublicKey, Script, ScriptBuf, Transaction,
 };

--- a/bitcoin/examples/sign-tx-segwit-v0.rs
+++ b/bitcoin/examples/sign-tx-segwit-v0.rs
@@ -3,11 +3,10 @@
 //! Demonstrate creating a transaction that spends to and from p2wpkh outputs.
 
 use bitcoin::key::WPubkeyHash;
+use bitcoin::ext::*;
 use bitcoin::locktime::absolute;
-use bitcoin::script::ScriptBufExt as _;
 use bitcoin::secp256k1::{rand, Message, Secp256k1, SecretKey, Signing};
 use bitcoin::sighash::{EcdsaSighashType, SighashCache};
-use bitcoin::witness::WitnessExt as _;
 use bitcoin::{
     transaction, Address, Amount, Network, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut,
     Txid, Witness,

--- a/bitcoin/examples/sign-tx-taproot.rs
+++ b/bitcoin/examples/sign-tx-taproot.rs
@@ -3,11 +3,10 @@
 //! Demonstrate creating a transaction that spends to and from p2tr outputs.
 
 use bitcoin::key::{Keypair, TapTweak, TweakedKeypair, UntweakedPublicKey};
+use bitcoin::ext::*;
 use bitcoin::locktime::absolute;
-use bitcoin::script::ScriptBufExt as _;
 use bitcoin::secp256k1::{rand, Message, Secp256k1, SecretKey, Signing, Verification};
 use bitcoin::sighash::{Prevouts, SighashCache, TapSighashType};
-use bitcoin::witness::WitnessExt as _;
 use bitcoin::{
     transaction, Address, Amount, Network, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut,
     Txid, Witness,

--- a/bitcoin/examples/taproot-psbt-simple.rs
+++ b/bitcoin/examples/taproot-psbt-simple.rs
@@ -23,12 +23,11 @@
 use std::collections::BTreeMap;
 
 use bitcoin::bip32::{ChildNumber, DerivationPath, Fingerprint, IntoDerivationPath, Xpriv, Xpub};
+use bitcoin::ext::*;
 use bitcoin::key::UntweakedPublicKey;
 use bitcoin::locktime::absolute;
 use bitcoin::psbt::Input;
-use bitcoin::script::ScriptBufExt as _;
 use bitcoin::secp256k1::{Secp256k1, Signing};
-use bitcoin::witness::WitnessExt as _;
 use bitcoin::{
     consensus, transaction, Address, Amount, Network, OutPoint, Psbt, ScriptBuf, Sequence,
     TapLeafHash, TapSighashType, Transaction, TxIn, TxOut, Txid, Witness, XOnlyPublicKey,

--- a/bitcoin/examples/taproot-psbt.rs
+++ b/bitcoin/examples/taproot-psbt.rs
@@ -79,11 +79,10 @@ use std::collections::BTreeMap;
 
 use bitcoin::bip32::{ChildNumber, DerivationPath, Fingerprint, Xpriv, Xpub};
 use bitcoin::consensus::encode;
-use bitcoin::consensus_validation::TransactionExt as _;
+use bitcoin::ext::*;
 use bitcoin::key::{TapTweak, XOnlyPublicKey};
 use bitcoin::opcodes::all::{OP_CHECKSIG, OP_CLTV, OP_DROP};
 use bitcoin::psbt::{self, Input, Output, Psbt, PsbtSighashType};
-use bitcoin::script::{ScriptBufExt as _, ScriptExt as _};
 use bitcoin::secp256k1::Secp256k1;
 use bitcoin::sighash::{self, SighashCache, TapSighash, TapSighashType};
 use bitcoin::taproot::{self, LeafVersion, TapLeafHash, TaprootBuilder, TaprootSpendInfo};

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -93,6 +93,33 @@ extern crate serde;
 
 mod internal_macros;
 
+pub mod ext {
+    //! Re-export all the extension traits so downstream can use wildcard imports.
+    //!
+    //! As part of stabilizing `primitives` and `units` we created a bunch of extension traits in
+    //! `rust-bitcoin` to hold all then API that we are not yet ready to stabilize. This module
+    //! re-exports all of them to improve ergonomics for users comfortable with wildcard imports.
+    //!
+    //! # Examples
+    //!
+    //! ```
+    //! // Wildcard import all of the extension crates.
+    //! use bitcoin::ext::*;
+    //!
+    //! // If, for some reason, you want the name to be in scope access it via the module. E.g.
+    //! use bitcoin::script::ScriptExt;
+    //! ```
+    #[rustfmt::skip] // Use terse custom grouping.
+    pub use crate::{
+        block::{BlockUncheckedExt as _, BlockCheckedExt as _, HeaderExt as _},
+        pow::CompactTargetExt as _,
+        script::{ScriptExt as _, ScriptBufExt as _},
+        transaction::{TxidExt as _, WtxidExt as _, OutPointExt as _, TxInExt as _, TxOutExt as _, TransactionExt as _},
+        witness::WitnessExt as _,
+    };
+    #[cfg(feature = "bitcoinconsensus")]
+    pub use crate::consensus_validation::{ScriptExt as _, TransactionExt as _};
+}
 #[macro_use]
 pub mod address;
 pub mod bip152;


### PR DESCRIPTION
bitcoin: Add crate level public ext module

Add a public `ext` module and re-export all the extension traits anonymously traits so users can use wildcard imports of form: `use bitcoin::ext::*;`

If, for some reason, users want the name in scope they have to go to the module its defined in e.g., `use bitcoin::script::ScriptExt`.

Update all files in the `examples` directory to use wildcard import, thereby verifying it all works as expected.

Note this is not exactly what is described in issue #4660 but it resolves it none the less.

Close: #4660

