### PR TITLE
Rename `TxOut::value` to `amount`

### DIFF
--- a/bitcoin/examples/ecdsa-psbt-simple.rs
+++ b/bitcoin/examples/ecdsa-psbt-simple.rs
@@ -109,7 +109,7 @@ fn dummy_unspent_transaction_outputs() -> Vec<(OutPoint, TxOut)> {
         vout: 0,
     };
 
-    let utxo_1 = TxOut { value: DUMMY_UTXO_AMOUNT_INPUT_1, script_pubkey: script_pubkey_1 };
+    let utxo_1 = TxOut { amount: DUMMY_UTXO_AMOUNT_INPUT_1, script_pubkey: script_pubkey_1 };
 
     let script_pubkey_2 = "bc1qy7swwpejlw7a2rp774pa8rymh8tw3xvd2x2xkd"
         .parse::<Address<_>>()
@@ -123,7 +123,7 @@ fn dummy_unspent_transaction_outputs() -> Vec<(OutPoint, TxOut)> {
         vout: 1,
     };
 
-    let utxo_2 = TxOut { value: DUMMY_UTXO_AMOUNT_INPUT_2, script_pubkey: script_pubkey_2 };
+    let utxo_2 = TxOut { amount: DUMMY_UTXO_AMOUNT_INPUT_2, script_pubkey: script_pubkey_2 };
     vec![(out_point_1, utxo_1), (out_point_2, utxo_2)]
 }
 
@@ -165,11 +165,11 @@ fn main() {
         .collect();
 
     // The spend output is locked to a key controlled by the receiver.
-    let spend = TxOut { value: SPEND_AMOUNT, script_pubkey: address.script_pubkey() };
+    let spend = TxOut { amount: SPEND_AMOUNT, script_pubkey: address.script_pubkey() };
 
     // The change output is locked to a key controlled by us.
     let change = TxOut {
-        value: CHANGE_AMOUNT,
+        amount: CHANGE_AMOUNT,
         script_pubkey: ScriptPubKeyBuf::new_p2wpkh(pk_change.wpubkey_hash()), // Change comes back to us.
     };
 

--- a/bitcoin/examples/ecdsa-psbt.rs
+++ b/bitcoin/examples/ecdsa-psbt.rs
@@ -51,7 +51,7 @@ const EXTENDED_MASTER_PRIVATE_KEY: &str = "tprv8ZgxMBicQKsPeSHZFZWT8zxie2dXWcwem
 const INPUT_UTXO_TXID: &str = "295f06639cde6039bf0c3dbf4827f0e3f2b2c2b476408e2f9af731a8d7a9c7fb";
 const INPUT_UTXO_VOUT: u32 = 0;
 const INPUT_UTXO_SCRIPT_PUBKEY: &str = "00149891eeb8891b3e80a2a1ade180f143add23bf5de";
-const INPUT_UTXO_VALUE: &str = "50 BTC";
+const INPUT_UTXO_AMOUNT: &str = "50 BTC";
 // Get this from the descriptor,
 // "wpkh([97f17dca/0'/0'/0']02749483607dafb30c66bd93ece4474be65745ce538c2d70e8e246f17e7a4e0c0c)#m9n56cx0".
 const INPUT_UTXO_DERIVATION_PATH: &str = "0h/0h/0h";
@@ -191,8 +191,8 @@ impl WatchOnly {
                 witness: Witness::default(),
             }],
             outputs: vec![
-                TxOut { value: to_amount, script_pubkey: to_address.script_pubkey() },
-                TxOut { value: change_amount, script_pubkey: change_address.script_pubkey() },
+                TxOut { amount: to_amount, script_pubkey: to_address.script_pubkey() },
+                TxOut { amount: change_amount, script_pubkey: change_address.script_pubkey() },
             ],
         };
 
