### PR TITLE
Derive `Arbitrary` where appropriate

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -162,6 +162,7 @@ dependencies = [
 name = "bitcoin_hashes"
 version = "0.16.0"
 dependencies = [
+ "arbitrary",
  "bitcoin-internals",
  "hex-conservative 0.3.0",
  "serde",

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -7,6 +7,9 @@ name = "arbitrary"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "arrayvec"
@@ -204,6 +207,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,18 +299,18 @@ checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.63"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -400,7 +414,7 @@ checksum = "d7e29c4601e36bcec74a223228dce795f4cd3616341a4af93520ca1a837c087d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -428,6 +442,17 @@ name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -161,6 +161,7 @@ dependencies = [
 name = "bitcoin_hashes"
 version = "0.16.0"
 dependencies = [
+ "arbitrary",
  "bitcoin-internals",
  "hex-conservative 0.3.0",
  "serde",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -7,6 +7,9 @@ name = "arbitrary"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "arrayvec"
@@ -203,6 +206,17 @@ name = "chacha20-poly1305"
 version = "0.1.2"
 dependencies = [
  "hex-conservative 0.3.0",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -36,7 +36,7 @@ primitives = { package = "bitcoin-primitives", path = "../primitives", default-f
 secp256k1 = { version = "0.30.0", default-features = false, features = ["hashes", "alloc", "rand"] }
 units = { package = "bitcoin-units", path = "../units", default-features = false, features = ["alloc"] }
 
-arbitrary = { version = "1.4", optional = true }
+arbitrary = { version = "1.4", optional = true, features = ["derive"] }
 base64 = { version = "0.22.0", optional = true, default-features = false, features = ["alloc"] }
 # `bitcoinconsensus` version includes metadata which indicates the version of Core. Use `cargo tree` to see it.
 bitcoinconsensus = { version = "0.106.0", default-features = false, optional = true }

--- a/bitcoin/src/bip152.rs
+++ b/bitcoin/src/bip152.rs
@@ -10,7 +10,7 @@ use core::{convert, fmt, mem};
 use std::error;
 
 #[cfg(feature = "arbitrary")]
-use arbitrary::{Arbitrary, Unstructured};
+use arbitrary::{Arbitrary};
 use hashes::{sha256, siphash24};
 use internals::array::ArrayExt as _;
 use internals::ToU64 as _;
@@ -61,6 +61,7 @@ impl std::error::Error for Error {
 /// A [`PrefilledTransaction`] structure is used in [`HeaderAndShortIds`] to
 /// provide a list of a few transactions explicitly.
 #[derive(PartialEq, Eq, Clone, Debug, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct PrefilledTransaction {
     /// The index of the transaction in the block.
     ///
@@ -102,6 +103,7 @@ impl Decodable for PrefilledTransaction {
 
 /// Short transaction IDs are used to represent a transaction without sending a full 256-bit hash.
 #[derive(PartialEq, Eq, Clone, Copy, Hash, Default, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct ShortId([u8; 6]);
 impl_array_newtype!(ShortId, u8, 6);
 impl_array_newtype_stringify!(ShortId, 6);
@@ -158,6 +160,7 @@ impl Decodable for ShortId {
 /// transactions IDs used for matching already-available transactions, and a
 /// select few transactions which we expect a peer may be missing.
 #[derive(PartialEq, Eq, Clone, Debug, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct HeaderAndShortIds {
     /// The header of the block being provided.
     pub header: block::Header,
@@ -281,6 +284,7 @@ impl HeaderAndShortIds {
 /// A [`BlockTransactionsRequest`] structure is used to list transaction indexes
 /// in a block being requested.
 #[derive(PartialEq, Eq, Clone, Debug, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct BlockTransactionsRequest {
     ///  The blockhash of the block which the transactions being requested are in.
     pub block_hash: BlockHash,
@@ -375,6 +379,7 @@ impl error::Error for TxIndexOutOfRangeError {
 /// A [`BlockTransactions`] structure is used to provide some of the transactions
 /// in a block, as requested.
 #[derive(PartialEq, Eq, Clone, Debug, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct BlockTransactions {
     ///  The blockhash of the block which the transactions being provided are in.
     pub block_hash: BlockHash,
@@ -402,52 +407,6 @@ impl BlockTransactions {
                 }
                 txs
             },
-        })
-    }
-}
-
-#[cfg(feature = "arbitrary")]
-impl<'a> Arbitrary<'a> for ShortId {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        Ok(ShortId(u.arbitrary()?))
-    }
-}
-
-#[cfg(feature = "arbitrary")]
-impl<'a> Arbitrary<'a> for PrefilledTransaction {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        Ok(PrefilledTransaction { idx: u.arbitrary()?, tx: u.arbitrary()? })
-    }
-}
-
-#[cfg(feature = "arbitrary")]
-impl<'a> Arbitrary<'a> for HeaderAndShortIds {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        Ok(HeaderAndShortIds {
-            header: u.arbitrary()?,
-            nonce: u.arbitrary()?,
-            short_ids: Vec::<ShortId>::arbitrary(u)?,
-            prefilled_txs: Vec::<PrefilledTransaction>::arbitrary(u)?,
-        })
-    }
-}
-
-#[cfg(feature = "arbitrary")]
-impl<'a> Arbitrary<'a> for BlockTransactions {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        Ok(BlockTransactions {
-            block_hash: u.arbitrary()?,
-            transactions: Vec::<Transaction>::arbitrary(u)?,
-        })
-    }
-}
-
-#[cfg(feature = "arbitrary")]
-impl<'a> Arbitrary<'a> for BlockTransactionsRequest {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        Ok(BlockTransactionsRequest {
-            block_hash: u.arbitrary()?,
-            indexes: Vec::<u64>::arbitrary(u)?,
         })
     }
 }

--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -42,7 +42,7 @@ use core::convert::Infallible;
 use core::fmt;
 
 #[cfg(feature = "arbitrary")]
-use arbitrary::{Arbitrary, Unstructured};
+use arbitrary::{Arbitrary};
 use hashes::{sha256d, siphash24, HashEngine as _};
 use internals::array::ArrayExt as _;
 use internals::{write_err, ToU64 as _};
@@ -61,8 +61,10 @@ const M: u64 = 784931;
 
 hashes::hash_newtype! {
     /// Filter hash, as defined in BIP-157.
+    #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
     pub struct FilterHash(sha256d::Hash);
     /// Filter header, as defined in BIP-157.
+    #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
     pub struct FilterHeader(sha256d::Hash);
 }
 
@@ -573,20 +575,6 @@ impl<'a, W: Write> BitStreamWriter<'a, W> {
         } else {
             Ok(0)
         }
-    }
-}
-
-#[cfg(feature = "arbitrary")]
-impl<'a> Arbitrary<'a> for FilterHash {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        Ok(FilterHash::from_byte_array(u.arbitrary()?))
-    }
-}
-
-#[cfg(feature = "arbitrary")]
-impl<'a> Arbitrary<'a> for FilterHeader {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        Ok(FilterHeader::from_byte_array(u.arbitrary()?))
     }
 }
 

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -15,7 +15,7 @@ use core::convert::Infallible;
 use core::{fmt, str};
 
 #[cfg(feature = "arbitrary")]
