### PR TITLE
Add empty `consensus_encoding` crate

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -203,6 +203,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "consensus-encoding"
+version = "0.0.0"
+
+[[package]]
 name = "getrandom"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -205,6 +205,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "consensus-encoding"
+version = "0.0.0"
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["addresses", "base58", "bitcoin", "chacha20_poly1305", "fuzz", "hashes", "internals", "io", "p2p", "primitives", "units"]
+members = ["addresses", "base58", "bitcoin", "chacha20_poly1305", "consensus_encoding", "fuzz", "hashes", "internals", "io", "p2p", "primitives", "units"]
 resolver = "2"
 
 # Keep this patch for hashes because secp256k1 depends on bitcoin-hashes via crates.io

--- a/consensus_encoding/CHANGELOG.md
+++ b/consensus_encoding/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.0.0 - Placeholder release
+
+Empty crate to reserve the name on crates.io

--- a/consensus_encoding/Cargo.toml
+++ b/consensus_encoding/Cargo.toml
@@ -1,0 +1,155 @@
+[package]
+name = "consensus-encoding"
+version = "0.0.0"
+authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>", "Tobin C. Harding <me@tobin.cc>"]
+license = "CC0-1.0"
+repository = "https://github.com/rust-bitcoin/rust-bitcoin/"
+description = "Consensus encoding and decoding"
+categories = ["cryptography::cryptocurrencies"]
+keywords = ["bitcoin", "no-std"]
+readme = "README.md"
+edition = "2021"
+rust-version = "1.63.0"
+exclude = ["tests", "contrib"]
+
+[features]
+default = ["std"]
+std = ["alloc"]
+alloc = []
+
+[dependencies]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[lints.rust]
+unexpected_cfgs = { level = "deny", check-cfg = [] }
+
+[lints.clippy]
+# Exclude lints we don't think are valuable.
+needless_question_mark = "allow" # https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
+manual_range_contains = "allow" # More readable than clippy's format.
+# Exhaustive list of pedantic clippy lints
+assigning_clones = "warn"
+bool_to_int_with_if = "warn"
+borrow_as_ptr = "warn"
+case_sensitive_file_extension_comparisons = "warn"
+cast_lossless = "warn"
+cast_possible_truncation = "allow" # All casts should include a code comment (except test code).
+cast_possible_wrap = "allow" # Same as above re code comment.
+cast_precision_loss = "warn"
+cast_ptr_alignment = "warn"
+cast_sign_loss = "allow" # All casts should include a code comment (except in test code).
+checked_conversions = "warn"
+cloned_instead_of_copied = "warn"
+copy_iterator = "warn"
+default_trait_access = "warn"
+doc_link_with_quotes = "warn"
+doc_markdown = "warn"
+empty_enum = "warn"
+enum_glob_use = "warn"
+expl_impl_clone_on_copy = "warn"
+explicit_deref_methods = "warn"
+explicit_into_iter_loop = "warn"
+explicit_iter_loop = "warn"
+filter_map_next = "warn"
+flat_map_option = "warn"
+float_cmp = "allow" # Bitcoin floats are typically limited to 8 decimal places and we want them exact.
+fn_params_excessive_bools = "warn"
+from_iter_instead_of_collect = "warn"
+if_not_else = "warn"
+ignored_unit_patterns = "warn"
+implicit_clone = "warn"
+implicit_hasher = "warn"
+inconsistent_struct_constructor = "warn"
+index_refutable_slice = "warn"
+inefficient_to_string = "warn"
+inline_always = "warn"
+into_iter_without_iter = "warn"
+invalid_upcast_comparisons = "warn"
+items_after_statements = "warn"
+iter_filter_is_ok = "warn"
+iter_filter_is_some = "warn"
+iter_not_returning_iterator = "warn"
+iter_without_into_iter = "warn"
+large_digit_groups = "warn"
+large_futures = "warn"
+large_stack_arrays = "warn"
+large_types_passed_by_value = "warn"
+linkedlist = "warn"
+macro_use_imports = "warn"
+manual_assert = "warn"
+manual_instant_elapsed = "warn"
+manual_is_power_of_two = "warn"
+manual_is_variant_and = "warn"
+manual_let_else = "warn"
+manual_ok_or = "warn"
+manual_string_new = "warn"
+many_single_char_names = "warn"
+map_unwrap_or = "warn"
+match_bool = "allow" # Adds extra indentation and LOC.
+match_on_vec_items = "warn"
+match_same_arms = "allow" # Collapses things that are conceptually unrelated to each other.
+match_wild_err_arm = "warn"
+match_wildcard_for_single_variants = "warn"
+maybe_infinite_iter = "warn"
+mismatching_type_param_order = "warn"
+missing_errors_doc = "warn"
+missing_fields_in_debug = "warn"
+missing_panics_doc = "warn"
+must_use_candidate = "allow" # Useful for audit but many false positives.
+mut_mut = "warn"
+naive_bytecount = "warn"
+needless_bitwise_bool = "warn"
+needless_continue = "warn"
+needless_for_each = "warn"
+needless_pass_by_value = "warn"
+needless_raw_string_hashes = "warn"
+no_effect_underscore_binding = "warn"
+no_mangle_with_rust_abi = "warn"
+option_as_ref_cloned = "warn"
+option_option = "warn"
+ptr_as_ptr = "warn"
+ptr_cast_constness = "warn"
+pub_underscore_fields = "warn"
+range_minus_one = "warn"
+range_plus_one = "warn"
+redundant_closure_for_method_calls = "warn"
+redundant_else = "warn"
+ref_as_ptr = "warn"
+ref_binding_to_reference = "warn"
+ref_option = "warn"
+ref_option_ref = "warn"
+return_self_not_must_use = "warn"
+same_functions_in_if_condition = "warn"
+semicolon_if_nothing_returned = "warn"
+should_panic_without_expect = "warn"
+similar_names = "allow" # Too many (subjectively) false positives.
+single_char_pattern = "warn"
+single_match_else = "warn"
+stable_sort_primitive = "warn"
+str_split_at_newline = "warn"
+string_add_assign = "warn"
+struct_excessive_bools = "warn"
+struct_field_names = "warn"
+too_many_lines = "warn"
+transmute_ptr_to_ptr = "warn"
+trivially_copy_pass_by_ref = "warn"
+unchecked_duration_subtraction = "warn"
+unicode_not_nfc = "warn"
+uninlined_format_args = "allow" # This is a subjective style choice.
+unnecessary_box_returns = "warn"
+unnecessary_join = "warn"
+unnecessary_literal_bound = "warn"
+unnecessary_wraps = "warn"
+unnested_or_patterns = "warn"
+unreadable_literal = "warn"
+unsafe_derive_deserialize = "warn"
+unused_async = "warn"
+unused_self = "warn"
+used_underscore_binding = "warn"
+used_underscore_items = "warn"
+verbose_bit_mask = "warn"
+wildcard_imports = "warn"
+zero_sized_map_values = "warn"