@@ -276,9 +276,9 @@ fn input_derivation_path() -> Result<DerivationPath> {
 fn previous_output() -> TxOut {
     let script_pubkey = ScriptPubKeyBuf::from_hex_no_length_prefix(INPUT_UTXO_SCRIPT_PUBKEY)
         .expect("failed to parse input utxo scriptPubkey");
-    let amount = INPUT_UTXO_VALUE.parse::<Amount>().expect("failed to parse input utxo value");
+    let amount = INPUT_UTXO_AMOUNT.parse::<Amount>().expect("failed to parse input utxo amount");
 
-    TxOut { value: amount, script_pubkey }
+    TxOut { amount, script_pubkey }
 }
 
 struct Error(Box<dyn std::error::Error>);

--- a/bitcoin/examples/sighash.rs
+++ b/bitcoin/examples/sighash.rs
@@ -19,7 +19,7 @@ use hex_lit::hex;
 ///
 /// * `raw_tx` - the spending tx hex
 /// * `inp_idx` - the spending tx input index
-/// * `amount` - the ref tx output value in sats
+/// * `amount` - the ref tx output amount.
 fn compute_sighash_p2wpkh(raw_tx: &[u8], inp_idx: usize, amount: Amount) {
     let tx: Transaction = consensus::deserialize(raw_tx).unwrap();
     let inp = &tx.inputs[inp_idx];
@@ -103,7 +103,7 @@ fn compute_sighash_legacy(raw_tx: &[u8], inp_idx: usize, script_pubkey_bytes_opt
 ///
 /// * `raw_tx` - the spending tx hex
 /// * `inp_idx` - the spending tx input index
-/// * `amount` - the ref tx output value in sats
+/// * `amount` - the ref tx output amount.
 fn compute_sighash_p2wsh(raw_tx: &[u8], inp_idx: usize, amount: Amount) {
     let tx: Transaction = consensus::deserialize(raw_tx).unwrap();
     let inp = &tx.inputs[inp_idx];
@@ -145,12 +145,12 @@ fn sighash_p2wpkh() {
 
     //vin:0
     let inp_idx = 0;
-    //output value from the referenced vout:0 from the referenced tx:
+    //output amount from the referenced vout:0 from the referenced tx:
     //bitcoin-cli getrawtransaction 752d675b9cc0bd14e0bd23969effee0005ad6d7e550dcc832f0216c7ffd4e15c  3
-    let ref_out_value = Amount::from_sat_u32(200000000);
+    let ref_out_amount = Amount::from_sat_u32(200000000);
 
     println!("\nsighash_p2wpkh:");
-    compute_sighash_p2wpkh(&raw_tx, inp_idx, ref_out_value);
+    compute_sighash_p2wpkh(&raw_tx, inp_idx, ref_out_amount);
 }
 
 fn sighash_p2sh_multisig_2x2() {
@@ -174,13 +174,13 @@ fn sighash_p2wsh_multisig_2x2() {
     //bitcoin-cli decodescript 52210289da5da9d3700156db2d01e6362491733f6c886971791deda74b4e9d707190b2210323c437f30384498be79df2990ce5a8de00844e768c0ccce914335b6c26adea7352ae
     //its ASM is 2 0289da5da9d3700156db2d01e6362491733f6c886971791deda74b4e9d707190b2 0323c437f30384498be79df2990ce5a8de00844e768c0ccce914335b6c26adea73 2 OP_CHECKMULTISIG
     let raw_tx = hex!("010000000001011b9eb4122976fad8f809ee4cea8ac8d1c5b6b8e0d0f9f93327a5d78c9a3945280000000000ffffffff02ba3e0d00000000002200201c3b09401aaa7c9709d118a75d301bdb2180fb68b2e9b3ade8ad4ff7281780cfa586010000000000220020a41d0d894799879ca1bd88c1c3f1c2fd4b1592821cc3c5bfd5be5238b904b09f040047304402201c7563e876d67b5702aea5726cd202bf92d0b1dc52c4acd03435d6073e630bac022032b64b70d7fba0cb8be30b882ea06c5f8ec7288d113459dd5d3e294214e2c96201483045022100f532f7e3b8fd01a0edc86de4870db4e04858964d0a609df81deb99d9581e6c2e02206d9e9b6ab661176be8194faded62f518cdc6ee74dba919e0f35d77cff81f38e5014752210289da5da9d3700156db2d01e6362491733f6c886971791deda74b4e9d707190b2210323c437f30384498be79df2990ce5a8de00844e768c0ccce914335b6c26adea7352ae00000000");
-    //For the witness transaction sighash computation, we need its referenced output's value from the original transaction:
+    //For the witness transaction sighash computation, we need its referenced output's amount from the original transaction:
     //bitcoin-cli getrawtransaction 2845399a8cd7a52733f9f9d0e0b8b6c5d1c88aea4cee09f8d8fa762912b49e1b  3
-    //we need vout 0 value in sats:
-    let ref_out_value = Amount::from_sat_u32(968240);
+    //we need vout 0 amount:
+    let ref_out_amount = Amount::from_sat_u32(968240);
 
     println!("\nsighash_p2wsh_multisig_2x2:");
-    compute_sighash_p2wsh(&raw_tx, 0, ref_out_value);
+    compute_sighash_p2wsh(&raw_tx, 0, ref_out_amount);
 }
 
 fn sighash_p2ms_multisig_2x3() {

--- a/bitcoin/examples/sign-tx-segwit-v0.rs
+++ b/bitcoin/examples/sign-tx-segwit-v0.rs
@@ -39,11 +39,11 @@ fn main() {
     };
 
     // The spend output is locked to a key controlled by the receiver.
-    let spend = TxOut { value: SPEND_AMOUNT, script_pubkey: address.script_pubkey() };
+    let spend = TxOut { amount: SPEND_AMOUNT, script_pubkey: address.script_pubkey() };
 
     // The change output is locked to a key controlled by us.
     let change = TxOut {
-        value: CHANGE_AMOUNT,
+        amount: CHANGE_AMOUNT,
         script_pubkey: ScriptPubKeyBuf::new_p2wpkh(wpkh), // Change comes back to us.
     };
 
@@ -112,7 +112,7 @@ fn receivers_address() -> Address {
 ///
 /// An utxo is described by the `OutPoint` (txid and index within the transaction that it was
 /// created). Using the out point one can get the transaction by `txid` and using the `vout` get the
-/// transaction value and script pubkey (`TxOut`) of the utxo.
+/// transaction amount and script pubkey (`TxOut`) of the utxo.
 ///
 /// This output is locked to keys that we control, in a real application this would be a valid
 /// output taken from a transaction that appears in the chain.
@@ -124,7 +124,7 @@ fn dummy_unspent_transaction_output(wpkh: WPubkeyHash) -> (OutPoint, TxOut) {
         vout: 0,
     };
 
-    let utxo = TxOut { value: DUMMY_UTXO_AMOUNT, script_pubkey };
+    let utxo = TxOut { amount: DUMMY_UTXO_AMOUNT, script_pubkey };
 
     (out_point, utxo)
 }

--- a/bitcoin/examples/sign-tx-taproot.rs
+++ b/bitcoin/examples/sign-tx-taproot.rs
@@ -39,11 +39,11 @@ fn main() {
     };
 
     // The spend output is locked to a key controlled by the receiver.
-    let spend = TxOut { value: SPEND_AMOUNT, script_pubkey: address.script_pubkey() };
+    let spend = TxOut { amount: SPEND_AMOUNT, script_pubkey: address.script_pubkey() };
 
     // The change output is locked to a key controlled by us.
     let change = TxOut {
-        value: CHANGE_AMOUNT,
+        amount: CHANGE_AMOUNT,
         script_pubkey: ScriptPubKeyBuf::new_p2tr(&secp, internal_key, None), // Change comes back to us.
     };
 
@@ -107,7 +107,7 @@ fn receivers_address() -> Address {
 ///
 /// An utxo is described by the `OutPoint` (txid and index within the transaction that it was
 /// created). Using the out point one can get the transaction by `txid` and using the `vout` get the
-/// transaction value and script pubkey (`TxOut`) of the utxo.
+/// transaction amount and script pubkey (`TxOut`) of the utxo.
 ///
 /// This output is locked to keys that we control, in a real application this would be a valid
 /// output taken from a transaction that appears in the chain.
@@ -123,7 +123,7 @@ fn dummy_unspent_transaction_output<C: Verification, K: Into<UntweakedPublicKey>
         vout: 0,
     };
 
-    let utxo = TxOut { value: DUMMY_UTXO_AMOUNT, script_pubkey };
+    let utxo = TxOut { amount: DUMMY_UTXO_AMOUNT, script_pubkey };
 
     (out_point, utxo)
 }

--- a/bitcoin/examples/taproot-psbt-simple.rs
+++ b/bitcoin/examples/taproot-psbt-simple.rs
@@ -119,7 +119,7 @@ fn dummy_unspent_transaction_outputs() -> Vec<(OutPoint, TxOut)> {
         vout: 0,
     };
 
-    let utxo_1 = TxOut { value: DUMMY_UTXO_AMOUNT_INPUT_1, script_pubkey: script_pubkey_1 };
+    let utxo_1 = TxOut { amount: DUMMY_UTXO_AMOUNT_INPUT_1, script_pubkey: script_pubkey_1 };
 
     let script_pubkey_2 = "bc1pfd0jmmdnp278vppcw68tkkmquxtq50xchy7f6wdmjtjm7fgsr8dszdcqce"
         .parse::<Address<_>>()
@@ -133,7 +133,7 @@ fn dummy_unspent_transaction_outputs() -> Vec<(OutPoint, TxOut)> {
         vout: 1,
     };
 
-    let utxo_2 = TxOut { value: DUMMY_UTXO_AMOUNT_INPUT_2, script_pubkey: script_pubkey_2 };
+    let utxo_2 = TxOut { amount: DUMMY_UTXO_AMOUNT_INPUT_2, script_pubkey: script_pubkey_2 };
     vec![(out_point_1, utxo_1), (out_point_2, utxo_2)]
 }
 
@@ -185,11 +185,11 @@ fn main() {
         .collect();
 
     // The spend output is locked to a key controlled by the receiver.
-    let spend = TxOut { value: SPEND_AMOUNT, script_pubkey: address.script_pubkey() };
+    let spend = TxOut { amount: SPEND_AMOUNT, script_pubkey: address.script_pubkey() };
 
     // The change output is locked to a key controlled by us.
     let change = TxOut {
-        value: CHANGE_AMOUNT,
+        amount: CHANGE_AMOUNT,
         script_pubkey: ScriptPubKeyBuf::new_p2tr(&secp, pk_change, None), // Change comes back to us.
     };
 

--- a/bitcoin/src/bip152.rs
+++ b/bitcoin/src/bip152.rs
@@ -475,7 +475,7 @@ mod test {
                 sequence: Sequence(1),
                 witness: Witness::new(),
             }],
-            outputs: vec![TxOut { value: Amount::ONE_SAT, script_pubkey: ScriptPubKeyBuf::new() }],
+            outputs: vec![TxOut { amount: Amount::ONE_SAT, script_pubkey: ScriptPubKeyBuf::new() }],
         }
     }
 

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -811,7 +811,7 @@ mod tests {
                 sequence: Sequence::ENABLE_LOCKTIME_AND_RBF,
                 witness: Witness::new(),
             }],
-            outputs: vec![TxOut { value: Amount::ONE_BTC, script_pubkey: ScriptPubKeyBuf::new() }],
+            outputs: vec![TxOut { amount: Amount::ONE_BTC, script_pubkey: ScriptPubKeyBuf::new() }],
         };
 
         let transactions = vec![non_coinbase_tx];
