### PR TITLE
Add Arbitary impls for some bip152, bip158 & merkle block types

### DIFF
--- a/bitcoin/src/bip152.rs
+++ b/bitcoin/src/bip152.rs
@@ -9,6 +9,8 @@ use core::{convert, fmt, mem};
 #[cfg(feature = "std")]
 use std::error;
 
+#[cfg(feature = "arbitrary")]
+use arbitrary::{Arbitrary, Unstructured};
 use hashes::{sha256, siphash24};
 use internals::array::ArrayExt as _;
 use internals::ToU64 as _;
@@ -401,6 +403,46 @@ impl BlockTransactions {
                 txs
             },
         })
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> Arbitrary<'a> for ShortId {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(ShortId(u.arbitrary()?))
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> Arbitrary<'a> for PrefilledTransaction {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(PrefilledTransaction { idx: u.arbitrary()?, tx: u.arbitrary()? })
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> Arbitrary<'a> for HeaderAndShortIds {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(HeaderAndShortIds {
+            header: u.arbitrary()?,
+            nonce: u.arbitrary()?,
+            short_ids: Vec::<ShortId>::arbitrary(u)?,
+            prefilled_txs: Vec::<PrefilledTransaction>::arbitrary(u)?,
+        })
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> Arbitrary<'a> for BlockTransactions {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(BlockTransactions { block_hash: u.arbitrary()?, transactions: Vec::<Transaction>::arbitrary(u)? })
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> Arbitrary<'a> for BlockTransactionsRequest {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(BlockTransactionsRequest { block_hash: u.arbitrary()?, indexes: Vec::<u64>::arbitrary(u)? })
     }
 }
 

--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -41,6 +41,8 @@ use core::cmp::{self, Ordering};
 use core::convert::Infallible;
 use core::fmt;
 
+#[cfg(feature = "arbitrary")]
+use arbitrary::{Arbitrary, Unstructured};
 use hashes::{sha256d, siphash24, HashEngine as _};
 use internals::array::ArrayExt as _;
 use internals::{write_err, ToU64 as _};
@@ -571,6 +573,20 @@ impl<'a, W: Write> BitStreamWriter<'a, W> {
         } else {
             Ok(0)
         }
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> Arbitrary<'a> for FilterHash {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(FilterHash::from_byte_array(u.arbitrary()?))
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> Arbitrary<'a> for FilterHeader {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(FilterHeader::from_byte_array(u.arbitrary()?))
     }
 }
 

--- a/bitcoin/src/merkle_tree/block.rs
+++ b/bitcoin/src/merkle_tree/block.rs
@@ -12,6 +12,8 @@
 use core::convert::Infallible;
 use core::fmt;
 
+#[cfg(feature = "arbitrary")]
+use arbitrary::{Arbitrary, Unstructured};
 use internals::ToU64 as _;
 use io::{BufRead, Write};
 
@@ -507,6 +509,24 @@ impl std::error::Error for MerkleBlockError {
             | NotEnoughBits | NotAllBitsConsumed | NotAllHashesConsumed | BitsArrayOverflow
             | HashesArrayOverflow | IdenticalHashesFound => None,
         }
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> Arbitrary<'a> for PartialMerkleTree {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(PartialMerkleTree {
+            num_transactions: u.arbitrary()?,
+            bits: Vec::<bool>::arbitrary(u)?,
+            hashes: Vec::<TxMerkleNode>::arbitrary(u)?,
+        })
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> Arbitrary<'a> for MerkleBlock {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(MerkleBlock { header: u.arbitrary()?, txn: u.arbitrary()? })
     }
 }
 


### PR DESCRIPTION
These are some children types of some `p2p` types for which I'm updating the fuzzing targets