### PR TITLE
Add docs directory

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,9 @@
+# rust-bitcoin documentation
+
+This directory holds documentation for the `rust-bitcoin` repository and potentially various other
+directly related crates from the `rust-bitcoin` GitHub organisation (e.g. `rust-secp256k1`).
+
+In general, PR discussions on source code should be about the technical content of changes. To debate
+whether a change should be made at all, or the strategy for making changes, it is better to first PR to
+the `docs/` tree. If a PR discussion veers into this sort of strategic discussion, the PR should be put on
+hold and a PR made to the `docs/` tree or in the Discussions section to debate it before moving forward.

--- a/docs/address.md
+++ b/docs/address.md
@@ -1,0 +1,3 @@
+# Split out an address crate
+
+Split the `address` module out into its own crate.

--- a/docs/bip-32.md
+++ b/docs/bip-32.md
@@ -1,0 +1,7 @@
+# BIP-32 and BIP-380
+
+The current module has not been patched much in the last 5 years and the rest of the code base has
+stylistically changed quite a bit.
+
+* Re-write the BIP-32 API
+* Add support for BIP-380

--- a/docs/psbt.md
+++ b/docs/psbt.md
@@ -1,0 +1,8 @@
+# PSBT
+
+We would like to enable support for PSBTv2, not necessarily add support to `rust-bitcoin`.
+Potentially we want to spilt out the current PSBTv1 into a separate crate. The serialization logic
+likely stays in `rust-bitcoin`. There are various attempts at this in flight but mostly stale.
+
+* Initial support in `rust-bitcoin`: [#3507](https://github.com/rust-bitcoin/rust-bitcoin/pull/3507)
+* Initial PSBTV2 impl: https://github.com/tcharding/rust-psbt

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,15 @@
+# `rust-bitcoin` repository roadmap
+
+* ~Release `units v1.0.0-rc.0`~
+* Release `primitives v1.0.0-rc.0`
+  * Implement script tagging
+  * Add support for consensus encoding to `primitives`
+* Release `bitcoin v0.33.0-rc.0`
+* Split out an address crate (see [address.md](./address.md))
+* BIP-32 and BIP-380 (see [bip-32.md](./bip-32.md))
+* PSBTv2 (see [psbt.md](./psbt.md))
+
+## RC cycle
+
+We want to do a long release candidate cycle to give time for downstream testing and feedback on the
+API of the 1.0 crates. At a minimum this will be 6 months from the release `primitives-1.0-rc.0`.


### PR DESCRIPTION
Add a `docs` directory including a basic README. The purpose is outline in the readme.

Add an initial `roadmap`, done as a single patch because the roadmap is referenced in the readme.