### PR TITLE
Encode the `Error` variant for `Inventory`

### DIFF
--- a/p2p/src/message_blockdata.rs
+++ b/p2p/src/message_blockdata.rs
@@ -67,7 +67,7 @@ impl Encodable for Inventory {
             };
         }
         Ok(match *self {
-            Inventory::Error(_) => encode_inv!(0, [0; 32]),
+            Inventory::Error(ref e) => encode_inv!(0, e),
             Inventory::Transaction(ref t) => encode_inv!(1, t),
             Inventory::Block(ref b) => encode_inv!(2, b),
             Inventory::CompactBlock(ref b) => encode_inv!(4, b),


### PR DESCRIPTION
Even though we can ignore these, this will allow the fuzzer to correctly check the serialization/deserialization logic for the `Inventory` type

Found here: https://github.com/rust-bitcoin/rust-bitcoin/pull/4768#issuecomment-3152694995