-use arbitrary::{Arbitrary, Unstructured};
+use arbitrary::{Arbitrary};
 use hashes::{hash_newtype, sha256, sha256d, sha256t, sha256t_tag};
 use internals::write_err;
 use io::Write;
@@ -167,6 +167,7 @@ pub struct ScriptPath<'s> {
 /// Hashtype of an input's signature, encoded in the last byte of the signature.
 /// Fixed values so they can be cast as integer types for encoding.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub enum TapSighashType {
     /// 0x0: Used when not explicitly specified, defaults to [`TapSighashType::All`]
     Default = 0x00,
@@ -360,6 +361,7 @@ impl<'s> From<ScriptPath<'s>> for TapLeafHash {
 /// Fixed values so they can be cast as integer types for encoding (see also
 /// [`TapSighashType`]).
 #[derive(PartialEq, Eq, Debug, Copy, Clone, Hash)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub enum EcdsaSighashType {
     /// 0x1: Sign all outputs.
     All = 0x01,
@@ -1494,37 +1496,6 @@ impl<E: std::error::Error + 'static> std::error::Error for SigningDataError<E> {
         match self {
             SigningDataError::Io(error) => Some(error),
             SigningDataError::Sighash(error) => Some(error),
-        }
-    }
-}
-
-#[cfg(feature = "arbitrary")]
-impl<'a> Arbitrary<'a> for EcdsaSighashType {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let choice = u.int_in_range(0..=5)?;
-        match choice {
-            0 => Ok(EcdsaSighashType::All),
-            1 => Ok(EcdsaSighashType::None),
-            2 => Ok(EcdsaSighashType::Single),
-            3 => Ok(EcdsaSighashType::AllPlusAnyoneCanPay),
-            4 => Ok(EcdsaSighashType::NonePlusAnyoneCanPay),
-            _ => Ok(EcdsaSighashType::SinglePlusAnyoneCanPay),
-        }
-    }
-}
-
-#[cfg(feature = "arbitrary")]
-impl<'a> Arbitrary<'a> for TapSighashType {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let choice = u.int_in_range(0..=6)?;
-        match choice {
-            0 => Ok(TapSighashType::Default),
-            1 => Ok(TapSighashType::All),
-            2 => Ok(TapSighashType::None),
-            3 => Ok(TapSighashType::Single),
-            4 => Ok(TapSighashType::AllPlusAnyoneCanPay),
-            5 => Ok(TapSighashType::NonePlusAnyoneCanPay),
-            _ => Ok(TapSighashType::SinglePlusAnyoneCanPay),
         }
     }
 }