@@ -887,7 +887,7 @@ mod tests {
                 sequence: Sequence::ENABLE_LOCKTIME_AND_RBF,
                 witness: Witness::new(),
             }],
-            outputs: vec![TxOut { value: Amount::ONE_BTC, script_pubkey: ScriptPubKeyBuf::new() }],
+            outputs: vec![TxOut { amount: Amount::ONE_BTC, script_pubkey: ScriptPubKeyBuf::new() }],
         };
 
         let invalid_coinbase_result = Block::new_checked(header, vec![non_coinbase_tx]);

--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -112,7 +112,7 @@ fn bitcoin_genesis_tx(params: &Params) -> Transaction {
         witness: Witness::default(),
     });
 
-    ret.outputs.push(TxOut { value: Amount::FIFTY_BTC, script_pubkey: out_script });
+    ret.outputs.push(TxOut { amount: Amount::FIFTY_BTC, script_pubkey: out_script });
 
     // end
     ret
@@ -287,7 +287,7 @@ mod test {
         assert_eq!(gen.outputs.len(), 1);
         assert_eq!(serialize(&gen.outputs[0].script_pubkey),
                    hex!("434104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac"));
-        assert_eq!(gen.outputs[0].value, "50 BTC".parse::<Amount>().unwrap());
+        assert_eq!(gen.outputs[0].amount, "50 BTC".parse::<Amount>().unwrap());
         assert_eq!(gen.lock_time, absolute::LockTime::ZERO);
 
         assert_eq!(

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -186,10 +186,10 @@ internal_macros::define_extension_trait! {
         ///
         /// [`minimal_non_dust_custom`]: TxOut::minimal_non_dust_custom
         fn minimal_non_dust(script_pubkey: ScriptPubKeyBuf) -> TxOut {
-            TxOut { value: script_pubkey.minimal_non_dust(), script_pubkey }
+            TxOut { amount: script_pubkey.minimal_non_dust(), script_pubkey }
         }
 
-        /// Constructs a new `TxOut` with given script and the smallest possible `value` that is **not** dust
+        /// Constructs a new `TxOut` with given script and the smallest possible `amount` that is **not** dust
         /// per current Core policy.
         ///
         /// Dust depends on the -dustrelayfee value of the Bitcoin Core node you are broadcasting to.
@@ -201,7 +201,7 @@ internal_macros::define_extension_trait! {
         ///
         /// [`minimal_non_dust`]: TxOut::minimal_non_dust
         fn minimal_non_dust_custom(script_pubkey: ScriptPubKeyBuf, dust_relay_fee: FeeRate) -> Option<TxOut> {
-            Some(TxOut { value: script_pubkey.minimal_non_dust_custom(dust_relay_fee)?, script_pubkey })
+            Some(TxOut { amount: script_pubkey.minimal_non_dust_custom(dust_relay_fee)?, script_pubkey })
         }
     }
 }
@@ -642,7 +642,7 @@ impl Decodable for Version {
     }
 }
 
-crate::internal_macros::impl_consensus_encoding!(TxOut, value, script_pubkey);
+internal_macros::impl_consensus_encoding!(TxOut, amount, script_pubkey);
 
 impl Encodable for OutPoint {
     fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {

--- a/bitcoin/src/consensus_validation.rs
+++ b/bitcoin/src/consensus_validation.rs
@@ -106,7 +106,7 @@ where
             verify_script_with_flags(
                 &output.script_pubkey,
                 idx,
-                output.value,
+                output.amount,
                 serialized_tx.as_slice(),
                 flags,
             )?;

--- a/bitcoin/tests/bip_174.rs
+++ b/bitcoin/tests/bip_174.rs
@@ -182,13 +182,13 @@ fn create_transaction() -> Transaction {
         ],
         outputs: vec![
             TxOut {
-                value: Amount::from_str_in(output_0.amount, Denomination::Bitcoin)
+                amount: Amount::from_str_in(output_0.amount, Denomination::Bitcoin)
                     .expect("failed to parse amount"),
                 script_pubkey: ScriptPubKeyBuf::from_hex_no_length_prefix(output_0.script_pubkey)
                     .expect("failed to parse script"),
             },
             TxOut {
-                value: Amount::from_str_in(output_1.amount, Denomination::Bitcoin)
+                amount: Amount::from_str_in(output_1.amount, Denomination::Bitcoin)
                     .expect("failed to parse amount"),
                 script_pubkey: ScriptPubKeyBuf::from_hex_no_length_prefix(output_1.script_pubkey)
                     .expect("failed to parse script"),

--- a/bitcoin/tests/psbt-sign-taproot.rs
+++ b/bitcoin/tests/psbt-sign-taproot.rs
@@ -200,9 +200,9 @@ fn create_psbt_for_taproot_key_path_spend(
     to_address: Address,
     tree: TaprootSpendInfo,
 ) -> Psbt {
-    let send_value = 6400;
+    let send_amount = 6400;
     let out_puts = vec![TxOut {
-        value: Amount::from_sat(send_value).unwrap(),
+        amount: Amount::from_sat(send_amount).unwrap(),
         script_pubkey: to_address.script_pubkey(),
     }];
     let prev_tx_id = "06980ca116f74c7845a897461dd0e1d15b114130176de5004957da516b4dee3a";
@@ -236,11 +236,11 @@ fn create_psbt_for_taproot_key_path_spend(
         ),
     );
 
-    let utxo_value = 6588;
+    let utxo_amount = 6588;
     let mut input = Input {
         witness_utxo: {
             let script_pubkey = from_address.script_pubkey();
-            Some(TxOut { value: Amount::from_sat(utxo_value).unwrap(), script_pubkey })
+            Some(TxOut { amount: Amount::from_sat(utxo_amount).unwrap(), script_pubkey })
         },
         tap_key_origins: origins,
         ..Default::default()
@@ -276,12 +276,12 @@ fn create_psbt_for_taproot_script_path_spend<K: Into<XOnlyPublicKey>>(
     use_script: TapScriptBuf,
 ) -> Psbt {
     let x_only_pubkey_of_signing_key = x_only_pubkey_of_signing_key.into();
-    let utxo_value = 6280;
-    let send_value = 6000;
+    let utxo_amount = 6280;
+    let send_amount = 6000;
     let mfp = "73c5da0a";
 
     let out_puts = vec![TxOut {
-        value: Amount::from_sat(send_value).unwrap(),
+        amount: Amount::from_sat(send_amount).unwrap(),
         script_pubkey: to_address.script_pubkey(),
     }];
     let prev_tx_id = "9d7c6770fca57285babab60c51834cfcfd10ad302119cae842d7216b4ac9a376";
@@ -320,7 +320,7 @@ fn create_psbt_for_taproot_script_path_spend<K: Into<XOnlyPublicKey>>(
     let mut input = Input {
         witness_utxo: {
             let script_pubkey = from_address.script_pubkey();
-            Some(TxOut { value: Amount::from_sat(utxo_value).unwrap(), script_pubkey })
+            Some(TxOut { amount: Amount::from_sat(utxo_amount).unwrap(), script_pubkey })
         },
         tap_key_origins: origins,
         tap_scripts,

--- a/bitcoin/tests/serde.rs
+++ b/bitcoin/tests/serde.rs
@@ -215,7 +215,7 @@ fn serde_regression_psbt() {
             .unwrap()]),
         }],
         outputs: vec![TxOut {
-            value: Amount::from_sat(190_303_501_938).unwrap(),
+            amount: Amount::from_sat(190_303_501_938).unwrap(),
             script_pubkey: ScriptPubKeyBuf::from_hex_no_length_prefix(
                 "a914339725ba21efd62ac753a9bcd067d6c7a6a39d0587",
             )
@@ -265,7 +265,7 @@ fn serde_regression_psbt() {
         inputs: vec![Input {
             non_witness_utxo: Some(tx),
             witness_utxo: Some(TxOut {
-                value: Amount::from_sat(190_303_501_938).unwrap(),
+                amount: Amount::from_sat(190_303_501_938).unwrap(),
                 script_pubkey: ScriptPubKeyBuf::from_hex_no_length_prefix("a914339725ba21efd62ac753a9bcd067d6c7a6a39d0587").unwrap(),
             }),
             sighash_type: Some(PsbtSighashType::from("SIGHASH_SINGLE|SIGHASH_ANYONECANPAY".parse::<EcdsaSighashType>().unwrap())),

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -267,7 +267,7 @@ fn hash_transaction(tx: &Transaction, uses_segwit_serialization: bool) -> sha256
     enc.input(compact_size::encode(output_len).as_slice());
     for output in &tx.outputs {
         // Encode each output same as we do in `Encodable for TxOut`.
-        enc.input(&output.value.to_sat().to_le_bytes());
+        enc.input(&output.amount.to_sat().to_le_bytes());
 
         let script_pubkey_bytes = output.script_pubkey.as_bytes();
         enc.input(compact_size::encode(script_pubkey_bytes.len()).as_slice());
@@ -347,8 +347,8 @@ impl TxIn {
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 #[cfg(feature = "alloc")]
 pub struct TxOut {
-    /// The value of the output, in satoshis.
-    pub value: Amount,
+    /// The value of the output.
+    pub amount: Amount,
     /// The script which must be satisfied for the output to be spent.
     pub script_pubkey: ScriptPubKeyBuf,
 }
@@ -616,7 +616,7 @@ impl<'a> Arbitrary<'a> for TxIn {
 #[cfg(feature = "alloc")]
 impl<'a> Arbitrary<'a> for TxOut {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        Ok(TxOut { value: Amount::arbitrary(u)?, script_pubkey: ScriptPubKeyBuf::arbitrary(u)? })
+        Ok(TxOut { amount: Amount::arbitrary(u)?, script_pubkey: ScriptPubKeyBuf::arbitrary(u)? })
     }
 }
 
@@ -690,7 +690,7 @@ mod tests {
         };
 
         let txout = TxOut {
-            value: Amount::from_sat(123_456_789).unwrap(),
+            amount: Amount::from_sat(123_456_789).unwrap(),
             script_pubkey: ScriptPubKeyBuf::new(),
         };
 
@@ -704,9 +704,9 @@ mod tests {
         // Test changing the transaction
         let mut tx = tx_orig.clone();
         tx.inputs[0].previous_output.txid = Txid::from_byte_array([0xFF; 32]);
-        tx.outputs[0].value = Amount::from_sat(987_654_321).unwrap();
+        tx.outputs[0].amount = Amount::from_sat(987_654_321).unwrap();
         assert_eq!(tx.inputs[0].previous_output.txid.to_byte_array(), [0xFF; 32]);
-        assert_eq!(tx.outputs[0].value.to_sat(), 987_654_321);
+        assert_eq!(tx.outputs[0].amount.to_sat(), 987_654_321);
 
         // Test uses_segwit_serialization
         assert!(!tx.uses_segwit_serialization());


### PR DESCRIPTION
There is a draft naming BIP [0] and in it `amount` is favoured over `value`. Since we are attempting to do a 1.0 stable release now is the time to lock things like this.

Also consensus reached on this re-name in #1824

[0] https://github.com/murchandamus/bips/blob/2022-04-tx-terminology/bip-tx-terminology.mediawiki