### PR TITLE
units: Check the API using `cargo public-api`

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -28,7 +28,8 @@ Run from rust.yml unless stated otherwise. Unfortunately we are now exceeding th
 14. `ASAN`
 15. `WASM`
 16. `Kani`
-17. `Coveralls` - run by `coveralls.yml`
-18. `release` - run by `release.yml`
-19. `labeler` - run by `manage-pr.yml`
-20. `Shellcheck` - run by `shellcheck.yml`
+17. `API`
+18. `Coveralls` - run by `coveralls.yml`
+19. `release` - run by `release.yml`
+20. `labeler` - run by `manage-pr.yml`
+21. `Shellcheck` - run by `shellcheck.yml`

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -304,3 +304,21 @@ jobs:
         uses: model-checking/kani-github-action@v1.1
         with:
           args: "--only-codegen"
+
+  API:
+    needs: Prepare
+    name: API - nightly toolchain
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+    steps:
+      - name: "Checkout repo"
+        uses: actions/checkout@v4
+      - name: "Select toolchain"
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ needs.Prepare.outputs.nightly_version }}
+      - name: "Install cargo-public-api"
+        run: cargo install --locked cargo-public-api
+      - name: "Run API checker script"
+        run: ./contrib/check-for-api-changes.sh

--- a/api/units/all-features.txt
+++ b/api/units/all-features.txt
@@ -1,0 +1,2209 @@
+#[non_exhaustive] pub enum bitcoin_units::MathOp
+#[non_exhaustive] pub enum bitcoin_units::amount::Denomination
+#[non_exhaustive] pub enum bitcoin_units::amount::ParseDenominationError
+#[non_exhaustive] pub struct bitcoin_units::NumOpError(_)
+#[non_exhaustive] pub struct bitcoin_units::amount::MissingDenominationError
+#[non_exhaustive] pub struct bitcoin_units::amount::PossiblyConfusingDenominationError(_)
+#[non_exhaustive] pub struct bitcoin_units::amount::UnknownDenominationError(_)
+#[non_exhaustive] pub struct bitcoin_units::fee_rate::serde::OverflowError
+#[non_exhaustive] pub struct bitcoin_units::locktime::absolute::ConversionError
+#[non_exhaustive] pub struct bitcoin_units::parse::ParseIntError
+impl bitcoin_units::Amount
+impl bitcoin_units::BlockTime
+impl bitcoin_units::FeeRate
+impl bitcoin_units::MathOp
+impl bitcoin_units::NumOpError
+impl bitcoin_units::SignedAmount
+impl bitcoin_units::Weight
+impl bitcoin_units::amount::Denomination
+impl bitcoin_units::amount::Display
+impl bitcoin_units::amount::OutOfRangeError
+impl bitcoin_units::amount::serde::SerdeAmount for bitcoin_units::Amount
+impl bitcoin_units::amount::serde::SerdeAmount for bitcoin_units::SignedAmount
+impl bitcoin_units::amount::serde::SerdeAmountForOpt for bitcoin_units::Amount
+impl bitcoin_units::amount::serde::SerdeAmountForOpt for bitcoin_units::SignedAmount
+impl bitcoin_units::block::BlockHeight
+impl bitcoin_units::block::BlockHeightInterval
+impl bitcoin_units::block::BlockMtp
+impl bitcoin_units::block::BlockMtpInterval
+impl bitcoin_units::locktime::absolute::Height
+impl bitcoin_units::locktime::absolute::MedianTimePast
+impl bitcoin_units::locktime::relative::NumberOf512Seconds
+impl bitcoin_units::locktime::relative::NumberOfBlocks
+impl bitcoin_units::parse::Integer for i128
+impl bitcoin_units::parse::Integer for i16
+impl bitcoin_units::parse::Integer for i32
+impl bitcoin_units::parse::Integer for i64
+impl bitcoin_units::parse::Integer for i8
+impl bitcoin_units::parse::Integer for u128
+impl bitcoin_units::parse::Integer for u16
+impl bitcoin_units::parse::Integer for u32
+impl bitcoin_units::parse::Integer for u64
+impl bitcoin_units::parse::Integer for u8
+impl core::clone::Clone for bitcoin_units::Amount
+impl core::clone::Clone for bitcoin_units::BlockTime
+impl core::clone::Clone for bitcoin_units::FeeRate
+impl core::clone::Clone for bitcoin_units::MathOp
+impl core::clone::Clone for bitcoin_units::NumOpError
+impl core::clone::Clone for bitcoin_units::SignedAmount
+impl core::clone::Clone for bitcoin_units::Weight
+impl core::clone::Clone for bitcoin_units::amount::Denomination
+impl core::clone::Clone for bitcoin_units::amount::Display
+impl core::clone::Clone for bitcoin_units::amount::InputTooLargeError
+impl core::clone::Clone for bitcoin_units::amount::InvalidCharacterError
+impl core::clone::Clone for bitcoin_units::amount::MissingDenominationError
+impl core::clone::Clone for bitcoin_units::amount::MissingDigitsError
+impl core::clone::Clone for bitcoin_units::amount::OutOfRangeError
+impl core::clone::Clone for bitcoin_units::amount::ParseAmountError
+impl core::clone::Clone for bitcoin_units::amount::ParseDenominationError
+impl core::clone::Clone for bitcoin_units::amount::ParseError
+impl core::clone::Clone for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::clone::Clone for bitcoin_units::amount::TooPreciseError
+impl core::clone::Clone for bitcoin_units::amount::UnknownDenominationError
+impl core::clone::Clone for bitcoin_units::block::BlockHeight
+impl core::clone::Clone for bitcoin_units::block::BlockHeightInterval
+impl core::clone::Clone for bitcoin_units::block::BlockMtp
+impl core::clone::Clone for bitcoin_units::block::BlockMtpInterval
+impl core::clone::Clone for bitcoin_units::block::TooBigForRelativeHeightError
+impl core::clone::Clone for bitcoin_units::fee_rate::serde::OverflowError
+impl core::clone::Clone for bitcoin_units::locktime::absolute::ConversionError
+impl core::clone::Clone for bitcoin_units::locktime::absolute::Height
+impl core::clone::Clone for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::clone::Clone for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::clone::Clone for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::clone::Clone for bitcoin_units::locktime::relative::InvalidHeightError
+impl core::clone::Clone for bitcoin_units::locktime::relative::InvalidTimeError
+impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::clone::Clone for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::clone::Clone for bitcoin_units::parse::ParseIntError
+impl core::clone::Clone for bitcoin_units::parse::PrefixedHexError
+impl core::clone::Clone for bitcoin_units::parse::UnprefixedHexError
+impl core::cmp::Eq for bitcoin_units::Amount
+impl core::cmp::Eq for bitcoin_units::BlockTime
+impl core::cmp::Eq for bitcoin_units::FeeRate
+impl core::cmp::Eq for bitcoin_units::MathOp
+impl core::cmp::Eq for bitcoin_units::NumOpError
+impl core::cmp::Eq for bitcoin_units::SignedAmount
+impl core::cmp::Eq for bitcoin_units::Weight
+impl core::cmp::Eq for bitcoin_units::amount::Denomination
+impl core::cmp::Eq for bitcoin_units::amount::InputTooLargeError
+impl core::cmp::Eq for bitcoin_units::amount::InvalidCharacterError
+impl core::cmp::Eq for bitcoin_units::amount::MissingDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::MissingDigitsError
+impl core::cmp::Eq for bitcoin_units::amount::OutOfRangeError
+impl core::cmp::Eq for bitcoin_units::amount::ParseAmountError
+impl core::cmp::Eq for bitcoin_units::amount::ParseDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::ParseError
+impl core::cmp::Eq for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::TooPreciseError
+impl core::cmp::Eq for bitcoin_units::amount::UnknownDenominationError
+impl core::cmp::Eq for bitcoin_units::block::BlockHeight
+impl core::cmp::Eq for bitcoin_units::block::BlockHeightInterval
+impl core::cmp::Eq for bitcoin_units::block::BlockMtp
+impl core::cmp::Eq for bitcoin_units::block::BlockMtpInterval
+impl core::cmp::Eq for bitcoin_units::block::TooBigForRelativeHeightError
+impl core::cmp::Eq for bitcoin_units::fee_rate::serde::OverflowError
+impl core::cmp::Eq for bitcoin_units::locktime::absolute::ConversionError
+impl core::cmp::Eq for bitcoin_units::locktime::absolute::Height
+impl core::cmp::Eq for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::cmp::Eq for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::cmp::Eq for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::cmp::Eq for bitcoin_units::locktime::relative::InvalidHeightError
+impl core::cmp::Eq for bitcoin_units::locktime::relative::InvalidTimeError
+impl core::cmp::Eq for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::cmp::Eq for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::cmp::Eq for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::cmp::Eq for bitcoin_units::parse::ParseIntError
+impl core::cmp::Eq for bitcoin_units::parse::PrefixedHexError
+impl core::cmp::Eq for bitcoin_units::parse::UnprefixedHexError
+impl core::cmp::Ord for bitcoin_units::Amount
+impl core::cmp::Ord for bitcoin_units::BlockTime
+impl core::cmp::Ord for bitcoin_units::FeeRate
+impl core::cmp::Ord for bitcoin_units::SignedAmount
+impl core::cmp::Ord for bitcoin_units::Weight
+impl core::cmp::Ord for bitcoin_units::block::BlockHeight
+impl core::cmp::Ord for bitcoin_units::block::BlockHeightInterval
+impl core::cmp::Ord for bitcoin_units::block::BlockMtp
+impl core::cmp::Ord for bitcoin_units::block::BlockMtpInterval
+impl core::cmp::Ord for bitcoin_units::locktime::absolute::Height
+impl core::cmp::Ord for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::cmp::Ord for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::cmp::Ord for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::cmp::PartialEq for bitcoin_units::Amount
+impl core::cmp::PartialEq for bitcoin_units::BlockTime
+impl core::cmp::PartialEq for bitcoin_units::FeeRate
+impl core::cmp::PartialEq for bitcoin_units::MathOp
+impl core::cmp::PartialEq for bitcoin_units::NumOpError
+impl core::cmp::PartialEq for bitcoin_units::SignedAmount
+impl core::cmp::PartialEq for bitcoin_units::Weight
+impl core::cmp::PartialEq for bitcoin_units::amount::Denomination
+impl core::cmp::PartialEq for bitcoin_units::amount::InputTooLargeError
+impl core::cmp::PartialEq for bitcoin_units::amount::InvalidCharacterError
+impl core::cmp::PartialEq for bitcoin_units::amount::MissingDenominationError
+impl core::cmp::PartialEq for bitcoin_units::amount::MissingDigitsError
+impl core::cmp::PartialEq for bitcoin_units::amount::OutOfRangeError
+impl core::cmp::PartialEq for bitcoin_units::amount::ParseAmountError
+impl core::cmp::PartialEq for bitcoin_units::amount::ParseDenominationError
+impl core::cmp::PartialEq for bitcoin_units::amount::ParseError
+impl core::cmp::PartialEq for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::cmp::PartialEq for bitcoin_units::amount::TooPreciseError
+impl core::cmp::PartialEq for bitcoin_units::amount::UnknownDenominationError
+impl core::cmp::PartialEq for bitcoin_units::block::BlockHeight
+impl core::cmp::PartialEq for bitcoin_units::block::BlockHeightInterval
+impl core::cmp::PartialEq for bitcoin_units::block::BlockMtp
+impl core::cmp::PartialEq for bitcoin_units::block::BlockMtpInterval
+impl core::cmp::PartialEq for bitcoin_units::block::TooBigForRelativeHeightError
+impl core::cmp::PartialEq for bitcoin_units::fee_rate::serde::OverflowError
+impl core::cmp::PartialEq for bitcoin_units::locktime::absolute::ConversionError
+impl core::cmp::PartialEq for bitcoin_units::locktime::absolute::Height
+impl core::cmp::PartialEq for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::cmp::PartialEq for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::cmp::PartialEq for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::InvalidHeightError
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::InvalidTimeError
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::cmp::PartialEq for bitcoin_units::parse::ParseIntError
+impl core::cmp::PartialEq for bitcoin_units::parse::PrefixedHexError
+impl core::cmp::PartialEq for bitcoin_units::parse::UnprefixedHexError
+impl core::cmp::PartialOrd for bitcoin_units::Amount
+impl core::cmp::PartialOrd for bitcoin_units::BlockTime
+impl core::cmp::PartialOrd for bitcoin_units::FeeRate
+impl core::cmp::PartialOrd for bitcoin_units::SignedAmount
+impl core::cmp::PartialOrd for bitcoin_units::Weight
+impl core::cmp::PartialOrd for bitcoin_units::block::BlockHeight
+impl core::cmp::PartialOrd for bitcoin_units::block::BlockHeightInterval
+impl core::cmp::PartialOrd for bitcoin_units::block::BlockMtp
+impl core::cmp::PartialOrd for bitcoin_units::block::BlockMtpInterval
+impl core::cmp::PartialOrd for bitcoin_units::locktime::absolute::Height
+impl core::cmp::PartialOrd for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::cmp::PartialOrd for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::cmp::PartialOrd for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::convert::AsRef<core::num::error::ParseIntError> for bitcoin_units::parse::ParseIntError
+impl core::convert::From<&bitcoin_units::Amount> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::convert::From<&bitcoin_units::SignedAmount> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::convert::From<bitcoin_units::Amount> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::convert::From<bitcoin_units::Amount> for bitcoin_units::SignedAmount
+impl core::convert::From<bitcoin_units::BlockTime> for u32
+impl core::convert::From<bitcoin_units::SignedAmount> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::convert::From<bitcoin_units::Weight> for u64
+impl core::convert::From<bitcoin_units::amount::InputTooLargeError> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::InputTooLargeError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::InvalidCharacterError> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::InvalidCharacterError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::MissingDigitsError> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::MissingDigitsError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::OutOfRangeError> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::OutOfRangeError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::ParseAmountError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::ParseDenominationError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::TooPreciseError> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::TooPreciseError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::block::BlockHeight> for u32
+impl core::convert::From<bitcoin_units::block::BlockHeightInterval> for u32
+impl core::convert::From<bitcoin_units::block::BlockMtp> for u32
+impl core::convert::From<bitcoin_units::block::BlockMtpInterval> for u32
+impl core::convert::From<bitcoin_units::locktime::absolute::Height> for bitcoin_units::block::BlockHeight
+impl core::convert::From<bitcoin_units::locktime::absolute::MedianTimePast> for bitcoin_units::block::BlockMtp
+impl core::convert::From<bitcoin_units::locktime::relative::NumberOf512Seconds> for bitcoin_units::block::BlockMtpInterval
+impl core::convert::From<bitcoin_units::locktime::relative::NumberOfBlocks> for bitcoin_units::block::BlockHeightInterval
+impl core::convert::From<bitcoin_units::parse::ParseIntError> for bitcoin_units::parse::PrefixedHexError
+impl core::convert::From<bitcoin_units::parse::ParseIntError> for bitcoin_units::parse::UnprefixedHexError
+impl core::convert::From<bitcoin_units::parse::ParseIntError> for core::num::error::ParseIntError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::ParseDenominationError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::ParseError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::fee_rate::serde::OverflowError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::parse::PrefixedHexError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::parse::UnprefixedHexError
+impl core::convert::From<u16> for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::convert::From<u32> for bitcoin_units::BlockTime
+impl core::convert::From<u32> for bitcoin_units::block::BlockHeight
+impl core::convert::From<u32> for bitcoin_units::block::BlockHeightInterval
+impl core::convert::From<u32> for bitcoin_units::block::BlockMtp
+impl core::convert::From<u32> for bitcoin_units::block::BlockMtpInterval
+impl core::convert::TryFrom<&str> for bitcoin_units::Weight
+impl core::convert::TryFrom<&str> for bitcoin_units::block::BlockHeight
+impl core::convert::TryFrom<&str> for bitcoin_units::block::BlockHeightInterval
+impl core::convert::TryFrom<&str> for bitcoin_units::block::BlockMtp
+impl core::convert::TryFrom<&str> for bitcoin_units::block::BlockMtpInterval
+impl core::convert::TryFrom<&str> for bitcoin_units::locktime::absolute::Height
+impl core::convert::TryFrom<&str> for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::convert::TryFrom<&str> for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::convert::TryFrom<&str> for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::Weight
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::block::BlockHeight
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::block::BlockHeightInterval
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::block::BlockMtp
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::block::BlockMtpInterval
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::locktime::absolute::Height
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::Weight
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::block::BlockHeight
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::block::BlockHeightInterval
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::block::BlockMtp
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::block::BlockMtpInterval
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::locktime::absolute::Height
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::convert::TryFrom<bitcoin_units::SignedAmount> for bitcoin_units::Amount
+impl core::convert::TryFrom<bitcoin_units::block::BlockHeight> for bitcoin_units::locktime::absolute::Height
+impl core::convert::TryFrom<bitcoin_units::block::BlockHeightInterval> for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::convert::TryFrom<bitcoin_units::block::BlockMtp> for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::default::Default for bitcoin_units::Amount
+impl core::default::Default for bitcoin_units::SignedAmount
+impl core::default::Default for bitcoin_units::block::BlockHeightInterval
+impl core::default::Default for bitcoin_units::block::BlockMtpInterval
+impl core::default::Default for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::default::Default for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::error::Error for bitcoin_units::NumOpError
+impl core::error::Error for bitcoin_units::amount::InputTooLargeError
+impl core::error::Error for bitcoin_units::amount::InvalidCharacterError
+impl core::error::Error for bitcoin_units::amount::MissingDigitsError
+impl core::error::Error for bitcoin_units::amount::OutOfRangeError
+impl core::error::Error for bitcoin_units::amount::ParseAmountError
+impl core::error::Error for bitcoin_units::amount::ParseDenominationError
+impl core::error::Error for bitcoin_units::amount::ParseError
+impl core::error::Error for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::error::Error for bitcoin_units::amount::TooPreciseError
+impl core::error::Error for bitcoin_units::amount::UnknownDenominationError
+impl core::error::Error for bitcoin_units::block::TooBigForRelativeHeightError
+impl core::error::Error for bitcoin_units::fee_rate::serde::OverflowError
+impl core::error::Error for bitcoin_units::locktime::absolute::ConversionError
+impl core::error::Error for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::error::Error for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::error::Error for bitcoin_units::locktime::relative::InvalidHeightError
+impl core::error::Error for bitcoin_units::locktime::relative::InvalidTimeError
+impl core::error::Error for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::error::Error for bitcoin_units::parse::ParseIntError
+impl core::error::Error for bitcoin_units::parse::PrefixedHexError
+impl core::error::Error for bitcoin_units::parse::UnprefixedHexError
+impl core::fmt::Debug for bitcoin_units::Amount
+impl core::fmt::Debug for bitcoin_units::BlockTime
+impl core::fmt::Debug for bitcoin_units::FeeRate
+impl core::fmt::Debug for bitcoin_units::MathOp
+impl core::fmt::Debug for bitcoin_units::NumOpError
+impl core::fmt::Debug for bitcoin_units::SignedAmount
+impl core::fmt::Debug for bitcoin_units::Weight
+impl core::fmt::Debug for bitcoin_units::amount::Denomination
+impl core::fmt::Debug for bitcoin_units::amount::Display
+impl core::fmt::Debug for bitcoin_units::amount::InputTooLargeError
+impl core::fmt::Debug for bitcoin_units::amount::InvalidCharacterError
+impl core::fmt::Debug for bitcoin_units::amount::MissingDenominationError
+impl core::fmt::Debug for bitcoin_units::amount::MissingDigitsError
+impl core::fmt::Debug for bitcoin_units::amount::OutOfRangeError
+impl core::fmt::Debug for bitcoin_units::amount::ParseAmountError
+impl core::fmt::Debug for bitcoin_units::amount::ParseDenominationError
+impl core::fmt::Debug for bitcoin_units::amount::ParseError
+impl core::fmt::Debug for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::fmt::Debug for bitcoin_units::amount::TooPreciseError
+impl core::fmt::Debug for bitcoin_units::amount::UnknownDenominationError
+impl core::fmt::Debug for bitcoin_units::block::BlockHeight
+impl core::fmt::Debug for bitcoin_units::block::BlockHeightInterval
+impl core::fmt::Debug for bitcoin_units::block::BlockMtp
+impl core::fmt::Debug for bitcoin_units::block::BlockMtpInterval
+impl core::fmt::Debug for bitcoin_units::block::TooBigForRelativeHeightError
+impl core::fmt::Debug for bitcoin_units::fee_rate::serde::OverflowError
+impl core::fmt::Debug for bitcoin_units::locktime::absolute::ConversionError
+impl core::fmt::Debug for bitcoin_units::locktime::absolute::Height
+impl core::fmt::Debug for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::fmt::Debug for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::fmt::Debug for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::fmt::Debug for bitcoin_units::locktime::relative::InvalidHeightError
+impl core::fmt::Debug for bitcoin_units::locktime::relative::InvalidTimeError
+impl core::fmt::Debug for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::fmt::Debug for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::fmt::Debug for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::fmt::Debug for bitcoin_units::parse::ParseIntError
+impl core::fmt::Debug for bitcoin_units::parse::PrefixedHexError
+impl core::fmt::Debug for bitcoin_units::parse::UnprefixedHexError
+impl core::fmt::Display for bitcoin_units::Amount
+impl core::fmt::Display for bitcoin_units::MathOp
+impl core::fmt::Display for bitcoin_units::NumOpError
+impl core::fmt::Display for bitcoin_units::SignedAmount
+impl core::fmt::Display for bitcoin_units::Weight
+impl core::fmt::Display for bitcoin_units::amount::Denomination
+impl core::fmt::Display for bitcoin_units::amount::Display
+impl core::fmt::Display for bitcoin_units::amount::InputTooLargeError
+impl core::fmt::Display for bitcoin_units::amount::InvalidCharacterError
+impl core::fmt::Display for bitcoin_units::amount::MissingDigitsError
+impl core::fmt::Display for bitcoin_units::amount::OutOfRangeError
+impl core::fmt::Display for bitcoin_units::amount::ParseAmountError
+impl core::fmt::Display for bitcoin_units::amount::ParseDenominationError
+impl core::fmt::Display for bitcoin_units::amount::ParseError
+impl core::fmt::Display for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::fmt::Display for bitcoin_units::amount::TooPreciseError
+impl core::fmt::Display for bitcoin_units::amount::UnknownDenominationError
+impl core::fmt::Display for bitcoin_units::block::BlockHeight
+impl core::fmt::Display for bitcoin_units::block::BlockHeightInterval
+impl core::fmt::Display for bitcoin_units::block::BlockMtp
+impl core::fmt::Display for bitcoin_units::block::BlockMtpInterval
+impl core::fmt::Display for bitcoin_units::block::TooBigForRelativeHeightError
+impl core::fmt::Display for bitcoin_units::fee_rate::serde::OverflowError
+impl core::fmt::Display for bitcoin_units::locktime::absolute::ConversionError
+impl core::fmt::Display for bitcoin_units::locktime::absolute::Height
+impl core::fmt::Display for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::fmt::Display for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::fmt::Display for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::fmt::Display for bitcoin_units::locktime::relative::InvalidHeightError
+impl core::fmt::Display for bitcoin_units::locktime::relative::InvalidTimeError
+impl core::fmt::Display for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::fmt::Display for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::fmt::Display for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::fmt::Display for bitcoin_units::parse::ParseIntError
+impl core::fmt::Display for bitcoin_units::parse::PrefixedHexError
+impl core::fmt::Display for bitcoin_units::parse::UnprefixedHexError
+impl core::hash::Hash for bitcoin_units::Amount
+impl core::hash::Hash for bitcoin_units::BlockTime
+impl core::hash::Hash for bitcoin_units::FeeRate
+impl core::hash::Hash for bitcoin_units::SignedAmount
+impl core::hash::Hash for bitcoin_units::Weight
+impl core::hash::Hash for bitcoin_units::amount::Denomination
+impl core::hash::Hash for bitcoin_units::block::BlockHeight
+impl core::hash::Hash for bitcoin_units::block::BlockHeightInterval
+impl core::hash::Hash for bitcoin_units::block::BlockMtp
+impl core::hash::Hash for bitcoin_units::block::BlockMtpInterval
+impl core::hash::Hash for bitcoin_units::locktime::absolute::Height
+impl core::hash::Hash for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::hash::Hash for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::hash::Hash for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::iter::traits::accum::Sum for bitcoin_units::FeeRate
+impl core::iter::traits::accum::Sum for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::iter::traits::accum::Sum for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::iter::traits::accum::Sum for bitcoin_units::Weight
+impl core::iter::traits::accum::Sum for bitcoin_units::block::BlockHeightInterval
+impl core::iter::traits::accum::Sum for bitcoin_units::block::BlockMtpInterval
+impl core::marker::Copy for bitcoin_units::Amount
+impl core::marker::Copy for bitcoin_units::BlockTime
+impl core::marker::Copy for bitcoin_units::FeeRate
+impl core::marker::Copy for bitcoin_units::MathOp
+impl core::marker::Copy for bitcoin_units::NumOpError
+impl core::marker::Copy for bitcoin_units::SignedAmount
+impl core::marker::Copy for bitcoin_units::Weight
+impl core::marker::Copy for bitcoin_units::amount::Denomination
+impl core::marker::Copy for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Copy for bitcoin_units::block::BlockHeight
+impl core::marker::Copy for bitcoin_units::block::BlockHeightInterval
+impl core::marker::Copy for bitcoin_units::block::BlockMtp
+impl core::marker::Copy for bitcoin_units::block::BlockMtpInterval
+impl core::marker::Copy for bitcoin_units::locktime::absolute::Height
+impl core::marker::Copy for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::marker::Copy for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::marker::Copy for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::marker::Freeze for bitcoin_units::Amount
+impl core::marker::Freeze for bitcoin_units::BlockTime
+impl core::marker::Freeze for bitcoin_units::FeeRate
+impl core::marker::Freeze for bitcoin_units::MathOp
+impl core::marker::Freeze for bitcoin_units::NumOpError
+impl core::marker::Freeze for bitcoin_units::SignedAmount
+impl core::marker::Freeze for bitcoin_units::Weight
+impl core::marker::Freeze for bitcoin_units::amount::Denomination
+impl core::marker::Freeze for bitcoin_units::amount::Display
+impl core::marker::Freeze for bitcoin_units::amount::InputTooLargeError
+impl core::marker::Freeze for bitcoin_units::amount::InvalidCharacterError
+impl core::marker::Freeze for bitcoin_units::amount::MissingDenominationError
+impl core::marker::Freeze for bitcoin_units::amount::MissingDigitsError
+impl core::marker::Freeze for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Freeze for bitcoin_units::amount::ParseAmountError
+impl core::marker::Freeze for bitcoin_units::amount::ParseDenominationError
+impl core::marker::Freeze for bitcoin_units::amount::ParseError
+impl core::marker::Freeze for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::Freeze for bitcoin_units::amount::TooPreciseError
+impl core::marker::Freeze for bitcoin_units::amount::UnknownDenominationError
+impl core::marker::Freeze for bitcoin_units::block::BlockHeight
+impl core::marker::Freeze for bitcoin_units::block::BlockHeightInterval
+impl core::marker::Freeze for bitcoin_units::block::BlockMtp
+impl core::marker::Freeze for bitcoin_units::block::BlockMtpInterval
+impl core::marker::Freeze for bitcoin_units::block::TooBigForRelativeHeightError
+impl core::marker::Freeze for bitcoin_units::fee_rate::serde::OverflowError
+impl core::marker::Freeze for bitcoin_units::locktime::absolute::ConversionError
+impl core::marker::Freeze for bitcoin_units::locktime::absolute::Height
+impl core::marker::Freeze for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::marker::Freeze for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::marker::Freeze for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::marker::Freeze for bitcoin_units::locktime::relative::InvalidHeightError
+impl core::marker::Freeze for bitcoin_units::locktime::relative::InvalidTimeError
+impl core::marker::Freeze for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::marker::Freeze for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::marker::Freeze for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::marker::Freeze for bitcoin_units::parse::ParseIntError
+impl core::marker::Freeze for bitcoin_units::parse::PrefixedHexError
+impl core::marker::Freeze for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::Send for bitcoin_units::Amount
+impl core::marker::Send for bitcoin_units::BlockTime
+impl core::marker::Send for bitcoin_units::FeeRate
+impl core::marker::Send for bitcoin_units::MathOp
+impl core::marker::Send for bitcoin_units::NumOpError
+impl core::marker::Send for bitcoin_units::SignedAmount
+impl core::marker::Send for bitcoin_units::Weight
+impl core::marker::Send for bitcoin_units::amount::Denomination
+impl core::marker::Send for bitcoin_units::amount::Display
+impl core::marker::Send for bitcoin_units::amount::InputTooLargeError
+impl core::marker::Send for bitcoin_units::amount::InvalidCharacterError
+impl core::marker::Send for bitcoin_units::amount::MissingDenominationError
+impl core::marker::Send for bitcoin_units::amount::MissingDigitsError
+impl core::marker::Send for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Send for bitcoin_units::amount::ParseAmountError
+impl core::marker::Send for bitcoin_units::amount::ParseDenominationError
+impl core::marker::Send for bitcoin_units::amount::ParseError
+impl core::marker::Send for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::Send for bitcoin_units::amount::TooPreciseError
+impl core::marker::Send for bitcoin_units::amount::UnknownDenominationError
+impl core::marker::Send for bitcoin_units::block::BlockHeight
+impl core::marker::Send for bitcoin_units::block::BlockHeightInterval
+impl core::marker::Send for bitcoin_units::block::BlockMtp
+impl core::marker::Send for bitcoin_units::block::BlockMtpInterval
+impl core::marker::Send for bitcoin_units::block::TooBigForRelativeHeightError
+impl core::marker::Send for bitcoin_units::fee_rate::serde::OverflowError
+impl core::marker::Send for bitcoin_units::locktime::absolute::ConversionError
+impl core::marker::Send for bitcoin_units::locktime::absolute::Height
+impl core::marker::Send for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::marker::Send for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::marker::Send for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::marker::Send for bitcoin_units::locktime::relative::InvalidHeightError
+impl core::marker::Send for bitcoin_units::locktime::relative::InvalidTimeError
+impl core::marker::Send for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::marker::Send for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::marker::Send for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::marker::Send for bitcoin_units::parse::ParseIntError
+impl core::marker::Send for bitcoin_units::parse::PrefixedHexError
+impl core::marker::Send for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::StructuralPartialEq for bitcoin_units::Amount
+impl core::marker::StructuralPartialEq for bitcoin_units::BlockTime
+impl core::marker::StructuralPartialEq for bitcoin_units::FeeRate
+impl core::marker::StructuralPartialEq for bitcoin_units::MathOp
+impl core::marker::StructuralPartialEq for bitcoin_units::NumOpError
+impl core::marker::StructuralPartialEq for bitcoin_units::SignedAmount
+impl core::marker::StructuralPartialEq for bitcoin_units::Weight
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::Denomination
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::InputTooLargeError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::InvalidCharacterError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::MissingDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::MissingDigitsError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::OutOfRangeError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::ParseAmountError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::ParseDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::ParseError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::TooPreciseError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::UnknownDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::block::BlockHeight
+impl core::marker::StructuralPartialEq for bitcoin_units::block::BlockHeightInterval
+impl core::marker::StructuralPartialEq for bitcoin_units::block::BlockMtp
+impl core::marker::StructuralPartialEq for bitcoin_units::block::BlockMtpInterval
+impl core::marker::StructuralPartialEq for bitcoin_units::block::TooBigForRelativeHeightError
+impl core::marker::StructuralPartialEq for bitcoin_units::fee_rate::serde::OverflowError
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::ConversionError
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::Height
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::InvalidHeightError
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::InvalidTimeError
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::marker::StructuralPartialEq for bitcoin_units::parse::ParseIntError
+impl core::marker::StructuralPartialEq for bitcoin_units::parse::PrefixedHexError
+impl core::marker::StructuralPartialEq for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::Sync for bitcoin_units::Amount
+impl core::marker::Sync for bitcoin_units::BlockTime
+impl core::marker::Sync for bitcoin_units::FeeRate
+impl core::marker::Sync for bitcoin_units::MathOp
+impl core::marker::Sync for bitcoin_units::NumOpError
+impl core::marker::Sync for bitcoin_units::SignedAmount
+impl core::marker::Sync for bitcoin_units::Weight
+impl core::marker::Sync for bitcoin_units::amount::Denomination
+impl core::marker::Sync for bitcoin_units::amount::Display
+impl core::marker::Sync for bitcoin_units::amount::InputTooLargeError
+impl core::marker::Sync for bitcoin_units::amount::InvalidCharacterError
+impl core::marker::Sync for bitcoin_units::amount::MissingDenominationError
+impl core::marker::Sync for bitcoin_units::amount::MissingDigitsError
+impl core::marker::Sync for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Sync for bitcoin_units::amount::ParseAmountError
+impl core::marker::Sync for bitcoin_units::amount::ParseDenominationError
+impl core::marker::Sync for bitcoin_units::amount::ParseError
+impl core::marker::Sync for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::Sync for bitcoin_units::amount::TooPreciseError
+impl core::marker::Sync for bitcoin_units::amount::UnknownDenominationError
+impl core::marker::Sync for bitcoin_units::block::BlockHeight
+impl core::marker::Sync for bitcoin_units::block::BlockHeightInterval
+impl core::marker::Sync for bitcoin_units::block::BlockMtp
+impl core::marker::Sync for bitcoin_units::block::BlockMtpInterval
+impl core::marker::Sync for bitcoin_units::block::TooBigForRelativeHeightError
+impl core::marker::Sync for bitcoin_units::fee_rate::serde::OverflowError
+impl core::marker::Sync for bitcoin_units::locktime::absolute::ConversionError
+impl core::marker::Sync for bitcoin_units::locktime::absolute::Height
+impl core::marker::Sync for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::marker::Sync for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::marker::Sync for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::marker::Sync for bitcoin_units::locktime::relative::InvalidHeightError
+impl core::marker::Sync for bitcoin_units::locktime::relative::InvalidTimeError
+impl core::marker::Sync for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::marker::Sync for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::marker::Sync for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::marker::Sync for bitcoin_units::parse::ParseIntError
+impl core::marker::Sync for bitcoin_units::parse::PrefixedHexError
+impl core::marker::Sync for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::Unpin for bitcoin_units::Amount
+impl core::marker::Unpin for bitcoin_units::BlockTime
+impl core::marker::Unpin for bitcoin_units::FeeRate
+impl core::marker::Unpin for bitcoin_units::MathOp
+impl core::marker::Unpin for bitcoin_units::NumOpError
+impl core::marker::Unpin for bitcoin_units::SignedAmount
+impl core::marker::Unpin for bitcoin_units::Weight
+impl core::marker::Unpin for bitcoin_units::amount::Denomination
+impl core::marker::Unpin for bitcoin_units::amount::Display
+impl core::marker::Unpin for bitcoin_units::amount::InputTooLargeError
+impl core::marker::Unpin for bitcoin_units::amount::InvalidCharacterError
+impl core::marker::Unpin for bitcoin_units::amount::MissingDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::MissingDigitsError
+impl core::marker::Unpin for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Unpin for bitcoin_units::amount::ParseAmountError
+impl core::marker::Unpin for bitcoin_units::amount::ParseDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::ParseError
+impl core::marker::Unpin for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::TooPreciseError
+impl core::marker::Unpin for bitcoin_units::amount::UnknownDenominationError
+impl core::marker::Unpin for bitcoin_units::block::BlockHeight
+impl core::marker::Unpin for bitcoin_units::block::BlockHeightInterval
+impl core::marker::Unpin for bitcoin_units::block::BlockMtp
+impl core::marker::Unpin for bitcoin_units::block::BlockMtpInterval
+impl core::marker::Unpin for bitcoin_units::block::TooBigForRelativeHeightError
+impl core::marker::Unpin for bitcoin_units::fee_rate::serde::OverflowError
+impl core::marker::Unpin for bitcoin_units::locktime::absolute::ConversionError
+impl core::marker::Unpin for bitcoin_units::locktime::absolute::Height
+impl core::marker::Unpin for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::marker::Unpin for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::marker::Unpin for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::marker::Unpin for bitcoin_units::locktime::relative::InvalidHeightError
+impl core::marker::Unpin for bitcoin_units::locktime::relative::InvalidTimeError
+impl core::marker::Unpin for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::marker::Unpin for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::marker::Unpin for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::marker::Unpin for bitcoin_units::parse::ParseIntError
+impl core::marker::Unpin for bitcoin_units::parse::PrefixedHexError
+impl core::marker::Unpin for bitcoin_units::parse::UnprefixedHexError
+impl core::ops::arith::Add for bitcoin_units::Amount
+impl core::ops::arith::Add for bitcoin_units::FeeRate
+impl core::ops::arith::Add for bitcoin_units::SignedAmount
+impl core::ops::arith::Add for bitcoin_units::Weight
+impl core::ops::arith::Add for bitcoin_units::block::BlockHeightInterval
+impl core::ops::arith::Add for bitcoin_units::block::BlockMtpInterval
+impl core::ops::arith::Add<&bitcoin_units::Amount> for bitcoin_units::Amount
+impl core::ops::arith::Add<&bitcoin_units::FeeRate> for bitcoin_units::FeeRate
+impl core::ops::arith::Add<&bitcoin_units::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount
+impl core::ops::arith::Add<&bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for bitcoin_units::SignedAmount
+impl core::ops::arith::Add<&bitcoin_units::SignedAmount> for bitcoin_units::SignedAmount
+impl core::ops::arith::Add<&bitcoin_units::Weight> for bitcoin_units::Weight
+impl core::ops::arith::Add<&bitcoin_units::block::BlockHeightInterval> for bitcoin_units::block::BlockHeight
+impl core::ops::arith::Add<&bitcoin_units::block::BlockHeightInterval> for bitcoin_units::block::BlockHeightInterval
+impl core::ops::arith::Add<&bitcoin_units::block::BlockMtpInterval> for bitcoin_units::block::BlockMtp
+impl core::ops::arith::Add<&bitcoin_units::block::BlockMtpInterval> for bitcoin_units::block::BlockMtpInterval
+impl core::ops::arith::Add<bitcoin_units::Amount> for &bitcoin_units::Amount
+impl core::ops::arith::Add<bitcoin_units::FeeRate> for &bitcoin_units::FeeRate
+impl core::ops::arith::Add<bitcoin_units::NumOpResult<bitcoin_units::Amount>> for &bitcoin_units::Amount
+impl core::ops::arith::Add<bitcoin_units::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount
+impl core::ops::arith::Add<bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for &bitcoin_units::SignedAmount
+impl core::ops::arith::Add<bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for bitcoin_units::SignedAmount
+impl core::ops::arith::Add<bitcoin_units::SignedAmount> for &bitcoin_units::SignedAmount
+impl core::ops::arith::Add<bitcoin_units::Weight> for &bitcoin_units::Weight
+impl core::ops::arith::Add<bitcoin_units::block::BlockHeightInterval> for &bitcoin_units::block::BlockHeight
+impl core::ops::arith::Add<bitcoin_units::block::BlockHeightInterval> for &bitcoin_units::block::BlockHeightInterval
+impl core::ops::arith::Add<bitcoin_units::block::BlockHeightInterval> for bitcoin_units::block::BlockHeight
+impl core::ops::arith::Add<bitcoin_units::block::BlockMtpInterval> for &bitcoin_units::block::BlockMtp
+impl core::ops::arith::Add<bitcoin_units::block::BlockMtpInterval> for &bitcoin_units::block::BlockMtpInterval
+impl core::ops::arith::Add<bitcoin_units::block::BlockMtpInterval> for bitcoin_units::block::BlockMtp
+impl core::ops::arith::AddAssign for bitcoin_units::FeeRate
+impl core::ops::arith::AddAssign for bitcoin_units::Weight
+impl core::ops::arith::AddAssign for bitcoin_units::block::BlockHeightInterval
+impl core::ops::arith::AddAssign for bitcoin_units::block::BlockMtpInterval
+impl core::ops::arith::AddAssign<&bitcoin_units::FeeRate> for bitcoin_units::FeeRate
+impl core::ops::arith::AddAssign<&bitcoin_units::Weight> for bitcoin_units::Weight
+impl core::ops::arith::AddAssign<&bitcoin_units::block::BlockHeightInterval> for bitcoin_units::block::BlockHeightInterval
+impl core::ops::arith::AddAssign<&bitcoin_units::block::BlockMtpInterval> for bitcoin_units::block::BlockMtpInterval
+impl core::ops::arith::Div for bitcoin_units::Amount
+impl core::ops::arith::Div for bitcoin_units::SignedAmount
+impl core::ops::arith::Div for bitcoin_units::Weight
+impl core::ops::arith::Div<&bitcoin_units::Amount> for bitcoin_units::Amount
+impl core::ops::arith::Div<&bitcoin_units::FeeRate> for bitcoin_units::Amount
+impl core::ops::arith::Div<&bitcoin_units::FeeRate> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<&bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for bitcoin_units::Amount
+impl core::ops::arith::Div<&bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<&bitcoin_units::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::Amount
+impl core::ops::arith::Div<&bitcoin_units::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<&bitcoin_units::SignedAmount> for bitcoin_units::SignedAmount
+impl core::ops::arith::Div<&bitcoin_units::Weight> for bitcoin_units::Amount
+impl core::ops::arith::Div<&bitcoin_units::Weight> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<&bitcoin_units::Weight> for bitcoin_units::Weight
+impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount
+impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount
+impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::FeeRate
+impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::Weight
+impl core::ops::arith::Div<&i64> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::Div<&i64> for bitcoin_units::SignedAmount
+impl core::ops::arith::Div<&u64> for bitcoin_units::Amount
+impl core::ops::arith::Div<&u64> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<&u64> for bitcoin_units::Weight
+impl core::ops::arith::Div<bitcoin_units::Amount> for &bitcoin_units::Amount
+impl core::ops::arith::Div<bitcoin_units::FeeRate> for &bitcoin_units::Amount
+impl core::ops::arith::Div<bitcoin_units::FeeRate> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<bitcoin_units::FeeRate> for bitcoin_units::Amount
+impl core::ops::arith::Div<bitcoin_units::FeeRate> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for &bitcoin_units::Amount
+impl core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for bitcoin_units::Amount
+impl core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::Amount
+impl core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::Amount
+impl core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<bitcoin_units::SignedAmount> for &bitcoin_units::SignedAmount
+impl core::ops::arith::Div<bitcoin_units::Weight> for &bitcoin_units::Amount
+impl core::ops::arith::Div<bitcoin_units::Weight> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<bitcoin_units::Weight> for &bitcoin_units::Weight
+impl core::ops::arith::Div<bitcoin_units::Weight> for bitcoin_units::Amount
+impl core::ops::arith::Div<bitcoin_units::Weight> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::SignedAmount
+impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::Amount
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::FeeRate
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::Weight
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::FeeRate
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::Weight
+impl core::ops::arith::Div<i64> for &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::Div<i64> for &bitcoin_units::SignedAmount
+impl core::ops::arith::Div<i64> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount
+impl core::ops::arith::Div<u64> for &bitcoin_units::Amount
+impl core::ops::arith::Div<u64> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<u64> for &bitcoin_units::Weight
+impl core::ops::arith::Div<u64> for bitcoin_units::Amount
+impl core::ops::arith::Div<u64> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<u64> for bitcoin_units::Weight
+impl core::ops::arith::DivAssign<&i64> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::DivAssign<&u64> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::DivAssign<i64> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::DivAssign<u64> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::DivAssign<u64> for bitcoin_units::Weight
+impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64
+impl core::ops::arith::Mul<&bitcoin_units::FeeRate> for bitcoin_units::NumOpResult<bitcoin_units::Weight>
+impl core::ops::arith::Mul<&bitcoin_units::FeeRate> for bitcoin_units::Weight
+impl core::ops::arith::Mul<&bitcoin_units::NumOpResult<bitcoin_units::Amount>> for u64
+impl core::ops::arith::Mul<&bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for bitcoin_units::NumOpResult<bitcoin_units::Weight>
+impl core::ops::arith::Mul<&bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for bitcoin_units::Weight
+impl core::ops::arith::Mul<&bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for i64
+impl core::ops::arith::Mul<&bitcoin_units::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::FeeRate
+impl core::ops::arith::Mul<&bitcoin_units::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::NumOpResult<bitcoin_units::FeeRate>
+impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64
+impl core::ops::arith::Mul<&bitcoin_units::Weight> for bitcoin_units::FeeRate
+impl core::ops::arith::Mul<&bitcoin_units::Weight> for bitcoin_units::NumOpResult<bitcoin_units::FeeRate>
+impl core::ops::arith::Mul<&bitcoin_units::Weight> for u64
+impl core::ops::arith::Mul<&i64> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::Mul<&i64> for bitcoin_units::SignedAmount
+impl core::ops::arith::Mul<&u64> for bitcoin_units::Amount
+impl core::ops::arith::Mul<&u64> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Mul<&u64> for bitcoin_units::Weight
+impl core::ops::arith::Mul<bitcoin_units::Amount> for &u64
+impl core::ops::arith::Mul<bitcoin_units::Amount> for u64
+impl core::ops::arith::Mul<bitcoin_units::FeeRate> for &bitcoin_units::NumOpResult<bitcoin_units::Weight>
+impl core::ops::arith::Mul<bitcoin_units::FeeRate> for &bitcoin_units::Weight
+impl core::ops::arith::Mul<bitcoin_units::FeeRate> for bitcoin_units::NumOpResult<bitcoin_units::Weight>
+impl core::ops::arith::Mul<bitcoin_units::FeeRate> for bitcoin_units::Weight
+impl core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::Amount>> for &u64
+impl core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::Amount>> for u64
+impl core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for &bitcoin_units::NumOpResult<bitcoin_units::Weight>
+impl core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for &bitcoin_units::Weight
+impl core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for bitcoin_units::NumOpResult<bitcoin_units::Weight>
+impl core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for bitcoin_units::Weight
+impl core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for &i64
+impl core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for i64
+impl core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::FeeRate
+impl core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>
+impl core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::FeeRate
+impl core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::NumOpResult<bitcoin_units::FeeRate>
+impl core::ops::arith::Mul<bitcoin_units::SignedAmount> for &i64
+impl core::ops::arith::Mul<bitcoin_units::SignedAmount> for i64
+impl core::ops::arith::Mul<bitcoin_units::Weight> for &bitcoin_units::FeeRate
+impl core::ops::arith::Mul<bitcoin_units::Weight> for &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>
+impl core::ops::arith::Mul<bitcoin_units::Weight> for &u64
+impl core::ops::arith::Mul<bitcoin_units::Weight> for bitcoin_units::FeeRate
+impl core::ops::arith::Mul<bitcoin_units::Weight> for bitcoin_units::NumOpResult<bitcoin_units::FeeRate>
+impl core::ops::arith::Mul<bitcoin_units::Weight> for u64
+impl core::ops::arith::Mul<i64> for &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::Mul<i64> for &bitcoin_units::SignedAmount
+impl core::ops::arith::Mul<i64> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::Mul<i64> for bitcoin_units::SignedAmount
+impl core::ops::arith::Mul<u64> for &bitcoin_units::Amount
+impl core::ops::arith::Mul<u64> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Mul<u64> for &bitcoin_units::Weight
+impl core::ops::arith::Mul<u64> for bitcoin_units::Amount
+impl core::ops::arith::Mul<u64> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Mul<u64> for bitcoin_units::Weight
+impl core::ops::arith::MulAssign<&i64> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::MulAssign<&u64> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::MulAssign<i64> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::MulAssign<u64> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::MulAssign<u64> for bitcoin_units::Weight
+impl core::ops::arith::Neg for bitcoin_units::SignedAmount
+impl core::ops::arith::Rem for bitcoin_units::Weight
+impl core::ops::arith::Rem<&bitcoin_units::Weight> for bitcoin_units::Weight
+impl core::ops::arith::Rem<&i64> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::Rem<&i64> for bitcoin_units::SignedAmount
+impl core::ops::arith::Rem<&u64> for bitcoin_units::Amount
+impl core::ops::arith::Rem<&u64> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Rem<&u64> for bitcoin_units::Weight
+impl core::ops::arith::Rem<bitcoin_units::Weight> for &bitcoin_units::Weight
+impl core::ops::arith::Rem<i64> for &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::Rem<i64> for &bitcoin_units::SignedAmount
+impl core::ops::arith::Rem<i64> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::Rem<i64> for bitcoin_units::SignedAmount
+impl core::ops::arith::Rem<u64> for &bitcoin_units::Amount
+impl core::ops::arith::Rem<u64> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Rem<u64> for &bitcoin_units::Weight
+impl core::ops::arith::Rem<u64> for bitcoin_units::Amount
+impl core::ops::arith::Rem<u64> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Rem<u64> for bitcoin_units::Weight
+impl core::ops::arith::RemAssign<u64> for bitcoin_units::Weight
+impl core::ops::arith::Sub for bitcoin_units::Amount
+impl core::ops::arith::Sub for bitcoin_units::FeeRate
+impl core::ops::arith::Sub for bitcoin_units::SignedAmount
+impl core::ops::arith::Sub for bitcoin_units::Weight
+impl core::ops::arith::Sub for bitcoin_units::block::BlockHeight
+impl core::ops::arith::Sub for bitcoin_units::block::BlockHeightInterval
+impl core::ops::arith::Sub for bitcoin_units::block::BlockMtp
+impl core::ops::arith::Sub for bitcoin_units::block::BlockMtpInterval
+impl core::ops::arith::Sub<&bitcoin_units::Amount> for bitcoin_units::Amount
+impl core::ops::arith::Sub<&bitcoin_units::FeeRate> for bitcoin_units::FeeRate
+impl core::ops::arith::Sub<&bitcoin_units::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount
+impl core::ops::arith::Sub<&bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for bitcoin_units::SignedAmount
+impl core::ops::arith::Sub<&bitcoin_units::SignedAmount> for bitcoin_units::SignedAmount
+impl core::ops::arith::Sub<&bitcoin_units::Weight> for bitcoin_units::Weight
+impl core::ops::arith::Sub<&bitcoin_units::block::BlockHeight> for bitcoin_units::block::BlockHeight
+impl core::ops::arith::Sub<&bitcoin_units::block::BlockHeightInterval> for bitcoin_units::block::BlockHeight
+impl core::ops::arith::Sub<&bitcoin_units::block::BlockHeightInterval> for bitcoin_units::block::BlockHeightInterval
+impl core::ops::arith::Sub<&bitcoin_units::block::BlockMtp> for bitcoin_units::block::BlockMtp
+impl core::ops::arith::Sub<&bitcoin_units::block::BlockMtpInterval> for bitcoin_units::block::BlockMtp
+impl core::ops::arith::Sub<&bitcoin_units::block::BlockMtpInterval> for bitcoin_units::block::BlockMtpInterval
+impl core::ops::arith::Sub<bitcoin_units::Amount> for &bitcoin_units::Amount
+impl core::ops::arith::Sub<bitcoin_units::FeeRate> for &bitcoin_units::FeeRate
+impl core::ops::arith::Sub<bitcoin_units::NumOpResult<bitcoin_units::Amount>> for &bitcoin_units::Amount
+impl core::ops::arith::Sub<bitcoin_units::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount
+impl core::ops::arith::Sub<bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for &bitcoin_units::SignedAmount
+impl core::ops::arith::Sub<bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for bitcoin_units::SignedAmount
+impl core::ops::arith::Sub<bitcoin_units::SignedAmount> for &bitcoin_units::SignedAmount
+impl core::ops::arith::Sub<bitcoin_units::Weight> for &bitcoin_units::Weight
+impl core::ops::arith::Sub<bitcoin_units::block::BlockHeight> for &bitcoin_units::block::BlockHeight
+impl core::ops::arith::Sub<bitcoin_units::block::BlockHeightInterval> for &bitcoin_units::block::BlockHeight
+impl core::ops::arith::Sub<bitcoin_units::block::BlockHeightInterval> for &bitcoin_units::block::BlockHeightInterval
+impl core::ops::arith::Sub<bitcoin_units::block::BlockHeightInterval> for bitcoin_units::block::BlockHeight
+impl core::ops::arith::Sub<bitcoin_units::block::BlockMtp> for &bitcoin_units::block::BlockMtp
+impl core::ops::arith::Sub<bitcoin_units::block::BlockMtpInterval> for &bitcoin_units::block::BlockMtp
+impl core::ops::arith::Sub<bitcoin_units::block::BlockMtpInterval> for &bitcoin_units::block::BlockMtpInterval
+impl core::ops::arith::Sub<bitcoin_units::block::BlockMtpInterval> for bitcoin_units::block::BlockMtp
+impl core::ops::arith::SubAssign for bitcoin_units::FeeRate
+impl core::ops::arith::SubAssign for bitcoin_units::Weight
+impl core::ops::arith::SubAssign for bitcoin_units::block::BlockHeightInterval
+impl core::ops::arith::SubAssign for bitcoin_units::block::BlockMtpInterval
+impl core::ops::arith::SubAssign<&bitcoin_units::FeeRate> for bitcoin_units::FeeRate
+impl core::ops::arith::SubAssign<&bitcoin_units::Weight> for bitcoin_units::Weight
+impl core::ops::arith::SubAssign<&bitcoin_units::block::BlockHeightInterval> for bitcoin_units::block::BlockHeightInterval
+impl core::ops::arith::SubAssign<&bitcoin_units::block::BlockMtpInterval> for bitcoin_units::block::BlockMtpInterval
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::Amount
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::BlockTime
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::FeeRate
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::MathOp
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::NumOpError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::SignedAmount
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::Weight
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::Denomination
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::Display
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::InputTooLargeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::InvalidCharacterError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::MissingDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::MissingDigitsError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::OutOfRangeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::ParseAmountError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::ParseDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::ParseError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::TooPreciseError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::UnknownDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::BlockHeight
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::BlockHeightInterval
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::BlockMtp
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::BlockMtpInterval
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::TooBigForRelativeHeightError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::fee_rate::serde::OverflowError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::absolute::ConversionError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::absolute::Height
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::InvalidHeightError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::InvalidTimeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::parse::ParseIntError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::parse::PrefixedHexError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::parse::UnprefixedHexError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::Amount
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::BlockTime
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::FeeRate
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::MathOp
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::NumOpError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::SignedAmount
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::Weight
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::Denomination
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::Display
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::InputTooLargeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::InvalidCharacterError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::MissingDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::MissingDigitsError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::OutOfRangeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::ParseAmountError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::ParseDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::ParseError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::TooPreciseError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::UnknownDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::BlockHeight
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::BlockHeightInterval
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::BlockMtp
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::BlockMtpInterval
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::TooBigForRelativeHeightError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::fee_rate::serde::OverflowError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::absolute::ConversionError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::absolute::Height
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::InvalidHeightError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::InvalidTimeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::parse::ParseIntError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::parse::PrefixedHexError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::parse::UnprefixedHexError
+impl core::str::traits::FromStr for bitcoin_units::Amount
+impl core::str::traits::FromStr for bitcoin_units::SignedAmount
+impl core::str::traits::FromStr for bitcoin_units::Weight
+impl core::str::traits::FromStr for bitcoin_units::amount::Denomination
+impl core::str::traits::FromStr for bitcoin_units::block::BlockHeight
+impl core::str::traits::FromStr for bitcoin_units::block::BlockHeightInterval
+impl core::str::traits::FromStr for bitcoin_units::block::BlockMtp
+impl core::str::traits::FromStr for bitcoin_units::block::BlockMtpInterval
+impl core::str::traits::FromStr for bitcoin_units::locktime::absolute::Height
+impl core::str::traits::FromStr for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::str::traits::FromStr for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::str::traits::FromStr for bitcoin_units::locktime::relative::NumberOfBlocks
+impl serde::ser::Serialize for bitcoin_units::BlockTime
+impl serde::ser::Serialize for bitcoin_units::Weight
+impl serde::ser::Serialize for bitcoin_units::block::BlockHeight
+impl serde::ser::Serialize for bitcoin_units::block::BlockHeightInterval
+impl serde::ser::Serialize for bitcoin_units::block::BlockMtp
+impl serde::ser::Serialize for bitcoin_units::block::BlockMtpInterval
+impl<'a, T: arbitrary::Arbitrary<'a>> arbitrary::Arbitrary<'a> for bitcoin_units::NumOpResult<T>
+impl<'a, T> core::ops::arith::Add<&'a T> for &bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Add<bitcoin_units::NumOpResult<T>, Output = bitcoin_units::NumOpResult<T>>
+impl<'a, T> core::ops::arith::Add<&'a bitcoin_units::NumOpResult<T>> for &bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Add<Output = bitcoin_units::NumOpResult<T>>
+impl<'a, T> core::ops::arith::Sub<&'a T> for &bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Sub<Output = bitcoin_units::NumOpResult<T>>
+impl<'a, T> core::ops::arith::Sub<&'a bitcoin_units::NumOpResult<T>> for &bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Sub<Output = bitcoin_units::NumOpResult<T>>
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::Amount
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::BlockTime
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::FeeRate
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::MathOp
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::SignedAmount
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::Weight
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::amount::Denomination
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::block::BlockHeight
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::block::BlockHeightInterval
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::block::BlockMtp
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::block::BlockMtpInterval
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::locktime::absolute::Height
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::locktime::absolute::MedianTimePast
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::locktime::relative::NumberOfBlocks
+impl<'a> core::iter::traits::accum::Sum<&'a bitcoin_units::FeeRate> for bitcoin_units::FeeRate
+impl<'a> core::iter::traits::accum::Sum<&'a bitcoin_units::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl<'a> core::iter::traits::accum::Sum<&'a bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl<'a> core::iter::traits::accum::Sum<&'a bitcoin_units::Weight> for bitcoin_units::Weight
+impl<'a> core::iter::traits::accum::Sum<&'a bitcoin_units::block::BlockHeightInterval> for bitcoin_units::block::BlockHeightInterval
+impl<'a> core::iter::traits::accum::Sum<&'a bitcoin_units::block::BlockMtpInterval> for bitcoin_units::block::BlockMtpInterval
+impl<'a> core::ops::arith::Add<&'a bitcoin_units::Amount> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Add<&'a bitcoin_units::FeeRate> for &bitcoin_units::FeeRate
+impl<'a> core::ops::arith::Add<&'a bitcoin_units::NumOpResult<bitcoin_units::Amount>> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Add<&'a bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for &bitcoin_units::SignedAmount
+impl<'a> core::ops::arith::Add<&'a bitcoin_units::SignedAmount> for &bitcoin_units::SignedAmount
+impl<'a> core::ops::arith::Add<&'a bitcoin_units::Weight> for &bitcoin_units::Weight
+impl<'a> core::ops::arith::Add<&'a bitcoin_units::block::BlockHeightInterval> for &bitcoin_units::block::BlockHeight
+impl<'a> core::ops::arith::Add<&'a bitcoin_units::block::BlockHeightInterval> for &bitcoin_units::block::BlockHeightInterval
+impl<'a> core::ops::arith::Add<&'a bitcoin_units::block::BlockMtpInterval> for &bitcoin_units::block::BlockMtp
+impl<'a> core::ops::arith::Add<&'a bitcoin_units::block::BlockMtpInterval> for &bitcoin_units::block::BlockMtpInterval
+impl<'a> core::ops::arith::Div<&'a bitcoin_units::Amount> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Div<&'a bitcoin_units::FeeRate> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Div<&'a bitcoin_units::FeeRate> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl<'a> core::ops::arith::Div<&'a bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Div<&'a bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl<'a> core::ops::arith::Div<&'a bitcoin_units::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Div<&'a bitcoin_units::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl<'a> core::ops::arith::Div<&'a bitcoin_units::SignedAmount> for &bitcoin_units::SignedAmount
+impl<'a> core::ops::arith::Div<&'a bitcoin_units::Weight> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Div<&'a bitcoin_units::Weight> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl<'a> core::ops::arith::Div<&'a bitcoin_units::Weight> for &bitcoin_units::Weight
+impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::SignedAmount
+impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::FeeRate
+impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::Weight
+impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::SignedAmount
+impl<'a> core::ops::arith::Div<&'a u64> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Div<&'a u64> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl<'a> core::ops::arith::Div<&'a u64> for &bitcoin_units::Weight
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::Amount> for &u64
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::FeeRate> for &bitcoin_units::NumOpResult<bitcoin_units::Weight>
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::FeeRate> for &bitcoin_units::Weight
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::NumOpResult<bitcoin_units::Amount>> for &u64
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for &bitcoin_units::NumOpResult<bitcoin_units::Weight>
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for &bitcoin_units::Weight
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for &i64
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::FeeRate
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::SignedAmount> for &i64
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::Weight> for &bitcoin_units::FeeRate
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::Weight> for &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::Weight> for &u64
+impl<'a> core::ops::arith::Mul<&'a i64> for &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl<'a> core::ops::arith::Mul<&'a i64> for &bitcoin_units::SignedAmount
+impl<'a> core::ops::arith::Mul<&'a u64> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Mul<&'a u64> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl<'a> core::ops::arith::Mul<&'a u64> for &bitcoin_units::Weight
+impl<'a> core::ops::arith::Rem<&'a bitcoin_units::Weight> for &bitcoin_units::Weight
+impl<'a> core::ops::arith::Rem<&'a i64> for &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl<'a> core::ops::arith::Rem<&'a i64> for &bitcoin_units::SignedAmount
+impl<'a> core::ops::arith::Rem<&'a u64> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Rem<&'a u64> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl<'a> core::ops::arith::Rem<&'a u64> for &bitcoin_units::Weight
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::Amount> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::FeeRate> for &bitcoin_units::FeeRate
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::NumOpResult<bitcoin_units::Amount>> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for &bitcoin_units::SignedAmount
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::SignedAmount> for &bitcoin_units::SignedAmount
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::Weight> for &bitcoin_units::Weight
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::block::BlockHeight> for &bitcoin_units::block::BlockHeight
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::block::BlockHeightInterval> for &bitcoin_units::block::BlockHeight
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::block::BlockHeightInterval> for &bitcoin_units::block::BlockHeightInterval
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::block::BlockMtp> for &bitcoin_units::block::BlockMtp
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::block::BlockMtpInterval> for &bitcoin_units::block::BlockMtp
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::block::BlockMtpInterval> for &bitcoin_units::block::BlockMtpInterval
+impl<'de> serde::de::Deserialize<'de> for bitcoin_units::BlockTime
+impl<'de> serde::de::Deserialize<'de> for bitcoin_units::Weight
+impl<'de> serde::de::Deserialize<'de> for bitcoin_units::block::BlockHeight
+impl<'de> serde::de::Deserialize<'de> for bitcoin_units::block::BlockHeightInterval
+impl<'de> serde::de::Deserialize<'de> for bitcoin_units::block::BlockMtp
+impl<'de> serde::de::Deserialize<'de> for bitcoin_units::block::BlockMtpInterval
+impl<T: core::clone::Clone> core::clone::Clone for bitcoin_units::NumOpResult<T>
+impl<T: core::cmp::Eq> core::cmp::Eq for bitcoin_units::NumOpResult<T>
+impl<T: core::cmp::PartialEq> core::cmp::PartialEq for bitcoin_units::NumOpResult<T>
+impl<T: core::fmt::Debug> bitcoin_units::NumOpResult<T>
+impl<T: core::fmt::Debug> core::fmt::Debug for bitcoin_units::NumOpResult<T>
+impl<T: core::marker::Copy> core::marker::Copy for bitcoin_units::NumOpResult<T>
+impl<T> bitcoin_units::CheckedSum<bitcoin_units::Amount> for T where T: core::iter::traits::iterator::Iterator<Item = bitcoin_units::Amount>
+impl<T> bitcoin_units::CheckedSum<bitcoin_units::SignedAmount> for T where T: core::iter::traits::iterator::Iterator<Item = bitcoin_units::SignedAmount>
+impl<T> bitcoin_units::CheckedSum<bitcoin_units::Weight> for T where T: core::iter::traits::iterator::Iterator<Item = bitcoin_units::Weight>
+impl<T> bitcoin_units::NumOpResult<T>
+impl<T> core::marker::Freeze for bitcoin_units::NumOpResult<T> where T: core::marker::Freeze
+impl<T> core::marker::Send for bitcoin_units::NumOpResult<T> where T: core::marker::Send
+impl<T> core::marker::StructuralPartialEq for bitcoin_units::NumOpResult<T>
+impl<T> core::marker::Sync for bitcoin_units::NumOpResult<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bitcoin_units::NumOpResult<T> where T: core::marker::Unpin
+impl<T> core::ops::arith::Add for bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Add<Output = bitcoin_units::NumOpResult<T>>
+impl<T> core::ops::arith::Add<&T> for bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Add<bitcoin_units::NumOpResult<T>, Output = bitcoin_units::NumOpResult<T>>
+impl<T> core::ops::arith::Add<&bitcoin_units::NumOpResult<T>> for bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Add<Output = bitcoin_units::NumOpResult<T>>
+impl<T> core::ops::arith::Add<T> for &bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Add<bitcoin_units::NumOpResult<T>, Output = bitcoin_units::NumOpResult<T>>
+impl<T> core::ops::arith::Add<T> for bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Add<bitcoin_units::NumOpResult<T>, Output = bitcoin_units::NumOpResult<T>>
+impl<T> core::ops::arith::Add<bitcoin_units::NumOpResult<T>> for &bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Add<Output = bitcoin_units::NumOpResult<T>>
+impl<T> core::ops::arith::Sub for bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Sub<Output = bitcoin_units::NumOpResult<T>>
+impl<T> core::ops::arith::Sub<&T> for bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Sub<Output = bitcoin_units::NumOpResult<T>>
+impl<T> core::ops::arith::Sub<&bitcoin_units::NumOpResult<T>> for bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Sub<Output = bitcoin_units::NumOpResult<T>>
+impl<T> core::ops::arith::Sub<T> for &bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Sub<Output = bitcoin_units::NumOpResult<T>>
+impl<T> core::ops::arith::Sub<T> for bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Sub<Output = bitcoin_units::NumOpResult<T>>
+impl<T> core::ops::arith::Sub<bitcoin_units::NumOpResult<T>> for &bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Sub<Output = bitcoin_units::NumOpResult<T>>
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::NumOpResult<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_units::NumOpResult<T> where T: core::panic::unwind_safe::UnwindSafe
+pub bitcoin_units::MathOp::Add
+pub bitcoin_units::MathOp::Div
+pub bitcoin_units::MathOp::Mul
+pub bitcoin_units::MathOp::Neg
+pub bitcoin_units::MathOp::Rem
+pub bitcoin_units::MathOp::Sub
+pub bitcoin_units::NumOpResult::Error(bitcoin_units::NumOpError)
+pub bitcoin_units::NumOpResult::Valid(T)
+pub bitcoin_units::amount::Denomination::Bit
+pub bitcoin_units::amount::Denomination::Bitcoin
+pub bitcoin_units::amount::Denomination::CentiBitcoin
+pub bitcoin_units::amount::Denomination::MicroBitcoin
+pub bitcoin_units::amount::Denomination::MilliBitcoin
+pub bitcoin_units::amount::Denomination::Satoshi
+pub bitcoin_units::amount::ParseDenominationError::PossiblyConfusing(bitcoin_units::amount::PossiblyConfusingDenominationError)
+pub bitcoin_units::amount::ParseDenominationError::Unknown(bitcoin_units::amount::UnknownDenominationError)
+pub const bitcoin_units::Amount::FIFTY_BTC: Self
+pub const bitcoin_units::Amount::MAX: Self
+pub const bitcoin_units::Amount::MAX_MONEY: Self
+pub const bitcoin_units::Amount::MIN: Self
+pub const bitcoin_units::Amount::ONE_BTC: Self
+pub const bitcoin_units::Amount::ONE_SAT: Self
+pub const bitcoin_units::Amount::SIZE: usize
+pub const bitcoin_units::Amount::ZERO: Self
+pub const bitcoin_units::FeeRate::BROADCAST_MIN: bitcoin_units::FeeRate
+pub const bitcoin_units::FeeRate::DUST: bitcoin_units::FeeRate
+pub const bitcoin_units::FeeRate::MAX: bitcoin_units::FeeRate
+pub const bitcoin_units::FeeRate::MIN: bitcoin_units::FeeRate
+pub const bitcoin_units::FeeRate::ZERO: bitcoin_units::FeeRate
+pub const bitcoin_units::SignedAmount::FIFTY_BTC: Self
+pub const bitcoin_units::SignedAmount::MAX: Self
+pub const bitcoin_units::SignedAmount::MAX_MONEY: Self
+pub const bitcoin_units::SignedAmount::MIN: Self
+pub const bitcoin_units::SignedAmount::ONE_BTC: Self
+pub const bitcoin_units::SignedAmount::ONE_SAT: Self
+pub const bitcoin_units::SignedAmount::ZERO: Self
+pub const bitcoin_units::Weight::MAX: bitcoin_units::Weight
+pub const bitcoin_units::Weight::MAX_BLOCK: bitcoin_units::Weight
+pub const bitcoin_units::Weight::MIN: bitcoin_units::Weight
+pub const bitcoin_units::Weight::MIN_TRANSACTION: bitcoin_units::Weight
+pub const bitcoin_units::Weight::WITNESS_SCALE_FACTOR: u64
+pub const bitcoin_units::Weight::ZERO: bitcoin_units::Weight
+pub const bitcoin_units::amount::Denomination::BTC: Self
+pub const bitcoin_units::amount::Denomination::SAT: Self
+pub const bitcoin_units::block::BlockHeight::MAX: Self
+pub const bitcoin_units::block::BlockHeight::MIN: Self
+pub const bitcoin_units::block::BlockHeight::ZERO: Self
+pub const bitcoin_units::block::BlockHeightInterval::MAX: Self
+pub const bitcoin_units::block::BlockHeightInterval::MIN: Self
+pub const bitcoin_units::block::BlockHeightInterval::ZERO: Self
+pub const bitcoin_units::block::BlockMtp::MAX: Self
+pub const bitcoin_units::block::BlockMtp::MIN: Self
+pub const bitcoin_units::block::BlockMtp::ZERO: Self
+pub const bitcoin_units::block::BlockMtpInterval::MAX: Self
+pub const bitcoin_units::block::BlockMtpInterval::MIN: Self
+pub const bitcoin_units::block::BlockMtpInterval::ZERO: Self
+pub const bitcoin_units::locktime::absolute::Height::MAX: Self
+pub const bitcoin_units::locktime::absolute::Height::MIN: Self
+pub const bitcoin_units::locktime::absolute::Height::ZERO: Self
+pub const bitcoin_units::locktime::absolute::LOCK_TIME_THRESHOLD: u32
+pub const bitcoin_units::locktime::absolute::MedianTimePast::MAX: Self
+pub const bitcoin_units::locktime::absolute::MedianTimePast::MIN: Self
+pub const bitcoin_units::locktime::relative::NumberOf512Seconds::MAX: Self
+pub const bitcoin_units::locktime::relative::NumberOf512Seconds::MIN: Self
+pub const bitcoin_units::locktime::relative::NumberOf512Seconds::ZERO: Self
+pub const bitcoin_units::locktime::relative::NumberOfBlocks::MAX: Self
+pub const bitcoin_units::locktime::relative::NumberOfBlocks::MIN: Self
+pub const bitcoin_units::locktime::relative::NumberOfBlocks::ZERO: Self
+pub const bitcoin_units::weight::WITNESS_SCALE_FACTOR: usize
+pub const fn bitcoin_units::Amount::checked_add(self, rhs: Self) -> core::option::Option<Self>
+pub const fn bitcoin_units::Amount::checked_div(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::Amount::checked_mul(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::Amount::checked_rem(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::Amount::checked_sub(self, rhs: Self) -> core::option::Option<Self>
+pub const fn bitcoin_units::Amount::div_by_fee_rate_ceil(self, fee_rate: bitcoin_units::FeeRate) -> bitcoin_units::NumOpResult<bitcoin_units::Weight>
+pub const fn bitcoin_units::Amount::div_by_fee_rate_floor(self, fee_rate: bitcoin_units::FeeRate) -> bitcoin_units::NumOpResult<bitcoin_units::Weight>
+pub const fn bitcoin_units::Amount::div_by_weight_ceil(self, weight: bitcoin_units::Weight) -> bitcoin_units::NumOpResult<bitcoin_units::FeeRate>
+pub const fn bitcoin_units::Amount::div_by_weight_floor(self, weight: bitcoin_units::Weight) -> bitcoin_units::NumOpResult<bitcoin_units::FeeRate>
+pub const fn bitcoin_units::Amount::from_btc_u16(whole_bitcoin: u16) -> Self
+pub const fn bitcoin_units::Amount::from_sat(satoshi: u64) -> core::result::Result<Self, bitcoin_units::amount::OutOfRangeError>
+pub const fn bitcoin_units::Amount::from_sat_u32(satoshi: u32) -> Self
+pub const fn bitcoin_units::Amount::to_sat(self) -> u64
+pub const fn bitcoin_units::BlockTime::from_u32(t: u32) -> Self
+pub const fn bitcoin_units::BlockTime::to_u32(self) -> u32
+pub const fn bitcoin_units::FeeRate::checked_add(self, rhs: bitcoin_units::FeeRate) -> core::option::Option<Self>
+pub const fn bitcoin_units::FeeRate::checked_div(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::FeeRate::checked_mul(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::FeeRate::checked_sub(self, rhs: bitcoin_units::FeeRate) -> core::option::Option<Self>
+pub const fn bitcoin_units::FeeRate::from_per_kvb(rate: bitcoin_units::Amount) -> bitcoin_units::NumOpResult<Self>
+pub const fn bitcoin_units::FeeRate::from_per_kwu(rate: bitcoin_units::Amount) -> bitcoin_units::NumOpResult<Self>
+pub const fn bitcoin_units::FeeRate::from_per_vb(rate: bitcoin_units::Amount) -> bitcoin_units::NumOpResult<Self>
+pub const fn bitcoin_units::FeeRate::from_sat_per_kvb(sat_kvb: u32) -> Self
+pub const fn bitcoin_units::FeeRate::from_sat_per_kwu(sat_kwu: u32) -> Self
+pub const fn bitcoin_units::FeeRate::from_sat_per_vb(sat_vb: u32) -> Self
+pub const fn bitcoin_units::FeeRate::mul_by_weight(self, weight: bitcoin_units::Weight) -> bitcoin_units::NumOpResult<bitcoin_units::Amount>
+pub const fn bitcoin_units::FeeRate::to_fee(self, weight: bitcoin_units::Weight) -> bitcoin_units::Amount
+pub const fn bitcoin_units::FeeRate::to_sat_per_kvb_ceil(self) -> u64
+pub const fn bitcoin_units::FeeRate::to_sat_per_kvb_floor(self) -> u64
+pub const fn bitcoin_units::FeeRate::to_sat_per_kwu_ceil(self) -> u64
+pub const fn bitcoin_units::FeeRate::to_sat_per_kwu_floor(self) -> u64
+pub const fn bitcoin_units::FeeRate::to_sat_per_vb_ceil(self) -> u64
+pub const fn bitcoin_units::FeeRate::to_sat_per_vb_floor(self) -> u64
+pub const fn bitcoin_units::SignedAmount::abs(self) -> Self
+pub const fn bitcoin_units::SignedAmount::checked_abs(self) -> core::option::Option<Self>
+pub const fn bitcoin_units::SignedAmount::checked_add(self, rhs: Self) -> core::option::Option<Self>
+pub const fn bitcoin_units::SignedAmount::checked_div(self, rhs: i64) -> core::option::Option<Self>
+pub const fn bitcoin_units::SignedAmount::checked_mul(self, rhs: i64) -> core::option::Option<Self>
+pub const fn bitcoin_units::SignedAmount::checked_rem(self, rhs: i64) -> core::option::Option<Self>
+pub const fn bitcoin_units::SignedAmount::checked_sub(self, rhs: Self) -> core::option::Option<Self>
+pub const fn bitcoin_units::SignedAmount::from_btc_i16(whole_bitcoin: i16) -> Self
+pub const fn bitcoin_units::SignedAmount::from_sat(satoshi: i64) -> core::result::Result<Self, bitcoin_units::amount::OutOfRangeError>
+pub const fn bitcoin_units::SignedAmount::from_sat_i32(satoshi: i32) -> Self
+pub const fn bitcoin_units::SignedAmount::to_sat(self) -> i64
+pub const fn bitcoin_units::Weight::checked_add(self, rhs: Self) -> core::option::Option<Self>
+pub const fn bitcoin_units::Weight::checked_div(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::Weight::checked_mul(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::Weight::checked_sub(self, rhs: Self) -> core::option::Option<Self>
+pub const fn bitcoin_units::Weight::from_kwu(wu: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::Weight::from_non_witness_data_size(non_witness_size: u64) -> Self
+pub const fn bitcoin_units::Weight::from_vb(vb: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::Weight::from_vb_unchecked(vb: u64) -> Self
+pub const fn bitcoin_units::Weight::from_vb_unwrap(vb: u64) -> bitcoin_units::Weight
+pub const fn bitcoin_units::Weight::from_witness_data_size(witness_size: u64) -> Self
+pub const fn bitcoin_units::Weight::from_wu(wu: u64) -> Self
+pub const fn bitcoin_units::Weight::mul_by_fee_rate(self, fee_rate: bitcoin_units::FeeRate) -> bitcoin_units::NumOpResult<bitcoin_units::Amount>
+pub const fn bitcoin_units::Weight::to_kwu_ceil(self) -> u64
+pub const fn bitcoin_units::Weight::to_kwu_floor(self) -> u64
+pub const fn bitcoin_units::Weight::to_vbytes_ceil(self) -> u64
+pub const fn bitcoin_units::Weight::to_vbytes_floor(self) -> u64
+pub const fn bitcoin_units::Weight::to_wu(self) -> u64
+pub const fn bitcoin_units::block::BlockHeight::from_u32(inner: u32) -> Self
+pub const fn bitcoin_units::block::BlockHeight::to_u32(self) -> u32
+pub const fn bitcoin_units::block::BlockHeightInterval::from_u32(inner: u32) -> Self
+pub const fn bitcoin_units::block::BlockHeightInterval::to_u32(self) -> u32
+pub const fn bitcoin_units::block::BlockMtp::from_u32(inner: u32) -> Self
+pub const fn bitcoin_units::block::BlockMtp::to_u32(self) -> u32
+pub const fn bitcoin_units::block::BlockMtpInterval::from_u32(inner: u32) -> Self
+pub const fn bitcoin_units::block::BlockMtpInterval::to_relative_mtp_interval_ceil(self) -> core::result::Result<bitcoin_units::locktime::relative::NumberOf512Seconds, bitcoin_units::locktime::relative::TimeOverflowError>
+pub const fn bitcoin_units::block::BlockMtpInterval::to_relative_mtp_interval_floor(self) -> core::result::Result<bitcoin_units::locktime::relative::NumberOf512Seconds, bitcoin_units::locktime::relative::TimeOverflowError>
+pub const fn bitcoin_units::block::BlockMtpInterval::to_u32(self) -> u32
+pub const fn bitcoin_units::locktime::absolute::Height::from_u32(n: u32) -> core::result::Result<bitcoin_units::locktime::absolute::Height, bitcoin_units::locktime::absolute::ConversionError>
+pub const fn bitcoin_units::locktime::absolute::Height::to_u32(self) -> u32
+pub const fn bitcoin_units::locktime::absolute::MedianTimePast::from_u32(n: u32) -> core::result::Result<Self, bitcoin_units::locktime::absolute::ConversionError>
+pub const fn bitcoin_units::locktime::absolute::MedianTimePast::to_u32(self) -> u32
+pub const fn bitcoin_units::locktime::absolute::is_block_height(n: u32) -> bool
+pub const fn bitcoin_units::locktime::absolute::is_block_time(n: u32) -> bool
+pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_512_second_intervals(intervals: u16) -> Self
+pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_seconds_ceil(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::TimeOverflowError>
+pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_seconds_floor(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::TimeOverflowError>
+pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::to_512_second_intervals(self) -> u16
+pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::to_consensus_u32(self) -> u32
+pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::to_seconds(self) -> u32
+pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::from_height(blocks: u16) -> Self
+pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::to_consensus_u32(self) -> u32
+pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::to_height(self) -> u16
+pub enum bitcoin_units::NumOpResult<T>
+pub fn &bitcoin_units::Amount::add(self, rhs: &bitcoin_units::Amount) -> Self::Output
+pub fn &bitcoin_units::Amount::add(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Amount>) -> Self::Output
+pub fn &bitcoin_units::Amount::add(self, rhs: bitcoin_units::Amount) -> Self::Output
+pub fn &bitcoin_units::Amount::add(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Amount>) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: &bitcoin_units::Amount) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: &bitcoin_units::FeeRate) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: &u64) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: bitcoin_units::Amount) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: bitcoin_units::FeeRate) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: u64) -> Self::Output
+pub fn &bitcoin_units::Amount::mul(self, rhs: &u64) -> Self::Output
+pub fn &bitcoin_units::Amount::mul(self, rhs: u64) -> Self::Output
+pub fn &bitcoin_units::Amount::rem(self, rhs: &u64) -> Self::Output
+pub fn &bitcoin_units::Amount::rem(self, rhs: u64) -> Self::Output
+pub fn &bitcoin_units::Amount::sub(self, rhs: &bitcoin_units::Amount) -> Self::Output
+pub fn &bitcoin_units::Amount::sub(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Amount>) -> Self::Output
+pub fn &bitcoin_units::Amount::sub(self, rhs: bitcoin_units::Amount) -> Self::Output
+pub fn &bitcoin_units::Amount::sub(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Amount>) -> Self::Output
+pub fn &bitcoin_units::FeeRate::add(self, rhs: &bitcoin_units::FeeRate) -> Self::Output
+pub fn &bitcoin_units::FeeRate::add(self, rhs: bitcoin_units::FeeRate) -> Self::Output
+pub fn &bitcoin_units::FeeRate::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output
+pub fn &bitcoin_units::FeeRate::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output
+pub fn &bitcoin_units::FeeRate::mul(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn &bitcoin_units::FeeRate::mul(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::FeeRate::mul(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn &bitcoin_units::FeeRate::mul(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::FeeRate::sub(self, rhs: &bitcoin_units::FeeRate) -> Self::Output
+pub fn &bitcoin_units::FeeRate::sub(self, rhs: bitcoin_units::FeeRate) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<T>::add(self, rhs: &T) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<T>::add(self, rhs: &bitcoin_units::NumOpResult<T>) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<T>::add(self, rhs: T) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<T>::add(self, rhs: bitcoin_units::NumOpResult<T>) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<T>::sub(self, rhs: &T) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<T>::sub(self, rhs: &bitcoin_units::NumOpResult<T>) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<T>::sub(self, rhs: T) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<T>::sub(self, rhs: bitcoin_units::NumOpResult<T>) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::FeeRate) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &u64) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: bitcoin_units::FeeRate) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: u64) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::mul(self, rhs: &u64) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::mul(self, rhs: u64) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::rem(self, rhs: &u64) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::rem(self, rhs: u64) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::mul(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::mul(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::mul(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::mul(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &i64) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: i64) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::mul(self, rhs: &i64) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::mul(self, rhs: i64) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::rem(self, rhs: &i64) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::rem(self, rhs: i64) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Weight>::mul(self, rhs: &bitcoin_units::FeeRate) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Weight>::mul(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Weight>::mul(self, rhs: bitcoin_units::FeeRate) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Weight>::mul(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::add(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::add(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::add(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::add(self, rhs: bitcoin_units::SignedAmount) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::div(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::div(self, rhs: &core::num::nonzero::NonZeroI64) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::div(self, rhs: &i64) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::div(self, rhs: bitcoin_units::SignedAmount) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::div(self, rhs: core::num::nonzero::NonZeroI64) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::div(self, rhs: i64) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::mul(self, rhs: &i64) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::mul(self, rhs: i64) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::rem(self, rhs: &i64) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::rem(self, rhs: i64) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::sub(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::sub(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::sub(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::sub(self, rhs: bitcoin_units::SignedAmount) -> Self::Output
+pub fn &bitcoin_units::Weight::add(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::Weight::add(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::Weight::div(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::Weight::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output
+pub fn &bitcoin_units::Weight::div(self, rhs: &u64) -> Self::Output
+pub fn &bitcoin_units::Weight::div(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::Weight::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output
+pub fn &bitcoin_units::Weight::div(self, rhs: u64) -> Self::Output
+pub fn &bitcoin_units::Weight::mul(self, rhs: &bitcoin_units::FeeRate) -> Self::Output
+pub fn &bitcoin_units::Weight::mul(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn &bitcoin_units::Weight::mul(self, rhs: &u64) -> Self::Output
+pub fn &bitcoin_units::Weight::mul(self, rhs: bitcoin_units::FeeRate) -> Self::Output
+pub fn &bitcoin_units::Weight::mul(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn &bitcoin_units::Weight::mul(self, rhs: u64) -> Self::Output
+pub fn &bitcoin_units::Weight::rem(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::Weight::rem(self, rhs: &u64) -> Self::Output
+pub fn &bitcoin_units::Weight::rem(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::Weight::rem(self, rhs: u64) -> Self::Output
+pub fn &bitcoin_units::Weight::sub(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::Weight::sub(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::block::BlockHeight::add(self, rhs: &bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockHeight::add(self, rhs: bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockHeight::sub(self, rhs: &bitcoin_units::block::BlockHeight) -> Self::Output
+pub fn &bitcoin_units::block::BlockHeight::sub(self, rhs: &bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockHeight::sub(self, rhs: bitcoin_units::block::BlockHeight) -> Self::Output
+pub fn &bitcoin_units::block::BlockHeight::sub(self, rhs: bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockHeightInterval::add(self, rhs: &bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockHeightInterval::add(self, rhs: bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockHeightInterval::sub(self, rhs: &bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockHeightInterval::sub(self, rhs: bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockMtp::add(self, rhs: &bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockMtp::add(self, rhs: bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockMtp::sub(self, rhs: &bitcoin_units::block::BlockMtp) -> Self::Output
+pub fn &bitcoin_units::block::BlockMtp::sub(self, rhs: &bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockMtp::sub(self, rhs: bitcoin_units::block::BlockMtp) -> Self::Output
+pub fn &bitcoin_units::block::BlockMtp::sub(self, rhs: bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockMtpInterval::add(self, rhs: &bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockMtpInterval::add(self, rhs: bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockMtpInterval::sub(self, rhs: &bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockMtpInterval::sub(self, rhs: bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn &i64::mul(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
+pub fn &i64::mul(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output
+pub fn &i64::mul(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
+pub fn &i64::mul(self, rhs: bitcoin_units::SignedAmount) -> Self::Output
+pub fn &u64::mul(self, rhs: &bitcoin_units::Amount) -> Self::Output
+pub fn &u64::mul(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Amount>) -> Self::Output
+pub fn &u64::mul(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn &u64::mul(self, rhs: bitcoin_units::Amount) -> Self::Output
+pub fn &u64::mul(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Amount>) -> Self::Output
+pub fn &u64::mul(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn T::checked_sum(self) -> core::option::Option<bitcoin_units::Amount>
+pub fn T::checked_sum(self) -> core::option::Option<bitcoin_units::SignedAmount>
+pub fn T::checked_sum(self) -> core::option::Option<bitcoin_units::Weight>
+pub fn bitcoin_units::Amount::add(self, rhs: &bitcoin_units::Amount) -> Self::Output
+pub fn bitcoin_units::Amount::add(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Amount>) -> Self::Output
+pub fn bitcoin_units::Amount::add(self, rhs: bitcoin_units::Amount) -> Self::Output
+pub fn bitcoin_units::Amount::add(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Amount>) -> Self::Output
+pub fn bitcoin_units::Amount::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_units::Amount::clone(&self) -> bitcoin_units::Amount
+pub fn bitcoin_units::Amount::cmp(&self, other: &bitcoin_units::Amount) -> core::cmp::Ordering
+pub fn bitcoin_units::Amount::default() -> Self
+pub fn bitcoin_units::Amount::des_btc<'d, D: serde::de::Deserializer<'d>>(d: D, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::Amount::des_sat<'d, D: serde::de::Deserializer<'d>>(d: D, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::Amount::des_str<'d, D: serde::de::Deserializer<'d>>(d: D, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::Amount::display_dynamic(self) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::Amount::display_in(self, denomination: bitcoin_units::amount::Denomination) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::Amount::div(self, rhs: &bitcoin_units::Amount) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: &bitcoin_units::FeeRate) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: &u64) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: bitcoin_units::Amount) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: bitcoin_units::FeeRate) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::Amount::eq(&self, other: &bitcoin_units::Amount) -> bool
+pub fn bitcoin_units::Amount::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::Amount::from_btc(btc: f64) -> core::result::Result<Self, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::Amount::from_float_in(value: f64, denom: bitcoin_units::amount::Denomination) -> core::result::Result<Self, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::Amount::from_int_btc<T: core::convert::Into<u16>>(whole_bitcoin: T) -> Self
+pub fn bitcoin_units::Amount::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::Amount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<Self, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::Amount::from_str_with_denomination(s: &str) -> core::result::Result<Self, bitcoin_units::amount::ParseError>
+pub fn bitcoin_units::Amount::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::Amount::mul(self, rhs: &u64) -> Self::Output
+pub fn bitcoin_units::Amount::mul(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::Amount::partial_cmp(&self, other: &bitcoin_units::Amount) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::Amount::rem(self, modulus: u64) -> Self::Output
+pub fn bitcoin_units::Amount::rem(self, rhs: &u64) -> Self::Output
+pub fn bitcoin_units::Amount::ser_btc<S: serde::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::Amount::ser_btc_opt<S: serde::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::Amount::ser_sat<S: serde::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::Amount::ser_sat_opt<S: serde::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::Amount::ser_str<S: serde::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::Amount::ser_str_opt<S: serde::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::Amount::sub(self, rhs: &bitcoin_units::Amount) -> Self::Output
+pub fn bitcoin_units::Amount::sub(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Amount>) -> Self::Output
+pub fn bitcoin_units::Amount::sub(self, rhs: bitcoin_units::Amount) -> Self::Output
+pub fn bitcoin_units::Amount::sub(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Amount>) -> Self::Output
+pub fn bitcoin_units::Amount::to_btc(self) -> f64
+pub fn bitcoin_units::Amount::to_float_in(self, denom: bitcoin_units::amount::Denomination) -> f64
+pub fn bitcoin_units::Amount::to_signed(self) -> bitcoin_units::SignedAmount
+pub fn bitcoin_units::Amount::to_string_in(self, denom: bitcoin_units::amount::Denomination) -> alloc::string::String
+pub fn bitcoin_units::Amount::to_string_with_denomination(self, denom: bitcoin_units::amount::Denomination) -> alloc::string::String
+pub fn bitcoin_units::Amount::try_from(value: bitcoin_units::SignedAmount) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::Amount::type_prefix(_: bitcoin_units::amount::serde::private::Token) -> &'static str
+pub fn bitcoin_units::BlockTime::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_units::BlockTime::clone(&self) -> bitcoin_units::BlockTime
+pub fn bitcoin_units::BlockTime::cmp(&self, other: &bitcoin_units::BlockTime) -> core::cmp::Ordering
+pub fn bitcoin_units::BlockTime::deserialize<D>(d: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+pub fn bitcoin_units::BlockTime::eq(&self, other: &bitcoin_units::BlockTime) -> bool
+pub fn bitcoin_units::BlockTime::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::BlockTime::from(t: u32) -> Self
+pub fn bitcoin_units::BlockTime::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::BlockTime::partial_cmp(&self, other: &bitcoin_units::BlockTime) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::BlockTime::serialize<S>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+pub fn bitcoin_units::CheckedSum::checked_sum(self) -> core::option::Option<R>
+pub fn bitcoin_units::FeeRate::add(self, rhs: &bitcoin_units::FeeRate) -> Self::Output
+pub fn bitcoin_units::FeeRate::add(self, rhs: bitcoin_units::FeeRate) -> Self::Output
+pub fn bitcoin_units::FeeRate::add_assign(&mut self, rhs: &bitcoin_units::FeeRate)
+pub fn bitcoin_units::FeeRate::add_assign(&mut self, rhs: bitcoin_units::FeeRate)
+pub fn bitcoin_units::FeeRate::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_units::FeeRate::clone(&self) -> bitcoin_units::FeeRate
+pub fn bitcoin_units::FeeRate::cmp(&self, other: &bitcoin_units::FeeRate) -> core::cmp::Ordering
+pub fn bitcoin_units::FeeRate::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output
+pub fn bitcoin_units::FeeRate::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output
+pub fn bitcoin_units::FeeRate::eq(&self, other: &bitcoin_units::FeeRate) -> bool
+pub fn bitcoin_units::FeeRate::fee_vb(self, vb: u64) -> core::option::Option<bitcoin_units::Amount>
+pub fn bitcoin_units::FeeRate::fee_wu(self, weight: bitcoin_units::Weight) -> core::option::Option<bitcoin_units::Amount>
+pub fn bitcoin_units::FeeRate::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::FeeRate::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::FeeRate::mul(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn bitcoin_units::FeeRate::mul(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::FeeRate::mul(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn bitcoin_units::FeeRate::mul(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::FeeRate::partial_cmp(&self, other: &bitcoin_units::FeeRate) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::FeeRate::sub(self, rhs: &bitcoin_units::FeeRate) -> Self::Output
+pub fn bitcoin_units::FeeRate::sub(self, rhs: bitcoin_units::FeeRate) -> Self::Output
+pub fn bitcoin_units::FeeRate::sub_assign(&mut self, rhs: &bitcoin_units::FeeRate)
+pub fn bitcoin_units::FeeRate::sub_assign(&mut self, rhs: bitcoin_units::FeeRate)
+pub fn bitcoin_units::FeeRate::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin_units::FeeRate>
+pub fn bitcoin_units::FeeRate::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = Self>
+pub fn bitcoin_units::MathOp::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_units::MathOp::clone(&self) -> bitcoin_units::MathOp
+pub fn bitcoin_units::MathOp::eq(&self, other: &bitcoin_units::MathOp) -> bool
+pub fn bitcoin_units::MathOp::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::MathOp::is_addition(self) -> bool
+pub fn bitcoin_units::MathOp::is_div_by_zero(self) -> bool
+pub fn bitcoin_units::MathOp::is_multiplication(self) -> bool
+pub fn bitcoin_units::MathOp::is_negation(self) -> bool
+pub fn bitcoin_units::MathOp::is_overflow(self) -> bool
+pub fn bitcoin_units::MathOp::is_subtraction(self) -> bool
+pub fn bitcoin_units::NumOpError::clone(&self) -> bitcoin_units::NumOpError
+pub fn bitcoin_units::NumOpError::eq(&self, other: &bitcoin_units::NumOpError) -> bool
+pub fn bitcoin_units::NumOpError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::NumOpError::is_div_by_zero(self) -> bool
+pub fn bitcoin_units::NumOpError::is_overflow(self) -> bool
+pub fn bitcoin_units::NumOpError::operation(self) -> bitcoin_units::MathOp
+pub fn bitcoin_units::NumOpResult<T>::add(self, rhs: &T) -> Self::Output
+pub fn bitcoin_units::NumOpResult<T>::add(self, rhs: &bitcoin_units::NumOpResult<T>) -> Self::Output
+pub fn bitcoin_units::NumOpResult<T>::add(self, rhs: Self) -> Self::Output
+pub fn bitcoin_units::NumOpResult<T>::add(self, rhs: T) -> Self::Output
+pub fn bitcoin_units::NumOpResult<T>::and_then<F>(self, op: F) -> bitcoin_units::NumOpResult<T> where F: core::ops::function::FnOnce(T) -> bitcoin_units::NumOpResult<T>
+pub fn bitcoin_units::NumOpResult<T>::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_units::NumOpResult<T>::clone(&self) -> bitcoin_units::NumOpResult<T>
+pub fn bitcoin_units::NumOpResult<T>::eq(&self, other: &bitcoin_units::NumOpResult<T>) -> bool
+pub fn bitcoin_units::NumOpResult<T>::expect(self, msg: &str) -> T
+pub fn bitcoin_units::NumOpResult<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::NumOpResult<T>::into_result(self) -> core::result::Result<T, bitcoin_units::NumOpError>
+pub fn bitcoin_units::NumOpResult<T>::is_error(&self) -> bool
+pub fn bitcoin_units::NumOpResult<T>::is_valid(&self) -> bool
+pub fn bitcoin_units::NumOpResult<T>::map<U, F: core::ops::function::FnOnce(T) -> U>(self, op: F) -> bitcoin_units::NumOpResult<U>
+pub fn bitcoin_units::NumOpResult<T>::ok(self) -> core::option::Option<T>
+pub fn bitcoin_units::NumOpResult<T>::sub(self, rhs: &T) -> Self::Output
+pub fn bitcoin_units::NumOpResult<T>::sub(self, rhs: &bitcoin_units::NumOpResult<T>) -> Self::Output
+pub fn bitcoin_units::NumOpResult<T>::sub(self, rhs: Self) -> Self::Output
+pub fn bitcoin_units::NumOpResult<T>::sub(self, rhs: T) -> Self::Output
+pub fn bitcoin_units::NumOpResult<T>::unwrap(self) -> T
+pub fn bitcoin_units::NumOpResult<T>::unwrap_err(self) -> bitcoin_units::NumOpError
+pub fn bitcoin_units::NumOpResult<T>::unwrap_or(self, default: T) -> T
+pub fn bitcoin_units::NumOpResult<T>::unwrap_or_else<F>(self, f: F) -> T where F: core::ops::function::FnOnce() -> T
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::FeeRate) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &u64) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: bitcoin_units::FeeRate) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: &u64)
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: u64)
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::from(a: &bitcoin_units::Amount) -> Self
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::from(a: bitcoin_units::Amount) -> Self
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::mul(self, rhs: &u64) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::mul(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::mul_assign(&mut self, rhs: &u64)
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::mul_assign(&mut self, rhs: u64)
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::rem(self, modulus: u64) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::rem(self, rhs: &u64) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin_units::NumOpResult<bitcoin_units::Amount>>
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = bitcoin_units::NumOpResult<bitcoin_units::Amount>>
+pub fn bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::mul(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::mul(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::mul(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::mul(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &i64) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: i64) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: &i64)
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: i64)
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::from(a: &bitcoin_units::SignedAmount) -> Self
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::from(a: bitcoin_units::SignedAmount) -> Self
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::mul(self, rhs: &i64) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::mul(self, rhs: i64) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::mul_assign(&mut self, rhs: &i64)
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::mul_assign(&mut self, rhs: i64)
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::rem(self, modulus: i64) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::rem(self, rhs: &i64) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>>
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>>
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Weight>::mul(self, rhs: &bitcoin_units::FeeRate) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Weight>::mul(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Weight>::mul(self, rhs: bitcoin_units::FeeRate) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Weight>::mul(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn bitcoin_units::SignedAmount::add(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
+pub fn bitcoin_units::SignedAmount::add(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output
+pub fn bitcoin_units::SignedAmount::add(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
+pub fn bitcoin_units::SignedAmount::add(self, rhs: bitcoin_units::SignedAmount) -> Self::Output
+pub fn bitcoin_units::SignedAmount::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_units::SignedAmount::clone(&self) -> bitcoin_units::SignedAmount
+pub fn bitcoin_units::SignedAmount::cmp(&self, other: &bitcoin_units::SignedAmount) -> core::cmp::Ordering
+pub fn bitcoin_units::SignedAmount::default() -> Self
+pub fn bitcoin_units::SignedAmount::des_btc<'d, D: serde::de::Deserializer<'d>>(d: D, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::SignedAmount::des_sat<'d, D: serde::de::Deserializer<'d>>(d: D, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::SignedAmount::des_str<'d, D: serde::de::Deserializer<'d>>(d: D, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::SignedAmount::display_dynamic(self) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::SignedAmount::display_in(self, denomination: bitcoin_units::amount::Denomination) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::SignedAmount::div(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output
+pub fn bitcoin_units::SignedAmount::div(self, rhs: &core::num::nonzero::NonZeroI64) -> Self::Output
+pub fn bitcoin_units::SignedAmount::div(self, rhs: &i64) -> Self::Output
+pub fn bitcoin_units::SignedAmount::div(self, rhs: bitcoin_units::SignedAmount) -> Self::Output
+pub fn bitcoin_units::SignedAmount::div(self, rhs: core::num::nonzero::NonZeroI64) -> Self::Output
+pub fn bitcoin_units::SignedAmount::div(self, rhs: i64) -> Self::Output
+pub fn bitcoin_units::SignedAmount::eq(&self, other: &bitcoin_units::SignedAmount) -> bool
+pub fn bitcoin_units::SignedAmount::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::SignedAmount::from(value: bitcoin_units::Amount) -> Self
+pub fn bitcoin_units::SignedAmount::from_btc(btc: f64) -> core::result::Result<Self, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::SignedAmount::from_float_in(value: f64, denom: bitcoin_units::amount::Denomination) -> core::result::Result<Self, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::SignedAmount::from_int_btc<T: core::convert::Into<i16>>(whole_bitcoin: T) -> Self
+pub fn bitcoin_units::SignedAmount::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::SignedAmount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<Self, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::SignedAmount::from_str_with_denomination(s: &str) -> core::result::Result<Self, bitcoin_units::amount::ParseError>
+pub fn bitcoin_units::SignedAmount::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::SignedAmount::is_negative(self) -> bool
+pub fn bitcoin_units::SignedAmount::is_positive(self) -> bool
+pub fn bitcoin_units::SignedAmount::mul(self, rhs: &i64) -> Self::Output
+pub fn bitcoin_units::SignedAmount::mul(self, rhs: i64) -> Self::Output
+pub fn bitcoin_units::SignedAmount::neg(self) -> Self::Output
+pub fn bitcoin_units::SignedAmount::partial_cmp(&self, other: &bitcoin_units::SignedAmount) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::SignedAmount::positive_sub(self, rhs: Self) -> core::option::Option<Self>
+pub fn bitcoin_units::SignedAmount::rem(self, modulus: i64) -> Self::Output
+pub fn bitcoin_units::SignedAmount::rem(self, rhs: &i64) -> Self::Output
+pub fn bitcoin_units::SignedAmount::ser_btc<S: serde::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::SignedAmount::ser_btc_opt<S: serde::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::SignedAmount::ser_sat<S: serde::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::SignedAmount::ser_sat_opt<S: serde::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::SignedAmount::ser_str<S: serde::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::SignedAmount::ser_str_opt<S: serde::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::SignedAmount::signum(self) -> i64
+pub fn bitcoin_units::SignedAmount::sub(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
+pub fn bitcoin_units::SignedAmount::sub(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output
+pub fn bitcoin_units::SignedAmount::sub(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
+pub fn bitcoin_units::SignedAmount::sub(self, rhs: bitcoin_units::SignedAmount) -> Self::Output
+pub fn bitcoin_units::SignedAmount::to_btc(self) -> f64
+pub fn bitcoin_units::SignedAmount::to_float_in(self, denom: bitcoin_units::amount::Denomination) -> f64
+pub fn bitcoin_units::SignedAmount::to_string_in(self, denom: bitcoin_units::amount::Denomination) -> alloc::string::String
+pub fn bitcoin_units::SignedAmount::to_string_with_denomination(self, denom: bitcoin_units::amount::Denomination) -> alloc::string::String
+pub fn bitcoin_units::SignedAmount::to_unsigned(self) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::OutOfRangeError>
+pub fn bitcoin_units::SignedAmount::type_prefix(_: bitcoin_units::amount::serde::private::Token) -> &'static str
+pub fn bitcoin_units::SignedAmount::unsigned_abs(self) -> bitcoin_units::Amount
+pub fn bitcoin_units::Weight::add(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::Weight::add(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::Weight::add_assign(&mut self, rhs: &bitcoin_units::Weight)
+pub fn bitcoin_units::Weight::add_assign(&mut self, rhs: bitcoin_units::Weight)
+pub fn bitcoin_units::Weight::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_units::Weight::clone(&self) -> bitcoin_units::Weight
+pub fn bitcoin_units::Weight::cmp(&self, other: &bitcoin_units::Weight) -> core::cmp::Ordering
+pub fn bitcoin_units::Weight::deserialize<D>(d: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+pub fn bitcoin_units::Weight::div(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::Weight::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output
+pub fn bitcoin_units::Weight::div(self, rhs: &u64) -> Self::Output
+pub fn bitcoin_units::Weight::div(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::Weight::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output
+pub fn bitcoin_units::Weight::div(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::Weight::div_assign(&mut self, rhs: u64)
+pub fn bitcoin_units::Weight::eq(&self, other: &bitcoin_units::Weight) -> bool
+pub fn bitcoin_units::Weight::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::Weight::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::Weight::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::Weight::mul(self, rhs: &bitcoin_units::FeeRate) -> Self::Output
+pub fn bitcoin_units::Weight::mul(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn bitcoin_units::Weight::mul(self, rhs: &u64) -> Self::Output
+pub fn bitcoin_units::Weight::mul(self, rhs: bitcoin_units::FeeRate) -> Self::Output
+pub fn bitcoin_units::Weight::mul(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn bitcoin_units::Weight::mul(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::Weight::mul_assign(&mut self, rhs: u64)
+pub fn bitcoin_units::Weight::partial_cmp(&self, other: &bitcoin_units::Weight) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::Weight::rem(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::Weight::rem(self, rhs: &u64) -> Self::Output
+pub fn bitcoin_units::Weight::rem(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::Weight::rem(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::Weight::rem_assign(&mut self, rhs: u64)
+pub fn bitcoin_units::Weight::serialize<S>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+pub fn bitcoin_units::Weight::sub(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::Weight::sub(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::Weight::sub_assign(&mut self, rhs: &bitcoin_units::Weight)
+pub fn bitcoin_units::Weight::sub_assign(&mut self, rhs: bitcoin_units::Weight)
+pub fn bitcoin_units::Weight::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin_units::Weight>
+pub fn bitcoin_units::Weight::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = Self>
+pub fn bitcoin_units::Weight::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::Weight::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::Weight::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::amount::Denomination::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_units::amount::Denomination::clone(&self) -> bitcoin_units::amount::Denomination
+pub fn bitcoin_units::amount::Denomination::eq(&self, other: &bitcoin_units::amount::Denomination) -> bool
+pub fn bitcoin_units::amount::Denomination::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::Denomination::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::amount::Denomination::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::amount::Display::clone(&self) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::amount::Display::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::Display::show_denomination(self) -> Self
+pub fn bitcoin_units::amount::InputTooLargeError::clone(&self) -> bitcoin_units::amount::InputTooLargeError
+pub fn bitcoin_units::amount::InputTooLargeError::eq(&self, other: &bitcoin_units::amount::InputTooLargeError) -> bool
+pub fn bitcoin_units::amount::InputTooLargeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::InvalidCharacterError::clone(&self) -> bitcoin_units::amount::InvalidCharacterError
+pub fn bitcoin_units::amount::InvalidCharacterError::eq(&self, other: &bitcoin_units::amount::InvalidCharacterError) -> bool
+pub fn bitcoin_units::amount::InvalidCharacterError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::MissingDenominationError::clone(&self) -> bitcoin_units::amount::MissingDenominationError
+pub fn bitcoin_units::amount::MissingDenominationError::eq(&self, other: &bitcoin_units::amount::MissingDenominationError) -> bool
+pub fn bitcoin_units::amount::MissingDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::MissingDigitsError::clone(&self) -> bitcoin_units::amount::MissingDigitsError
+pub fn bitcoin_units::amount::MissingDigitsError::eq(&self, other: &bitcoin_units::amount::MissingDigitsError) -> bool
+pub fn bitcoin_units::amount::MissingDigitsError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::OutOfRangeError::clone(&self) -> bitcoin_units::amount::OutOfRangeError
+pub fn bitcoin_units::amount::OutOfRangeError::eq(&self, other: &bitcoin_units::amount::OutOfRangeError) -> bool
+pub fn bitcoin_units::amount::OutOfRangeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::OutOfRangeError::is_above_max(self) -> bool
+pub fn bitcoin_units::amount::OutOfRangeError::is_below_min(self) -> bool
+pub fn bitcoin_units::amount::OutOfRangeError::valid_range(self) -> (i64, u64)
+pub fn bitcoin_units::amount::ParseAmountError::clone(&self) -> bitcoin_units::amount::ParseAmountError
+pub fn bitcoin_units::amount::ParseAmountError::eq(&self, other: &bitcoin_units::amount::ParseAmountError) -> bool
+pub fn bitcoin_units::amount::ParseAmountError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::ParseAmountError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::amount::ParseAmountError::from(value: bitcoin_units::amount::InputTooLargeError) -> Self
+pub fn bitcoin_units::amount::ParseAmountError::from(value: bitcoin_units::amount::InvalidCharacterError) -> Self
+pub fn bitcoin_units::amount::ParseAmountError::from(value: bitcoin_units::amount::MissingDigitsError) -> Self
+pub fn bitcoin_units::amount::ParseAmountError::from(value: bitcoin_units::amount::OutOfRangeError) -> Self
+pub fn bitcoin_units::amount::ParseAmountError::from(value: bitcoin_units::amount::TooPreciseError) -> Self
+pub fn bitcoin_units::amount::ParseAmountError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_units::amount::ParseDenominationError::clone(&self) -> bitcoin_units::amount::ParseDenominationError
+pub fn bitcoin_units::amount::ParseDenominationError::eq(&self, other: &bitcoin_units::amount::ParseDenominationError) -> bool
+pub fn bitcoin_units::amount::ParseDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::ParseDenominationError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::amount::ParseDenominationError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_units::amount::ParseError::clone(&self) -> bitcoin_units::amount::ParseError
+pub fn bitcoin_units::amount::ParseError::eq(&self, other: &bitcoin_units::amount::ParseError) -> bool
+pub fn bitcoin_units::amount::ParseError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::InputTooLargeError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::InvalidCharacterError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::MissingDigitsError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::OutOfRangeError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::ParseAmountError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::ParseDenominationError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::TooPreciseError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::amount::ParseError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_units::amount::PossiblyConfusingDenominationError::clone(&self) -> bitcoin_units::amount::PossiblyConfusingDenominationError
+pub fn bitcoin_units::amount::PossiblyConfusingDenominationError::eq(&self, other: &bitcoin_units::amount::PossiblyConfusingDenominationError) -> bool
+pub fn bitcoin_units::amount::PossiblyConfusingDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::PossiblyConfusingDenominationError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_units::amount::TooPreciseError::clone(&self) -> bitcoin_units::amount::TooPreciseError
+pub fn bitcoin_units::amount::TooPreciseError::eq(&self, other: &bitcoin_units::amount::TooPreciseError) -> bool
+pub fn bitcoin_units::amount::TooPreciseError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::UnknownDenominationError::clone(&self) -> bitcoin_units::amount::UnknownDenominationError
+pub fn bitcoin_units::amount::UnknownDenominationError::eq(&self, other: &bitcoin_units::amount::UnknownDenominationError) -> bool
+pub fn bitcoin_units::amount::UnknownDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::UnknownDenominationError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_units::amount::serde::SerdeAmount::des_btc<'d, D: serde::de::Deserializer<'d>>(d: D, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::amount::serde::SerdeAmount::des_sat<'d, D: serde::de::Deserializer<'d>>(d: D, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::amount::serde::SerdeAmount::des_str<'d, D: serde::de::Deserializer<'d>>(d: D, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::amount::serde::SerdeAmount::ser_btc<S: serde::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::serde::SerdeAmount::ser_sat<S: serde::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::serde::SerdeAmount::ser_str<S: serde::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::serde::SerdeAmountForOpt::ser_btc_opt<S: serde::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::serde::SerdeAmountForOpt::ser_sat_opt<S: serde::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::serde::SerdeAmountForOpt::ser_str_opt<S: serde::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::serde::SerdeAmountForOpt::type_prefix(_: bitcoin_units::amount::serde::private::Token) -> &'static str
+pub fn bitcoin_units::amount::serde::as_btc::deserialize<'d, A: bitcoin_units::amount::serde::SerdeAmount, D: serde::de::Deserializer<'d>>(d: D) -> core::result::Result<A, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::amount::serde::as_btc::opt::deserialize<'d, A: bitcoin_units::amount::serde::SerdeAmountForOpt, D: serde::de::Deserializer<'d>>(d: D) -> core::result::Result<core::option::Option<A>, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::amount::serde::as_btc::opt::serialize<A: bitcoin_units::amount::serde::SerdeAmountForOpt, S: serde::ser::Serializer>(a: &core::option::Option<A>, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::serde::as_btc::serialize<A: bitcoin_units::amount::serde::SerdeAmount, S: serde::ser::Serializer>(a: &A, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::serde::as_sat::deserialize<'d, A: bitcoin_units::amount::serde::SerdeAmount, D: serde::de::Deserializer<'d>>(d: D) -> core::result::Result<A, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::amount::serde::as_sat::opt::deserialize<'d, A: bitcoin_units::amount::serde::SerdeAmountForOpt, D: serde::de::Deserializer<'d>>(d: D) -> core::result::Result<core::option::Option<A>, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::amount::serde::as_sat::opt::serialize<A: bitcoin_units::amount::serde::SerdeAmountForOpt, S: serde::ser::Serializer>(a: &core::option::Option<A>, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::serde::as_sat::serialize<A: bitcoin_units::amount::serde::SerdeAmount, S: serde::ser::Serializer>(a: &A, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::serde::as_str::deserialize<'d, A: bitcoin_units::amount::serde::SerdeAmount, D: serde::de::Deserializer<'d>>(d: D) -> core::result::Result<A, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::amount::serde::as_str::opt::deserialize<'d, A: bitcoin_units::amount::serde::SerdeAmountForOpt, D: serde::de::Deserializer<'d>>(d: D) -> core::result::Result<core::option::Option<A>, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::amount::serde::as_str::opt::serialize<A: bitcoin_units::amount::serde::SerdeAmountForOpt, S: serde::ser::Serializer>(a: &core::option::Option<A>, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::serde::as_str::serialize<A: bitcoin_units::amount::serde::SerdeAmount, S: serde::ser::Serializer>(a: &A, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::block::BlockHeight::add(self, rhs: &bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockHeight::add(self, rhs: bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockHeight::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_units::block::BlockHeight::checked_add(self, other: bitcoin_units::block::BlockHeightInterval) -> core::option::Option<Self>
+pub fn bitcoin_units::block::BlockHeight::checked_sub(self, other: Self) -> core::option::Option<bitcoin_units::block::BlockHeightInterval>
+pub fn bitcoin_units::block::BlockHeight::clone(&self) -> bitcoin_units::block::BlockHeight
+pub fn bitcoin_units::block::BlockHeight::cmp(&self, other: &bitcoin_units::block::BlockHeight) -> core::cmp::Ordering
+pub fn bitcoin_units::block::BlockHeight::deserialize<D>(d: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+pub fn bitcoin_units::block::BlockHeight::eq(&self, other: &bitcoin_units::block::BlockHeight) -> bool
+pub fn bitcoin_units::block::BlockHeight::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::block::BlockHeight::from(h: bitcoin_units::locktime::absolute::Height) -> Self
+pub fn bitcoin_units::block::BlockHeight::from(inner: u32) -> Self
+pub fn bitcoin_units::block::BlockHeight::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::block::BlockHeight::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::block::BlockHeight::partial_cmp(&self, other: &bitcoin_units::block::BlockHeight) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::block::BlockHeight::serialize<S>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+pub fn bitcoin_units::block::BlockHeight::sub(self, rhs: &bitcoin_units::block::BlockHeight) -> Self::Output
+pub fn bitcoin_units::block::BlockHeight::sub(self, rhs: &bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockHeight::sub(self, rhs: bitcoin_units::block::BlockHeight) -> Self::Output
+pub fn bitcoin_units::block::BlockHeight::sub(self, rhs: bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockHeight::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockHeight::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockHeight::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockHeightInterval::add(self, rhs: &bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockHeightInterval::add(self, rhs: bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockHeightInterval::add_assign(&mut self, rhs: &bitcoin_units::block::BlockHeightInterval)
+pub fn bitcoin_units::block::BlockHeightInterval::add_assign(&mut self, rhs: bitcoin_units::block::BlockHeightInterval)
+pub fn bitcoin_units::block::BlockHeightInterval::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_units::block::BlockHeightInterval::checked_add(self, other: Self) -> core::option::Option<Self>
+pub fn bitcoin_units::block::BlockHeightInterval::checked_sub(self, other: Self) -> core::option::Option<Self>
+pub fn bitcoin_units::block::BlockHeightInterval::clone(&self) -> bitcoin_units::block::BlockHeightInterval
+pub fn bitcoin_units::block::BlockHeightInterval::cmp(&self, other: &bitcoin_units::block::BlockHeightInterval) -> core::cmp::Ordering
+pub fn bitcoin_units::block::BlockHeightInterval::default() -> bitcoin_units::block::BlockHeightInterval
+pub fn bitcoin_units::block::BlockHeightInterval::deserialize<D>(d: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+pub fn bitcoin_units::block::BlockHeightInterval::eq(&self, other: &bitcoin_units::block::BlockHeightInterval) -> bool
+pub fn bitcoin_units::block::BlockHeightInterval::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::block::BlockHeightInterval::from(h: bitcoin_units::locktime::relative::NumberOfBlocks) -> Self
+pub fn bitcoin_units::block::BlockHeightInterval::from(inner: u32) -> Self
+pub fn bitcoin_units::block::BlockHeightInterval::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::block::BlockHeightInterval::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::block::BlockHeightInterval::partial_cmp(&self, other: &bitcoin_units::block::BlockHeightInterval) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::block::BlockHeightInterval::serialize<S>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+pub fn bitcoin_units::block::BlockHeightInterval::sub(self, rhs: &bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockHeightInterval::sub(self, rhs: bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockHeightInterval::sub_assign(&mut self, rhs: &bitcoin_units::block::BlockHeightInterval)
+pub fn bitcoin_units::block::BlockHeightInterval::sub_assign(&mut self, rhs: bitcoin_units::block::BlockHeightInterval)
+pub fn bitcoin_units::block::BlockHeightInterval::sum<I: core::iter::traits::iterator::Iterator<Item = Self>>(iter: I) -> Self
+pub fn bitcoin_units::block::BlockHeightInterval::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin_units::block::BlockHeightInterval>
+pub fn bitcoin_units::block::BlockHeightInterval::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockHeightInterval::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockHeightInterval::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockMtp::add(self, rhs: &bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockMtp::add(self, rhs: bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockMtp::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_units::block::BlockMtp::checked_add(self, other: bitcoin_units::block::BlockMtpInterval) -> core::option::Option<Self>
+pub fn bitcoin_units::block::BlockMtp::checked_sub(self, other: Self) -> core::option::Option<bitcoin_units::block::BlockMtpInterval>
+pub fn bitcoin_units::block::BlockMtp::clone(&self) -> bitcoin_units::block::BlockMtp
+pub fn bitcoin_units::block::BlockMtp::cmp(&self, other: &bitcoin_units::block::BlockMtp) -> core::cmp::Ordering
+pub fn bitcoin_units::block::BlockMtp::deserialize<D>(d: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+pub fn bitcoin_units::block::BlockMtp::eq(&self, other: &bitcoin_units::block::BlockMtp) -> bool
+pub fn bitcoin_units::block::BlockMtp::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::block::BlockMtp::from(h: bitcoin_units::locktime::absolute::MedianTimePast) -> Self
+pub fn bitcoin_units::block::BlockMtp::from(inner: u32) -> Self
+pub fn bitcoin_units::block::BlockMtp::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::block::BlockMtp::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::block::BlockMtp::new(timestamps: [bitcoin_units::BlockTime; 11]) -> Self
+pub fn bitcoin_units::block::BlockMtp::partial_cmp(&self, other: &bitcoin_units::block::BlockMtp) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::block::BlockMtp::serialize<S>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+pub fn bitcoin_units::block::BlockMtp::sub(self, rhs: &bitcoin_units::block::BlockMtp) -> Self::Output
+pub fn bitcoin_units::block::BlockMtp::sub(self, rhs: &bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockMtp::sub(self, rhs: bitcoin_units::block::BlockMtp) -> Self::Output
+pub fn bitcoin_units::block::BlockMtp::sub(self, rhs: bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockMtp::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockMtp::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockMtp::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockMtpInterval::add(self, rhs: &bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockMtpInterval::add(self, rhs: bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockMtpInterval::add_assign(&mut self, rhs: &bitcoin_units::block::BlockMtpInterval)
+pub fn bitcoin_units::block::BlockMtpInterval::add_assign(&mut self, rhs: bitcoin_units::block::BlockMtpInterval)
+pub fn bitcoin_units::block::BlockMtpInterval::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_units::block::BlockMtpInterval::checked_add(self, other: Self) -> core::option::Option<Self>
+pub fn bitcoin_units::block::BlockMtpInterval::checked_sub(self, other: Self) -> core::option::Option<Self>
+pub fn bitcoin_units::block::BlockMtpInterval::clone(&self) -> bitcoin_units::block::BlockMtpInterval
+pub fn bitcoin_units::block::BlockMtpInterval::cmp(&self, other: &bitcoin_units::block::BlockMtpInterval) -> core::cmp::Ordering
+pub fn bitcoin_units::block::BlockMtpInterval::default() -> bitcoin_units::block::BlockMtpInterval
+pub fn bitcoin_units::block::BlockMtpInterval::deserialize<D>(d: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+pub fn bitcoin_units::block::BlockMtpInterval::eq(&self, other: &bitcoin_units::block::BlockMtpInterval) -> bool
+pub fn bitcoin_units::block::BlockMtpInterval::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::block::BlockMtpInterval::from(h: bitcoin_units::locktime::relative::NumberOf512Seconds) -> Self
+pub fn bitcoin_units::block::BlockMtpInterval::from(inner: u32) -> Self
+pub fn bitcoin_units::block::BlockMtpInterval::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::block::BlockMtpInterval::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::block::BlockMtpInterval::partial_cmp(&self, other: &bitcoin_units::block::BlockMtpInterval) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::block::BlockMtpInterval::serialize<S>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+pub fn bitcoin_units::block::BlockMtpInterval::sub(self, rhs: &bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockMtpInterval::sub(self, rhs: bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockMtpInterval::sub_assign(&mut self, rhs: &bitcoin_units::block::BlockMtpInterval)
+pub fn bitcoin_units::block::BlockMtpInterval::sub_assign(&mut self, rhs: bitcoin_units::block::BlockMtpInterval)
+pub fn bitcoin_units::block::BlockMtpInterval::sum<I: core::iter::traits::iterator::Iterator<Item = Self>>(iter: I) -> Self
+pub fn bitcoin_units::block::BlockMtpInterval::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin_units::block::BlockMtpInterval>
+pub fn bitcoin_units::block::BlockMtpInterval::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockMtpInterval::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockMtpInterval::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::TooBigForRelativeHeightError::clone(&self) -> bitcoin_units::block::TooBigForRelativeHeightError
+pub fn bitcoin_units::block::TooBigForRelativeHeightError::eq(&self, other: &bitcoin_units::block::TooBigForRelativeHeightError) -> bool
+pub fn bitcoin_units::block::TooBigForRelativeHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::fee_rate::serde::OverflowError::clone(&self) -> bitcoin_units::fee_rate::serde::OverflowError
+pub fn bitcoin_units::fee_rate::serde::OverflowError::eq(&self, other: &bitcoin_units::fee_rate::serde::OverflowError) -> bool
+pub fn bitcoin_units::fee_rate::serde::OverflowError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::fee_rate::serde::OverflowError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::fee_rate::serde::as_sat_per_kwu_floor::deserialize<'d, D: serde::de::Deserializer<'d>>(d: D) -> core::result::Result<bitcoin_units::FeeRate, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::fee_rate::serde::as_sat_per_kwu_floor::opt::deserialize<'d, D: serde::de::Deserializer<'d>>(d: D) -> core::result::Result<core::option::Option<bitcoin_units::FeeRate>, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::fee_rate::serde::as_sat_per_kwu_floor::opt::serialize<S: serde::ser::Serializer>(f: &core::option::Option<bitcoin_units::FeeRate>, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::fee_rate::serde::as_sat_per_kwu_floor::serialize<S: serde::ser::Serializer>(f: &bitcoin_units::FeeRate, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::fee_rate::serde::as_sat_per_vb_ceil::deserialize<'d, D: serde::de::Deserializer<'d>>(d: D) -> core::result::Result<bitcoin_units::FeeRate, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::fee_rate::serde::as_sat_per_vb_ceil::opt::deserialize<'d, D: serde::de::Deserializer<'d>>(d: D) -> core::result::Result<core::option::Option<bitcoin_units::FeeRate>, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::fee_rate::serde::as_sat_per_vb_ceil::opt::serialize<S: serde::ser::Serializer>(f: &core::option::Option<bitcoin_units::FeeRate>, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::fee_rate::serde::as_sat_per_vb_ceil::serialize<S: serde::ser::Serializer>(f: &bitcoin_units::FeeRate, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::fee_rate::serde::as_sat_per_vb_floor::deserialize<'d, D: serde::de::Deserializer<'d>>(d: D) -> core::result::Result<bitcoin_units::FeeRate, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::fee_rate::serde::as_sat_per_vb_floor::opt::deserialize<'d, D: serde::de::Deserializer<'d>>(d: D) -> core::result::Result<core::option::Option<bitcoin_units::FeeRate>, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_units::fee_rate::serde::as_sat_per_vb_floor::opt::serialize<S: serde::ser::Serializer>(f: &core::option::Option<bitcoin_units::FeeRate>, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::fee_rate::serde::as_sat_per_vb_floor::serialize<S: serde::ser::Serializer>(f: &bitcoin_units::FeeRate, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::locktime::absolute::ConversionError::clone(&self) -> bitcoin_units::locktime::absolute::ConversionError
+pub fn bitcoin_units::locktime::absolute::ConversionError::eq(&self, other: &bitcoin_units::locktime::absolute::ConversionError) -> bool
+pub fn bitcoin_units::locktime::absolute::ConversionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::absolute::ConversionError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_units::locktime::absolute::Height::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_units::locktime::absolute::Height::clone(&self) -> bitcoin_units::locktime::absolute::Height
+pub fn bitcoin_units::locktime::absolute::Height::cmp(&self, other: &bitcoin_units::locktime::absolute::Height) -> core::cmp::Ordering
+pub fn bitcoin_units::locktime::absolute::Height::eq(&self, other: &bitcoin_units::locktime::absolute::Height) -> bool
+pub fn bitcoin_units::locktime::absolute::Height::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::absolute::Height::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::locktime::absolute::ParseHeightError>
+pub fn bitcoin_units::locktime::absolute::Height::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::locktime::absolute::Height::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::locktime::absolute::Height::is_satisfied_by(self, height: bitcoin_units::locktime::absolute::Height) -> bool
+pub fn bitcoin_units::locktime::absolute::Height::partial_cmp(&self, other: &bitcoin_units::locktime::absolute::Height) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::locktime::absolute::Height::try_from(h: bitcoin_units::block::BlockHeight) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::absolute::Height::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::absolute::Height::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::absolute::Height::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::clone(&self) -> bitcoin_units::locktime::absolute::MedianTimePast
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::cmp(&self, other: &bitcoin_units::locktime::absolute::MedianTimePast) -> core::cmp::Ordering
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::eq(&self, other: &bitcoin_units::locktime::absolute::MedianTimePast) -> bool
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::locktime::absolute::ParseTimeError>
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::is_satisfied_by(self, time: bitcoin_units::locktime::absolute::MedianTimePast) -> bool
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::new(timestamps: [bitcoin_units::BlockTime; 11]) -> core::result::Result<Self, bitcoin_units::locktime::absolute::ConversionError>
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::partial_cmp(&self, other: &bitcoin_units::locktime::absolute::MedianTimePast) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::try_from(h: bitcoin_units::block::BlockMtp) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::absolute::ParseHeightError::clone(&self) -> bitcoin_units::locktime::absolute::ParseHeightError
+pub fn bitcoin_units::locktime::absolute::ParseHeightError::eq(&self, other: &bitcoin_units::locktime::absolute::ParseHeightError) -> bool
+pub fn bitcoin_units::locktime::absolute::ParseHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::absolute::ParseHeightError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_units::locktime::absolute::ParseTimeError::clone(&self) -> bitcoin_units::locktime::absolute::ParseTimeError
+pub fn bitcoin_units::locktime::absolute::ParseTimeError::eq(&self, other: &bitcoin_units::locktime::absolute::ParseTimeError) -> bool
+pub fn bitcoin_units::locktime::absolute::ParseTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::absolute::ParseTimeError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_units::locktime::relative::InvalidHeightError::clone(&self) -> bitcoin_units::locktime::relative::InvalidHeightError
+pub fn bitcoin_units::locktime::relative::InvalidHeightError::eq(&self, other: &bitcoin_units::locktime::relative::InvalidHeightError) -> bool
+pub fn bitcoin_units::locktime::relative::InvalidHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::relative::InvalidTimeError::clone(&self) -> bitcoin_units::locktime::relative::InvalidTimeError
+pub fn bitcoin_units::locktime::relative::InvalidTimeError::eq(&self, other: &bitcoin_units::locktime::relative::InvalidTimeError) -> bool
+pub fn bitcoin_units::locktime::relative::InvalidTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::clone(&self) -> bitcoin_units::locktime::relative::NumberOf512Seconds
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::cmp(&self, other: &bitcoin_units::locktime::relative::NumberOf512Seconds) -> core::cmp::Ordering
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::default() -> bitcoin_units::locktime::relative::NumberOf512Seconds
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::eq(&self, other: &bitcoin_units::locktime::relative::NumberOf512Seconds) -> bool
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockMtp, utxo_mined_at: bitcoin_units::block::BlockMtp) -> core::result::Result<bool, bitcoin_units::locktime::relative::InvalidTimeError>
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::partial_cmp(&self, other: &bitcoin_units::locktime::relative::NumberOf512Seconds) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::clone(&self) -> bitcoin_units::locktime::relative::NumberOfBlocks
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::cmp(&self, other: &bitcoin_units::locktime::relative::NumberOfBlocks) -> core::cmp::Ordering
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::default() -> bitcoin_units::locktime::relative::NumberOfBlocks
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::eq(&self, other: &bitcoin_units::locktime::relative::NumberOfBlocks) -> bool
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from(value: u16) -> Self
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockHeight, utxo_mined_at: bitcoin_units::block::BlockHeight) -> core::result::Result<bool, bitcoin_units::locktime::relative::InvalidHeightError>
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::partial_cmp(&self, other: &bitcoin_units::locktime::relative::NumberOfBlocks) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::try_from(h: bitcoin_units::block::BlockHeightInterval) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::relative::TimeOverflowError::clone(&self) -> bitcoin_units::locktime::relative::TimeOverflowError
+pub fn bitcoin_units::locktime::relative::TimeOverflowError::eq(&self, other: &bitcoin_units::locktime::relative::TimeOverflowError) -> bool
+pub fn bitcoin_units::locktime::relative::TimeOverflowError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::parse::ParseIntError::as_ref(&self) -> &core::num::error::ParseIntError
+pub fn bitcoin_units::parse::ParseIntError::clone(&self) -> bitcoin_units::parse::ParseIntError
+pub fn bitcoin_units::parse::ParseIntError::eq(&self, other: &bitcoin_units::parse::ParseIntError) -> bool
+pub fn bitcoin_units::parse::ParseIntError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::parse::ParseIntError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_units::parse::PrefixedHexError::clone(&self) -> bitcoin_units::parse::PrefixedHexError
+pub fn bitcoin_units::parse::PrefixedHexError::eq(&self, other: &bitcoin_units::parse::PrefixedHexError) -> bool
+pub fn bitcoin_units::parse::PrefixedHexError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::parse::PrefixedHexError::from(e: bitcoin_units::parse::ParseIntError) -> Self
+pub fn bitcoin_units::parse::PrefixedHexError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::parse::PrefixedHexError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_units::parse::UnprefixedHexError::clone(&self) -> bitcoin_units::parse::UnprefixedHexError
+pub fn bitcoin_units::parse::UnprefixedHexError::eq(&self, other: &bitcoin_units::parse::UnprefixedHexError) -> bool
+pub fn bitcoin_units::parse::UnprefixedHexError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::parse::UnprefixedHexError::from(e: bitcoin_units::parse::ParseIntError) -> Self
+pub fn bitcoin_units::parse::UnprefixedHexError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::parse::UnprefixedHexError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_units::parse::hex_check_unprefixed(s: &str) -> core::result::Result<&str, bitcoin_units::parse::UnprefixedHexError>
+pub fn bitcoin_units::parse::hex_remove_prefix(s: &str) -> core::result::Result<&str, bitcoin_units::parse::PrefixedHexError>
+pub fn bitcoin_units::parse::hex_u128(s: &str) -> core::result::Result<u128, bitcoin_units::parse::ParseIntError>
+pub fn bitcoin_units::parse::hex_u128_prefixed(s: &str) -> core::result::Result<u128, bitcoin_units::parse::PrefixedHexError>
+pub fn bitcoin_units::parse::hex_u128_unchecked(s: &str) -> core::result::Result<u128, bitcoin_units::parse::ParseIntError>
+pub fn bitcoin_units::parse::hex_u128_unprefixed(s: &str) -> core::result::Result<u128, bitcoin_units::parse::UnprefixedHexError>
+pub fn bitcoin_units::parse::hex_u32(s: &str) -> core::result::Result<u32, bitcoin_units::parse::ParseIntError>
+pub fn bitcoin_units::parse::hex_u32_prefixed(s: &str) -> core::result::Result<u32, bitcoin_units::parse::PrefixedHexError>
+pub fn bitcoin_units::parse::hex_u32_unchecked(s: &str) -> core::result::Result<u32, bitcoin_units::parse::ParseIntError>
+pub fn bitcoin_units::parse::hex_u32_unprefixed(s: &str) -> core::result::Result<u32, bitcoin_units::parse::UnprefixedHexError>
+pub fn bitcoin_units::parse::int_from_box<T: bitcoin_units::parse::Integer>(s: alloc::boxed::Box<str>) -> core::result::Result<T, bitcoin_units::parse::ParseIntError>
+pub fn bitcoin_units::parse::int_from_str<T: bitcoin_units::parse::Integer>(s: &str) -> core::result::Result<T, bitcoin_units::parse::ParseIntError>
+pub fn bitcoin_units::parse::int_from_string<T: bitcoin_units::parse::Integer>(s: alloc::string::String) -> core::result::Result<T, bitcoin_units::parse::ParseIntError>
+pub fn core::num::error::ParseIntError::from(value: bitcoin_units::parse::ParseIntError) -> Self
+pub fn i64::mul(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
+pub fn i64::mul(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output
+pub fn i64::mul(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
+pub fn i64::mul(self, rhs: bitcoin_units::SignedAmount) -> Self::Output
+pub fn u32::from(height: bitcoin_units::block::BlockHeight) -> Self
+pub fn u32::from(height: bitcoin_units::block::BlockHeightInterval) -> Self
+pub fn u32::from(height: bitcoin_units::block::BlockMtp) -> Self
+pub fn u32::from(height: bitcoin_units::block::BlockMtpInterval) -> Self
+pub fn u32::from(t: bitcoin_units::BlockTime) -> Self
+pub fn u64::from(value: bitcoin_units::Weight) -> Self
+pub fn u64::mul(self, rhs: &bitcoin_units::Amount) -> Self::Output
+pub fn u64::mul(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Amount>) -> Self::Output
+pub fn u64::mul(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn u64::mul(self, rhs: bitcoin_units::Amount) -> Self::Output
+pub fn u64::mul(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Amount>) -> Self::Output
+pub fn u64::mul(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub mod bitcoin_units
+pub mod bitcoin_units::amount
+pub mod bitcoin_units::amount::serde
+pub mod bitcoin_units::amount::serde::as_btc
+pub mod bitcoin_units::amount::serde::as_btc::opt
+pub mod bitcoin_units::amount::serde::as_sat
+pub mod bitcoin_units::amount::serde::as_sat::opt
+pub mod bitcoin_units::amount::serde::as_str
+pub mod bitcoin_units::amount::serde::as_str::opt
+pub mod bitcoin_units::block
+pub mod bitcoin_units::fee
+pub mod bitcoin_units::fee_rate
+pub mod bitcoin_units::fee_rate::serde
+pub mod bitcoin_units::fee_rate::serde::as_sat_per_kwu_floor
+pub mod bitcoin_units::fee_rate::serde::as_sat_per_kwu_floor::opt
+pub mod bitcoin_units::fee_rate::serde::as_sat_per_vb_ceil
+pub mod bitcoin_units::fee_rate::serde::as_sat_per_vb_ceil::opt
+pub mod bitcoin_units::fee_rate::serde::as_sat_per_vb_floor
+pub mod bitcoin_units::fee_rate::serde::as_sat_per_vb_floor::opt
+pub mod bitcoin_units::locktime
+pub mod bitcoin_units::locktime::absolute
+pub mod bitcoin_units::locktime::relative
+pub mod bitcoin_units::parse
+pub mod bitcoin_units::time
+pub mod bitcoin_units::weight
+pub struct bitcoin_units::Amount(_)
+pub struct bitcoin_units::BlockHeight(_)
+pub struct bitcoin_units::BlockHeightInterval(_)
+pub struct bitcoin_units::BlockMtp(_)
+pub struct bitcoin_units::BlockMtpInterval(_)
+pub struct bitcoin_units::BlockTime(_)
+pub struct bitcoin_units::FeeRate(_)
+pub struct bitcoin_units::SignedAmount(_)
+pub struct bitcoin_units::Weight(_)
+pub struct bitcoin_units::amount::Amount(_)
+pub struct bitcoin_units::amount::Display
+pub struct bitcoin_units::amount::InputTooLargeError
+pub struct bitcoin_units::amount::InvalidCharacterError
+pub struct bitcoin_units::amount::MissingDigitsError
+pub struct bitcoin_units::amount::OutOfRangeError
+pub struct bitcoin_units::amount::ParseAmountError(_)
+pub struct bitcoin_units::amount::ParseError(_)
+pub struct bitcoin_units::amount::SignedAmount(_)
+pub struct bitcoin_units::amount::TooPreciseError
+pub struct bitcoin_units::block::BlockHeight(_)
+pub struct bitcoin_units::block::BlockHeightInterval(_)
+pub struct bitcoin_units::block::BlockMtp(_)
+pub struct bitcoin_units::block::BlockMtpInterval(_)
+pub struct bitcoin_units::block::TooBigForRelativeHeightError(_)
+pub struct bitcoin_units::fee_rate::FeeRate(_)
+pub struct bitcoin_units::locktime::absolute::Height(_)
+pub struct bitcoin_units::locktime::absolute::MedianTimePast(_)
+pub struct bitcoin_units::locktime::absolute::ParseHeightError(_)
+pub struct bitcoin_units::locktime::absolute::ParseTimeError(_)
+pub struct bitcoin_units::locktime::relative::InvalidHeightError
+pub struct bitcoin_units::locktime::relative::InvalidTimeError
+pub struct bitcoin_units::locktime::relative::NumberOf512Seconds(_)
+pub struct bitcoin_units::locktime::relative::NumberOfBlocks(_)
+pub struct bitcoin_units::locktime::relative::TimeOverflowError
+pub struct bitcoin_units::parse::PrefixedHexError(_)
+pub struct bitcoin_units::parse::UnprefixedHexError(_)
+pub struct bitcoin_units::time::BlockTime(_)
+pub struct bitcoin_units::weight::Weight(_)
+pub trait bitcoin_units::CheckedSum<R>: bitcoin_units::sealed::Sealed<R>
+pub trait bitcoin_units::amount::serde::SerdeAmount: core::marker::Copy + core::marker::Sized
+pub trait bitcoin_units::amount::serde::SerdeAmountForOpt: core::marker::Copy + core::marker::Sized + bitcoin_units::amount::serde::SerdeAmount
+pub trait bitcoin_units::parse::Integer: core::str::traits::FromStr<Err = core::num::error::ParseIntError> + core::convert::TryFrom<i8> + core::marker::Sized + bitcoin_units::parse::sealed::Sealed
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Add<bitcoin_units::NumOpResult<bitcoin_units::Amount>>>::Output
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Add>::Output
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<bitcoin_units::FeeRate>>::Output
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>>>::Output
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::Weight>>>::Output
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<bitcoin_units::Weight>>::Output
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<u64>>::Output
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div>::Output
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Mul<u64>>::Output
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Rem<u64>>::Output
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Sub<bitcoin_units::NumOpResult<bitcoin_units::Amount>>>::Output
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Sub>::Output
+pub type &bitcoin_units::FeeRate::Output = <bitcoin_units::FeeRate as core::ops::arith::Add>::Output
+pub type &bitcoin_units::FeeRate::Output = <bitcoin_units::FeeRate as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output
+pub type &bitcoin_units::FeeRate::Output = <bitcoin_units::FeeRate as core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::Weight>>>::Output
+pub type &bitcoin_units::FeeRate::Output = <bitcoin_units::FeeRate as core::ops::arith::Mul<bitcoin_units::Weight>>::Output
+pub type &bitcoin_units::FeeRate::Output = <bitcoin_units::FeeRate as core::ops::arith::Sub>::Output
+pub type &bitcoin_units::NumOpResult<T>::Output = <bitcoin_units::NumOpResult<T> as core::ops::arith::Add<T>>::Output
+pub type &bitcoin_units::NumOpResult<T>::Output = <bitcoin_units::NumOpResult<T> as core::ops::arith::Add>::Output
+pub type &bitcoin_units::NumOpResult<T>::Output = <bitcoin_units::NumOpResult<T> as core::ops::arith::Sub<T>>::Output
+pub type &bitcoin_units::NumOpResult<T>::Output = <bitcoin_units::NumOpResult<T> as core::ops::arith::Sub>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::FeeRate>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::Weight>>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::Weight>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<u64>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Mul<u64>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Rem<u64>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::Output = <bitcoin_units::NumOpResult<bitcoin_units::FeeRate> as core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::Weight>>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::Output = <bitcoin_units::NumOpResult<bitcoin_units::FeeRate> as core::ops::arith::Mul<bitcoin_units::Weight>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Mul<i64>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Rem<i64>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::Weight>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Weight> as core::ops::arith::Mul<bitcoin_units::FeeRate>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::Weight>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Weight> as core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>>>::Output
+pub type &bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Add<bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>>>::Output
+pub type &bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Add>::Output
+pub type &bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output
+pub type &bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Div<i64>>::Output
+pub type &bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Div>::Output
+pub type &bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Mul<i64>>::Output
+pub type &bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Rem<i64>>::Output
+pub type &bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Sub<bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>>>::Output
+pub type &bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Sub>::Output
+pub type &bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Add>::Output
+pub type &bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output
+pub type &bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Div<u64>>::Output
+pub type &bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Div>::Output
+pub type &bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Mul<bitcoin_units::FeeRate>>::Output
+pub type &bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>>>::Output
+pub type &bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Mul<u64>>::Output
+pub type &bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Rem<u64>>::Output
+pub type &bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Rem>::Output
+pub type &bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Sub>::Output
+pub type &bitcoin_units::block::BlockHeight::Output = <bitcoin_units::block::BlockHeight as core::ops::arith::Add<bitcoin_units::block::BlockHeightInterval>>::Output
+pub type &bitcoin_units::block::BlockHeight::Output = <bitcoin_units::block::BlockHeight as core::ops::arith::Sub<bitcoin_units::block::BlockHeightInterval>>::Output
+pub type &bitcoin_units::block::BlockHeight::Output = <bitcoin_units::block::BlockHeight as core::ops::arith::Sub>::Output
+pub type &bitcoin_units::block::BlockHeightInterval::Output = <bitcoin_units::block::BlockHeightInterval as core::ops::arith::Add>::Output
+pub type &bitcoin_units::block::BlockHeightInterval::Output = <bitcoin_units::block::BlockHeightInterval as core::ops::arith::Sub>::Output
+pub type &bitcoin_units::block::BlockMtp::Output = <bitcoin_units::block::BlockMtp as core::ops::arith::Add<bitcoin_units::block::BlockMtpInterval>>::Output
+pub type &bitcoin_units::block::BlockMtp::Output = <bitcoin_units::block::BlockMtp as core::ops::arith::Sub<bitcoin_units::block::BlockMtpInterval>>::Output
+pub type &bitcoin_units::block::BlockMtp::Output = <bitcoin_units::block::BlockMtp as core::ops::arith::Sub>::Output
+pub type &bitcoin_units::block::BlockMtpInterval::Output = <bitcoin_units::block::BlockMtpInterval as core::ops::arith::Add>::Output
+pub type &bitcoin_units::block::BlockMtpInterval::Output = <bitcoin_units::block::BlockMtpInterval as core::ops::arith::Sub>::Output
+pub type &i64::Output = <i64 as core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>>>::Output
+pub type &i64::Output = <i64 as core::ops::arith::Mul<bitcoin_units::SignedAmount>>::Output
+pub type &u64::Output = <u64 as core::ops::arith::Mul<bitcoin_units::Amount>>::Output
+pub type &u64::Output = <u64 as core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::Amount>>>::Output
+pub type &u64::Output = <u64 as core::ops::arith::Mul<bitcoin_units::Weight>>::Output
+pub type bitcoin_units::Amount::Err = bitcoin_units::amount::ParseError
+pub type bitcoin_units::Amount::Error = bitcoin_units::amount::OutOfRangeError
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Add<bitcoin_units::NumOpResult<bitcoin_units::Amount>>>::Output
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Add>::Output
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<bitcoin_units::FeeRate>>::Output
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>>>::Output
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::Weight>>>::Output
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<bitcoin_units::Weight>>::Output
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<u64>>::Output
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div>::Output
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Mul<u64>>::Output
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Rem<u64>>::Output
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Sub<bitcoin_units::NumOpResult<bitcoin_units::Amount>>>::Output
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Sub>::Output
+pub type bitcoin_units::Amount::Output = bitcoin_units::Amount
+pub type bitcoin_units::Amount::Output = bitcoin_units::NumOpResult<bitcoin_units::Amount>
+pub type bitcoin_units::Amount::Output = bitcoin_units::NumOpResult<bitcoin_units::FeeRate>
+pub type bitcoin_units::Amount::Output = bitcoin_units::NumOpResult<bitcoin_units::Weight>
+pub type bitcoin_units::Amount::Output = bitcoin_units::NumOpResult<u64>
+pub type bitcoin_units::FeeRate::Output = <bitcoin_units::FeeRate as core::ops::arith::Add>::Output
+pub type bitcoin_units::FeeRate::Output = <bitcoin_units::FeeRate as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output
+pub type bitcoin_units::FeeRate::Output = <bitcoin_units::FeeRate as core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::Weight>>>::Output
+pub type bitcoin_units::FeeRate::Output = <bitcoin_units::FeeRate as core::ops::arith::Mul<bitcoin_units::Weight>>::Output
+pub type bitcoin_units::FeeRate::Output = <bitcoin_units::FeeRate as core::ops::arith::Sub>::Output
+pub type bitcoin_units::FeeRate::Output = bitcoin_units::FeeRate
+pub type bitcoin_units::FeeRate::Output = bitcoin_units::NumOpResult<bitcoin_units::Amount>
+pub type bitcoin_units::NumOpResult<T>::Output = <bitcoin_units::NumOpResult<T> as core::ops::arith::Add<T>>::Output
+pub type bitcoin_units::NumOpResult<T>::Output = <bitcoin_units::NumOpResult<T> as core::ops::arith::Add>::Output
+pub type bitcoin_units::NumOpResult<T>::Output = <bitcoin_units::NumOpResult<T> as core::ops::arith::Sub<T>>::Output
+pub type bitcoin_units::NumOpResult<T>::Output = <bitcoin_units::NumOpResult<T> as core::ops::arith::Sub>::Output
+pub type bitcoin_units::NumOpResult<T>::Output = bitcoin_units::NumOpResult<T>
+pub type bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::FeeRate>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::Weight>>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::Weight>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<u64>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Mul<u64>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Rem<u64>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::NumOpResult<bitcoin_units::Amount>
+pub type bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::NumOpResult<bitcoin_units::FeeRate>
+pub type bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::NumOpResult<bitcoin_units::Weight>
+pub type bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::Output = <bitcoin_units::NumOpResult<bitcoin_units::FeeRate> as core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::Weight>>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::Output = <bitcoin_units::NumOpResult<bitcoin_units::FeeRate> as core::ops::arith::Mul<bitcoin_units::Weight>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::Output = bitcoin_units::NumOpResult<bitcoin_units::Amount>
+pub type bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Mul<i64>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Rem<i64>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::Output = bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+pub type bitcoin_units::NumOpResult<bitcoin_units::Weight>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Weight> as core::ops::arith::Mul<bitcoin_units::FeeRate>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::Weight>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Weight> as core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::Weight>::Output = bitcoin_units::NumOpResult<bitcoin_units::Amount>
+pub type bitcoin_units::SignedAmount::Err = bitcoin_units::amount::ParseError
+pub type bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Add<bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>>>::Output
+pub type bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Add>::Output
+pub type bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output
+pub type bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Div<i64>>::Output
+pub type bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Div>::Output
+pub type bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Mul<i64>>::Output
+pub type bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Rem<i64>>::Output
+pub type bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Sub<bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>>>::Output
+pub type bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Sub>::Output
+pub type bitcoin_units::SignedAmount::Output = bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+pub type bitcoin_units::SignedAmount::Output = bitcoin_units::NumOpResult<i64>
+pub type bitcoin_units::SignedAmount::Output = bitcoin_units::SignedAmount
+pub type bitcoin_units::Weight::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::Weight::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Add>::Output
+pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output
+pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Div<u64>>::Output
+pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Div>::Output
+pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Mul<bitcoin_units::FeeRate>>::Output
+pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>>>::Output
+pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Mul<u64>>::Output
+pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Rem<u64>>::Output
+pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Rem>::Output
+pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Sub>::Output
+pub type bitcoin_units::Weight::Output = bitcoin_units::NumOpResult<bitcoin_units::Amount>
+pub type bitcoin_units::Weight::Output = bitcoin_units::Weight
+pub type bitcoin_units::Weight::Output = u64
+pub type bitcoin_units::amount::Denomination::Err = bitcoin_units::amount::ParseDenominationError
+pub type bitcoin_units::block::BlockHeight::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockHeight::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockHeight::Output = <bitcoin_units::block::BlockHeight as core::ops::arith::Add<bitcoin_units::block::BlockHeightInterval>>::Output
+pub type bitcoin_units::block::BlockHeight::Output = <bitcoin_units::block::BlockHeight as core::ops::arith::Sub<bitcoin_units::block::BlockHeightInterval>>::Output
+pub type bitcoin_units::block::BlockHeight::Output = <bitcoin_units::block::BlockHeight as core::ops::arith::Sub>::Output
+pub type bitcoin_units::block::BlockHeight::Output = bitcoin_units::block::BlockHeight
+pub type bitcoin_units::block::BlockHeight::Output = bitcoin_units::block::BlockHeightInterval
+pub type bitcoin_units::block::BlockHeightInterval::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockHeightInterval::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockHeightInterval::Output = <bitcoin_units::block::BlockHeightInterval as core::ops::arith::Add>::Output
+pub type bitcoin_units::block::BlockHeightInterval::Output = <bitcoin_units::block::BlockHeightInterval as core::ops::arith::Sub>::Output
+pub type bitcoin_units::block::BlockHeightInterval::Output = bitcoin_units::block::BlockHeightInterval
+pub type bitcoin_units::block::BlockMtp::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockMtp::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockMtp::Output = <bitcoin_units::block::BlockMtp as core::ops::arith::Add<bitcoin_units::block::BlockMtpInterval>>::Output
+pub type bitcoin_units::block::BlockMtp::Output = <bitcoin_units::block::BlockMtp as core::ops::arith::Sub<bitcoin_units::block::BlockMtpInterval>>::Output
+pub type bitcoin_units::block::BlockMtp::Output = <bitcoin_units::block::BlockMtp as core::ops::arith::Sub>::Output
+pub type bitcoin_units::block::BlockMtp::Output = bitcoin_units::block::BlockMtp
+pub type bitcoin_units::block::BlockMtp::Output = bitcoin_units::block::BlockMtpInterval
+pub type bitcoin_units::block::BlockMtpInterval::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockMtpInterval::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockMtpInterval::Output = <bitcoin_units::block::BlockMtpInterval as core::ops::arith::Add>::Output
+pub type bitcoin_units::block::BlockMtpInterval::Output = <bitcoin_units::block::BlockMtpInterval as core::ops::arith::Sub>::Output
+pub type bitcoin_units::block::BlockMtpInterval::Output = bitcoin_units::block::BlockMtpInterval
+pub type bitcoin_units::locktime::absolute::Height::Err = bitcoin_units::locktime::absolute::ParseHeightError
+pub type bitcoin_units::locktime::absolute::Height::Error = bitcoin_units::locktime::absolute::ConversionError
+pub type bitcoin_units::locktime::absolute::Height::Error = bitcoin_units::locktime::absolute::ParseHeightError
+pub type bitcoin_units::locktime::absolute::MedianTimePast::Err = bitcoin_units::locktime::absolute::ParseTimeError
+pub type bitcoin_units::locktime::absolute::MedianTimePast::Error = bitcoin_units::locktime::absolute::ConversionError
+pub type bitcoin_units::locktime::absolute::MedianTimePast::Error = bitcoin_units::locktime::absolute::ParseTimeError
+pub type bitcoin_units::locktime::relative::NumberOf512Seconds::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::locktime::relative::NumberOf512Seconds::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::locktime::relative::NumberOfBlocks::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::locktime::relative::NumberOfBlocks::Error = bitcoin_units::block::TooBigForRelativeHeightError
+pub type bitcoin_units::locktime::relative::NumberOfBlocks::Error = bitcoin_units::parse::ParseIntError
+pub type i64::Output = <i64 as core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>>>::Output
+pub type i64::Output = <i64 as core::ops::arith::Mul<bitcoin_units::SignedAmount>>::Output
+pub type i64::Output = bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+pub type u64::Output = <u64 as core::ops::arith::Mul<bitcoin_units::Amount>>::Output
+pub type u64::Output = <u64 as core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::Amount>>>::Output
+pub type u64::Output = <u64 as core::ops::arith::Mul<bitcoin_units::Weight>>::Output
+pub type u64::Output = bitcoin_units::NumOpResult<bitcoin_units::Amount>
+pub type u64::Output = bitcoin_units::Weight

--- a/api/units/alloc-only.txt
+++ b/api/units/alloc-only.txt
@@ -1,0 +1,2028 @@
+#[non_exhaustive] pub enum bitcoin_units::MathOp
+#[non_exhaustive] pub enum bitcoin_units::amount::Denomination
+#[non_exhaustive] pub enum bitcoin_units::amount::ParseDenominationError
+#[non_exhaustive] pub struct bitcoin_units::NumOpError(_)
+#[non_exhaustive] pub struct bitcoin_units::amount::MissingDenominationError
+#[non_exhaustive] pub struct bitcoin_units::amount::PossiblyConfusingDenominationError(_)
+#[non_exhaustive] pub struct bitcoin_units::amount::UnknownDenominationError(_)
+#[non_exhaustive] pub struct bitcoin_units::locktime::absolute::ConversionError
+#[non_exhaustive] pub struct bitcoin_units::parse::ParseIntError
+impl bitcoin_units::Amount
+impl bitcoin_units::BlockTime
+impl bitcoin_units::FeeRate
+impl bitcoin_units::MathOp
+impl bitcoin_units::NumOpError
+impl bitcoin_units::SignedAmount
+impl bitcoin_units::Weight
+impl bitcoin_units::amount::Denomination
+impl bitcoin_units::amount::Display
+impl bitcoin_units::amount::OutOfRangeError
+impl bitcoin_units::block::BlockHeight
+impl bitcoin_units::block::BlockHeightInterval
+impl bitcoin_units::block::BlockMtp
+impl bitcoin_units::block::BlockMtpInterval
+impl bitcoin_units::locktime::absolute::Height
+impl bitcoin_units::locktime::absolute::MedianTimePast
+impl bitcoin_units::locktime::relative::NumberOf512Seconds
+impl bitcoin_units::locktime::relative::NumberOfBlocks
+impl bitcoin_units::parse::Integer for i128
+impl bitcoin_units::parse::Integer for i16
+impl bitcoin_units::parse::Integer for i32
+impl bitcoin_units::parse::Integer for i64
+impl bitcoin_units::parse::Integer for i8
+impl bitcoin_units::parse::Integer for u128
+impl bitcoin_units::parse::Integer for u16
+impl bitcoin_units::parse::Integer for u32
+impl bitcoin_units::parse::Integer for u64
+impl bitcoin_units::parse::Integer for u8
+impl core::clone::Clone for bitcoin_units::Amount
+impl core::clone::Clone for bitcoin_units::BlockTime
+impl core::clone::Clone for bitcoin_units::FeeRate
+impl core::clone::Clone for bitcoin_units::MathOp
+impl core::clone::Clone for bitcoin_units::NumOpError
+impl core::clone::Clone for bitcoin_units::SignedAmount
+impl core::clone::Clone for bitcoin_units::Weight
+impl core::clone::Clone for bitcoin_units::amount::Denomination
+impl core::clone::Clone for bitcoin_units::amount::Display
+impl core::clone::Clone for bitcoin_units::amount::InputTooLargeError
+impl core::clone::Clone for bitcoin_units::amount::InvalidCharacterError
+impl core::clone::Clone for bitcoin_units::amount::MissingDenominationError
+impl core::clone::Clone for bitcoin_units::amount::MissingDigitsError
+impl core::clone::Clone for bitcoin_units::amount::OutOfRangeError
+impl core::clone::Clone for bitcoin_units::amount::ParseAmountError
+impl core::clone::Clone for bitcoin_units::amount::ParseDenominationError
+impl core::clone::Clone for bitcoin_units::amount::ParseError
+impl core::clone::Clone for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::clone::Clone for bitcoin_units::amount::TooPreciseError
+impl core::clone::Clone for bitcoin_units::amount::UnknownDenominationError
+impl core::clone::Clone for bitcoin_units::block::BlockHeight
+impl core::clone::Clone for bitcoin_units::block::BlockHeightInterval
+impl core::clone::Clone for bitcoin_units::block::BlockMtp
+impl core::clone::Clone for bitcoin_units::block::BlockMtpInterval
+impl core::clone::Clone for bitcoin_units::block::TooBigForRelativeHeightError
+impl core::clone::Clone for bitcoin_units::locktime::absolute::ConversionError
+impl core::clone::Clone for bitcoin_units::locktime::absolute::Height
+impl core::clone::Clone for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::clone::Clone for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::clone::Clone for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::clone::Clone for bitcoin_units::locktime::relative::InvalidHeightError
+impl core::clone::Clone for bitcoin_units::locktime::relative::InvalidTimeError
+impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::clone::Clone for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::clone::Clone for bitcoin_units::parse::ParseIntError
+impl core::clone::Clone for bitcoin_units::parse::PrefixedHexError
+impl core::clone::Clone for bitcoin_units::parse::UnprefixedHexError
+impl core::cmp::Eq for bitcoin_units::Amount
+impl core::cmp::Eq for bitcoin_units::BlockTime
+impl core::cmp::Eq for bitcoin_units::FeeRate
+impl core::cmp::Eq for bitcoin_units::MathOp
+impl core::cmp::Eq for bitcoin_units::NumOpError
+impl core::cmp::Eq for bitcoin_units::SignedAmount
+impl core::cmp::Eq for bitcoin_units::Weight
+impl core::cmp::Eq for bitcoin_units::amount::Denomination
+impl core::cmp::Eq for bitcoin_units::amount::InputTooLargeError
+impl core::cmp::Eq for bitcoin_units::amount::InvalidCharacterError
+impl core::cmp::Eq for bitcoin_units::amount::MissingDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::MissingDigitsError
+impl core::cmp::Eq for bitcoin_units::amount::OutOfRangeError
+impl core::cmp::Eq for bitcoin_units::amount::ParseAmountError
+impl core::cmp::Eq for bitcoin_units::amount::ParseDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::ParseError
+impl core::cmp::Eq for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::TooPreciseError
+impl core::cmp::Eq for bitcoin_units::amount::UnknownDenominationError
+impl core::cmp::Eq for bitcoin_units::block::BlockHeight
+impl core::cmp::Eq for bitcoin_units::block::BlockHeightInterval
+impl core::cmp::Eq for bitcoin_units::block::BlockMtp
+impl core::cmp::Eq for bitcoin_units::block::BlockMtpInterval
+impl core::cmp::Eq for bitcoin_units::block::TooBigForRelativeHeightError
+impl core::cmp::Eq for bitcoin_units::locktime::absolute::ConversionError
+impl core::cmp::Eq for bitcoin_units::locktime::absolute::Height
+impl core::cmp::Eq for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::cmp::Eq for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::cmp::Eq for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::cmp::Eq for bitcoin_units::locktime::relative::InvalidHeightError
+impl core::cmp::Eq for bitcoin_units::locktime::relative::InvalidTimeError
+impl core::cmp::Eq for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::cmp::Eq for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::cmp::Eq for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::cmp::Eq for bitcoin_units::parse::ParseIntError
+impl core::cmp::Eq for bitcoin_units::parse::PrefixedHexError
+impl core::cmp::Eq for bitcoin_units::parse::UnprefixedHexError
+impl core::cmp::Ord for bitcoin_units::Amount
+impl core::cmp::Ord for bitcoin_units::BlockTime
+impl core::cmp::Ord for bitcoin_units::FeeRate
+impl core::cmp::Ord for bitcoin_units::SignedAmount
+impl core::cmp::Ord for bitcoin_units::Weight
+impl core::cmp::Ord for bitcoin_units::block::BlockHeight
+impl core::cmp::Ord for bitcoin_units::block::BlockHeightInterval
+impl core::cmp::Ord for bitcoin_units::block::BlockMtp
+impl core::cmp::Ord for bitcoin_units::block::BlockMtpInterval
+impl core::cmp::Ord for bitcoin_units::locktime::absolute::Height
+impl core::cmp::Ord for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::cmp::Ord for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::cmp::Ord for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::cmp::PartialEq for bitcoin_units::Amount
+impl core::cmp::PartialEq for bitcoin_units::BlockTime
+impl core::cmp::PartialEq for bitcoin_units::FeeRate
+impl core::cmp::PartialEq for bitcoin_units::MathOp
+impl core::cmp::PartialEq for bitcoin_units::NumOpError
+impl core::cmp::PartialEq for bitcoin_units::SignedAmount
+impl core::cmp::PartialEq for bitcoin_units::Weight
+impl core::cmp::PartialEq for bitcoin_units::amount::Denomination
+impl core::cmp::PartialEq for bitcoin_units::amount::InputTooLargeError
+impl core::cmp::PartialEq for bitcoin_units::amount::InvalidCharacterError
+impl core::cmp::PartialEq for bitcoin_units::amount::MissingDenominationError
+impl core::cmp::PartialEq for bitcoin_units::amount::MissingDigitsError
+impl core::cmp::PartialEq for bitcoin_units::amount::OutOfRangeError
+impl core::cmp::PartialEq for bitcoin_units::amount::ParseAmountError
+impl core::cmp::PartialEq for bitcoin_units::amount::ParseDenominationError
+impl core::cmp::PartialEq for bitcoin_units::amount::ParseError
+impl core::cmp::PartialEq for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::cmp::PartialEq for bitcoin_units::amount::TooPreciseError
+impl core::cmp::PartialEq for bitcoin_units::amount::UnknownDenominationError
+impl core::cmp::PartialEq for bitcoin_units::block::BlockHeight
+impl core::cmp::PartialEq for bitcoin_units::block::BlockHeightInterval
+impl core::cmp::PartialEq for bitcoin_units::block::BlockMtp
+impl core::cmp::PartialEq for bitcoin_units::block::BlockMtpInterval
+impl core::cmp::PartialEq for bitcoin_units::block::TooBigForRelativeHeightError
+impl core::cmp::PartialEq for bitcoin_units::locktime::absolute::ConversionError
+impl core::cmp::PartialEq for bitcoin_units::locktime::absolute::Height
+impl core::cmp::PartialEq for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::cmp::PartialEq for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::cmp::PartialEq for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::InvalidHeightError
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::InvalidTimeError
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::cmp::PartialEq for bitcoin_units::parse::ParseIntError
+impl core::cmp::PartialEq for bitcoin_units::parse::PrefixedHexError
+impl core::cmp::PartialEq for bitcoin_units::parse::UnprefixedHexError
+impl core::cmp::PartialOrd for bitcoin_units::Amount
+impl core::cmp::PartialOrd for bitcoin_units::BlockTime
+impl core::cmp::PartialOrd for bitcoin_units::FeeRate
+impl core::cmp::PartialOrd for bitcoin_units::SignedAmount
+impl core::cmp::PartialOrd for bitcoin_units::Weight
+impl core::cmp::PartialOrd for bitcoin_units::block::BlockHeight
+impl core::cmp::PartialOrd for bitcoin_units::block::BlockHeightInterval
+impl core::cmp::PartialOrd for bitcoin_units::block::BlockMtp
+impl core::cmp::PartialOrd for bitcoin_units::block::BlockMtpInterval
+impl core::cmp::PartialOrd for bitcoin_units::locktime::absolute::Height
+impl core::cmp::PartialOrd for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::cmp::PartialOrd for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::cmp::PartialOrd for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::convert::AsRef<core::num::error::ParseIntError> for bitcoin_units::parse::ParseIntError
+impl core::convert::From<&bitcoin_units::Amount> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::convert::From<&bitcoin_units::SignedAmount> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::convert::From<bitcoin_units::Amount> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::convert::From<bitcoin_units::Amount> for bitcoin_units::SignedAmount
+impl core::convert::From<bitcoin_units::BlockTime> for u32
+impl core::convert::From<bitcoin_units::SignedAmount> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::convert::From<bitcoin_units::Weight> for u64
+impl core::convert::From<bitcoin_units::amount::InputTooLargeError> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::InputTooLargeError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::InvalidCharacterError> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::InvalidCharacterError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::MissingDigitsError> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::MissingDigitsError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::OutOfRangeError> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::OutOfRangeError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::ParseAmountError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::ParseDenominationError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::TooPreciseError> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::TooPreciseError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::block::BlockHeight> for u32
+impl core::convert::From<bitcoin_units::block::BlockHeightInterval> for u32
+impl core::convert::From<bitcoin_units::block::BlockMtp> for u32
+impl core::convert::From<bitcoin_units::block::BlockMtpInterval> for u32
+impl core::convert::From<bitcoin_units::locktime::absolute::Height> for bitcoin_units::block::BlockHeight
+impl core::convert::From<bitcoin_units::locktime::absolute::MedianTimePast> for bitcoin_units::block::BlockMtp
+impl core::convert::From<bitcoin_units::locktime::relative::NumberOf512Seconds> for bitcoin_units::block::BlockMtpInterval
+impl core::convert::From<bitcoin_units::locktime::relative::NumberOfBlocks> for bitcoin_units::block::BlockHeightInterval
+impl core::convert::From<bitcoin_units::parse::ParseIntError> for bitcoin_units::parse::PrefixedHexError
+impl core::convert::From<bitcoin_units::parse::ParseIntError> for bitcoin_units::parse::UnprefixedHexError
+impl core::convert::From<bitcoin_units::parse::ParseIntError> for core::num::error::ParseIntError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::ParseDenominationError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::ParseError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::parse::PrefixedHexError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::parse::UnprefixedHexError
+impl core::convert::From<u16> for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::convert::From<u32> for bitcoin_units::BlockTime
+impl core::convert::From<u32> for bitcoin_units::block::BlockHeight
+impl core::convert::From<u32> for bitcoin_units::block::BlockHeightInterval
+impl core::convert::From<u32> for bitcoin_units::block::BlockMtp
+impl core::convert::From<u32> for bitcoin_units::block::BlockMtpInterval
+impl core::convert::TryFrom<&str> for bitcoin_units::Weight
+impl core::convert::TryFrom<&str> for bitcoin_units::block::BlockHeight
+impl core::convert::TryFrom<&str> for bitcoin_units::block::BlockHeightInterval
+impl core::convert::TryFrom<&str> for bitcoin_units::block::BlockMtp
+impl core::convert::TryFrom<&str> for bitcoin_units::block::BlockMtpInterval
+impl core::convert::TryFrom<&str> for bitcoin_units::locktime::absolute::Height
+impl core::convert::TryFrom<&str> for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::convert::TryFrom<&str> for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::convert::TryFrom<&str> for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::Weight
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::block::BlockHeight
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::block::BlockHeightInterval
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::block::BlockMtp
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::block::BlockMtpInterval
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::locktime::absolute::Height
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::Weight
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::block::BlockHeight
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::block::BlockHeightInterval
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::block::BlockMtp
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::block::BlockMtpInterval
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::locktime::absolute::Height
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::convert::TryFrom<bitcoin_units::SignedAmount> for bitcoin_units::Amount
+impl core::convert::TryFrom<bitcoin_units::block::BlockHeight> for bitcoin_units::locktime::absolute::Height
+impl core::convert::TryFrom<bitcoin_units::block::BlockHeightInterval> for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::convert::TryFrom<bitcoin_units::block::BlockMtp> for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::default::Default for bitcoin_units::Amount
+impl core::default::Default for bitcoin_units::SignedAmount
+impl core::default::Default for bitcoin_units::block::BlockHeightInterval
+impl core::default::Default for bitcoin_units::block::BlockMtpInterval
+impl core::default::Default for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::default::Default for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::fmt::Debug for bitcoin_units::Amount
+impl core::fmt::Debug for bitcoin_units::BlockTime
+impl core::fmt::Debug for bitcoin_units::FeeRate
+impl core::fmt::Debug for bitcoin_units::MathOp
+impl core::fmt::Debug for bitcoin_units::NumOpError
+impl core::fmt::Debug for bitcoin_units::SignedAmount
+impl core::fmt::Debug for bitcoin_units::Weight
+impl core::fmt::Debug for bitcoin_units::amount::Denomination
+impl core::fmt::Debug for bitcoin_units::amount::Display
+impl core::fmt::Debug for bitcoin_units::amount::InputTooLargeError
+impl core::fmt::Debug for bitcoin_units::amount::InvalidCharacterError
+impl core::fmt::Debug for bitcoin_units::amount::MissingDenominationError
+impl core::fmt::Debug for bitcoin_units::amount::MissingDigitsError
+impl core::fmt::Debug for bitcoin_units::amount::OutOfRangeError
+impl core::fmt::Debug for bitcoin_units::amount::ParseAmountError
+impl core::fmt::Debug for bitcoin_units::amount::ParseDenominationError
+impl core::fmt::Debug for bitcoin_units::amount::ParseError
+impl core::fmt::Debug for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::fmt::Debug for bitcoin_units::amount::TooPreciseError
+impl core::fmt::Debug for bitcoin_units::amount::UnknownDenominationError
+impl core::fmt::Debug for bitcoin_units::block::BlockHeight
+impl core::fmt::Debug for bitcoin_units::block::BlockHeightInterval
+impl core::fmt::Debug for bitcoin_units::block::BlockMtp
+impl core::fmt::Debug for bitcoin_units::block::BlockMtpInterval
+impl core::fmt::Debug for bitcoin_units::block::TooBigForRelativeHeightError
+impl core::fmt::Debug for bitcoin_units::locktime::absolute::ConversionError
+impl core::fmt::Debug for bitcoin_units::locktime::absolute::Height
+impl core::fmt::Debug for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::fmt::Debug for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::fmt::Debug for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::fmt::Debug for bitcoin_units::locktime::relative::InvalidHeightError
+impl core::fmt::Debug for bitcoin_units::locktime::relative::InvalidTimeError
+impl core::fmt::Debug for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::fmt::Debug for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::fmt::Debug for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::fmt::Debug for bitcoin_units::parse::ParseIntError
+impl core::fmt::Debug for bitcoin_units::parse::PrefixedHexError
+impl core::fmt::Debug for bitcoin_units::parse::UnprefixedHexError
+impl core::fmt::Display for bitcoin_units::Amount
+impl core::fmt::Display for bitcoin_units::MathOp
+impl core::fmt::Display for bitcoin_units::NumOpError
+impl core::fmt::Display for bitcoin_units::SignedAmount
+impl core::fmt::Display for bitcoin_units::Weight
+impl core::fmt::Display for bitcoin_units::amount::Denomination
+impl core::fmt::Display for bitcoin_units::amount::Display
+impl core::fmt::Display for bitcoin_units::amount::InputTooLargeError
+impl core::fmt::Display for bitcoin_units::amount::InvalidCharacterError
+impl core::fmt::Display for bitcoin_units::amount::MissingDigitsError
+impl core::fmt::Display for bitcoin_units::amount::OutOfRangeError
+impl core::fmt::Display for bitcoin_units::amount::ParseAmountError
+impl core::fmt::Display for bitcoin_units::amount::ParseDenominationError
+impl core::fmt::Display for bitcoin_units::amount::ParseError
+impl core::fmt::Display for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::fmt::Display for bitcoin_units::amount::TooPreciseError
+impl core::fmt::Display for bitcoin_units::amount::UnknownDenominationError
+impl core::fmt::Display for bitcoin_units::block::BlockHeight
+impl core::fmt::Display for bitcoin_units::block::BlockHeightInterval
+impl core::fmt::Display for bitcoin_units::block::BlockMtp
+impl core::fmt::Display for bitcoin_units::block::BlockMtpInterval
+impl core::fmt::Display for bitcoin_units::block::TooBigForRelativeHeightError
+impl core::fmt::Display for bitcoin_units::locktime::absolute::ConversionError
+impl core::fmt::Display for bitcoin_units::locktime::absolute::Height
+impl core::fmt::Display for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::fmt::Display for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::fmt::Display for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::fmt::Display for bitcoin_units::locktime::relative::InvalidHeightError
+impl core::fmt::Display for bitcoin_units::locktime::relative::InvalidTimeError
+impl core::fmt::Display for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::fmt::Display for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::fmt::Display for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::fmt::Display for bitcoin_units::parse::ParseIntError
+impl core::fmt::Display for bitcoin_units::parse::PrefixedHexError
+impl core::fmt::Display for bitcoin_units::parse::UnprefixedHexError
+impl core::hash::Hash for bitcoin_units::Amount
+impl core::hash::Hash for bitcoin_units::BlockTime
+impl core::hash::Hash for bitcoin_units::FeeRate
+impl core::hash::Hash for bitcoin_units::SignedAmount
+impl core::hash::Hash for bitcoin_units::Weight
+impl core::hash::Hash for bitcoin_units::amount::Denomination
+impl core::hash::Hash for bitcoin_units::block::BlockHeight
+impl core::hash::Hash for bitcoin_units::block::BlockHeightInterval
+impl core::hash::Hash for bitcoin_units::block::BlockMtp
+impl core::hash::Hash for bitcoin_units::block::BlockMtpInterval
+impl core::hash::Hash for bitcoin_units::locktime::absolute::Height
+impl core::hash::Hash for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::hash::Hash for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::hash::Hash for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::iter::traits::accum::Sum for bitcoin_units::FeeRate
+impl core::iter::traits::accum::Sum for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::iter::traits::accum::Sum for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::iter::traits::accum::Sum for bitcoin_units::Weight
+impl core::iter::traits::accum::Sum for bitcoin_units::block::BlockHeightInterval
+impl core::iter::traits::accum::Sum for bitcoin_units::block::BlockMtpInterval
+impl core::marker::Copy for bitcoin_units::Amount
+impl core::marker::Copy for bitcoin_units::BlockTime
+impl core::marker::Copy for bitcoin_units::FeeRate
+impl core::marker::Copy for bitcoin_units::MathOp
+impl core::marker::Copy for bitcoin_units::NumOpError
+impl core::marker::Copy for bitcoin_units::SignedAmount
+impl core::marker::Copy for bitcoin_units::Weight
+impl core::marker::Copy for bitcoin_units::amount::Denomination
+impl core::marker::Copy for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Copy for bitcoin_units::block::BlockHeight
+impl core::marker::Copy for bitcoin_units::block::BlockHeightInterval
+impl core::marker::Copy for bitcoin_units::block::BlockMtp
+impl core::marker::Copy for bitcoin_units::block::BlockMtpInterval
+impl core::marker::Copy for bitcoin_units::locktime::absolute::Height
+impl core::marker::Copy for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::marker::Copy for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::marker::Copy for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::marker::Freeze for bitcoin_units::Amount
+impl core::marker::Freeze for bitcoin_units::BlockTime
+impl core::marker::Freeze for bitcoin_units::FeeRate
+impl core::marker::Freeze for bitcoin_units::MathOp
+impl core::marker::Freeze for bitcoin_units::NumOpError
+impl core::marker::Freeze for bitcoin_units::SignedAmount
+impl core::marker::Freeze for bitcoin_units::Weight
+impl core::marker::Freeze for bitcoin_units::amount::Denomination
+impl core::marker::Freeze for bitcoin_units::amount::Display
+impl core::marker::Freeze for bitcoin_units::amount::InputTooLargeError
+impl core::marker::Freeze for bitcoin_units::amount::InvalidCharacterError
+impl core::marker::Freeze for bitcoin_units::amount::MissingDenominationError
+impl core::marker::Freeze for bitcoin_units::amount::MissingDigitsError
+impl core::marker::Freeze for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Freeze for bitcoin_units::amount::ParseAmountError
+impl core::marker::Freeze for bitcoin_units::amount::ParseDenominationError
+impl core::marker::Freeze for bitcoin_units::amount::ParseError
+impl core::marker::Freeze for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::Freeze for bitcoin_units::amount::TooPreciseError
+impl core::marker::Freeze for bitcoin_units::amount::UnknownDenominationError
+impl core::marker::Freeze for bitcoin_units::block::BlockHeight
+impl core::marker::Freeze for bitcoin_units::block::BlockHeightInterval
+impl core::marker::Freeze for bitcoin_units::block::BlockMtp
+impl core::marker::Freeze for bitcoin_units::block::BlockMtpInterval
+impl core::marker::Freeze for bitcoin_units::block::TooBigForRelativeHeightError
+impl core::marker::Freeze for bitcoin_units::locktime::absolute::ConversionError
+impl core::marker::Freeze for bitcoin_units::locktime::absolute::Height
+impl core::marker::Freeze for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::marker::Freeze for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::marker::Freeze for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::marker::Freeze for bitcoin_units::locktime::relative::InvalidHeightError
+impl core::marker::Freeze for bitcoin_units::locktime::relative::InvalidTimeError
+impl core::marker::Freeze for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::marker::Freeze for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::marker::Freeze for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::marker::Freeze for bitcoin_units::parse::ParseIntError
+impl core::marker::Freeze for bitcoin_units::parse::PrefixedHexError
+impl core::marker::Freeze for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::Send for bitcoin_units::Amount
+impl core::marker::Send for bitcoin_units::BlockTime
+impl core::marker::Send for bitcoin_units::FeeRate
+impl core::marker::Send for bitcoin_units::MathOp
+impl core::marker::Send for bitcoin_units::NumOpError
+impl core::marker::Send for bitcoin_units::SignedAmount
+impl core::marker::Send for bitcoin_units::Weight
+impl core::marker::Send for bitcoin_units::amount::Denomination
+impl core::marker::Send for bitcoin_units::amount::Display
+impl core::marker::Send for bitcoin_units::amount::InputTooLargeError
+impl core::marker::Send for bitcoin_units::amount::InvalidCharacterError
+impl core::marker::Send for bitcoin_units::amount::MissingDenominationError
+impl core::marker::Send for bitcoin_units::amount::MissingDigitsError
+impl core::marker::Send for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Send for bitcoin_units::amount::ParseAmountError
+impl core::marker::Send for bitcoin_units::amount::ParseDenominationError
+impl core::marker::Send for bitcoin_units::amount::ParseError
+impl core::marker::Send for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::Send for bitcoin_units::amount::TooPreciseError
+impl core::marker::Send for bitcoin_units::amount::UnknownDenominationError
+impl core::marker::Send for bitcoin_units::block::BlockHeight
+impl core::marker::Send for bitcoin_units::block::BlockHeightInterval
+impl core::marker::Send for bitcoin_units::block::BlockMtp
+impl core::marker::Send for bitcoin_units::block::BlockMtpInterval
+impl core::marker::Send for bitcoin_units::block::TooBigForRelativeHeightError
+impl core::marker::Send for bitcoin_units::locktime::absolute::ConversionError
+impl core::marker::Send for bitcoin_units::locktime::absolute::Height
+impl core::marker::Send for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::marker::Send for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::marker::Send for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::marker::Send for bitcoin_units::locktime::relative::InvalidHeightError
+impl core::marker::Send for bitcoin_units::locktime::relative::InvalidTimeError
+impl core::marker::Send for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::marker::Send for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::marker::Send for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::marker::Send for bitcoin_units::parse::ParseIntError
+impl core::marker::Send for bitcoin_units::parse::PrefixedHexError
+impl core::marker::Send for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::StructuralPartialEq for bitcoin_units::Amount
+impl core::marker::StructuralPartialEq for bitcoin_units::BlockTime
+impl core::marker::StructuralPartialEq for bitcoin_units::FeeRate
+impl core::marker::StructuralPartialEq for bitcoin_units::MathOp
+impl core::marker::StructuralPartialEq for bitcoin_units::NumOpError
+impl core::marker::StructuralPartialEq for bitcoin_units::SignedAmount
+impl core::marker::StructuralPartialEq for bitcoin_units::Weight
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::Denomination
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::InputTooLargeError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::InvalidCharacterError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::MissingDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::MissingDigitsError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::OutOfRangeError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::ParseAmountError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::ParseDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::ParseError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::TooPreciseError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::UnknownDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::block::BlockHeight
+impl core::marker::StructuralPartialEq for bitcoin_units::block::BlockHeightInterval
+impl core::marker::StructuralPartialEq for bitcoin_units::block::BlockMtp
+impl core::marker::StructuralPartialEq for bitcoin_units::block::BlockMtpInterval
+impl core::marker::StructuralPartialEq for bitcoin_units::block::TooBigForRelativeHeightError
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::ConversionError
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::Height
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::InvalidHeightError
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::InvalidTimeError
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::marker::StructuralPartialEq for bitcoin_units::parse::ParseIntError
+impl core::marker::StructuralPartialEq for bitcoin_units::parse::PrefixedHexError
+impl core::marker::StructuralPartialEq for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::Sync for bitcoin_units::Amount
+impl core::marker::Sync for bitcoin_units::BlockTime
+impl core::marker::Sync for bitcoin_units::FeeRate
+impl core::marker::Sync for bitcoin_units::MathOp
+impl core::marker::Sync for bitcoin_units::NumOpError
+impl core::marker::Sync for bitcoin_units::SignedAmount
+impl core::marker::Sync for bitcoin_units::Weight
+impl core::marker::Sync for bitcoin_units::amount::Denomination
+impl core::marker::Sync for bitcoin_units::amount::Display
+impl core::marker::Sync for bitcoin_units::amount::InputTooLargeError
+impl core::marker::Sync for bitcoin_units::amount::InvalidCharacterError
+impl core::marker::Sync for bitcoin_units::amount::MissingDenominationError
+impl core::marker::Sync for bitcoin_units::amount::MissingDigitsError
+impl core::marker::Sync for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Sync for bitcoin_units::amount::ParseAmountError
+impl core::marker::Sync for bitcoin_units::amount::ParseDenominationError
+impl core::marker::Sync for bitcoin_units::amount::ParseError
+impl core::marker::Sync for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::Sync for bitcoin_units::amount::TooPreciseError
+impl core::marker::Sync for bitcoin_units::amount::UnknownDenominationError
+impl core::marker::Sync for bitcoin_units::block::BlockHeight
+impl core::marker::Sync for bitcoin_units::block::BlockHeightInterval
+impl core::marker::Sync for bitcoin_units::block::BlockMtp
+impl core::marker::Sync for bitcoin_units::block::BlockMtpInterval
+impl core::marker::Sync for bitcoin_units::block::TooBigForRelativeHeightError
+impl core::marker::Sync for bitcoin_units::locktime::absolute::ConversionError
+impl core::marker::Sync for bitcoin_units::locktime::absolute::Height
+impl core::marker::Sync for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::marker::Sync for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::marker::Sync for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::marker::Sync for bitcoin_units::locktime::relative::InvalidHeightError
+impl core::marker::Sync for bitcoin_units::locktime::relative::InvalidTimeError
+impl core::marker::Sync for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::marker::Sync for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::marker::Sync for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::marker::Sync for bitcoin_units::parse::ParseIntError
+impl core::marker::Sync for bitcoin_units::parse::PrefixedHexError
+impl core::marker::Sync for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::Unpin for bitcoin_units::Amount
+impl core::marker::Unpin for bitcoin_units::BlockTime
+impl core::marker::Unpin for bitcoin_units::FeeRate
+impl core::marker::Unpin for bitcoin_units::MathOp
+impl core::marker::Unpin for bitcoin_units::NumOpError
+impl core::marker::Unpin for bitcoin_units::SignedAmount
+impl core::marker::Unpin for bitcoin_units::Weight
+impl core::marker::Unpin for bitcoin_units::amount::Denomination
+impl core::marker::Unpin for bitcoin_units::amount::Display
+impl core::marker::Unpin for bitcoin_units::amount::InputTooLargeError
+impl core::marker::Unpin for bitcoin_units::amount::InvalidCharacterError
+impl core::marker::Unpin for bitcoin_units::amount::MissingDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::MissingDigitsError
+impl core::marker::Unpin for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Unpin for bitcoin_units::amount::ParseAmountError
+impl core::marker::Unpin for bitcoin_units::amount::ParseDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::ParseError
+impl core::marker::Unpin for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::TooPreciseError
+impl core::marker::Unpin for bitcoin_units::amount::UnknownDenominationError
+impl core::marker::Unpin for bitcoin_units::block::BlockHeight
+impl core::marker::Unpin for bitcoin_units::block::BlockHeightInterval
+impl core::marker::Unpin for bitcoin_units::block::BlockMtp
+impl core::marker::Unpin for bitcoin_units::block::BlockMtpInterval
+impl core::marker::Unpin for bitcoin_units::block::TooBigForRelativeHeightError
+impl core::marker::Unpin for bitcoin_units::locktime::absolute::ConversionError
+impl core::marker::Unpin for bitcoin_units::locktime::absolute::Height
+impl core::marker::Unpin for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::marker::Unpin for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::marker::Unpin for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::marker::Unpin for bitcoin_units::locktime::relative::InvalidHeightError
+impl core::marker::Unpin for bitcoin_units::locktime::relative::InvalidTimeError
+impl core::marker::Unpin for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::marker::Unpin for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::marker::Unpin for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::marker::Unpin for bitcoin_units::parse::ParseIntError
+impl core::marker::Unpin for bitcoin_units::parse::PrefixedHexError
+impl core::marker::Unpin for bitcoin_units::parse::UnprefixedHexError
+impl core::ops::arith::Add for bitcoin_units::Amount
+impl core::ops::arith::Add for bitcoin_units::FeeRate
+impl core::ops::arith::Add for bitcoin_units::SignedAmount
+impl core::ops::arith::Add for bitcoin_units::Weight
+impl core::ops::arith::Add for bitcoin_units::block::BlockHeightInterval
+impl core::ops::arith::Add for bitcoin_units::block::BlockMtpInterval
+impl core::ops::arith::Add<&bitcoin_units::Amount> for bitcoin_units::Amount
+impl core::ops::arith::Add<&bitcoin_units::FeeRate> for bitcoin_units::FeeRate
+impl core::ops::arith::Add<&bitcoin_units::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount
+impl core::ops::arith::Add<&bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for bitcoin_units::SignedAmount
+impl core::ops::arith::Add<&bitcoin_units::SignedAmount> for bitcoin_units::SignedAmount
+impl core::ops::arith::Add<&bitcoin_units::Weight> for bitcoin_units::Weight
+impl core::ops::arith::Add<&bitcoin_units::block::BlockHeightInterval> for bitcoin_units::block::BlockHeight
+impl core::ops::arith::Add<&bitcoin_units::block::BlockHeightInterval> for bitcoin_units::block::BlockHeightInterval
+impl core::ops::arith::Add<&bitcoin_units::block::BlockMtpInterval> for bitcoin_units::block::BlockMtp
+impl core::ops::arith::Add<&bitcoin_units::block::BlockMtpInterval> for bitcoin_units::block::BlockMtpInterval
+impl core::ops::arith::Add<bitcoin_units::Amount> for &bitcoin_units::Amount
+impl core::ops::arith::Add<bitcoin_units::FeeRate> for &bitcoin_units::FeeRate
+impl core::ops::arith::Add<bitcoin_units::NumOpResult<bitcoin_units::Amount>> for &bitcoin_units::Amount
+impl core::ops::arith::Add<bitcoin_units::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount
+impl core::ops::arith::Add<bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for &bitcoin_units::SignedAmount
+impl core::ops::arith::Add<bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for bitcoin_units::SignedAmount
+impl core::ops::arith::Add<bitcoin_units::SignedAmount> for &bitcoin_units::SignedAmount
+impl core::ops::arith::Add<bitcoin_units::Weight> for &bitcoin_units::Weight
+impl core::ops::arith::Add<bitcoin_units::block::BlockHeightInterval> for &bitcoin_units::block::BlockHeight
+impl core::ops::arith::Add<bitcoin_units::block::BlockHeightInterval> for &bitcoin_units::block::BlockHeightInterval
+impl core::ops::arith::Add<bitcoin_units::block::BlockHeightInterval> for bitcoin_units::block::BlockHeight
+impl core::ops::arith::Add<bitcoin_units::block::BlockMtpInterval> for &bitcoin_units::block::BlockMtp
+impl core::ops::arith::Add<bitcoin_units::block::BlockMtpInterval> for &bitcoin_units::block::BlockMtpInterval
+impl core::ops::arith::Add<bitcoin_units::block::BlockMtpInterval> for bitcoin_units::block::BlockMtp
+impl core::ops::arith::AddAssign for bitcoin_units::FeeRate
+impl core::ops::arith::AddAssign for bitcoin_units::Weight
+impl core::ops::arith::AddAssign for bitcoin_units::block::BlockHeightInterval
+impl core::ops::arith::AddAssign for bitcoin_units::block::BlockMtpInterval
+impl core::ops::arith::AddAssign<&bitcoin_units::FeeRate> for bitcoin_units::FeeRate
+impl core::ops::arith::AddAssign<&bitcoin_units::Weight> for bitcoin_units::Weight
+impl core::ops::arith::AddAssign<&bitcoin_units::block::BlockHeightInterval> for bitcoin_units::block::BlockHeightInterval
+impl core::ops::arith::AddAssign<&bitcoin_units::block::BlockMtpInterval> for bitcoin_units::block::BlockMtpInterval
+impl core::ops::arith::Div for bitcoin_units::Amount
+impl core::ops::arith::Div for bitcoin_units::SignedAmount
+impl core::ops::arith::Div for bitcoin_units::Weight
+impl core::ops::arith::Div<&bitcoin_units::Amount> for bitcoin_units::Amount
+impl core::ops::arith::Div<&bitcoin_units::FeeRate> for bitcoin_units::Amount
+impl core::ops::arith::Div<&bitcoin_units::FeeRate> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<&bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for bitcoin_units::Amount
+impl core::ops::arith::Div<&bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<&bitcoin_units::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::Amount
+impl core::ops::arith::Div<&bitcoin_units::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<&bitcoin_units::SignedAmount> for bitcoin_units::SignedAmount
+impl core::ops::arith::Div<&bitcoin_units::Weight> for bitcoin_units::Amount
+impl core::ops::arith::Div<&bitcoin_units::Weight> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<&bitcoin_units::Weight> for bitcoin_units::Weight
+impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount
+impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount
+impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::FeeRate
+impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::Weight
+impl core::ops::arith::Div<&i64> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::Div<&i64> for bitcoin_units::SignedAmount
+impl core::ops::arith::Div<&u64> for bitcoin_units::Amount
+impl core::ops::arith::Div<&u64> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<&u64> for bitcoin_units::Weight
+impl core::ops::arith::Div<bitcoin_units::Amount> for &bitcoin_units::Amount
+impl core::ops::arith::Div<bitcoin_units::FeeRate> for &bitcoin_units::Amount
+impl core::ops::arith::Div<bitcoin_units::FeeRate> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<bitcoin_units::FeeRate> for bitcoin_units::Amount
+impl core::ops::arith::Div<bitcoin_units::FeeRate> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for &bitcoin_units::Amount
+impl core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for bitcoin_units::Amount
+impl core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::Amount
+impl core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::Amount
+impl core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<bitcoin_units::SignedAmount> for &bitcoin_units::SignedAmount
+impl core::ops::arith::Div<bitcoin_units::Weight> for &bitcoin_units::Amount
+impl core::ops::arith::Div<bitcoin_units::Weight> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<bitcoin_units::Weight> for &bitcoin_units::Weight
+impl core::ops::arith::Div<bitcoin_units::Weight> for bitcoin_units::Amount
+impl core::ops::arith::Div<bitcoin_units::Weight> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::SignedAmount
+impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::Amount
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::FeeRate
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::Weight
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::FeeRate
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::Weight
+impl core::ops::arith::Div<i64> for &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::Div<i64> for &bitcoin_units::SignedAmount
+impl core::ops::arith::Div<i64> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount
+impl core::ops::arith::Div<u64> for &bitcoin_units::Amount
+impl core::ops::arith::Div<u64> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<u64> for &bitcoin_units::Weight
+impl core::ops::arith::Div<u64> for bitcoin_units::Amount
+impl core::ops::arith::Div<u64> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<u64> for bitcoin_units::Weight
+impl core::ops::arith::DivAssign<&i64> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::DivAssign<&u64> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::DivAssign<i64> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::DivAssign<u64> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::DivAssign<u64> for bitcoin_units::Weight
+impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64
+impl core::ops::arith::Mul<&bitcoin_units::FeeRate> for bitcoin_units::NumOpResult<bitcoin_units::Weight>
+impl core::ops::arith::Mul<&bitcoin_units::FeeRate> for bitcoin_units::Weight
+impl core::ops::arith::Mul<&bitcoin_units::NumOpResult<bitcoin_units::Amount>> for u64
+impl core::ops::arith::Mul<&bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for bitcoin_units::NumOpResult<bitcoin_units::Weight>
+impl core::ops::arith::Mul<&bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for bitcoin_units::Weight
+impl core::ops::arith::Mul<&bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for i64
+impl core::ops::arith::Mul<&bitcoin_units::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::FeeRate
+impl core::ops::arith::Mul<&bitcoin_units::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::NumOpResult<bitcoin_units::FeeRate>
+impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64
+impl core::ops::arith::Mul<&bitcoin_units::Weight> for bitcoin_units::FeeRate
+impl core::ops::arith::Mul<&bitcoin_units::Weight> for bitcoin_units::NumOpResult<bitcoin_units::FeeRate>
+impl core::ops::arith::Mul<&bitcoin_units::Weight> for u64
+impl core::ops::arith::Mul<&i64> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::Mul<&i64> for bitcoin_units::SignedAmount
+impl core::ops::arith::Mul<&u64> for bitcoin_units::Amount
+impl core::ops::arith::Mul<&u64> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Mul<&u64> for bitcoin_units::Weight
+impl core::ops::arith::Mul<bitcoin_units::Amount> for &u64
+impl core::ops::arith::Mul<bitcoin_units::Amount> for u64
+impl core::ops::arith::Mul<bitcoin_units::FeeRate> for &bitcoin_units::NumOpResult<bitcoin_units::Weight>
+impl core::ops::arith::Mul<bitcoin_units::FeeRate> for &bitcoin_units::Weight
+impl core::ops::arith::Mul<bitcoin_units::FeeRate> for bitcoin_units::NumOpResult<bitcoin_units::Weight>
+impl core::ops::arith::Mul<bitcoin_units::FeeRate> for bitcoin_units::Weight
+impl core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::Amount>> for &u64
+impl core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::Amount>> for u64
+impl core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for &bitcoin_units::NumOpResult<bitcoin_units::Weight>
+impl core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for &bitcoin_units::Weight
+impl core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for bitcoin_units::NumOpResult<bitcoin_units::Weight>
+impl core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for bitcoin_units::Weight
+impl core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for &i64
+impl core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for i64
+impl core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::FeeRate
+impl core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>
+impl core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::FeeRate
+impl core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::NumOpResult<bitcoin_units::FeeRate>
+impl core::ops::arith::Mul<bitcoin_units::SignedAmount> for &i64
+impl core::ops::arith::Mul<bitcoin_units::SignedAmount> for i64
+impl core::ops::arith::Mul<bitcoin_units::Weight> for &bitcoin_units::FeeRate
+impl core::ops::arith::Mul<bitcoin_units::Weight> for &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>
+impl core::ops::arith::Mul<bitcoin_units::Weight> for &u64
+impl core::ops::arith::Mul<bitcoin_units::Weight> for bitcoin_units::FeeRate
+impl core::ops::arith::Mul<bitcoin_units::Weight> for bitcoin_units::NumOpResult<bitcoin_units::FeeRate>
+impl core::ops::arith::Mul<bitcoin_units::Weight> for u64
+impl core::ops::arith::Mul<i64> for &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::Mul<i64> for &bitcoin_units::SignedAmount
+impl core::ops::arith::Mul<i64> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::Mul<i64> for bitcoin_units::SignedAmount
+impl core::ops::arith::Mul<u64> for &bitcoin_units::Amount
+impl core::ops::arith::Mul<u64> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Mul<u64> for &bitcoin_units::Weight
+impl core::ops::arith::Mul<u64> for bitcoin_units::Amount
+impl core::ops::arith::Mul<u64> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Mul<u64> for bitcoin_units::Weight
+impl core::ops::arith::MulAssign<&i64> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::MulAssign<&u64> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::MulAssign<i64> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::MulAssign<u64> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::MulAssign<u64> for bitcoin_units::Weight
+impl core::ops::arith::Neg for bitcoin_units::SignedAmount
+impl core::ops::arith::Rem for bitcoin_units::Weight
+impl core::ops::arith::Rem<&bitcoin_units::Weight> for bitcoin_units::Weight
+impl core::ops::arith::Rem<&i64> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::Rem<&i64> for bitcoin_units::SignedAmount
+impl core::ops::arith::Rem<&u64> for bitcoin_units::Amount
+impl core::ops::arith::Rem<&u64> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Rem<&u64> for bitcoin_units::Weight
+impl core::ops::arith::Rem<bitcoin_units::Weight> for &bitcoin_units::Weight
+impl core::ops::arith::Rem<i64> for &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::Rem<i64> for &bitcoin_units::SignedAmount
+impl core::ops::arith::Rem<i64> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::Rem<i64> for bitcoin_units::SignedAmount
+impl core::ops::arith::Rem<u64> for &bitcoin_units::Amount
+impl core::ops::arith::Rem<u64> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Rem<u64> for &bitcoin_units::Weight
+impl core::ops::arith::Rem<u64> for bitcoin_units::Amount
+impl core::ops::arith::Rem<u64> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Rem<u64> for bitcoin_units::Weight
+impl core::ops::arith::RemAssign<u64> for bitcoin_units::Weight
+impl core::ops::arith::Sub for bitcoin_units::Amount
+impl core::ops::arith::Sub for bitcoin_units::FeeRate
+impl core::ops::arith::Sub for bitcoin_units::SignedAmount
+impl core::ops::arith::Sub for bitcoin_units::Weight
+impl core::ops::arith::Sub for bitcoin_units::block::BlockHeight
+impl core::ops::arith::Sub for bitcoin_units::block::BlockHeightInterval
+impl core::ops::arith::Sub for bitcoin_units::block::BlockMtp
+impl core::ops::arith::Sub for bitcoin_units::block::BlockMtpInterval
+impl core::ops::arith::Sub<&bitcoin_units::Amount> for bitcoin_units::Amount
+impl core::ops::arith::Sub<&bitcoin_units::FeeRate> for bitcoin_units::FeeRate
+impl core::ops::arith::Sub<&bitcoin_units::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount
+impl core::ops::arith::Sub<&bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for bitcoin_units::SignedAmount
+impl core::ops::arith::Sub<&bitcoin_units::SignedAmount> for bitcoin_units::SignedAmount
+impl core::ops::arith::Sub<&bitcoin_units::Weight> for bitcoin_units::Weight
+impl core::ops::arith::Sub<&bitcoin_units::block::BlockHeight> for bitcoin_units::block::BlockHeight
+impl core::ops::arith::Sub<&bitcoin_units::block::BlockHeightInterval> for bitcoin_units::block::BlockHeight
+impl core::ops::arith::Sub<&bitcoin_units::block::BlockHeightInterval> for bitcoin_units::block::BlockHeightInterval
+impl core::ops::arith::Sub<&bitcoin_units::block::BlockMtp> for bitcoin_units::block::BlockMtp
+impl core::ops::arith::Sub<&bitcoin_units::block::BlockMtpInterval> for bitcoin_units::block::BlockMtp
+impl core::ops::arith::Sub<&bitcoin_units::block::BlockMtpInterval> for bitcoin_units::block::BlockMtpInterval
+impl core::ops::arith::Sub<bitcoin_units::Amount> for &bitcoin_units::Amount
+impl core::ops::arith::Sub<bitcoin_units::FeeRate> for &bitcoin_units::FeeRate
+impl core::ops::arith::Sub<bitcoin_units::NumOpResult<bitcoin_units::Amount>> for &bitcoin_units::Amount
+impl core::ops::arith::Sub<bitcoin_units::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount
+impl core::ops::arith::Sub<bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for &bitcoin_units::SignedAmount
+impl core::ops::arith::Sub<bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for bitcoin_units::SignedAmount
+impl core::ops::arith::Sub<bitcoin_units::SignedAmount> for &bitcoin_units::SignedAmount
+impl core::ops::arith::Sub<bitcoin_units::Weight> for &bitcoin_units::Weight
+impl core::ops::arith::Sub<bitcoin_units::block::BlockHeight> for &bitcoin_units::block::BlockHeight
+impl core::ops::arith::Sub<bitcoin_units::block::BlockHeightInterval> for &bitcoin_units::block::BlockHeight
+impl core::ops::arith::Sub<bitcoin_units::block::BlockHeightInterval> for &bitcoin_units::block::BlockHeightInterval
+impl core::ops::arith::Sub<bitcoin_units::block::BlockHeightInterval> for bitcoin_units::block::BlockHeight
+impl core::ops::arith::Sub<bitcoin_units::block::BlockMtp> for &bitcoin_units::block::BlockMtp
+impl core::ops::arith::Sub<bitcoin_units::block::BlockMtpInterval> for &bitcoin_units::block::BlockMtp
+impl core::ops::arith::Sub<bitcoin_units::block::BlockMtpInterval> for &bitcoin_units::block::BlockMtpInterval
+impl core::ops::arith::Sub<bitcoin_units::block::BlockMtpInterval> for bitcoin_units::block::BlockMtp
+impl core::ops::arith::SubAssign for bitcoin_units::FeeRate
+impl core::ops::arith::SubAssign for bitcoin_units::Weight
+impl core::ops::arith::SubAssign for bitcoin_units::block::BlockHeightInterval
+impl core::ops::arith::SubAssign for bitcoin_units::block::BlockMtpInterval
+impl core::ops::arith::SubAssign<&bitcoin_units::FeeRate> for bitcoin_units::FeeRate
+impl core::ops::arith::SubAssign<&bitcoin_units::Weight> for bitcoin_units::Weight
+impl core::ops::arith::SubAssign<&bitcoin_units::block::BlockHeightInterval> for bitcoin_units::block::BlockHeightInterval
+impl core::ops::arith::SubAssign<&bitcoin_units::block::BlockMtpInterval> for bitcoin_units::block::BlockMtpInterval
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::Amount
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::BlockTime
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::FeeRate
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::MathOp
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::NumOpError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::SignedAmount
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::Weight
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::Denomination
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::Display
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::InputTooLargeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::InvalidCharacterError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::MissingDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::MissingDigitsError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::OutOfRangeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::ParseAmountError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::ParseDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::ParseError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::TooPreciseError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::UnknownDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::BlockHeight
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::BlockHeightInterval
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::BlockMtp
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::BlockMtpInterval
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::TooBigForRelativeHeightError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::absolute::ConversionError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::absolute::Height
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::InvalidHeightError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::InvalidTimeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::parse::ParseIntError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::parse::PrefixedHexError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::parse::UnprefixedHexError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::Amount
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::BlockTime
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::FeeRate
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::MathOp
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::NumOpError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::SignedAmount
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::Weight
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::Denomination
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::Display
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::InputTooLargeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::InvalidCharacterError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::MissingDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::MissingDigitsError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::OutOfRangeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::ParseAmountError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::ParseDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::ParseError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::TooPreciseError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::UnknownDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::BlockHeight
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::BlockHeightInterval
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::BlockMtp
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::BlockMtpInterval
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::TooBigForRelativeHeightError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::absolute::ConversionError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::absolute::Height
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::InvalidHeightError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::InvalidTimeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::parse::ParseIntError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::parse::PrefixedHexError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::parse::UnprefixedHexError
+impl core::str::traits::FromStr for bitcoin_units::Amount
+impl core::str::traits::FromStr for bitcoin_units::SignedAmount
+impl core::str::traits::FromStr for bitcoin_units::Weight
+impl core::str::traits::FromStr for bitcoin_units::amount::Denomination
+impl core::str::traits::FromStr for bitcoin_units::block::BlockHeight
+impl core::str::traits::FromStr for bitcoin_units::block::BlockHeightInterval
+impl core::str::traits::FromStr for bitcoin_units::block::BlockMtp
+impl core::str::traits::FromStr for bitcoin_units::block::BlockMtpInterval
+impl core::str::traits::FromStr for bitcoin_units::locktime::absolute::Height
+impl core::str::traits::FromStr for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::str::traits::FromStr for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::str::traits::FromStr for bitcoin_units::locktime::relative::NumberOfBlocks
+impl<'a, T> core::ops::arith::Add<&'a T> for &bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Add<bitcoin_units::NumOpResult<T>, Output = bitcoin_units::NumOpResult<T>>
+impl<'a, T> core::ops::arith::Add<&'a bitcoin_units::NumOpResult<T>> for &bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Add<Output = bitcoin_units::NumOpResult<T>>
+impl<'a, T> core::ops::arith::Sub<&'a T> for &bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Sub<Output = bitcoin_units::NumOpResult<T>>
+impl<'a, T> core::ops::arith::Sub<&'a bitcoin_units::NumOpResult<T>> for &bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Sub<Output = bitcoin_units::NumOpResult<T>>
+impl<'a> core::iter::traits::accum::Sum<&'a bitcoin_units::FeeRate> for bitcoin_units::FeeRate
+impl<'a> core::iter::traits::accum::Sum<&'a bitcoin_units::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl<'a> core::iter::traits::accum::Sum<&'a bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl<'a> core::iter::traits::accum::Sum<&'a bitcoin_units::Weight> for bitcoin_units::Weight
+impl<'a> core::iter::traits::accum::Sum<&'a bitcoin_units::block::BlockHeightInterval> for bitcoin_units::block::BlockHeightInterval
+impl<'a> core::iter::traits::accum::Sum<&'a bitcoin_units::block::BlockMtpInterval> for bitcoin_units::block::BlockMtpInterval
+impl<'a> core::ops::arith::Add<&'a bitcoin_units::Amount> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Add<&'a bitcoin_units::FeeRate> for &bitcoin_units::FeeRate
+impl<'a> core::ops::arith::Add<&'a bitcoin_units::NumOpResult<bitcoin_units::Amount>> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Add<&'a bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for &bitcoin_units::SignedAmount
+impl<'a> core::ops::arith::Add<&'a bitcoin_units::SignedAmount> for &bitcoin_units::SignedAmount
+impl<'a> core::ops::arith::Add<&'a bitcoin_units::Weight> for &bitcoin_units::Weight
+impl<'a> core::ops::arith::Add<&'a bitcoin_units::block::BlockHeightInterval> for &bitcoin_units::block::BlockHeight
+impl<'a> core::ops::arith::Add<&'a bitcoin_units::block::BlockHeightInterval> for &bitcoin_units::block::BlockHeightInterval
+impl<'a> core::ops::arith::Add<&'a bitcoin_units::block::BlockMtpInterval> for &bitcoin_units::block::BlockMtp
+impl<'a> core::ops::arith::Add<&'a bitcoin_units::block::BlockMtpInterval> for &bitcoin_units::block::BlockMtpInterval
+impl<'a> core::ops::arith::Div<&'a bitcoin_units::Amount> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Div<&'a bitcoin_units::FeeRate> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Div<&'a bitcoin_units::FeeRate> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl<'a> core::ops::arith::Div<&'a bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Div<&'a bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl<'a> core::ops::arith::Div<&'a bitcoin_units::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Div<&'a bitcoin_units::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl<'a> core::ops::arith::Div<&'a bitcoin_units::SignedAmount> for &bitcoin_units::SignedAmount
+impl<'a> core::ops::arith::Div<&'a bitcoin_units::Weight> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Div<&'a bitcoin_units::Weight> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl<'a> core::ops::arith::Div<&'a bitcoin_units::Weight> for &bitcoin_units::Weight
+impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::SignedAmount
+impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::FeeRate
+impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::Weight
+impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::SignedAmount
+impl<'a> core::ops::arith::Div<&'a u64> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Div<&'a u64> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl<'a> core::ops::arith::Div<&'a u64> for &bitcoin_units::Weight
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::Amount> for &u64
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::FeeRate> for &bitcoin_units::NumOpResult<bitcoin_units::Weight>
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::FeeRate> for &bitcoin_units::Weight
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::NumOpResult<bitcoin_units::Amount>> for &u64
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for &bitcoin_units::NumOpResult<bitcoin_units::Weight>
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for &bitcoin_units::Weight
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for &i64
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::FeeRate
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::SignedAmount> for &i64
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::Weight> for &bitcoin_units::FeeRate
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::Weight> for &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::Weight> for &u64
+impl<'a> core::ops::arith::Mul<&'a i64> for &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl<'a> core::ops::arith::Mul<&'a i64> for &bitcoin_units::SignedAmount
+impl<'a> core::ops::arith::Mul<&'a u64> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Mul<&'a u64> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl<'a> core::ops::arith::Mul<&'a u64> for &bitcoin_units::Weight
+impl<'a> core::ops::arith::Rem<&'a bitcoin_units::Weight> for &bitcoin_units::Weight
+impl<'a> core::ops::arith::Rem<&'a i64> for &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl<'a> core::ops::arith::Rem<&'a i64> for &bitcoin_units::SignedAmount
+impl<'a> core::ops::arith::Rem<&'a u64> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Rem<&'a u64> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl<'a> core::ops::arith::Rem<&'a u64> for &bitcoin_units::Weight
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::Amount> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::FeeRate> for &bitcoin_units::FeeRate
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::NumOpResult<bitcoin_units::Amount>> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for &bitcoin_units::SignedAmount
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::SignedAmount> for &bitcoin_units::SignedAmount
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::Weight> for &bitcoin_units::Weight
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::block::BlockHeight> for &bitcoin_units::block::BlockHeight
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::block::BlockHeightInterval> for &bitcoin_units::block::BlockHeight
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::block::BlockHeightInterval> for &bitcoin_units::block::BlockHeightInterval
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::block::BlockMtp> for &bitcoin_units::block::BlockMtp
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::block::BlockMtpInterval> for &bitcoin_units::block::BlockMtp
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::block::BlockMtpInterval> for &bitcoin_units::block::BlockMtpInterval
+impl<T: core::clone::Clone> core::clone::Clone for bitcoin_units::NumOpResult<T>
+impl<T: core::cmp::Eq> core::cmp::Eq for bitcoin_units::NumOpResult<T>
+impl<T: core::cmp::PartialEq> core::cmp::PartialEq for bitcoin_units::NumOpResult<T>
+impl<T: core::fmt::Debug> bitcoin_units::NumOpResult<T>
+impl<T: core::fmt::Debug> core::fmt::Debug for bitcoin_units::NumOpResult<T>
+impl<T: core::marker::Copy> core::marker::Copy for bitcoin_units::NumOpResult<T>
+impl<T> bitcoin_units::CheckedSum<bitcoin_units::Amount> for T where T: core::iter::traits::iterator::Iterator<Item = bitcoin_units::Amount>
+impl<T> bitcoin_units::CheckedSum<bitcoin_units::SignedAmount> for T where T: core::iter::traits::iterator::Iterator<Item = bitcoin_units::SignedAmount>
+impl<T> bitcoin_units::CheckedSum<bitcoin_units::Weight> for T where T: core::iter::traits::iterator::Iterator<Item = bitcoin_units::Weight>
+impl<T> bitcoin_units::NumOpResult<T>
+impl<T> core::marker::Freeze for bitcoin_units::NumOpResult<T> where T: core::marker::Freeze
+impl<T> core::marker::Send for bitcoin_units::NumOpResult<T> where T: core::marker::Send
+impl<T> core::marker::StructuralPartialEq for bitcoin_units::NumOpResult<T>
+impl<T> core::marker::Sync for bitcoin_units::NumOpResult<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bitcoin_units::NumOpResult<T> where T: core::marker::Unpin
+impl<T> core::ops::arith::Add for bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Add<Output = bitcoin_units::NumOpResult<T>>
+impl<T> core::ops::arith::Add<&T> for bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Add<bitcoin_units::NumOpResult<T>, Output = bitcoin_units::NumOpResult<T>>
+impl<T> core::ops::arith::Add<&bitcoin_units::NumOpResult<T>> for bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Add<Output = bitcoin_units::NumOpResult<T>>
+impl<T> core::ops::arith::Add<T> for &bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Add<bitcoin_units::NumOpResult<T>, Output = bitcoin_units::NumOpResult<T>>
+impl<T> core::ops::arith::Add<T> for bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Add<bitcoin_units::NumOpResult<T>, Output = bitcoin_units::NumOpResult<T>>
+impl<T> core::ops::arith::Add<bitcoin_units::NumOpResult<T>> for &bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Add<Output = bitcoin_units::NumOpResult<T>>
+impl<T> core::ops::arith::Sub for bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Sub<Output = bitcoin_units::NumOpResult<T>>
+impl<T> core::ops::arith::Sub<&T> for bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Sub<Output = bitcoin_units::NumOpResult<T>>
+impl<T> core::ops::arith::Sub<&bitcoin_units::NumOpResult<T>> for bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Sub<Output = bitcoin_units::NumOpResult<T>>
+impl<T> core::ops::arith::Sub<T> for &bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Sub<Output = bitcoin_units::NumOpResult<T>>
+impl<T> core::ops::arith::Sub<T> for bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Sub<Output = bitcoin_units::NumOpResult<T>>
+impl<T> core::ops::arith::Sub<bitcoin_units::NumOpResult<T>> for &bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Sub<Output = bitcoin_units::NumOpResult<T>>
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::NumOpResult<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_units::NumOpResult<T> where T: core::panic::unwind_safe::UnwindSafe
+pub bitcoin_units::MathOp::Add
+pub bitcoin_units::MathOp::Div
+pub bitcoin_units::MathOp::Mul
+pub bitcoin_units::MathOp::Neg
+pub bitcoin_units::MathOp::Rem
+pub bitcoin_units::MathOp::Sub
+pub bitcoin_units::NumOpResult::Error(bitcoin_units::NumOpError)
+pub bitcoin_units::NumOpResult::Valid(T)
+pub bitcoin_units::amount::Denomination::Bit
+pub bitcoin_units::amount::Denomination::Bitcoin
+pub bitcoin_units::amount::Denomination::CentiBitcoin
+pub bitcoin_units::amount::Denomination::MicroBitcoin
+pub bitcoin_units::amount::Denomination::MilliBitcoin
+pub bitcoin_units::amount::Denomination::Satoshi
+pub bitcoin_units::amount::ParseDenominationError::PossiblyConfusing(bitcoin_units::amount::PossiblyConfusingDenominationError)
+pub bitcoin_units::amount::ParseDenominationError::Unknown(bitcoin_units::amount::UnknownDenominationError)
+pub const bitcoin_units::Amount::FIFTY_BTC: Self
+pub const bitcoin_units::Amount::MAX: Self
+pub const bitcoin_units::Amount::MAX_MONEY: Self
+pub const bitcoin_units::Amount::MIN: Self
+pub const bitcoin_units::Amount::ONE_BTC: Self
+pub const bitcoin_units::Amount::ONE_SAT: Self
+pub const bitcoin_units::Amount::SIZE: usize
+pub const bitcoin_units::Amount::ZERO: Self
+pub const bitcoin_units::FeeRate::BROADCAST_MIN: bitcoin_units::FeeRate
+pub const bitcoin_units::FeeRate::DUST: bitcoin_units::FeeRate
+pub const bitcoin_units::FeeRate::MAX: bitcoin_units::FeeRate
+pub const bitcoin_units::FeeRate::MIN: bitcoin_units::FeeRate
+pub const bitcoin_units::FeeRate::ZERO: bitcoin_units::FeeRate
+pub const bitcoin_units::SignedAmount::FIFTY_BTC: Self
+pub const bitcoin_units::SignedAmount::MAX: Self
+pub const bitcoin_units::SignedAmount::MAX_MONEY: Self
+pub const bitcoin_units::SignedAmount::MIN: Self
+pub const bitcoin_units::SignedAmount::ONE_BTC: Self
+pub const bitcoin_units::SignedAmount::ONE_SAT: Self
+pub const bitcoin_units::SignedAmount::ZERO: Self
+pub const bitcoin_units::Weight::MAX: bitcoin_units::Weight
+pub const bitcoin_units::Weight::MAX_BLOCK: bitcoin_units::Weight
+pub const bitcoin_units::Weight::MIN: bitcoin_units::Weight
+pub const bitcoin_units::Weight::MIN_TRANSACTION: bitcoin_units::Weight
+pub const bitcoin_units::Weight::WITNESS_SCALE_FACTOR: u64
+pub const bitcoin_units::Weight::ZERO: bitcoin_units::Weight
+pub const bitcoin_units::amount::Denomination::BTC: Self
+pub const bitcoin_units::amount::Denomination::SAT: Self
+pub const bitcoin_units::block::BlockHeight::MAX: Self
+pub const bitcoin_units::block::BlockHeight::MIN: Self
+pub const bitcoin_units::block::BlockHeight::ZERO: Self
+pub const bitcoin_units::block::BlockHeightInterval::MAX: Self
+pub const bitcoin_units::block::BlockHeightInterval::MIN: Self
+pub const bitcoin_units::block::BlockHeightInterval::ZERO: Self
+pub const bitcoin_units::block::BlockMtp::MAX: Self
+pub const bitcoin_units::block::BlockMtp::MIN: Self
+pub const bitcoin_units::block::BlockMtp::ZERO: Self
+pub const bitcoin_units::block::BlockMtpInterval::MAX: Self
+pub const bitcoin_units::block::BlockMtpInterval::MIN: Self
+pub const bitcoin_units::block::BlockMtpInterval::ZERO: Self
+pub const bitcoin_units::locktime::absolute::Height::MAX: Self
+pub const bitcoin_units::locktime::absolute::Height::MIN: Self
+pub const bitcoin_units::locktime::absolute::Height::ZERO: Self
+pub const bitcoin_units::locktime::absolute::LOCK_TIME_THRESHOLD: u32
+pub const bitcoin_units::locktime::absolute::MedianTimePast::MAX: Self
+pub const bitcoin_units::locktime::absolute::MedianTimePast::MIN: Self
+pub const bitcoin_units::locktime::relative::NumberOf512Seconds::MAX: Self
+pub const bitcoin_units::locktime::relative::NumberOf512Seconds::MIN: Self
+pub const bitcoin_units::locktime::relative::NumberOf512Seconds::ZERO: Self
+pub const bitcoin_units::locktime::relative::NumberOfBlocks::MAX: Self
+pub const bitcoin_units::locktime::relative::NumberOfBlocks::MIN: Self
+pub const bitcoin_units::locktime::relative::NumberOfBlocks::ZERO: Self
+pub const bitcoin_units::weight::WITNESS_SCALE_FACTOR: usize
+pub const fn bitcoin_units::Amount::checked_add(self, rhs: Self) -> core::option::Option<Self>
+pub const fn bitcoin_units::Amount::checked_div(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::Amount::checked_mul(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::Amount::checked_rem(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::Amount::checked_sub(self, rhs: Self) -> core::option::Option<Self>
+pub const fn bitcoin_units::Amount::div_by_fee_rate_ceil(self, fee_rate: bitcoin_units::FeeRate) -> bitcoin_units::NumOpResult<bitcoin_units::Weight>
+pub const fn bitcoin_units::Amount::div_by_fee_rate_floor(self, fee_rate: bitcoin_units::FeeRate) -> bitcoin_units::NumOpResult<bitcoin_units::Weight>
+pub const fn bitcoin_units::Amount::div_by_weight_ceil(self, weight: bitcoin_units::Weight) -> bitcoin_units::NumOpResult<bitcoin_units::FeeRate>
+pub const fn bitcoin_units::Amount::div_by_weight_floor(self, weight: bitcoin_units::Weight) -> bitcoin_units::NumOpResult<bitcoin_units::FeeRate>
+pub const fn bitcoin_units::Amount::from_btc_u16(whole_bitcoin: u16) -> Self
+pub const fn bitcoin_units::Amount::from_sat(satoshi: u64) -> core::result::Result<Self, bitcoin_units::amount::OutOfRangeError>
+pub const fn bitcoin_units::Amount::from_sat_u32(satoshi: u32) -> Self
+pub const fn bitcoin_units::Amount::to_sat(self) -> u64
+pub const fn bitcoin_units::BlockTime::from_u32(t: u32) -> Self
+pub const fn bitcoin_units::BlockTime::to_u32(self) -> u32
+pub const fn bitcoin_units::FeeRate::checked_add(self, rhs: bitcoin_units::FeeRate) -> core::option::Option<Self>
+pub const fn bitcoin_units::FeeRate::checked_div(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::FeeRate::checked_mul(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::FeeRate::checked_sub(self, rhs: bitcoin_units::FeeRate) -> core::option::Option<Self>
+pub const fn bitcoin_units::FeeRate::from_per_kvb(rate: bitcoin_units::Amount) -> bitcoin_units::NumOpResult<Self>
+pub const fn bitcoin_units::FeeRate::from_per_kwu(rate: bitcoin_units::Amount) -> bitcoin_units::NumOpResult<Self>
+pub const fn bitcoin_units::FeeRate::from_per_vb(rate: bitcoin_units::Amount) -> bitcoin_units::NumOpResult<Self>
+pub const fn bitcoin_units::FeeRate::from_sat_per_kvb(sat_kvb: u32) -> Self
+pub const fn bitcoin_units::FeeRate::from_sat_per_kwu(sat_kwu: u32) -> Self
+pub const fn bitcoin_units::FeeRate::from_sat_per_vb(sat_vb: u32) -> Self
+pub const fn bitcoin_units::FeeRate::mul_by_weight(self, weight: bitcoin_units::Weight) -> bitcoin_units::NumOpResult<bitcoin_units::Amount>
+pub const fn bitcoin_units::FeeRate::to_fee(self, weight: bitcoin_units::Weight) -> bitcoin_units::Amount
+pub const fn bitcoin_units::FeeRate::to_sat_per_kvb_ceil(self) -> u64
+pub const fn bitcoin_units::FeeRate::to_sat_per_kvb_floor(self) -> u64
+pub const fn bitcoin_units::FeeRate::to_sat_per_kwu_ceil(self) -> u64
+pub const fn bitcoin_units::FeeRate::to_sat_per_kwu_floor(self) -> u64
+pub const fn bitcoin_units::FeeRate::to_sat_per_vb_ceil(self) -> u64
+pub const fn bitcoin_units::FeeRate::to_sat_per_vb_floor(self) -> u64
+pub const fn bitcoin_units::SignedAmount::abs(self) -> Self
+pub const fn bitcoin_units::SignedAmount::checked_abs(self) -> core::option::Option<Self>
+pub const fn bitcoin_units::SignedAmount::checked_add(self, rhs: Self) -> core::option::Option<Self>
+pub const fn bitcoin_units::SignedAmount::checked_div(self, rhs: i64) -> core::option::Option<Self>
+pub const fn bitcoin_units::SignedAmount::checked_mul(self, rhs: i64) -> core::option::Option<Self>
+pub const fn bitcoin_units::SignedAmount::checked_rem(self, rhs: i64) -> core::option::Option<Self>
+pub const fn bitcoin_units::SignedAmount::checked_sub(self, rhs: Self) -> core::option::Option<Self>
+pub const fn bitcoin_units::SignedAmount::from_btc_i16(whole_bitcoin: i16) -> Self
+pub const fn bitcoin_units::SignedAmount::from_sat(satoshi: i64) -> core::result::Result<Self, bitcoin_units::amount::OutOfRangeError>
+pub const fn bitcoin_units::SignedAmount::from_sat_i32(satoshi: i32) -> Self
+pub const fn bitcoin_units::SignedAmount::to_sat(self) -> i64
+pub const fn bitcoin_units::Weight::checked_add(self, rhs: Self) -> core::option::Option<Self>
+pub const fn bitcoin_units::Weight::checked_div(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::Weight::checked_mul(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::Weight::checked_sub(self, rhs: Self) -> core::option::Option<Self>
+pub const fn bitcoin_units::Weight::from_kwu(wu: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::Weight::from_non_witness_data_size(non_witness_size: u64) -> Self
+pub const fn bitcoin_units::Weight::from_vb(vb: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::Weight::from_vb_unchecked(vb: u64) -> Self
+pub const fn bitcoin_units::Weight::from_vb_unwrap(vb: u64) -> bitcoin_units::Weight
+pub const fn bitcoin_units::Weight::from_witness_data_size(witness_size: u64) -> Self
+pub const fn bitcoin_units::Weight::from_wu(wu: u64) -> Self
+pub const fn bitcoin_units::Weight::mul_by_fee_rate(self, fee_rate: bitcoin_units::FeeRate) -> bitcoin_units::NumOpResult<bitcoin_units::Amount>
+pub const fn bitcoin_units::Weight::to_kwu_ceil(self) -> u64
+pub const fn bitcoin_units::Weight::to_kwu_floor(self) -> u64
+pub const fn bitcoin_units::Weight::to_vbytes_ceil(self) -> u64
+pub const fn bitcoin_units::Weight::to_vbytes_floor(self) -> u64
+pub const fn bitcoin_units::Weight::to_wu(self) -> u64
+pub const fn bitcoin_units::block::BlockHeight::from_u32(inner: u32) -> Self
+pub const fn bitcoin_units::block::BlockHeight::to_u32(self) -> u32
+pub const fn bitcoin_units::block::BlockHeightInterval::from_u32(inner: u32) -> Self
+pub const fn bitcoin_units::block::BlockHeightInterval::to_u32(self) -> u32
+pub const fn bitcoin_units::block::BlockMtp::from_u32(inner: u32) -> Self
+pub const fn bitcoin_units::block::BlockMtp::to_u32(self) -> u32
+pub const fn bitcoin_units::block::BlockMtpInterval::from_u32(inner: u32) -> Self
+pub const fn bitcoin_units::block::BlockMtpInterval::to_relative_mtp_interval_ceil(self) -> core::result::Result<bitcoin_units::locktime::relative::NumberOf512Seconds, bitcoin_units::locktime::relative::TimeOverflowError>
+pub const fn bitcoin_units::block::BlockMtpInterval::to_relative_mtp_interval_floor(self) -> core::result::Result<bitcoin_units::locktime::relative::NumberOf512Seconds, bitcoin_units::locktime::relative::TimeOverflowError>
+pub const fn bitcoin_units::block::BlockMtpInterval::to_u32(self) -> u32
+pub const fn bitcoin_units::locktime::absolute::Height::from_u32(n: u32) -> core::result::Result<bitcoin_units::locktime::absolute::Height, bitcoin_units::locktime::absolute::ConversionError>
+pub const fn bitcoin_units::locktime::absolute::Height::to_u32(self) -> u32
+pub const fn bitcoin_units::locktime::absolute::MedianTimePast::from_u32(n: u32) -> core::result::Result<Self, bitcoin_units::locktime::absolute::ConversionError>
+pub const fn bitcoin_units::locktime::absolute::MedianTimePast::to_u32(self) -> u32
+pub const fn bitcoin_units::locktime::absolute::is_block_height(n: u32) -> bool
+pub const fn bitcoin_units::locktime::absolute::is_block_time(n: u32) -> bool
+pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_512_second_intervals(intervals: u16) -> Self
+pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_seconds_ceil(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::TimeOverflowError>
+pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_seconds_floor(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::TimeOverflowError>
+pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::to_512_second_intervals(self) -> u16
+pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::to_consensus_u32(self) -> u32
+pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::to_seconds(self) -> u32
+pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::from_height(blocks: u16) -> Self
+pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::to_consensus_u32(self) -> u32
+pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::to_height(self) -> u16
+pub enum bitcoin_units::NumOpResult<T>
+pub fn &bitcoin_units::Amount::add(self, rhs: &bitcoin_units::Amount) -> Self::Output
+pub fn &bitcoin_units::Amount::add(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Amount>) -> Self::Output
+pub fn &bitcoin_units::Amount::add(self, rhs: bitcoin_units::Amount) -> Self::Output
+pub fn &bitcoin_units::Amount::add(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Amount>) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: &bitcoin_units::Amount) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: &bitcoin_units::FeeRate) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: &u64) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: bitcoin_units::Amount) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: bitcoin_units::FeeRate) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: u64) -> Self::Output
+pub fn &bitcoin_units::Amount::mul(self, rhs: &u64) -> Self::Output
+pub fn &bitcoin_units::Amount::mul(self, rhs: u64) -> Self::Output
+pub fn &bitcoin_units::Amount::rem(self, rhs: &u64) -> Self::Output
+pub fn &bitcoin_units::Amount::rem(self, rhs: u64) -> Self::Output
+pub fn &bitcoin_units::Amount::sub(self, rhs: &bitcoin_units::Amount) -> Self::Output
+pub fn &bitcoin_units::Amount::sub(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Amount>) -> Self::Output
+pub fn &bitcoin_units::Amount::sub(self, rhs: bitcoin_units::Amount) -> Self::Output
+pub fn &bitcoin_units::Amount::sub(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Amount>) -> Self::Output
+pub fn &bitcoin_units::FeeRate::add(self, rhs: &bitcoin_units::FeeRate) -> Self::Output
+pub fn &bitcoin_units::FeeRate::add(self, rhs: bitcoin_units::FeeRate) -> Self::Output
+pub fn &bitcoin_units::FeeRate::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output
+pub fn &bitcoin_units::FeeRate::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output
+pub fn &bitcoin_units::FeeRate::mul(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn &bitcoin_units::FeeRate::mul(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::FeeRate::mul(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn &bitcoin_units::FeeRate::mul(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::FeeRate::sub(self, rhs: &bitcoin_units::FeeRate) -> Self::Output
+pub fn &bitcoin_units::FeeRate::sub(self, rhs: bitcoin_units::FeeRate) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<T>::add(self, rhs: &T) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<T>::add(self, rhs: &bitcoin_units::NumOpResult<T>) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<T>::add(self, rhs: T) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<T>::add(self, rhs: bitcoin_units::NumOpResult<T>) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<T>::sub(self, rhs: &T) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<T>::sub(self, rhs: &bitcoin_units::NumOpResult<T>) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<T>::sub(self, rhs: T) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<T>::sub(self, rhs: bitcoin_units::NumOpResult<T>) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::FeeRate) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &u64) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: bitcoin_units::FeeRate) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: u64) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::mul(self, rhs: &u64) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::mul(self, rhs: u64) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::rem(self, rhs: &u64) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::rem(self, rhs: u64) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::mul(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::mul(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::mul(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::mul(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &i64) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: i64) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::mul(self, rhs: &i64) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::mul(self, rhs: i64) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::rem(self, rhs: &i64) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::rem(self, rhs: i64) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Weight>::mul(self, rhs: &bitcoin_units::FeeRate) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Weight>::mul(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Weight>::mul(self, rhs: bitcoin_units::FeeRate) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Weight>::mul(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::add(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::add(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::add(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::add(self, rhs: bitcoin_units::SignedAmount) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::div(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::div(self, rhs: &core::num::nonzero::NonZeroI64) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::div(self, rhs: &i64) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::div(self, rhs: bitcoin_units::SignedAmount) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::div(self, rhs: core::num::nonzero::NonZeroI64) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::div(self, rhs: i64) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::mul(self, rhs: &i64) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::mul(self, rhs: i64) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::rem(self, rhs: &i64) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::rem(self, rhs: i64) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::sub(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::sub(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::sub(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::sub(self, rhs: bitcoin_units::SignedAmount) -> Self::Output
+pub fn &bitcoin_units::Weight::add(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::Weight::add(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::Weight::div(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::Weight::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output
+pub fn &bitcoin_units::Weight::div(self, rhs: &u64) -> Self::Output
+pub fn &bitcoin_units::Weight::div(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::Weight::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output
+pub fn &bitcoin_units::Weight::div(self, rhs: u64) -> Self::Output
+pub fn &bitcoin_units::Weight::mul(self, rhs: &bitcoin_units::FeeRate) -> Self::Output
+pub fn &bitcoin_units::Weight::mul(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn &bitcoin_units::Weight::mul(self, rhs: &u64) -> Self::Output
+pub fn &bitcoin_units::Weight::mul(self, rhs: bitcoin_units::FeeRate) -> Self::Output
+pub fn &bitcoin_units::Weight::mul(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn &bitcoin_units::Weight::mul(self, rhs: u64) -> Self::Output
+pub fn &bitcoin_units::Weight::rem(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::Weight::rem(self, rhs: &u64) -> Self::Output
+pub fn &bitcoin_units::Weight::rem(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::Weight::rem(self, rhs: u64) -> Self::Output
+pub fn &bitcoin_units::Weight::sub(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::Weight::sub(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::block::BlockHeight::add(self, rhs: &bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockHeight::add(self, rhs: bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockHeight::sub(self, rhs: &bitcoin_units::block::BlockHeight) -> Self::Output
+pub fn &bitcoin_units::block::BlockHeight::sub(self, rhs: &bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockHeight::sub(self, rhs: bitcoin_units::block::BlockHeight) -> Self::Output
+pub fn &bitcoin_units::block::BlockHeight::sub(self, rhs: bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockHeightInterval::add(self, rhs: &bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockHeightInterval::add(self, rhs: bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockHeightInterval::sub(self, rhs: &bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockHeightInterval::sub(self, rhs: bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockMtp::add(self, rhs: &bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockMtp::add(self, rhs: bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockMtp::sub(self, rhs: &bitcoin_units::block::BlockMtp) -> Self::Output
+pub fn &bitcoin_units::block::BlockMtp::sub(self, rhs: &bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockMtp::sub(self, rhs: bitcoin_units::block::BlockMtp) -> Self::Output
+pub fn &bitcoin_units::block::BlockMtp::sub(self, rhs: bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockMtpInterval::add(self, rhs: &bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockMtpInterval::add(self, rhs: bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockMtpInterval::sub(self, rhs: &bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockMtpInterval::sub(self, rhs: bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn &i64::mul(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
+pub fn &i64::mul(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output
+pub fn &i64::mul(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
+pub fn &i64::mul(self, rhs: bitcoin_units::SignedAmount) -> Self::Output
+pub fn &u64::mul(self, rhs: &bitcoin_units::Amount) -> Self::Output
+pub fn &u64::mul(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Amount>) -> Self::Output
+pub fn &u64::mul(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn &u64::mul(self, rhs: bitcoin_units::Amount) -> Self::Output
+pub fn &u64::mul(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Amount>) -> Self::Output
+pub fn &u64::mul(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn T::checked_sum(self) -> core::option::Option<bitcoin_units::Amount>
+pub fn T::checked_sum(self) -> core::option::Option<bitcoin_units::SignedAmount>
+pub fn T::checked_sum(self) -> core::option::Option<bitcoin_units::Weight>
+pub fn bitcoin_units::Amount::add(self, rhs: &bitcoin_units::Amount) -> Self::Output
+pub fn bitcoin_units::Amount::add(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Amount>) -> Self::Output
+pub fn bitcoin_units::Amount::add(self, rhs: bitcoin_units::Amount) -> Self::Output
+pub fn bitcoin_units::Amount::add(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Amount>) -> Self::Output
+pub fn bitcoin_units::Amount::clone(&self) -> bitcoin_units::Amount
+pub fn bitcoin_units::Amount::cmp(&self, other: &bitcoin_units::Amount) -> core::cmp::Ordering
+pub fn bitcoin_units::Amount::default() -> Self
+pub fn bitcoin_units::Amount::display_dynamic(self) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::Amount::display_in(self, denomination: bitcoin_units::amount::Denomination) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::Amount::div(self, rhs: &bitcoin_units::Amount) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: &bitcoin_units::FeeRate) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: &u64) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: bitcoin_units::Amount) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: bitcoin_units::FeeRate) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::Amount::eq(&self, other: &bitcoin_units::Amount) -> bool
+pub fn bitcoin_units::Amount::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::Amount::from_btc(btc: f64) -> core::result::Result<Self, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::Amount::from_float_in(value: f64, denom: bitcoin_units::amount::Denomination) -> core::result::Result<Self, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::Amount::from_int_btc<T: core::convert::Into<u16>>(whole_bitcoin: T) -> Self
+pub fn bitcoin_units::Amount::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::Amount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<Self, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::Amount::from_str_with_denomination(s: &str) -> core::result::Result<Self, bitcoin_units::amount::ParseError>
+pub fn bitcoin_units::Amount::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::Amount::mul(self, rhs: &u64) -> Self::Output
+pub fn bitcoin_units::Amount::mul(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::Amount::partial_cmp(&self, other: &bitcoin_units::Amount) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::Amount::rem(self, modulus: u64) -> Self::Output
+pub fn bitcoin_units::Amount::rem(self, rhs: &u64) -> Self::Output
+pub fn bitcoin_units::Amount::sub(self, rhs: &bitcoin_units::Amount) -> Self::Output
+pub fn bitcoin_units::Amount::sub(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Amount>) -> Self::Output
+pub fn bitcoin_units::Amount::sub(self, rhs: bitcoin_units::Amount) -> Self::Output
+pub fn bitcoin_units::Amount::sub(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Amount>) -> Self::Output
+pub fn bitcoin_units::Amount::to_btc(self) -> f64
+pub fn bitcoin_units::Amount::to_float_in(self, denom: bitcoin_units::amount::Denomination) -> f64
+pub fn bitcoin_units::Amount::to_signed(self) -> bitcoin_units::SignedAmount
+pub fn bitcoin_units::Amount::to_string_in(self, denom: bitcoin_units::amount::Denomination) -> alloc::string::String
+pub fn bitcoin_units::Amount::to_string_with_denomination(self, denom: bitcoin_units::amount::Denomination) -> alloc::string::String
+pub fn bitcoin_units::Amount::try_from(value: bitcoin_units::SignedAmount) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::BlockTime::clone(&self) -> bitcoin_units::BlockTime
+pub fn bitcoin_units::BlockTime::cmp(&self, other: &bitcoin_units::BlockTime) -> core::cmp::Ordering
+pub fn bitcoin_units::BlockTime::eq(&self, other: &bitcoin_units::BlockTime) -> bool
+pub fn bitcoin_units::BlockTime::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::BlockTime::from(t: u32) -> Self
+pub fn bitcoin_units::BlockTime::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::BlockTime::partial_cmp(&self, other: &bitcoin_units::BlockTime) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::CheckedSum::checked_sum(self) -> core::option::Option<R>
+pub fn bitcoin_units::FeeRate::add(self, rhs: &bitcoin_units::FeeRate) -> Self::Output
+pub fn bitcoin_units::FeeRate::add(self, rhs: bitcoin_units::FeeRate) -> Self::Output
+pub fn bitcoin_units::FeeRate::add_assign(&mut self, rhs: &bitcoin_units::FeeRate)
+pub fn bitcoin_units::FeeRate::add_assign(&mut self, rhs: bitcoin_units::FeeRate)
+pub fn bitcoin_units::FeeRate::clone(&self) -> bitcoin_units::FeeRate
+pub fn bitcoin_units::FeeRate::cmp(&self, other: &bitcoin_units::FeeRate) -> core::cmp::Ordering
+pub fn bitcoin_units::FeeRate::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output
+pub fn bitcoin_units::FeeRate::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output
+pub fn bitcoin_units::FeeRate::eq(&self, other: &bitcoin_units::FeeRate) -> bool
+pub fn bitcoin_units::FeeRate::fee_vb(self, vb: u64) -> core::option::Option<bitcoin_units::Amount>
+pub fn bitcoin_units::FeeRate::fee_wu(self, weight: bitcoin_units::Weight) -> core::option::Option<bitcoin_units::Amount>
+pub fn bitcoin_units::FeeRate::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::FeeRate::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::FeeRate::mul(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn bitcoin_units::FeeRate::mul(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::FeeRate::mul(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn bitcoin_units::FeeRate::mul(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::FeeRate::partial_cmp(&self, other: &bitcoin_units::FeeRate) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::FeeRate::sub(self, rhs: &bitcoin_units::FeeRate) -> Self::Output
+pub fn bitcoin_units::FeeRate::sub(self, rhs: bitcoin_units::FeeRate) -> Self::Output
+pub fn bitcoin_units::FeeRate::sub_assign(&mut self, rhs: &bitcoin_units::FeeRate)
+pub fn bitcoin_units::FeeRate::sub_assign(&mut self, rhs: bitcoin_units::FeeRate)
+pub fn bitcoin_units::FeeRate::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin_units::FeeRate>
+pub fn bitcoin_units::FeeRate::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = Self>
+pub fn bitcoin_units::MathOp::clone(&self) -> bitcoin_units::MathOp
+pub fn bitcoin_units::MathOp::eq(&self, other: &bitcoin_units::MathOp) -> bool
+pub fn bitcoin_units::MathOp::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::MathOp::is_addition(self) -> bool
+pub fn bitcoin_units::MathOp::is_div_by_zero(self) -> bool
+pub fn bitcoin_units::MathOp::is_multiplication(self) -> bool
+pub fn bitcoin_units::MathOp::is_negation(self) -> bool
+pub fn bitcoin_units::MathOp::is_overflow(self) -> bool
+pub fn bitcoin_units::MathOp::is_subtraction(self) -> bool
+pub fn bitcoin_units::NumOpError::clone(&self) -> bitcoin_units::NumOpError
+pub fn bitcoin_units::NumOpError::eq(&self, other: &bitcoin_units::NumOpError) -> bool
+pub fn bitcoin_units::NumOpError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::NumOpError::is_div_by_zero(self) -> bool
+pub fn bitcoin_units::NumOpError::is_overflow(self) -> bool
+pub fn bitcoin_units::NumOpError::operation(self) -> bitcoin_units::MathOp
+pub fn bitcoin_units::NumOpResult<T>::add(self, rhs: &T) -> Self::Output
+pub fn bitcoin_units::NumOpResult<T>::add(self, rhs: &bitcoin_units::NumOpResult<T>) -> Self::Output
+pub fn bitcoin_units::NumOpResult<T>::add(self, rhs: Self) -> Self::Output
+pub fn bitcoin_units::NumOpResult<T>::add(self, rhs: T) -> Self::Output
+pub fn bitcoin_units::NumOpResult<T>::and_then<F>(self, op: F) -> bitcoin_units::NumOpResult<T> where F: core::ops::function::FnOnce(T) -> bitcoin_units::NumOpResult<T>
+pub fn bitcoin_units::NumOpResult<T>::clone(&self) -> bitcoin_units::NumOpResult<T>
+pub fn bitcoin_units::NumOpResult<T>::eq(&self, other: &bitcoin_units::NumOpResult<T>) -> bool
+pub fn bitcoin_units::NumOpResult<T>::expect(self, msg: &str) -> T
+pub fn bitcoin_units::NumOpResult<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::NumOpResult<T>::into_result(self) -> core::result::Result<T, bitcoin_units::NumOpError>
+pub fn bitcoin_units::NumOpResult<T>::is_error(&self) -> bool
+pub fn bitcoin_units::NumOpResult<T>::is_valid(&self) -> bool
+pub fn bitcoin_units::NumOpResult<T>::map<U, F: core::ops::function::FnOnce(T) -> U>(self, op: F) -> bitcoin_units::NumOpResult<U>
+pub fn bitcoin_units::NumOpResult<T>::ok(self) -> core::option::Option<T>
+pub fn bitcoin_units::NumOpResult<T>::sub(self, rhs: &T) -> Self::Output
+pub fn bitcoin_units::NumOpResult<T>::sub(self, rhs: &bitcoin_units::NumOpResult<T>) -> Self::Output
+pub fn bitcoin_units::NumOpResult<T>::sub(self, rhs: Self) -> Self::Output
+pub fn bitcoin_units::NumOpResult<T>::sub(self, rhs: T) -> Self::Output
+pub fn bitcoin_units::NumOpResult<T>::unwrap(self) -> T
+pub fn bitcoin_units::NumOpResult<T>::unwrap_err(self) -> bitcoin_units::NumOpError
+pub fn bitcoin_units::NumOpResult<T>::unwrap_or(self, default: T) -> T
+pub fn bitcoin_units::NumOpResult<T>::unwrap_or_else<F>(self, f: F) -> T where F: core::ops::function::FnOnce() -> T
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::FeeRate) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &u64) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: bitcoin_units::FeeRate) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: &u64)
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: u64)
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::from(a: &bitcoin_units::Amount) -> Self
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::from(a: bitcoin_units::Amount) -> Self
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::mul(self, rhs: &u64) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::mul(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::mul_assign(&mut self, rhs: &u64)
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::mul_assign(&mut self, rhs: u64)
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::rem(self, modulus: u64) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::rem(self, rhs: &u64) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin_units::NumOpResult<bitcoin_units::Amount>>
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = bitcoin_units::NumOpResult<bitcoin_units::Amount>>
+pub fn bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::mul(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::mul(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::mul(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::mul(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &i64) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: i64) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: &i64)
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: i64)
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::from(a: &bitcoin_units::SignedAmount) -> Self
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::from(a: bitcoin_units::SignedAmount) -> Self
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::mul(self, rhs: &i64) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::mul(self, rhs: i64) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::mul_assign(&mut self, rhs: &i64)
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::mul_assign(&mut self, rhs: i64)
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::rem(self, modulus: i64) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::rem(self, rhs: &i64) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>>
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>>
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Weight>::mul(self, rhs: &bitcoin_units::FeeRate) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Weight>::mul(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Weight>::mul(self, rhs: bitcoin_units::FeeRate) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Weight>::mul(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn bitcoin_units::SignedAmount::add(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
+pub fn bitcoin_units::SignedAmount::add(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output
+pub fn bitcoin_units::SignedAmount::add(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
+pub fn bitcoin_units::SignedAmount::add(self, rhs: bitcoin_units::SignedAmount) -> Self::Output
+pub fn bitcoin_units::SignedAmount::clone(&self) -> bitcoin_units::SignedAmount
+pub fn bitcoin_units::SignedAmount::cmp(&self, other: &bitcoin_units::SignedAmount) -> core::cmp::Ordering
+pub fn bitcoin_units::SignedAmount::default() -> Self
+pub fn bitcoin_units::SignedAmount::display_dynamic(self) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::SignedAmount::display_in(self, denomination: bitcoin_units::amount::Denomination) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::SignedAmount::div(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output
+pub fn bitcoin_units::SignedAmount::div(self, rhs: &core::num::nonzero::NonZeroI64) -> Self::Output
+pub fn bitcoin_units::SignedAmount::div(self, rhs: &i64) -> Self::Output
+pub fn bitcoin_units::SignedAmount::div(self, rhs: bitcoin_units::SignedAmount) -> Self::Output
+pub fn bitcoin_units::SignedAmount::div(self, rhs: core::num::nonzero::NonZeroI64) -> Self::Output
+pub fn bitcoin_units::SignedAmount::div(self, rhs: i64) -> Self::Output
+pub fn bitcoin_units::SignedAmount::eq(&self, other: &bitcoin_units::SignedAmount) -> bool
+pub fn bitcoin_units::SignedAmount::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::SignedAmount::from(value: bitcoin_units::Amount) -> Self
+pub fn bitcoin_units::SignedAmount::from_btc(btc: f64) -> core::result::Result<Self, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::SignedAmount::from_float_in(value: f64, denom: bitcoin_units::amount::Denomination) -> core::result::Result<Self, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::SignedAmount::from_int_btc<T: core::convert::Into<i16>>(whole_bitcoin: T) -> Self
+pub fn bitcoin_units::SignedAmount::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::SignedAmount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<Self, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::SignedAmount::from_str_with_denomination(s: &str) -> core::result::Result<Self, bitcoin_units::amount::ParseError>
+pub fn bitcoin_units::SignedAmount::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::SignedAmount::is_negative(self) -> bool
+pub fn bitcoin_units::SignedAmount::is_positive(self) -> bool
+pub fn bitcoin_units::SignedAmount::mul(self, rhs: &i64) -> Self::Output
+pub fn bitcoin_units::SignedAmount::mul(self, rhs: i64) -> Self::Output
+pub fn bitcoin_units::SignedAmount::neg(self) -> Self::Output
+pub fn bitcoin_units::SignedAmount::partial_cmp(&self, other: &bitcoin_units::SignedAmount) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::SignedAmount::positive_sub(self, rhs: Self) -> core::option::Option<Self>
+pub fn bitcoin_units::SignedAmount::rem(self, modulus: i64) -> Self::Output
+pub fn bitcoin_units::SignedAmount::rem(self, rhs: &i64) -> Self::Output
+pub fn bitcoin_units::SignedAmount::signum(self) -> i64
+pub fn bitcoin_units::SignedAmount::sub(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
+pub fn bitcoin_units::SignedAmount::sub(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output
+pub fn bitcoin_units::SignedAmount::sub(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
+pub fn bitcoin_units::SignedAmount::sub(self, rhs: bitcoin_units::SignedAmount) -> Self::Output
+pub fn bitcoin_units::SignedAmount::to_btc(self) -> f64
+pub fn bitcoin_units::SignedAmount::to_float_in(self, denom: bitcoin_units::amount::Denomination) -> f64
+pub fn bitcoin_units::SignedAmount::to_string_in(self, denom: bitcoin_units::amount::Denomination) -> alloc::string::String
+pub fn bitcoin_units::SignedAmount::to_string_with_denomination(self, denom: bitcoin_units::amount::Denomination) -> alloc::string::String
+pub fn bitcoin_units::SignedAmount::to_unsigned(self) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::OutOfRangeError>
+pub fn bitcoin_units::SignedAmount::unsigned_abs(self) -> bitcoin_units::Amount
+pub fn bitcoin_units::Weight::add(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::Weight::add(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::Weight::add_assign(&mut self, rhs: &bitcoin_units::Weight)
+pub fn bitcoin_units::Weight::add_assign(&mut self, rhs: bitcoin_units::Weight)
+pub fn bitcoin_units::Weight::clone(&self) -> bitcoin_units::Weight
+pub fn bitcoin_units::Weight::cmp(&self, other: &bitcoin_units::Weight) -> core::cmp::Ordering
+pub fn bitcoin_units::Weight::div(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::Weight::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output
+pub fn bitcoin_units::Weight::div(self, rhs: &u64) -> Self::Output
+pub fn bitcoin_units::Weight::div(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::Weight::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output
+pub fn bitcoin_units::Weight::div(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::Weight::div_assign(&mut self, rhs: u64)
+pub fn bitcoin_units::Weight::eq(&self, other: &bitcoin_units::Weight) -> bool
+pub fn bitcoin_units::Weight::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::Weight::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::Weight::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::Weight::mul(self, rhs: &bitcoin_units::FeeRate) -> Self::Output
+pub fn bitcoin_units::Weight::mul(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn bitcoin_units::Weight::mul(self, rhs: &u64) -> Self::Output
+pub fn bitcoin_units::Weight::mul(self, rhs: bitcoin_units::FeeRate) -> Self::Output
+pub fn bitcoin_units::Weight::mul(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn bitcoin_units::Weight::mul(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::Weight::mul_assign(&mut self, rhs: u64)
+pub fn bitcoin_units::Weight::partial_cmp(&self, other: &bitcoin_units::Weight) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::Weight::rem(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::Weight::rem(self, rhs: &u64) -> Self::Output
+pub fn bitcoin_units::Weight::rem(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::Weight::rem(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::Weight::rem_assign(&mut self, rhs: u64)
+pub fn bitcoin_units::Weight::sub(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::Weight::sub(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::Weight::sub_assign(&mut self, rhs: &bitcoin_units::Weight)
+pub fn bitcoin_units::Weight::sub_assign(&mut self, rhs: bitcoin_units::Weight)
+pub fn bitcoin_units::Weight::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin_units::Weight>
+pub fn bitcoin_units::Weight::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = Self>
+pub fn bitcoin_units::Weight::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::Weight::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::Weight::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::amount::Denomination::clone(&self) -> bitcoin_units::amount::Denomination
+pub fn bitcoin_units::amount::Denomination::eq(&self, other: &bitcoin_units::amount::Denomination) -> bool
+pub fn bitcoin_units::amount::Denomination::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::Denomination::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::amount::Denomination::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::amount::Display::clone(&self) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::amount::Display::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::Display::show_denomination(self) -> Self
+pub fn bitcoin_units::amount::InputTooLargeError::clone(&self) -> bitcoin_units::amount::InputTooLargeError
+pub fn bitcoin_units::amount::InputTooLargeError::eq(&self, other: &bitcoin_units::amount::InputTooLargeError) -> bool
+pub fn bitcoin_units::amount::InputTooLargeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::InvalidCharacterError::clone(&self) -> bitcoin_units::amount::InvalidCharacterError
+pub fn bitcoin_units::amount::InvalidCharacterError::eq(&self, other: &bitcoin_units::amount::InvalidCharacterError) -> bool
+pub fn bitcoin_units::amount::InvalidCharacterError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::MissingDenominationError::clone(&self) -> bitcoin_units::amount::MissingDenominationError
+pub fn bitcoin_units::amount::MissingDenominationError::eq(&self, other: &bitcoin_units::amount::MissingDenominationError) -> bool
+pub fn bitcoin_units::amount::MissingDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::MissingDigitsError::clone(&self) -> bitcoin_units::amount::MissingDigitsError
+pub fn bitcoin_units::amount::MissingDigitsError::eq(&self, other: &bitcoin_units::amount::MissingDigitsError) -> bool
+pub fn bitcoin_units::amount::MissingDigitsError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::OutOfRangeError::clone(&self) -> bitcoin_units::amount::OutOfRangeError
+pub fn bitcoin_units::amount::OutOfRangeError::eq(&self, other: &bitcoin_units::amount::OutOfRangeError) -> bool
+pub fn bitcoin_units::amount::OutOfRangeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::OutOfRangeError::is_above_max(self) -> bool
+pub fn bitcoin_units::amount::OutOfRangeError::is_below_min(self) -> bool
+pub fn bitcoin_units::amount::OutOfRangeError::valid_range(self) -> (i64, u64)
+pub fn bitcoin_units::amount::ParseAmountError::clone(&self) -> bitcoin_units::amount::ParseAmountError
+pub fn bitcoin_units::amount::ParseAmountError::eq(&self, other: &bitcoin_units::amount::ParseAmountError) -> bool
+pub fn bitcoin_units::amount::ParseAmountError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::ParseAmountError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::amount::ParseAmountError::from(value: bitcoin_units::amount::InputTooLargeError) -> Self
+pub fn bitcoin_units::amount::ParseAmountError::from(value: bitcoin_units::amount::InvalidCharacterError) -> Self
+pub fn bitcoin_units::amount::ParseAmountError::from(value: bitcoin_units::amount::MissingDigitsError) -> Self
+pub fn bitcoin_units::amount::ParseAmountError::from(value: bitcoin_units::amount::OutOfRangeError) -> Self
+pub fn bitcoin_units::amount::ParseAmountError::from(value: bitcoin_units::amount::TooPreciseError) -> Self
+pub fn bitcoin_units::amount::ParseDenominationError::clone(&self) -> bitcoin_units::amount::ParseDenominationError
+pub fn bitcoin_units::amount::ParseDenominationError::eq(&self, other: &bitcoin_units::amount::ParseDenominationError) -> bool
+pub fn bitcoin_units::amount::ParseDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::ParseDenominationError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::amount::ParseError::clone(&self) -> bitcoin_units::amount::ParseError
+pub fn bitcoin_units::amount::ParseError::eq(&self, other: &bitcoin_units::amount::ParseError) -> bool
+pub fn bitcoin_units::amount::ParseError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::InputTooLargeError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::InvalidCharacterError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::MissingDigitsError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::OutOfRangeError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::ParseAmountError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::ParseDenominationError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::TooPreciseError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::amount::PossiblyConfusingDenominationError::clone(&self) -> bitcoin_units::amount::PossiblyConfusingDenominationError
+pub fn bitcoin_units::amount::PossiblyConfusingDenominationError::eq(&self, other: &bitcoin_units::amount::PossiblyConfusingDenominationError) -> bool
+pub fn bitcoin_units::amount::PossiblyConfusingDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::TooPreciseError::clone(&self) -> bitcoin_units::amount::TooPreciseError
+pub fn bitcoin_units::amount::TooPreciseError::eq(&self, other: &bitcoin_units::amount::TooPreciseError) -> bool
+pub fn bitcoin_units::amount::TooPreciseError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::UnknownDenominationError::clone(&self) -> bitcoin_units::amount::UnknownDenominationError
+pub fn bitcoin_units::amount::UnknownDenominationError::eq(&self, other: &bitcoin_units::amount::UnknownDenominationError) -> bool
+pub fn bitcoin_units::amount::UnknownDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::block::BlockHeight::add(self, rhs: &bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockHeight::add(self, rhs: bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockHeight::checked_add(self, other: bitcoin_units::block::BlockHeightInterval) -> core::option::Option<Self>
+pub fn bitcoin_units::block::BlockHeight::checked_sub(self, other: Self) -> core::option::Option<bitcoin_units::block::BlockHeightInterval>
+pub fn bitcoin_units::block::BlockHeight::clone(&self) -> bitcoin_units::block::BlockHeight
+pub fn bitcoin_units::block::BlockHeight::cmp(&self, other: &bitcoin_units::block::BlockHeight) -> core::cmp::Ordering
+pub fn bitcoin_units::block::BlockHeight::eq(&self, other: &bitcoin_units::block::BlockHeight) -> bool
+pub fn bitcoin_units::block::BlockHeight::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::block::BlockHeight::from(h: bitcoin_units::locktime::absolute::Height) -> Self
+pub fn bitcoin_units::block::BlockHeight::from(inner: u32) -> Self
+pub fn bitcoin_units::block::BlockHeight::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::block::BlockHeight::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::block::BlockHeight::partial_cmp(&self, other: &bitcoin_units::block::BlockHeight) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::block::BlockHeight::sub(self, rhs: &bitcoin_units::block::BlockHeight) -> Self::Output
+pub fn bitcoin_units::block::BlockHeight::sub(self, rhs: &bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockHeight::sub(self, rhs: bitcoin_units::block::BlockHeight) -> Self::Output
+pub fn bitcoin_units::block::BlockHeight::sub(self, rhs: bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockHeight::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockHeight::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockHeight::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockHeightInterval::add(self, rhs: &bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockHeightInterval::add(self, rhs: bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockHeightInterval::add_assign(&mut self, rhs: &bitcoin_units::block::BlockHeightInterval)
+pub fn bitcoin_units::block::BlockHeightInterval::add_assign(&mut self, rhs: bitcoin_units::block::BlockHeightInterval)
+pub fn bitcoin_units::block::BlockHeightInterval::checked_add(self, other: Self) -> core::option::Option<Self>
+pub fn bitcoin_units::block::BlockHeightInterval::checked_sub(self, other: Self) -> core::option::Option<Self>
+pub fn bitcoin_units::block::BlockHeightInterval::clone(&self) -> bitcoin_units::block::BlockHeightInterval
+pub fn bitcoin_units::block::BlockHeightInterval::cmp(&self, other: &bitcoin_units::block::BlockHeightInterval) -> core::cmp::Ordering
+pub fn bitcoin_units::block::BlockHeightInterval::default() -> bitcoin_units::block::BlockHeightInterval
+pub fn bitcoin_units::block::BlockHeightInterval::eq(&self, other: &bitcoin_units::block::BlockHeightInterval) -> bool
+pub fn bitcoin_units::block::BlockHeightInterval::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::block::BlockHeightInterval::from(h: bitcoin_units::locktime::relative::NumberOfBlocks) -> Self
+pub fn bitcoin_units::block::BlockHeightInterval::from(inner: u32) -> Self
+pub fn bitcoin_units::block::BlockHeightInterval::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::block::BlockHeightInterval::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::block::BlockHeightInterval::partial_cmp(&self, other: &bitcoin_units::block::BlockHeightInterval) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::block::BlockHeightInterval::sub(self, rhs: &bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockHeightInterval::sub(self, rhs: bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockHeightInterval::sub_assign(&mut self, rhs: &bitcoin_units::block::BlockHeightInterval)
+pub fn bitcoin_units::block::BlockHeightInterval::sub_assign(&mut self, rhs: bitcoin_units::block::BlockHeightInterval)
+pub fn bitcoin_units::block::BlockHeightInterval::sum<I: core::iter::traits::iterator::Iterator<Item = Self>>(iter: I) -> Self
+pub fn bitcoin_units::block::BlockHeightInterval::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin_units::block::BlockHeightInterval>
+pub fn bitcoin_units::block::BlockHeightInterval::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockHeightInterval::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockHeightInterval::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockMtp::add(self, rhs: &bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockMtp::add(self, rhs: bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockMtp::checked_add(self, other: bitcoin_units::block::BlockMtpInterval) -> core::option::Option<Self>
+pub fn bitcoin_units::block::BlockMtp::checked_sub(self, other: Self) -> core::option::Option<bitcoin_units::block::BlockMtpInterval>
+pub fn bitcoin_units::block::BlockMtp::clone(&self) -> bitcoin_units::block::BlockMtp
+pub fn bitcoin_units::block::BlockMtp::cmp(&self, other: &bitcoin_units::block::BlockMtp) -> core::cmp::Ordering
+pub fn bitcoin_units::block::BlockMtp::eq(&self, other: &bitcoin_units::block::BlockMtp) -> bool
+pub fn bitcoin_units::block::BlockMtp::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::block::BlockMtp::from(h: bitcoin_units::locktime::absolute::MedianTimePast) -> Self
+pub fn bitcoin_units::block::BlockMtp::from(inner: u32) -> Self
+pub fn bitcoin_units::block::BlockMtp::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::block::BlockMtp::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::block::BlockMtp::new(timestamps: [bitcoin_units::BlockTime; 11]) -> Self
+pub fn bitcoin_units::block::BlockMtp::partial_cmp(&self, other: &bitcoin_units::block::BlockMtp) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::block::BlockMtp::sub(self, rhs: &bitcoin_units::block::BlockMtp) -> Self::Output
+pub fn bitcoin_units::block::BlockMtp::sub(self, rhs: &bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockMtp::sub(self, rhs: bitcoin_units::block::BlockMtp) -> Self::Output
+pub fn bitcoin_units::block::BlockMtp::sub(self, rhs: bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockMtp::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockMtp::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockMtp::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockMtpInterval::add(self, rhs: &bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockMtpInterval::add(self, rhs: bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockMtpInterval::add_assign(&mut self, rhs: &bitcoin_units::block::BlockMtpInterval)
+pub fn bitcoin_units::block::BlockMtpInterval::add_assign(&mut self, rhs: bitcoin_units::block::BlockMtpInterval)
+pub fn bitcoin_units::block::BlockMtpInterval::checked_add(self, other: Self) -> core::option::Option<Self>
+pub fn bitcoin_units::block::BlockMtpInterval::checked_sub(self, other: Self) -> core::option::Option<Self>
+pub fn bitcoin_units::block::BlockMtpInterval::clone(&self) -> bitcoin_units::block::BlockMtpInterval
+pub fn bitcoin_units::block::BlockMtpInterval::cmp(&self, other: &bitcoin_units::block::BlockMtpInterval) -> core::cmp::Ordering
+pub fn bitcoin_units::block::BlockMtpInterval::default() -> bitcoin_units::block::BlockMtpInterval
+pub fn bitcoin_units::block::BlockMtpInterval::eq(&self, other: &bitcoin_units::block::BlockMtpInterval) -> bool
+pub fn bitcoin_units::block::BlockMtpInterval::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::block::BlockMtpInterval::from(h: bitcoin_units::locktime::relative::NumberOf512Seconds) -> Self
+pub fn bitcoin_units::block::BlockMtpInterval::from(inner: u32) -> Self
+pub fn bitcoin_units::block::BlockMtpInterval::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::block::BlockMtpInterval::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::block::BlockMtpInterval::partial_cmp(&self, other: &bitcoin_units::block::BlockMtpInterval) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::block::BlockMtpInterval::sub(self, rhs: &bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockMtpInterval::sub(self, rhs: bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockMtpInterval::sub_assign(&mut self, rhs: &bitcoin_units::block::BlockMtpInterval)
+pub fn bitcoin_units::block::BlockMtpInterval::sub_assign(&mut self, rhs: bitcoin_units::block::BlockMtpInterval)
+pub fn bitcoin_units::block::BlockMtpInterval::sum<I: core::iter::traits::iterator::Iterator<Item = Self>>(iter: I) -> Self
+pub fn bitcoin_units::block::BlockMtpInterval::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin_units::block::BlockMtpInterval>
+pub fn bitcoin_units::block::BlockMtpInterval::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockMtpInterval::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockMtpInterval::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::TooBigForRelativeHeightError::clone(&self) -> bitcoin_units::block::TooBigForRelativeHeightError
+pub fn bitcoin_units::block::TooBigForRelativeHeightError::eq(&self, other: &bitcoin_units::block::TooBigForRelativeHeightError) -> bool
+pub fn bitcoin_units::block::TooBigForRelativeHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::absolute::ConversionError::clone(&self) -> bitcoin_units::locktime::absolute::ConversionError
+pub fn bitcoin_units::locktime::absolute::ConversionError::eq(&self, other: &bitcoin_units::locktime::absolute::ConversionError) -> bool
+pub fn bitcoin_units::locktime::absolute::ConversionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::absolute::Height::clone(&self) -> bitcoin_units::locktime::absolute::Height
+pub fn bitcoin_units::locktime::absolute::Height::cmp(&self, other: &bitcoin_units::locktime::absolute::Height) -> core::cmp::Ordering
+pub fn bitcoin_units::locktime::absolute::Height::eq(&self, other: &bitcoin_units::locktime::absolute::Height) -> bool
+pub fn bitcoin_units::locktime::absolute::Height::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::absolute::Height::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::locktime::absolute::ParseHeightError>
+pub fn bitcoin_units::locktime::absolute::Height::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::locktime::absolute::Height::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::locktime::absolute::Height::is_satisfied_by(self, height: bitcoin_units::locktime::absolute::Height) -> bool
+pub fn bitcoin_units::locktime::absolute::Height::partial_cmp(&self, other: &bitcoin_units::locktime::absolute::Height) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::locktime::absolute::Height::try_from(h: bitcoin_units::block::BlockHeight) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::absolute::Height::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::absolute::Height::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::absolute::Height::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::clone(&self) -> bitcoin_units::locktime::absolute::MedianTimePast
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::cmp(&self, other: &bitcoin_units::locktime::absolute::MedianTimePast) -> core::cmp::Ordering
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::eq(&self, other: &bitcoin_units::locktime::absolute::MedianTimePast) -> bool
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::locktime::absolute::ParseTimeError>
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::is_satisfied_by(self, time: bitcoin_units::locktime::absolute::MedianTimePast) -> bool
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::new(timestamps: [bitcoin_units::BlockTime; 11]) -> core::result::Result<Self, bitcoin_units::locktime::absolute::ConversionError>
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::partial_cmp(&self, other: &bitcoin_units::locktime::absolute::MedianTimePast) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::try_from(h: bitcoin_units::block::BlockMtp) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::absolute::ParseHeightError::clone(&self) -> bitcoin_units::locktime::absolute::ParseHeightError
+pub fn bitcoin_units::locktime::absolute::ParseHeightError::eq(&self, other: &bitcoin_units::locktime::absolute::ParseHeightError) -> bool
+pub fn bitcoin_units::locktime::absolute::ParseHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::absolute::ParseTimeError::clone(&self) -> bitcoin_units::locktime::absolute::ParseTimeError
+pub fn bitcoin_units::locktime::absolute::ParseTimeError::eq(&self, other: &bitcoin_units::locktime::absolute::ParseTimeError) -> bool
+pub fn bitcoin_units::locktime::absolute::ParseTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::relative::InvalidHeightError::clone(&self) -> bitcoin_units::locktime::relative::InvalidHeightError
+pub fn bitcoin_units::locktime::relative::InvalidHeightError::eq(&self, other: &bitcoin_units::locktime::relative::InvalidHeightError) -> bool
+pub fn bitcoin_units::locktime::relative::InvalidHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::relative::InvalidTimeError::clone(&self) -> bitcoin_units::locktime::relative::InvalidTimeError
+pub fn bitcoin_units::locktime::relative::InvalidTimeError::eq(&self, other: &bitcoin_units::locktime::relative::InvalidTimeError) -> bool
+pub fn bitcoin_units::locktime::relative::InvalidTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::clone(&self) -> bitcoin_units::locktime::relative::NumberOf512Seconds
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::cmp(&self, other: &bitcoin_units::locktime::relative::NumberOf512Seconds) -> core::cmp::Ordering
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::default() -> bitcoin_units::locktime::relative::NumberOf512Seconds
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::eq(&self, other: &bitcoin_units::locktime::relative::NumberOf512Seconds) -> bool
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockMtp, utxo_mined_at: bitcoin_units::block::BlockMtp) -> core::result::Result<bool, bitcoin_units::locktime::relative::InvalidTimeError>
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::partial_cmp(&self, other: &bitcoin_units::locktime::relative::NumberOf512Seconds) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::clone(&self) -> bitcoin_units::locktime::relative::NumberOfBlocks
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::cmp(&self, other: &bitcoin_units::locktime::relative::NumberOfBlocks) -> core::cmp::Ordering
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::default() -> bitcoin_units::locktime::relative::NumberOfBlocks
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::eq(&self, other: &bitcoin_units::locktime::relative::NumberOfBlocks) -> bool
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from(value: u16) -> Self
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockHeight, utxo_mined_at: bitcoin_units::block::BlockHeight) -> core::result::Result<bool, bitcoin_units::locktime::relative::InvalidHeightError>
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::partial_cmp(&self, other: &bitcoin_units::locktime::relative::NumberOfBlocks) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::try_from(h: bitcoin_units::block::BlockHeightInterval) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::relative::TimeOverflowError::clone(&self) -> bitcoin_units::locktime::relative::TimeOverflowError
+pub fn bitcoin_units::locktime::relative::TimeOverflowError::eq(&self, other: &bitcoin_units::locktime::relative::TimeOverflowError) -> bool
+pub fn bitcoin_units::locktime::relative::TimeOverflowError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::parse::ParseIntError::as_ref(&self) -> &core::num::error::ParseIntError
+pub fn bitcoin_units::parse::ParseIntError::clone(&self) -> bitcoin_units::parse::ParseIntError
+pub fn bitcoin_units::parse::ParseIntError::eq(&self, other: &bitcoin_units::parse::ParseIntError) -> bool
+pub fn bitcoin_units::parse::ParseIntError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::parse::PrefixedHexError::clone(&self) -> bitcoin_units::parse::PrefixedHexError
+pub fn bitcoin_units::parse::PrefixedHexError::eq(&self, other: &bitcoin_units::parse::PrefixedHexError) -> bool
+pub fn bitcoin_units::parse::PrefixedHexError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::parse::PrefixedHexError::from(e: bitcoin_units::parse::ParseIntError) -> Self
+pub fn bitcoin_units::parse::PrefixedHexError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::parse::UnprefixedHexError::clone(&self) -> bitcoin_units::parse::UnprefixedHexError
+pub fn bitcoin_units::parse::UnprefixedHexError::eq(&self, other: &bitcoin_units::parse::UnprefixedHexError) -> bool
+pub fn bitcoin_units::parse::UnprefixedHexError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::parse::UnprefixedHexError::from(e: bitcoin_units::parse::ParseIntError) -> Self
+pub fn bitcoin_units::parse::UnprefixedHexError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::parse::hex_check_unprefixed(s: &str) -> core::result::Result<&str, bitcoin_units::parse::UnprefixedHexError>
+pub fn bitcoin_units::parse::hex_remove_prefix(s: &str) -> core::result::Result<&str, bitcoin_units::parse::PrefixedHexError>
+pub fn bitcoin_units::parse::hex_u128(s: &str) -> core::result::Result<u128, bitcoin_units::parse::ParseIntError>
+pub fn bitcoin_units::parse::hex_u128_prefixed(s: &str) -> core::result::Result<u128, bitcoin_units::parse::PrefixedHexError>
+pub fn bitcoin_units::parse::hex_u128_unchecked(s: &str) -> core::result::Result<u128, bitcoin_units::parse::ParseIntError>
+pub fn bitcoin_units::parse::hex_u128_unprefixed(s: &str) -> core::result::Result<u128, bitcoin_units::parse::UnprefixedHexError>
+pub fn bitcoin_units::parse::hex_u32(s: &str) -> core::result::Result<u32, bitcoin_units::parse::ParseIntError>
+pub fn bitcoin_units::parse::hex_u32_prefixed(s: &str) -> core::result::Result<u32, bitcoin_units::parse::PrefixedHexError>
+pub fn bitcoin_units::parse::hex_u32_unchecked(s: &str) -> core::result::Result<u32, bitcoin_units::parse::ParseIntError>
+pub fn bitcoin_units::parse::hex_u32_unprefixed(s: &str) -> core::result::Result<u32, bitcoin_units::parse::UnprefixedHexError>
+pub fn bitcoin_units::parse::int_from_box<T: bitcoin_units::parse::Integer>(s: alloc::boxed::Box<str>) -> core::result::Result<T, bitcoin_units::parse::ParseIntError>
+pub fn bitcoin_units::parse::int_from_str<T: bitcoin_units::parse::Integer>(s: &str) -> core::result::Result<T, bitcoin_units::parse::ParseIntError>
+pub fn bitcoin_units::parse::int_from_string<T: bitcoin_units::parse::Integer>(s: alloc::string::String) -> core::result::Result<T, bitcoin_units::parse::ParseIntError>
+pub fn core::num::error::ParseIntError::from(value: bitcoin_units::parse::ParseIntError) -> Self
+pub fn i64::mul(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
+pub fn i64::mul(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output
+pub fn i64::mul(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
+pub fn i64::mul(self, rhs: bitcoin_units::SignedAmount) -> Self::Output
+pub fn u32::from(height: bitcoin_units::block::BlockHeight) -> Self
+pub fn u32::from(height: bitcoin_units::block::BlockHeightInterval) -> Self
+pub fn u32::from(height: bitcoin_units::block::BlockMtp) -> Self
+pub fn u32::from(height: bitcoin_units::block::BlockMtpInterval) -> Self
+pub fn u32::from(t: bitcoin_units::BlockTime) -> Self
+pub fn u64::from(value: bitcoin_units::Weight) -> Self
+pub fn u64::mul(self, rhs: &bitcoin_units::Amount) -> Self::Output
+pub fn u64::mul(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Amount>) -> Self::Output
+pub fn u64::mul(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn u64::mul(self, rhs: bitcoin_units::Amount) -> Self::Output
+pub fn u64::mul(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Amount>) -> Self::Output
+pub fn u64::mul(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub mod bitcoin_units
+pub mod bitcoin_units::amount
+pub mod bitcoin_units::block
+pub mod bitcoin_units::fee
+pub mod bitcoin_units::fee_rate
+pub mod bitcoin_units::locktime
+pub mod bitcoin_units::locktime::absolute
+pub mod bitcoin_units::locktime::relative
+pub mod bitcoin_units::parse
+pub mod bitcoin_units::time
+pub mod bitcoin_units::weight
+pub struct bitcoin_units::Amount(_)
+pub struct bitcoin_units::BlockHeight(_)
+pub struct bitcoin_units::BlockHeightInterval(_)
+pub struct bitcoin_units::BlockMtp(_)
+pub struct bitcoin_units::BlockMtpInterval(_)
+pub struct bitcoin_units::BlockTime(_)
+pub struct bitcoin_units::FeeRate(_)
+pub struct bitcoin_units::SignedAmount(_)
+pub struct bitcoin_units::Weight(_)
+pub struct bitcoin_units::amount::Amount(_)
+pub struct bitcoin_units::amount::Display
+pub struct bitcoin_units::amount::InputTooLargeError
+pub struct bitcoin_units::amount::InvalidCharacterError
+pub struct bitcoin_units::amount::MissingDigitsError
+pub struct bitcoin_units::amount::OutOfRangeError
+pub struct bitcoin_units::amount::ParseAmountError(_)
+pub struct bitcoin_units::amount::ParseError(_)
+pub struct bitcoin_units::amount::SignedAmount(_)
+pub struct bitcoin_units::amount::TooPreciseError
+pub struct bitcoin_units::block::BlockHeight(_)
+pub struct bitcoin_units::block::BlockHeightInterval(_)
+pub struct bitcoin_units::block::BlockMtp(_)
+pub struct bitcoin_units::block::BlockMtpInterval(_)
+pub struct bitcoin_units::block::TooBigForRelativeHeightError(_)
+pub struct bitcoin_units::fee_rate::FeeRate(_)
+pub struct bitcoin_units::locktime::absolute::Height(_)
+pub struct bitcoin_units::locktime::absolute::MedianTimePast(_)
+pub struct bitcoin_units::locktime::absolute::ParseHeightError(_)
+pub struct bitcoin_units::locktime::absolute::ParseTimeError(_)
+pub struct bitcoin_units::locktime::relative::InvalidHeightError
+pub struct bitcoin_units::locktime::relative::InvalidTimeError
+pub struct bitcoin_units::locktime::relative::NumberOf512Seconds(_)
+pub struct bitcoin_units::locktime::relative::NumberOfBlocks(_)
+pub struct bitcoin_units::locktime::relative::TimeOverflowError
+pub struct bitcoin_units::parse::PrefixedHexError(_)
+pub struct bitcoin_units::parse::UnprefixedHexError(_)
+pub struct bitcoin_units::time::BlockTime(_)
+pub struct bitcoin_units::weight::Weight(_)
+pub trait bitcoin_units::CheckedSum<R>: bitcoin_units::sealed::Sealed<R>
+pub trait bitcoin_units::parse::Integer: core::str::traits::FromStr<Err = core::num::error::ParseIntError> + core::convert::TryFrom<i8> + core::marker::Sized + bitcoin_units::parse::sealed::Sealed
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Add<bitcoin_units::NumOpResult<bitcoin_units::Amount>>>::Output
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Add>::Output
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<bitcoin_units::FeeRate>>::Output
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>>>::Output
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::Weight>>>::Output
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<bitcoin_units::Weight>>::Output
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<u64>>::Output
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div>::Output
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Mul<u64>>::Output
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Rem<u64>>::Output
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Sub<bitcoin_units::NumOpResult<bitcoin_units::Amount>>>::Output
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Sub>::Output
+pub type &bitcoin_units::FeeRate::Output = <bitcoin_units::FeeRate as core::ops::arith::Add>::Output
+pub type &bitcoin_units::FeeRate::Output = <bitcoin_units::FeeRate as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output
+pub type &bitcoin_units::FeeRate::Output = <bitcoin_units::FeeRate as core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::Weight>>>::Output
+pub type &bitcoin_units::FeeRate::Output = <bitcoin_units::FeeRate as core::ops::arith::Mul<bitcoin_units::Weight>>::Output
+pub type &bitcoin_units::FeeRate::Output = <bitcoin_units::FeeRate as core::ops::arith::Sub>::Output
+pub type &bitcoin_units::NumOpResult<T>::Output = <bitcoin_units::NumOpResult<T> as core::ops::arith::Add<T>>::Output
+pub type &bitcoin_units::NumOpResult<T>::Output = <bitcoin_units::NumOpResult<T> as core::ops::arith::Add>::Output
+pub type &bitcoin_units::NumOpResult<T>::Output = <bitcoin_units::NumOpResult<T> as core::ops::arith::Sub<T>>::Output
+pub type &bitcoin_units::NumOpResult<T>::Output = <bitcoin_units::NumOpResult<T> as core::ops::arith::Sub>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::FeeRate>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::Weight>>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::Weight>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<u64>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Mul<u64>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Rem<u64>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::Output = <bitcoin_units::NumOpResult<bitcoin_units::FeeRate> as core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::Weight>>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::Output = <bitcoin_units::NumOpResult<bitcoin_units::FeeRate> as core::ops::arith::Mul<bitcoin_units::Weight>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Mul<i64>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Rem<i64>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::Weight>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Weight> as core::ops::arith::Mul<bitcoin_units::FeeRate>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::Weight>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Weight> as core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>>>::Output
+pub type &bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Add<bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>>>::Output
+pub type &bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Add>::Output
+pub type &bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output
+pub type &bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Div<i64>>::Output
+pub type &bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Div>::Output
+pub type &bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Mul<i64>>::Output
+pub type &bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Rem<i64>>::Output
+pub type &bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Sub<bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>>>::Output
+pub type &bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Sub>::Output
+pub type &bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Add>::Output
+pub type &bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output
+pub type &bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Div<u64>>::Output
+pub type &bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Div>::Output
+pub type &bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Mul<bitcoin_units::FeeRate>>::Output
+pub type &bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>>>::Output
+pub type &bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Mul<u64>>::Output
+pub type &bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Rem<u64>>::Output
+pub type &bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Rem>::Output
+pub type &bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Sub>::Output
+pub type &bitcoin_units::block::BlockHeight::Output = <bitcoin_units::block::BlockHeight as core::ops::arith::Add<bitcoin_units::block::BlockHeightInterval>>::Output
+pub type &bitcoin_units::block::BlockHeight::Output = <bitcoin_units::block::BlockHeight as core::ops::arith::Sub<bitcoin_units::block::BlockHeightInterval>>::Output
+pub type &bitcoin_units::block::BlockHeight::Output = <bitcoin_units::block::BlockHeight as core::ops::arith::Sub>::Output
+pub type &bitcoin_units::block::BlockHeightInterval::Output = <bitcoin_units::block::BlockHeightInterval as core::ops::arith::Add>::Output
+pub type &bitcoin_units::block::BlockHeightInterval::Output = <bitcoin_units::block::BlockHeightInterval as core::ops::arith::Sub>::Output
+pub type &bitcoin_units::block::BlockMtp::Output = <bitcoin_units::block::BlockMtp as core::ops::arith::Add<bitcoin_units::block::BlockMtpInterval>>::Output
+pub type &bitcoin_units::block::BlockMtp::Output = <bitcoin_units::block::BlockMtp as core::ops::arith::Sub<bitcoin_units::block::BlockMtpInterval>>::Output
+pub type &bitcoin_units::block::BlockMtp::Output = <bitcoin_units::block::BlockMtp as core::ops::arith::Sub>::Output
+pub type &bitcoin_units::block::BlockMtpInterval::Output = <bitcoin_units::block::BlockMtpInterval as core::ops::arith::Add>::Output
+pub type &bitcoin_units::block::BlockMtpInterval::Output = <bitcoin_units::block::BlockMtpInterval as core::ops::arith::Sub>::Output
+pub type &i64::Output = <i64 as core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>>>::Output
+pub type &i64::Output = <i64 as core::ops::arith::Mul<bitcoin_units::SignedAmount>>::Output
+pub type &u64::Output = <u64 as core::ops::arith::Mul<bitcoin_units::Amount>>::Output
+pub type &u64::Output = <u64 as core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::Amount>>>::Output
+pub type &u64::Output = <u64 as core::ops::arith::Mul<bitcoin_units::Weight>>::Output
+pub type bitcoin_units::Amount::Err = bitcoin_units::amount::ParseError
+pub type bitcoin_units::Amount::Error = bitcoin_units::amount::OutOfRangeError
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Add<bitcoin_units::NumOpResult<bitcoin_units::Amount>>>::Output
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Add>::Output
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<bitcoin_units::FeeRate>>::Output
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>>>::Output
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::Weight>>>::Output
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<bitcoin_units::Weight>>::Output
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<u64>>::Output
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div>::Output
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Mul<u64>>::Output
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Rem<u64>>::Output
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Sub<bitcoin_units::NumOpResult<bitcoin_units::Amount>>>::Output
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Sub>::Output
+pub type bitcoin_units::Amount::Output = bitcoin_units::Amount
+pub type bitcoin_units::Amount::Output = bitcoin_units::NumOpResult<bitcoin_units::Amount>
+pub type bitcoin_units::Amount::Output = bitcoin_units::NumOpResult<bitcoin_units::FeeRate>
+pub type bitcoin_units::Amount::Output = bitcoin_units::NumOpResult<bitcoin_units::Weight>
+pub type bitcoin_units::Amount::Output = bitcoin_units::NumOpResult<u64>
+pub type bitcoin_units::FeeRate::Output = <bitcoin_units::FeeRate as core::ops::arith::Add>::Output
+pub type bitcoin_units::FeeRate::Output = <bitcoin_units::FeeRate as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output
+pub type bitcoin_units::FeeRate::Output = <bitcoin_units::FeeRate as core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::Weight>>>::Output
+pub type bitcoin_units::FeeRate::Output = <bitcoin_units::FeeRate as core::ops::arith::Mul<bitcoin_units::Weight>>::Output
+pub type bitcoin_units::FeeRate::Output = <bitcoin_units::FeeRate as core::ops::arith::Sub>::Output
+pub type bitcoin_units::FeeRate::Output = bitcoin_units::FeeRate
+pub type bitcoin_units::FeeRate::Output = bitcoin_units::NumOpResult<bitcoin_units::Amount>
+pub type bitcoin_units::NumOpResult<T>::Output = <bitcoin_units::NumOpResult<T> as core::ops::arith::Add<T>>::Output
+pub type bitcoin_units::NumOpResult<T>::Output = <bitcoin_units::NumOpResult<T> as core::ops::arith::Add>::Output
+pub type bitcoin_units::NumOpResult<T>::Output = <bitcoin_units::NumOpResult<T> as core::ops::arith::Sub<T>>::Output
+pub type bitcoin_units::NumOpResult<T>::Output = <bitcoin_units::NumOpResult<T> as core::ops::arith::Sub>::Output
+pub type bitcoin_units::NumOpResult<T>::Output = bitcoin_units::NumOpResult<T>
+pub type bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::FeeRate>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::Weight>>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::Weight>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<u64>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Mul<u64>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Rem<u64>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::NumOpResult<bitcoin_units::Amount>
+pub type bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::NumOpResult<bitcoin_units::FeeRate>
+pub type bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::NumOpResult<bitcoin_units::Weight>
+pub type bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::Output = <bitcoin_units::NumOpResult<bitcoin_units::FeeRate> as core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::Weight>>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::Output = <bitcoin_units::NumOpResult<bitcoin_units::FeeRate> as core::ops::arith::Mul<bitcoin_units::Weight>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::Output = bitcoin_units::NumOpResult<bitcoin_units::Amount>
+pub type bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Mul<i64>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Rem<i64>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::Output = bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+pub type bitcoin_units::NumOpResult<bitcoin_units::Weight>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Weight> as core::ops::arith::Mul<bitcoin_units::FeeRate>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::Weight>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Weight> as core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::Weight>::Output = bitcoin_units::NumOpResult<bitcoin_units::Amount>
+pub type bitcoin_units::SignedAmount::Err = bitcoin_units::amount::ParseError
+pub type bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Add<bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>>>::Output
+pub type bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Add>::Output
+pub type bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output
+pub type bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Div<i64>>::Output
+pub type bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Div>::Output
+pub type bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Mul<i64>>::Output
+pub type bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Rem<i64>>::Output
+pub type bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Sub<bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>>>::Output
+pub type bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Sub>::Output
+pub type bitcoin_units::SignedAmount::Output = bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+pub type bitcoin_units::SignedAmount::Output = bitcoin_units::NumOpResult<i64>
+pub type bitcoin_units::SignedAmount::Output = bitcoin_units::SignedAmount
+pub type bitcoin_units::Weight::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::Weight::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Add>::Output
+pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output
+pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Div<u64>>::Output
+pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Div>::Output
+pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Mul<bitcoin_units::FeeRate>>::Output
+pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>>>::Output
+pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Mul<u64>>::Output
+pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Rem<u64>>::Output
+pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Rem>::Output
+pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Sub>::Output
+pub type bitcoin_units::Weight::Output = bitcoin_units::NumOpResult<bitcoin_units::Amount>
+pub type bitcoin_units::Weight::Output = bitcoin_units::Weight
+pub type bitcoin_units::Weight::Output = u64
+pub type bitcoin_units::amount::Denomination::Err = bitcoin_units::amount::ParseDenominationError
+pub type bitcoin_units::block::BlockHeight::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockHeight::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockHeight::Output = <bitcoin_units::block::BlockHeight as core::ops::arith::Add<bitcoin_units::block::BlockHeightInterval>>::Output
+pub type bitcoin_units::block::BlockHeight::Output = <bitcoin_units::block::BlockHeight as core::ops::arith::Sub<bitcoin_units::block::BlockHeightInterval>>::Output
+pub type bitcoin_units::block::BlockHeight::Output = <bitcoin_units::block::BlockHeight as core::ops::arith::Sub>::Output
+pub type bitcoin_units::block::BlockHeight::Output = bitcoin_units::block::BlockHeight
+pub type bitcoin_units::block::BlockHeight::Output = bitcoin_units::block::BlockHeightInterval
+pub type bitcoin_units::block::BlockHeightInterval::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockHeightInterval::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockHeightInterval::Output = <bitcoin_units::block::BlockHeightInterval as core::ops::arith::Add>::Output
+pub type bitcoin_units::block::BlockHeightInterval::Output = <bitcoin_units::block::BlockHeightInterval as core::ops::arith::Sub>::Output
+pub type bitcoin_units::block::BlockHeightInterval::Output = bitcoin_units::block::BlockHeightInterval
+pub type bitcoin_units::block::BlockMtp::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockMtp::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockMtp::Output = <bitcoin_units::block::BlockMtp as core::ops::arith::Add<bitcoin_units::block::BlockMtpInterval>>::Output
+pub type bitcoin_units::block::BlockMtp::Output = <bitcoin_units::block::BlockMtp as core::ops::arith::Sub<bitcoin_units::block::BlockMtpInterval>>::Output
+pub type bitcoin_units::block::BlockMtp::Output = <bitcoin_units::block::BlockMtp as core::ops::arith::Sub>::Output
+pub type bitcoin_units::block::BlockMtp::Output = bitcoin_units::block::BlockMtp
+pub type bitcoin_units::block::BlockMtp::Output = bitcoin_units::block::BlockMtpInterval
+pub type bitcoin_units::block::BlockMtpInterval::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockMtpInterval::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockMtpInterval::Output = <bitcoin_units::block::BlockMtpInterval as core::ops::arith::Add>::Output
+pub type bitcoin_units::block::BlockMtpInterval::Output = <bitcoin_units::block::BlockMtpInterval as core::ops::arith::Sub>::Output
+pub type bitcoin_units::block::BlockMtpInterval::Output = bitcoin_units::block::BlockMtpInterval
+pub type bitcoin_units::locktime::absolute::Height::Err = bitcoin_units::locktime::absolute::ParseHeightError
+pub type bitcoin_units::locktime::absolute::Height::Error = bitcoin_units::locktime::absolute::ConversionError
+pub type bitcoin_units::locktime::absolute::Height::Error = bitcoin_units::locktime::absolute::ParseHeightError
+pub type bitcoin_units::locktime::absolute::MedianTimePast::Err = bitcoin_units::locktime::absolute::ParseTimeError
+pub type bitcoin_units::locktime::absolute::MedianTimePast::Error = bitcoin_units::locktime::absolute::ConversionError
+pub type bitcoin_units::locktime::absolute::MedianTimePast::Error = bitcoin_units::locktime::absolute::ParseTimeError
+pub type bitcoin_units::locktime::relative::NumberOf512Seconds::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::locktime::relative::NumberOf512Seconds::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::locktime::relative::NumberOfBlocks::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::locktime::relative::NumberOfBlocks::Error = bitcoin_units::block::TooBigForRelativeHeightError
+pub type bitcoin_units::locktime::relative::NumberOfBlocks::Error = bitcoin_units::parse::ParseIntError
+pub type i64::Output = <i64 as core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>>>::Output
+pub type i64::Output = <i64 as core::ops::arith::Mul<bitcoin_units::SignedAmount>>::Output
+pub type i64::Output = bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+pub type u64::Output = <u64 as core::ops::arith::Mul<bitcoin_units::Amount>>::Output
+pub type u64::Output = <u64 as core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::Amount>>>::Output
+pub type u64::Output = <u64 as core::ops::arith::Mul<bitcoin_units::Weight>>::Output
+pub type u64::Output = bitcoin_units::NumOpResult<bitcoin_units::Amount>
+pub type u64::Output = bitcoin_units::Weight

--- a/api/units/no-features.txt
+++ b/api/units/no-features.txt
@@ -1,0 +1,1978 @@
+#[non_exhaustive] pub enum bitcoin_units::MathOp
+#[non_exhaustive] pub enum bitcoin_units::amount::Denomination
+#[non_exhaustive] pub enum bitcoin_units::amount::ParseDenominationError
+#[non_exhaustive] pub struct bitcoin_units::NumOpError(_)
+#[non_exhaustive] pub struct bitcoin_units::amount::MissingDenominationError
+#[non_exhaustive] pub struct bitcoin_units::amount::PossiblyConfusingDenominationError(_)
+#[non_exhaustive] pub struct bitcoin_units::amount::UnknownDenominationError(_)
+#[non_exhaustive] pub struct bitcoin_units::locktime::absolute::ConversionError
+#[non_exhaustive] pub struct bitcoin_units::parse::ParseIntError
+impl bitcoin_units::Amount
+impl bitcoin_units::BlockTime
+impl bitcoin_units::FeeRate
+impl bitcoin_units::MathOp
+impl bitcoin_units::NumOpError
+impl bitcoin_units::SignedAmount
+impl bitcoin_units::Weight
+impl bitcoin_units::amount::Denomination
+impl bitcoin_units::amount::Display
+impl bitcoin_units::amount::OutOfRangeError
+impl bitcoin_units::block::BlockHeight
+impl bitcoin_units::block::BlockHeightInterval
+impl bitcoin_units::block::BlockMtp
+impl bitcoin_units::block::BlockMtpInterval
+impl bitcoin_units::locktime::absolute::Height
+impl bitcoin_units::locktime::absolute::MedianTimePast
+impl bitcoin_units::locktime::relative::NumberOf512Seconds
+impl bitcoin_units::locktime::relative::NumberOfBlocks
+impl bitcoin_units::parse::Integer for i128
+impl bitcoin_units::parse::Integer for i16
+impl bitcoin_units::parse::Integer for i32
+impl bitcoin_units::parse::Integer for i64
+impl bitcoin_units::parse::Integer for i8
+impl bitcoin_units::parse::Integer for u128
+impl bitcoin_units::parse::Integer for u16
+impl bitcoin_units::parse::Integer for u32
+impl bitcoin_units::parse::Integer for u64
+impl bitcoin_units::parse::Integer for u8
+impl core::clone::Clone for bitcoin_units::Amount
+impl core::clone::Clone for bitcoin_units::BlockTime
+impl core::clone::Clone for bitcoin_units::FeeRate
+impl core::clone::Clone for bitcoin_units::MathOp
+impl core::clone::Clone for bitcoin_units::NumOpError
+impl core::clone::Clone for bitcoin_units::SignedAmount
+impl core::clone::Clone for bitcoin_units::Weight
+impl core::clone::Clone for bitcoin_units::amount::Denomination
+impl core::clone::Clone for bitcoin_units::amount::Display
+impl core::clone::Clone for bitcoin_units::amount::InputTooLargeError
+impl core::clone::Clone for bitcoin_units::amount::InvalidCharacterError
+impl core::clone::Clone for bitcoin_units::amount::MissingDenominationError
+impl core::clone::Clone for bitcoin_units::amount::MissingDigitsError
+impl core::clone::Clone for bitcoin_units::amount::OutOfRangeError
+impl core::clone::Clone for bitcoin_units::amount::ParseAmountError
+impl core::clone::Clone for bitcoin_units::amount::ParseDenominationError
+impl core::clone::Clone for bitcoin_units::amount::ParseError
+impl core::clone::Clone for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::clone::Clone for bitcoin_units::amount::TooPreciseError
+impl core::clone::Clone for bitcoin_units::amount::UnknownDenominationError
+impl core::clone::Clone for bitcoin_units::block::BlockHeight
+impl core::clone::Clone for bitcoin_units::block::BlockHeightInterval
+impl core::clone::Clone for bitcoin_units::block::BlockMtp
+impl core::clone::Clone for bitcoin_units::block::BlockMtpInterval
+impl core::clone::Clone for bitcoin_units::block::TooBigForRelativeHeightError
+impl core::clone::Clone for bitcoin_units::locktime::absolute::ConversionError
+impl core::clone::Clone for bitcoin_units::locktime::absolute::Height
+impl core::clone::Clone for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::clone::Clone for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::clone::Clone for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::clone::Clone for bitcoin_units::locktime::relative::InvalidHeightError
+impl core::clone::Clone for bitcoin_units::locktime::relative::InvalidTimeError
+impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::clone::Clone for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::clone::Clone for bitcoin_units::parse::ParseIntError
+impl core::clone::Clone for bitcoin_units::parse::PrefixedHexError
+impl core::clone::Clone for bitcoin_units::parse::UnprefixedHexError
+impl core::cmp::Eq for bitcoin_units::Amount
+impl core::cmp::Eq for bitcoin_units::BlockTime
+impl core::cmp::Eq for bitcoin_units::FeeRate
+impl core::cmp::Eq for bitcoin_units::MathOp
+impl core::cmp::Eq for bitcoin_units::NumOpError
+impl core::cmp::Eq for bitcoin_units::SignedAmount
+impl core::cmp::Eq for bitcoin_units::Weight
+impl core::cmp::Eq for bitcoin_units::amount::Denomination
+impl core::cmp::Eq for bitcoin_units::amount::InputTooLargeError
+impl core::cmp::Eq for bitcoin_units::amount::InvalidCharacterError
+impl core::cmp::Eq for bitcoin_units::amount::MissingDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::MissingDigitsError
+impl core::cmp::Eq for bitcoin_units::amount::OutOfRangeError
+impl core::cmp::Eq for bitcoin_units::amount::ParseAmountError
+impl core::cmp::Eq for bitcoin_units::amount::ParseDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::ParseError
+impl core::cmp::Eq for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::cmp::Eq for bitcoin_units::amount::TooPreciseError
+impl core::cmp::Eq for bitcoin_units::amount::UnknownDenominationError
+impl core::cmp::Eq for bitcoin_units::block::BlockHeight
+impl core::cmp::Eq for bitcoin_units::block::BlockHeightInterval
+impl core::cmp::Eq for bitcoin_units::block::BlockMtp
+impl core::cmp::Eq for bitcoin_units::block::BlockMtpInterval
+impl core::cmp::Eq for bitcoin_units::block::TooBigForRelativeHeightError
+impl core::cmp::Eq for bitcoin_units::locktime::absolute::ConversionError
+impl core::cmp::Eq for bitcoin_units::locktime::absolute::Height
+impl core::cmp::Eq for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::cmp::Eq for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::cmp::Eq for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::cmp::Eq for bitcoin_units::locktime::relative::InvalidHeightError
+impl core::cmp::Eq for bitcoin_units::locktime::relative::InvalidTimeError
+impl core::cmp::Eq for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::cmp::Eq for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::cmp::Eq for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::cmp::Eq for bitcoin_units::parse::ParseIntError
+impl core::cmp::Eq for bitcoin_units::parse::PrefixedHexError
+impl core::cmp::Eq for bitcoin_units::parse::UnprefixedHexError
+impl core::cmp::Ord for bitcoin_units::Amount
+impl core::cmp::Ord for bitcoin_units::BlockTime
+impl core::cmp::Ord for bitcoin_units::FeeRate
+impl core::cmp::Ord for bitcoin_units::SignedAmount
+impl core::cmp::Ord for bitcoin_units::Weight
+impl core::cmp::Ord for bitcoin_units::block::BlockHeight
+impl core::cmp::Ord for bitcoin_units::block::BlockHeightInterval
+impl core::cmp::Ord for bitcoin_units::block::BlockMtp
+impl core::cmp::Ord for bitcoin_units::block::BlockMtpInterval
+impl core::cmp::Ord for bitcoin_units::locktime::absolute::Height
+impl core::cmp::Ord for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::cmp::Ord for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::cmp::Ord for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::cmp::PartialEq for bitcoin_units::Amount
+impl core::cmp::PartialEq for bitcoin_units::BlockTime
+impl core::cmp::PartialEq for bitcoin_units::FeeRate
+impl core::cmp::PartialEq for bitcoin_units::MathOp
+impl core::cmp::PartialEq for bitcoin_units::NumOpError
+impl core::cmp::PartialEq for bitcoin_units::SignedAmount
+impl core::cmp::PartialEq for bitcoin_units::Weight
+impl core::cmp::PartialEq for bitcoin_units::amount::Denomination
+impl core::cmp::PartialEq for bitcoin_units::amount::InputTooLargeError
+impl core::cmp::PartialEq for bitcoin_units::amount::InvalidCharacterError
+impl core::cmp::PartialEq for bitcoin_units::amount::MissingDenominationError
+impl core::cmp::PartialEq for bitcoin_units::amount::MissingDigitsError
+impl core::cmp::PartialEq for bitcoin_units::amount::OutOfRangeError
+impl core::cmp::PartialEq for bitcoin_units::amount::ParseAmountError
+impl core::cmp::PartialEq for bitcoin_units::amount::ParseDenominationError
+impl core::cmp::PartialEq for bitcoin_units::amount::ParseError
+impl core::cmp::PartialEq for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::cmp::PartialEq for bitcoin_units::amount::TooPreciseError
+impl core::cmp::PartialEq for bitcoin_units::amount::UnknownDenominationError
+impl core::cmp::PartialEq for bitcoin_units::block::BlockHeight
+impl core::cmp::PartialEq for bitcoin_units::block::BlockHeightInterval
+impl core::cmp::PartialEq for bitcoin_units::block::BlockMtp
+impl core::cmp::PartialEq for bitcoin_units::block::BlockMtpInterval
+impl core::cmp::PartialEq for bitcoin_units::block::TooBigForRelativeHeightError
+impl core::cmp::PartialEq for bitcoin_units::locktime::absolute::ConversionError
+impl core::cmp::PartialEq for bitcoin_units::locktime::absolute::Height
+impl core::cmp::PartialEq for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::cmp::PartialEq for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::cmp::PartialEq for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::InvalidHeightError
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::InvalidTimeError
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::cmp::PartialEq for bitcoin_units::parse::ParseIntError
+impl core::cmp::PartialEq for bitcoin_units::parse::PrefixedHexError
+impl core::cmp::PartialEq for bitcoin_units::parse::UnprefixedHexError
+impl core::cmp::PartialOrd for bitcoin_units::Amount
+impl core::cmp::PartialOrd for bitcoin_units::BlockTime
+impl core::cmp::PartialOrd for bitcoin_units::FeeRate
+impl core::cmp::PartialOrd for bitcoin_units::SignedAmount
+impl core::cmp::PartialOrd for bitcoin_units::Weight
+impl core::cmp::PartialOrd for bitcoin_units::block::BlockHeight
+impl core::cmp::PartialOrd for bitcoin_units::block::BlockHeightInterval
+impl core::cmp::PartialOrd for bitcoin_units::block::BlockMtp
+impl core::cmp::PartialOrd for bitcoin_units::block::BlockMtpInterval
+impl core::cmp::PartialOrd for bitcoin_units::locktime::absolute::Height
+impl core::cmp::PartialOrd for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::cmp::PartialOrd for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::cmp::PartialOrd for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::convert::AsRef<core::num::error::ParseIntError> for bitcoin_units::parse::ParseIntError
+impl core::convert::From<&bitcoin_units::Amount> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::convert::From<&bitcoin_units::SignedAmount> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::convert::From<bitcoin_units::Amount> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::convert::From<bitcoin_units::Amount> for bitcoin_units::SignedAmount
+impl core::convert::From<bitcoin_units::BlockTime> for u32
+impl core::convert::From<bitcoin_units::SignedAmount> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::convert::From<bitcoin_units::Weight> for u64
+impl core::convert::From<bitcoin_units::amount::InputTooLargeError> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::InputTooLargeError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::InvalidCharacterError> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::InvalidCharacterError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::MissingDigitsError> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::MissingDigitsError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::OutOfRangeError> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::OutOfRangeError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::ParseAmountError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::ParseDenominationError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::amount::TooPreciseError> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<bitcoin_units::amount::TooPreciseError> for bitcoin_units::amount::ParseError
+impl core::convert::From<bitcoin_units::block::BlockHeight> for u32
+impl core::convert::From<bitcoin_units::block::BlockHeightInterval> for u32
+impl core::convert::From<bitcoin_units::block::BlockMtp> for u32
+impl core::convert::From<bitcoin_units::block::BlockMtpInterval> for u32
+impl core::convert::From<bitcoin_units::locktime::absolute::Height> for bitcoin_units::block::BlockHeight
+impl core::convert::From<bitcoin_units::locktime::absolute::MedianTimePast> for bitcoin_units::block::BlockMtp
+impl core::convert::From<bitcoin_units::locktime::relative::NumberOf512Seconds> for bitcoin_units::block::BlockMtpInterval
+impl core::convert::From<bitcoin_units::locktime::relative::NumberOfBlocks> for bitcoin_units::block::BlockHeightInterval
+impl core::convert::From<bitcoin_units::parse::ParseIntError> for bitcoin_units::parse::PrefixedHexError
+impl core::convert::From<bitcoin_units::parse::ParseIntError> for bitcoin_units::parse::UnprefixedHexError
+impl core::convert::From<bitcoin_units::parse::ParseIntError> for core::num::error::ParseIntError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::ParseAmountError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::ParseDenominationError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::ParseError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::parse::PrefixedHexError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::parse::UnprefixedHexError
+impl core::convert::From<u16> for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::convert::From<u32> for bitcoin_units::BlockTime
+impl core::convert::From<u32> for bitcoin_units::block::BlockHeight
+impl core::convert::From<u32> for bitcoin_units::block::BlockHeightInterval
+impl core::convert::From<u32> for bitcoin_units::block::BlockMtp
+impl core::convert::From<u32> for bitcoin_units::block::BlockMtpInterval
+impl core::convert::TryFrom<&str> for bitcoin_units::Weight
+impl core::convert::TryFrom<&str> for bitcoin_units::block::BlockHeight
+impl core::convert::TryFrom<&str> for bitcoin_units::block::BlockHeightInterval
+impl core::convert::TryFrom<&str> for bitcoin_units::block::BlockMtp
+impl core::convert::TryFrom<&str> for bitcoin_units::block::BlockMtpInterval
+impl core::convert::TryFrom<&str> for bitcoin_units::locktime::absolute::Height
+impl core::convert::TryFrom<&str> for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::convert::TryFrom<&str> for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::convert::TryFrom<&str> for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::convert::TryFrom<bitcoin_units::SignedAmount> for bitcoin_units::Amount
+impl core::convert::TryFrom<bitcoin_units::block::BlockHeight> for bitcoin_units::locktime::absolute::Height
+impl core::convert::TryFrom<bitcoin_units::block::BlockHeightInterval> for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::convert::TryFrom<bitcoin_units::block::BlockMtp> for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::default::Default for bitcoin_units::Amount
+impl core::default::Default for bitcoin_units::SignedAmount
+impl core::default::Default for bitcoin_units::block::BlockHeightInterval
+impl core::default::Default for bitcoin_units::block::BlockMtpInterval
+impl core::default::Default for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::default::Default for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::fmt::Debug for bitcoin_units::Amount
+impl core::fmt::Debug for bitcoin_units::BlockTime
+impl core::fmt::Debug for bitcoin_units::FeeRate
+impl core::fmt::Debug for bitcoin_units::MathOp
+impl core::fmt::Debug for bitcoin_units::NumOpError
+impl core::fmt::Debug for bitcoin_units::SignedAmount
+impl core::fmt::Debug for bitcoin_units::Weight
+impl core::fmt::Debug for bitcoin_units::amount::Denomination
+impl core::fmt::Debug for bitcoin_units::amount::Display
+impl core::fmt::Debug for bitcoin_units::amount::InputTooLargeError
+impl core::fmt::Debug for bitcoin_units::amount::InvalidCharacterError
+impl core::fmt::Debug for bitcoin_units::amount::MissingDenominationError
+impl core::fmt::Debug for bitcoin_units::amount::MissingDigitsError
+impl core::fmt::Debug for bitcoin_units::amount::OutOfRangeError
+impl core::fmt::Debug for bitcoin_units::amount::ParseAmountError
+impl core::fmt::Debug for bitcoin_units::amount::ParseDenominationError
+impl core::fmt::Debug for bitcoin_units::amount::ParseError
+impl core::fmt::Debug for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::fmt::Debug for bitcoin_units::amount::TooPreciseError
+impl core::fmt::Debug for bitcoin_units::amount::UnknownDenominationError
+impl core::fmt::Debug for bitcoin_units::block::BlockHeight
+impl core::fmt::Debug for bitcoin_units::block::BlockHeightInterval
+impl core::fmt::Debug for bitcoin_units::block::BlockMtp
+impl core::fmt::Debug for bitcoin_units::block::BlockMtpInterval
+impl core::fmt::Debug for bitcoin_units::block::TooBigForRelativeHeightError
+impl core::fmt::Debug for bitcoin_units::locktime::absolute::ConversionError
+impl core::fmt::Debug for bitcoin_units::locktime::absolute::Height
+impl core::fmt::Debug for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::fmt::Debug for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::fmt::Debug for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::fmt::Debug for bitcoin_units::locktime::relative::InvalidHeightError
+impl core::fmt::Debug for bitcoin_units::locktime::relative::InvalidTimeError
+impl core::fmt::Debug for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::fmt::Debug for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::fmt::Debug for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::fmt::Debug for bitcoin_units::parse::ParseIntError
+impl core::fmt::Debug for bitcoin_units::parse::PrefixedHexError
+impl core::fmt::Debug for bitcoin_units::parse::UnprefixedHexError
+impl core::fmt::Display for bitcoin_units::Amount
+impl core::fmt::Display for bitcoin_units::MathOp
+impl core::fmt::Display for bitcoin_units::NumOpError
+impl core::fmt::Display for bitcoin_units::SignedAmount
+impl core::fmt::Display for bitcoin_units::Weight
+impl core::fmt::Display for bitcoin_units::amount::Denomination
+impl core::fmt::Display for bitcoin_units::amount::Display
+impl core::fmt::Display for bitcoin_units::amount::InputTooLargeError
+impl core::fmt::Display for bitcoin_units::amount::InvalidCharacterError
+impl core::fmt::Display for bitcoin_units::amount::MissingDigitsError
+impl core::fmt::Display for bitcoin_units::amount::OutOfRangeError
+impl core::fmt::Display for bitcoin_units::amount::ParseAmountError
+impl core::fmt::Display for bitcoin_units::amount::ParseDenominationError
+impl core::fmt::Display for bitcoin_units::amount::ParseError
+impl core::fmt::Display for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::fmt::Display for bitcoin_units::amount::TooPreciseError
+impl core::fmt::Display for bitcoin_units::amount::UnknownDenominationError
+impl core::fmt::Display for bitcoin_units::block::BlockHeight
+impl core::fmt::Display for bitcoin_units::block::BlockHeightInterval
+impl core::fmt::Display for bitcoin_units::block::BlockMtp
+impl core::fmt::Display for bitcoin_units::block::BlockMtpInterval
+impl core::fmt::Display for bitcoin_units::block::TooBigForRelativeHeightError
+impl core::fmt::Display for bitcoin_units::locktime::absolute::ConversionError
+impl core::fmt::Display for bitcoin_units::locktime::absolute::Height
+impl core::fmt::Display for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::fmt::Display for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::fmt::Display for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::fmt::Display for bitcoin_units::locktime::relative::InvalidHeightError
+impl core::fmt::Display for bitcoin_units::locktime::relative::InvalidTimeError
+impl core::fmt::Display for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::fmt::Display for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::fmt::Display for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::fmt::Display for bitcoin_units::parse::ParseIntError
+impl core::fmt::Display for bitcoin_units::parse::PrefixedHexError
+impl core::fmt::Display for bitcoin_units::parse::UnprefixedHexError
+impl core::hash::Hash for bitcoin_units::Amount
+impl core::hash::Hash for bitcoin_units::BlockTime
+impl core::hash::Hash for bitcoin_units::FeeRate
+impl core::hash::Hash for bitcoin_units::SignedAmount
+impl core::hash::Hash for bitcoin_units::Weight
+impl core::hash::Hash for bitcoin_units::amount::Denomination
+impl core::hash::Hash for bitcoin_units::block::BlockHeight
+impl core::hash::Hash for bitcoin_units::block::BlockHeightInterval
+impl core::hash::Hash for bitcoin_units::block::BlockMtp
+impl core::hash::Hash for bitcoin_units::block::BlockMtpInterval
+impl core::hash::Hash for bitcoin_units::locktime::absolute::Height
+impl core::hash::Hash for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::hash::Hash for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::hash::Hash for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::iter::traits::accum::Sum for bitcoin_units::FeeRate
+impl core::iter::traits::accum::Sum for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::iter::traits::accum::Sum for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::iter::traits::accum::Sum for bitcoin_units::Weight
+impl core::iter::traits::accum::Sum for bitcoin_units::block::BlockHeightInterval
+impl core::iter::traits::accum::Sum for bitcoin_units::block::BlockMtpInterval
+impl core::marker::Copy for bitcoin_units::Amount
+impl core::marker::Copy for bitcoin_units::BlockTime
+impl core::marker::Copy for bitcoin_units::FeeRate
+impl core::marker::Copy for bitcoin_units::MathOp
+impl core::marker::Copy for bitcoin_units::NumOpError
+impl core::marker::Copy for bitcoin_units::SignedAmount
+impl core::marker::Copy for bitcoin_units::Weight
+impl core::marker::Copy for bitcoin_units::amount::Denomination
+impl core::marker::Copy for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Copy for bitcoin_units::block::BlockHeight
+impl core::marker::Copy for bitcoin_units::block::BlockHeightInterval
+impl core::marker::Copy for bitcoin_units::block::BlockMtp
+impl core::marker::Copy for bitcoin_units::block::BlockMtpInterval
+impl core::marker::Copy for bitcoin_units::locktime::absolute::Height
+impl core::marker::Copy for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::marker::Copy for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::marker::Copy for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::marker::Freeze for bitcoin_units::Amount
+impl core::marker::Freeze for bitcoin_units::BlockTime
+impl core::marker::Freeze for bitcoin_units::FeeRate
+impl core::marker::Freeze for bitcoin_units::MathOp
+impl core::marker::Freeze for bitcoin_units::NumOpError
+impl core::marker::Freeze for bitcoin_units::SignedAmount
+impl core::marker::Freeze for bitcoin_units::Weight
+impl core::marker::Freeze for bitcoin_units::amount::Denomination
+impl core::marker::Freeze for bitcoin_units::amount::Display
+impl core::marker::Freeze for bitcoin_units::amount::InputTooLargeError
+impl core::marker::Freeze for bitcoin_units::amount::InvalidCharacterError
+impl core::marker::Freeze for bitcoin_units::amount::MissingDenominationError
+impl core::marker::Freeze for bitcoin_units::amount::MissingDigitsError
+impl core::marker::Freeze for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Freeze for bitcoin_units::amount::ParseAmountError
+impl core::marker::Freeze for bitcoin_units::amount::ParseDenominationError
+impl core::marker::Freeze for bitcoin_units::amount::ParseError
+impl core::marker::Freeze for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::Freeze for bitcoin_units::amount::TooPreciseError
+impl core::marker::Freeze for bitcoin_units::amount::UnknownDenominationError
+impl core::marker::Freeze for bitcoin_units::block::BlockHeight
+impl core::marker::Freeze for bitcoin_units::block::BlockHeightInterval
+impl core::marker::Freeze for bitcoin_units::block::BlockMtp
+impl core::marker::Freeze for bitcoin_units::block::BlockMtpInterval
+impl core::marker::Freeze for bitcoin_units::block::TooBigForRelativeHeightError
+impl core::marker::Freeze for bitcoin_units::locktime::absolute::ConversionError
+impl core::marker::Freeze for bitcoin_units::locktime::absolute::Height
+impl core::marker::Freeze for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::marker::Freeze for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::marker::Freeze for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::marker::Freeze for bitcoin_units::locktime::relative::InvalidHeightError
+impl core::marker::Freeze for bitcoin_units::locktime::relative::InvalidTimeError
+impl core::marker::Freeze for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::marker::Freeze for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::marker::Freeze for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::marker::Freeze for bitcoin_units::parse::ParseIntError
+impl core::marker::Freeze for bitcoin_units::parse::PrefixedHexError
+impl core::marker::Freeze for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::Send for bitcoin_units::Amount
+impl core::marker::Send for bitcoin_units::BlockTime
+impl core::marker::Send for bitcoin_units::FeeRate
+impl core::marker::Send for bitcoin_units::MathOp
+impl core::marker::Send for bitcoin_units::NumOpError
+impl core::marker::Send for bitcoin_units::SignedAmount
+impl core::marker::Send for bitcoin_units::Weight
+impl core::marker::Send for bitcoin_units::amount::Denomination
+impl core::marker::Send for bitcoin_units::amount::Display
+impl core::marker::Send for bitcoin_units::amount::InputTooLargeError
+impl core::marker::Send for bitcoin_units::amount::InvalidCharacterError
+impl core::marker::Send for bitcoin_units::amount::MissingDenominationError
+impl core::marker::Send for bitcoin_units::amount::MissingDigitsError
+impl core::marker::Send for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Send for bitcoin_units::amount::ParseAmountError
+impl core::marker::Send for bitcoin_units::amount::ParseDenominationError
+impl core::marker::Send for bitcoin_units::amount::ParseError
+impl core::marker::Send for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::Send for bitcoin_units::amount::TooPreciseError
+impl core::marker::Send for bitcoin_units::amount::UnknownDenominationError
+impl core::marker::Send for bitcoin_units::block::BlockHeight
+impl core::marker::Send for bitcoin_units::block::BlockHeightInterval
+impl core::marker::Send for bitcoin_units::block::BlockMtp
+impl core::marker::Send for bitcoin_units::block::BlockMtpInterval
+impl core::marker::Send for bitcoin_units::block::TooBigForRelativeHeightError
+impl core::marker::Send for bitcoin_units::locktime::absolute::ConversionError
+impl core::marker::Send for bitcoin_units::locktime::absolute::Height
+impl core::marker::Send for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::marker::Send for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::marker::Send for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::marker::Send for bitcoin_units::locktime::relative::InvalidHeightError
+impl core::marker::Send for bitcoin_units::locktime::relative::InvalidTimeError
+impl core::marker::Send for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::marker::Send for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::marker::Send for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::marker::Send for bitcoin_units::parse::ParseIntError
+impl core::marker::Send for bitcoin_units::parse::PrefixedHexError
+impl core::marker::Send for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::StructuralPartialEq for bitcoin_units::Amount
+impl core::marker::StructuralPartialEq for bitcoin_units::BlockTime
+impl core::marker::StructuralPartialEq for bitcoin_units::FeeRate
+impl core::marker::StructuralPartialEq for bitcoin_units::MathOp
+impl core::marker::StructuralPartialEq for bitcoin_units::NumOpError
+impl core::marker::StructuralPartialEq for bitcoin_units::SignedAmount
+impl core::marker::StructuralPartialEq for bitcoin_units::Weight
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::Denomination
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::InputTooLargeError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::InvalidCharacterError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::MissingDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::MissingDigitsError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::OutOfRangeError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::ParseAmountError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::ParseDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::ParseError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::TooPreciseError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::UnknownDenominationError
+impl core::marker::StructuralPartialEq for bitcoin_units::block::BlockHeight
+impl core::marker::StructuralPartialEq for bitcoin_units::block::BlockHeightInterval
+impl core::marker::StructuralPartialEq for bitcoin_units::block::BlockMtp
+impl core::marker::StructuralPartialEq for bitcoin_units::block::BlockMtpInterval
+impl core::marker::StructuralPartialEq for bitcoin_units::block::TooBigForRelativeHeightError
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::ConversionError
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::Height
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::InvalidHeightError
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::InvalidTimeError
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::marker::StructuralPartialEq for bitcoin_units::parse::ParseIntError
+impl core::marker::StructuralPartialEq for bitcoin_units::parse::PrefixedHexError
+impl core::marker::StructuralPartialEq for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::Sync for bitcoin_units::Amount
+impl core::marker::Sync for bitcoin_units::BlockTime
+impl core::marker::Sync for bitcoin_units::FeeRate
+impl core::marker::Sync for bitcoin_units::MathOp
+impl core::marker::Sync for bitcoin_units::NumOpError
+impl core::marker::Sync for bitcoin_units::SignedAmount
+impl core::marker::Sync for bitcoin_units::Weight
+impl core::marker::Sync for bitcoin_units::amount::Denomination
+impl core::marker::Sync for bitcoin_units::amount::Display
+impl core::marker::Sync for bitcoin_units::amount::InputTooLargeError
+impl core::marker::Sync for bitcoin_units::amount::InvalidCharacterError
+impl core::marker::Sync for bitcoin_units::amount::MissingDenominationError
+impl core::marker::Sync for bitcoin_units::amount::MissingDigitsError
+impl core::marker::Sync for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Sync for bitcoin_units::amount::ParseAmountError
+impl core::marker::Sync for bitcoin_units::amount::ParseDenominationError
+impl core::marker::Sync for bitcoin_units::amount::ParseError
+impl core::marker::Sync for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::Sync for bitcoin_units::amount::TooPreciseError
+impl core::marker::Sync for bitcoin_units::amount::UnknownDenominationError
+impl core::marker::Sync for bitcoin_units::block::BlockHeight
+impl core::marker::Sync for bitcoin_units::block::BlockHeightInterval
+impl core::marker::Sync for bitcoin_units::block::BlockMtp
+impl core::marker::Sync for bitcoin_units::block::BlockMtpInterval
+impl core::marker::Sync for bitcoin_units::block::TooBigForRelativeHeightError
+impl core::marker::Sync for bitcoin_units::locktime::absolute::ConversionError
+impl core::marker::Sync for bitcoin_units::locktime::absolute::Height
+impl core::marker::Sync for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::marker::Sync for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::marker::Sync for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::marker::Sync for bitcoin_units::locktime::relative::InvalidHeightError
+impl core::marker::Sync for bitcoin_units::locktime::relative::InvalidTimeError
+impl core::marker::Sync for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::marker::Sync for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::marker::Sync for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::marker::Sync for bitcoin_units::parse::ParseIntError
+impl core::marker::Sync for bitcoin_units::parse::PrefixedHexError
+impl core::marker::Sync for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::Unpin for bitcoin_units::Amount
+impl core::marker::Unpin for bitcoin_units::BlockTime
+impl core::marker::Unpin for bitcoin_units::FeeRate
+impl core::marker::Unpin for bitcoin_units::MathOp
+impl core::marker::Unpin for bitcoin_units::NumOpError
+impl core::marker::Unpin for bitcoin_units::SignedAmount
+impl core::marker::Unpin for bitcoin_units::Weight
+impl core::marker::Unpin for bitcoin_units::amount::Denomination
+impl core::marker::Unpin for bitcoin_units::amount::Display
+impl core::marker::Unpin for bitcoin_units::amount::InputTooLargeError
+impl core::marker::Unpin for bitcoin_units::amount::InvalidCharacterError
+impl core::marker::Unpin for bitcoin_units::amount::MissingDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::MissingDigitsError
+impl core::marker::Unpin for bitcoin_units::amount::OutOfRangeError
+impl core::marker::Unpin for bitcoin_units::amount::ParseAmountError
+impl core::marker::Unpin for bitcoin_units::amount::ParseDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::ParseError
+impl core::marker::Unpin for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::marker::Unpin for bitcoin_units::amount::TooPreciseError
+impl core::marker::Unpin for bitcoin_units::amount::UnknownDenominationError
+impl core::marker::Unpin for bitcoin_units::block::BlockHeight
+impl core::marker::Unpin for bitcoin_units::block::BlockHeightInterval
+impl core::marker::Unpin for bitcoin_units::block::BlockMtp
+impl core::marker::Unpin for bitcoin_units::block::BlockMtpInterval
+impl core::marker::Unpin for bitcoin_units::block::TooBigForRelativeHeightError
+impl core::marker::Unpin for bitcoin_units::locktime::absolute::ConversionError
+impl core::marker::Unpin for bitcoin_units::locktime::absolute::Height
+impl core::marker::Unpin for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::marker::Unpin for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::marker::Unpin for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::marker::Unpin for bitcoin_units::locktime::relative::InvalidHeightError
+impl core::marker::Unpin for bitcoin_units::locktime::relative::InvalidTimeError
+impl core::marker::Unpin for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::marker::Unpin for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::marker::Unpin for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::marker::Unpin for bitcoin_units::parse::ParseIntError
+impl core::marker::Unpin for bitcoin_units::parse::PrefixedHexError
+impl core::marker::Unpin for bitcoin_units::parse::UnprefixedHexError
+impl core::ops::arith::Add for bitcoin_units::Amount
+impl core::ops::arith::Add for bitcoin_units::FeeRate
+impl core::ops::arith::Add for bitcoin_units::SignedAmount
+impl core::ops::arith::Add for bitcoin_units::Weight
+impl core::ops::arith::Add for bitcoin_units::block::BlockHeightInterval
+impl core::ops::arith::Add for bitcoin_units::block::BlockMtpInterval
+impl core::ops::arith::Add<&bitcoin_units::Amount> for bitcoin_units::Amount
+impl core::ops::arith::Add<&bitcoin_units::FeeRate> for bitcoin_units::FeeRate
+impl core::ops::arith::Add<&bitcoin_units::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount
+impl core::ops::arith::Add<&bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for bitcoin_units::SignedAmount
+impl core::ops::arith::Add<&bitcoin_units::SignedAmount> for bitcoin_units::SignedAmount
+impl core::ops::arith::Add<&bitcoin_units::Weight> for bitcoin_units::Weight
+impl core::ops::arith::Add<&bitcoin_units::block::BlockHeightInterval> for bitcoin_units::block::BlockHeight
+impl core::ops::arith::Add<&bitcoin_units::block::BlockHeightInterval> for bitcoin_units::block::BlockHeightInterval
+impl core::ops::arith::Add<&bitcoin_units::block::BlockMtpInterval> for bitcoin_units::block::BlockMtp
+impl core::ops::arith::Add<&bitcoin_units::block::BlockMtpInterval> for bitcoin_units::block::BlockMtpInterval
+impl core::ops::arith::Add<bitcoin_units::Amount> for &bitcoin_units::Amount
+impl core::ops::arith::Add<bitcoin_units::FeeRate> for &bitcoin_units::FeeRate
+impl core::ops::arith::Add<bitcoin_units::NumOpResult<bitcoin_units::Amount>> for &bitcoin_units::Amount
+impl core::ops::arith::Add<bitcoin_units::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount
+impl core::ops::arith::Add<bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for &bitcoin_units::SignedAmount
+impl core::ops::arith::Add<bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for bitcoin_units::SignedAmount
+impl core::ops::arith::Add<bitcoin_units::SignedAmount> for &bitcoin_units::SignedAmount
+impl core::ops::arith::Add<bitcoin_units::Weight> for &bitcoin_units::Weight
+impl core::ops::arith::Add<bitcoin_units::block::BlockHeightInterval> for &bitcoin_units::block::BlockHeight
+impl core::ops::arith::Add<bitcoin_units::block::BlockHeightInterval> for &bitcoin_units::block::BlockHeightInterval
+impl core::ops::arith::Add<bitcoin_units::block::BlockHeightInterval> for bitcoin_units::block::BlockHeight
+impl core::ops::arith::Add<bitcoin_units::block::BlockMtpInterval> for &bitcoin_units::block::BlockMtp
+impl core::ops::arith::Add<bitcoin_units::block::BlockMtpInterval> for &bitcoin_units::block::BlockMtpInterval
+impl core::ops::arith::Add<bitcoin_units::block::BlockMtpInterval> for bitcoin_units::block::BlockMtp
+impl core::ops::arith::AddAssign for bitcoin_units::FeeRate
+impl core::ops::arith::AddAssign for bitcoin_units::Weight
+impl core::ops::arith::AddAssign for bitcoin_units::block::BlockHeightInterval
+impl core::ops::arith::AddAssign for bitcoin_units::block::BlockMtpInterval
+impl core::ops::arith::AddAssign<&bitcoin_units::FeeRate> for bitcoin_units::FeeRate
+impl core::ops::arith::AddAssign<&bitcoin_units::Weight> for bitcoin_units::Weight
+impl core::ops::arith::AddAssign<&bitcoin_units::block::BlockHeightInterval> for bitcoin_units::block::BlockHeightInterval
+impl core::ops::arith::AddAssign<&bitcoin_units::block::BlockMtpInterval> for bitcoin_units::block::BlockMtpInterval
+impl core::ops::arith::Div for bitcoin_units::Amount
+impl core::ops::arith::Div for bitcoin_units::SignedAmount
+impl core::ops::arith::Div for bitcoin_units::Weight
+impl core::ops::arith::Div<&bitcoin_units::Amount> for bitcoin_units::Amount
+impl core::ops::arith::Div<&bitcoin_units::FeeRate> for bitcoin_units::Amount
+impl core::ops::arith::Div<&bitcoin_units::FeeRate> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<&bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for bitcoin_units::Amount
+impl core::ops::arith::Div<&bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<&bitcoin_units::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::Amount
+impl core::ops::arith::Div<&bitcoin_units::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<&bitcoin_units::SignedAmount> for bitcoin_units::SignedAmount
+impl core::ops::arith::Div<&bitcoin_units::Weight> for bitcoin_units::Amount
+impl core::ops::arith::Div<&bitcoin_units::Weight> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<&bitcoin_units::Weight> for bitcoin_units::Weight
+impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount
+impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount
+impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::FeeRate
+impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::Weight
+impl core::ops::arith::Div<&i64> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::Div<&i64> for bitcoin_units::SignedAmount
+impl core::ops::arith::Div<&u64> for bitcoin_units::Amount
+impl core::ops::arith::Div<&u64> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<&u64> for bitcoin_units::Weight
+impl core::ops::arith::Div<bitcoin_units::Amount> for &bitcoin_units::Amount
+impl core::ops::arith::Div<bitcoin_units::FeeRate> for &bitcoin_units::Amount
+impl core::ops::arith::Div<bitcoin_units::FeeRate> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<bitcoin_units::FeeRate> for bitcoin_units::Amount
+impl core::ops::arith::Div<bitcoin_units::FeeRate> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for &bitcoin_units::Amount
+impl core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for bitcoin_units::Amount
+impl core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::Amount
+impl core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::Amount
+impl core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<bitcoin_units::SignedAmount> for &bitcoin_units::SignedAmount
+impl core::ops::arith::Div<bitcoin_units::Weight> for &bitcoin_units::Amount
+impl core::ops::arith::Div<bitcoin_units::Weight> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<bitcoin_units::Weight> for &bitcoin_units::Weight
+impl core::ops::arith::Div<bitcoin_units::Weight> for bitcoin_units::Amount
+impl core::ops::arith::Div<bitcoin_units::Weight> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::SignedAmount
+impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::Amount
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::FeeRate
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::Weight
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::FeeRate
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::Weight
+impl core::ops::arith::Div<i64> for &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::Div<i64> for &bitcoin_units::SignedAmount
+impl core::ops::arith::Div<i64> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount
+impl core::ops::arith::Div<u64> for &bitcoin_units::Amount
+impl core::ops::arith::Div<u64> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<u64> for &bitcoin_units::Weight
+impl core::ops::arith::Div<u64> for bitcoin_units::Amount
+impl core::ops::arith::Div<u64> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Div<u64> for bitcoin_units::Weight
+impl core::ops::arith::DivAssign<&i64> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::DivAssign<&u64> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::DivAssign<i64> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::DivAssign<u64> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::DivAssign<u64> for bitcoin_units::Weight
+impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64
+impl core::ops::arith::Mul<&bitcoin_units::FeeRate> for bitcoin_units::NumOpResult<bitcoin_units::Weight>
+impl core::ops::arith::Mul<&bitcoin_units::FeeRate> for bitcoin_units::Weight
+impl core::ops::arith::Mul<&bitcoin_units::NumOpResult<bitcoin_units::Amount>> for u64
+impl core::ops::arith::Mul<&bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for bitcoin_units::NumOpResult<bitcoin_units::Weight>
+impl core::ops::arith::Mul<&bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for bitcoin_units::Weight
+impl core::ops::arith::Mul<&bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for i64
+impl core::ops::arith::Mul<&bitcoin_units::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::FeeRate
+impl core::ops::arith::Mul<&bitcoin_units::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::NumOpResult<bitcoin_units::FeeRate>
+impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64
+impl core::ops::arith::Mul<&bitcoin_units::Weight> for bitcoin_units::FeeRate
+impl core::ops::arith::Mul<&bitcoin_units::Weight> for bitcoin_units::NumOpResult<bitcoin_units::FeeRate>
+impl core::ops::arith::Mul<&bitcoin_units::Weight> for u64
+impl core::ops::arith::Mul<&i64> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::Mul<&i64> for bitcoin_units::SignedAmount
+impl core::ops::arith::Mul<&u64> for bitcoin_units::Amount
+impl core::ops::arith::Mul<&u64> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Mul<&u64> for bitcoin_units::Weight
+impl core::ops::arith::Mul<bitcoin_units::Amount> for &u64
+impl core::ops::arith::Mul<bitcoin_units::Amount> for u64
+impl core::ops::arith::Mul<bitcoin_units::FeeRate> for &bitcoin_units::NumOpResult<bitcoin_units::Weight>
+impl core::ops::arith::Mul<bitcoin_units::FeeRate> for &bitcoin_units::Weight
+impl core::ops::arith::Mul<bitcoin_units::FeeRate> for bitcoin_units::NumOpResult<bitcoin_units::Weight>
+impl core::ops::arith::Mul<bitcoin_units::FeeRate> for bitcoin_units::Weight
+impl core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::Amount>> for &u64
+impl core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::Amount>> for u64
+impl core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for &bitcoin_units::NumOpResult<bitcoin_units::Weight>
+impl core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for &bitcoin_units::Weight
+impl core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for bitcoin_units::NumOpResult<bitcoin_units::Weight>
+impl core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for bitcoin_units::Weight
+impl core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for &i64
+impl core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for i64
+impl core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::FeeRate
+impl core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>
+impl core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::FeeRate
+impl core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::NumOpResult<bitcoin_units::FeeRate>
+impl core::ops::arith::Mul<bitcoin_units::SignedAmount> for &i64
+impl core::ops::arith::Mul<bitcoin_units::SignedAmount> for i64
+impl core::ops::arith::Mul<bitcoin_units::Weight> for &bitcoin_units::FeeRate
+impl core::ops::arith::Mul<bitcoin_units::Weight> for &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>
+impl core::ops::arith::Mul<bitcoin_units::Weight> for &u64
+impl core::ops::arith::Mul<bitcoin_units::Weight> for bitcoin_units::FeeRate
+impl core::ops::arith::Mul<bitcoin_units::Weight> for bitcoin_units::NumOpResult<bitcoin_units::FeeRate>
+impl core::ops::arith::Mul<bitcoin_units::Weight> for u64
+impl core::ops::arith::Mul<i64> for &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::Mul<i64> for &bitcoin_units::SignedAmount
+impl core::ops::arith::Mul<i64> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::Mul<i64> for bitcoin_units::SignedAmount
+impl core::ops::arith::Mul<u64> for &bitcoin_units::Amount
+impl core::ops::arith::Mul<u64> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Mul<u64> for &bitcoin_units::Weight
+impl core::ops::arith::Mul<u64> for bitcoin_units::Amount
+impl core::ops::arith::Mul<u64> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Mul<u64> for bitcoin_units::Weight
+impl core::ops::arith::MulAssign<&i64> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::MulAssign<&u64> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::MulAssign<i64> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::MulAssign<u64> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::MulAssign<u64> for bitcoin_units::Weight
+impl core::ops::arith::Neg for bitcoin_units::SignedAmount
+impl core::ops::arith::Rem for bitcoin_units::Weight
+impl core::ops::arith::Rem<&bitcoin_units::Weight> for bitcoin_units::Weight
+impl core::ops::arith::Rem<&i64> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::Rem<&i64> for bitcoin_units::SignedAmount
+impl core::ops::arith::Rem<&u64> for bitcoin_units::Amount
+impl core::ops::arith::Rem<&u64> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Rem<&u64> for bitcoin_units::Weight
+impl core::ops::arith::Rem<bitcoin_units::Weight> for &bitcoin_units::Weight
+impl core::ops::arith::Rem<i64> for &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::Rem<i64> for &bitcoin_units::SignedAmount
+impl core::ops::arith::Rem<i64> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl core::ops::arith::Rem<i64> for bitcoin_units::SignedAmount
+impl core::ops::arith::Rem<u64> for &bitcoin_units::Amount
+impl core::ops::arith::Rem<u64> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Rem<u64> for &bitcoin_units::Weight
+impl core::ops::arith::Rem<u64> for bitcoin_units::Amount
+impl core::ops::arith::Rem<u64> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl core::ops::arith::Rem<u64> for bitcoin_units::Weight
+impl core::ops::arith::RemAssign<u64> for bitcoin_units::Weight
+impl core::ops::arith::Sub for bitcoin_units::Amount
+impl core::ops::arith::Sub for bitcoin_units::FeeRate
+impl core::ops::arith::Sub for bitcoin_units::SignedAmount
+impl core::ops::arith::Sub for bitcoin_units::Weight
+impl core::ops::arith::Sub for bitcoin_units::block::BlockHeight
+impl core::ops::arith::Sub for bitcoin_units::block::BlockHeightInterval
+impl core::ops::arith::Sub for bitcoin_units::block::BlockMtp
+impl core::ops::arith::Sub for bitcoin_units::block::BlockMtpInterval
+impl core::ops::arith::Sub<&bitcoin_units::Amount> for bitcoin_units::Amount
+impl core::ops::arith::Sub<&bitcoin_units::FeeRate> for bitcoin_units::FeeRate
+impl core::ops::arith::Sub<&bitcoin_units::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount
+impl core::ops::arith::Sub<&bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for bitcoin_units::SignedAmount
+impl core::ops::arith::Sub<&bitcoin_units::SignedAmount> for bitcoin_units::SignedAmount
+impl core::ops::arith::Sub<&bitcoin_units::Weight> for bitcoin_units::Weight
+impl core::ops::arith::Sub<&bitcoin_units::block::BlockHeight> for bitcoin_units::block::BlockHeight
+impl core::ops::arith::Sub<&bitcoin_units::block::BlockHeightInterval> for bitcoin_units::block::BlockHeight
+impl core::ops::arith::Sub<&bitcoin_units::block::BlockHeightInterval> for bitcoin_units::block::BlockHeightInterval
+impl core::ops::arith::Sub<&bitcoin_units::block::BlockMtp> for bitcoin_units::block::BlockMtp
+impl core::ops::arith::Sub<&bitcoin_units::block::BlockMtpInterval> for bitcoin_units::block::BlockMtp
+impl core::ops::arith::Sub<&bitcoin_units::block::BlockMtpInterval> for bitcoin_units::block::BlockMtpInterval
+impl core::ops::arith::Sub<bitcoin_units::Amount> for &bitcoin_units::Amount
+impl core::ops::arith::Sub<bitcoin_units::FeeRate> for &bitcoin_units::FeeRate
+impl core::ops::arith::Sub<bitcoin_units::NumOpResult<bitcoin_units::Amount>> for &bitcoin_units::Amount
+impl core::ops::arith::Sub<bitcoin_units::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount
+impl core::ops::arith::Sub<bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for &bitcoin_units::SignedAmount
+impl core::ops::arith::Sub<bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for bitcoin_units::SignedAmount
+impl core::ops::arith::Sub<bitcoin_units::SignedAmount> for &bitcoin_units::SignedAmount
+impl core::ops::arith::Sub<bitcoin_units::Weight> for &bitcoin_units::Weight
+impl core::ops::arith::Sub<bitcoin_units::block::BlockHeight> for &bitcoin_units::block::BlockHeight
+impl core::ops::arith::Sub<bitcoin_units::block::BlockHeightInterval> for &bitcoin_units::block::BlockHeight
+impl core::ops::arith::Sub<bitcoin_units::block::BlockHeightInterval> for &bitcoin_units::block::BlockHeightInterval
+impl core::ops::arith::Sub<bitcoin_units::block::BlockHeightInterval> for bitcoin_units::block::BlockHeight
+impl core::ops::arith::Sub<bitcoin_units::block::BlockMtp> for &bitcoin_units::block::BlockMtp
+impl core::ops::arith::Sub<bitcoin_units::block::BlockMtpInterval> for &bitcoin_units::block::BlockMtp
+impl core::ops::arith::Sub<bitcoin_units::block::BlockMtpInterval> for &bitcoin_units::block::BlockMtpInterval
+impl core::ops::arith::Sub<bitcoin_units::block::BlockMtpInterval> for bitcoin_units::block::BlockMtp
+impl core::ops::arith::SubAssign for bitcoin_units::FeeRate
+impl core::ops::arith::SubAssign for bitcoin_units::Weight
+impl core::ops::arith::SubAssign for bitcoin_units::block::BlockHeightInterval
+impl core::ops::arith::SubAssign for bitcoin_units::block::BlockMtpInterval
+impl core::ops::arith::SubAssign<&bitcoin_units::FeeRate> for bitcoin_units::FeeRate
+impl core::ops::arith::SubAssign<&bitcoin_units::Weight> for bitcoin_units::Weight
+impl core::ops::arith::SubAssign<&bitcoin_units::block::BlockHeightInterval> for bitcoin_units::block::BlockHeightInterval
+impl core::ops::arith::SubAssign<&bitcoin_units::block::BlockMtpInterval> for bitcoin_units::block::BlockMtpInterval
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::Amount
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::BlockTime
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::FeeRate
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::MathOp
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::NumOpError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::SignedAmount
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::Weight
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::Denomination
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::Display
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::InputTooLargeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::InvalidCharacterError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::MissingDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::MissingDigitsError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::OutOfRangeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::ParseAmountError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::ParseDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::ParseError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::TooPreciseError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::UnknownDenominationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::BlockHeight
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::BlockHeightInterval
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::BlockMtp
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::BlockMtpInterval
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::block::TooBigForRelativeHeightError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::absolute::ConversionError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::absolute::Height
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::InvalidHeightError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::InvalidTimeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::parse::ParseIntError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::parse::PrefixedHexError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::parse::UnprefixedHexError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::Amount
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::BlockTime
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::FeeRate
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::MathOp
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::NumOpError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::SignedAmount
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::Weight
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::Denomination
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::Display
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::InputTooLargeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::InvalidCharacterError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::MissingDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::MissingDigitsError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::OutOfRangeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::ParseAmountError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::ParseDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::ParseError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::PossiblyConfusingDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::TooPreciseError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::UnknownDenominationError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::BlockHeight
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::BlockHeightInterval
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::BlockMtp
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::BlockMtpInterval
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::block::TooBigForRelativeHeightError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::absolute::ConversionError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::absolute::Height
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::absolute::ParseHeightError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::absolute::ParseTimeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::InvalidHeightError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::InvalidTimeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::NumberOfBlocks
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::TimeOverflowError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::parse::ParseIntError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::parse::PrefixedHexError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::parse::UnprefixedHexError
+impl core::str::traits::FromStr for bitcoin_units::Amount
+impl core::str::traits::FromStr for bitcoin_units::SignedAmount
+impl core::str::traits::FromStr for bitcoin_units::Weight
+impl core::str::traits::FromStr for bitcoin_units::amount::Denomination
+impl core::str::traits::FromStr for bitcoin_units::block::BlockHeight
+impl core::str::traits::FromStr for bitcoin_units::block::BlockHeightInterval
+impl core::str::traits::FromStr for bitcoin_units::block::BlockMtp
+impl core::str::traits::FromStr for bitcoin_units::block::BlockMtpInterval
+impl core::str::traits::FromStr for bitcoin_units::locktime::absolute::Height
+impl core::str::traits::FromStr for bitcoin_units::locktime::absolute::MedianTimePast
+impl core::str::traits::FromStr for bitcoin_units::locktime::relative::NumberOf512Seconds
+impl core::str::traits::FromStr for bitcoin_units::locktime::relative::NumberOfBlocks
+impl<'a, T> core::ops::arith::Add<&'a T> for &bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Add<bitcoin_units::NumOpResult<T>, Output = bitcoin_units::NumOpResult<T>>
+impl<'a, T> core::ops::arith::Add<&'a bitcoin_units::NumOpResult<T>> for &bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Add<Output = bitcoin_units::NumOpResult<T>>
+impl<'a, T> core::ops::arith::Sub<&'a T> for &bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Sub<Output = bitcoin_units::NumOpResult<T>>
+impl<'a, T> core::ops::arith::Sub<&'a bitcoin_units::NumOpResult<T>> for &bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Sub<Output = bitcoin_units::NumOpResult<T>>
+impl<'a> core::iter::traits::accum::Sum<&'a bitcoin_units::FeeRate> for bitcoin_units::FeeRate
+impl<'a> core::iter::traits::accum::Sum<&'a bitcoin_units::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl<'a> core::iter::traits::accum::Sum<&'a bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl<'a> core::iter::traits::accum::Sum<&'a bitcoin_units::Weight> for bitcoin_units::Weight
+impl<'a> core::iter::traits::accum::Sum<&'a bitcoin_units::block::BlockHeightInterval> for bitcoin_units::block::BlockHeightInterval
+impl<'a> core::iter::traits::accum::Sum<&'a bitcoin_units::block::BlockMtpInterval> for bitcoin_units::block::BlockMtpInterval
+impl<'a> core::ops::arith::Add<&'a bitcoin_units::Amount> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Add<&'a bitcoin_units::FeeRate> for &bitcoin_units::FeeRate
+impl<'a> core::ops::arith::Add<&'a bitcoin_units::NumOpResult<bitcoin_units::Amount>> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Add<&'a bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for &bitcoin_units::SignedAmount
+impl<'a> core::ops::arith::Add<&'a bitcoin_units::SignedAmount> for &bitcoin_units::SignedAmount
+impl<'a> core::ops::arith::Add<&'a bitcoin_units::Weight> for &bitcoin_units::Weight
+impl<'a> core::ops::arith::Add<&'a bitcoin_units::block::BlockHeightInterval> for &bitcoin_units::block::BlockHeight
+impl<'a> core::ops::arith::Add<&'a bitcoin_units::block::BlockHeightInterval> for &bitcoin_units::block::BlockHeightInterval
+impl<'a> core::ops::arith::Add<&'a bitcoin_units::block::BlockMtpInterval> for &bitcoin_units::block::BlockMtp
+impl<'a> core::ops::arith::Add<&'a bitcoin_units::block::BlockMtpInterval> for &bitcoin_units::block::BlockMtpInterval
+impl<'a> core::ops::arith::Div<&'a bitcoin_units::Amount> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Div<&'a bitcoin_units::FeeRate> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Div<&'a bitcoin_units::FeeRate> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl<'a> core::ops::arith::Div<&'a bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Div<&'a bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl<'a> core::ops::arith::Div<&'a bitcoin_units::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Div<&'a bitcoin_units::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl<'a> core::ops::arith::Div<&'a bitcoin_units::SignedAmount> for &bitcoin_units::SignedAmount
+impl<'a> core::ops::arith::Div<&'a bitcoin_units::Weight> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Div<&'a bitcoin_units::Weight> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl<'a> core::ops::arith::Div<&'a bitcoin_units::Weight> for &bitcoin_units::Weight
+impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::SignedAmount
+impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::FeeRate
+impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::Weight
+impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::SignedAmount
+impl<'a> core::ops::arith::Div<&'a u64> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Div<&'a u64> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl<'a> core::ops::arith::Div<&'a u64> for &bitcoin_units::Weight
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::Amount> for &u64
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::FeeRate> for &bitcoin_units::NumOpResult<bitcoin_units::Weight>
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::FeeRate> for &bitcoin_units::Weight
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::NumOpResult<bitcoin_units::Amount>> for &u64
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for &bitcoin_units::NumOpResult<bitcoin_units::Weight>
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::NumOpResult<bitcoin_units::FeeRate>> for &bitcoin_units::Weight
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for &i64
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::FeeRate
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::SignedAmount> for &i64
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::Weight> for &bitcoin_units::FeeRate
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::Weight> for &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>
+impl<'a> core::ops::arith::Mul<&'a bitcoin_units::Weight> for &u64
+impl<'a> core::ops::arith::Mul<&'a i64> for &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl<'a> core::ops::arith::Mul<&'a i64> for &bitcoin_units::SignedAmount
+impl<'a> core::ops::arith::Mul<&'a u64> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Mul<&'a u64> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl<'a> core::ops::arith::Mul<&'a u64> for &bitcoin_units::Weight
+impl<'a> core::ops::arith::Rem<&'a bitcoin_units::Weight> for &bitcoin_units::Weight
+impl<'a> core::ops::arith::Rem<&'a i64> for &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+impl<'a> core::ops::arith::Rem<&'a i64> for &bitcoin_units::SignedAmount
+impl<'a> core::ops::arith::Rem<&'a u64> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Rem<&'a u64> for &bitcoin_units::NumOpResult<bitcoin_units::Amount>
+impl<'a> core::ops::arith::Rem<&'a u64> for &bitcoin_units::Weight
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::Amount> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::FeeRate> for &bitcoin_units::FeeRate
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::NumOpResult<bitcoin_units::Amount>> for &bitcoin_units::Amount
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>> for &bitcoin_units::SignedAmount
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::SignedAmount> for &bitcoin_units::SignedAmount
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::Weight> for &bitcoin_units::Weight
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::block::BlockHeight> for &bitcoin_units::block::BlockHeight
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::block::BlockHeightInterval> for &bitcoin_units::block::BlockHeight
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::block::BlockHeightInterval> for &bitcoin_units::block::BlockHeightInterval
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::block::BlockMtp> for &bitcoin_units::block::BlockMtp
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::block::BlockMtpInterval> for &bitcoin_units::block::BlockMtp
+impl<'a> core::ops::arith::Sub<&'a bitcoin_units::block::BlockMtpInterval> for &bitcoin_units::block::BlockMtpInterval
+impl<T: core::clone::Clone> core::clone::Clone for bitcoin_units::NumOpResult<T>
+impl<T: core::cmp::Eq> core::cmp::Eq for bitcoin_units::NumOpResult<T>
+impl<T: core::cmp::PartialEq> core::cmp::PartialEq for bitcoin_units::NumOpResult<T>
+impl<T: core::fmt::Debug> bitcoin_units::NumOpResult<T>
+impl<T: core::fmt::Debug> core::fmt::Debug for bitcoin_units::NumOpResult<T>
+impl<T: core::marker::Copy> core::marker::Copy for bitcoin_units::NumOpResult<T>
+impl<T> bitcoin_units::CheckedSum<bitcoin_units::Amount> for T where T: core::iter::traits::iterator::Iterator<Item = bitcoin_units::Amount>
+impl<T> bitcoin_units::CheckedSum<bitcoin_units::SignedAmount> for T where T: core::iter::traits::iterator::Iterator<Item = bitcoin_units::SignedAmount>
+impl<T> bitcoin_units::CheckedSum<bitcoin_units::Weight> for T where T: core::iter::traits::iterator::Iterator<Item = bitcoin_units::Weight>
+impl<T> bitcoin_units::NumOpResult<T>
+impl<T> core::marker::Freeze for bitcoin_units::NumOpResult<T> where T: core::marker::Freeze
+impl<T> core::marker::Send for bitcoin_units::NumOpResult<T> where T: core::marker::Send
+impl<T> core::marker::StructuralPartialEq for bitcoin_units::NumOpResult<T>
+impl<T> core::marker::Sync for bitcoin_units::NumOpResult<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bitcoin_units::NumOpResult<T> where T: core::marker::Unpin
+impl<T> core::ops::arith::Add for bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Add<Output = bitcoin_units::NumOpResult<T>>
+impl<T> core::ops::arith::Add<&T> for bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Add<bitcoin_units::NumOpResult<T>, Output = bitcoin_units::NumOpResult<T>>
+impl<T> core::ops::arith::Add<&bitcoin_units::NumOpResult<T>> for bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Add<Output = bitcoin_units::NumOpResult<T>>
+impl<T> core::ops::arith::Add<T> for &bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Add<bitcoin_units::NumOpResult<T>, Output = bitcoin_units::NumOpResult<T>>
+impl<T> core::ops::arith::Add<T> for bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Add<bitcoin_units::NumOpResult<T>, Output = bitcoin_units::NumOpResult<T>>
+impl<T> core::ops::arith::Add<bitcoin_units::NumOpResult<T>> for &bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Add<Output = bitcoin_units::NumOpResult<T>>
+impl<T> core::ops::arith::Sub for bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Sub<Output = bitcoin_units::NumOpResult<T>>
+impl<T> core::ops::arith::Sub<&T> for bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Sub<Output = bitcoin_units::NumOpResult<T>>
+impl<T> core::ops::arith::Sub<&bitcoin_units::NumOpResult<T>> for bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Sub<Output = bitcoin_units::NumOpResult<T>>
+impl<T> core::ops::arith::Sub<T> for &bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Sub<Output = bitcoin_units::NumOpResult<T>>
+impl<T> core::ops::arith::Sub<T> for bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Sub<Output = bitcoin_units::NumOpResult<T>>
+impl<T> core::ops::arith::Sub<bitcoin_units::NumOpResult<T>> for &bitcoin_units::NumOpResult<T> where T: core::marker::Copy + core::ops::arith::Sub<Output = bitcoin_units::NumOpResult<T>>
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::NumOpResult<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_units::NumOpResult<T> where T: core::panic::unwind_safe::UnwindSafe
+pub bitcoin_units::MathOp::Add
+pub bitcoin_units::MathOp::Div
+pub bitcoin_units::MathOp::Mul
+pub bitcoin_units::MathOp::Neg
+pub bitcoin_units::MathOp::Rem
+pub bitcoin_units::MathOp::Sub
+pub bitcoin_units::NumOpResult::Error(bitcoin_units::NumOpError)
+pub bitcoin_units::NumOpResult::Valid(T)
+pub bitcoin_units::amount::Denomination::Bit
+pub bitcoin_units::amount::Denomination::Bitcoin
+pub bitcoin_units::amount::Denomination::CentiBitcoin
+pub bitcoin_units::amount::Denomination::MicroBitcoin
+pub bitcoin_units::amount::Denomination::MilliBitcoin
+pub bitcoin_units::amount::Denomination::Satoshi
+pub bitcoin_units::amount::ParseDenominationError::PossiblyConfusing(bitcoin_units::amount::PossiblyConfusingDenominationError)
+pub bitcoin_units::amount::ParseDenominationError::Unknown(bitcoin_units::amount::UnknownDenominationError)
+pub const bitcoin_units::Amount::FIFTY_BTC: Self
+pub const bitcoin_units::Amount::MAX: Self
+pub const bitcoin_units::Amount::MAX_MONEY: Self
+pub const bitcoin_units::Amount::MIN: Self
+pub const bitcoin_units::Amount::ONE_BTC: Self
+pub const bitcoin_units::Amount::ONE_SAT: Self
+pub const bitcoin_units::Amount::SIZE: usize
+pub const bitcoin_units::Amount::ZERO: Self
+pub const bitcoin_units::FeeRate::BROADCAST_MIN: bitcoin_units::FeeRate
+pub const bitcoin_units::FeeRate::DUST: bitcoin_units::FeeRate
+pub const bitcoin_units::FeeRate::MAX: bitcoin_units::FeeRate
+pub const bitcoin_units::FeeRate::MIN: bitcoin_units::FeeRate
+pub const bitcoin_units::FeeRate::ZERO: bitcoin_units::FeeRate
+pub const bitcoin_units::SignedAmount::FIFTY_BTC: Self
+pub const bitcoin_units::SignedAmount::MAX: Self
+pub const bitcoin_units::SignedAmount::MAX_MONEY: Self
+pub const bitcoin_units::SignedAmount::MIN: Self
+pub const bitcoin_units::SignedAmount::ONE_BTC: Self
+pub const bitcoin_units::SignedAmount::ONE_SAT: Self
+pub const bitcoin_units::SignedAmount::ZERO: Self
+pub const bitcoin_units::Weight::MAX: bitcoin_units::Weight
+pub const bitcoin_units::Weight::MAX_BLOCK: bitcoin_units::Weight
+pub const bitcoin_units::Weight::MIN: bitcoin_units::Weight
+pub const bitcoin_units::Weight::MIN_TRANSACTION: bitcoin_units::Weight
+pub const bitcoin_units::Weight::WITNESS_SCALE_FACTOR: u64
+pub const bitcoin_units::Weight::ZERO: bitcoin_units::Weight
+pub const bitcoin_units::amount::Denomination::BTC: Self
+pub const bitcoin_units::amount::Denomination::SAT: Self
+pub const bitcoin_units::block::BlockHeight::MAX: Self
+pub const bitcoin_units::block::BlockHeight::MIN: Self
+pub const bitcoin_units::block::BlockHeight::ZERO: Self
+pub const bitcoin_units::block::BlockHeightInterval::MAX: Self
+pub const bitcoin_units::block::BlockHeightInterval::MIN: Self
+pub const bitcoin_units::block::BlockHeightInterval::ZERO: Self
+pub const bitcoin_units::block::BlockMtp::MAX: Self
+pub const bitcoin_units::block::BlockMtp::MIN: Self
+pub const bitcoin_units::block::BlockMtp::ZERO: Self
+pub const bitcoin_units::block::BlockMtpInterval::MAX: Self
+pub const bitcoin_units::block::BlockMtpInterval::MIN: Self
+pub const bitcoin_units::block::BlockMtpInterval::ZERO: Self
+pub const bitcoin_units::locktime::absolute::Height::MAX: Self
+pub const bitcoin_units::locktime::absolute::Height::MIN: Self
+pub const bitcoin_units::locktime::absolute::Height::ZERO: Self
+pub const bitcoin_units::locktime::absolute::LOCK_TIME_THRESHOLD: u32
+pub const bitcoin_units::locktime::absolute::MedianTimePast::MAX: Self
+pub const bitcoin_units::locktime::absolute::MedianTimePast::MIN: Self
+pub const bitcoin_units::locktime::relative::NumberOf512Seconds::MAX: Self
+pub const bitcoin_units::locktime::relative::NumberOf512Seconds::MIN: Self
+pub const bitcoin_units::locktime::relative::NumberOf512Seconds::ZERO: Self
+pub const bitcoin_units::locktime::relative::NumberOfBlocks::MAX: Self
+pub const bitcoin_units::locktime::relative::NumberOfBlocks::MIN: Self
+pub const bitcoin_units::locktime::relative::NumberOfBlocks::ZERO: Self
+pub const bitcoin_units::weight::WITNESS_SCALE_FACTOR: usize
+pub const fn bitcoin_units::Amount::checked_add(self, rhs: Self) -> core::option::Option<Self>
+pub const fn bitcoin_units::Amount::checked_div(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::Amount::checked_mul(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::Amount::checked_rem(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::Amount::checked_sub(self, rhs: Self) -> core::option::Option<Self>
+pub const fn bitcoin_units::Amount::div_by_fee_rate_ceil(self, fee_rate: bitcoin_units::FeeRate) -> bitcoin_units::NumOpResult<bitcoin_units::Weight>
+pub const fn bitcoin_units::Amount::div_by_fee_rate_floor(self, fee_rate: bitcoin_units::FeeRate) -> bitcoin_units::NumOpResult<bitcoin_units::Weight>
+pub const fn bitcoin_units::Amount::div_by_weight_ceil(self, weight: bitcoin_units::Weight) -> bitcoin_units::NumOpResult<bitcoin_units::FeeRate>
+pub const fn bitcoin_units::Amount::div_by_weight_floor(self, weight: bitcoin_units::Weight) -> bitcoin_units::NumOpResult<bitcoin_units::FeeRate>
+pub const fn bitcoin_units::Amount::from_btc_u16(whole_bitcoin: u16) -> Self
+pub const fn bitcoin_units::Amount::from_sat(satoshi: u64) -> core::result::Result<Self, bitcoin_units::amount::OutOfRangeError>
+pub const fn bitcoin_units::Amount::from_sat_u32(satoshi: u32) -> Self
+pub const fn bitcoin_units::Amount::to_sat(self) -> u64
+pub const fn bitcoin_units::BlockTime::from_u32(t: u32) -> Self
+pub const fn bitcoin_units::BlockTime::to_u32(self) -> u32
+pub const fn bitcoin_units::FeeRate::checked_add(self, rhs: bitcoin_units::FeeRate) -> core::option::Option<Self>
+pub const fn bitcoin_units::FeeRate::checked_div(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::FeeRate::checked_mul(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::FeeRate::checked_sub(self, rhs: bitcoin_units::FeeRate) -> core::option::Option<Self>
+pub const fn bitcoin_units::FeeRate::from_per_kvb(rate: bitcoin_units::Amount) -> bitcoin_units::NumOpResult<Self>
+pub const fn bitcoin_units::FeeRate::from_per_kwu(rate: bitcoin_units::Amount) -> bitcoin_units::NumOpResult<Self>
+pub const fn bitcoin_units::FeeRate::from_per_vb(rate: bitcoin_units::Amount) -> bitcoin_units::NumOpResult<Self>
+pub const fn bitcoin_units::FeeRate::from_sat_per_kvb(sat_kvb: u32) -> Self
+pub const fn bitcoin_units::FeeRate::from_sat_per_kwu(sat_kwu: u32) -> Self
+pub const fn bitcoin_units::FeeRate::from_sat_per_vb(sat_vb: u32) -> Self
+pub const fn bitcoin_units::FeeRate::mul_by_weight(self, weight: bitcoin_units::Weight) -> bitcoin_units::NumOpResult<bitcoin_units::Amount>
+pub const fn bitcoin_units::FeeRate::to_fee(self, weight: bitcoin_units::Weight) -> bitcoin_units::Amount
+pub const fn bitcoin_units::FeeRate::to_sat_per_kvb_ceil(self) -> u64
+pub const fn bitcoin_units::FeeRate::to_sat_per_kvb_floor(self) -> u64
+pub const fn bitcoin_units::FeeRate::to_sat_per_kwu_ceil(self) -> u64
+pub const fn bitcoin_units::FeeRate::to_sat_per_kwu_floor(self) -> u64
+pub const fn bitcoin_units::FeeRate::to_sat_per_vb_ceil(self) -> u64
+pub const fn bitcoin_units::FeeRate::to_sat_per_vb_floor(self) -> u64
+pub const fn bitcoin_units::SignedAmount::abs(self) -> Self
+pub const fn bitcoin_units::SignedAmount::checked_abs(self) -> core::option::Option<Self>
+pub const fn bitcoin_units::SignedAmount::checked_add(self, rhs: Self) -> core::option::Option<Self>
+pub const fn bitcoin_units::SignedAmount::checked_div(self, rhs: i64) -> core::option::Option<Self>
+pub const fn bitcoin_units::SignedAmount::checked_mul(self, rhs: i64) -> core::option::Option<Self>
+pub const fn bitcoin_units::SignedAmount::checked_rem(self, rhs: i64) -> core::option::Option<Self>
+pub const fn bitcoin_units::SignedAmount::checked_sub(self, rhs: Self) -> core::option::Option<Self>
+pub const fn bitcoin_units::SignedAmount::from_btc_i16(whole_bitcoin: i16) -> Self
+pub const fn bitcoin_units::SignedAmount::from_sat(satoshi: i64) -> core::result::Result<Self, bitcoin_units::amount::OutOfRangeError>
+pub const fn bitcoin_units::SignedAmount::from_sat_i32(satoshi: i32) -> Self
+pub const fn bitcoin_units::SignedAmount::to_sat(self) -> i64
+pub const fn bitcoin_units::Weight::checked_add(self, rhs: Self) -> core::option::Option<Self>
+pub const fn bitcoin_units::Weight::checked_div(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::Weight::checked_mul(self, rhs: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::Weight::checked_sub(self, rhs: Self) -> core::option::Option<Self>
+pub const fn bitcoin_units::Weight::from_kwu(wu: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::Weight::from_non_witness_data_size(non_witness_size: u64) -> Self
+pub const fn bitcoin_units::Weight::from_vb(vb: u64) -> core::option::Option<Self>
+pub const fn bitcoin_units::Weight::from_vb_unchecked(vb: u64) -> Self
+pub const fn bitcoin_units::Weight::from_vb_unwrap(vb: u64) -> bitcoin_units::Weight
+pub const fn bitcoin_units::Weight::from_witness_data_size(witness_size: u64) -> Self
+pub const fn bitcoin_units::Weight::from_wu(wu: u64) -> Self
+pub const fn bitcoin_units::Weight::mul_by_fee_rate(self, fee_rate: bitcoin_units::FeeRate) -> bitcoin_units::NumOpResult<bitcoin_units::Amount>
+pub const fn bitcoin_units::Weight::to_kwu_ceil(self) -> u64
+pub const fn bitcoin_units::Weight::to_kwu_floor(self) -> u64
+pub const fn bitcoin_units::Weight::to_vbytes_ceil(self) -> u64
+pub const fn bitcoin_units::Weight::to_vbytes_floor(self) -> u64
+pub const fn bitcoin_units::Weight::to_wu(self) -> u64
+pub const fn bitcoin_units::block::BlockHeight::from_u32(inner: u32) -> Self
+pub const fn bitcoin_units::block::BlockHeight::to_u32(self) -> u32
+pub const fn bitcoin_units::block::BlockHeightInterval::from_u32(inner: u32) -> Self
+pub const fn bitcoin_units::block::BlockHeightInterval::to_u32(self) -> u32
+pub const fn bitcoin_units::block::BlockMtp::from_u32(inner: u32) -> Self
+pub const fn bitcoin_units::block::BlockMtp::to_u32(self) -> u32
+pub const fn bitcoin_units::block::BlockMtpInterval::from_u32(inner: u32) -> Self
+pub const fn bitcoin_units::block::BlockMtpInterval::to_relative_mtp_interval_ceil(self) -> core::result::Result<bitcoin_units::locktime::relative::NumberOf512Seconds, bitcoin_units::locktime::relative::TimeOverflowError>
+pub const fn bitcoin_units::block::BlockMtpInterval::to_relative_mtp_interval_floor(self) -> core::result::Result<bitcoin_units::locktime::relative::NumberOf512Seconds, bitcoin_units::locktime::relative::TimeOverflowError>
+pub const fn bitcoin_units::block::BlockMtpInterval::to_u32(self) -> u32
+pub const fn bitcoin_units::locktime::absolute::Height::from_u32(n: u32) -> core::result::Result<bitcoin_units::locktime::absolute::Height, bitcoin_units::locktime::absolute::ConversionError>
+pub const fn bitcoin_units::locktime::absolute::Height::to_u32(self) -> u32
+pub const fn bitcoin_units::locktime::absolute::MedianTimePast::from_u32(n: u32) -> core::result::Result<Self, bitcoin_units::locktime::absolute::ConversionError>
+pub const fn bitcoin_units::locktime::absolute::MedianTimePast::to_u32(self) -> u32
+pub const fn bitcoin_units::locktime::absolute::is_block_height(n: u32) -> bool
+pub const fn bitcoin_units::locktime::absolute::is_block_time(n: u32) -> bool
+pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_512_second_intervals(intervals: u16) -> Self
+pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_seconds_ceil(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::TimeOverflowError>
+pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_seconds_floor(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::TimeOverflowError>
+pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::to_512_second_intervals(self) -> u16
+pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::to_consensus_u32(self) -> u32
+pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::to_seconds(self) -> u32
+pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::from_height(blocks: u16) -> Self
+pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::to_consensus_u32(self) -> u32
+pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::to_height(self) -> u16
+pub enum bitcoin_units::NumOpResult<T>
+pub fn &bitcoin_units::Amount::add(self, rhs: &bitcoin_units::Amount) -> Self::Output
+pub fn &bitcoin_units::Amount::add(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Amount>) -> Self::Output
+pub fn &bitcoin_units::Amount::add(self, rhs: bitcoin_units::Amount) -> Self::Output
+pub fn &bitcoin_units::Amount::add(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Amount>) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: &bitcoin_units::Amount) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: &bitcoin_units::FeeRate) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: &u64) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: bitcoin_units::Amount) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: bitcoin_units::FeeRate) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output
+pub fn &bitcoin_units::Amount::div(self, rhs: u64) -> Self::Output
+pub fn &bitcoin_units::Amount::mul(self, rhs: &u64) -> Self::Output
+pub fn &bitcoin_units::Amount::mul(self, rhs: u64) -> Self::Output
+pub fn &bitcoin_units::Amount::rem(self, rhs: &u64) -> Self::Output
+pub fn &bitcoin_units::Amount::rem(self, rhs: u64) -> Self::Output
+pub fn &bitcoin_units::Amount::sub(self, rhs: &bitcoin_units::Amount) -> Self::Output
+pub fn &bitcoin_units::Amount::sub(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Amount>) -> Self::Output
+pub fn &bitcoin_units::Amount::sub(self, rhs: bitcoin_units::Amount) -> Self::Output
+pub fn &bitcoin_units::Amount::sub(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Amount>) -> Self::Output
+pub fn &bitcoin_units::FeeRate::add(self, rhs: &bitcoin_units::FeeRate) -> Self::Output
+pub fn &bitcoin_units::FeeRate::add(self, rhs: bitcoin_units::FeeRate) -> Self::Output
+pub fn &bitcoin_units::FeeRate::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output
+pub fn &bitcoin_units::FeeRate::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output
+pub fn &bitcoin_units::FeeRate::mul(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn &bitcoin_units::FeeRate::mul(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::FeeRate::mul(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn &bitcoin_units::FeeRate::mul(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::FeeRate::sub(self, rhs: &bitcoin_units::FeeRate) -> Self::Output
+pub fn &bitcoin_units::FeeRate::sub(self, rhs: bitcoin_units::FeeRate) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<T>::add(self, rhs: &T) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<T>::add(self, rhs: &bitcoin_units::NumOpResult<T>) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<T>::add(self, rhs: T) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<T>::add(self, rhs: bitcoin_units::NumOpResult<T>) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<T>::sub(self, rhs: &T) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<T>::sub(self, rhs: &bitcoin_units::NumOpResult<T>) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<T>::sub(self, rhs: T) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<T>::sub(self, rhs: bitcoin_units::NumOpResult<T>) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::FeeRate) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &u64) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: bitcoin_units::FeeRate) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: u64) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::mul(self, rhs: &u64) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::mul(self, rhs: u64) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::rem(self, rhs: &u64) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Amount>::rem(self, rhs: u64) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::mul(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::mul(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::mul(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::mul(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &i64) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: i64) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::mul(self, rhs: &i64) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::mul(self, rhs: i64) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::rem(self, rhs: &i64) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::rem(self, rhs: i64) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Weight>::mul(self, rhs: &bitcoin_units::FeeRate) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Weight>::mul(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Weight>::mul(self, rhs: bitcoin_units::FeeRate) -> Self::Output
+pub fn &bitcoin_units::NumOpResult<bitcoin_units::Weight>::mul(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::add(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::add(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::add(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::add(self, rhs: bitcoin_units::SignedAmount) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::div(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::div(self, rhs: &core::num::nonzero::NonZeroI64) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::div(self, rhs: &i64) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::div(self, rhs: bitcoin_units::SignedAmount) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::div(self, rhs: core::num::nonzero::NonZeroI64) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::div(self, rhs: i64) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::mul(self, rhs: &i64) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::mul(self, rhs: i64) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::rem(self, rhs: &i64) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::rem(self, rhs: i64) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::sub(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::sub(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::sub(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
+pub fn &bitcoin_units::SignedAmount::sub(self, rhs: bitcoin_units::SignedAmount) -> Self::Output
+pub fn &bitcoin_units::Weight::add(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::Weight::add(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::Weight::div(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::Weight::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output
+pub fn &bitcoin_units::Weight::div(self, rhs: &u64) -> Self::Output
+pub fn &bitcoin_units::Weight::div(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::Weight::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output
+pub fn &bitcoin_units::Weight::div(self, rhs: u64) -> Self::Output
+pub fn &bitcoin_units::Weight::mul(self, rhs: &bitcoin_units::FeeRate) -> Self::Output
+pub fn &bitcoin_units::Weight::mul(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn &bitcoin_units::Weight::mul(self, rhs: &u64) -> Self::Output
+pub fn &bitcoin_units::Weight::mul(self, rhs: bitcoin_units::FeeRate) -> Self::Output
+pub fn &bitcoin_units::Weight::mul(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn &bitcoin_units::Weight::mul(self, rhs: u64) -> Self::Output
+pub fn &bitcoin_units::Weight::rem(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::Weight::rem(self, rhs: &u64) -> Self::Output
+pub fn &bitcoin_units::Weight::rem(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::Weight::rem(self, rhs: u64) -> Self::Output
+pub fn &bitcoin_units::Weight::sub(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::Weight::sub(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn &bitcoin_units::block::BlockHeight::add(self, rhs: &bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockHeight::add(self, rhs: bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockHeight::sub(self, rhs: &bitcoin_units::block::BlockHeight) -> Self::Output
+pub fn &bitcoin_units::block::BlockHeight::sub(self, rhs: &bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockHeight::sub(self, rhs: bitcoin_units::block::BlockHeight) -> Self::Output
+pub fn &bitcoin_units::block::BlockHeight::sub(self, rhs: bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockHeightInterval::add(self, rhs: &bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockHeightInterval::add(self, rhs: bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockHeightInterval::sub(self, rhs: &bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockHeightInterval::sub(self, rhs: bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockMtp::add(self, rhs: &bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockMtp::add(self, rhs: bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockMtp::sub(self, rhs: &bitcoin_units::block::BlockMtp) -> Self::Output
+pub fn &bitcoin_units::block::BlockMtp::sub(self, rhs: &bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockMtp::sub(self, rhs: bitcoin_units::block::BlockMtp) -> Self::Output
+pub fn &bitcoin_units::block::BlockMtp::sub(self, rhs: bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockMtpInterval::add(self, rhs: &bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockMtpInterval::add(self, rhs: bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockMtpInterval::sub(self, rhs: &bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn &bitcoin_units::block::BlockMtpInterval::sub(self, rhs: bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn &i64::mul(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
+pub fn &i64::mul(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output
+pub fn &i64::mul(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
+pub fn &i64::mul(self, rhs: bitcoin_units::SignedAmount) -> Self::Output
+pub fn &u64::mul(self, rhs: &bitcoin_units::Amount) -> Self::Output
+pub fn &u64::mul(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Amount>) -> Self::Output
+pub fn &u64::mul(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn &u64::mul(self, rhs: bitcoin_units::Amount) -> Self::Output
+pub fn &u64::mul(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Amount>) -> Self::Output
+pub fn &u64::mul(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn T::checked_sum(self) -> core::option::Option<bitcoin_units::Amount>
+pub fn T::checked_sum(self) -> core::option::Option<bitcoin_units::SignedAmount>
+pub fn T::checked_sum(self) -> core::option::Option<bitcoin_units::Weight>
+pub fn bitcoin_units::Amount::add(self, rhs: &bitcoin_units::Amount) -> Self::Output
+pub fn bitcoin_units::Amount::add(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Amount>) -> Self::Output
+pub fn bitcoin_units::Amount::add(self, rhs: bitcoin_units::Amount) -> Self::Output
+pub fn bitcoin_units::Amount::add(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Amount>) -> Self::Output
+pub fn bitcoin_units::Amount::clone(&self) -> bitcoin_units::Amount
+pub fn bitcoin_units::Amount::cmp(&self, other: &bitcoin_units::Amount) -> core::cmp::Ordering
+pub fn bitcoin_units::Amount::default() -> Self
+pub fn bitcoin_units::Amount::display_dynamic(self) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::Amount::display_in(self, denomination: bitcoin_units::amount::Denomination) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::Amount::div(self, rhs: &bitcoin_units::Amount) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: &bitcoin_units::FeeRate) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: &u64) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: bitcoin_units::Amount) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: bitcoin_units::FeeRate) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output
+pub fn bitcoin_units::Amount::div(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::Amount::eq(&self, other: &bitcoin_units::Amount) -> bool
+pub fn bitcoin_units::Amount::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::Amount::from_int_btc<T: core::convert::Into<u16>>(whole_bitcoin: T) -> Self
+pub fn bitcoin_units::Amount::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::Amount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<Self, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::Amount::from_str_with_denomination(s: &str) -> core::result::Result<Self, bitcoin_units::amount::ParseError>
+pub fn bitcoin_units::Amount::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::Amount::mul(self, rhs: &u64) -> Self::Output
+pub fn bitcoin_units::Amount::mul(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::Amount::partial_cmp(&self, other: &bitcoin_units::Amount) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::Amount::rem(self, modulus: u64) -> Self::Output
+pub fn bitcoin_units::Amount::rem(self, rhs: &u64) -> Self::Output
+pub fn bitcoin_units::Amount::sub(self, rhs: &bitcoin_units::Amount) -> Self::Output
+pub fn bitcoin_units::Amount::sub(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Amount>) -> Self::Output
+pub fn bitcoin_units::Amount::sub(self, rhs: bitcoin_units::Amount) -> Self::Output
+pub fn bitcoin_units::Amount::sub(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Amount>) -> Self::Output
+pub fn bitcoin_units::Amount::to_signed(self) -> bitcoin_units::SignedAmount
+pub fn bitcoin_units::Amount::try_from(value: bitcoin_units::SignedAmount) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::BlockTime::clone(&self) -> bitcoin_units::BlockTime
+pub fn bitcoin_units::BlockTime::cmp(&self, other: &bitcoin_units::BlockTime) -> core::cmp::Ordering
+pub fn bitcoin_units::BlockTime::eq(&self, other: &bitcoin_units::BlockTime) -> bool
+pub fn bitcoin_units::BlockTime::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::BlockTime::from(t: u32) -> Self
+pub fn bitcoin_units::BlockTime::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::BlockTime::partial_cmp(&self, other: &bitcoin_units::BlockTime) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::CheckedSum::checked_sum(self) -> core::option::Option<R>
+pub fn bitcoin_units::FeeRate::add(self, rhs: &bitcoin_units::FeeRate) -> Self::Output
+pub fn bitcoin_units::FeeRate::add(self, rhs: bitcoin_units::FeeRate) -> Self::Output
+pub fn bitcoin_units::FeeRate::add_assign(&mut self, rhs: &bitcoin_units::FeeRate)
+pub fn bitcoin_units::FeeRate::add_assign(&mut self, rhs: bitcoin_units::FeeRate)
+pub fn bitcoin_units::FeeRate::clone(&self) -> bitcoin_units::FeeRate
+pub fn bitcoin_units::FeeRate::cmp(&self, other: &bitcoin_units::FeeRate) -> core::cmp::Ordering
+pub fn bitcoin_units::FeeRate::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output
+pub fn bitcoin_units::FeeRate::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output
+pub fn bitcoin_units::FeeRate::eq(&self, other: &bitcoin_units::FeeRate) -> bool
+pub fn bitcoin_units::FeeRate::fee_vb(self, vb: u64) -> core::option::Option<bitcoin_units::Amount>
+pub fn bitcoin_units::FeeRate::fee_wu(self, weight: bitcoin_units::Weight) -> core::option::Option<bitcoin_units::Amount>
+pub fn bitcoin_units::FeeRate::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::FeeRate::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::FeeRate::mul(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn bitcoin_units::FeeRate::mul(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::FeeRate::mul(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn bitcoin_units::FeeRate::mul(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::FeeRate::partial_cmp(&self, other: &bitcoin_units::FeeRate) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::FeeRate::sub(self, rhs: &bitcoin_units::FeeRate) -> Self::Output
+pub fn bitcoin_units::FeeRate::sub(self, rhs: bitcoin_units::FeeRate) -> Self::Output
+pub fn bitcoin_units::FeeRate::sub_assign(&mut self, rhs: &bitcoin_units::FeeRate)
+pub fn bitcoin_units::FeeRate::sub_assign(&mut self, rhs: bitcoin_units::FeeRate)
+pub fn bitcoin_units::FeeRate::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin_units::FeeRate>
+pub fn bitcoin_units::FeeRate::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = Self>
+pub fn bitcoin_units::MathOp::clone(&self) -> bitcoin_units::MathOp
+pub fn bitcoin_units::MathOp::eq(&self, other: &bitcoin_units::MathOp) -> bool
+pub fn bitcoin_units::MathOp::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::MathOp::is_addition(self) -> bool
+pub fn bitcoin_units::MathOp::is_div_by_zero(self) -> bool
+pub fn bitcoin_units::MathOp::is_multiplication(self) -> bool
+pub fn bitcoin_units::MathOp::is_negation(self) -> bool
+pub fn bitcoin_units::MathOp::is_overflow(self) -> bool
+pub fn bitcoin_units::MathOp::is_subtraction(self) -> bool
+pub fn bitcoin_units::NumOpError::clone(&self) -> bitcoin_units::NumOpError
+pub fn bitcoin_units::NumOpError::eq(&self, other: &bitcoin_units::NumOpError) -> bool
+pub fn bitcoin_units::NumOpError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::NumOpError::is_div_by_zero(self) -> bool
+pub fn bitcoin_units::NumOpError::is_overflow(self) -> bool
+pub fn bitcoin_units::NumOpError::operation(self) -> bitcoin_units::MathOp
+pub fn bitcoin_units::NumOpResult<T>::add(self, rhs: &T) -> Self::Output
+pub fn bitcoin_units::NumOpResult<T>::add(self, rhs: &bitcoin_units::NumOpResult<T>) -> Self::Output
+pub fn bitcoin_units::NumOpResult<T>::add(self, rhs: Self) -> Self::Output
+pub fn bitcoin_units::NumOpResult<T>::add(self, rhs: T) -> Self::Output
+pub fn bitcoin_units::NumOpResult<T>::and_then<F>(self, op: F) -> bitcoin_units::NumOpResult<T> where F: core::ops::function::FnOnce(T) -> bitcoin_units::NumOpResult<T>
+pub fn bitcoin_units::NumOpResult<T>::clone(&self) -> bitcoin_units::NumOpResult<T>
+pub fn bitcoin_units::NumOpResult<T>::eq(&self, other: &bitcoin_units::NumOpResult<T>) -> bool
+pub fn bitcoin_units::NumOpResult<T>::expect(self, msg: &str) -> T
+pub fn bitcoin_units::NumOpResult<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::NumOpResult<T>::into_result(self) -> core::result::Result<T, bitcoin_units::NumOpError>
+pub fn bitcoin_units::NumOpResult<T>::is_error(&self) -> bool
+pub fn bitcoin_units::NumOpResult<T>::is_valid(&self) -> bool
+pub fn bitcoin_units::NumOpResult<T>::map<U, F: core::ops::function::FnOnce(T) -> U>(self, op: F) -> bitcoin_units::NumOpResult<U>
+pub fn bitcoin_units::NumOpResult<T>::ok(self) -> core::option::Option<T>
+pub fn bitcoin_units::NumOpResult<T>::sub(self, rhs: &T) -> Self::Output
+pub fn bitcoin_units::NumOpResult<T>::sub(self, rhs: &bitcoin_units::NumOpResult<T>) -> Self::Output
+pub fn bitcoin_units::NumOpResult<T>::sub(self, rhs: Self) -> Self::Output
+pub fn bitcoin_units::NumOpResult<T>::sub(self, rhs: T) -> Self::Output
+pub fn bitcoin_units::NumOpResult<T>::unwrap(self) -> T
+pub fn bitcoin_units::NumOpResult<T>::unwrap_err(self) -> bitcoin_units::NumOpError
+pub fn bitcoin_units::NumOpResult<T>::unwrap_or(self, default: T) -> T
+pub fn bitcoin_units::NumOpResult<T>::unwrap_or_else<F>(self, f: F) -> T where F: core::ops::function::FnOnce() -> T
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::FeeRate) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &u64) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: bitcoin_units::FeeRate) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::div(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: &u64)
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: u64)
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::from(a: &bitcoin_units::Amount) -> Self
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::from(a: bitcoin_units::Amount) -> Self
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::mul(self, rhs: &u64) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::mul(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::mul_assign(&mut self, rhs: &u64)
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::mul_assign(&mut self, rhs: u64)
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::rem(self, modulus: u64) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::rem(self, rhs: &u64) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin_units::NumOpResult<bitcoin_units::Amount>>
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Amount>::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = bitcoin_units::NumOpResult<bitcoin_units::Amount>>
+pub fn bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::mul(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::mul(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::mul(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Weight>) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::mul(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &i64) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: i64) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: &i64)
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: i64)
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::from(a: &bitcoin_units::SignedAmount) -> Self
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::from(a: bitcoin_units::SignedAmount) -> Self
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::mul(self, rhs: &i64) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::mul(self, rhs: i64) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::mul_assign(&mut self, rhs: &i64)
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::mul_assign(&mut self, rhs: i64)
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::rem(self, modulus: i64) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::rem(self, rhs: &i64) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>>
+pub fn bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>>
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Weight>::mul(self, rhs: &bitcoin_units::FeeRate) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Weight>::mul(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Weight>::mul(self, rhs: bitcoin_units::FeeRate) -> Self::Output
+pub fn bitcoin_units::NumOpResult<bitcoin_units::Weight>::mul(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn bitcoin_units::SignedAmount::add(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
+pub fn bitcoin_units::SignedAmount::add(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output
+pub fn bitcoin_units::SignedAmount::add(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
+pub fn bitcoin_units::SignedAmount::add(self, rhs: bitcoin_units::SignedAmount) -> Self::Output
+pub fn bitcoin_units::SignedAmount::clone(&self) -> bitcoin_units::SignedAmount
+pub fn bitcoin_units::SignedAmount::cmp(&self, other: &bitcoin_units::SignedAmount) -> core::cmp::Ordering
+pub fn bitcoin_units::SignedAmount::default() -> Self
+pub fn bitcoin_units::SignedAmount::display_dynamic(self) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::SignedAmount::display_in(self, denomination: bitcoin_units::amount::Denomination) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::SignedAmount::div(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output
+pub fn bitcoin_units::SignedAmount::div(self, rhs: &core::num::nonzero::NonZeroI64) -> Self::Output
+pub fn bitcoin_units::SignedAmount::div(self, rhs: &i64) -> Self::Output
+pub fn bitcoin_units::SignedAmount::div(self, rhs: bitcoin_units::SignedAmount) -> Self::Output
+pub fn bitcoin_units::SignedAmount::div(self, rhs: core::num::nonzero::NonZeroI64) -> Self::Output
+pub fn bitcoin_units::SignedAmount::div(self, rhs: i64) -> Self::Output
+pub fn bitcoin_units::SignedAmount::eq(&self, other: &bitcoin_units::SignedAmount) -> bool
+pub fn bitcoin_units::SignedAmount::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::SignedAmount::from(value: bitcoin_units::Amount) -> Self
+pub fn bitcoin_units::SignedAmount::from_int_btc<T: core::convert::Into<i16>>(whole_bitcoin: T) -> Self
+pub fn bitcoin_units::SignedAmount::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::SignedAmount::from_str_in(s: &str, denom: bitcoin_units::amount::Denomination) -> core::result::Result<Self, bitcoin_units::amount::ParseAmountError>
+pub fn bitcoin_units::SignedAmount::from_str_with_denomination(s: &str) -> core::result::Result<Self, bitcoin_units::amount::ParseError>
+pub fn bitcoin_units::SignedAmount::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::SignedAmount::is_negative(self) -> bool
+pub fn bitcoin_units::SignedAmount::is_positive(self) -> bool
+pub fn bitcoin_units::SignedAmount::mul(self, rhs: &i64) -> Self::Output
+pub fn bitcoin_units::SignedAmount::mul(self, rhs: i64) -> Self::Output
+pub fn bitcoin_units::SignedAmount::neg(self) -> Self::Output
+pub fn bitcoin_units::SignedAmount::partial_cmp(&self, other: &bitcoin_units::SignedAmount) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::SignedAmount::positive_sub(self, rhs: Self) -> core::option::Option<Self>
+pub fn bitcoin_units::SignedAmount::rem(self, modulus: i64) -> Self::Output
+pub fn bitcoin_units::SignedAmount::rem(self, rhs: &i64) -> Self::Output
+pub fn bitcoin_units::SignedAmount::signum(self) -> i64
+pub fn bitcoin_units::SignedAmount::sub(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
+pub fn bitcoin_units::SignedAmount::sub(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output
+pub fn bitcoin_units::SignedAmount::sub(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
+pub fn bitcoin_units::SignedAmount::sub(self, rhs: bitcoin_units::SignedAmount) -> Self::Output
+pub fn bitcoin_units::SignedAmount::to_unsigned(self) -> core::result::Result<bitcoin_units::Amount, bitcoin_units::amount::OutOfRangeError>
+pub fn bitcoin_units::SignedAmount::unsigned_abs(self) -> bitcoin_units::Amount
+pub fn bitcoin_units::Weight::add(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::Weight::add(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::Weight::add_assign(&mut self, rhs: &bitcoin_units::Weight)
+pub fn bitcoin_units::Weight::add_assign(&mut self, rhs: bitcoin_units::Weight)
+pub fn bitcoin_units::Weight::clone(&self) -> bitcoin_units::Weight
+pub fn bitcoin_units::Weight::cmp(&self, other: &bitcoin_units::Weight) -> core::cmp::Ordering
+pub fn bitcoin_units::Weight::div(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::Weight::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output
+pub fn bitcoin_units::Weight::div(self, rhs: &u64) -> Self::Output
+pub fn bitcoin_units::Weight::div(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::Weight::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output
+pub fn bitcoin_units::Weight::div(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::Weight::div_assign(&mut self, rhs: u64)
+pub fn bitcoin_units::Weight::eq(&self, other: &bitcoin_units::Weight) -> bool
+pub fn bitcoin_units::Weight::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::Weight::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::Weight::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::Weight::mul(self, rhs: &bitcoin_units::FeeRate) -> Self::Output
+pub fn bitcoin_units::Weight::mul(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn bitcoin_units::Weight::mul(self, rhs: &u64) -> Self::Output
+pub fn bitcoin_units::Weight::mul(self, rhs: bitcoin_units::FeeRate) -> Self::Output
+pub fn bitcoin_units::Weight::mul(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::FeeRate>) -> Self::Output
+pub fn bitcoin_units::Weight::mul(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::Weight::mul_assign(&mut self, rhs: u64)
+pub fn bitcoin_units::Weight::partial_cmp(&self, other: &bitcoin_units::Weight) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::Weight::rem(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::Weight::rem(self, rhs: &u64) -> Self::Output
+pub fn bitcoin_units::Weight::rem(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::Weight::rem(self, rhs: u64) -> Self::Output
+pub fn bitcoin_units::Weight::rem_assign(&mut self, rhs: u64)
+pub fn bitcoin_units::Weight::sub(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::Weight::sub(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub fn bitcoin_units::Weight::sub_assign(&mut self, rhs: &bitcoin_units::Weight)
+pub fn bitcoin_units::Weight::sub_assign(&mut self, rhs: bitcoin_units::Weight)
+pub fn bitcoin_units::Weight::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin_units::Weight>
+pub fn bitcoin_units::Weight::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = Self>
+pub fn bitcoin_units::Weight::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::amount::Denomination::clone(&self) -> bitcoin_units::amount::Denomination
+pub fn bitcoin_units::amount::Denomination::eq(&self, other: &bitcoin_units::amount::Denomination) -> bool
+pub fn bitcoin_units::amount::Denomination::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::Denomination::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::amount::Denomination::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::amount::Display::clone(&self) -> bitcoin_units::amount::Display
+pub fn bitcoin_units::amount::Display::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::Display::show_denomination(self) -> Self
+pub fn bitcoin_units::amount::InputTooLargeError::clone(&self) -> bitcoin_units::amount::InputTooLargeError
+pub fn bitcoin_units::amount::InputTooLargeError::eq(&self, other: &bitcoin_units::amount::InputTooLargeError) -> bool
+pub fn bitcoin_units::amount::InputTooLargeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::InvalidCharacterError::clone(&self) -> bitcoin_units::amount::InvalidCharacterError
+pub fn bitcoin_units::amount::InvalidCharacterError::eq(&self, other: &bitcoin_units::amount::InvalidCharacterError) -> bool
+pub fn bitcoin_units::amount::InvalidCharacterError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::MissingDenominationError::clone(&self) -> bitcoin_units::amount::MissingDenominationError
+pub fn bitcoin_units::amount::MissingDenominationError::eq(&self, other: &bitcoin_units::amount::MissingDenominationError) -> bool
+pub fn bitcoin_units::amount::MissingDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::MissingDigitsError::clone(&self) -> bitcoin_units::amount::MissingDigitsError
+pub fn bitcoin_units::amount::MissingDigitsError::eq(&self, other: &bitcoin_units::amount::MissingDigitsError) -> bool
+pub fn bitcoin_units::amount::MissingDigitsError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::OutOfRangeError::clone(&self) -> bitcoin_units::amount::OutOfRangeError
+pub fn bitcoin_units::amount::OutOfRangeError::eq(&self, other: &bitcoin_units::amount::OutOfRangeError) -> bool
+pub fn bitcoin_units::amount::OutOfRangeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::OutOfRangeError::is_above_max(self) -> bool
+pub fn bitcoin_units::amount::OutOfRangeError::is_below_min(self) -> bool
+pub fn bitcoin_units::amount::OutOfRangeError::valid_range(self) -> (i64, u64)
+pub fn bitcoin_units::amount::ParseAmountError::clone(&self) -> bitcoin_units::amount::ParseAmountError
+pub fn bitcoin_units::amount::ParseAmountError::eq(&self, other: &bitcoin_units::amount::ParseAmountError) -> bool
+pub fn bitcoin_units::amount::ParseAmountError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::ParseAmountError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::amount::ParseAmountError::from(value: bitcoin_units::amount::InputTooLargeError) -> Self
+pub fn bitcoin_units::amount::ParseAmountError::from(value: bitcoin_units::amount::InvalidCharacterError) -> Self
+pub fn bitcoin_units::amount::ParseAmountError::from(value: bitcoin_units::amount::MissingDigitsError) -> Self
+pub fn bitcoin_units::amount::ParseAmountError::from(value: bitcoin_units::amount::OutOfRangeError) -> Self
+pub fn bitcoin_units::amount::ParseAmountError::from(value: bitcoin_units::amount::TooPreciseError) -> Self
+pub fn bitcoin_units::amount::ParseDenominationError::clone(&self) -> bitcoin_units::amount::ParseDenominationError
+pub fn bitcoin_units::amount::ParseDenominationError::eq(&self, other: &bitcoin_units::amount::ParseDenominationError) -> bool
+pub fn bitcoin_units::amount::ParseDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::ParseDenominationError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::amount::ParseError::clone(&self) -> bitcoin_units::amount::ParseError
+pub fn bitcoin_units::amount::ParseError::eq(&self, other: &bitcoin_units::amount::ParseError) -> bool
+pub fn bitcoin_units::amount::ParseError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::InputTooLargeError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::InvalidCharacterError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::MissingDigitsError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::OutOfRangeError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::ParseAmountError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::ParseDenominationError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(e: bitcoin_units::amount::TooPreciseError) -> Self
+pub fn bitcoin_units::amount::ParseError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::amount::PossiblyConfusingDenominationError::clone(&self) -> bitcoin_units::amount::PossiblyConfusingDenominationError
+pub fn bitcoin_units::amount::PossiblyConfusingDenominationError::eq(&self, other: &bitcoin_units::amount::PossiblyConfusingDenominationError) -> bool
+pub fn bitcoin_units::amount::PossiblyConfusingDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::TooPreciseError::clone(&self) -> bitcoin_units::amount::TooPreciseError
+pub fn bitcoin_units::amount::TooPreciseError::eq(&self, other: &bitcoin_units::amount::TooPreciseError) -> bool
+pub fn bitcoin_units::amount::TooPreciseError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::amount::UnknownDenominationError::clone(&self) -> bitcoin_units::amount::UnknownDenominationError
+pub fn bitcoin_units::amount::UnknownDenominationError::eq(&self, other: &bitcoin_units::amount::UnknownDenominationError) -> bool
+pub fn bitcoin_units::amount::UnknownDenominationError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::block::BlockHeight::add(self, rhs: &bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockHeight::add(self, rhs: bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockHeight::checked_add(self, other: bitcoin_units::block::BlockHeightInterval) -> core::option::Option<Self>
+pub fn bitcoin_units::block::BlockHeight::checked_sub(self, other: Self) -> core::option::Option<bitcoin_units::block::BlockHeightInterval>
+pub fn bitcoin_units::block::BlockHeight::clone(&self) -> bitcoin_units::block::BlockHeight
+pub fn bitcoin_units::block::BlockHeight::cmp(&self, other: &bitcoin_units::block::BlockHeight) -> core::cmp::Ordering
+pub fn bitcoin_units::block::BlockHeight::eq(&self, other: &bitcoin_units::block::BlockHeight) -> bool
+pub fn bitcoin_units::block::BlockHeight::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::block::BlockHeight::from(h: bitcoin_units::locktime::absolute::Height) -> Self
+pub fn bitcoin_units::block::BlockHeight::from(inner: u32) -> Self
+pub fn bitcoin_units::block::BlockHeight::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::block::BlockHeight::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::block::BlockHeight::partial_cmp(&self, other: &bitcoin_units::block::BlockHeight) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::block::BlockHeight::sub(self, rhs: &bitcoin_units::block::BlockHeight) -> Self::Output
+pub fn bitcoin_units::block::BlockHeight::sub(self, rhs: &bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockHeight::sub(self, rhs: bitcoin_units::block::BlockHeight) -> Self::Output
+pub fn bitcoin_units::block::BlockHeight::sub(self, rhs: bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockHeight::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockHeightInterval::add(self, rhs: &bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockHeightInterval::add(self, rhs: bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockHeightInterval::add_assign(&mut self, rhs: &bitcoin_units::block::BlockHeightInterval)
+pub fn bitcoin_units::block::BlockHeightInterval::add_assign(&mut self, rhs: bitcoin_units::block::BlockHeightInterval)
+pub fn bitcoin_units::block::BlockHeightInterval::checked_add(self, other: Self) -> core::option::Option<Self>
+pub fn bitcoin_units::block::BlockHeightInterval::checked_sub(self, other: Self) -> core::option::Option<Self>
+pub fn bitcoin_units::block::BlockHeightInterval::clone(&self) -> bitcoin_units::block::BlockHeightInterval
+pub fn bitcoin_units::block::BlockHeightInterval::cmp(&self, other: &bitcoin_units::block::BlockHeightInterval) -> core::cmp::Ordering
+pub fn bitcoin_units::block::BlockHeightInterval::default() -> bitcoin_units::block::BlockHeightInterval
+pub fn bitcoin_units::block::BlockHeightInterval::eq(&self, other: &bitcoin_units::block::BlockHeightInterval) -> bool
+pub fn bitcoin_units::block::BlockHeightInterval::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::block::BlockHeightInterval::from(h: bitcoin_units::locktime::relative::NumberOfBlocks) -> Self
+pub fn bitcoin_units::block::BlockHeightInterval::from(inner: u32) -> Self
+pub fn bitcoin_units::block::BlockHeightInterval::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::block::BlockHeightInterval::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::block::BlockHeightInterval::partial_cmp(&self, other: &bitcoin_units::block::BlockHeightInterval) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::block::BlockHeightInterval::sub(self, rhs: &bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockHeightInterval::sub(self, rhs: bitcoin_units::block::BlockHeightInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockHeightInterval::sub_assign(&mut self, rhs: &bitcoin_units::block::BlockHeightInterval)
+pub fn bitcoin_units::block::BlockHeightInterval::sub_assign(&mut self, rhs: bitcoin_units::block::BlockHeightInterval)
+pub fn bitcoin_units::block::BlockHeightInterval::sum<I: core::iter::traits::iterator::Iterator<Item = Self>>(iter: I) -> Self
+pub fn bitcoin_units::block::BlockHeightInterval::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin_units::block::BlockHeightInterval>
+pub fn bitcoin_units::block::BlockHeightInterval::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockMtp::add(self, rhs: &bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockMtp::add(self, rhs: bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockMtp::checked_add(self, other: bitcoin_units::block::BlockMtpInterval) -> core::option::Option<Self>
+pub fn bitcoin_units::block::BlockMtp::checked_sub(self, other: Self) -> core::option::Option<bitcoin_units::block::BlockMtpInterval>
+pub fn bitcoin_units::block::BlockMtp::clone(&self) -> bitcoin_units::block::BlockMtp
+pub fn bitcoin_units::block::BlockMtp::cmp(&self, other: &bitcoin_units::block::BlockMtp) -> core::cmp::Ordering
+pub fn bitcoin_units::block::BlockMtp::eq(&self, other: &bitcoin_units::block::BlockMtp) -> bool
+pub fn bitcoin_units::block::BlockMtp::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::block::BlockMtp::from(h: bitcoin_units::locktime::absolute::MedianTimePast) -> Self
+pub fn bitcoin_units::block::BlockMtp::from(inner: u32) -> Self
+pub fn bitcoin_units::block::BlockMtp::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::block::BlockMtp::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::block::BlockMtp::new(timestamps: [bitcoin_units::BlockTime; 11]) -> Self
+pub fn bitcoin_units::block::BlockMtp::partial_cmp(&self, other: &bitcoin_units::block::BlockMtp) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::block::BlockMtp::sub(self, rhs: &bitcoin_units::block::BlockMtp) -> Self::Output
+pub fn bitcoin_units::block::BlockMtp::sub(self, rhs: &bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockMtp::sub(self, rhs: bitcoin_units::block::BlockMtp) -> Self::Output
+pub fn bitcoin_units::block::BlockMtp::sub(self, rhs: bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockMtp::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockMtpInterval::add(self, rhs: &bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockMtpInterval::add(self, rhs: bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockMtpInterval::add_assign(&mut self, rhs: &bitcoin_units::block::BlockMtpInterval)
+pub fn bitcoin_units::block::BlockMtpInterval::add_assign(&mut self, rhs: bitcoin_units::block::BlockMtpInterval)
+pub fn bitcoin_units::block::BlockMtpInterval::checked_add(self, other: Self) -> core::option::Option<Self>
+pub fn bitcoin_units::block::BlockMtpInterval::checked_sub(self, other: Self) -> core::option::Option<Self>
+pub fn bitcoin_units::block::BlockMtpInterval::clone(&self) -> bitcoin_units::block::BlockMtpInterval
+pub fn bitcoin_units::block::BlockMtpInterval::cmp(&self, other: &bitcoin_units::block::BlockMtpInterval) -> core::cmp::Ordering
+pub fn bitcoin_units::block::BlockMtpInterval::default() -> bitcoin_units::block::BlockMtpInterval
+pub fn bitcoin_units::block::BlockMtpInterval::eq(&self, other: &bitcoin_units::block::BlockMtpInterval) -> bool
+pub fn bitcoin_units::block::BlockMtpInterval::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::block::BlockMtpInterval::from(h: bitcoin_units::locktime::relative::NumberOf512Seconds) -> Self
+pub fn bitcoin_units::block::BlockMtpInterval::from(inner: u32) -> Self
+pub fn bitcoin_units::block::BlockMtpInterval::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::block::BlockMtpInterval::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::block::BlockMtpInterval::partial_cmp(&self, other: &bitcoin_units::block::BlockMtpInterval) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::block::BlockMtpInterval::sub(self, rhs: &bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockMtpInterval::sub(self, rhs: bitcoin_units::block::BlockMtpInterval) -> Self::Output
+pub fn bitcoin_units::block::BlockMtpInterval::sub_assign(&mut self, rhs: &bitcoin_units::block::BlockMtpInterval)
+pub fn bitcoin_units::block::BlockMtpInterval::sub_assign(&mut self, rhs: bitcoin_units::block::BlockMtpInterval)
+pub fn bitcoin_units::block::BlockMtpInterval::sum<I: core::iter::traits::iterator::Iterator<Item = Self>>(iter: I) -> Self
+pub fn bitcoin_units::block::BlockMtpInterval::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin_units::block::BlockMtpInterval>
+pub fn bitcoin_units::block::BlockMtpInterval::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::TooBigForRelativeHeightError::clone(&self) -> bitcoin_units::block::TooBigForRelativeHeightError
+pub fn bitcoin_units::block::TooBigForRelativeHeightError::eq(&self, other: &bitcoin_units::block::TooBigForRelativeHeightError) -> bool
+pub fn bitcoin_units::block::TooBigForRelativeHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::absolute::ConversionError::clone(&self) -> bitcoin_units::locktime::absolute::ConversionError
+pub fn bitcoin_units::locktime::absolute::ConversionError::eq(&self, other: &bitcoin_units::locktime::absolute::ConversionError) -> bool
+pub fn bitcoin_units::locktime::absolute::ConversionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::absolute::Height::clone(&self) -> bitcoin_units::locktime::absolute::Height
+pub fn bitcoin_units::locktime::absolute::Height::cmp(&self, other: &bitcoin_units::locktime::absolute::Height) -> core::cmp::Ordering
+pub fn bitcoin_units::locktime::absolute::Height::eq(&self, other: &bitcoin_units::locktime::absolute::Height) -> bool
+pub fn bitcoin_units::locktime::absolute::Height::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::absolute::Height::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::locktime::absolute::ParseHeightError>
+pub fn bitcoin_units::locktime::absolute::Height::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::locktime::absolute::Height::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::locktime::absolute::Height::is_satisfied_by(self, height: bitcoin_units::locktime::absolute::Height) -> bool
+pub fn bitcoin_units::locktime::absolute::Height::partial_cmp(&self, other: &bitcoin_units::locktime::absolute::Height) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::locktime::absolute::Height::try_from(h: bitcoin_units::block::BlockHeight) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::absolute::Height::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::clone(&self) -> bitcoin_units::locktime::absolute::MedianTimePast
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::cmp(&self, other: &bitcoin_units::locktime::absolute::MedianTimePast) -> core::cmp::Ordering
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::eq(&self, other: &bitcoin_units::locktime::absolute::MedianTimePast) -> bool
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::locktime::absolute::ParseTimeError>
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::is_satisfied_by(self, time: bitcoin_units::locktime::absolute::MedianTimePast) -> bool
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::new(timestamps: [bitcoin_units::BlockTime; 11]) -> core::result::Result<Self, bitcoin_units::locktime::absolute::ConversionError>
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::partial_cmp(&self, other: &bitcoin_units::locktime::absolute::MedianTimePast) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::try_from(h: bitcoin_units::block::BlockMtp) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::absolute::MedianTimePast::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::absolute::ParseHeightError::clone(&self) -> bitcoin_units::locktime::absolute::ParseHeightError
+pub fn bitcoin_units::locktime::absolute::ParseHeightError::eq(&self, other: &bitcoin_units::locktime::absolute::ParseHeightError) -> bool
+pub fn bitcoin_units::locktime::absolute::ParseHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::absolute::ParseTimeError::clone(&self) -> bitcoin_units::locktime::absolute::ParseTimeError
+pub fn bitcoin_units::locktime::absolute::ParseTimeError::eq(&self, other: &bitcoin_units::locktime::absolute::ParseTimeError) -> bool
+pub fn bitcoin_units::locktime::absolute::ParseTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::relative::InvalidHeightError::clone(&self) -> bitcoin_units::locktime::relative::InvalidHeightError
+pub fn bitcoin_units::locktime::relative::InvalidHeightError::eq(&self, other: &bitcoin_units::locktime::relative::InvalidHeightError) -> bool
+pub fn bitcoin_units::locktime::relative::InvalidHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::relative::InvalidTimeError::clone(&self) -> bitcoin_units::locktime::relative::InvalidTimeError
+pub fn bitcoin_units::locktime::relative::InvalidTimeError::eq(&self, other: &bitcoin_units::locktime::relative::InvalidTimeError) -> bool
+pub fn bitcoin_units::locktime::relative::InvalidTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::clone(&self) -> bitcoin_units::locktime::relative::NumberOf512Seconds
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::cmp(&self, other: &bitcoin_units::locktime::relative::NumberOf512Seconds) -> core::cmp::Ordering
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::default() -> bitcoin_units::locktime::relative::NumberOf512Seconds
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::eq(&self, other: &bitcoin_units::locktime::relative::NumberOf512Seconds) -> bool
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockMtp, utxo_mined_at: bitcoin_units::block::BlockMtp) -> core::result::Result<bool, bitcoin_units::locktime::relative::InvalidTimeError>
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::partial_cmp(&self, other: &bitcoin_units::locktime::relative::NumberOf512Seconds) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::clone(&self) -> bitcoin_units::locktime::relative::NumberOfBlocks
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::cmp(&self, other: &bitcoin_units::locktime::relative::NumberOfBlocks) -> core::cmp::Ordering
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::default() -> bitcoin_units::locktime::relative::NumberOfBlocks
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::eq(&self, other: &bitcoin_units::locktime::relative::NumberOfBlocks) -> bool
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from(value: u16) -> Self
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockHeight, utxo_mined_at: bitcoin_units::block::BlockHeight) -> core::result::Result<bool, bitcoin_units::locktime::relative::InvalidHeightError>
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::partial_cmp(&self, other: &bitcoin_units::locktime::relative::NumberOfBlocks) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::try_from(h: bitcoin_units::block::BlockHeightInterval) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::try_from(s: &str) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::relative::TimeOverflowError::clone(&self) -> bitcoin_units::locktime::relative::TimeOverflowError
+pub fn bitcoin_units::locktime::relative::TimeOverflowError::eq(&self, other: &bitcoin_units::locktime::relative::TimeOverflowError) -> bool
+pub fn bitcoin_units::locktime::relative::TimeOverflowError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::parse::ParseIntError::as_ref(&self) -> &core::num::error::ParseIntError
+pub fn bitcoin_units::parse::ParseIntError::clone(&self) -> bitcoin_units::parse::ParseIntError
+pub fn bitcoin_units::parse::ParseIntError::eq(&self, other: &bitcoin_units::parse::ParseIntError) -> bool
+pub fn bitcoin_units::parse::ParseIntError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::parse::PrefixedHexError::clone(&self) -> bitcoin_units::parse::PrefixedHexError
+pub fn bitcoin_units::parse::PrefixedHexError::eq(&self, other: &bitcoin_units::parse::PrefixedHexError) -> bool
+pub fn bitcoin_units::parse::PrefixedHexError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::parse::PrefixedHexError::from(e: bitcoin_units::parse::ParseIntError) -> Self
+pub fn bitcoin_units::parse::PrefixedHexError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::parse::UnprefixedHexError::clone(&self) -> bitcoin_units::parse::UnprefixedHexError
+pub fn bitcoin_units::parse::UnprefixedHexError::eq(&self, other: &bitcoin_units::parse::UnprefixedHexError) -> bool
+pub fn bitcoin_units::parse::UnprefixedHexError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::parse::UnprefixedHexError::from(e: bitcoin_units::parse::ParseIntError) -> Self
+pub fn bitcoin_units::parse::UnprefixedHexError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::parse::hex_check_unprefixed(s: &str) -> core::result::Result<&str, bitcoin_units::parse::UnprefixedHexError>
+pub fn bitcoin_units::parse::hex_remove_prefix(s: &str) -> core::result::Result<&str, bitcoin_units::parse::PrefixedHexError>
+pub fn bitcoin_units::parse::hex_u128(s: &str) -> core::result::Result<u128, bitcoin_units::parse::ParseIntError>
+pub fn bitcoin_units::parse::hex_u128_prefixed(s: &str) -> core::result::Result<u128, bitcoin_units::parse::PrefixedHexError>
+pub fn bitcoin_units::parse::hex_u128_unchecked(s: &str) -> core::result::Result<u128, bitcoin_units::parse::ParseIntError>
+pub fn bitcoin_units::parse::hex_u128_unprefixed(s: &str) -> core::result::Result<u128, bitcoin_units::parse::UnprefixedHexError>
+pub fn bitcoin_units::parse::hex_u32(s: &str) -> core::result::Result<u32, bitcoin_units::parse::ParseIntError>
+pub fn bitcoin_units::parse::hex_u32_prefixed(s: &str) -> core::result::Result<u32, bitcoin_units::parse::PrefixedHexError>
+pub fn bitcoin_units::parse::hex_u32_unchecked(s: &str) -> core::result::Result<u32, bitcoin_units::parse::ParseIntError>
+pub fn bitcoin_units::parse::hex_u32_unprefixed(s: &str) -> core::result::Result<u32, bitcoin_units::parse::UnprefixedHexError>
+pub fn bitcoin_units::parse::int_from_str<T: bitcoin_units::parse::Integer>(s: &str) -> core::result::Result<T, bitcoin_units::parse::ParseIntError>
+pub fn core::num::error::ParseIntError::from(value: bitcoin_units::parse::ParseIntError) -> Self
+pub fn i64::mul(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
+pub fn i64::mul(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output
+pub fn i64::mul(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
+pub fn i64::mul(self, rhs: bitcoin_units::SignedAmount) -> Self::Output
+pub fn u32::from(height: bitcoin_units::block::BlockHeight) -> Self
+pub fn u32::from(height: bitcoin_units::block::BlockHeightInterval) -> Self
+pub fn u32::from(height: bitcoin_units::block::BlockMtp) -> Self
+pub fn u32::from(height: bitcoin_units::block::BlockMtpInterval) -> Self
+pub fn u32::from(t: bitcoin_units::BlockTime) -> Self
+pub fn u64::from(value: bitcoin_units::Weight) -> Self
+pub fn u64::mul(self, rhs: &bitcoin_units::Amount) -> Self::Output
+pub fn u64::mul(self, rhs: &bitcoin_units::NumOpResult<bitcoin_units::Amount>) -> Self::Output
+pub fn u64::mul(self, rhs: &bitcoin_units::Weight) -> Self::Output
+pub fn u64::mul(self, rhs: bitcoin_units::Amount) -> Self::Output
+pub fn u64::mul(self, rhs: bitcoin_units::NumOpResult<bitcoin_units::Amount>) -> Self::Output
+pub fn u64::mul(self, rhs: bitcoin_units::Weight) -> Self::Output
+pub mod bitcoin_units
+pub mod bitcoin_units::amount
+pub mod bitcoin_units::block
+pub mod bitcoin_units::fee
+pub mod bitcoin_units::fee_rate
+pub mod bitcoin_units::locktime
+pub mod bitcoin_units::locktime::absolute
+pub mod bitcoin_units::locktime::relative
+pub mod bitcoin_units::parse
+pub mod bitcoin_units::time
+pub mod bitcoin_units::weight
+pub struct bitcoin_units::Amount(_)
+pub struct bitcoin_units::BlockHeight(_)
+pub struct bitcoin_units::BlockHeightInterval(_)
+pub struct bitcoin_units::BlockMtp(_)
+pub struct bitcoin_units::BlockMtpInterval(_)
+pub struct bitcoin_units::BlockTime(_)
+pub struct bitcoin_units::FeeRate(_)
+pub struct bitcoin_units::SignedAmount(_)
+pub struct bitcoin_units::Weight(_)
+pub struct bitcoin_units::amount::Amount(_)
+pub struct bitcoin_units::amount::Display
+pub struct bitcoin_units::amount::InputTooLargeError
+pub struct bitcoin_units::amount::InvalidCharacterError
+pub struct bitcoin_units::amount::MissingDigitsError
+pub struct bitcoin_units::amount::OutOfRangeError
+pub struct bitcoin_units::amount::ParseAmountError(_)
+pub struct bitcoin_units::amount::ParseError(_)
+pub struct bitcoin_units::amount::SignedAmount(_)
+pub struct bitcoin_units::amount::TooPreciseError
+pub struct bitcoin_units::block::BlockHeight(_)
+pub struct bitcoin_units::block::BlockHeightInterval(_)
+pub struct bitcoin_units::block::BlockMtp(_)
+pub struct bitcoin_units::block::BlockMtpInterval(_)
+pub struct bitcoin_units::block::TooBigForRelativeHeightError(_)
+pub struct bitcoin_units::fee_rate::FeeRate(_)
+pub struct bitcoin_units::locktime::absolute::Height(_)
+pub struct bitcoin_units::locktime::absolute::MedianTimePast(_)
+pub struct bitcoin_units::locktime::absolute::ParseHeightError(_)
+pub struct bitcoin_units::locktime::absolute::ParseTimeError(_)
+pub struct bitcoin_units::locktime::relative::InvalidHeightError
+pub struct bitcoin_units::locktime::relative::InvalidTimeError
+pub struct bitcoin_units::locktime::relative::NumberOf512Seconds(_)
+pub struct bitcoin_units::locktime::relative::NumberOfBlocks(_)
+pub struct bitcoin_units::locktime::relative::TimeOverflowError
+pub struct bitcoin_units::parse::PrefixedHexError(_)
+pub struct bitcoin_units::parse::UnprefixedHexError(_)
+pub struct bitcoin_units::time::BlockTime(_)
+pub struct bitcoin_units::weight::Weight(_)
+pub trait bitcoin_units::CheckedSum<R>: bitcoin_units::sealed::Sealed<R>
+pub trait bitcoin_units::parse::Integer: core::str::traits::FromStr<Err = core::num::error::ParseIntError> + core::convert::TryFrom<i8> + core::marker::Sized + bitcoin_units::parse::sealed::Sealed
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Add<bitcoin_units::NumOpResult<bitcoin_units::Amount>>>::Output
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Add>::Output
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<bitcoin_units::FeeRate>>::Output
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>>>::Output
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::Weight>>>::Output
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<bitcoin_units::Weight>>::Output
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<u64>>::Output
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div>::Output
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Mul<u64>>::Output
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Rem<u64>>::Output
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Sub<bitcoin_units::NumOpResult<bitcoin_units::Amount>>>::Output
+pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Sub>::Output
+pub type &bitcoin_units::FeeRate::Output = <bitcoin_units::FeeRate as core::ops::arith::Add>::Output
+pub type &bitcoin_units::FeeRate::Output = <bitcoin_units::FeeRate as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output
+pub type &bitcoin_units::FeeRate::Output = <bitcoin_units::FeeRate as core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::Weight>>>::Output
+pub type &bitcoin_units::FeeRate::Output = <bitcoin_units::FeeRate as core::ops::arith::Mul<bitcoin_units::Weight>>::Output
+pub type &bitcoin_units::FeeRate::Output = <bitcoin_units::FeeRate as core::ops::arith::Sub>::Output
+pub type &bitcoin_units::NumOpResult<T>::Output = <bitcoin_units::NumOpResult<T> as core::ops::arith::Add<T>>::Output
+pub type &bitcoin_units::NumOpResult<T>::Output = <bitcoin_units::NumOpResult<T> as core::ops::arith::Add>::Output
+pub type &bitcoin_units::NumOpResult<T>::Output = <bitcoin_units::NumOpResult<T> as core::ops::arith::Sub<T>>::Output
+pub type &bitcoin_units::NumOpResult<T>::Output = <bitcoin_units::NumOpResult<T> as core::ops::arith::Sub>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::FeeRate>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::Weight>>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::Weight>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<u64>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Mul<u64>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Rem<u64>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::Output = <bitcoin_units::NumOpResult<bitcoin_units::FeeRate> as core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::Weight>>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::Output = <bitcoin_units::NumOpResult<bitcoin_units::FeeRate> as core::ops::arith::Mul<bitcoin_units::Weight>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Mul<i64>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Rem<i64>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::Weight>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Weight> as core::ops::arith::Mul<bitcoin_units::FeeRate>>::Output
+pub type &bitcoin_units::NumOpResult<bitcoin_units::Weight>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Weight> as core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>>>::Output
+pub type &bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Add<bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>>>::Output
+pub type &bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Add>::Output
+pub type &bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output
+pub type &bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Div<i64>>::Output
+pub type &bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Div>::Output
+pub type &bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Mul<i64>>::Output
+pub type &bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Rem<i64>>::Output
+pub type &bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Sub<bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>>>::Output
+pub type &bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Sub>::Output
+pub type &bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Add>::Output
+pub type &bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output
+pub type &bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Div<u64>>::Output
+pub type &bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Div>::Output
+pub type &bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Mul<bitcoin_units::FeeRate>>::Output
+pub type &bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>>>::Output
+pub type &bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Mul<u64>>::Output
+pub type &bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Rem<u64>>::Output
+pub type &bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Rem>::Output
+pub type &bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Sub>::Output
+pub type &bitcoin_units::block::BlockHeight::Output = <bitcoin_units::block::BlockHeight as core::ops::arith::Add<bitcoin_units::block::BlockHeightInterval>>::Output
+pub type &bitcoin_units::block::BlockHeight::Output = <bitcoin_units::block::BlockHeight as core::ops::arith::Sub<bitcoin_units::block::BlockHeightInterval>>::Output
+pub type &bitcoin_units::block::BlockHeight::Output = <bitcoin_units::block::BlockHeight as core::ops::arith::Sub>::Output
+pub type &bitcoin_units::block::BlockHeightInterval::Output = <bitcoin_units::block::BlockHeightInterval as core::ops::arith::Add>::Output
+pub type &bitcoin_units::block::BlockHeightInterval::Output = <bitcoin_units::block::BlockHeightInterval as core::ops::arith::Sub>::Output
+pub type &bitcoin_units::block::BlockMtp::Output = <bitcoin_units::block::BlockMtp as core::ops::arith::Add<bitcoin_units::block::BlockMtpInterval>>::Output
+pub type &bitcoin_units::block::BlockMtp::Output = <bitcoin_units::block::BlockMtp as core::ops::arith::Sub<bitcoin_units::block::BlockMtpInterval>>::Output
+pub type &bitcoin_units::block::BlockMtp::Output = <bitcoin_units::block::BlockMtp as core::ops::arith::Sub>::Output
+pub type &bitcoin_units::block::BlockMtpInterval::Output = <bitcoin_units::block::BlockMtpInterval as core::ops::arith::Add>::Output
+pub type &bitcoin_units::block::BlockMtpInterval::Output = <bitcoin_units::block::BlockMtpInterval as core::ops::arith::Sub>::Output
+pub type &i64::Output = <i64 as core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>>>::Output
+pub type &i64::Output = <i64 as core::ops::arith::Mul<bitcoin_units::SignedAmount>>::Output
+pub type &u64::Output = <u64 as core::ops::arith::Mul<bitcoin_units::Amount>>::Output
+pub type &u64::Output = <u64 as core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::Amount>>>::Output
+pub type &u64::Output = <u64 as core::ops::arith::Mul<bitcoin_units::Weight>>::Output
+pub type bitcoin_units::Amount::Err = bitcoin_units::amount::ParseError
+pub type bitcoin_units::Amount::Error = bitcoin_units::amount::OutOfRangeError
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Add<bitcoin_units::NumOpResult<bitcoin_units::Amount>>>::Output
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Add>::Output
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<bitcoin_units::FeeRate>>::Output
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>>>::Output
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::Weight>>>::Output
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<bitcoin_units::Weight>>::Output
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<u64>>::Output
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div>::Output
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Mul<u64>>::Output
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Rem<u64>>::Output
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Sub<bitcoin_units::NumOpResult<bitcoin_units::Amount>>>::Output
+pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Sub>::Output
+pub type bitcoin_units::Amount::Output = bitcoin_units::Amount
+pub type bitcoin_units::Amount::Output = bitcoin_units::NumOpResult<bitcoin_units::Amount>
+pub type bitcoin_units::Amount::Output = bitcoin_units::NumOpResult<bitcoin_units::FeeRate>
+pub type bitcoin_units::Amount::Output = bitcoin_units::NumOpResult<bitcoin_units::Weight>
+pub type bitcoin_units::Amount::Output = bitcoin_units::NumOpResult<u64>
+pub type bitcoin_units::FeeRate::Output = <bitcoin_units::FeeRate as core::ops::arith::Add>::Output
+pub type bitcoin_units::FeeRate::Output = <bitcoin_units::FeeRate as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output
+pub type bitcoin_units::FeeRate::Output = <bitcoin_units::FeeRate as core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::Weight>>>::Output
+pub type bitcoin_units::FeeRate::Output = <bitcoin_units::FeeRate as core::ops::arith::Mul<bitcoin_units::Weight>>::Output
+pub type bitcoin_units::FeeRate::Output = <bitcoin_units::FeeRate as core::ops::arith::Sub>::Output
+pub type bitcoin_units::FeeRate::Output = bitcoin_units::FeeRate
+pub type bitcoin_units::FeeRate::Output = bitcoin_units::NumOpResult<bitcoin_units::Amount>
+pub type bitcoin_units::NumOpResult<T>::Output = <bitcoin_units::NumOpResult<T> as core::ops::arith::Add<T>>::Output
+pub type bitcoin_units::NumOpResult<T>::Output = <bitcoin_units::NumOpResult<T> as core::ops::arith::Add>::Output
+pub type bitcoin_units::NumOpResult<T>::Output = <bitcoin_units::NumOpResult<T> as core::ops::arith::Sub<T>>::Output
+pub type bitcoin_units::NumOpResult<T>::Output = <bitcoin_units::NumOpResult<T> as core::ops::arith::Sub>::Output
+pub type bitcoin_units::NumOpResult<T>::Output = bitcoin_units::NumOpResult<T>
+pub type bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::FeeRate>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::NumOpResult<bitcoin_units::Weight>>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::Weight>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<u64>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Mul<u64>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Rem<u64>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::NumOpResult<bitcoin_units::Amount>
+pub type bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::NumOpResult<bitcoin_units::FeeRate>
+pub type bitcoin_units::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::NumOpResult<bitcoin_units::Weight>
+pub type bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::Output = <bitcoin_units::NumOpResult<bitcoin_units::FeeRate> as core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::Weight>>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::Output = <bitcoin_units::NumOpResult<bitcoin_units::FeeRate> as core::ops::arith::Mul<bitcoin_units::Weight>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::FeeRate>::Output = bitcoin_units::NumOpResult<bitcoin_units::Amount>
+pub type bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Mul<i64>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Rem<i64>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>::Output = bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+pub type bitcoin_units::NumOpResult<bitcoin_units::Weight>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Weight> as core::ops::arith::Mul<bitcoin_units::FeeRate>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::Weight>::Output = <bitcoin_units::NumOpResult<bitcoin_units::Weight> as core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>>>::Output
+pub type bitcoin_units::NumOpResult<bitcoin_units::Weight>::Output = bitcoin_units::NumOpResult<bitcoin_units::Amount>
+pub type bitcoin_units::SignedAmount::Err = bitcoin_units::amount::ParseError
+pub type bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Add<bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>>>::Output
+pub type bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Add>::Output
+pub type bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output
+pub type bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Div<i64>>::Output
+pub type bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Div>::Output
+pub type bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Mul<i64>>::Output
+pub type bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Rem<i64>>::Output
+pub type bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Sub<bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>>>::Output
+pub type bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as core::ops::arith::Sub>::Output
+pub type bitcoin_units::SignedAmount::Output = bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+pub type bitcoin_units::SignedAmount::Output = bitcoin_units::NumOpResult<i64>
+pub type bitcoin_units::SignedAmount::Output = bitcoin_units::SignedAmount
+pub type bitcoin_units::Weight::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::Weight::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Add>::Output
+pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output
+pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Div<u64>>::Output
+pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Div>::Output
+pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Mul<bitcoin_units::FeeRate>>::Output
+pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::FeeRate>>>::Output
+pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Mul<u64>>::Output
+pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Rem<u64>>::Output
+pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Rem>::Output
+pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Sub>::Output
+pub type bitcoin_units::Weight::Output = bitcoin_units::NumOpResult<bitcoin_units::Amount>
+pub type bitcoin_units::Weight::Output = bitcoin_units::Weight
+pub type bitcoin_units::Weight::Output = u64
+pub type bitcoin_units::amount::Denomination::Err = bitcoin_units::amount::ParseDenominationError
+pub type bitcoin_units::block::BlockHeight::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockHeight::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockHeight::Output = <bitcoin_units::block::BlockHeight as core::ops::arith::Add<bitcoin_units::block::BlockHeightInterval>>::Output
+pub type bitcoin_units::block::BlockHeight::Output = <bitcoin_units::block::BlockHeight as core::ops::arith::Sub<bitcoin_units::block::BlockHeightInterval>>::Output
+pub type bitcoin_units::block::BlockHeight::Output = <bitcoin_units::block::BlockHeight as core::ops::arith::Sub>::Output
+pub type bitcoin_units::block::BlockHeight::Output = bitcoin_units::block::BlockHeight
+pub type bitcoin_units::block::BlockHeight::Output = bitcoin_units::block::BlockHeightInterval
+pub type bitcoin_units::block::BlockHeightInterval::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockHeightInterval::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockHeightInterval::Output = <bitcoin_units::block::BlockHeightInterval as core::ops::arith::Add>::Output
+pub type bitcoin_units::block::BlockHeightInterval::Output = <bitcoin_units::block::BlockHeightInterval as core::ops::arith::Sub>::Output
+pub type bitcoin_units::block::BlockHeightInterval::Output = bitcoin_units::block::BlockHeightInterval
+pub type bitcoin_units::block::BlockMtp::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockMtp::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockMtp::Output = <bitcoin_units::block::BlockMtp as core::ops::arith::Add<bitcoin_units::block::BlockMtpInterval>>::Output
+pub type bitcoin_units::block::BlockMtp::Output = <bitcoin_units::block::BlockMtp as core::ops::arith::Sub<bitcoin_units::block::BlockMtpInterval>>::Output
+pub type bitcoin_units::block::BlockMtp::Output = <bitcoin_units::block::BlockMtp as core::ops::arith::Sub>::Output
+pub type bitcoin_units::block::BlockMtp::Output = bitcoin_units::block::BlockMtp
+pub type bitcoin_units::block::BlockMtp::Output = bitcoin_units::block::BlockMtpInterval
+pub type bitcoin_units::block::BlockMtpInterval::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockMtpInterval::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockMtpInterval::Output = <bitcoin_units::block::BlockMtpInterval as core::ops::arith::Add>::Output
+pub type bitcoin_units::block::BlockMtpInterval::Output = <bitcoin_units::block::BlockMtpInterval as core::ops::arith::Sub>::Output
+pub type bitcoin_units::block::BlockMtpInterval::Output = bitcoin_units::block::BlockMtpInterval
+pub type bitcoin_units::locktime::absolute::Height::Err = bitcoin_units::locktime::absolute::ParseHeightError
+pub type bitcoin_units::locktime::absolute::Height::Error = bitcoin_units::locktime::absolute::ConversionError
+pub type bitcoin_units::locktime::absolute::Height::Error = bitcoin_units::locktime::absolute::ParseHeightError
+pub type bitcoin_units::locktime::absolute::MedianTimePast::Err = bitcoin_units::locktime::absolute::ParseTimeError
+pub type bitcoin_units::locktime::absolute::MedianTimePast::Error = bitcoin_units::locktime::absolute::ConversionError
+pub type bitcoin_units::locktime::absolute::MedianTimePast::Error = bitcoin_units::locktime::absolute::ParseTimeError
+pub type bitcoin_units::locktime::relative::NumberOf512Seconds::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::locktime::relative::NumberOf512Seconds::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::locktime::relative::NumberOfBlocks::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::locktime::relative::NumberOfBlocks::Error = bitcoin_units::block::TooBigForRelativeHeightError
+pub type bitcoin_units::locktime::relative::NumberOfBlocks::Error = bitcoin_units::parse::ParseIntError
+pub type i64::Output = <i64 as core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>>>::Output
+pub type i64::Output = <i64 as core::ops::arith::Mul<bitcoin_units::SignedAmount>>::Output
+pub type i64::Output = bitcoin_units::NumOpResult<bitcoin_units::SignedAmount>
+pub type u64::Output = <u64 as core::ops::arith::Mul<bitcoin_units::Amount>>::Output
+pub type u64::Output = <u64 as core::ops::arith::Mul<bitcoin_units::NumOpResult<bitcoin_units::Amount>>>::Output
+pub type u64::Output = <u64 as core::ops::arith::Mul<bitcoin_units::Weight>>::Output
+pub type u64::Output = bitcoin_units::NumOpResult<bitcoin_units::Amount>
+pub type u64::Output = bitcoin_units::Weight

--- a/contrib/check-for-api-changes.sh
+++ b/contrib/check-for-api-changes.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 REPO_DIR=$(git rev-parse --show-toplevel)
 API_DIR="$REPO_DIR/api"
 
-NIGHTLY=$(cat nightly-version)
+NIGHTLY=$(cat "$REPO_DIR/nightly-version")
 # Our docs have broken intra doc links if all features are not enabled.
 RUSTDOCFLAGS="-A rustdoc::broken_intra_doc_links"
 
@@ -24,9 +24,7 @@ main() {
     need_nightly
     need_cargo_public_api
 
-    generate_api_files "hashes"
-    generate_api_files "io"
-    generate_api_files "primitives"
+    # Just check crates that are stabilising.
     generate_api_files "units"
 
     check_for_changes


### PR DESCRIPTION
Now that `units`  is stabilising we can bring back the API checking script so that it is intentionally cumbersome for devs to change the public API and also to help catch mistakes in case we accidentally do so. 