### PR TITLE
Remove # from crate rustdoc titles

### DIFF
--- a/addresses/src/lib.rs
+++ b/addresses/src/lib.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! # Bitcoin Addresses
+//! Bitcoin Addresses
 //!
 //! Bitcoin addresses do not appear on chain; rather, they are conventions used by Bitcoin (wallet)
 //! software to communicate where coins should be sent and are based on the output type e.g., P2WPKH.

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! # Rust Bitcoin Library
+//! Rust Bitcoin Library
 //!
 //! This is a library that supports the Bitcoin network protocol and associated primitives. It is
 //! designed for Rust programs built to work with the Bitcoin network.

--- a/chacha20_poly1305/src/lib.rs
+++ b/chacha20_poly1305/src/lib.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! # ChaCha20 - Poly1305
+//! ChaCha20 - Poly1305
 //!
 //! Combine the ChaCha20 stream cipher with the Poly1305 message authentication code
 //! to form an authenticated encryption with additional data (AEAD) algorithm.

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! # Fuzzing
+//! Fuzzing
 
 pub mod fuzz_utils;

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! # Rust Bitcoin Hashes Library
+//! Rust Bitcoin Hashes Library
 //!
 //! This library implements the hash functions needed by Bitcoin. As an ancillary thing, it exposes
 //! hexadecimal serialization and deserialization, since these are needed to display hashes.

--- a/internals/src/lib.rs
+++ b/internals/src/lib.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! # Rust Bitcoin Internal
+//! Rust Bitcoin Internal
 //!
 //! This crate is only meant to be used internally by crates in the
 //! [rust-bitcoin](https://github.com/rust-bitcoin) ecosystem.

--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! # Rust Bitcoin I/O Library
+//! Rust Bitcoin I/O Library
 //!
 //! The [`std::io`] module is not exposed in `no-std` Rust so building `no-std` applications which
 //! require reading and writing objects via standard traits is not generally possible. Thus, this

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! # Rust Bitcoin Peer to Peer Message Types
+//! Rust Bitcoin Peer to Peer Message Types
 
 // Experimental features we need.
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! # Rust Bitcoin - primitive types
+//! Rust Bitcoin - primitive types
 //!
 //! Primitive data types that are used throughout the [`rust-bitcoin`] ecosystem.
 //!

--- a/units/src/lib.rs
+++ b/units/src/lib.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! # Rust Bitcoin - unit types
+//! Rust Bitcoin - unit types
 //!
 //! This library provides basic types used by the Rust Bitcoin ecosystem.
 //!


### PR DESCRIPTION
rustdocs renders the title the same with and without the #

Resolves: #4677