### PR TITLE
Add user-agent header to `Update cargo-semver-checks` curl command

### DIFF
--- a/.github/workflows/cron-weekly-update-cargo-semver-checks.yml
+++ b/.github/workflows/cron-weekly-update-cargo-semver-checks.yml
@@ -14,7 +14,7 @@ jobs:
           set -x
           # Grab the latest version of cargo semver-checks from crates.io
           # that is not yanked.
-          LATEST_VERSION=$(curl --proto '=https' --tlsv1.3 -sSf https://crates.io/api/v1/crates/cargo-semver-checks/versions | jq -r 'first( .versions[] | select(.yanked == false) ) | .num')
+          LATEST_VERSION=$(curl --proto '=https' --tlsv1.3 -sSf -H "User-Agent: rust-bitcoin-ci" https://crates.io/api/v1/crates/cargo-semver-checks/versions | jq -r 'first( .versions[] | select(.yanked == false) ) | .num')
           # Update the latest version in the reference file.
           echo "${LATEST_VERSION}" > ./.github/workflows/cargo-semver-checks-version
           echo "cargo_semver_checks_version=${LATEST_VERSION}" >> $GITHUB_ENV


### PR DESCRIPTION
The weekly `Update cargo-semver-checks` returned `curl: (22) The requested URL returned error: 403` when run in CI.

Add a user-agent header to fix it.