--- a/bitcoin/src/merkle_tree/block.rs
+++ b/bitcoin/src/merkle_tree/block.rs
@@ -13,7 +13,7 @@ use core::convert::Infallible;
 use core::fmt;
 
 #[cfg(feature = "arbitrary")]
-use arbitrary::{Arbitrary, Unstructured};
+use arbitrary::{Arbitrary};
 use internals::ToU64 as _;
 use io::{BufRead, Write};
 
@@ -30,6 +30,7 @@ use crate::Weight;
 /// NOTE: This assumes that the given Block has *at least* 1 transaction. If the Block has 0 txs,
 /// it will hit an assertion.
 #[derive(PartialEq, Eq, Clone, Debug)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct MerkleBlock {
     /// The block header
     pub header: block::Header,
@@ -171,6 +172,7 @@ impl Decodable for MerkleBlock {
 ///
 /// The size constraints follow from this.
 #[derive(PartialEq, Eq, Clone, Debug)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct PartialMerkleTree {
     /// The total number of transactions in the block
     num_transactions: u32,
@@ -509,24 +511,6 @@ impl std::error::Error for MerkleBlockError {
             | NotEnoughBits | NotAllBitsConsumed | NotAllHashesConsumed | BitsArrayOverflow
             | HashesArrayOverflow | IdenticalHashesFound => None,
         }
-    }
-}
-
-#[cfg(feature = "arbitrary")]
-impl<'a> Arbitrary<'a> for PartialMerkleTree {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        Ok(PartialMerkleTree {
-            num_transactions: u.arbitrary()?,
-            bits: Vec::<bool>::arbitrary(u)?,
-            hashes: Vec::<TxMerkleNode>::arbitrary(u)?,
-        })
-    }
-}
-
-#[cfg(feature = "arbitrary")]
-impl<'a> Arbitrary<'a> for MerkleBlock {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        Ok(MerkleBlock { header: u.arbitrary()?, txn: u.arbitrary()? })
     }
 }
 

--- a/bitcoin/src/psbt/raw.rs
+++ b/bitcoin/src/psbt/raw.rs
@@ -8,7 +8,7 @@
 use core::fmt;
 
 #[cfg(feature = "arbitrary")]
-use arbitrary::{Arbitrary, Unstructured};
+use arbitrary::{Arbitrary};
 use internals::ToU64 as _;
 use io::{BufRead, Write};
 
@@ -23,6 +23,7 @@ use crate::psbt::Error;
 ///
 /// `<key> := <keylen> <keytype> <keydata>`
 #[derive(Debug, PartialEq, Hash, Eq, Clone, Ord, PartialOrd)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct Key {
     /// The type of this PSBT key.
     pub type_value: u64, // Encoded as a compact size.
@@ -33,6 +34,7 @@ pub struct Key {
 /// A PSBT key-value pair in its raw byte form.
 /// `<keypair> := <key> <value>`
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct Pair {
     /// The key of this key-value pair.
     pub key: Key,
@@ -47,6 +49,7 @@ pub type ProprietaryType = u64;
 /// Proprietary keys (i.e. keys starting with 0xFC byte) with their internal
 /// structure according to BIP 174.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct ProprietaryKey<Subtype = ProprietaryType>
 where
     Subtype: Copy + From<u64> + Into<u64>,
@@ -188,23 +191,5 @@ where
         }
 
         Ok(deserialize(&key.key_data)?)
-    }
-}
-
-#[cfg(feature = "arbitrary")]
-impl<'a> Arbitrary<'a> for ProprietaryKey {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        Ok(ProprietaryKey {
-            prefix: Vec::<u8>::arbitrary(u)?,
-            subtype: u64::arbitrary(u)?,
-            key: Vec::<u8>::arbitrary(u)?,
-        })
-    }
-}
-
-#[cfg(feature = "arbitrary")]
-impl<'a> Arbitrary<'a> for Key {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        Ok(Key { type_value: u.arbitrary()?, key_data: Vec::<u8>::arbitrary(u)? })
     }
 }

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -17,6 +17,7 @@ exclude = ["tests", "contrib"]
 default = ["std"]
 std = ["alloc", "hex?/std"]
 alloc = ["hex?/alloc"]
