### PR TITLE
p2p: Remove deprecated const

### DIFF
--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -224,9 +224,6 @@ impl Magic {
     /// Bitcoin mainnet network magic bytes.
     pub const BITCOIN: Self = Self([0xF9, 0xBE, 0xB4, 0xD9]);
     /// Bitcoin testnet3 network magic bytes.
-    #[deprecated(since = "0.33.0", note = "use `TESTNET3` instead")]
-    pub const TESTNET: Self = Self([0x0B, 0x11, 0x09, 0x07]);
-    /// Bitcoin testnet3 network magic bytes.
     pub const TESTNET3: Self = Self([0x0B, 0x11, 0x09, 0x07]);
     /// Bitcoin testnet4 network magic bytes.
     pub const TESTNET4: Self = Self([0x1c, 0x16, 0x3f, 0x28]);


### PR DESCRIPTION
We deprecated this const when backporting the testnet v4 stuff in  #3453 and even though we typically keep deprecated things around for two releases since `p2p` is a new crate lets just get rid of it.

FTR with this applied there are no more uses of the `deprecated` attribute in `p2p`.

Close: #4711