### PR TITLE
fix: panic messages in from_sat_i32 and from_sat_u32 to use satoshi limits

### DIFF
--- a/units/src/amount/signed.rs
+++ b/units/src/amount/signed.rs
@@ -116,7 +116,7 @@ impl SignedAmount {
         let sats = satoshi as i64; // cannot use i64::from in a constfn
         match Self::from_sat(sats) {
             Ok(amount) => amount,
-            Err(_) => panic!("unreachable - 32,767 BTC is within range"),
+            Err(_) => panic!("unreachable - i32 input [-2,147,483,648 to 2,147,483,647 satoshis] is within range"),
         }
     }
 

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -118,7 +118,8 @@ impl Amount {
         let sats = satoshi as u64; // cannot use i64::from in a constfn
         match Self::from_sat(sats) {
             Ok(amount) => amount,
-            Err(_) => panic!("unreachable - 65,536 BTC is within range"),
+            Err(_) =>
+                panic!("unreachable - u32 input [0 to 4,294,967,295 satoshis] is within range"),
         }
     }
 


### PR DESCRIPTION
**Fixes**: #4727 

Updates panic messages in `from_sat_i32` and `from_sat_u32` to fix incorrect "32,767 BTC" reference..
- `from_sat_i32`: "unreachable - i32 input [-2,147,483,648 to 2,147,483,647 satoshis] is within range"
- `from_sat_u32`: "unreachable - u32 input [0 to 4,294,967,295 satoshis] is within range"

Also updates docstrings to emphasize satoshi ranges, removing BTC approximations as it's not relevant for the conversion. 

**Testing**:
- Ran `cargo test` to confirm no regressions.