### PR TITLE
Add a `ProtocolVersion` type with named values

### DIFF
--- a/p2p/examples/handshake.rs
+++ b/p2p/examples/handshake.rs
@@ -69,6 +69,9 @@ fn build_version_message(address: SocketAddr) -> message::NetworkMessage {
     // Building version message, see https://en.bitcoin.it/wiki/Protocol_documentation#version
     let my_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 0);
 
+    // The version of the p2p protocol this client will use
+    let protocol_version = 70001;
+
     // "bitfield of features to be enabled for this connection"
     let services = ServiceFlags::NONE;
 
@@ -93,6 +96,7 @@ fn build_version_message(address: SocketAddr) -> message::NetworkMessage {
 
     // Construct the message
     message::NetworkMessage::Version(message_network::VersionMessage::new(
+        protocol_version,
         services,
         timestamp as i64,
         addr_recv,

--- a/p2p/examples/handshake.rs
+++ b/p2p/examples/handshake.rs
@@ -4,7 +4,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use std::{env, process};
 
 use bitcoin::consensus::{encode, Decodable};
-use bitcoin_p2p_messages::{self, address, message, message_network, Magic, ServiceFlags};
+use bitcoin_p2p_messages::{
+    self, address, message, message_network, Magic, ProtocolVersion, ServiceFlags,
+};
 
 fn main() {
     // This example establishes a connection to a Bitcoin node, sends the initial
@@ -70,7 +72,7 @@ fn build_version_message(address: SocketAddr) -> message::NetworkMessage {
     let my_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 0);
 
     // The version of the p2p protocol this client will use
-    let protocol_version = 70001;
+    let protocol_version = ProtocolVersion::BIP0031_VERSION;
 
     // "bitfield of features to be enabled for this connection"
     let services = ServiceFlags::NONE;

--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -763,7 +763,7 @@ mod test {
         CFCheckpt, CFHeaders, CFilter, GetCFCheckpt, GetCFHeaders, GetCFilters,
     };
     use crate::message_network::{Alert, Reject, RejectReason, VersionMessage};
-    use crate::ServiceFlags;
+    use crate::{ProtocolVersion, ServiceFlags};
 
     fn hash(array: [u8; 32]) -> sha256d::Hash { sha256d::Hash::from_byte_array(array) }
 
@@ -794,7 +794,7 @@ mod test {
             )])),
             NetworkMessage::NotFound(InventoryPayload(vec![Inventory::Error([0u8; 32])])),
             NetworkMessage::GetBlocks(GetBlocksMessage {
-                version: 70001,
+                version: ProtocolVersion::from_nonstandard(70001),
                 locator_hashes: vec![
                     BlockHash::from_byte_array(hash([1u8; 32]).to_byte_array()),
                     BlockHash::from_byte_array(hash([4u8; 32]).to_byte_array()),
@@ -802,7 +802,7 @@ mod test {
                 stop_hash: BlockHash::from_byte_array(hash([5u8; 32]).to_byte_array()),
             }),
             NetworkMessage::GetHeaders(GetHeadersMessage {
-                version: 70001,
+                version: ProtocolVersion::from_nonstandard(70001),
                 locator_hashes: vec![
                     BlockHash::from_byte_array(hash([10u8; 32]).to_byte_array()),
                     BlockHash::from_byte_array(hash([40u8; 32]).to_byte_array()),
@@ -1079,7 +1079,7 @@ mod test {
         let msg = msg.unwrap();
         assert_eq!(msg.magic, Magic::BITCOIN);
         if let NetworkMessage::Version(version_msg) = msg.payload {
-            assert_eq!(version_msg.version, 70015);
+            assert_eq!(version_msg.version, ProtocolVersion::INVALID_CB_NO_BAN_VERSION);
             assert_eq!(
                 version_msg.services,
                 ServiceFlags::NETWORK
@@ -1117,7 +1117,7 @@ mod test {
         ]).unwrap();
 
         if let NetworkMessage::Version(version_msg) = msg.payload {
-            assert_eq!(version_msg.version, 70015);
+            assert_eq!(version_msg.version, ProtocolVersion::INVALID_CB_NO_BAN_VERSION);
             assert_eq!(
                 version_msg.services,
                 ServiceFlags::NETWORK
@@ -1163,7 +1163,7 @@ mod test {
         assert_eq!(consumed, data.to_vec().len() - 2);
         assert_eq!(msg.magic, Magic::BITCOIN);
         if let NetworkMessage::Version(version_msg) = msg.payload {
-            assert_eq!(version_msg.version, 70015);
+            assert_eq!(version_msg.version, ProtocolVersion::INVALID_CB_NO_BAN_VERSION);
             assert_eq!(
                 version_msg.services,
                 ServiceFlags::NETWORK

--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -793,20 +793,22 @@ mod test {
                 Txid::from_byte_array(hash([45u8; 32]).to_byte_array()),
             )])),
             NetworkMessage::NotFound(InventoryPayload(vec![Inventory::Error([0u8; 32])])),
-            NetworkMessage::GetBlocks(GetBlocksMessage::new(
-                vec![
+            NetworkMessage::GetBlocks(GetBlocksMessage {
+                version: 70001,
+                locator_hashes: vec![
                     BlockHash::from_byte_array(hash([1u8; 32]).to_byte_array()),
                     BlockHash::from_byte_array(hash([4u8; 32]).to_byte_array()),
                 ],
-                BlockHash::from_byte_array(hash([5u8; 32]).to_byte_array()),
-            )),
-            NetworkMessage::GetHeaders(GetHeadersMessage::new(
-                vec![
+                stop_hash: BlockHash::from_byte_array(hash([5u8; 32]).to_byte_array()),
+            }),
+            NetworkMessage::GetHeaders(GetHeadersMessage {
+                version: 70001,
+                locator_hashes: vec![
                     BlockHash::from_byte_array(hash([10u8; 32]).to_byte_array()),
                     BlockHash::from_byte_array(hash([40u8; 32]).to_byte_array()),
                 ],
-                BlockHash::from_byte_array(hash([50u8; 32]).to_byte_array()),
-            )),
+                stop_hash: BlockHash::from_byte_array(hash([50u8; 32]).to_byte_array()),
+            }),
             NetworkMessage::MemPool,
             NetworkMessage::Tx(tx),
             NetworkMessage::Block(block),

--- a/p2p/src/message_blockdata.rs
+++ b/p2p/src/message_blockdata.rs
@@ -11,6 +11,7 @@ use bitcoin::transaction::{Txid, Wtxid};
 use io::{BufRead, Write};
 
 use crate::consensus::impl_consensus_encoding;
+use crate::ProtocolVersion;
 
 /// An inventory item.
 #[derive(PartialEq, Eq, Clone, Debug, Copy, Hash, PartialOrd, Ord)]
@@ -101,7 +102,7 @@ impl Decodable for Inventory {
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub struct GetBlocksMessage {
     /// The protocol version
-    pub version: u32,
+    pub version: ProtocolVersion,
     /// Locator hashes --- ordered newest to oldest. The remote peer will
     /// reply with its longest known chain, starting from a locator hash
     /// if possible and block 1 otherwise.
@@ -114,7 +115,7 @@ pub struct GetBlocksMessage {
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub struct GetHeadersMessage {
     /// The protocol version
-    pub version: u32,
+    pub version: ProtocolVersion,
     /// Locator hashes --- ordered newest to oldest. The remote peer will
     /// reply with its longest known chain, starting from a locator hash
     /// if possible and block 1 otherwise.
@@ -142,7 +143,7 @@ mod tests {
         let decode: Result<GetBlocksMessage, _> = deserialize(&from_sat);
         assert!(decode.is_ok());
         let real_decode = decode.unwrap();
-        assert_eq!(real_decode.version, 70002);
+        assert_eq!(real_decode.version.0, 70002);
         assert_eq!(real_decode.locator_hashes.len(), 1);
         assert_eq!(serialize(&real_decode.locator_hashes[0]), genhash);
         assert_eq!(real_decode.stop_hash, BlockHash::GENESIS_PREVIOUS_BLOCK_HASH);
@@ -158,7 +159,7 @@ mod tests {
         let decode: Result<GetHeadersMessage, _> = deserialize(&from_sat);
         assert!(decode.is_ok());
         let real_decode = decode.unwrap();
-        assert_eq!(real_decode.version, 70002);
+        assert_eq!(real_decode.version.0, 70002);
         assert_eq!(real_decode.locator_hashes.len(), 1);
         assert_eq!(serialize(&real_decode.locator_hashes[0]), genhash);
         assert_eq!(real_decode.stop_hash, BlockHash::GENESIS_PREVIOUS_BLOCK_HASH);

--- a/p2p/src/message_blockdata.rs
+++ b/p2p/src/message_blockdata.rs
@@ -123,21 +123,7 @@ pub struct GetHeadersMessage {
     pub stop_hash: BlockHash,
 }
 
-impl GetBlocksMessage {
-    /// Construct a new `getblocks` message
-    pub fn new(locator_hashes: Vec<BlockHash>, stop_hash: BlockHash) -> GetBlocksMessage {
-        GetBlocksMessage { version: crate::PROTOCOL_VERSION, locator_hashes, stop_hash }
-    }
-}
-
 impl_consensus_encoding!(GetBlocksMessage, version, locator_hashes, stop_hash);
-
-impl GetHeadersMessage {
-    /// Construct a new `getheaders` message
-    pub fn new(locator_hashes: Vec<BlockHash>, stop_hash: BlockHash) -> GetHeadersMessage {
-        GetHeadersMessage { version: crate::PROTOCOL_VERSION, locator_hashes, stop_hash }
-    }
-}
 
 impl_consensus_encoding!(GetHeadersMessage, version, locator_hashes, stop_hash);
 

--- a/p2p/src/message_network.rs
+++ b/p2p/src/message_network.rs
@@ -51,6 +51,7 @@ pub struct VersionMessage {
 impl VersionMessage {
     /// Constructs a new `version` message with `relay` set to false
     pub fn new(
+        version: u32,
         services: ServiceFlags,
         timestamp: i64,
         receiver: Address,
@@ -60,7 +61,7 @@ impl VersionMessage {
         start_height: i32,
     ) -> VersionMessage {
         VersionMessage {
-            version: crate::PROTOCOL_VERSION,
+            version,
             services,
             timestamp,
             receiver,

--- a/p2p/src/message_network.rs
+++ b/p2p/src/message_network.rs
@@ -12,7 +12,7 @@ use io::{BufRead, Write};
 
 use crate::address::Address;
 use crate::consensus::{impl_consensus_encoding, impl_vec_wrapper};
-use crate::ServiceFlags;
+use crate::{ProtocolVersion, ServiceFlags};
 
 // Some simple messages
 
@@ -20,7 +20,7 @@ use crate::ServiceFlags;
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub struct VersionMessage {
     /// The P2P network protocol version
-    pub version: u32,
+    pub version: ProtocolVersion,
     /// A bitmask describing the services supported by this node
     pub services: ServiceFlags,
     /// The time at which the `version` message was sent
@@ -51,7 +51,7 @@ pub struct VersionMessage {
 impl VersionMessage {
     /// Constructs a new `version` message with `relay` set to false
     pub fn new(
-        version: u32,
+        version: ProtocolVersion,
         services: ServiceFlags,
         timestamp: i64,
         receiver: Address,
@@ -184,7 +184,7 @@ mod tests {
         let decode: Result<VersionMessage, _> = deserialize(&from_sat);
         assert!(decode.is_ok());
         let real_decode = decode.unwrap();
-        assert_eq!(real_decode.version, 70002);
+        assert_eq!(real_decode.version.0, 70002);
         assert_eq!(real_decode.services, ServiceFlags::NETWORK);
         assert_eq!(real_decode.timestamp, 1401217254);
         // address decodes should be covered by Address tests


### PR DESCRIPTION
Protocol versions should be comparable by name when considering if we would like to maintain a connection or not. For instance it is nice to be able to say "reject all connections below this feature". It is also nice to know you aren't sending some nonsense version (e.g. 70071) because of a typo.

The naming comes from similar constants defined in Bitcoin Core [here](https://github.com/bitcoin/bitcoin/blob/master/src/node/protocol_version.h). 