### PR TITLE
Use no_std when testing

### DIFF
--- a/addresses/src/lib.rs
+++ b/addresses/src/lib.rs
@@ -11,7 +11,7 @@
 
 // NB: This crate is empty if `alloc` is not enabled.
 #![cfg(feature = "alloc")]
-#![cfg_attr(all(not(test), not(feature = "std")), no_std)]
+#![no_std]
 // Experimental features we need.
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc(test(attr(warn(unused))))]

--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -393,6 +393,9 @@ impl<'a> Arbitrary<'a> for Version {
 mod tests {
     use super::*;
 
+    #[cfg(feature = "alloc")] 
+    use alloc::{format, vec};
+
     fn dummy_header() -> Header {
         Header {
             version: Version::ONE,
@@ -550,6 +553,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "alloc")]
     fn header_debug() {
         let header = dummy_header();
         let expected = format!(
@@ -567,6 +571,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "hex")]
+    #[cfg(feature = "alloc")]
     fn header_display() {
         let seconds: u32 = 1_653_195_600; // Arbitrary timestamp: May 22nd, 5am UTC.
 

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -9,7 +9,7 @@
 //!
 //! [`rust-bitcoin`]: <https://github.com/rust-bitcoin>
 
-#![cfg_attr(all(not(test), not(feature = "std")), no_std)]
+#![no_std]
 // Experimental features we need.
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Coding conventions.

--- a/primitives/src/opcodes.rs
+++ b/primitives/src/opcodes.rs
@@ -545,10 +545,12 @@ impl Ordinary {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
-
     use super::*;
 
+    #[cfg(feature = "alloc")]
+    use alloc::{collections::BTreeSet, format};
+
+    #[cfg(feature = "alloc")]
     macro_rules! roundtrip {
         ($unique:expr, $op:ident) => {
             assert_eq!($op, Opcode::from($op.to_u8()));
@@ -562,6 +564,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "alloc")]
     fn formatting_works() {
         let op = all::OP_NOP;
         let s = format!("{:>10}", op);
@@ -642,8 +645,9 @@ mod tests {
 
     #[test]
     #[allow(clippy::too_many_lines)] // This is fine, we never need to read it.
+    #[cfg(feature = "alloc")]
     fn str_roundtrip() {
-        let mut unique = HashSet::new();
+        let mut unique = BTreeSet::new();
         roundtrip!(unique, OP_PUSHBYTES_0);
         roundtrip!(unique, OP_PUSHBYTES_1);
         roundtrip!(unique, OP_PUSHBYTES_2);

--- a/primitives/src/pow.rs
+++ b/primitives/src/pow.rs
@@ -52,6 +52,9 @@ impl fmt::UpperHex for CompactTarget {
 mod tests {
     use super::*;
 
+    #[cfg(feature = "alloc")]
+    use alloc::{format};
+
     #[test]
     fn compact_target_ordering() {
         let lower = CompactTarget::from_consensus(0x1d00_fffe);
@@ -63,6 +66,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "alloc")]
     fn compact_target_formatting() {
         let compact_target = CompactTarget::from_consensus(0x1d00_ffff);
         assert_eq!(format!("{:x}", compact_target), "1d00ffff");

--- a/primitives/src/script/borrowed.rs
+++ b/primitives/src/script/borrowed.rs
@@ -190,6 +190,9 @@ delegate_index!(
 mod tests {
     use super::*;
 
+    #[cfg(feature = "alloc")]
+    use alloc::{vec};
+
     #[test]
     fn script_from_bytes() {
         let script = Script::from_bytes(&[1, 2, 3]);

--- a/primitives/src/script/mod.rs
+++ b/primitives/src/script/mod.rs
@@ -613,6 +613,9 @@ impl<'de> serde::Deserialize<'de> for ScriptBuf {
 mod tests {
     use super::*;
 
+    #[cfg(feature = "alloc")]
+    use alloc::{format, vec};
+
     #[test]
     fn scriptbuf_from_vec_u8() {
         let vec = vec![0x51, 0x52, 0x53];

--- a/primitives/src/script/owned.rs
+++ b/primitives/src/script/owned.rs
@@ -150,6 +150,9 @@ impl<'a> Arbitrary<'a> for ScriptBuf {
 mod tests {
     use super::*;
 
+    #[cfg(feature = "alloc")]
+    use alloc::{vec};
+
     #[test]
     fn script_buf_from_bytes() {
         let bytes = vec![1, 2, 3];

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -664,6 +664,9 @@ impl<'a> Arbitrary<'a> for Wtxid {
 mod tests {
     use super::*;
 
+    #[cfg(feature = "alloc")]
+    use alloc::{format, vec};
+
     #[test]
     fn sanity_check() {
         let version = Version(123);

--- a/primitives/src/witness.rs
+++ b/primitives/src/witness.rs
@@ -575,6 +575,12 @@ impl<'a> Arbitrary<'a> for Witness {
 mod test {
     use super::*;
 
+    #[cfg(feature = "alloc")]
+    use alloc::{vec};
+
+    #[cfg(feature = "std")]
+    use std::println;
+
     // Appends all the indices onto the end of a list of elements.
     fn append_u32_vec(elements: &[u8], indices: &[u32]) -> Vec<u8> {
         let mut v = elements.to_vec();
@@ -588,6 +594,7 @@ mod test {
     fn single_empty_element() -> Witness { Witness::from([[0u8; 0]]) }
 
     #[test]
+    #[cfg(feature = "std")]
     fn witness_debug_can_display_empty_element() {
         let witness = single_empty_element();
         println!("{:?}", witness);


### PR DESCRIPTION
Fixes #4681 by making `primitives` and `addresses` crates consistently use `#![no_std]` like the `units` crate.

**Changes:**
- Change from conditional `no_std` to always `no_std` 
- Add test macro imports to resolve `format!`/`vec!`/`println!` issues

This makes the test environment consistent with production and aligns all crates in the codebase.