### PR TITLE
script: Remove public re-exports

### DIFF
--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -10,7 +10,7 @@ use secp256k1::{Secp256k1, Verification};
 use super::witness_version::WitnessVersion;
 use super::{
     Builder, Instruction, InstructionIndices, Instructions, PushBytes, RedeemScriptSizeError,
-    ScriptHash, WScriptHash, WitnessScriptSizeError,
+    Script, ScriptHash, WScriptHash, WitnessScriptSizeError,
 };
 use crate::consensus::{self, Encodable};
 use crate::key::{PublicKey, UntweakedPublicKey, WPubkeyHash};
@@ -21,10 +21,6 @@ use crate::prelude::{sink, String, ToString};
 use crate::script::{self, ScriptBufExt as _};
 use crate::taproot::{LeafVersion, TapLeafHash, TapNodeHash};
 use crate::{Amount, FeeRate, ScriptBuf};
-
-#[rustfmt::skip]            // Keep public re-exports separate.
-#[doc(inline)]
-pub use primitives::script::Script;
 
 crate::internal_macros::define_extension_trait! {
     /// Extension functionality for the [`Script`] type.

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -7,7 +7,7 @@ use hex::FromHex as _;
 use internals::ToU64 as _;
 use secp256k1::{Secp256k1, Verification};
 
-use super::{opcode_to_verify, Builder, Instruction, PushBytes, ScriptExtPriv as _};
+use super::{opcode_to_verify, Builder, Instruction, PushBytes, ScriptBuf, ScriptExtPriv as _};
 use crate::consensus;
 use crate::key::{
     PubkeyHash, PublicKey, TapTweak, TweakedPublicKey, UntweakedPublicKey, WPubkeyHash,
@@ -19,10 +19,6 @@ use crate::script::witness_program::{WitnessProgram, P2A_PROGRAM};
 use crate::script::witness_version::WitnessVersion;
 use crate::script::{self, ScriptHash, WScriptHash};
 use crate::taproot::TapNodeHash;
-
-#[rustfmt::skip]            // Keep public re-exports separate.
-#[doc(inline)]
-pub use primitives::script::ScriptBuf;
 
 crate::internal_macros::define_extension_trait! {
     /// Extension functionality for the [`ScriptBuf`] type.


### PR DESCRIPTION
By convention we do not re-export things from modules where they are used. Also the `borrowed` and `owned` modules are private so these public re-exports make no sense.

FTR users can do both of these already

- `use bitcoin::script::{Script, ScriptBuf};`
- `use bitcoin::{Script, ScriptBuf};`