### PR TITLE
doc: Remove duplicate word

### DIFF
--- a/bitcoin/src/network/mod.rs
+++ b/bitcoin/src/network/mod.rs
@@ -65,7 +65,7 @@ pub enum TestnetVersion {
 /// new, incompatible version of this type. If you are using this type directly and wish to support the
 /// new network, this will be a breaking change to your APIs and likely require changes in your code.
 ///
-/// If you are concerned about forward compatibility, consider using `T: Into<Params>` instead of this
+/// If you are concerned about forward compatibility, consider using `T: Into<Params>` instead of
 /// this type as a parameter to functions in your public API, or directly using the `Params` type.
 // For extensive discussion on the usage of `non_exhaustive` please see:
 // https://github.com/rust-bitcoin/rust-bitcoin/issues/2225


### PR DESCRIPTION
Remove typo; duplicate word 'this'.