### PR TITLE
p2p: Allow building a "useless" address

### DIFF
--- a/p2p/src/address.rs
+++ b/p2p/src/address.rs
@@ -35,6 +35,12 @@ impl Address {
         };
         Address { address, port, services }
     }
+    
+    /// Build an useless address that cannot be connected to. One may find this desirable if it is
+    /// known the data will be ignored by the recipient.
+    pub const fn useless() -> Address {
+        Address { services: ServiceFlags::NONE, address: [0; 8], port: 0 }
+    }
 
     /// Extract socket address from an [Address] message.
     /// This will return [io::Error] [io::ErrorKind::AddrNotAvailable]


### PR DESCRIPTION
The version message in the p2p protocol includes two `p2p::Address` fields, one of these fields is completely ignored in practice. Additionally, one might want to send an unreachable address if they do not want to be discovered as a peer, i.e. they are not listening for connections.

I opted out of using `Default` as this is a specific use case, and there is no reasonable default for an IP address.

Reference to the line in Bitcoin Core that drops the `Address`: https://github.com/bitcoin/bitcoin/blob/v29.1rc1/src/net_processing.cpp#L3435