### PR TITLE
Update NumOpResult arbitrary impl to only consume 1 byte of entropy

### DIFF
--- a/units/src/result.rs
+++ b/units/src/result.rs
@@ -325,10 +325,9 @@ impl fmt::Display for MathOp {
 #[cfg(feature = "arbitrary")]
 impl<'a, T: Arbitrary<'a>> Arbitrary<'a> for NumOpResult<T> {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let choice = u.int_in_range(0..=1)?;
-        match choice {
-            0 => Ok(NumOpResult::Valid(T::arbitrary(u)?)),
-            _ => Ok(NumOpResult::Error(NumOpError(MathOp::arbitrary(u)?))),
+        match bool::arbitrary(u)? {
+            true => Ok(NumOpResult::Valid(T::arbitrary(u)?)),
+            false => Ok(NumOpResult::Error(NumOpError(MathOp::arbitrary(u)?))),
         }
     }
 }


### PR DESCRIPTION
Took some inspiration from [a comment](https://github.com/rust-bitcoin/rust-bitcoin/pull/4689#issuecomment-3073834482) in #4689 and looked through the rest of the codebase to update `u.int_in_range(0..=1)` to use `bool::arbitrary(u)`