--- a/consensus_encoding/README.md
+++ b/consensus_encoding/README.md
@@ -1,0 +1,12 @@
+# Bitcoin Consensus Encoding
+
+This crate provides traits that can be used to encode/decode objects in a consensus-consistent way.
+
+## Minimum Supported Rust Version (MSRV)
+
+This library should always compile with any combination of features on **Rust 1.63.0**.
+
+## Licensing
+
+The code in this project is licensed under the [Creative Commons CC0 1.0 Universal license](../LICENSE).
+We use the [SPDX license list](https://spdx.org/licenses/) and [SPDX IDs](https://spdx.dev/ids/).

--- a/consensus_encoding/contrib/test_vars.sh
+++ b/consensus_encoding/contrib/test_vars.sh
@@ -1,0 +1,14 @@
+# No shebang, this file should not be executed.
+# shellcheck disable=SC2148
+#
+# disable verify unused vars, despite the fact that they are used when sourced
+# shellcheck disable=SC2034
+
+# Test all these features with "std" enabled.
+FEATURES_WITH_STD=""
+
+# Test all these features without "std" enabled.
+FEATURES_WITHOUT_STD="alloc"
+
+# Run these examples.
+EXAMPLES=""

--- a/consensus_encoding/src/lib.rs
+++ b/consensus_encoding/src/lib.rs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! # Rust Bitcoin - consensus encoding and decoding
+//!
+//! This library provides traits that can be used to encode/decode objects in a
+//! consensus-consistent way.
+//!
+//! ## Notes on I/O
+//!
+//! I/O in Rust has a few problems in relation to no-std, as such we depend on the [`bitcoin-io`]
+//! crate and this library uses `io::Read` and `io::Write` to read and write respectively to readers
+//! and writers that are, to the best of our ability, interoperable with `std::io`. This includes
+//! error handling by way of the [`bitcoin_io::Error`].
+//!
+//! [bitcoin-io]: io
+//! [`bitcoin_io::Error`]: io::Error
+
+#![no_std]
+// Experimental features we need.
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+// Coding conventions.
+#![warn(missing_docs)]
+#![warn(deprecated_in_future)]
+#![doc(test(attr(warn(unused))))]
+// Exclude lints we don't think are valuable.
+#![allow(clippy::uninlined_format_args)] // Allow `format!("{}", x)`instead of enforcing `format!("{x}")`
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;


### PR DESCRIPTION
Add an empty `consensus_encoding` crate so we can grab the name on crates.io

The reason I did this was that I stated working on the inherent methods PR and it quickly became obvious that it was going to be pretty ugly without traits. Doable but ugly.

## Aims of the crate

This crate will hold the encoding traits and be depended on by `units`, `primitives`, and `bitcoin` where implementations of the traits will live.

All this will be feature gated so users can opt in. This nicely bypasses the `Read`/`Write` vs `BufRead`/`BufWrite` problem because later we can add an additional crate for the buffered stuff and users can opt in to the one they want to use.

This crate will be no-std by default and depend on `bitcoin-io` for I/O.

First release will just bring everything as it is from `bitcoin` over here, then we can implement the traits in the various other crates, then iterate - like its our job.