### PR TITLE
fix: typo in panic message in amount module tests

### DIFF
--- a/units/src/amount/tests.rs
+++ b/units/src/amount/tests.rs
@@ -70,7 +70,7 @@ fn from_str_zero() {
         for v in &["0", "000"] {
             let s = format!("{} {}", v, denom);
             match s.parse::<Amount>() {
-                Err(e) => panic!("failed to crate amount from {}: {:?}", s, e),
+                Err(e) => panic!("failed to create amount from {}: {:?}", s, e),
                 Ok(amount) => assert_eq!(amount, Amount::ZERO),
             }
         }


### PR DESCRIPTION
The panic message in the amount module tests contained a typo: "failed to crate amount from" was corrected to "failed to create amount from".