### PR TITLE
Update source code to current rust-secp256k1 API (d329d79)

### DIFF
--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -33,7 +33,7 @@ hex = { package = "hex-conservative", version = "0.3.0", default-features = fals
 internals = { package = "bitcoin-internals", path = "../internals", features = ["alloc", "hex"] }
 io = { package = "bitcoin-io", path = "../io", default-features = false, features = ["alloc", "hashes"] }
 primitives = { package = "bitcoin-primitives", path = "../primitives", default-features = false, features = ["alloc", "hex"] }
-secp256k1 = { version = "0.30.0", default-features = false, features = ["hashes", "alloc", "rand"] }
+secp256k1 = { git = "https://github.com/rust-bitcoin/rust-secp256k1.git", rev = "d329d79cda40b763a60c4fa1b28a4ea52653cb9e", default-features = false, features = ["alloc", "hashes", "rand", "std"] }
 units = { package = "bitcoin-units", path = "../units", default-features = false, features = ["alloc"] }
 
 arbitrary = { version = "1.4", optional = true }

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -721,7 +721,7 @@ impl Xpriv {
             parent_fingerprint: Default::default(),
             child_number: ChildNumber::ZERO_NORMAL,
             private_key: secp256k1::SecretKey::from_byte_array(
-                hmac.as_byte_array().split_array::<32, 32>().0,
+                *hmac.as_byte_array().split_array::<32, 32>().0,
             )
             .expect("cryptographically unreachable"),
             chain_code: ChainCode::from_hmac(hmac),
@@ -745,7 +745,7 @@ impl Xpriv {
     /// Constructs a new BIP340 keypair for Schnorr signatures and Taproot use matching the internal
     /// secret key representation.
     pub fn to_keypair<C: secp256k1::Signing>(self, secp: &Secp256k1<C>) -> Keypair {
-        Keypair::from_seckey_slice(secp, &self.private_key[..])
+        Keypair::from_seckey_byte_array(secp, self.private_key.secret_bytes())
             .expect("BIP32 internal private key representation is broken")
     }
 
@@ -800,7 +800,7 @@ impl Xpriv {
         engine.input(&u32::from(i).to_be_bytes());
         let hmac: Hmac<sha512::Hash> = engine.finalize();
         let sk =
-            secp256k1::SecretKey::from_byte_array(hmac.as_byte_array().split_array::<32, 32>().0)
+            secp256k1::SecretKey::from_byte_array(*hmac.as_byte_array().split_array::<32, 32>().0)
                 .expect("statistically impossible to hit");
         let tweaked =
             sk.add_tweak(&self.private_key.into()).expect("statistically impossible to hit");
@@ -837,7 +837,7 @@ impl Xpriv {
             parent_fingerprint,
             child_number,
             chain_code,
-            private_key: secp256k1::SecretKey::from_byte_array(private_key)?,
+            private_key: secp256k1::SecretKey::from_byte_array(*private_key)?,
         })
     }
 
@@ -944,7 +944,7 @@ impl Xpub {
 
                 let hmac = engine.finalize();
                 let private_key = secp256k1::SecretKey::from_byte_array(
-                    hmac.as_byte_array().split_array::<32, 32>().0,
+                    *hmac.as_byte_array().split_array::<32, 32>().0,
                 )
                 .expect("cryptographically unreachable");
                 let chain_code = ChainCode::from_hmac(hmac);

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -57,7 +57,7 @@ impl XOnlyPublicKey {
     pub fn from_byte_array(
         data: &[u8; constants::SCHNORR_PUBLIC_KEY_SIZE],
     ) -> Result<XOnlyPublicKey, ParseXOnlyPublicKeyError> {
-        secp256k1::XOnlyPublicKey::from_byte_array(data)
+        secp256k1::XOnlyPublicKey::from_byte_array(*data)
             .map(XOnlyPublicKey::new)
             .map_err(|_| ParseXOnlyPublicKeyError::InvalidXCoordinate)
     }
@@ -322,7 +322,7 @@ impl PublicKey {
         msg: secp256k1::Message,
         sig: ecdsa::Signature,
     ) -> Result<(), secp256k1::Error> {
-        secp.verify_ecdsa(&msg, &sig.signature, &self.inner)
+        secp.verify_ecdsa(&sig.signature, msg, &self.inner)
     }
 }
 
@@ -460,7 +460,7 @@ impl CompressedPublicKey {
         msg: secp256k1::Message,
         sig: ecdsa::Signature,
     ) -> Result<(), secp256k1::Error> {
-        Ok(secp.verify_ecdsa(&msg, &sig.signature, &self.0)?)
+        Ok(secp.verify_ecdsa(&sig.signature, msg, &self.0)?)
     }
 }
 
@@ -574,7 +574,7 @@ impl PrivateKey {
         data: [u8; 32],
         network: impl Into<NetworkKind>,
     ) -> Result<PrivateKey, secp256k1::Error> {
-        Ok(PrivateKey::new(secp256k1::SecretKey::from_byte_array(&data)?, network))
+        Ok(PrivateKey::new(secp256k1::SecretKey::from_byte_array(data)?, network))
     }
 
     /// Deserializes a private key from a slice.
@@ -636,7 +636,7 @@ impl PrivateKey {
             }
         };
 
-        Ok(PrivateKey { compressed, network, inner: secp256k1::SecretKey::from_byte_array(key)? })
+        Ok(PrivateKey { compressed, network, inner: secp256k1::SecretKey::from_byte_array(*key)? })
     }
 
     /// Returns a new private key with the negated secret value.

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -379,7 +379,7 @@ impl Psbt {
             };
 
             let sig = ecdsa::Signature {
-                signature: secp.sign_ecdsa(&msg, &sk.inner),
+                signature: secp.sign_ecdsa(msg, &sk.inner),
                 sighash_type: sighash_ty,
             };
 

