### PR TITLE
Fix LICENSE link in p2p/README.md

### DIFF
--- a/p2p/README.md
+++ b/p2p/README.md
@@ -8,5 +8,5 @@ This library should always compile with any combination of features on **Rust 1.
 
 ## Licensing
 
-The code in this project is licensed under the [Creative Commons CC0 1.0 Universal license](LICENSE).
+The code in this project is licensed under the [Creative Commons CC0 1.0 Universal license](../LICENSE).
 We use the [SPDX license list](https://spdx.org/licenses/) and [SPDX IDs](https://spdx.dev/ids/).


### PR DESCRIPTION
Fixed broken link to License
Now the link looks like just in primitives/README.md, base58/README.md and units/README.md
