### PR TITLE
Refactor how we call private macros

### DIFF
--- a/bitcoin/src/bip152.rs
+++ b/bitcoin/src/bip152.rs
@@ -18,7 +18,7 @@ use io::{BufRead, Write};
 
 use crate::consensus::encode::{self, Decodable, Encodable, ReadExt, WriteExt};
 use crate::internal_macros::{
-    impl_array_newtype, impl_array_newtype_stringify, impl_consensus_encoding,
+    self, impl_array_newtype, impl_array_newtype_stringify,
 };
 use crate::prelude::Vec;
 use crate::transaction::TxIdentifier;
@@ -381,7 +381,7 @@ pub struct BlockTransactions {
     ///  The transactions provided.
     pub transactions: Vec<Transaction>,
 }
-impl_consensus_encoding!(BlockTransactions, block_hash, transactions);
+internal_macros::impl_consensus_encoding!(BlockTransactions, block_hash, transactions);
 
 impl BlockTransactions {
     /// Constructs a new [`BlockTransactions`] from a [`BlockTransactionsRequest`] and

--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -50,10 +50,10 @@ use io::{BufRead, Write};
 
 use crate::block::{Block, BlockHash, Checked};
 use crate::consensus::{ReadExt, WriteExt};
-use crate::internal_macros::impl_hashencode;
 use crate::prelude::{BTreeSet, Borrow, Vec};
 use crate::script::{Script, ScriptExt as _};
 use crate::transaction::OutPoint;
+use crate::internal_macros;
 
 /// Golomb encoding parameter as in BIP-158, see also https://gist.github.com/sipa/576d5f09c3b86c3b1b75598d799fc845
 const P: u8 = 19;
@@ -70,8 +70,8 @@ hashes::impl_hex_for_newtype!(FilterHash, FilterHeader);
 #[cfg(feature = "serde")]
 hashes::impl_serde_for_newtype!(FilterHash, FilterHeader);
 
-impl_hashencode!(FilterHash);
-impl_hashencode!(FilterHeader);
+internal_macros::impl_hashencode!(FilterHash);
+internal_macros::impl_hashencode!(FilterHeader);
 
 /// Errors for blockfilter.
 #[derive(Debug)]

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -16,9 +16,9 @@ use internals::write_err;
 use secp256k1::Secp256k1;
 
 use crate::crypto::key::{CompressedPublicKey, Keypair, PrivateKey, XOnlyPublicKey};
-use crate::internal_macros::{impl_array_newtype, impl_array_newtype_stringify};
 use crate::network::NetworkKind;
 use crate::prelude::{String, Vec};
+use crate::internal_macros;
 
 /// Version bytes for extended public keys on the Bitcoin network.
 const VERSION_BYTES_MAINNET_PUBLIC: [u8; 4] = [0x04, 0x88, 0xB2, 0x1E];
@@ -40,8 +40,8 @@ pub type ExtendedPrivKey = Xpriv;
 /// A chain code
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChainCode([u8; 32]);
-impl_array_newtype!(ChainCode, u8, 32);
-impl_array_newtype_stringify!(ChainCode, 32);
+internal_macros::impl_array_newtype!(ChainCode, u8, 32);
+internal_macros::impl_array_newtype_stringify!(ChainCode, 32);
 
 impl ChainCode {
     fn from_hmac(hmac: Hmac<sha512::Hash>) -> Self {
@@ -52,8 +52,8 @@ impl ChainCode {
 /// A fingerprint
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct Fingerprint([u8; 4]);
-impl_array_newtype!(Fingerprint, u8, 4);
-impl_array_newtype_stringify!(Fingerprint, 4);
+internal_macros::impl_array_newtype!(Fingerprint, u8, 4);
+internal_macros::impl_array_newtype_stringify!(Fingerprint, 4);
 
 hash_newtype! {
     /// Extended key identifier as defined in BIP-32.

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -19,13 +19,13 @@ use super::transaction::Coinbase;
 use super::Weight;
 use crate::consensus::encode::WriteExt as _;
 use crate::consensus::{encode, Decodable, Encodable};
-use crate::internal_macros::{impl_consensus_encoding, impl_hashencode};
 use crate::merkle_tree::{MerkleNode as _, TxMerkleNode, WitnessMerkleNode};
 use crate::network::Params;
 use crate::pow::{Target, Work};
 use crate::prelude::Vec;
 use crate::script::{self, ScriptExt as _};
 use crate::transaction::{Transaction, TransactionExt as _, Wtxid};
+use crate::internal_macros;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
@@ -37,9 +37,9 @@ pub use units::block::{BlockHeight, BlockHeightInterval, TooBigForRelativeHeight
 #[doc(hidden)]
 pub type BlockInterval = BlockHeightInterval;
 
-impl_hashencode!(BlockHash);
+internal_macros::impl_hashencode!(BlockHash);
 
-impl_consensus_encoding!(Header, version, prev_blockhash, merkle_root, time, bits, nonce);
+internal_macros::impl_consensus_encoding!(Header, version, prev_blockhash, merkle_root, time, bits, nonce);
 
 crate::internal_macros::define_extension_trait! {
     /// Extension functionality for the [`Header`] type.

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -41,7 +41,7 @@ internal_macros::impl_hashencode!(BlockHash);
 
 internal_macros::impl_consensus_encoding!(Header, version, prev_blockhash, merkle_root, time, bits, nonce);
 
-crate::internal_macros::define_extension_trait! {
+internal_macros::define_extension_trait! {
     /// Extension functionality for the [`Header`] type.
     pub trait HeaderExt impl for Header {
         /// Computes the target (range [0, T] inclusive) that a blockhash must land in to be valid.

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -20,9 +20,9 @@ use crate::policy::{DUST_RELAY_TX_FEE, MAX_OP_RETURN_RELAY};
 use crate::prelude::{sink, String, ToString};
 use crate::script::{self, ScriptBufExt as _};
 use crate::taproot::{LeafVersion, TapLeafHash, TapNodeHash};
-use crate::{Amount, FeeRate, ScriptBuf};
+use crate::{internal_macros, Amount, FeeRate, ScriptBuf};
 
-crate::internal_macros::define_extension_trait! {
+internal_macros::define_extension_trait! {
     /// Extension functionality for the [`Script`] type.
     pub trait ScriptExt impl for Script {
         /// Returns an iterator over script bytes.
@@ -459,7 +459,7 @@ mod sealed {
     impl Sealed for super::Script {}
 }
 
-crate::internal_macros::define_extension_trait! {
+internal_macros::define_extension_trait! {
     pub(crate) trait ScriptExtPriv impl for Script {
         /// Returns the bytes of the (possibly invalid) public key if this script is P2PK.
         fn p2pk_pubkey_bytes(&self) -> Option<&[u8]> {

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -19,8 +19,9 @@ use crate::script::witness_program::{WitnessProgram, P2A_PROGRAM};
 use crate::script::witness_version::WitnessVersion;
 use crate::script::{self, ScriptHash, WScriptHash};
 use crate::taproot::TapNodeHash;
+use crate::internal_macros;
 
-crate::internal_macros::define_extension_trait! {
+internal_macros::define_extension_trait! {
     /// Extension functionality for the [`ScriptBuf`] type.
     pub trait ScriptBufExt impl for ScriptBuf {
         /// Constructs a new script builder
@@ -195,7 +196,7 @@ mod sealed {
     impl Sealed for super::ScriptBuf {}
 }
 
-crate::internal_macros::define_extension_trait! {
+internal_macros::define_extension_trait! {
     pub(crate) trait ScriptBufExtPriv impl for ScriptBuf {
         /// Pretends to convert `&mut ScriptBuf` to `&mut Vec<u8>` so that it can be modified.
         ///

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -36,7 +36,7 @@ pub use primitives::transaction::{OutPoint, ParseOutPointError, Transaction, Txi
 internal_macros::impl_hashencode!(Txid);
 internal_macros::impl_hashencode!(Wtxid);
 
-crate::internal_macros::define_extension_trait! {
+internal_macros::define_extension_trait! {
     /// Extension functionality for the [`Txid`] type.
     pub trait TxidExt impl for Txid {
         /// The "all zeros" TXID.
@@ -45,7 +45,7 @@ crate::internal_macros::define_extension_trait! {
     }
 }
 
-crate::internal_macros::define_extension_trait! {
+internal_macros::define_extension_trait! {
     /// Extension functionality for the [`Wtxid`] type.
     pub trait WtxidExt impl for Wtxid {
         /// The "all zeros" wTXID.
@@ -66,7 +66,7 @@ const SEGWIT_MARKER: u8 = 0x00;
 /// The flag MUST be a 1-byte non-zero value. Currently, 0x01 MUST be used. (BIP-141)
 const SEGWIT_FLAG: u8 = 0x01;
 
-crate::internal_macros::define_extension_trait! {
+internal_macros::define_extension_trait! {
     /// Extension functionality for the [`OutPoint`] type.
     pub trait OutPointExt impl for OutPoint {
         /// Constructs a new [`OutPoint`].
@@ -89,7 +89,7 @@ crate::internal_macros::define_extension_trait! {
 const TX_IN_BASE_WEIGHT: Weight =
     Weight::from_vb_unchecked(OutPoint::SIZE as u64 + Sequence::SIZE as u64);
 
-crate::internal_macros::define_extension_trait! {
+internal_macros::define_extension_trait! {
     /// Extension functionality for the [`TxIn`] type.
     pub trait TxInExt impl for TxIn {
         /// Returns true if this input enables the [`absolute::LockTime`] (aka `nLockTime`) of its
@@ -151,7 +151,7 @@ crate::internal_macros::define_extension_trait! {
     }
 }
 
-crate::internal_macros::define_extension_trait! {
+internal_macros::define_extension_trait! {
     /// Extension functionality for the [`TxOut`] type.
     pub trait TxOutExt impl for TxOut {
         /// The weight of this output.

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -21,21 +21,20 @@ use primitives::Sequence;
 
 use super::Weight;
 use crate::consensus::{self, encode, Decodable, Encodable};
-use crate::internal_macros::{impl_consensus_encoding, impl_hashencode};
 use crate::locktime::absolute::{self, Height, MedianTimePast};
 use crate::prelude::{Borrow, Vec};
 use crate::script::{Script, ScriptBuf, ScriptExt as _, ScriptExtPriv as _};
 #[cfg(doc)]
 use crate::sighash::{EcdsaSighashType, TapSighashType};
 use crate::witness::Witness;
-use crate::{Amount, FeeRate, SignedAmount};
+use crate::{internal_macros, Amount, FeeRate, SignedAmount};
 
 #[rustfmt::skip]            // Keep public re-exports separate.
 #[doc(inline)]
 pub use primitives::transaction::{OutPoint, ParseOutPointError, Transaction, Txid, Wtxid, Version, TxIn, TxOut};
 
-impl_hashencode!(Txid);
-impl_hashencode!(Wtxid);
+internal_macros::impl_hashencode!(Txid);
+internal_macros::impl_hashencode!(Wtxid);
 
 crate::internal_macros::define_extension_trait! {
     /// Extension functionality for the [`Txid`] type.
@@ -637,7 +636,7 @@ impl Decodable for Version {
     }
 }
 
-impl_consensus_encoding!(TxOut, value, script_pubkey);
+crate::internal_macros::impl_consensus_encoding!(TxOut, value, script_pubkey);
 
 impl Encodable for OutPoint {
     fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -15,7 +15,7 @@ use crate::prelude::Vec;
 #[cfg(doc)]
 use crate::script::ScriptExt as _;
 use crate::taproot::{self, ControlBlock, LeafScript, TaprootMerkleBranch, TAPROOT_ANNEX_PREFIX};
-use crate::Script;
+use crate::{internal_macros, Script};
 
 type BorrowedControlBlock<'a> = ControlBlock<&'a TaprootMerkleBranch, &'a SerializedXOnlyPublicKey>;
 
@@ -112,7 +112,7 @@ impl Encodable for Witness {
     }
 }
 
-crate::internal_macros::define_extension_trait! {
+internal_macros::define_extension_trait! {
     /// Extension functionality for the [`Witness`] type.
     pub trait WitnessExt impl for Witness {
         /// Constructs a new witness required to spend a P2WPKH output.

--- a/bitcoin/src/merkle_tree/mod.rs
+++ b/bitcoin/src/merkle_tree/mod.rs
@@ -18,18 +18,17 @@ mod block;
 
 use hashes::{sha256d, HashEngine as _};
 
-use crate::internal_macros::impl_hashencode;
 use crate::prelude::Vec;
 use crate::transaction::TxIdentifier;
-use crate::{Txid, Wtxid};
+use crate::{internal_macros, Txid, Wtxid};
 
 #[rustfmt::skip]
 #[doc(inline)]
 pub use self::block::{MerkleBlock, MerkleBlockError, PartialMerkleTree};
 pub use primitives::merkle_tree::{TxMerkleNode, WitnessMerkleNode};
 
-impl_hashencode!(TxMerkleNode);
-impl_hashencode!(WitnessMerkleNode);
+internal_macros::impl_hashencode!(TxMerkleNode);
+internal_macros::impl_hashencode!(WitnessMerkleNode);
 
 /// A node in a Merkle tree of transactions or witness data within a block.
 ///

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -14,8 +14,8 @@ use units::parse::{self, ParseIntError, PrefixedHexError, UnprefixedHexError};
 
 use crate::block::{BlockHash, Header};
 use crate::consensus::encode::{self, Decodable, Encodable};
-use crate::internal_macros::define_extension_trait;
 use crate::network::Params;
+use crate::internal_macros;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
@@ -332,7 +332,7 @@ impl Target {
 do_impl!(Target);
 impl_to_hex_from_lower_hex!(Target, |_| 64);
 
-define_extension_trait! {
+internal_macros::define_extension_trait! {
     /// Extension functionality for the [`CompactTarget`] type.
     pub trait CompactTargetExt impl for CompactTarget {
         /// Constructs a new `CompactTarget` from a prefixed hex string.


### PR DESCRIPTION
How, when, and why we use macros has evolved over time. We are kind of only begrudgingly using them. And we are trying to not call them across crate boundaries. 

Clean up how we call private macros to use a single level of path so the calls are terse but explicit.