### PR TITLE
bitcoin: Remove re-export of Denomination

### DIFF
--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -131,7 +131,7 @@ pub use primitives::{
 };
 #[doc(inline)]
 pub use units::{
-    amount::{Amount, Denomination, SignedAmount},
+    amount::{Amount, SignedAmount},
     block::{BlockHeight, BlockHeightInterval, BlockMtp},
     fee_rate::FeeRate,
     time::{self, BlockTime},

--- a/bitcoin/tests/bip_174.rs
+++ b/bitcoin/tests/bip_174.rs
@@ -3,6 +3,7 @@
 
 use std::collections::BTreeMap;
 
+use bitcoin::amount::{Amount, Denomination};
 use bitcoin::bip32::{Fingerprint, IntoDerivationPath, KeySource, Xpriv, Xpub};
 use bitcoin::consensus::encode::{deserialize, serialize_hex};
 use bitcoin::hex::FromHex;
@@ -11,7 +12,7 @@ use bitcoin::psbt::{Psbt, PsbtSighashType};
 use bitcoin::script::{PushBytes, ScriptBufExt as _};
 use bitcoin::secp256k1::Secp256k1;
 use bitcoin::{
-    absolute, script, transaction, Amount, Denomination, NetworkKind, OutPoint, PrivateKey,
+    absolute, script, transaction, NetworkKind, OutPoint, PrivateKey,
     PublicKey, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Witness,
 };
 


### PR DESCRIPTION
`units::Denomination` does not exist, it is only at `units::amount::Denomination`. Our policy is to make the following three equivalent `bitcoin::Foo`, `primitives::Foo`, and `units::Foo` therefor we should not re-export `Denomination` at the crate root of `bitcoin`.