+arbitrary = ["dep:arbitrary"]
 serde = ["dep:serde", "hex"]
 # Smaller (but slower) implementation of sha256, sha512 and ripemd160
 small-hash = []
@@ -25,6 +26,7 @@ small-hash = []
 internals = { package = "bitcoin-internals", path = "../internals" }
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false, optional = true }
 serde = { version = "1.0.103", default-features = false, optional = true }
+arbitrary = { version = "1.4", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 serde_test = "1.0"

--- a/hashes/contrib/test_vars.sh
+++ b/hashes/contrib/test_vars.sh
@@ -5,10 +5,10 @@
 # shellcheck disable=SC2034
 
 # Test all these features with "std" enabled.
-FEATURES_WITH_STD="serde small-hash"
+FEATURES_WITH_STD="arbitrary serde small-hash"
 
 # Test all these features without "std" enabled.
-FEATURES_WITHOUT_STD="alloc serde small-hash"
+FEATURES_WITHOUT_STD="arbitrary alloc serde small-hash"
 
 # Run these examples.
 EXAMPLES=""

--- a/hashes/src/sha256d/mod.rs
+++ b/hashes/src/sha256d/mod.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: CC0-1.0
 
 //! SHA256d implementation (double SHA256).
+//!
+#[cfg(feature = "arbitrary")]
+use arbitrary::{Arbitrary, Unstructured};
 
 use crate::sha256;
 
@@ -43,6 +46,13 @@ impl crate::HashEngine for HashEngine {
     fn input(&mut self, data: &[u8]) { self.0.input(data) }
     fn n_bytes_hashed(&self) -> u64 { self.0.n_bytes_hashed() }
     fn finalize(self) -> Self::Hash { Hash::from_engine(self) }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> Arbitrary<'a> for Hash {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Hash::from_byte_array(u.arbitrary()?))
+    }
 }
 
 #[cfg(test)]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -19,7 +19,7 @@ default = ["std", "hex"]
 std = ["alloc", "hashes/std", "hex?/std", "internals/std", "units/std", "arrayvec/std"]
 alloc = ["hashes/alloc", "hex?/alloc", "internals/alloc", "units/alloc"]
 serde = ["dep:serde", "hashes/serde", "hex?/serde", "internals/serde", "units/serde", "alloc", "hex"]
-arbitrary = ["dep:arbitrary", "units/arbitrary"]
+arbitrary = ["dep:arbitrary", "units/arbitrary", "hashes/arbitrary"]
 hex = ["dep:hex", "hashes/hex", "internals/hex"]
 
 [dependencies]
@@ -28,7 +28,7 @@ internals = { package = "bitcoin-internals", path = "../internals" }
 units = { package = "bitcoin-units", path = "../units", default-features = false }
 arrayvec = { version = "0.7", default-features = false }
 
-arbitrary = { version = "1.4", optional = true }
+arbitrary = { version = "1.4", optional = true, features = ["derive"] }
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false, optional = true }
 serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"], optional = true }
 

--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -172,6 +172,7 @@ mod sealed {
 /// * [CBlockHeader definition](https://github.com/bitcoin/bitcoin/blob/345457b542b6a980ccfbc868af0970a6f91d1b82/src/primitives/block.h#L20)
 #[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct Header {
     /// Block version, now repurposed for soft fork signalling.
     pub version: Version,
@@ -327,8 +328,10 @@ impl Default for Version {
 
 hashes::hash_newtype! {
     /// A bitcoin block hash.
+    #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
     pub struct BlockHash(sha256d::Hash);
     /// A hash corresponding to the witness structure commitment in the coinbase transaction.
+    #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
     pub struct WitnessCommitment(sha256d::Hash);
 }
 
@@ -351,27 +354,6 @@ impl<'a> Arbitrary<'a> for Block {
         let header = Header::arbitrary(u)?;
         let transactions = Vec::<Transaction>::arbitrary(u)?;
         Ok(Block::new_unchecked(header, transactions))
-    }
-}
-
-#[cfg(feature = "arbitrary")]
-impl<'a> Arbitrary<'a> for BlockHash {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        Ok(BlockHash::from_byte_array(u.arbitrary()?))
-    }
-}
-
-#[cfg(feature = "arbitrary")]
-impl<'a> Arbitrary<'a> for Header {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        Ok(Header {
-            version: Version::arbitrary(u)?,
-            prev_blockhash: BlockHash::from_byte_array(u.arbitrary()?),
-            merkle_root: TxMerkleNode::from_byte_array(u.arbitrary()?),
-            time: u.arbitrary()?,
-            bits: CompactTarget::from_consensus(u.arbitrary()?),
-            nonce: u.arbitrary()?,
-        })
     }
 }
 

