### PR TITLE
fix: correct typo in test function name "tyes" to "types"

### DIFF
--- a/io/tests/api.rs
+++ b/io/tests/api.rs
@@ -130,7 +130,7 @@ fn api_all_non_error_types_have_non_empty_debug() {
 }
 
 #[test]
-fn all_non_error_tyes_implement_send_sync() {
+fn all_non_error_types_implement_send_sync() {
     fn assert_send<T: Send>() {}
     fn assert_sync<T: Sync>() {}
 


### PR DESCRIPTION
Fix a typo in the function name `all_non_error_tyes_implement_send_sync` by changing "tyes" to "types" to maintain consistency with other function names like `api_all_non_error_types_have_non_empty_debug`