### PR TITLE
p2p: Add a `V1MessageHeader`

### DIFF
--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -17,7 +17,7 @@ use internals::ToU64 as _;
 use io::{BufRead, Write};
 
 use crate::address::{AddrV2Message, Address};
-use crate::consensus::impl_vec_wrapper;
+use crate::consensus::{impl_consensus_encoding, impl_vec_wrapper};
 use crate::{
     message_blockdata, message_bloom, message_compact_blocks, message_filter, message_network,
     Magic,
@@ -158,6 +158,21 @@ pub struct RawNetworkMessage {
     payload_len: u32,
     checksum: [u8; 4],
 }
+
+/// A v1 message header used to describe the incoming payload.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct V1MessageHeader {
+    /// The network magic, a unique 4 byte sequence.
+    pub magic: Magic,
+    /// The "command" used to describe the payload.
+    pub command: CommandString,
+    /// The length of the payload.
+    pub length: u32,
+    /// A checksum to the afformentioned data.
+    pub checksum: [u8; 4],
+}
+
+impl_consensus_encoding!(V1MessageHeader, magic, command, length, checksum);
 
 /// A Network message using the v2 p2p protocol defined in BIP324.
 #[derive(Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
When using `p2p` and version one messaging, the user is put into a strange position where they must figure out how many bytes to read, but cannot do so without implementing some version of this type in their crate. Add a first-class `V1MessageHeader` so users may first decoded this, then the rest of the message.

An example is in Floresta here: https://github.com/vinteumorg/Floresta/blob/5e78a8179da596101508ac6ad1a454e80c1635bc/crates/floresta-wire/src/p2p_wire/transport.rs#L85

Which is used to parse data here: https://github.com/vinteumorg/Floresta/blob/5e78a8179da596101508ac6ad1a454e80c1635bc/crates/floresta-wire/src/p2p_wire/transport.rs#L333