--- a/primitives/src/merkle_tree.rs
+++ b/primitives/src/merkle_tree.rs
@@ -3,13 +3,15 @@
 //! Bitcoin Merkle tree functions.
 
 #[cfg(feature = "arbitrary")]
-use arbitrary::{Arbitrary, Unstructured};
+use arbitrary::{Arbitrary};
 use hashes::sha256d;
 
 hashes::hash_newtype! {
     /// A hash of the Merkle tree branch or root for transactions.
+    #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
     pub struct TxMerkleNode(sha256d::Hash);
     /// A hash corresponding to the Merkle tree root for witness data.
+    #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
     pub struct WitnessMerkleNode(sha256d::Hash);
 }
 
@@ -19,10 +21,3 @@ hashes::impl_hex_for_newtype!(TxMerkleNode, WitnessMerkleNode);
 hashes::impl_debug_only_for_newtype!(TxMerkleNode, WitnessMerkleNode);
 #[cfg(feature = "serde")]
 hashes::impl_serde_for_newtype!(TxMerkleNode, WitnessMerkleNode);
-
-#[cfg(feature = "arbitrary")]
-impl<'a> Arbitrary<'a> for TxMerkleNode {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        Ok(TxMerkleNode::from_byte_array(u.arbitrary()?))
-    }
-}

--- a/primitives/src/pow.rs
+++ b/primitives/src/pow.rs
@@ -3,6 +3,8 @@
 //! Proof-of-work related integer types.
 
 use core::fmt;
+#[cfg(feature = "arbitrary")]
+use arbitrary::Arbitrary;
 
 /// Encoding of 256-bit target as 32-bit float.
 ///