--- a/bitcoin/src/sign_message.rs
+++ b/bitcoin/src/sign_message.rs
@@ -104,7 +104,7 @@ mod message_signing {
         pub fn serialize(&self) -> [u8; 65] {
             let (recid, raw) = self.signature.serialize_compact();
             let mut serialized = [0u8; 65];
-            serialized[0] = i32::from(recid) as u8 + if self.compressed { 31 } else { 27 };
+            serialized[0] = recid.to_u8() + if self.compressed { 31 } else { 27 };
             serialized[1..].copy_from_slice(&raw[..]);
             serialized
         }
@@ -139,7 +139,7 @@ mod message_signing {
             msg_hash: sha256d::Hash,
         ) -> Result<PublicKey, MessageSignatureError> {
             let msg = secp256k1::Message::from_digest(msg_hash.to_byte_array());
-            let pubkey = secp_ctx.recover_ecdsa(&msg, &self.signature)?;
+            let pubkey = secp_ctx.recover_ecdsa(msg, &self.signature)?;
             Ok(PublicKey { inner: pubkey, compressed: self.compressed })
         }
 
@@ -224,7 +224,7 @@ pub fn sign<C: secp256k1::Signing>(
 ) -> MessageSignature {
     let msg_hash = signed_msg_hash(msg);
     let msg_to_sign = secp256k1::Message::from_digest(msg_hash.to_byte_array());
-    let secp_sig = secp_ctx.sign_ecdsa_recoverable(&msg_to_sign, &privkey);
+    let secp_sig = secp_ctx.sign_ecdsa_recoverable(msg_to_sign, &privkey);
     MessageSignature { signature: secp_sig, compressed: true }
 }
 


### PR DESCRIPTION
This PR updates source code to current rust-secp256k1 API (https://github.com/rust-bitcoin/rust-secp256k1/commit/d329d79cda40b763a60c4fa1b28a4ea52653cb9e at the time of this PR).

Changes in `Cargo.toml` can be ignored.