### PR TITLE
WIP: Add inherent consensus encoding methods

### DIFF
--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -17,7 +17,7 @@ exclude = ["tests", "contrib"]
 [features]
 default = ["std", "hex"]
 std = ["alloc", "hashes/std", "hex?/std", "internals/std", "units/std", "arrayvec/std"]
-alloc = ["hashes/alloc", "hex?/alloc", "internals/alloc", "units/alloc"]
+alloc = ["hashes/alloc", "hex?/alloc", "internals/alloc", "io/alloc", "units/alloc"]
 serde = ["dep:serde", "hashes/serde", "hex?/serde", "internals/serde", "units/serde", "alloc", "hex"]
 arbitrary = ["dep:arbitrary", "units/arbitrary"]
 hex = ["dep:hex", "hashes/hex", "internals/hex"]
@@ -30,6 +30,7 @@ arrayvec = { version = "0.7", default-features = false }
 
 arbitrary = { version = "1.4", optional = true }
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false, optional = true }
+io = { package = "bitcoin-io", path = "../io", default-features = false, features = ["hashes"], optional = true }
 serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"], optional = true }
 
 [dev-dependencies]

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -17,9 +17,14 @@ use core::cmp;
 use core::convert::Infallible;
 use core::fmt;
 
+#[cfg(feature = "io")]
+use io::Write;
+
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
 use hashes::sha256d;
+#[cfg(feature = "hex")]
+use hex::DisplayHex as _;
 #[cfg(feature = "alloc")]
 use internals::compact_size;
 #[cfg(feature = "hex")]
@@ -194,6 +199,63 @@ impl Transaction {
         // `Transaction` docs for full explanation).
         self.input.is_empty()
     }
+
+    /// Consensus encodes a transaction.
+    #[cfg(feature = "alloc")]
+    pub fn serialize(&self) -> Vec<u8> {
+        let mut encoder = Vec::new();
+        let len = self.serialize_to_writer(&mut encoder).expect("in-memory writers don't error");
+        debug_assert_eq!(len, encoder.len());
+        encoder
+    }
+
+    /// Consensus encodes a transaction as a hex string.
+    #[cfg(all(feature = "alloc", feature = "hex"))]
+    pub fn serialize_hex(&self) -> String {
+        self.serialize().to_lower_hex_string()
+    }
+
+    /// Consensus encodes transaction to writer.
+    ///
+    /// # Returns
+    ///
+    /// The number of bytes written on success. The only errors returned are errors propagated from
+    /// the writer.
+    #[cfg(feature = "io")]
+    fn serialize_to_writer<W: Write + ?Sized>(&self, _: &mut W) -> Result<usize, io::Error> {
+        todo!()
+    }
+
+    /// Deserializes an object from a vector, will error if said deserialization
+    /// doesn't consume the entire vector.
+    pub fn deserialize(data: &[u8]) -> Result<Transaction, ()> {
+        let (rv, consumed) = Self::deserialize_partial(data)?; // TODO: Return parse error.
+
+        // Fail if data are not consumed entirely.
+        if consumed == data.len() {
+            Ok(rv)
+        } else {
+            Err(())             // TODO: Return nconsumed error.
+        }
+    }
+
+    /// Deserialize transaction from a hex string, will error if said deserialization doesn't
+    /// consume the entire vector.
+    pub fn deserialize_hex(_: &str) -> Result<Transaction, ()> {
+        todo!()
+    }
+
+    /// Deserializes transaction from a vector, but will not report an error if said deserialization
+    /// doesn't consume the entire vector.
+    ///
+    /// # Returns
+    ///
+    /// The transaction along with the number of bytes consumed during deserialization.
+    // TODO: Add a new and improved `ParseError`.
+    pub fn deserialize_partial(_: &[u8]) -> Result<(Transaction, usize), ()> {
+        todo!()
+    }
+
 }
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
Currently one must use `rust-bitcoin` to get at consensus encoding for types in `units` and `primitives`. This is overly restrictive.

Currently this is just a skeleton for `Transaction` so we can discuss the API.

Question: Which types should we add this same API to?

- Just the 'top level' types we want (e.g., Block, Transaction)?
- Everything that implements `Encodable`?