@@ -20,6 +22,7 @@ use core::fmt;
 /// terms of the underlying `u32`.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct CompactTarget(u32);
 
 impl CompactTarget {

--- a/primitives/src/script/owned.rs
+++ b/primitives/src/script/owned.rs
@@ -3,7 +3,7 @@
 use core::ops::{Deref, DerefMut};
 
 #[cfg(feature = "arbitrary")]
-use arbitrary::{Arbitrary, Unstructured};
+use arbitrary::{Arbitrary};
 
 use super::Script;
 use crate::prelude::{Box, Vec};
@@ -27,6 +27,7 @@ use crate::prelude::{Box, Vec};
 /// [`examples/script.rs`]: <https://github.com/rust-bitcoin/rust-bitcoin/blob/master/bitcoin/examples/script.rs>
 /// [deref coercions]: https://doc.rust-lang.org/std/ops/trait.Deref.html#more-on-deref-coercion
 #[derive(Default, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct ScriptBuf(Vec<u8>);
 
 impl ScriptBuf {
@@ -135,15 +136,6 @@ impl Deref for ScriptBuf {
 impl DerefMut for ScriptBuf {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target { self.as_mut_script() }
-}
-
-#[cfg(feature = "arbitrary")]
-impl<'a> Arbitrary<'a> for ScriptBuf {
-    #[inline]
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let v = Vec::<u8>::arbitrary(u)?;
-        Ok(ScriptBuf::from_bytes(v))
-    }
 }
 
 #[cfg(test)]

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -21,7 +21,7 @@ alloc = ["internals/alloc","serde?/alloc"]
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.4.0" }
 
 serde = { version = "1.0.103", default-features = false, features = ["derive"], optional = true }
-arbitrary = { version = "1.4", optional = true }
+arbitrary = { version = "1.4",  default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.4.0", features = ["test-serde"] }

--- a/units/src/locktime/absolute/mod.rs
+++ b/units/src/locktime/absolute/mod.rs
@@ -73,6 +73,7 @@ pub const LOCK_TIME_THRESHOLD: u32 = 500_000_000;
 /// };
 /// ```
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub enum LockTime {
     /// A block height lock time value.
     ///
@@ -693,14 +694,6 @@ pub const fn is_block_height(n: u32) -> bool { n < LOCK_TIME_THRESHOLD }
 
 /// Returns true if `n` is a UNIX timestamp i.e., greater than or equal to 500,000,000.
 pub const fn is_block_time(n: u32) -> bool { n >= LOCK_TIME_THRESHOLD }
-
-#[cfg(feature = "arbitrary")]
-impl<'a> Arbitrary<'a> for LockTime {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let l = u32::arbitrary(u)?;
-        Ok(LockTime::from_consensus(l))
-    }
-}
 
 #[cfg(feature = "arbitrary")]
 impl<'a> Arbitrary<'a> for Height {

--- a/units/src/time.rs
+++ b/units/src/time.rs
@@ -7,12 +7,13 @@
 //! This differs from other UNIX timestamps in that we only use non-negative values. The Epoch
 //! pre-dates Bitcoin so timestamps before this are not useful for block timestamps.
 
-#[cfg(feature = "arbitrary")]
-use arbitrary::{Arbitrary, Unstructured};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 mod encapsulate {
+    #[cfg(feature = "arbitrary")]
+    use arbitrary::Arbitrary;
+
     /// A Bitcoin block timestamp.
     ///
     /// > Each block contains a Unix time timestamp. In addition to serving as a source of variation for
@@ -26,6 +27,7 @@ mod encapsulate {
     ///
     /// ref: <https://en.bitcoin.it/wiki/Block_timestamp>
     #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
     pub struct BlockTime(u32);
 
     impl BlockTime {
@@ -70,15 +72,6 @@ impl<'de> Deserialize<'de> for BlockTime {
         D: Deserializer<'de>,
     {
         Ok(Self::from_u32(u32::deserialize(d)?))
-    }
-}
-
-#[cfg(feature = "arbitrary")]
-impl<'a> Arbitrary<'a> for BlockTime {
-    #[inline]
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let t: u32 = u.arbitrary()?;
-        Ok(BlockTime::from(t))
     }
 }
 

--- a/units/src/weight.rs
+++ b/units/src/weight.rs
@@ -5,8 +5,6 @@
 use core::num::NonZeroU64;
 use core::{fmt, ops};
 
-#[cfg(feature = "arbitrary")]
-use arbitrary::{Arbitrary, Unstructured};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -16,11 +14,15 @@ use crate::{Amount, FeeRate, NumOpResult};
 pub const WITNESS_SCALE_FACTOR: usize = 4;
 
 mod encapsulate {
+    #[cfg(feature = "arbitrary")]
+    use arbitrary::Arbitrary;
+
     /// The weight of a transaction or block.
     ///
     /// This is an integer newtype representing weight in weight units. It provides protection
     /// against mixing up the types, conversion functions, and basic formatting.
     #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+    #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
     pub struct Weight(u64);
 
     impl Weight {
@@ -290,14 +292,6 @@ impl<'de> Deserialize<'de> for Weight {
         D: Deserializer<'de>,
     {
         Ok(Self::from_wu(u64::deserialize(d)?))
-    }
-}
-
-#[cfg(feature = "arbitrary")]
-impl<'a> Arbitrary<'a> for Weight {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let w = u64::arbitrary(u)?;
-        Ok(Weight::from_wu(w))
     }
 }
 


### PR DESCRIPTION
I missed the fact that `Arbitrary` [can be derived](https://github.com/rust-fuzz/arbitrary/tree/main?tab=readme-ov-file#automatically-deriving-arbitrary) and is the recommended way to implement it, so I went through the implementations and derived what I thought made sense. Deriving these implementations should remove some unnecessary code and avoid clutter. 

There were some cases where it made sense to implement it manually, and I left these implementations alone:
 - Implementations where we specifically choose interesting values and weight them equally to an arbitrary value e.g. MIN and MAX values for `MedianTimePast` and `Height`
 - Implementations where we want values within a certain range e.g. `Amount` between `Amount::MIN` and `Amount::MAX`. There is a way to derive with a range, but for more complex logic like arbitrary `bitcoin::crypto::ecdsa::Signature`s, that's best done manually
 - Implementations where a constructor should be used instead of struct literal initialization e.g. `Witness`
 - Implementations for enums for which there are variants that should be ignored e.g. ignoring `_DoNotUse` in `MathOp`

