### PR TITLE
hashes: Separate optional dependencies

### DIFF
--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -23,6 +23,7 @@ small-hash = []
 
 [dependencies]
 internals = { package = "bitcoin-internals", path = "../internals" }
+
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false, optional = true }
 serde = { version = "1.0.103", default-features = false, optional = true }
 


### PR DESCRIPTION
As is customary around here put a line of whitespace in between optional and non-optional dependencies.