### PR TITLE
primitives: Introduce API text files

### DIFF
--- a/api/primitives/all-features.txt
+++ b/api/primitives/all-features.txt
@@ -1,0 +1,1232 @@
+#[non_exhaustive] pub enum bitcoin_primitives::transaction::ParseOutPointError
+#[repr(transparent)] pub struct bitcoin_primitives::Script(_)
+#[repr(transparent)] pub struct bitcoin_primitives::script::Script(_)
+impl !core::marker::Sized for bitcoin_primitives::Script
+impl alloc::borrow::ToOwned for bitcoin_primitives::Script
+impl bitcoin_hashes::Hash for bitcoin_primitives::block::BlockHash
+impl bitcoin_hashes::Hash for bitcoin_primitives::block::WitnessCommitment
+impl bitcoin_hashes::Hash for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl bitcoin_hashes::Hash for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl bitcoin_hashes::Hash for bitcoin_primitives::script::ScriptHash
+impl bitcoin_hashes::Hash for bitcoin_primitives::script::WScriptHash
+impl bitcoin_hashes::Hash for bitcoin_primitives::transaction::Txid
+impl bitcoin_hashes::Hash for bitcoin_primitives::transaction::Wtxid
+impl bitcoin_primitives::Script
+impl bitcoin_primitives::ScriptBuf
+impl bitcoin_primitives::block::Block<bitcoin_primitives::block::Checked>
+impl bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>
+impl bitcoin_primitives::block::BlockHash
+impl bitcoin_primitives::block::Header
+impl bitcoin_primitives::block::Validation for bitcoin_primitives::block::Checked
+impl bitcoin_primitives::block::Validation for bitcoin_primitives::block::Unchecked
+impl bitcoin_primitives::block::Version
+impl bitcoin_primitives::block::WitnessCommitment
+impl bitcoin_primitives::merkle_tree::TxMerkleNode
+impl bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl bitcoin_primitives::pow::CompactTarget
+impl bitcoin_primitives::script::RedeemScriptSizeError
+impl bitcoin_primitives::script::ScriptHash
+impl bitcoin_primitives::script::WScriptHash
+impl bitcoin_primitives::script::WitnessScriptSizeError
+impl bitcoin_primitives::transaction::OutPoint
+impl bitcoin_primitives::transaction::Transaction
+impl bitcoin_primitives::transaction::TxIn
+impl bitcoin_primitives::transaction::Txid
+impl bitcoin_primitives::transaction::Version
+impl bitcoin_primitives::transaction::Wtxid
+impl bitcoin_primitives::witness::Witness
+impl core::borrow::Borrow<[u8; 20]> for bitcoin_primitives::script::ScriptHash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::block::BlockHash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::block::WitnessCommitment
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::script::WScriptHash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::transaction::Txid
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::transaction::Wtxid
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::block::BlockHash
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::block::WitnessCommitment
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::script::ScriptHash
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::script::WScriptHash
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::transaction::Txid
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::transaction::Wtxid
+impl core::borrow::Borrow<bitcoin_primitives::Script> for bitcoin_primitives::ScriptBuf
+impl core::borrow::BorrowMut<bitcoin_primitives::Script> for bitcoin_primitives::ScriptBuf
+impl core::clone::Clone for bitcoin_primitives::ScriptBuf
+impl core::clone::Clone for bitcoin_primitives::block::BlockHash
+impl core::clone::Clone for bitcoin_primitives::block::Checked
+impl core::clone::Clone for bitcoin_primitives::block::Header
+impl core::clone::Clone for bitcoin_primitives::block::Unchecked
+impl core::clone::Clone for bitcoin_primitives::block::Version
+impl core::clone::Clone for bitcoin_primitives::block::WitnessCommitment
+impl core::clone::Clone for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::clone::Clone for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::clone::Clone for bitcoin_primitives::pow::CompactTarget
+impl core::clone::Clone for bitcoin_primitives::script::RedeemScriptSizeError
+impl core::clone::Clone for bitcoin_primitives::script::ScriptHash
+impl core::clone::Clone for bitcoin_primitives::script::WScriptHash
+impl core::clone::Clone for bitcoin_primitives::script::WitnessScriptSizeError
+impl core::clone::Clone for bitcoin_primitives::transaction::OutPoint
+impl core::clone::Clone for bitcoin_primitives::transaction::ParseOutPointError
+impl core::clone::Clone for bitcoin_primitives::transaction::Transaction
+impl core::clone::Clone for bitcoin_primitives::transaction::TxIn
+impl core::clone::Clone for bitcoin_primitives::transaction::TxOut
+impl core::clone::Clone for bitcoin_primitives::transaction::Txid
+impl core::clone::Clone for bitcoin_primitives::transaction::Version
+impl core::clone::Clone for bitcoin_primitives::transaction::Wtxid
+impl core::clone::Clone for bitcoin_primitives::witness::Witness
+impl core::cmp::Eq for bitcoin_primitives::Script
+impl core::cmp::Eq for bitcoin_primitives::ScriptBuf
+impl core::cmp::Eq for bitcoin_primitives::block::BlockHash
+impl core::cmp::Eq for bitcoin_primitives::block::Checked
+impl core::cmp::Eq for bitcoin_primitives::block::Header
+impl core::cmp::Eq for bitcoin_primitives::block::Unchecked
+impl core::cmp::Eq for bitcoin_primitives::block::Version
+impl core::cmp::Eq for bitcoin_primitives::block::WitnessCommitment
+impl core::cmp::Eq for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::cmp::Eq for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::cmp::Eq for bitcoin_primitives::pow::CompactTarget
+impl core::cmp::Eq for bitcoin_primitives::script::RedeemScriptSizeError
+impl core::cmp::Eq for bitcoin_primitives::script::ScriptHash
+impl core::cmp::Eq for bitcoin_primitives::script::WScriptHash
+impl core::cmp::Eq for bitcoin_primitives::script::WitnessScriptSizeError
+impl core::cmp::Eq for bitcoin_primitives::transaction::OutPoint
+impl core::cmp::Eq for bitcoin_primitives::transaction::ParseOutPointError
+impl core::cmp::Eq for bitcoin_primitives::transaction::Transaction
+impl core::cmp::Eq for bitcoin_primitives::transaction::TxIn
+impl core::cmp::Eq for bitcoin_primitives::transaction::TxOut
+impl core::cmp::Eq for bitcoin_primitives::transaction::Txid
+impl core::cmp::Eq for bitcoin_primitives::transaction::Version
+impl core::cmp::Eq for bitcoin_primitives::transaction::Wtxid
+impl core::cmp::Eq for bitcoin_primitives::witness::Witness
+impl core::cmp::Ord for bitcoin_primitives::Script
+impl core::cmp::Ord for bitcoin_primitives::ScriptBuf
+impl core::cmp::Ord for bitcoin_primitives::block::BlockHash
+impl core::cmp::Ord for bitcoin_primitives::block::Checked
+impl core::cmp::Ord for bitcoin_primitives::block::Header
+impl core::cmp::Ord for bitcoin_primitives::block::Unchecked
+impl core::cmp::Ord for bitcoin_primitives::block::Version
+impl core::cmp::Ord for bitcoin_primitives::block::WitnessCommitment
+impl core::cmp::Ord for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::cmp::Ord for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::cmp::Ord for bitcoin_primitives::pow::CompactTarget
+impl core::cmp::Ord for bitcoin_primitives::script::ScriptHash
+impl core::cmp::Ord for bitcoin_primitives::script::WScriptHash
+impl core::cmp::Ord for bitcoin_primitives::transaction::OutPoint
+impl core::cmp::Ord for bitcoin_primitives::transaction::Transaction
+impl core::cmp::Ord for bitcoin_primitives::transaction::TxIn
+impl core::cmp::Ord for bitcoin_primitives::transaction::TxOut
+impl core::cmp::Ord for bitcoin_primitives::transaction::Txid
+impl core::cmp::Ord for bitcoin_primitives::transaction::Version
+impl core::cmp::Ord for bitcoin_primitives::transaction::Wtxid
+impl core::cmp::Ord for bitcoin_primitives::witness::Witness
+impl core::cmp::PartialEq for bitcoin_primitives::Script
+impl core::cmp::PartialEq for bitcoin_primitives::ScriptBuf
+impl core::cmp::PartialEq for bitcoin_primitives::block::BlockHash
+impl core::cmp::PartialEq for bitcoin_primitives::block::Checked
+impl core::cmp::PartialEq for bitcoin_primitives::block::Header
+impl core::cmp::PartialEq for bitcoin_primitives::block::Unchecked
+impl core::cmp::PartialEq for bitcoin_primitives::block::Version
+impl core::cmp::PartialEq for bitcoin_primitives::block::WitnessCommitment
+impl core::cmp::PartialEq for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::cmp::PartialEq for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::cmp::PartialEq for bitcoin_primitives::pow::CompactTarget
+impl core::cmp::PartialEq for bitcoin_primitives::script::RedeemScriptSizeError
+impl core::cmp::PartialEq for bitcoin_primitives::script::ScriptHash
+impl core::cmp::PartialEq for bitcoin_primitives::script::WScriptHash
+impl core::cmp::PartialEq for bitcoin_primitives::script::WitnessScriptSizeError
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::OutPoint
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::ParseOutPointError
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::Transaction
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::TxIn
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::TxOut
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::Txid
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::Version
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::Wtxid
+impl core::cmp::PartialEq for bitcoin_primitives::witness::Witness
+impl core::cmp::PartialEq<bitcoin_primitives::Script> for bitcoin_primitives::ScriptBuf
+impl core::cmp::PartialEq<bitcoin_primitives::ScriptBuf> for bitcoin_primitives::Script
+impl core::cmp::PartialOrd for bitcoin_primitives::Script
+impl core::cmp::PartialOrd for bitcoin_primitives::ScriptBuf
+impl core::cmp::PartialOrd for bitcoin_primitives::block::BlockHash
+impl core::cmp::PartialOrd for bitcoin_primitives::block::Checked
+impl core::cmp::PartialOrd for bitcoin_primitives::block::Header
+impl core::cmp::PartialOrd for bitcoin_primitives::block::Unchecked
+impl core::cmp::PartialOrd for bitcoin_primitives::block::Version
+impl core::cmp::PartialOrd for bitcoin_primitives::block::WitnessCommitment
+impl core::cmp::PartialOrd for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::cmp::PartialOrd for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::cmp::PartialOrd for bitcoin_primitives::pow::CompactTarget
+impl core::cmp::PartialOrd for bitcoin_primitives::script::ScriptHash
+impl core::cmp::PartialOrd for bitcoin_primitives::script::WScriptHash
+impl core::cmp::PartialOrd for bitcoin_primitives::transaction::OutPoint
+impl core::cmp::PartialOrd for bitcoin_primitives::transaction::Transaction
+impl core::cmp::PartialOrd for bitcoin_primitives::transaction::TxIn
+impl core::cmp::PartialOrd for bitcoin_primitives::transaction::TxOut
+impl core::cmp::PartialOrd for bitcoin_primitives::transaction::Txid
+impl core::cmp::PartialOrd for bitcoin_primitives::transaction::Version
+impl core::cmp::PartialOrd for bitcoin_primitives::transaction::Wtxid
+impl core::cmp::PartialOrd for bitcoin_primitives::witness::Witness
+impl core::cmp::PartialOrd<bitcoin_primitives::Script> for bitcoin_primitives::ScriptBuf
+impl core::cmp::PartialOrd<bitcoin_primitives::ScriptBuf> for bitcoin_primitives::Script
+impl core::convert::AsMut<[u8]> for bitcoin_primitives::Script
+impl core::convert::AsMut<[u8]> for bitcoin_primitives::ScriptBuf
+impl core::convert::AsMut<bitcoin_primitives::Script> for bitcoin_primitives::Script
+impl core::convert::AsMut<bitcoin_primitives::Script> for bitcoin_primitives::ScriptBuf
+impl core::convert::AsRef<[u8; 20]> for bitcoin_primitives::script::ScriptHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::block::BlockHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::block::WitnessCommitment
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::script::WScriptHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::transaction::Txid
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::transaction::Wtxid
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::Script
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::ScriptBuf
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::block::BlockHash
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::block::WitnessCommitment
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::script::ScriptHash
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::script::WScriptHash
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::transaction::Txid
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::transaction::Wtxid
+impl core::convert::AsRef<bitcoin_primitives::Script> for bitcoin_primitives::Script
+impl core::convert::AsRef<bitcoin_primitives::Script> for bitcoin_primitives::ScriptBuf
+impl core::convert::From<&[&[u8]]> for bitcoin_primitives::witness::Witness
+impl core::convert::From<&[alloc::vec::Vec<u8>]> for bitcoin_primitives::witness::Witness
+impl core::convert::From<&bitcoin_primitives::block::Block> for bitcoin_primitives::block::BlockHash
+impl core::convert::From<&bitcoin_primitives::block::Header> for bitcoin_primitives::block::BlockHash
+impl core::convert::From<&bitcoin_primitives::transaction::Transaction> for bitcoin_primitives::transaction::Txid
+impl core::convert::From<&bitcoin_primitives::transaction::Transaction> for bitcoin_primitives::transaction::Wtxid
+impl core::convert::From<alloc::vec::Vec<&[u8]>> for bitcoin_primitives::witness::Witness
+impl core::convert::From<alloc::vec::Vec<alloc::vec::Vec<u8>>> for bitcoin_primitives::witness::Witness
+impl core::convert::From<alloc::vec::Vec<u8>> for bitcoin_primitives::ScriptBuf
+impl core::convert::From<bitcoin_primitives::ScriptBuf> for alloc::borrow::Cow<'_, bitcoin_primitives::Script>
+impl core::convert::From<bitcoin_primitives::ScriptBuf> for alloc::boxed::Box<bitcoin_primitives::Script>
+impl core::convert::From<bitcoin_primitives::ScriptBuf> for alloc::vec::Vec<u8>
+impl core::convert::From<bitcoin_primitives::block::Block> for bitcoin_primitives::block::BlockHash
+impl core::convert::From<bitcoin_primitives::block::Header> for bitcoin_primitives::block::BlockHash
+impl core::convert::From<bitcoin_primitives::transaction::Transaction> for bitcoin_primitives::transaction::Txid
+impl core::convert::From<bitcoin_primitives::transaction::Transaction> for bitcoin_primitives::transaction::Wtxid
+impl core::convert::From<bitcoin_primitives::transaction::Version> for u32
+impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::script::RedeemScriptSizeError
+impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::script::WitnessScriptSizeError
+impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::transaction::ParseOutPointError
+impl core::convert::TryFrom<&bitcoin_primitives::Script> for bitcoin_primitives::script::ScriptHash
+impl core::convert::TryFrom<&bitcoin_primitives::Script> for bitcoin_primitives::script::WScriptHash
+impl core::convert::TryFrom<&bitcoin_primitives::ScriptBuf> for bitcoin_primitives::script::ScriptHash
+impl core::convert::TryFrom<&bitcoin_primitives::ScriptBuf> for bitcoin_primitives::script::WScriptHash
+impl core::convert::TryFrom<bitcoin_primitives::ScriptBuf> for bitcoin_primitives::script::ScriptHash
+impl core::convert::TryFrom<bitcoin_primitives::ScriptBuf> for bitcoin_primitives::script::WScriptHash
+impl core::default::Default for &bitcoin_primitives::Script
+impl core::default::Default for bitcoin_primitives::ScriptBuf
+impl core::default::Default for bitcoin_primitives::block::Version
+impl core::default::Default for bitcoin_primitives::witness::Witness
+impl core::error::Error for bitcoin_primitives::script::RedeemScriptSizeError
+impl core::error::Error for bitcoin_primitives::script::WitnessScriptSizeError
+impl core::error::Error for bitcoin_primitives::transaction::ParseOutPointError
+impl core::fmt::Debug for bitcoin_primitives::Script
+impl core::fmt::Debug for bitcoin_primitives::ScriptBuf
+impl core::fmt::Debug for bitcoin_primitives::block::BlockHash
+impl core::fmt::Debug for bitcoin_primitives::block::Checked
+impl core::fmt::Debug for bitcoin_primitives::block::Header
+impl core::fmt::Debug for bitcoin_primitives::block::Unchecked
+impl core::fmt::Debug for bitcoin_primitives::block::Version
+impl core::fmt::Debug for bitcoin_primitives::block::WitnessCommitment
+impl core::fmt::Debug for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::fmt::Debug for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::fmt::Debug for bitcoin_primitives::pow::CompactTarget
+impl core::fmt::Debug for bitcoin_primitives::script::RedeemScriptSizeError
+impl core::fmt::Debug for bitcoin_primitives::script::ScriptHash
+impl core::fmt::Debug for bitcoin_primitives::script::WScriptHash
+impl core::fmt::Debug for bitcoin_primitives::script::WitnessScriptSizeError
+impl core::fmt::Debug for bitcoin_primitives::transaction::OutPoint
+impl core::fmt::Debug for bitcoin_primitives::transaction::ParseOutPointError
+impl core::fmt::Debug for bitcoin_primitives::transaction::Transaction
+impl core::fmt::Debug for bitcoin_primitives::transaction::TxIn
+impl core::fmt::Debug for bitcoin_primitives::transaction::TxOut
+impl core::fmt::Debug for bitcoin_primitives::transaction::Txid
+impl core::fmt::Debug for bitcoin_primitives::transaction::Version
+impl core::fmt::Debug for bitcoin_primitives::transaction::Wtxid
+impl core::fmt::Debug for bitcoin_primitives::witness::Witness
+impl core::fmt::Display for bitcoin_primitives::Script
+impl core::fmt::Display for bitcoin_primitives::ScriptBuf
+impl core::fmt::Display for bitcoin_primitives::block::BlockHash
+impl core::fmt::Display for bitcoin_primitives::block::Header
+impl core::fmt::Display for bitcoin_primitives::block::WitnessCommitment
+impl core::fmt::Display for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::fmt::Display for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::fmt::Display for bitcoin_primitives::script::RedeemScriptSizeError
+impl core::fmt::Display for bitcoin_primitives::script::ScriptHash
+impl core::fmt::Display for bitcoin_primitives::script::WScriptHash
+impl core::fmt::Display for bitcoin_primitives::script::WitnessScriptSizeError
+impl core::fmt::Display for bitcoin_primitives::transaction::OutPoint
+impl core::fmt::Display for bitcoin_primitives::transaction::ParseOutPointError
+impl core::fmt::Display for bitcoin_primitives::transaction::Txid
+impl core::fmt::Display for bitcoin_primitives::transaction::Version
+impl core::fmt::Display for bitcoin_primitives::transaction::Wtxid
+impl core::fmt::LowerHex for bitcoin_primitives::Script
+impl core::fmt::LowerHex for bitcoin_primitives::ScriptBuf
+impl core::fmt::LowerHex for bitcoin_primitives::block::BlockHash
+impl core::fmt::LowerHex for bitcoin_primitives::block::WitnessCommitment
+impl core::fmt::LowerHex for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::fmt::LowerHex for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::fmt::LowerHex for bitcoin_primitives::pow::CompactTarget
+impl core::fmt::LowerHex for bitcoin_primitives::script::ScriptHash
+impl core::fmt::LowerHex for bitcoin_primitives::script::WScriptHash
+impl core::fmt::LowerHex for bitcoin_primitives::transaction::Txid
+impl core::fmt::LowerHex for bitcoin_primitives::transaction::Wtxid
+impl core::fmt::UpperHex for bitcoin_primitives::Script
+impl core::fmt::UpperHex for bitcoin_primitives::ScriptBuf
+impl core::fmt::UpperHex for bitcoin_primitives::block::BlockHash
+impl core::fmt::UpperHex for bitcoin_primitives::block::WitnessCommitment
+impl core::fmt::UpperHex for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::fmt::UpperHex for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::fmt::UpperHex for bitcoin_primitives::pow::CompactTarget
+impl core::fmt::UpperHex for bitcoin_primitives::script::ScriptHash
+impl core::fmt::UpperHex for bitcoin_primitives::script::WScriptHash
+impl core::fmt::UpperHex for bitcoin_primitives::transaction::Txid
+impl core::fmt::UpperHex for bitcoin_primitives::transaction::Wtxid
+impl core::hash::Hash for bitcoin_primitives::Script
+impl core::hash::Hash for bitcoin_primitives::ScriptBuf
+impl core::hash::Hash for bitcoin_primitives::block::BlockHash
+impl core::hash::Hash for bitcoin_primitives::block::Checked
+impl core::hash::Hash for bitcoin_primitives::block::Header
+impl core::hash::Hash for bitcoin_primitives::block::Unchecked
+impl core::hash::Hash for bitcoin_primitives::block::Version
+impl core::hash::Hash for bitcoin_primitives::block::WitnessCommitment
+impl core::hash::Hash for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::hash::Hash for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::hash::Hash for bitcoin_primitives::pow::CompactTarget
+impl core::hash::Hash for bitcoin_primitives::script::ScriptHash
+impl core::hash::Hash for bitcoin_primitives::script::WScriptHash
+impl core::hash::Hash for bitcoin_primitives::transaction::OutPoint
+impl core::hash::Hash for bitcoin_primitives::transaction::Transaction
+impl core::hash::Hash for bitcoin_primitives::transaction::TxIn
+impl core::hash::Hash for bitcoin_primitives::transaction::TxOut
+impl core::hash::Hash for bitcoin_primitives::transaction::Txid
+impl core::hash::Hash for bitcoin_primitives::transaction::Version
+impl core::hash::Hash for bitcoin_primitives::transaction::Wtxid
+impl core::hash::Hash for bitcoin_primitives::witness::Witness
+impl core::iter::traits::exact_size::ExactSizeIterator for bitcoin_primitives::witness::Iter<'_>
+impl core::marker::Copy for bitcoin_primitives::block::BlockHash
+impl core::marker::Copy for bitcoin_primitives::block::Header
+impl core::marker::Copy for bitcoin_primitives::block::Version
+impl core::marker::Copy for bitcoin_primitives::block::WitnessCommitment
+impl core::marker::Copy for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::marker::Copy for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::marker::Copy for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Copy for bitcoin_primitives::script::ScriptHash
+impl core::marker::Copy for bitcoin_primitives::script::WScriptHash
+impl core::marker::Copy for bitcoin_primitives::transaction::OutPoint
+impl core::marker::Copy for bitcoin_primitives::transaction::Txid
+impl core::marker::Copy for bitcoin_primitives::transaction::Version
+impl core::marker::Copy for bitcoin_primitives::transaction::Wtxid
+impl core::marker::Freeze for bitcoin_primitives::Script
+impl core::marker::Freeze for bitcoin_primitives::ScriptBuf
+impl core::marker::Freeze for bitcoin_primitives::block::BlockHash
+impl core::marker::Freeze for bitcoin_primitives::block::Checked
+impl core::marker::Freeze for bitcoin_primitives::block::Header
+impl core::marker::Freeze for bitcoin_primitives::block::Unchecked
+impl core::marker::Freeze for bitcoin_primitives::block::Version
+impl core::marker::Freeze for bitcoin_primitives::block::WitnessCommitment
+impl core::marker::Freeze for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::marker::Freeze for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::marker::Freeze for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Freeze for bitcoin_primitives::script::RedeemScriptSizeError
+impl core::marker::Freeze for bitcoin_primitives::script::ScriptHash
+impl core::marker::Freeze for bitcoin_primitives::script::WScriptHash
+impl core::marker::Freeze for bitcoin_primitives::script::WitnessScriptSizeError
+impl core::marker::Freeze for bitcoin_primitives::transaction::OutPoint
+impl core::marker::Freeze for bitcoin_primitives::transaction::ParseOutPointError
+impl core::marker::Freeze for bitcoin_primitives::transaction::Transaction
+impl core::marker::Freeze for bitcoin_primitives::transaction::TxIn
+impl core::marker::Freeze for bitcoin_primitives::transaction::TxOut
+impl core::marker::Freeze for bitcoin_primitives::transaction::Txid
+impl core::marker::Freeze for bitcoin_primitives::transaction::Version
+impl core::marker::Freeze for bitcoin_primitives::transaction::Wtxid
+impl core::marker::Freeze for bitcoin_primitives::witness::Witness
+impl core::marker::Send for bitcoin_primitives::Script
+impl core::marker::Send for bitcoin_primitives::ScriptBuf
+impl core::marker::Send for bitcoin_primitives::block::BlockHash
+impl core::marker::Send for bitcoin_primitives::block::Checked
+impl core::marker::Send for bitcoin_primitives::block::Header
+impl core::marker::Send for bitcoin_primitives::block::Unchecked
+impl core::marker::Send for bitcoin_primitives::block::Version
+impl core::marker::Send for bitcoin_primitives::block::WitnessCommitment
+impl core::marker::Send for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::marker::Send for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::marker::Send for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Send for bitcoin_primitives::script::RedeemScriptSizeError
+impl core::marker::Send for bitcoin_primitives::script::ScriptHash
+impl core::marker::Send for bitcoin_primitives::script::WScriptHash
+impl core::marker::Send for bitcoin_primitives::script::WitnessScriptSizeError
+impl core::marker::Send for bitcoin_primitives::transaction::OutPoint
+impl core::marker::Send for bitcoin_primitives::transaction::ParseOutPointError
+impl core::marker::Send for bitcoin_primitives::transaction::Transaction
+impl core::marker::Send for bitcoin_primitives::transaction::TxIn
+impl core::marker::Send for bitcoin_primitives::transaction::TxOut
+impl core::marker::Send for bitcoin_primitives::transaction::Txid
+impl core::marker::Send for bitcoin_primitives::transaction::Version
+impl core::marker::Send for bitcoin_primitives::transaction::Wtxid
+impl core::marker::Send for bitcoin_primitives::witness::Witness
+impl core::marker::StructuralPartialEq for bitcoin_primitives::Script
+impl core::marker::StructuralPartialEq for bitcoin_primitives::ScriptBuf
+impl core::marker::StructuralPartialEq for bitcoin_primitives::block::BlockHash
+impl core::marker::StructuralPartialEq for bitcoin_primitives::block::Checked
+impl core::marker::StructuralPartialEq for bitcoin_primitives::block::Header
+impl core::marker::StructuralPartialEq for bitcoin_primitives::block::Unchecked
+impl core::marker::StructuralPartialEq for bitcoin_primitives::block::Version
+impl core::marker::StructuralPartialEq for bitcoin_primitives::block::WitnessCommitment
+impl core::marker::StructuralPartialEq for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::marker::StructuralPartialEq for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::marker::StructuralPartialEq for bitcoin_primitives::pow::CompactTarget
+impl core::marker::StructuralPartialEq for bitcoin_primitives::script::RedeemScriptSizeError
+impl core::marker::StructuralPartialEq for bitcoin_primitives::script::ScriptHash
+impl core::marker::StructuralPartialEq for bitcoin_primitives::script::WScriptHash
+impl core::marker::StructuralPartialEq for bitcoin_primitives::script::WitnessScriptSizeError
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::OutPoint
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::ParseOutPointError
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::Transaction
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::TxIn
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::TxOut
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::Txid
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::Version
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::Wtxid
+impl core::marker::StructuralPartialEq for bitcoin_primitives::witness::Witness
+impl core::marker::Sync for bitcoin_primitives::Script
+impl core::marker::Sync for bitcoin_primitives::ScriptBuf
+impl core::marker::Sync for bitcoin_primitives::block::BlockHash
+impl core::marker::Sync for bitcoin_primitives::block::Checked
+impl core::marker::Sync for bitcoin_primitives::block::Header
+impl core::marker::Sync for bitcoin_primitives::block::Unchecked
+impl core::marker::Sync for bitcoin_primitives::block::Version
+impl core::marker::Sync for bitcoin_primitives::block::WitnessCommitment
+impl core::marker::Sync for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::marker::Sync for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::marker::Sync for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Sync for bitcoin_primitives::script::RedeemScriptSizeError
+impl core::marker::Sync for bitcoin_primitives::script::ScriptHash
+impl core::marker::Sync for bitcoin_primitives::script::WScriptHash
+impl core::marker::Sync for bitcoin_primitives::script::WitnessScriptSizeError
+impl core::marker::Sync for bitcoin_primitives::transaction::OutPoint
+impl core::marker::Sync for bitcoin_primitives::transaction::ParseOutPointError
+impl core::marker::Sync for bitcoin_primitives::transaction::Transaction
+impl core::marker::Sync for bitcoin_primitives::transaction::TxIn
+impl core::marker::Sync for bitcoin_primitives::transaction::TxOut
+impl core::marker::Sync for bitcoin_primitives::transaction::Txid
+impl core::marker::Sync for bitcoin_primitives::transaction::Version
+impl core::marker::Sync for bitcoin_primitives::transaction::Wtxid
+impl core::marker::Sync for bitcoin_primitives::witness::Witness
+impl core::marker::Unpin for bitcoin_primitives::Script
+impl core::marker::Unpin for bitcoin_primitives::ScriptBuf
+impl core::marker::Unpin for bitcoin_primitives::block::BlockHash
+impl core::marker::Unpin for bitcoin_primitives::block::Checked
+impl core::marker::Unpin for bitcoin_primitives::block::Header
+impl core::marker::Unpin for bitcoin_primitives::block::Unchecked
+impl core::marker::Unpin for bitcoin_primitives::block::Version
+impl core::marker::Unpin for bitcoin_primitives::block::WitnessCommitment
+impl core::marker::Unpin for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::marker::Unpin for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::marker::Unpin for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Unpin for bitcoin_primitives::script::RedeemScriptSizeError
+impl core::marker::Unpin for bitcoin_primitives::script::ScriptHash
+impl core::marker::Unpin for bitcoin_primitives::script::WScriptHash
+impl core::marker::Unpin for bitcoin_primitives::script::WitnessScriptSizeError
+impl core::marker::Unpin for bitcoin_primitives::transaction::OutPoint
+impl core::marker::Unpin for bitcoin_primitives::transaction::ParseOutPointError
+impl core::marker::Unpin for bitcoin_primitives::transaction::Transaction
+impl core::marker::Unpin for bitcoin_primitives::transaction::TxIn
+impl core::marker::Unpin for bitcoin_primitives::transaction::TxOut
+impl core::marker::Unpin for bitcoin_primitives::transaction::Txid
+impl core::marker::Unpin for bitcoin_primitives::transaction::Version
+impl core::marker::Unpin for bitcoin_primitives::transaction::Wtxid
+impl core::marker::Unpin for bitcoin_primitives::witness::Witness
+impl core::ops::deref::Deref for bitcoin_primitives::ScriptBuf
+impl core::ops::deref::DerefMut for bitcoin_primitives::ScriptBuf
+impl core::ops::index::Index<(core::ops::range::Bound<usize>, core::ops::range::Bound<usize>)> for bitcoin_primitives::Script
+impl core::ops::index::Index<core::ops::range::Range<usize>> for bitcoin_primitives::Script
+impl core::ops::index::Index<core::ops::range::RangeFrom<usize>> for bitcoin_primitives::Script
+impl core::ops::index::Index<core::ops::range::RangeFull> for bitcoin_primitives::Script
+impl core::ops::index::Index<core::ops::range::RangeInclusive<usize>> for bitcoin_primitives::Script
+impl core::ops::index::Index<core::ops::range::RangeTo<usize>> for bitcoin_primitives::Script
+impl core::ops::index::Index<core::ops::range::RangeToInclusive<usize>> for bitcoin_primitives::Script
+impl core::ops::index::Index<usize> for bitcoin_primitives::witness::Witness
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::Script
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::ScriptBuf
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::BlockHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::Checked
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::Header
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::Unchecked
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::Version
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::WitnessCommitment
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::pow::CompactTarget
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::script::RedeemScriptSizeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::script::ScriptHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::script::WScriptHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::script::WitnessScriptSizeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::OutPoint
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::ParseOutPointError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::Transaction
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::TxIn
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::TxOut
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::Txid
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::Version
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::Wtxid
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness::Witness
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::Script
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::ScriptBuf
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::BlockHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::Checked
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::Header
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::Unchecked
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::Version
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::WitnessCommitment
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::pow::CompactTarget
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::script::RedeemScriptSizeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::script::ScriptHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::script::WScriptHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::script::WitnessScriptSizeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::OutPoint
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::ParseOutPointError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::Transaction
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::TxIn
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::TxOut
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::Txid
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::Version
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::Wtxid
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness::Witness
+impl core::str::traits::FromStr for bitcoin_primitives::block::BlockHash
+impl core::str::traits::FromStr for bitcoin_primitives::block::WitnessCommitment
+impl core::str::traits::FromStr for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::str::traits::FromStr for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::str::traits::FromStr for bitcoin_primitives::script::ScriptHash
+impl core::str::traits::FromStr for bitcoin_primitives::script::WScriptHash
+impl core::str::traits::FromStr for bitcoin_primitives::transaction::OutPoint
+impl core::str::traits::FromStr for bitcoin_primitives::transaction::Txid
+impl core::str::traits::FromStr for bitcoin_primitives::transaction::Wtxid
+impl serde::ser::Serialize for bitcoin_primitives::Script
+impl serde::ser::Serialize for bitcoin_primitives::ScriptBuf
+impl serde::ser::Serialize for bitcoin_primitives::block::BlockHash
+impl serde::ser::Serialize for bitcoin_primitives::block::Header
+impl serde::ser::Serialize for bitcoin_primitives::block::Version
+impl serde::ser::Serialize for bitcoin_primitives::block::WitnessCommitment
+impl serde::ser::Serialize for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl serde::ser::Serialize for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl serde::ser::Serialize for bitcoin_primitives::pow::CompactTarget
+impl serde::ser::Serialize for bitcoin_primitives::script::ScriptHash
+impl serde::ser::Serialize for bitcoin_primitives::script::WScriptHash
+impl serde::ser::Serialize for bitcoin_primitives::transaction::OutPoint
+impl serde::ser::Serialize for bitcoin_primitives::transaction::Transaction
+impl serde::ser::Serialize for bitcoin_primitives::transaction::TxIn
+impl serde::ser::Serialize for bitcoin_primitives::transaction::TxOut
+impl serde::ser::Serialize for bitcoin_primitives::transaction::Txid
+impl serde::ser::Serialize for bitcoin_primitives::transaction::Version
+impl serde::ser::Serialize for bitcoin_primitives::transaction::Wtxid
+impl serde::ser::Serialize for bitcoin_primitives::witness::Witness
+impl<'a> arbitrary::Arbitrary<'a> for &'a bitcoin_primitives::Script
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::ScriptBuf
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::block::Block
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::block::BlockHash
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::block::Header
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::block::Version
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::transaction::OutPoint
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::transaction::Transaction
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::transaction::TxIn
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::transaction::TxOut
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::transaction::Txid
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::transaction::Version
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::transaction::Wtxid
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::witness::Witness
+impl<'a> core::clone::Clone for bitcoin_primitives::witness::Iter<'a>
+impl<'a> core::convert::From<&'a bitcoin_primitives::Script> for alloc::borrow::Cow<'a, bitcoin_primitives::Script>
+impl<'a> core::convert::From<&'a bitcoin_primitives::Script> for alloc::boxed::Box<bitcoin_primitives::Script>
+impl<'a> core::convert::From<&'a bitcoin_primitives::Script> for alloc::rc::Rc<bitcoin_primitives::Script>
+impl<'a> core::convert::From<&'a bitcoin_primitives::Script> for alloc::sync::Arc<bitcoin_primitives::Script>
+impl<'a> core::convert::From<&'a bitcoin_primitives::Script> for bitcoin_primitives::ScriptBuf
+impl<'a> core::convert::From<alloc::borrow::Cow<'a, bitcoin_primitives::Script>> for alloc::boxed::Box<bitcoin_primitives::Script>
+impl<'a> core::convert::From<alloc::borrow::Cow<'a, bitcoin_primitives::Script>> for bitcoin_primitives::ScriptBuf
+impl<'a> core::iter::traits::collect::IntoIterator for &'a bitcoin_primitives::witness::Witness
+impl<'a> core::iter::traits::iterator::Iterator for bitcoin_primitives::witness::Iter<'a>
+impl<'a> core::marker::Freeze for bitcoin_primitives::witness::Iter<'a>
+impl<'a> core::marker::Send for bitcoin_primitives::witness::Iter<'a>
+impl<'a> core::marker::Sync for bitcoin_primitives::witness::Iter<'a>
+impl<'a> core::marker::Unpin for bitcoin_primitives::witness::Iter<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness::Iter<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness::Iter<'a>
+impl<'de, V> serde::de::Deserialize<'de> for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation
+impl<'de> serde::de::Deserialize<'de> for &'de bitcoin_primitives::Script
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::ScriptBuf
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::block::BlockHash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::block::Header
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::block::Version
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::block::WitnessCommitment
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::pow::CompactTarget
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::script::ScriptHash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::script::WScriptHash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::transaction::OutPoint
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::transaction::Transaction
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::transaction::TxIn
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::transaction::TxOut
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::transaction::Txid
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::transaction::Version
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::transaction::Wtxid
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::witness::Witness
+impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<&[T]> for bitcoin_primitives::witness::Witness
+impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<[T]> for bitcoin_primitives::witness::Witness
+impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<alloc::boxed::Box<[T]>> for bitcoin_primitives::witness::Witness
+impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<alloc::rc::Rc<[T]>> for bitcoin_primitives::witness::Witness
+impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<alloc::sync::Arc<[T]>> for bitcoin_primitives::witness::Witness
+impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<alloc::vec::Vec<T>> for bitcoin_primitives::witness::Witness
+impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<bitcoin_primitives::witness::Witness> for &[T]
+impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<bitcoin_primitives::witness::Witness> for [T]
+impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<bitcoin_primitives::witness::Witness> for alloc::boxed::Box<[T]>
+impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<bitcoin_primitives::witness::Witness> for alloc::rc::Rc<[T]>
+impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<bitcoin_primitives::witness::Witness> for alloc::sync::Arc<[T]>
+impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<bitcoin_primitives::witness::Witness> for alloc::vec::Vec<T>
+impl<T: core::convert::AsRef<[u8]>> core::iter::traits::collect::FromIterator<T> for bitcoin_primitives::witness::Witness
+impl<V: bitcoin_primitives::block::Validation> bitcoin_primitives::block::Block<V>
+impl<V> core::clone::Clone for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::clone::Clone
+impl<V> core::cmp::Eq for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::cmp::Eq
+impl<V> core::cmp::PartialEq for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::cmp::PartialEq
+impl<V> core::fmt::Debug for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::fmt::Debug
+impl<V> core::marker::Freeze for bitcoin_primitives::block::Block<V>
+impl<V> core::marker::Send for bitcoin_primitives::block::Block<V>
+impl<V> core::marker::StructuralPartialEq for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation
+impl<V> core::marker::Sync for bitcoin_primitives::block::Block<V>
+impl<V> core::marker::Unpin for bitcoin_primitives::block::Block<V>
+impl<V> core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::Block<V> where V: core::panic::unwind_safe::RefUnwindSafe
+impl<V> core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::Block<V> where V: core::panic::unwind_safe::UnwindSafe
+impl<V> serde::ser::Serialize for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation
+impl<const N: usize, T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<&[T; N]> for bitcoin_primitives::witness::Witness
+impl<const N: usize, T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<[T; N]> for bitcoin_primitives::witness::Witness
+impl<const N: usize, T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<bitcoin_primitives::witness::Witness> for &[T; N]
+impl<const N: usize, T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<bitcoin_primitives::witness::Witness> for [T; N]
+impl<const N: usize, const M: usize> core::convert::From<&[&[u8; M]; N]> for bitcoin_primitives::witness::Witness
+impl<const N: usize, const M: usize> core::convert::From<&[[u8; M]; N]> for bitcoin_primitives::witness::Witness
+impl<const N: usize, const M: usize> core::convert::From<[&[u8; M]; N]> for bitcoin_primitives::witness::Witness
+impl<const N: usize, const M: usize> core::convert::From<[[u8; M]; N]> for bitcoin_primitives::witness::Witness
+impl<const N: usize> core::convert::From<&[&[u8; N]]> for bitcoin_primitives::witness::Witness
+impl<const N: usize> core::convert::From<&[&[u8]; N]> for bitcoin_primitives::witness::Witness
+impl<const N: usize> core::convert::From<&[[u8; N]]> for bitcoin_primitives::witness::Witness
+impl<const N: usize> core::convert::From<[&[u8]; N]> for bitcoin_primitives::witness::Witness
+pub bitcoin_primitives::BlockHeader::bits: bitcoin_primitives::pow::CompactTarget
+pub bitcoin_primitives::BlockHeader::merkle_root: bitcoin_primitives::merkle_tree::TxMerkleNode
+pub bitcoin_primitives::BlockHeader::nonce: u32
+pub bitcoin_primitives::BlockHeader::prev_blockhash: bitcoin_primitives::block::BlockHash
+pub bitcoin_primitives::BlockHeader::time: bitcoin_units::time::encapsulate::BlockTime
+pub bitcoin_primitives::BlockHeader::version: bitcoin_primitives::block::Version
+pub bitcoin_primitives::OutPoint::txid: bitcoin_primitives::transaction::Txid
+pub bitcoin_primitives::OutPoint::vout: u32
+pub bitcoin_primitives::Transaction::input: alloc::vec::Vec<bitcoin_primitives::transaction::TxIn>
+pub bitcoin_primitives::Transaction::lock_time: bitcoin_units::locktime::absolute::LockTime
+pub bitcoin_primitives::Transaction::output: alloc::vec::Vec<bitcoin_primitives::transaction::TxOut>
+pub bitcoin_primitives::Transaction::version: bitcoin_primitives::transaction::Version
+pub bitcoin_primitives::TxIn::previous_output: bitcoin_primitives::transaction::OutPoint
+pub bitcoin_primitives::TxIn::script_sig: bitcoin_primitives::ScriptBuf
+pub bitcoin_primitives::TxIn::sequence: bitcoin_units::sequence::Sequence
+pub bitcoin_primitives::TxIn::witness: bitcoin_primitives::witness::Witness
+pub bitcoin_primitives::TxOut::script_pubkey: bitcoin_primitives::ScriptBuf
+pub bitcoin_primitives::TxOut::value: bitcoin_units::amount::unsigned::encapsulate::Amount
+pub bitcoin_primitives::block::Header::bits: bitcoin_primitives::pow::CompactTarget
+pub bitcoin_primitives::block::Header::merkle_root: bitcoin_primitives::merkle_tree::TxMerkleNode
+pub bitcoin_primitives::block::Header::nonce: u32
+pub bitcoin_primitives::block::Header::prev_blockhash: bitcoin_primitives::block::BlockHash
+pub bitcoin_primitives::block::Header::time: bitcoin_units::time::encapsulate::BlockTime
+pub bitcoin_primitives::block::Header::version: bitcoin_primitives::block::Version
+pub bitcoin_primitives::transaction::OutPoint::txid: bitcoin_primitives::transaction::Txid
+pub bitcoin_primitives::transaction::OutPoint::vout: u32
+pub bitcoin_primitives::transaction::ParseOutPointError::Format
+pub bitcoin_primitives::transaction::ParseOutPointError::TooLong
+pub bitcoin_primitives::transaction::ParseOutPointError::Txid(hex_conservative::error::HexToArrayError)
+pub bitcoin_primitives::transaction::ParseOutPointError::Vout(bitcoin_units::parse::ParseIntError)
+pub bitcoin_primitives::transaction::ParseOutPointError::VoutNotCanonical
+pub bitcoin_primitives::transaction::Transaction::input: alloc::vec::Vec<bitcoin_primitives::transaction::TxIn>
+pub bitcoin_primitives::transaction::Transaction::lock_time: bitcoin_units::locktime::absolute::LockTime
+pub bitcoin_primitives::transaction::Transaction::output: alloc::vec::Vec<bitcoin_primitives::transaction::TxOut>
+pub bitcoin_primitives::transaction::Transaction::version: bitcoin_primitives::transaction::Version
+pub bitcoin_primitives::transaction::TxIn::previous_output: bitcoin_primitives::transaction::OutPoint
+pub bitcoin_primitives::transaction::TxIn::script_sig: bitcoin_primitives::ScriptBuf
+pub bitcoin_primitives::transaction::TxIn::sequence: bitcoin_units::sequence::Sequence
+pub bitcoin_primitives::transaction::TxIn::witness: bitcoin_primitives::witness::Witness
+pub bitcoin_primitives::transaction::TxOut::script_pubkey: bitcoin_primitives::ScriptBuf
+pub bitcoin_primitives::transaction::TxOut::value: bitcoin_units::amount::unsigned::encapsulate::Amount
+pub const bitcoin_primitives::BlockValidation::IS_CHECKED: bool
+pub const bitcoin_primitives::block::BlockHash::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::block::BlockHash::GENESIS_PREVIOUS_BLOCK_HASH: Self
+pub const bitcoin_primitives::block::Checked::IS_CHECKED: bool
+pub const bitcoin_primitives::block::Header::SIZE: usize
+pub const bitcoin_primitives::block::Unchecked::IS_CHECKED: bool
+pub const bitcoin_primitives::block::Validation::IS_CHECKED: bool
+pub const bitcoin_primitives::block::Version::NO_SOFT_FORK_SIGNALLING: Self
+pub const bitcoin_primitives::block::Version::ONE: Self
+pub const bitcoin_primitives::block::Version::TWO: Self
+pub const bitcoin_primitives::block::WitnessCommitment::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::merkle_tree::TxMerkleNode::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::merkle_tree::WitnessMerkleNode::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::script::MAX_REDEEM_SCRIPT_SIZE: usize
+pub const bitcoin_primitives::script::MAX_WITNESS_SCRIPT_SIZE: usize
+pub const bitcoin_primitives::script::ScriptHash::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::script::WScriptHash::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::transaction::OutPoint::COINBASE_PREVOUT: Self
+pub const bitcoin_primitives::transaction::OutPoint::SIZE: usize
+pub const bitcoin_primitives::transaction::Transaction::MAX_STANDARD_WEIGHT: bitcoin_units::weight::encapsulate::Weight
+pub const bitcoin_primitives::transaction::TxIn::EMPTY_COINBASE: bitcoin_primitives::transaction::TxIn
+pub const bitcoin_primitives::transaction::Txid::COINBASE_PREVOUT: Self
+pub const bitcoin_primitives::transaction::Txid::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::transaction::Version::ONE: Self
+pub const bitcoin_primitives::transaction::Version::THREE: Self
+pub const bitcoin_primitives::transaction::Version::TWO: Self
+pub const bitcoin_primitives::transaction::Wtxid::COINBASE: Self
+pub const bitcoin_primitives::transaction::Wtxid::DISPLAY_BACKWARD: bool
+pub const fn bitcoin_primitives::Script::as_bytes(&self) -> &[u8]
+pub const fn bitcoin_primitives::Script::from_bytes(bytes: &[u8]) -> &Self
+pub const fn bitcoin_primitives::Script::is_empty(&self) -> bool
+pub const fn bitcoin_primitives::Script::len(&self) -> usize
+pub const fn bitcoin_primitives::Script::new() -> &'static Self
+pub const fn bitcoin_primitives::ScriptBuf::from_bytes(bytes: alloc::vec::Vec<u8>) -> Self
+pub const fn bitcoin_primitives::ScriptBuf::new() -> Self
+pub const fn bitcoin_primitives::block::BlockHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::block::BlockHash::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::block::BlockHash::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::block::Version::from_consensus(v: i32) -> Self
+pub const fn bitcoin_primitives::block::WitnessCommitment::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::block::WitnessCommitment::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::block::WitnessCommitment::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::merkle_tree::TxMerkleNode::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::merkle_tree::TxMerkleNode::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::merkle_tree::TxMerkleNode::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::script::ScriptHash::as_byte_array(&self) -> &<bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::script::ScriptHash::from_byte_array(bytes: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::script::ScriptHash::to_byte_array(self) -> <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::script::WScriptHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::script::WScriptHash::from_byte_array(bytes: <bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::script::WScriptHash::to_byte_array(self) -> <bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::transaction::Txid::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::transaction::Txid::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::transaction::Txid::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::transaction::Version::is_standard(self) -> bool
+pub const fn bitcoin_primitives::transaction::Version::maybe_non_standard(version: u32) -> bitcoin_primitives::transaction::Version
+pub const fn bitcoin_primitives::transaction::Version::to_u32(self) -> u32
+pub const fn bitcoin_primitives::transaction::Wtxid::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::transaction::Wtxid::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::transaction::Wtxid::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::witness::Witness::new() -> Self
+pub enum bitcoin_primitives::BlockChecked
+pub enum bitcoin_primitives::BlockUnchecked
+pub enum bitcoin_primitives::block::Checked
+pub enum bitcoin_primitives::block::Unchecked
+pub fn &'a bitcoin_primitives::Script::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn &'a bitcoin_primitives::witness::Witness::into_iter(self) -> Self::IntoIter
+pub fn &'de bitcoin_primitives::Script::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+pub fn &[T; N]::eq(&self, rhs: &bitcoin_primitives::witness::Witness) -> bool
+pub fn &[T]::eq(&self, rhs: &bitcoin_primitives::witness::Witness) -> bool
+pub fn &bitcoin_primitives::Script::default() -> Self
+pub fn [T; N]::eq(&self, rhs: &bitcoin_primitives::witness::Witness) -> bool
+pub fn [T]::eq(&self, rhs: &bitcoin_primitives::witness::Witness) -> bool
+pub fn alloc::borrow::Cow<'_, bitcoin_primitives::Script>::from(value: bitcoin_primitives::ScriptBuf) -> Self
+pub fn alloc::borrow::Cow<'a, bitcoin_primitives::Script>::from(value: &'a bitcoin_primitives::Script) -> Self
+pub fn alloc::boxed::Box<[T]>::eq(&self, rhs: &bitcoin_primitives::witness::Witness) -> bool
+pub fn alloc::boxed::Box<bitcoin_primitives::Script>::from(v: bitcoin_primitives::ScriptBuf) -> Self
+pub fn alloc::boxed::Box<bitcoin_primitives::Script>::from(value: &'a bitcoin_primitives::Script) -> Self
+pub fn alloc::boxed::Box<bitcoin_primitives::Script>::from(value: alloc::borrow::Cow<'a, bitcoin_primitives::Script>) -> Self
+pub fn alloc::rc::Rc<[T]>::eq(&self, rhs: &bitcoin_primitives::witness::Witness) -> bool
+pub fn alloc::rc::Rc<bitcoin_primitives::Script>::from(value: &'a bitcoin_primitives::Script) -> Self
+pub fn alloc::sync::Arc<[T]>::eq(&self, rhs: &bitcoin_primitives::witness::Witness) -> bool
+pub fn alloc::sync::Arc<bitcoin_primitives::Script>::from(value: &'a bitcoin_primitives::Script) -> Self
+pub fn alloc::vec::Vec<T>::eq(&self, rhs: &bitcoin_primitives::witness::Witness) -> bool
+pub fn alloc::vec::Vec<u8>::from(v: bitcoin_primitives::ScriptBuf) -> Self
+pub fn bitcoin_primitives::Script::as_mut(&mut self) -> &mut Self
+pub fn bitcoin_primitives::Script::as_mut(&mut self) -> &mut [u8]
+pub fn bitcoin_primitives::Script::as_mut_bytes(&mut self) -> &mut [u8]
+pub fn bitcoin_primitives::Script::as_ref(&self) -> &Self
+pub fn bitcoin_primitives::Script::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::Script::cmp(&self, other: &bitcoin_primitives::Script) -> core::cmp::Ordering
+pub fn bitcoin_primitives::Script::eq(&self, other: &bitcoin_primitives::Script) -> bool
+pub fn bitcoin_primitives::Script::eq(&self, other: &bitcoin_primitives::ScriptBuf) -> bool
+pub fn bitcoin_primitives::Script::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::Script::from_bytes_mut(bytes: &mut [u8]) -> &mut Self
+pub fn bitcoin_primitives::Script::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::Script::index(&self, index: (core::ops::range::Bound<usize>, core::ops::range::Bound<usize>)) -> &Self::Output
+pub fn bitcoin_primitives::Script::index(&self, index: core::ops::range::Range<usize>) -> &Self::Output
+pub fn bitcoin_primitives::Script::index(&self, index: core::ops::range::RangeFrom<usize>) -> &Self::Output
+pub fn bitcoin_primitives::Script::index(&self, index: core::ops::range::RangeFull) -> &Self::Output
+pub fn bitcoin_primitives::Script::index(&self, index: core::ops::range::RangeInclusive<usize>) -> &Self::Output
+pub fn bitcoin_primitives::Script::index(&self, index: core::ops::range::RangeTo<usize>) -> &Self::Output
+pub fn bitcoin_primitives::Script::index(&self, index: core::ops::range::RangeToInclusive<usize>) -> &Self::Output
+pub fn bitcoin_primitives::Script::into_script_buf(self: alloc::boxed::Box<Self>) -> bitcoin_primitives::ScriptBuf
+pub fn bitcoin_primitives::Script::partial_cmp(&self, other: &bitcoin_primitives::Script) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::Script::partial_cmp(&self, other: &bitcoin_primitives::ScriptBuf) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::Script::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+pub fn bitcoin_primitives::Script::to_bytes(&self) -> alloc::vec::Vec<u8>
+pub fn bitcoin_primitives::Script::to_hex(&self) -> alloc::string::String
+pub fn bitcoin_primitives::Script::to_owned(&self) -> Self::Owned
+pub fn bitcoin_primitives::Script::to_vec(&self) -> alloc::vec::Vec<u8>
+pub fn bitcoin_primitives::ScriptBuf::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_primitives::ScriptBuf::as_mut(&mut self) -> &mut [u8]
+pub fn bitcoin_primitives::ScriptBuf::as_mut(&mut self) -> &mut bitcoin_primitives::Script
+pub fn bitcoin_primitives::ScriptBuf::as_mut_script(&mut self) -> &mut bitcoin_primitives::Script
+pub fn bitcoin_primitives::ScriptBuf::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::ScriptBuf::as_ref(&self) -> &bitcoin_primitives::Script
+pub fn bitcoin_primitives::ScriptBuf::as_script(&self) -> &bitcoin_primitives::Script
+pub fn bitcoin_primitives::ScriptBuf::borrow(&self) -> &bitcoin_primitives::Script
+pub fn bitcoin_primitives::ScriptBuf::borrow_mut(&mut self) -> &mut bitcoin_primitives::Script
+pub fn bitcoin_primitives::ScriptBuf::capacity(&self) -> usize
+pub fn bitcoin_primitives::ScriptBuf::clone(&self) -> bitcoin_primitives::ScriptBuf
+pub fn bitcoin_primitives::ScriptBuf::cmp(&self, other: &bitcoin_primitives::ScriptBuf) -> core::cmp::Ordering
+pub fn bitcoin_primitives::ScriptBuf::default() -> bitcoin_primitives::ScriptBuf
+pub fn bitcoin_primitives::ScriptBuf::deref(&self) -> &Self::Target
+pub fn bitcoin_primitives::ScriptBuf::deref_mut(&mut self) -> &mut Self::Target
+pub fn bitcoin_primitives::ScriptBuf::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+pub fn bitcoin_primitives::ScriptBuf::eq(&self, other: &bitcoin_primitives::Script) -> bool
+pub fn bitcoin_primitives::ScriptBuf::eq(&self, other: &bitcoin_primitives::ScriptBuf) -> bool
+pub fn bitcoin_primitives::ScriptBuf::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::ScriptBuf::from(v: alloc::vec::Vec<u8>) -> Self
+pub fn bitcoin_primitives::ScriptBuf::from(value: &'a bitcoin_primitives::Script) -> Self
+pub fn bitcoin_primitives::ScriptBuf::from(value: alloc::borrow::Cow<'a, bitcoin_primitives::Script>) -> Self
+pub fn bitcoin_primitives::ScriptBuf::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::ScriptBuf::into_boxed_script(self) -> alloc::boxed::Box<bitcoin_primitives::Script>
+pub fn bitcoin_primitives::ScriptBuf::into_bytes(self) -> alloc::vec::Vec<u8>
+pub fn bitcoin_primitives::ScriptBuf::partial_cmp(&self, other: &bitcoin_primitives::Script) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::ScriptBuf::partial_cmp(&self, other: &bitcoin_primitives::ScriptBuf) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::ScriptBuf::reserve(&mut self, additional_len: usize)
+pub fn bitcoin_primitives::ScriptBuf::reserve_exact(&mut self, additional_len: usize)
+pub fn bitcoin_primitives::ScriptBuf::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+pub fn bitcoin_primitives::ScriptBuf::to_hex(&self) -> alloc::string::String
+pub fn bitcoin_primitives::ScriptBuf::with_capacity(capacity: usize) -> Self
+pub fn bitcoin_primitives::block::Block::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_primitives::block::Block<V>::block_hash(&self) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::Block<V>::clone(&self) -> bitcoin_primitives::block::Block<V>
+pub fn bitcoin_primitives::block::Block<V>::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin_primitives::block::Block<V>::eq(&self, other: &bitcoin_primitives::block::Block<V>) -> bool
+pub fn bitcoin_primitives::block::Block<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::block::Block<V>::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Checked>::cached_witness_root(&self) -> core::option::Option<bitcoin_primitives::merkle_tree::WitnessMerkleNode>
+pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Checked>::header(&self) -> &bitcoin_primitives::block::Header
+pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Checked>::transactions(&self) -> &[bitcoin_primitives::transaction::Transaction]
+pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::assume_checked(self, witness_root: core::option::Option<bitcoin_primitives::merkle_tree::WitnessMerkleNode>) -> bitcoin_primitives::block::Block<bitcoin_primitives::block::Checked>
+pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::into_parts(self) -> (bitcoin_primitives::block::Header, alloc::vec::Vec<bitcoin_primitives::transaction::Transaction>)
+pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::new_unchecked(header: bitcoin_primitives::block::Header, transactions: alloc::vec::Vec<bitcoin_primitives::transaction::Transaction>) -> bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>
+pub fn bitcoin_primitives::block::BlockHash::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_primitives::block::BlockHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::block::BlockHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::block::BlockHash::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::block::BlockHash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::block::BlockHash::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::block::BlockHash::clone(&self) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::BlockHash::cmp(&self, other: &bitcoin_primitives::block::BlockHash) -> core::cmp::Ordering
+pub fn bitcoin_primitives::block::BlockHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_primitives::block::BlockHash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_primitives::block::BlockHash::eq(&self, other: &bitcoin_primitives::block::BlockHash) -> bool
+pub fn bitcoin_primitives::block::BlockHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::block::BlockHash::from(block: &bitcoin_primitives::block::Block) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::BlockHash::from(block: bitcoin_primitives::block::Block) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::BlockHash::from(header: &bitcoin_primitives::block::Header) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::BlockHash::from(header: bitcoin_primitives::block::Header) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::BlockHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::block::BlockHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::block::BlockHash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_primitives::block::BlockHash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::block::BlockHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::block::BlockHash::partial_cmp(&self, other: &bitcoin_primitives::block::BlockHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::block::BlockHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_primitives::block::BlockHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::block::Checked::clone(&self) -> bitcoin_primitives::block::Checked
+pub fn bitcoin_primitives::block::Checked::cmp(&self, other: &bitcoin_primitives::block::Checked) -> core::cmp::Ordering
+pub fn bitcoin_primitives::block::Checked::eq(&self, other: &bitcoin_primitives::block::Checked) -> bool
+pub fn bitcoin_primitives::block::Checked::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::block::Checked::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::block::Checked::partial_cmp(&self, other: &bitcoin_primitives::block::Checked) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::block::Header::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_primitives::block::Header::block_hash(&self) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::Header::clone(&self) -> bitcoin_primitives::block::Header
+pub fn bitcoin_primitives::block::Header::cmp(&self, other: &bitcoin_primitives::block::Header) -> core::cmp::Ordering
+pub fn bitcoin_primitives::block::Header::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin_primitives::block::Header::eq(&self, other: &bitcoin_primitives::block::Header) -> bool
+pub fn bitcoin_primitives::block::Header::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::block::Header::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::block::Header::partial_cmp(&self, other: &bitcoin_primitives::block::Header) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::block::Header::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin_primitives::block::Unchecked::clone(&self) -> bitcoin_primitives::block::Unchecked
+pub fn bitcoin_primitives::block::Unchecked::cmp(&self, other: &bitcoin_primitives::block::Unchecked) -> core::cmp::Ordering
+pub fn bitcoin_primitives::block::Unchecked::eq(&self, other: &bitcoin_primitives::block::Unchecked) -> bool
+pub fn bitcoin_primitives::block::Unchecked::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::block::Unchecked::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::block::Unchecked::partial_cmp(&self, other: &bitcoin_primitives::block::Unchecked) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::block::Version::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_primitives::block::Version::clone(&self) -> bitcoin_primitives::block::Version
+pub fn bitcoin_primitives::block::Version::cmp(&self, other: &bitcoin_primitives::block::Version) -> core::cmp::Ordering
+pub fn bitcoin_primitives::block::Version::default() -> bitcoin_primitives::block::Version
+pub fn bitcoin_primitives::block::Version::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin_primitives::block::Version::eq(&self, other: &bitcoin_primitives::block::Version) -> bool
+pub fn bitcoin_primitives::block::Version::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::block::Version::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::block::Version::is_signalling_soft_fork(self, bit: u8) -> bool
+pub fn bitcoin_primitives::block::Version::partial_cmp(&self, other: &bitcoin_primitives::block::Version) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::block::Version::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin_primitives::block::Version::to_consensus(self) -> i32
+pub fn bitcoin_primitives::block::WitnessCommitment::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::block::WitnessCommitment::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::block::WitnessCommitment::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::block::WitnessCommitment::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::block::WitnessCommitment::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::block::WitnessCommitment::clone(&self) -> bitcoin_primitives::block::WitnessCommitment
+pub fn bitcoin_primitives::block::WitnessCommitment::cmp(&self, other: &bitcoin_primitives::block::WitnessCommitment) -> core::cmp::Ordering
+pub fn bitcoin_primitives::block::WitnessCommitment::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_primitives::block::WitnessCommitment, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_primitives::block::WitnessCommitment::eq(&self, other: &bitcoin_primitives::block::WitnessCommitment) -> bool
+pub fn bitcoin_primitives::block::WitnessCommitment::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::block::WitnessCommitment::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::block::WitnessCommitment::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::block::WitnessCommitment, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_primitives::block::WitnessCommitment::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::block::WitnessCommitment::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::block::WitnessCommitment::partial_cmp(&self, other: &bitcoin_primitives::block::WitnessCommitment) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::block::WitnessCommitment::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_primitives::block::WitnessCommitment::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::clone(&self) -> bitcoin_primitives::merkle_tree::TxMerkleNode
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::cmp(&self, other: &bitcoin_primitives::merkle_tree::TxMerkleNode) -> core::cmp::Ordering
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_primitives::merkle_tree::TxMerkleNode, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::eq(&self, other: &bitcoin_primitives::merkle_tree::TxMerkleNode) -> bool
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::merkle_tree::TxMerkleNode, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::partial_cmp(&self, other: &bitcoin_primitives::merkle_tree::TxMerkleNode) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::clone(&self) -> bitcoin_primitives::merkle_tree::WitnessMerkleNode
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::cmp(&self, other: &bitcoin_primitives::merkle_tree::WitnessMerkleNode) -> core::cmp::Ordering
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_primitives::merkle_tree::WitnessMerkleNode, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::eq(&self, other: &bitcoin_primitives::merkle_tree::WitnessMerkleNode) -> bool
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::merkle_tree::WitnessMerkleNode, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::partial_cmp(&self, other: &bitcoin_primitives::merkle_tree::WitnessMerkleNode) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::pow::CompactTarget::clone(&self) -> bitcoin_primitives::pow::CompactTarget
+pub fn bitcoin_primitives::pow::CompactTarget::cmp(&self, other: &bitcoin_primitives::pow::CompactTarget) -> core::cmp::Ordering
+pub fn bitcoin_primitives::pow::CompactTarget::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin_primitives::pow::CompactTarget::eq(&self, other: &bitcoin_primitives::pow::CompactTarget) -> bool
+pub fn bitcoin_primitives::pow::CompactTarget::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::pow::CompactTarget::from_consensus(bits: u32) -> Self
+pub fn bitcoin_primitives::pow::CompactTarget::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::pow::CompactTarget::partial_cmp(&self, other: &bitcoin_primitives::pow::CompactTarget) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::pow::CompactTarget::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin_primitives::pow::CompactTarget::to_consensus(self) -> u32
+pub fn bitcoin_primitives::pow::CompactTarget::to_hex(self) -> alloc::string::String
+pub fn bitcoin_primitives::script::RedeemScriptSizeError::clone(&self) -> bitcoin_primitives::script::RedeemScriptSizeError
+pub fn bitcoin_primitives::script::RedeemScriptSizeError::eq(&self, other: &bitcoin_primitives::script::RedeemScriptSizeError) -> bool
+pub fn bitcoin_primitives::script::RedeemScriptSizeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::script::RedeemScriptSizeError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_primitives::script::RedeemScriptSizeError::invalid_size(&self) -> usize
+pub fn bitcoin_primitives::script::ScriptHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::script::ScriptHash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_primitives::script::ScriptHash::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::script::ScriptHash::borrow(&self) -> &[u8; 20]
+pub fn bitcoin_primitives::script::ScriptHash::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::script::ScriptHash::clone(&self) -> bitcoin_primitives::script::ScriptHash
+pub fn bitcoin_primitives::script::ScriptHash::cmp(&self, other: &bitcoin_primitives::script::ScriptHash) -> core::cmp::Ordering
+pub fn bitcoin_primitives::script::ScriptHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_primitives::script::ScriptHash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_primitives::script::ScriptHash::eq(&self, other: &bitcoin_primitives::script::ScriptHash) -> bool
+pub fn bitcoin_primitives::script::ScriptHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::script::ScriptHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::script::ScriptHash::from_script(redeem_script: &bitcoin_primitives::Script) -> core::result::Result<Self, bitcoin_primitives::script::RedeemScriptSizeError>
+pub fn bitcoin_primitives::script::ScriptHash::from_script_unchecked(script: &bitcoin_primitives::Script) -> Self
+pub fn bitcoin_primitives::script::ScriptHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::script::ScriptHash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_primitives::script::ScriptHash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::script::ScriptHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::script::ScriptHash::partial_cmp(&self, other: &bitcoin_primitives::script::ScriptHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::script::ScriptHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_primitives::script::ScriptHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::script::ScriptHash::try_from(redeem_script: &bitcoin_primitives::Script) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_primitives::script::ScriptHash::try_from(redeem_script: &bitcoin_primitives::ScriptBuf) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_primitives::script::ScriptHash::try_from(redeem_script: bitcoin_primitives::ScriptBuf) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_primitives::script::WScriptHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::script::WScriptHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::script::WScriptHash::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::script::WScriptHash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::script::WScriptHash::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::script::WScriptHash::clone(&self) -> bitcoin_primitives::script::WScriptHash
+pub fn bitcoin_primitives::script::WScriptHash::cmp(&self, other: &bitcoin_primitives::script::WScriptHash) -> core::cmp::Ordering
+pub fn bitcoin_primitives::script::WScriptHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_primitives::script::WScriptHash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_primitives::script::WScriptHash::eq(&self, other: &bitcoin_primitives::script::WScriptHash) -> bool
+pub fn bitcoin_primitives::script::WScriptHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::script::WScriptHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::script::WScriptHash::from_script(witness_script: &bitcoin_primitives::Script) -> core::result::Result<Self, bitcoin_primitives::script::WitnessScriptSizeError>
+pub fn bitcoin_primitives::script::WScriptHash::from_script_unchecked(script: &bitcoin_primitives::Script) -> Self
+pub fn bitcoin_primitives::script::WScriptHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::script::WScriptHash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_primitives::script::WScriptHash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::script::WScriptHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::script::WScriptHash::partial_cmp(&self, other: &bitcoin_primitives::script::WScriptHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::script::WScriptHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_primitives::script::WScriptHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::script::WScriptHash::try_from(witness_script: &bitcoin_primitives::Script) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_primitives::script::WScriptHash::try_from(witness_script: &bitcoin_primitives::ScriptBuf) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_primitives::script::WScriptHash::try_from(witness_script: bitcoin_primitives::ScriptBuf) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_primitives::script::WitnessScriptSizeError::clone(&self) -> bitcoin_primitives::script::WitnessScriptSizeError
+pub fn bitcoin_primitives::script::WitnessScriptSizeError::eq(&self, other: &bitcoin_primitives::script::WitnessScriptSizeError) -> bool
+pub fn bitcoin_primitives::script::WitnessScriptSizeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::script::WitnessScriptSizeError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_primitives::script::WitnessScriptSizeError::invalid_size(&self) -> usize
+pub fn bitcoin_primitives::transaction::OutPoint::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_primitives::transaction::OutPoint::clone(&self) -> bitcoin_primitives::transaction::OutPoint
+pub fn bitcoin_primitives::transaction::OutPoint::cmp(&self, other: &bitcoin_primitives::transaction::OutPoint) -> core::cmp::Ordering
+pub fn bitcoin_primitives::transaction::OutPoint::deserialize<D>(deserializer: D) -> core::result::Result<bitcoin_primitives::transaction::OutPoint, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+pub fn bitcoin_primitives::transaction::OutPoint::eq(&self, other: &bitcoin_primitives::transaction::OutPoint) -> bool
+pub fn bitcoin_primitives::transaction::OutPoint::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::OutPoint::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::transaction::OutPoint::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::transaction::OutPoint::partial_cmp(&self, other: &bitcoin_primitives::transaction::OutPoint) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::OutPoint::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+pub fn bitcoin_primitives::transaction::ParseOutPointError::clone(&self) -> bitcoin_primitives::transaction::ParseOutPointError
+pub fn bitcoin_primitives::transaction::ParseOutPointError::eq(&self, other: &bitcoin_primitives::transaction::ParseOutPointError) -> bool
+pub fn bitcoin_primitives::transaction::ParseOutPointError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::ParseOutPointError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_primitives::transaction::ParseOutPointError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_primitives::transaction::Transaction::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_primitives::transaction::Transaction::clone(&self) -> bitcoin_primitives::transaction::Transaction
+pub fn bitcoin_primitives::transaction::Transaction::cmp(&self, other: &Self) -> core::cmp::Ordering
+pub fn bitcoin_primitives::transaction::Transaction::compute_ntxid(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_primitives::transaction::Transaction::compute_txid(&self) -> bitcoin_primitives::transaction::Txid
+pub fn bitcoin_primitives::transaction::Transaction::compute_wtxid(&self) -> bitcoin_primitives::transaction::Wtxid
+pub fn bitcoin_primitives::transaction::Transaction::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin_primitives::transaction::Transaction::eq(&self, other: &bitcoin_primitives::transaction::Transaction) -> bool
+pub fn bitcoin_primitives::transaction::Transaction::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::Transaction::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::transaction::Transaction::inputs(&self) -> &[bitcoin_primitives::transaction::TxIn]
+pub fn bitcoin_primitives::transaction::Transaction::inputs_mut(&mut self) -> &mut [bitcoin_primitives::transaction::TxIn]
+pub fn bitcoin_primitives::transaction::Transaction::outputs(&self) -> &[bitcoin_primitives::transaction::TxOut]
+pub fn bitcoin_primitives::transaction::Transaction::outputs_mut(&mut self) -> &mut [bitcoin_primitives::transaction::TxOut]
+pub fn bitcoin_primitives::transaction::Transaction::partial_cmp(&self, other: &Self) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::Transaction::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin_primitives::transaction::TxIn::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_primitives::transaction::TxIn::clone(&self) -> bitcoin_primitives::transaction::TxIn
+pub fn bitcoin_primitives::transaction::TxIn::cmp(&self, other: &bitcoin_primitives::transaction::TxIn) -> core::cmp::Ordering
+pub fn bitcoin_primitives::transaction::TxIn::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin_primitives::transaction::TxIn::eq(&self, other: &bitcoin_primitives::transaction::TxIn) -> bool
+pub fn bitcoin_primitives::transaction::TxIn::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::TxIn::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::transaction::TxIn::partial_cmp(&self, other: &bitcoin_primitives::transaction::TxIn) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::TxIn::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin_primitives::transaction::TxOut::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_primitives::transaction::TxOut::clone(&self) -> bitcoin_primitives::transaction::TxOut
+pub fn bitcoin_primitives::transaction::TxOut::cmp(&self, other: &bitcoin_primitives::transaction::TxOut) -> core::cmp::Ordering
+pub fn bitcoin_primitives::transaction::TxOut::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin_primitives::transaction::TxOut::eq(&self, other: &bitcoin_primitives::transaction::TxOut) -> bool
+pub fn bitcoin_primitives::transaction::TxOut::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::TxOut::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::transaction::TxOut::partial_cmp(&self, other: &bitcoin_primitives::transaction::TxOut) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::TxOut::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin_primitives::transaction::Txid::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_primitives::transaction::Txid::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::transaction::Txid::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::transaction::Txid::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::transaction::Txid::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::transaction::Txid::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::transaction::Txid::clone(&self) -> bitcoin_primitives::transaction::Txid
+pub fn bitcoin_primitives::transaction::Txid::cmp(&self, other: &bitcoin_primitives::transaction::Txid) -> core::cmp::Ordering
+pub fn bitcoin_primitives::transaction::Txid::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_primitives::transaction::Txid, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_primitives::transaction::Txid::eq(&self, other: &bitcoin_primitives::transaction::Txid) -> bool
+pub fn bitcoin_primitives::transaction::Txid::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::Txid::from(tx: &bitcoin_primitives::transaction::Transaction) -> bitcoin_primitives::transaction::Txid
+pub fn bitcoin_primitives::transaction::Txid::from(tx: bitcoin_primitives::transaction::Transaction) -> bitcoin_primitives::transaction::Txid
+pub fn bitcoin_primitives::transaction::Txid::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::transaction::Txid::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::transaction::Txid, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_primitives::transaction::Txid::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::transaction::Txid::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::transaction::Txid::partial_cmp(&self, other: &bitcoin_primitives::transaction::Txid) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::Txid::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_primitives::transaction::Txid::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::transaction::Version::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_primitives::transaction::Version::clone(&self) -> bitcoin_primitives::transaction::Version
+pub fn bitcoin_primitives::transaction::Version::cmp(&self, other: &bitcoin_primitives::transaction::Version) -> core::cmp::Ordering
+pub fn bitcoin_primitives::transaction::Version::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+pub fn bitcoin_primitives::transaction::Version::eq(&self, other: &bitcoin_primitives::transaction::Version) -> bool
+pub fn bitcoin_primitives::transaction::Version::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::Version::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::transaction::Version::partial_cmp(&self, other: &bitcoin_primitives::transaction::Version) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::Version::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+pub fn bitcoin_primitives::transaction::Wtxid::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_primitives::transaction::Wtxid::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::transaction::Wtxid::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::transaction::Wtxid::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::transaction::Wtxid::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::transaction::Wtxid::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::transaction::Wtxid::clone(&self) -> bitcoin_primitives::transaction::Wtxid
+pub fn bitcoin_primitives::transaction::Wtxid::cmp(&self, other: &bitcoin_primitives::transaction::Wtxid) -> core::cmp::Ordering
+pub fn bitcoin_primitives::transaction::Wtxid::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_primitives::transaction::Wtxid, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_primitives::transaction::Wtxid::eq(&self, other: &bitcoin_primitives::transaction::Wtxid) -> bool
+pub fn bitcoin_primitives::transaction::Wtxid::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::Wtxid::from(tx: &bitcoin_primitives::transaction::Transaction) -> bitcoin_primitives::transaction::Wtxid
+pub fn bitcoin_primitives::transaction::Wtxid::from(tx: bitcoin_primitives::transaction::Transaction) -> bitcoin_primitives::transaction::Wtxid
+pub fn bitcoin_primitives::transaction::Wtxid::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::transaction::Wtxid::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::transaction::Wtxid, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_primitives::transaction::Wtxid::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_primitives::transaction::Wtxid::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::transaction::Wtxid::partial_cmp(&self, other: &bitcoin_primitives::transaction::Wtxid) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::Wtxid::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_primitives::transaction::Wtxid::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::witness::Iter<'a>::clone(&self) -> bitcoin_primitives::witness::Iter<'a>
+pub fn bitcoin_primitives::witness::Iter<'a>::next(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin_primitives::witness::Iter<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn bitcoin_primitives::witness::Witness::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_primitives::witness::Witness::clear(&mut self)
+pub fn bitcoin_primitives::witness::Witness::clone(&self) -> bitcoin_primitives::witness::Witness
+pub fn bitcoin_primitives::witness::Witness::cmp(&self, other: &bitcoin_primitives::witness::Witness) -> core::cmp::Ordering
+pub fn bitcoin_primitives::witness::Witness::default() -> Self
+pub fn bitcoin_primitives::witness::Witness::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+pub fn bitcoin_primitives::witness::Witness::eq(&self, other: &bitcoin_primitives::witness::Witness) -> bool
+pub fn bitcoin_primitives::witness::Witness::eq(&self, rhs: &&[T; N]) -> bool
+pub fn bitcoin_primitives::witness::Witness::eq(&self, rhs: &&[T]) -> bool
+pub fn bitcoin_primitives::witness::Witness::eq(&self, rhs: &[T; N]) -> bool
+pub fn bitcoin_primitives::witness::Witness::eq(&self, rhs: &[T]) -> bool
+pub fn bitcoin_primitives::witness::Witness::eq(&self, rhs: &alloc::boxed::Box<[T]>) -> bool
+pub fn bitcoin_primitives::witness::Witness::eq(&self, rhs: &alloc::rc::Rc<[T]>) -> bool
+pub fn bitcoin_primitives::witness::Witness::eq(&self, rhs: &alloc::sync::Arc<[T]>) -> bool
+pub fn bitcoin_primitives::witness::Witness::eq(&self, rhs: &alloc::vec::Vec<T>) -> bool
+pub fn bitcoin_primitives::witness::Witness::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::witness::Witness::from(arr: &[&[u8]; N]) -> Self
+pub fn bitcoin_primitives::witness::Witness::from(arr: [&[u8]; N]) -> Self
+pub fn bitcoin_primitives::witness::Witness::from(slice: &[&[u8; M]; N]) -> Self
+pub fn bitcoin_primitives::witness::Witness::from(slice: &[&[u8; N]]) -> Self
+pub fn bitcoin_primitives::witness::Witness::from(slice: &[&[u8]]) -> Self
+pub fn bitcoin_primitives::witness::Witness::from(slice: &[[u8; M]; N]) -> Self
+pub fn bitcoin_primitives::witness::Witness::from(slice: &[[u8; N]]) -> Self
+pub fn bitcoin_primitives::witness::Witness::from(slice: &[alloc::vec::Vec<u8>]) -> Self
+pub fn bitcoin_primitives::witness::Witness::from(slice: [&[u8; M]; N]) -> Self
+pub fn bitcoin_primitives::witness::Witness::from(slice: [[u8; M]; N]) -> Self
+pub fn bitcoin_primitives::witness::Witness::from(vec: alloc::vec::Vec<&[u8]>) -> Self
+pub fn bitcoin_primitives::witness::Witness::from(vec: alloc::vec::Vec<alloc::vec::Vec<u8>>) -> Self
+pub fn bitcoin_primitives::witness::Witness::from_hex<I, T>(iter: I) -> core::result::Result<Self, hex_conservative::error::HexToBytesError> where I: core::iter::traits::collect::IntoIterator<Item = T>, T: core::convert::AsRef<str>
+pub fn bitcoin_primitives::witness::Witness::from_iter<I: core::iter::traits::collect::IntoIterator<Item = T>>(iter: I) -> Self
+pub fn bitcoin_primitives::witness::Witness::from_slice<T: core::convert::AsRef<[u8]>>(slice: &[T]) -> Self
+pub fn bitcoin_primitives::witness::Witness::get(&self, index: usize) -> core::option::Option<&[u8]>
+pub fn bitcoin_primitives::witness::Witness::get_back(&self, index: usize) -> core::option::Option<&[u8]>
+pub fn bitcoin_primitives::witness::Witness::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::witness::Witness::index(&self, index: usize) -> &Self::Output
+pub fn bitcoin_primitives::witness::Witness::is_empty(&self) -> bool
+pub fn bitcoin_primitives::witness::Witness::iter(&self) -> bitcoin_primitives::witness::Iter<'_>
+pub fn bitcoin_primitives::witness::Witness::last(&self) -> core::option::Option<&[u8]>
+pub fn bitcoin_primitives::witness::Witness::len(&self) -> usize
+pub fn bitcoin_primitives::witness::Witness::partial_cmp(&self, other: &bitcoin_primitives::witness::Witness) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::witness::Witness::push<T: core::convert::AsRef<[u8]>>(&mut self, new_element: T)
+pub fn bitcoin_primitives::witness::Witness::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+pub fn bitcoin_primitives::witness::Witness::size(&self) -> usize
+pub fn bitcoin_primitives::witness::Witness::to_vec(&self) -> alloc::vec::Vec<alloc::vec::Vec<u8>>
+pub fn u32::from(version: bitcoin_primitives::transaction::Version) -> Self
+pub mod bitcoin_primitives
+pub mod bitcoin_primitives::block
+pub mod bitcoin_primitives::merkle_tree
+pub mod bitcoin_primitives::pow
+pub mod bitcoin_primitives::script
+pub mod bitcoin_primitives::transaction
+pub mod bitcoin_primitives::witness
+pub struct bitcoin_primitives::Block<V> where V: bitcoin_primitives::block::Validation
+pub struct bitcoin_primitives::BlockHash(_)
+pub struct bitcoin_primitives::BlockHeader
+pub struct bitcoin_primitives::BlockVersion(_)
+pub struct bitcoin_primitives::CompactTarget(_)
+pub struct bitcoin_primitives::OutPoint
+pub struct bitcoin_primitives::ScriptBuf(_)
+pub struct bitcoin_primitives::Transaction
+pub struct bitcoin_primitives::TransactionVersion(_)
+pub struct bitcoin_primitives::TxIn
+pub struct bitcoin_primitives::TxMerkleNode(_)
+pub struct bitcoin_primitives::TxOut
+pub struct bitcoin_primitives::Txid(_)
+pub struct bitcoin_primitives::Witness
+pub struct bitcoin_primitives::WitnessCommitment(_)
+pub struct bitcoin_primitives::WitnessMerkleNode(_)
+pub struct bitcoin_primitives::Wtxid(_)
+pub struct bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation
+pub struct bitcoin_primitives::block::BlockHash(_)
+pub struct bitcoin_primitives::block::Header
+pub struct bitcoin_primitives::block::Version(_)
+pub struct bitcoin_primitives::block::WitnessCommitment(_)
+pub struct bitcoin_primitives::merkle_tree::TxMerkleNode(_)
+pub struct bitcoin_primitives::merkle_tree::WitnessMerkleNode(_)
+pub struct bitcoin_primitives::pow::CompactTarget(_)
+pub struct bitcoin_primitives::script::RedeemScriptSizeError
+pub struct bitcoin_primitives::script::ScriptBuf(_)
+pub struct bitcoin_primitives::script::ScriptHash(_)
+pub struct bitcoin_primitives::script::WScriptHash(_)
+pub struct bitcoin_primitives::script::WitnessScriptSizeError
+pub struct bitcoin_primitives::transaction::OutPoint
+pub struct bitcoin_primitives::transaction::Transaction
+pub struct bitcoin_primitives::transaction::TxIn
+pub struct bitcoin_primitives::transaction::TxOut
+pub struct bitcoin_primitives::transaction::Txid(_)
+pub struct bitcoin_primitives::transaction::Version(_)
+pub struct bitcoin_primitives::transaction::Wtxid(_)
+pub struct bitcoin_primitives::witness::Iter<'a>
+pub struct bitcoin_primitives::witness::Witness
+pub trait bitcoin_primitives::BlockValidation: bitcoin_primitives::block::sealed::Validation + core::marker::Sync + core::marker::Send + core::marker::Sized + core::marker::Unpin
+pub trait bitcoin_primitives::block::Validation: bitcoin_primitives::block::sealed::Validation + core::marker::Sync + core::marker::Send + core::marker::Sized + core::marker::Unpin
+pub type &'a bitcoin_primitives::witness::Witness::IntoIter = bitcoin_primitives::witness::Iter<'a>
+pub type &'a bitcoin_primitives::witness::Witness::Item = &'a [u8]
+pub type bitcoin_primitives::Script::Output = bitcoin_primitives::Script
+pub type bitcoin_primitives::Script::Owned = bitcoin_primitives::ScriptBuf
+pub type bitcoin_primitives::ScriptBuf::Target = bitcoin_primitives::Script
+pub type bitcoin_primitives::block::BlockHash::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::block::BlockHash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::block::WitnessCommitment::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::block::WitnessCommitment::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::merkle_tree::TxMerkleNode::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::merkle_tree::TxMerkleNode::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::merkle_tree::WitnessMerkleNode::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::merkle_tree::WitnessMerkleNode::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::script::ScriptHash::Bytes = <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::script::ScriptHash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::script::ScriptHash::Error = bitcoin_primitives::script::RedeemScriptSizeError
+pub type bitcoin_primitives::script::WScriptHash::Bytes = <bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::script::WScriptHash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::script::WScriptHash::Error = bitcoin_primitives::script::WitnessScriptSizeError
+pub type bitcoin_primitives::transaction::OutPoint::Err = bitcoin_primitives::transaction::ParseOutPointError
+pub type bitcoin_primitives::transaction::Txid::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::transaction::Txid::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::transaction::Wtxid::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::transaction::Wtxid::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_primitives::witness::Iter<'a>::Item = &'a [u8]
+pub type bitcoin_primitives::witness::Witness::Output = [u8]
+pub use bitcoin_primitives::Amount
+pub use bitcoin_primitives::BlockHeight
+pub use bitcoin_primitives::BlockHeightInterval
+pub use bitcoin_primitives::BlockMtp
+pub use bitcoin_primitives::BlockMtpInterval
+pub use bitcoin_primitives::BlockTime
+pub use bitcoin_primitives::FeeRate
+pub use bitcoin_primitives::Sequence
+pub use bitcoin_primitives::SignedAmount
+pub use bitcoin_primitives::Weight
+pub use bitcoin_primitives::absolute
+pub use bitcoin_primitives::amount
+pub use bitcoin_primitives::fee_rate
+pub use bitcoin_primitives::locktime
+pub use bitcoin_primitives::relative
+pub use bitcoin_primitives::sequence
+pub use bitcoin_primitives::time
+pub use bitcoin_primitives::weight

--- a/api/primitives/alloc-only.txt
+++ b/api/primitives/alloc-only.txt
@@ -1,0 +1,1035 @@
+#[repr(transparent)] pub struct bitcoin_primitives::Script(_)
+#[repr(transparent)] pub struct bitcoin_primitives::script::Script(_)
+impl !core::marker::Sized for bitcoin_primitives::Script
+impl alloc::borrow::ToOwned for bitcoin_primitives::Script
+impl bitcoin_hashes::Hash for bitcoin_primitives::block::BlockHash
+impl bitcoin_hashes::Hash for bitcoin_primitives::block::WitnessCommitment
+impl bitcoin_hashes::Hash for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl bitcoin_hashes::Hash for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl bitcoin_hashes::Hash for bitcoin_primitives::script::ScriptHash
+impl bitcoin_hashes::Hash for bitcoin_primitives::script::WScriptHash
+impl bitcoin_hashes::Hash for bitcoin_primitives::transaction::Txid
+impl bitcoin_hashes::Hash for bitcoin_primitives::transaction::Wtxid
+impl bitcoin_primitives::Script
+impl bitcoin_primitives::ScriptBuf
+impl bitcoin_primitives::block::Block<bitcoin_primitives::block::Checked>
+impl bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>
+impl bitcoin_primitives::block::BlockHash
+impl bitcoin_primitives::block::Header
+impl bitcoin_primitives::block::Validation for bitcoin_primitives::block::Checked
+impl bitcoin_primitives::block::Validation for bitcoin_primitives::block::Unchecked
+impl bitcoin_primitives::block::Version
+impl bitcoin_primitives::block::WitnessCommitment
+impl bitcoin_primitives::merkle_tree::TxMerkleNode
+impl bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl bitcoin_primitives::pow::CompactTarget
+impl bitcoin_primitives::script::RedeemScriptSizeError
+impl bitcoin_primitives::script::ScriptHash
+impl bitcoin_primitives::script::WScriptHash
+impl bitcoin_primitives::script::WitnessScriptSizeError
+impl bitcoin_primitives::transaction::OutPoint
+impl bitcoin_primitives::transaction::Transaction
+impl bitcoin_primitives::transaction::TxIn
+impl bitcoin_primitives::transaction::Txid
+impl bitcoin_primitives::transaction::Version
+impl bitcoin_primitives::transaction::Wtxid
+impl bitcoin_primitives::witness::Witness
+impl core::borrow::Borrow<[u8; 20]> for bitcoin_primitives::script::ScriptHash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::block::BlockHash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::block::WitnessCommitment
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::script::WScriptHash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::transaction::Txid
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::transaction::Wtxid
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::block::BlockHash
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::block::WitnessCommitment
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::script::ScriptHash
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::script::WScriptHash
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::transaction::Txid
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::transaction::Wtxid
+impl core::borrow::Borrow<bitcoin_primitives::Script> for bitcoin_primitives::ScriptBuf
+impl core::borrow::BorrowMut<bitcoin_primitives::Script> for bitcoin_primitives::ScriptBuf
+impl core::clone::Clone for bitcoin_primitives::ScriptBuf
+impl core::clone::Clone for bitcoin_primitives::block::BlockHash
+impl core::clone::Clone for bitcoin_primitives::block::Checked
+impl core::clone::Clone for bitcoin_primitives::block::Header
+impl core::clone::Clone for bitcoin_primitives::block::Unchecked
+impl core::clone::Clone for bitcoin_primitives::block::Version
+impl core::clone::Clone for bitcoin_primitives::block::WitnessCommitment
+impl core::clone::Clone for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::clone::Clone for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::clone::Clone for bitcoin_primitives::pow::CompactTarget
+impl core::clone::Clone for bitcoin_primitives::script::RedeemScriptSizeError
+impl core::clone::Clone for bitcoin_primitives::script::ScriptHash
+impl core::clone::Clone for bitcoin_primitives::script::WScriptHash
+impl core::clone::Clone for bitcoin_primitives::script::WitnessScriptSizeError
+impl core::clone::Clone for bitcoin_primitives::transaction::OutPoint
+impl core::clone::Clone for bitcoin_primitives::transaction::Transaction
+impl core::clone::Clone for bitcoin_primitives::transaction::TxIn
+impl core::clone::Clone for bitcoin_primitives::transaction::TxOut
+impl core::clone::Clone for bitcoin_primitives::transaction::Txid
+impl core::clone::Clone for bitcoin_primitives::transaction::Version
+impl core::clone::Clone for bitcoin_primitives::transaction::Wtxid
+impl core::clone::Clone for bitcoin_primitives::witness::Witness
+impl core::cmp::Eq for bitcoin_primitives::Script
+impl core::cmp::Eq for bitcoin_primitives::ScriptBuf
+impl core::cmp::Eq for bitcoin_primitives::block::BlockHash
+impl core::cmp::Eq for bitcoin_primitives::block::Checked
+impl core::cmp::Eq for bitcoin_primitives::block::Header
+impl core::cmp::Eq for bitcoin_primitives::block::Unchecked
+impl core::cmp::Eq for bitcoin_primitives::block::Version
+impl core::cmp::Eq for bitcoin_primitives::block::WitnessCommitment
+impl core::cmp::Eq for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::cmp::Eq for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::cmp::Eq for bitcoin_primitives::pow::CompactTarget
+impl core::cmp::Eq for bitcoin_primitives::script::RedeemScriptSizeError
+impl core::cmp::Eq for bitcoin_primitives::script::ScriptHash
+impl core::cmp::Eq for bitcoin_primitives::script::WScriptHash
+impl core::cmp::Eq for bitcoin_primitives::script::WitnessScriptSizeError
+impl core::cmp::Eq for bitcoin_primitives::transaction::OutPoint
+impl core::cmp::Eq for bitcoin_primitives::transaction::Transaction
+impl core::cmp::Eq for bitcoin_primitives::transaction::TxIn
+impl core::cmp::Eq for bitcoin_primitives::transaction::TxOut
+impl core::cmp::Eq for bitcoin_primitives::transaction::Txid
+impl core::cmp::Eq for bitcoin_primitives::transaction::Version
+impl core::cmp::Eq for bitcoin_primitives::transaction::Wtxid
+impl core::cmp::Eq for bitcoin_primitives::witness::Witness
+impl core::cmp::Ord for bitcoin_primitives::Script
+impl core::cmp::Ord for bitcoin_primitives::ScriptBuf
+impl core::cmp::Ord for bitcoin_primitives::block::BlockHash
+impl core::cmp::Ord for bitcoin_primitives::block::Checked
+impl core::cmp::Ord for bitcoin_primitives::block::Header
+impl core::cmp::Ord for bitcoin_primitives::block::Unchecked
+impl core::cmp::Ord for bitcoin_primitives::block::Version
+impl core::cmp::Ord for bitcoin_primitives::block::WitnessCommitment
+impl core::cmp::Ord for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::cmp::Ord for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::cmp::Ord for bitcoin_primitives::pow::CompactTarget
+impl core::cmp::Ord for bitcoin_primitives::script::ScriptHash
+impl core::cmp::Ord for bitcoin_primitives::script::WScriptHash
+impl core::cmp::Ord for bitcoin_primitives::transaction::OutPoint
+impl core::cmp::Ord for bitcoin_primitives::transaction::Transaction
+impl core::cmp::Ord for bitcoin_primitives::transaction::TxIn
+impl core::cmp::Ord for bitcoin_primitives::transaction::TxOut
+impl core::cmp::Ord for bitcoin_primitives::transaction::Txid
+impl core::cmp::Ord for bitcoin_primitives::transaction::Version
+impl core::cmp::Ord for bitcoin_primitives::transaction::Wtxid
+impl core::cmp::Ord for bitcoin_primitives::witness::Witness
+impl core::cmp::PartialEq for bitcoin_primitives::Script
+impl core::cmp::PartialEq for bitcoin_primitives::ScriptBuf
+impl core::cmp::PartialEq for bitcoin_primitives::block::BlockHash
+impl core::cmp::PartialEq for bitcoin_primitives::block::Checked
+impl core::cmp::PartialEq for bitcoin_primitives::block::Header
+impl core::cmp::PartialEq for bitcoin_primitives::block::Unchecked
+impl core::cmp::PartialEq for bitcoin_primitives::block::Version
+impl core::cmp::PartialEq for bitcoin_primitives::block::WitnessCommitment
+impl core::cmp::PartialEq for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::cmp::PartialEq for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::cmp::PartialEq for bitcoin_primitives::pow::CompactTarget
+impl core::cmp::PartialEq for bitcoin_primitives::script::RedeemScriptSizeError
+impl core::cmp::PartialEq for bitcoin_primitives::script::ScriptHash
+impl core::cmp::PartialEq for bitcoin_primitives::script::WScriptHash
+impl core::cmp::PartialEq for bitcoin_primitives::script::WitnessScriptSizeError
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::OutPoint
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::Transaction
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::TxIn
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::TxOut
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::Txid
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::Version
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::Wtxid
+impl core::cmp::PartialEq for bitcoin_primitives::witness::Witness
+impl core::cmp::PartialEq<bitcoin_primitives::Script> for bitcoin_primitives::ScriptBuf
+impl core::cmp::PartialEq<bitcoin_primitives::ScriptBuf> for bitcoin_primitives::Script
+impl core::cmp::PartialOrd for bitcoin_primitives::Script
+impl core::cmp::PartialOrd for bitcoin_primitives::ScriptBuf
+impl core::cmp::PartialOrd for bitcoin_primitives::block::BlockHash
+impl core::cmp::PartialOrd for bitcoin_primitives::block::Checked
+impl core::cmp::PartialOrd for bitcoin_primitives::block::Header
+impl core::cmp::PartialOrd for bitcoin_primitives::block::Unchecked
+impl core::cmp::PartialOrd for bitcoin_primitives::block::Version
+impl core::cmp::PartialOrd for bitcoin_primitives::block::WitnessCommitment
+impl core::cmp::PartialOrd for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::cmp::PartialOrd for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::cmp::PartialOrd for bitcoin_primitives::pow::CompactTarget
+impl core::cmp::PartialOrd for bitcoin_primitives::script::ScriptHash
+impl core::cmp::PartialOrd for bitcoin_primitives::script::WScriptHash
+impl core::cmp::PartialOrd for bitcoin_primitives::transaction::OutPoint
+impl core::cmp::PartialOrd for bitcoin_primitives::transaction::Transaction
+impl core::cmp::PartialOrd for bitcoin_primitives::transaction::TxIn
+impl core::cmp::PartialOrd for bitcoin_primitives::transaction::TxOut
+impl core::cmp::PartialOrd for bitcoin_primitives::transaction::Txid
+impl core::cmp::PartialOrd for bitcoin_primitives::transaction::Version
+impl core::cmp::PartialOrd for bitcoin_primitives::transaction::Wtxid
+impl core::cmp::PartialOrd for bitcoin_primitives::witness::Witness
+impl core::cmp::PartialOrd<bitcoin_primitives::Script> for bitcoin_primitives::ScriptBuf
+impl core::cmp::PartialOrd<bitcoin_primitives::ScriptBuf> for bitcoin_primitives::Script
+impl core::convert::AsMut<[u8]> for bitcoin_primitives::Script
+impl core::convert::AsMut<[u8]> for bitcoin_primitives::ScriptBuf
+impl core::convert::AsMut<bitcoin_primitives::Script> for bitcoin_primitives::Script
+impl core::convert::AsMut<bitcoin_primitives::Script> for bitcoin_primitives::ScriptBuf
+impl core::convert::AsRef<[u8; 20]> for bitcoin_primitives::script::ScriptHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::block::BlockHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::block::WitnessCommitment
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::script::WScriptHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::transaction::Txid
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::transaction::Wtxid
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::Script
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::ScriptBuf
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::block::BlockHash
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::block::WitnessCommitment
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::script::ScriptHash
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::script::WScriptHash
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::transaction::Txid
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::transaction::Wtxid
+impl core::convert::AsRef<bitcoin_primitives::Script> for bitcoin_primitives::Script
+impl core::convert::AsRef<bitcoin_primitives::Script> for bitcoin_primitives::ScriptBuf
+impl core::convert::From<&[&[u8]]> for bitcoin_primitives::witness::Witness
+impl core::convert::From<&[alloc::vec::Vec<u8>]> for bitcoin_primitives::witness::Witness
+impl core::convert::From<&bitcoin_primitives::block::Block> for bitcoin_primitives::block::BlockHash
+impl core::convert::From<&bitcoin_primitives::block::Header> for bitcoin_primitives::block::BlockHash
+impl core::convert::From<&bitcoin_primitives::transaction::Transaction> for bitcoin_primitives::transaction::Txid
+impl core::convert::From<&bitcoin_primitives::transaction::Transaction> for bitcoin_primitives::transaction::Wtxid
+impl core::convert::From<alloc::vec::Vec<&[u8]>> for bitcoin_primitives::witness::Witness
+impl core::convert::From<alloc::vec::Vec<alloc::vec::Vec<u8>>> for bitcoin_primitives::witness::Witness
+impl core::convert::From<alloc::vec::Vec<u8>> for bitcoin_primitives::ScriptBuf
+impl core::convert::From<bitcoin_primitives::ScriptBuf> for alloc::borrow::Cow<'_, bitcoin_primitives::Script>
+impl core::convert::From<bitcoin_primitives::ScriptBuf> for alloc::boxed::Box<bitcoin_primitives::Script>
+impl core::convert::From<bitcoin_primitives::ScriptBuf> for alloc::vec::Vec<u8>
+impl core::convert::From<bitcoin_primitives::block::Block> for bitcoin_primitives::block::BlockHash
+impl core::convert::From<bitcoin_primitives::block::Header> for bitcoin_primitives::block::BlockHash
+impl core::convert::From<bitcoin_primitives::transaction::Transaction> for bitcoin_primitives::transaction::Txid
+impl core::convert::From<bitcoin_primitives::transaction::Transaction> for bitcoin_primitives::transaction::Wtxid
+impl core::convert::From<bitcoin_primitives::transaction::Version> for u32
+impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::script::RedeemScriptSizeError
+impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::script::WitnessScriptSizeError
+impl core::convert::TryFrom<&bitcoin_primitives::Script> for bitcoin_primitives::script::ScriptHash
+impl core::convert::TryFrom<&bitcoin_primitives::Script> for bitcoin_primitives::script::WScriptHash
+impl core::convert::TryFrom<&bitcoin_primitives::ScriptBuf> for bitcoin_primitives::script::ScriptHash
+impl core::convert::TryFrom<&bitcoin_primitives::ScriptBuf> for bitcoin_primitives::script::WScriptHash
+impl core::convert::TryFrom<bitcoin_primitives::ScriptBuf> for bitcoin_primitives::script::ScriptHash
+impl core::convert::TryFrom<bitcoin_primitives::ScriptBuf> for bitcoin_primitives::script::WScriptHash
+impl core::default::Default for &bitcoin_primitives::Script
+impl core::default::Default for bitcoin_primitives::ScriptBuf
+impl core::default::Default for bitcoin_primitives::block::Version
+impl core::default::Default for bitcoin_primitives::witness::Witness
+impl core::fmt::Debug for bitcoin_primitives::Script
+impl core::fmt::Debug for bitcoin_primitives::ScriptBuf
+impl core::fmt::Debug for bitcoin_primitives::block::BlockHash
+impl core::fmt::Debug for bitcoin_primitives::block::Checked
+impl core::fmt::Debug for bitcoin_primitives::block::Header
+impl core::fmt::Debug for bitcoin_primitives::block::Unchecked
+impl core::fmt::Debug for bitcoin_primitives::block::Version
+impl core::fmt::Debug for bitcoin_primitives::block::WitnessCommitment
+impl core::fmt::Debug for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::fmt::Debug for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::fmt::Debug for bitcoin_primitives::pow::CompactTarget
+impl core::fmt::Debug for bitcoin_primitives::script::RedeemScriptSizeError
+impl core::fmt::Debug for bitcoin_primitives::script::ScriptHash
+impl core::fmt::Debug for bitcoin_primitives::script::WScriptHash
+impl core::fmt::Debug for bitcoin_primitives::script::WitnessScriptSizeError
+impl core::fmt::Debug for bitcoin_primitives::transaction::OutPoint
+impl core::fmt::Debug for bitcoin_primitives::transaction::Transaction
+impl core::fmt::Debug for bitcoin_primitives::transaction::TxIn
+impl core::fmt::Debug for bitcoin_primitives::transaction::TxOut
+impl core::fmt::Debug for bitcoin_primitives::transaction::Txid
+impl core::fmt::Debug for bitcoin_primitives::transaction::Version
+impl core::fmt::Debug for bitcoin_primitives::transaction::Wtxid
+impl core::fmt::Debug for bitcoin_primitives::witness::Witness
+impl core::fmt::Display for bitcoin_primitives::Script
+impl core::fmt::Display for bitcoin_primitives::ScriptBuf
+impl core::fmt::Display for bitcoin_primitives::script::RedeemScriptSizeError
+impl core::fmt::Display for bitcoin_primitives::script::WitnessScriptSizeError
+impl core::fmt::Display for bitcoin_primitives::transaction::Version
+impl core::fmt::LowerHex for bitcoin_primitives::pow::CompactTarget
+impl core::fmt::UpperHex for bitcoin_primitives::pow::CompactTarget
+impl core::hash::Hash for bitcoin_primitives::Script
+impl core::hash::Hash for bitcoin_primitives::ScriptBuf
+impl core::hash::Hash for bitcoin_primitives::block::BlockHash
+impl core::hash::Hash for bitcoin_primitives::block::Checked
+impl core::hash::Hash for bitcoin_primitives::block::Header
+impl core::hash::Hash for bitcoin_primitives::block::Unchecked
+impl core::hash::Hash for bitcoin_primitives::block::Version
+impl core::hash::Hash for bitcoin_primitives::block::WitnessCommitment
+impl core::hash::Hash for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::hash::Hash for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::hash::Hash for bitcoin_primitives::pow::CompactTarget
+impl core::hash::Hash for bitcoin_primitives::script::ScriptHash
+impl core::hash::Hash for bitcoin_primitives::script::WScriptHash
+impl core::hash::Hash for bitcoin_primitives::transaction::OutPoint
+impl core::hash::Hash for bitcoin_primitives::transaction::Transaction
+impl core::hash::Hash for bitcoin_primitives::transaction::TxIn
+impl core::hash::Hash for bitcoin_primitives::transaction::TxOut
+impl core::hash::Hash for bitcoin_primitives::transaction::Txid
+impl core::hash::Hash for bitcoin_primitives::transaction::Version
+impl core::hash::Hash for bitcoin_primitives::transaction::Wtxid
+impl core::hash::Hash for bitcoin_primitives::witness::Witness
+impl core::iter::traits::exact_size::ExactSizeIterator for bitcoin_primitives::witness::Iter<'_>
+impl core::marker::Copy for bitcoin_primitives::block::BlockHash
+impl core::marker::Copy for bitcoin_primitives::block::Header
+impl core::marker::Copy for bitcoin_primitives::block::Version
+impl core::marker::Copy for bitcoin_primitives::block::WitnessCommitment
+impl core::marker::Copy for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::marker::Copy for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::marker::Copy for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Copy for bitcoin_primitives::script::ScriptHash
+impl core::marker::Copy for bitcoin_primitives::script::WScriptHash
+impl core::marker::Copy for bitcoin_primitives::transaction::OutPoint
+impl core::marker::Copy for bitcoin_primitives::transaction::Txid
+impl core::marker::Copy for bitcoin_primitives::transaction::Version
+impl core::marker::Copy for bitcoin_primitives::transaction::Wtxid
+impl core::marker::Freeze for bitcoin_primitives::Script
+impl core::marker::Freeze for bitcoin_primitives::ScriptBuf
+impl core::marker::Freeze for bitcoin_primitives::block::BlockHash
+impl core::marker::Freeze for bitcoin_primitives::block::Checked
+impl core::marker::Freeze for bitcoin_primitives::block::Header
+impl core::marker::Freeze for bitcoin_primitives::block::Unchecked
+impl core::marker::Freeze for bitcoin_primitives::block::Version
+impl core::marker::Freeze for bitcoin_primitives::block::WitnessCommitment
+impl core::marker::Freeze for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::marker::Freeze for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::marker::Freeze for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Freeze for bitcoin_primitives::script::RedeemScriptSizeError
+impl core::marker::Freeze for bitcoin_primitives::script::ScriptHash
+impl core::marker::Freeze for bitcoin_primitives::script::WScriptHash
+impl core::marker::Freeze for bitcoin_primitives::script::WitnessScriptSizeError
+impl core::marker::Freeze for bitcoin_primitives::transaction::OutPoint
+impl core::marker::Freeze for bitcoin_primitives::transaction::Transaction
+impl core::marker::Freeze for bitcoin_primitives::transaction::TxIn
+impl core::marker::Freeze for bitcoin_primitives::transaction::TxOut
+impl core::marker::Freeze for bitcoin_primitives::transaction::Txid
+impl core::marker::Freeze for bitcoin_primitives::transaction::Version
+impl core::marker::Freeze for bitcoin_primitives::transaction::Wtxid
+impl core::marker::Freeze for bitcoin_primitives::witness::Witness
+impl core::marker::Send for bitcoin_primitives::Script
+impl core::marker::Send for bitcoin_primitives::ScriptBuf
+impl core::marker::Send for bitcoin_primitives::block::BlockHash
+impl core::marker::Send for bitcoin_primitives::block::Checked
+impl core::marker::Send for bitcoin_primitives::block::Header
+impl core::marker::Send for bitcoin_primitives::block::Unchecked
+impl core::marker::Send for bitcoin_primitives::block::Version
+impl core::marker::Send for bitcoin_primitives::block::WitnessCommitment
+impl core::marker::Send for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::marker::Send for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::marker::Send for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Send for bitcoin_primitives::script::RedeemScriptSizeError
+impl core::marker::Send for bitcoin_primitives::script::ScriptHash
+impl core::marker::Send for bitcoin_primitives::script::WScriptHash
+impl core::marker::Send for bitcoin_primitives::script::WitnessScriptSizeError
+impl core::marker::Send for bitcoin_primitives::transaction::OutPoint
+impl core::marker::Send for bitcoin_primitives::transaction::Transaction
+impl core::marker::Send for bitcoin_primitives::transaction::TxIn
+impl core::marker::Send for bitcoin_primitives::transaction::TxOut
+impl core::marker::Send for bitcoin_primitives::transaction::Txid
+impl core::marker::Send for bitcoin_primitives::transaction::Version
+impl core::marker::Send for bitcoin_primitives::transaction::Wtxid
+impl core::marker::Send for bitcoin_primitives::witness::Witness
+impl core::marker::StructuralPartialEq for bitcoin_primitives::Script
+impl core::marker::StructuralPartialEq for bitcoin_primitives::ScriptBuf
+impl core::marker::StructuralPartialEq for bitcoin_primitives::block::BlockHash
+impl core::marker::StructuralPartialEq for bitcoin_primitives::block::Checked
+impl core::marker::StructuralPartialEq for bitcoin_primitives::block::Header
+impl core::marker::StructuralPartialEq for bitcoin_primitives::block::Unchecked
+impl core::marker::StructuralPartialEq for bitcoin_primitives::block::Version
+impl core::marker::StructuralPartialEq for bitcoin_primitives::block::WitnessCommitment
+impl core::marker::StructuralPartialEq for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::marker::StructuralPartialEq for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::marker::StructuralPartialEq for bitcoin_primitives::pow::CompactTarget
+impl core::marker::StructuralPartialEq for bitcoin_primitives::script::RedeemScriptSizeError
+impl core::marker::StructuralPartialEq for bitcoin_primitives::script::ScriptHash
+impl core::marker::StructuralPartialEq for bitcoin_primitives::script::WScriptHash
+impl core::marker::StructuralPartialEq for bitcoin_primitives::script::WitnessScriptSizeError
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::OutPoint
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::Transaction
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::TxIn
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::TxOut
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::Txid
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::Version
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::Wtxid
+impl core::marker::StructuralPartialEq for bitcoin_primitives::witness::Witness
+impl core::marker::Sync for bitcoin_primitives::Script
+impl core::marker::Sync for bitcoin_primitives::ScriptBuf
+impl core::marker::Sync for bitcoin_primitives::block::BlockHash
+impl core::marker::Sync for bitcoin_primitives::block::Checked
+impl core::marker::Sync for bitcoin_primitives::block::Header
+impl core::marker::Sync for bitcoin_primitives::block::Unchecked
+impl core::marker::Sync for bitcoin_primitives::block::Version
+impl core::marker::Sync for bitcoin_primitives::block::WitnessCommitment
+impl core::marker::Sync for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::marker::Sync for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::marker::Sync for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Sync for bitcoin_primitives::script::RedeemScriptSizeError
+impl core::marker::Sync for bitcoin_primitives::script::ScriptHash
+impl core::marker::Sync for bitcoin_primitives::script::WScriptHash
+impl core::marker::Sync for bitcoin_primitives::script::WitnessScriptSizeError
+impl core::marker::Sync for bitcoin_primitives::transaction::OutPoint
+impl core::marker::Sync for bitcoin_primitives::transaction::Transaction
+impl core::marker::Sync for bitcoin_primitives::transaction::TxIn
+impl core::marker::Sync for bitcoin_primitives::transaction::TxOut
+impl core::marker::Sync for bitcoin_primitives::transaction::Txid
+impl core::marker::Sync for bitcoin_primitives::transaction::Version
+impl core::marker::Sync for bitcoin_primitives::transaction::Wtxid
+impl core::marker::Sync for bitcoin_primitives::witness::Witness
+impl core::marker::Unpin for bitcoin_primitives::Script
+impl core::marker::Unpin for bitcoin_primitives::ScriptBuf
+impl core::marker::Unpin for bitcoin_primitives::block::BlockHash
+impl core::marker::Unpin for bitcoin_primitives::block::Checked
+impl core::marker::Unpin for bitcoin_primitives::block::Header
+impl core::marker::Unpin for bitcoin_primitives::block::Unchecked
+impl core::marker::Unpin for bitcoin_primitives::block::Version
+impl core::marker::Unpin for bitcoin_primitives::block::WitnessCommitment
+impl core::marker::Unpin for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::marker::Unpin for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::marker::Unpin for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Unpin for bitcoin_primitives::script::RedeemScriptSizeError
+impl core::marker::Unpin for bitcoin_primitives::script::ScriptHash
+impl core::marker::Unpin for bitcoin_primitives::script::WScriptHash
+impl core::marker::Unpin for bitcoin_primitives::script::WitnessScriptSizeError
+impl core::marker::Unpin for bitcoin_primitives::transaction::OutPoint
+impl core::marker::Unpin for bitcoin_primitives::transaction::Transaction
+impl core::marker::Unpin for bitcoin_primitives::transaction::TxIn
+impl core::marker::Unpin for bitcoin_primitives::transaction::TxOut
+impl core::marker::Unpin for bitcoin_primitives::transaction::Txid
+impl core::marker::Unpin for bitcoin_primitives::transaction::Version
+impl core::marker::Unpin for bitcoin_primitives::transaction::Wtxid
+impl core::marker::Unpin for bitcoin_primitives::witness::Witness
+impl core::ops::deref::Deref for bitcoin_primitives::ScriptBuf
+impl core::ops::deref::DerefMut for bitcoin_primitives::ScriptBuf
+impl core::ops::index::Index<(core::ops::range::Bound<usize>, core::ops::range::Bound<usize>)> for bitcoin_primitives::Script
+impl core::ops::index::Index<core::ops::range::Range<usize>> for bitcoin_primitives::Script
+impl core::ops::index::Index<core::ops::range::RangeFrom<usize>> for bitcoin_primitives::Script
+impl core::ops::index::Index<core::ops::range::RangeFull> for bitcoin_primitives::Script
+impl core::ops::index::Index<core::ops::range::RangeInclusive<usize>> for bitcoin_primitives::Script
+impl core::ops::index::Index<core::ops::range::RangeTo<usize>> for bitcoin_primitives::Script
+impl core::ops::index::Index<core::ops::range::RangeToInclusive<usize>> for bitcoin_primitives::Script
+impl core::ops::index::Index<usize> for bitcoin_primitives::witness::Witness
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::Script
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::ScriptBuf
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::BlockHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::Checked
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::Header
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::Unchecked
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::Version
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::WitnessCommitment
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::pow::CompactTarget
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::script::RedeemScriptSizeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::script::ScriptHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::script::WScriptHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::script::WitnessScriptSizeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::OutPoint
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::Transaction
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::TxIn
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::TxOut
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::Txid
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::Version
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::Wtxid
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness::Witness
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::Script
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::ScriptBuf
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::BlockHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::Checked
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::Header
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::Unchecked
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::Version
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::WitnessCommitment
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::pow::CompactTarget
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::script::RedeemScriptSizeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::script::ScriptHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::script::WScriptHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::script::WitnessScriptSizeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::OutPoint
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::Transaction
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::TxIn
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::TxOut
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::Txid
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::Version
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::Wtxid
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness::Witness
+impl<'a> core::clone::Clone for bitcoin_primitives::witness::Iter<'a>
+impl<'a> core::convert::From<&'a bitcoin_primitives::Script> for alloc::borrow::Cow<'a, bitcoin_primitives::Script>
+impl<'a> core::convert::From<&'a bitcoin_primitives::Script> for alloc::boxed::Box<bitcoin_primitives::Script>
+impl<'a> core::convert::From<&'a bitcoin_primitives::Script> for alloc::rc::Rc<bitcoin_primitives::Script>
+impl<'a> core::convert::From<&'a bitcoin_primitives::Script> for alloc::sync::Arc<bitcoin_primitives::Script>
+impl<'a> core::convert::From<&'a bitcoin_primitives::Script> for bitcoin_primitives::ScriptBuf
+impl<'a> core::convert::From<alloc::borrow::Cow<'a, bitcoin_primitives::Script>> for alloc::boxed::Box<bitcoin_primitives::Script>
+impl<'a> core::convert::From<alloc::borrow::Cow<'a, bitcoin_primitives::Script>> for bitcoin_primitives::ScriptBuf
+impl<'a> core::iter::traits::collect::IntoIterator for &'a bitcoin_primitives::witness::Witness
+impl<'a> core::iter::traits::iterator::Iterator for bitcoin_primitives::witness::Iter<'a>
+impl<'a> core::marker::Freeze for bitcoin_primitives::witness::Iter<'a>
+impl<'a> core::marker::Send for bitcoin_primitives::witness::Iter<'a>
+impl<'a> core::marker::Sync for bitcoin_primitives::witness::Iter<'a>
+impl<'a> core::marker::Unpin for bitcoin_primitives::witness::Iter<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness::Iter<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness::Iter<'a>
+impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<&[T]> for bitcoin_primitives::witness::Witness
+impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<[T]> for bitcoin_primitives::witness::Witness
+impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<alloc::boxed::Box<[T]>> for bitcoin_primitives::witness::Witness
+impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<alloc::rc::Rc<[T]>> for bitcoin_primitives::witness::Witness
+impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<alloc::sync::Arc<[T]>> for bitcoin_primitives::witness::Witness
+impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<alloc::vec::Vec<T>> for bitcoin_primitives::witness::Witness
+impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<bitcoin_primitives::witness::Witness> for &[T]
+impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<bitcoin_primitives::witness::Witness> for [T]
+impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<bitcoin_primitives::witness::Witness> for alloc::boxed::Box<[T]>
+impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<bitcoin_primitives::witness::Witness> for alloc::rc::Rc<[T]>
+impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<bitcoin_primitives::witness::Witness> for alloc::sync::Arc<[T]>
+impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<bitcoin_primitives::witness::Witness> for alloc::vec::Vec<T>
+impl<T: core::convert::AsRef<[u8]>> core::iter::traits::collect::FromIterator<T> for bitcoin_primitives::witness::Witness
+impl<V: bitcoin_primitives::block::Validation> bitcoin_primitives::block::Block<V>
+impl<V> core::clone::Clone for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::clone::Clone
+impl<V> core::cmp::Eq for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::cmp::Eq
+impl<V> core::cmp::PartialEq for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::cmp::PartialEq
+impl<V> core::fmt::Debug for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::fmt::Debug
+impl<V> core::marker::Freeze for bitcoin_primitives::block::Block<V>
+impl<V> core::marker::Send for bitcoin_primitives::block::Block<V>
+impl<V> core::marker::StructuralPartialEq for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation
+impl<V> core::marker::Sync for bitcoin_primitives::block::Block<V>
+impl<V> core::marker::Unpin for bitcoin_primitives::block::Block<V>
+impl<V> core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::Block<V> where V: core::panic::unwind_safe::RefUnwindSafe
+impl<V> core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::Block<V> where V: core::panic::unwind_safe::UnwindSafe
+impl<const N: usize, T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<&[T; N]> for bitcoin_primitives::witness::Witness
+impl<const N: usize, T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<[T; N]> for bitcoin_primitives::witness::Witness
+impl<const N: usize, T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<bitcoin_primitives::witness::Witness> for &[T; N]
+impl<const N: usize, T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<bitcoin_primitives::witness::Witness> for [T; N]
+impl<const N: usize, const M: usize> core::convert::From<&[&[u8; M]; N]> for bitcoin_primitives::witness::Witness
+impl<const N: usize, const M: usize> core::convert::From<&[[u8; M]; N]> for bitcoin_primitives::witness::Witness
+impl<const N: usize, const M: usize> core::convert::From<[&[u8; M]; N]> for bitcoin_primitives::witness::Witness
+impl<const N: usize, const M: usize> core::convert::From<[[u8; M]; N]> for bitcoin_primitives::witness::Witness
+impl<const N: usize> core::convert::From<&[&[u8; N]]> for bitcoin_primitives::witness::Witness
+impl<const N: usize> core::convert::From<&[&[u8]; N]> for bitcoin_primitives::witness::Witness
+impl<const N: usize> core::convert::From<&[[u8; N]]> for bitcoin_primitives::witness::Witness
+impl<const N: usize> core::convert::From<[&[u8]; N]> for bitcoin_primitives::witness::Witness
+pub bitcoin_primitives::BlockHeader::bits: bitcoin_primitives::pow::CompactTarget
+pub bitcoin_primitives::BlockHeader::merkle_root: bitcoin_primitives::merkle_tree::TxMerkleNode
+pub bitcoin_primitives::BlockHeader::nonce: u32
+pub bitcoin_primitives::BlockHeader::prev_blockhash: bitcoin_primitives::block::BlockHash
+pub bitcoin_primitives::BlockHeader::time: bitcoin_units::time::encapsulate::BlockTime
+pub bitcoin_primitives::BlockHeader::version: bitcoin_primitives::block::Version
+pub bitcoin_primitives::OutPoint::txid: bitcoin_primitives::transaction::Txid
+pub bitcoin_primitives::OutPoint::vout: u32
+pub bitcoin_primitives::Transaction::input: alloc::vec::Vec<bitcoin_primitives::transaction::TxIn>
+pub bitcoin_primitives::Transaction::lock_time: bitcoin_units::locktime::absolute::LockTime
+pub bitcoin_primitives::Transaction::output: alloc::vec::Vec<bitcoin_primitives::transaction::TxOut>
+pub bitcoin_primitives::Transaction::version: bitcoin_primitives::transaction::Version
+pub bitcoin_primitives::TxIn::previous_output: bitcoin_primitives::transaction::OutPoint
+pub bitcoin_primitives::TxIn::script_sig: bitcoin_primitives::ScriptBuf
+pub bitcoin_primitives::TxIn::sequence: bitcoin_units::sequence::Sequence
+pub bitcoin_primitives::TxIn::witness: bitcoin_primitives::witness::Witness
+pub bitcoin_primitives::TxOut::script_pubkey: bitcoin_primitives::ScriptBuf
+pub bitcoin_primitives::TxOut::value: bitcoin_units::amount::unsigned::encapsulate::Amount
+pub bitcoin_primitives::block::Header::bits: bitcoin_primitives::pow::CompactTarget
+pub bitcoin_primitives::block::Header::merkle_root: bitcoin_primitives::merkle_tree::TxMerkleNode
+pub bitcoin_primitives::block::Header::nonce: u32
+pub bitcoin_primitives::block::Header::prev_blockhash: bitcoin_primitives::block::BlockHash
+pub bitcoin_primitives::block::Header::time: bitcoin_units::time::encapsulate::BlockTime
+pub bitcoin_primitives::block::Header::version: bitcoin_primitives::block::Version
+pub bitcoin_primitives::transaction::OutPoint::txid: bitcoin_primitives::transaction::Txid
+pub bitcoin_primitives::transaction::OutPoint::vout: u32
+pub bitcoin_primitives::transaction::Transaction::input: alloc::vec::Vec<bitcoin_primitives::transaction::TxIn>
+pub bitcoin_primitives::transaction::Transaction::lock_time: bitcoin_units::locktime::absolute::LockTime
+pub bitcoin_primitives::transaction::Transaction::output: alloc::vec::Vec<bitcoin_primitives::transaction::TxOut>
+pub bitcoin_primitives::transaction::Transaction::version: bitcoin_primitives::transaction::Version
+pub bitcoin_primitives::transaction::TxIn::previous_output: bitcoin_primitives::transaction::OutPoint
+pub bitcoin_primitives::transaction::TxIn::script_sig: bitcoin_primitives::ScriptBuf
+pub bitcoin_primitives::transaction::TxIn::sequence: bitcoin_units::sequence::Sequence
+pub bitcoin_primitives::transaction::TxIn::witness: bitcoin_primitives::witness::Witness
+pub bitcoin_primitives::transaction::TxOut::script_pubkey: bitcoin_primitives::ScriptBuf
+pub bitcoin_primitives::transaction::TxOut::value: bitcoin_units::amount::unsigned::encapsulate::Amount
+pub const bitcoin_primitives::BlockValidation::IS_CHECKED: bool
+pub const bitcoin_primitives::block::BlockHash::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::block::BlockHash::GENESIS_PREVIOUS_BLOCK_HASH: Self
+pub const bitcoin_primitives::block::Checked::IS_CHECKED: bool
+pub const bitcoin_primitives::block::Header::SIZE: usize
+pub const bitcoin_primitives::block::Unchecked::IS_CHECKED: bool
+pub const bitcoin_primitives::block::Validation::IS_CHECKED: bool
+pub const bitcoin_primitives::block::Version::NO_SOFT_FORK_SIGNALLING: Self
+pub const bitcoin_primitives::block::Version::ONE: Self
+pub const bitcoin_primitives::block::Version::TWO: Self
+pub const bitcoin_primitives::block::WitnessCommitment::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::merkle_tree::TxMerkleNode::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::merkle_tree::WitnessMerkleNode::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::script::MAX_REDEEM_SCRIPT_SIZE: usize
+pub const bitcoin_primitives::script::MAX_WITNESS_SCRIPT_SIZE: usize
+pub const bitcoin_primitives::script::ScriptHash::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::script::WScriptHash::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::transaction::OutPoint::COINBASE_PREVOUT: Self
+pub const bitcoin_primitives::transaction::OutPoint::SIZE: usize
+pub const bitcoin_primitives::transaction::Transaction::MAX_STANDARD_WEIGHT: bitcoin_units::weight::encapsulate::Weight
+pub const bitcoin_primitives::transaction::TxIn::EMPTY_COINBASE: bitcoin_primitives::transaction::TxIn
+pub const bitcoin_primitives::transaction::Txid::COINBASE_PREVOUT: Self
+pub const bitcoin_primitives::transaction::Txid::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::transaction::Version::ONE: Self
+pub const bitcoin_primitives::transaction::Version::THREE: Self
+pub const bitcoin_primitives::transaction::Version::TWO: Self
+pub const bitcoin_primitives::transaction::Wtxid::COINBASE: Self
+pub const bitcoin_primitives::transaction::Wtxid::DISPLAY_BACKWARD: bool
+pub const fn bitcoin_primitives::Script::as_bytes(&self) -> &[u8]
+pub const fn bitcoin_primitives::Script::from_bytes(bytes: &[u8]) -> &Self
+pub const fn bitcoin_primitives::Script::is_empty(&self) -> bool
+pub const fn bitcoin_primitives::Script::len(&self) -> usize
+pub const fn bitcoin_primitives::Script::new() -> &'static Self
+pub const fn bitcoin_primitives::ScriptBuf::from_bytes(bytes: alloc::vec::Vec<u8>) -> Self
+pub const fn bitcoin_primitives::ScriptBuf::new() -> Self
+pub const fn bitcoin_primitives::block::BlockHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::block::BlockHash::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::block::BlockHash::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::block::Version::from_consensus(v: i32) -> Self
+pub const fn bitcoin_primitives::block::WitnessCommitment::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::block::WitnessCommitment::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::block::WitnessCommitment::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::merkle_tree::TxMerkleNode::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::merkle_tree::TxMerkleNode::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::merkle_tree::TxMerkleNode::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::script::ScriptHash::as_byte_array(&self) -> &<bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::script::ScriptHash::from_byte_array(bytes: <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::script::ScriptHash::to_byte_array(self) -> <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::script::WScriptHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::script::WScriptHash::from_byte_array(bytes: <bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::script::WScriptHash::to_byte_array(self) -> <bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::transaction::Txid::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::transaction::Txid::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::transaction::Txid::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::transaction::Version::is_standard(self) -> bool
+pub const fn bitcoin_primitives::transaction::Version::maybe_non_standard(version: u32) -> bitcoin_primitives::transaction::Version
+pub const fn bitcoin_primitives::transaction::Version::to_u32(self) -> u32
+pub const fn bitcoin_primitives::transaction::Wtxid::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::transaction::Wtxid::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::transaction::Wtxid::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::witness::Witness::new() -> Self
+pub enum bitcoin_primitives::BlockChecked
+pub enum bitcoin_primitives::BlockUnchecked
+pub enum bitcoin_primitives::block::Checked
+pub enum bitcoin_primitives::block::Unchecked
+pub fn &'a bitcoin_primitives::witness::Witness::into_iter(self) -> Self::IntoIter
+pub fn &[T; N]::eq(&self, rhs: &bitcoin_primitives::witness::Witness) -> bool
+pub fn &[T]::eq(&self, rhs: &bitcoin_primitives::witness::Witness) -> bool
+pub fn &bitcoin_primitives::Script::default() -> Self
+pub fn [T; N]::eq(&self, rhs: &bitcoin_primitives::witness::Witness) -> bool
+pub fn [T]::eq(&self, rhs: &bitcoin_primitives::witness::Witness) -> bool
+pub fn alloc::borrow::Cow<'_, bitcoin_primitives::Script>::from(value: bitcoin_primitives::ScriptBuf) -> Self
+pub fn alloc::borrow::Cow<'a, bitcoin_primitives::Script>::from(value: &'a bitcoin_primitives::Script) -> Self
+pub fn alloc::boxed::Box<[T]>::eq(&self, rhs: &bitcoin_primitives::witness::Witness) -> bool
+pub fn alloc::boxed::Box<bitcoin_primitives::Script>::from(v: bitcoin_primitives::ScriptBuf) -> Self
+pub fn alloc::boxed::Box<bitcoin_primitives::Script>::from(value: &'a bitcoin_primitives::Script) -> Self
+pub fn alloc::boxed::Box<bitcoin_primitives::Script>::from(value: alloc::borrow::Cow<'a, bitcoin_primitives::Script>) -> Self
+pub fn alloc::rc::Rc<[T]>::eq(&self, rhs: &bitcoin_primitives::witness::Witness) -> bool
+pub fn alloc::rc::Rc<bitcoin_primitives::Script>::from(value: &'a bitcoin_primitives::Script) -> Self
+pub fn alloc::sync::Arc<[T]>::eq(&self, rhs: &bitcoin_primitives::witness::Witness) -> bool
+pub fn alloc::sync::Arc<bitcoin_primitives::Script>::from(value: &'a bitcoin_primitives::Script) -> Self
+pub fn alloc::vec::Vec<T>::eq(&self, rhs: &bitcoin_primitives::witness::Witness) -> bool
+pub fn alloc::vec::Vec<u8>::from(v: bitcoin_primitives::ScriptBuf) -> Self
+pub fn bitcoin_primitives::Script::as_mut(&mut self) -> &mut Self
+pub fn bitcoin_primitives::Script::as_mut(&mut self) -> &mut [u8]
+pub fn bitcoin_primitives::Script::as_mut_bytes(&mut self) -> &mut [u8]
+pub fn bitcoin_primitives::Script::as_ref(&self) -> &Self
+pub fn bitcoin_primitives::Script::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::Script::cmp(&self, other: &bitcoin_primitives::Script) -> core::cmp::Ordering
+pub fn bitcoin_primitives::Script::eq(&self, other: &bitcoin_primitives::Script) -> bool
+pub fn bitcoin_primitives::Script::eq(&self, other: &bitcoin_primitives::ScriptBuf) -> bool
+pub fn bitcoin_primitives::Script::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::Script::from_bytes_mut(bytes: &mut [u8]) -> &mut Self
+pub fn bitcoin_primitives::Script::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::Script::index(&self, index: (core::ops::range::Bound<usize>, core::ops::range::Bound<usize>)) -> &Self::Output
+pub fn bitcoin_primitives::Script::index(&self, index: core::ops::range::Range<usize>) -> &Self::Output
+pub fn bitcoin_primitives::Script::index(&self, index: core::ops::range::RangeFrom<usize>) -> &Self::Output
+pub fn bitcoin_primitives::Script::index(&self, index: core::ops::range::RangeFull) -> &Self::Output
+pub fn bitcoin_primitives::Script::index(&self, index: core::ops::range::RangeInclusive<usize>) -> &Self::Output
+pub fn bitcoin_primitives::Script::index(&self, index: core::ops::range::RangeTo<usize>) -> &Self::Output
+pub fn bitcoin_primitives::Script::index(&self, index: core::ops::range::RangeToInclusive<usize>) -> &Self::Output
+pub fn bitcoin_primitives::Script::into_script_buf(self: alloc::boxed::Box<Self>) -> bitcoin_primitives::ScriptBuf
+pub fn bitcoin_primitives::Script::partial_cmp(&self, other: &bitcoin_primitives::Script) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::Script::partial_cmp(&self, other: &bitcoin_primitives::ScriptBuf) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::Script::to_bytes(&self) -> alloc::vec::Vec<u8>
+pub fn bitcoin_primitives::Script::to_owned(&self) -> Self::Owned
+pub fn bitcoin_primitives::Script::to_vec(&self) -> alloc::vec::Vec<u8>
+pub fn bitcoin_primitives::ScriptBuf::as_mut(&mut self) -> &mut [u8]
+pub fn bitcoin_primitives::ScriptBuf::as_mut(&mut self) -> &mut bitcoin_primitives::Script
+pub fn bitcoin_primitives::ScriptBuf::as_mut_script(&mut self) -> &mut bitcoin_primitives::Script
+pub fn bitcoin_primitives::ScriptBuf::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::ScriptBuf::as_ref(&self) -> &bitcoin_primitives::Script
+pub fn bitcoin_primitives::ScriptBuf::as_script(&self) -> &bitcoin_primitives::Script
+pub fn bitcoin_primitives::ScriptBuf::borrow(&self) -> &bitcoin_primitives::Script
+pub fn bitcoin_primitives::ScriptBuf::borrow_mut(&mut self) -> &mut bitcoin_primitives::Script
+pub fn bitcoin_primitives::ScriptBuf::capacity(&self) -> usize
+pub fn bitcoin_primitives::ScriptBuf::clone(&self) -> bitcoin_primitives::ScriptBuf
+pub fn bitcoin_primitives::ScriptBuf::cmp(&self, other: &bitcoin_primitives::ScriptBuf) -> core::cmp::Ordering
+pub fn bitcoin_primitives::ScriptBuf::default() -> bitcoin_primitives::ScriptBuf
+pub fn bitcoin_primitives::ScriptBuf::deref(&self) -> &Self::Target
+pub fn bitcoin_primitives::ScriptBuf::deref_mut(&mut self) -> &mut Self::Target
+pub fn bitcoin_primitives::ScriptBuf::eq(&self, other: &bitcoin_primitives::Script) -> bool
+pub fn bitcoin_primitives::ScriptBuf::eq(&self, other: &bitcoin_primitives::ScriptBuf) -> bool
+pub fn bitcoin_primitives::ScriptBuf::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::ScriptBuf::from(v: alloc::vec::Vec<u8>) -> Self
+pub fn bitcoin_primitives::ScriptBuf::from(value: &'a bitcoin_primitives::Script) -> Self
+pub fn bitcoin_primitives::ScriptBuf::from(value: alloc::borrow::Cow<'a, bitcoin_primitives::Script>) -> Self
+pub fn bitcoin_primitives::ScriptBuf::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::ScriptBuf::into_boxed_script(self) -> alloc::boxed::Box<bitcoin_primitives::Script>
+pub fn bitcoin_primitives::ScriptBuf::into_bytes(self) -> alloc::vec::Vec<u8>
+pub fn bitcoin_primitives::ScriptBuf::partial_cmp(&self, other: &bitcoin_primitives::Script) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::ScriptBuf::partial_cmp(&self, other: &bitcoin_primitives::ScriptBuf) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::ScriptBuf::reserve(&mut self, additional_len: usize)
+pub fn bitcoin_primitives::ScriptBuf::reserve_exact(&mut self, additional_len: usize)
+pub fn bitcoin_primitives::ScriptBuf::with_capacity(capacity: usize) -> Self
+pub fn bitcoin_primitives::block::Block<V>::block_hash(&self) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::Block<V>::clone(&self) -> bitcoin_primitives::block::Block<V>
+pub fn bitcoin_primitives::block::Block<V>::eq(&self, other: &bitcoin_primitives::block::Block<V>) -> bool
+pub fn bitcoin_primitives::block::Block<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Checked>::cached_witness_root(&self) -> core::option::Option<bitcoin_primitives::merkle_tree::WitnessMerkleNode>
+pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Checked>::header(&self) -> &bitcoin_primitives::block::Header
+pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Checked>::transactions(&self) -> &[bitcoin_primitives::transaction::Transaction]
+pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::assume_checked(self, witness_root: core::option::Option<bitcoin_primitives::merkle_tree::WitnessMerkleNode>) -> bitcoin_primitives::block::Block<bitcoin_primitives::block::Checked>
+pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::into_parts(self) -> (bitcoin_primitives::block::Header, alloc::vec::Vec<bitcoin_primitives::transaction::Transaction>)
+pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::new_unchecked(header: bitcoin_primitives::block::Header, transactions: alloc::vec::Vec<bitcoin_primitives::transaction::Transaction>) -> bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>
+pub fn bitcoin_primitives::block::BlockHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::block::BlockHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::block::BlockHash::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::block::BlockHash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::block::BlockHash::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::block::BlockHash::clone(&self) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::BlockHash::cmp(&self, other: &bitcoin_primitives::block::BlockHash) -> core::cmp::Ordering
+pub fn bitcoin_primitives::block::BlockHash::eq(&self, other: &bitcoin_primitives::block::BlockHash) -> bool
+pub fn bitcoin_primitives::block::BlockHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::block::BlockHash::from(block: &bitcoin_primitives::block::Block) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::BlockHash::from(block: bitcoin_primitives::block::Block) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::BlockHash::from(header: &bitcoin_primitives::block::Header) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::BlockHash::from(header: bitcoin_primitives::block::Header) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::BlockHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::block::BlockHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::block::BlockHash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_primitives::block::BlockHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::block::BlockHash::partial_cmp(&self, other: &bitcoin_primitives::block::BlockHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::block::BlockHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::block::Checked::clone(&self) -> bitcoin_primitives::block::Checked
+pub fn bitcoin_primitives::block::Checked::cmp(&self, other: &bitcoin_primitives::block::Checked) -> core::cmp::Ordering
+pub fn bitcoin_primitives::block::Checked::eq(&self, other: &bitcoin_primitives::block::Checked) -> bool
+pub fn bitcoin_primitives::block::Checked::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::block::Checked::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::block::Checked::partial_cmp(&self, other: &bitcoin_primitives::block::Checked) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::block::Header::block_hash(&self) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::Header::clone(&self) -> bitcoin_primitives::block::Header
+pub fn bitcoin_primitives::block::Header::cmp(&self, other: &bitcoin_primitives::block::Header) -> core::cmp::Ordering
+pub fn bitcoin_primitives::block::Header::eq(&self, other: &bitcoin_primitives::block::Header) -> bool
+pub fn bitcoin_primitives::block::Header::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::block::Header::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::block::Header::partial_cmp(&self, other: &bitcoin_primitives::block::Header) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::block::Unchecked::clone(&self) -> bitcoin_primitives::block::Unchecked
+pub fn bitcoin_primitives::block::Unchecked::cmp(&self, other: &bitcoin_primitives::block::Unchecked) -> core::cmp::Ordering
+pub fn bitcoin_primitives::block::Unchecked::eq(&self, other: &bitcoin_primitives::block::Unchecked) -> bool
+pub fn bitcoin_primitives::block::Unchecked::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::block::Unchecked::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::block::Unchecked::partial_cmp(&self, other: &bitcoin_primitives::block::Unchecked) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::block::Version::clone(&self) -> bitcoin_primitives::block::Version
+pub fn bitcoin_primitives::block::Version::cmp(&self, other: &bitcoin_primitives::block::Version) -> core::cmp::Ordering
+pub fn bitcoin_primitives::block::Version::default() -> bitcoin_primitives::block::Version
+pub fn bitcoin_primitives::block::Version::eq(&self, other: &bitcoin_primitives::block::Version) -> bool
+pub fn bitcoin_primitives::block::Version::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::block::Version::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::block::Version::is_signalling_soft_fork(self, bit: u8) -> bool
+pub fn bitcoin_primitives::block::Version::partial_cmp(&self, other: &bitcoin_primitives::block::Version) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::block::Version::to_consensus(self) -> i32
+pub fn bitcoin_primitives::block::WitnessCommitment::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::block::WitnessCommitment::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::block::WitnessCommitment::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::block::WitnessCommitment::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::block::WitnessCommitment::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::block::WitnessCommitment::clone(&self) -> bitcoin_primitives::block::WitnessCommitment
+pub fn bitcoin_primitives::block::WitnessCommitment::cmp(&self, other: &bitcoin_primitives::block::WitnessCommitment) -> core::cmp::Ordering
+pub fn bitcoin_primitives::block::WitnessCommitment::eq(&self, other: &bitcoin_primitives::block::WitnessCommitment) -> bool
+pub fn bitcoin_primitives::block::WitnessCommitment::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::block::WitnessCommitment::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::block::WitnessCommitment::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::block::WitnessCommitment, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_primitives::block::WitnessCommitment::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::block::WitnessCommitment::partial_cmp(&self, other: &bitcoin_primitives::block::WitnessCommitment) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::block::WitnessCommitment::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::clone(&self) -> bitcoin_primitives::merkle_tree::TxMerkleNode
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::cmp(&self, other: &bitcoin_primitives::merkle_tree::TxMerkleNode) -> core::cmp::Ordering
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::eq(&self, other: &bitcoin_primitives::merkle_tree::TxMerkleNode) -> bool
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::merkle_tree::TxMerkleNode, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::partial_cmp(&self, other: &bitcoin_primitives::merkle_tree::TxMerkleNode) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::clone(&self) -> bitcoin_primitives::merkle_tree::WitnessMerkleNode
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::cmp(&self, other: &bitcoin_primitives::merkle_tree::WitnessMerkleNode) -> core::cmp::Ordering
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::eq(&self, other: &bitcoin_primitives::merkle_tree::WitnessMerkleNode) -> bool
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::merkle_tree::WitnessMerkleNode, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::partial_cmp(&self, other: &bitcoin_primitives::merkle_tree::WitnessMerkleNode) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::pow::CompactTarget::clone(&self) -> bitcoin_primitives::pow::CompactTarget
+pub fn bitcoin_primitives::pow::CompactTarget::cmp(&self, other: &bitcoin_primitives::pow::CompactTarget) -> core::cmp::Ordering
+pub fn bitcoin_primitives::pow::CompactTarget::eq(&self, other: &bitcoin_primitives::pow::CompactTarget) -> bool
+pub fn bitcoin_primitives::pow::CompactTarget::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::pow::CompactTarget::from_consensus(bits: u32) -> Self
+pub fn bitcoin_primitives::pow::CompactTarget::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::pow::CompactTarget::partial_cmp(&self, other: &bitcoin_primitives::pow::CompactTarget) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::pow::CompactTarget::to_consensus(self) -> u32
+pub fn bitcoin_primitives::pow::CompactTarget::to_hex(self) -> alloc::string::String
+pub fn bitcoin_primitives::script::RedeemScriptSizeError::clone(&self) -> bitcoin_primitives::script::RedeemScriptSizeError
+pub fn bitcoin_primitives::script::RedeemScriptSizeError::eq(&self, other: &bitcoin_primitives::script::RedeemScriptSizeError) -> bool
+pub fn bitcoin_primitives::script::RedeemScriptSizeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::script::RedeemScriptSizeError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_primitives::script::RedeemScriptSizeError::invalid_size(&self) -> usize
+pub fn bitcoin_primitives::script::ScriptHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::script::ScriptHash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_primitives::script::ScriptHash::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::script::ScriptHash::borrow(&self) -> &[u8; 20]
+pub fn bitcoin_primitives::script::ScriptHash::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::script::ScriptHash::clone(&self) -> bitcoin_primitives::script::ScriptHash
+pub fn bitcoin_primitives::script::ScriptHash::cmp(&self, other: &bitcoin_primitives::script::ScriptHash) -> core::cmp::Ordering
+pub fn bitcoin_primitives::script::ScriptHash::eq(&self, other: &bitcoin_primitives::script::ScriptHash) -> bool
+pub fn bitcoin_primitives::script::ScriptHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::script::ScriptHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::script::ScriptHash::from_script(redeem_script: &bitcoin_primitives::Script) -> core::result::Result<Self, bitcoin_primitives::script::RedeemScriptSizeError>
+pub fn bitcoin_primitives::script::ScriptHash::from_script_unchecked(script: &bitcoin_primitives::Script) -> Self
+pub fn bitcoin_primitives::script::ScriptHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::script::ScriptHash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_primitives::script::ScriptHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::script::ScriptHash::partial_cmp(&self, other: &bitcoin_primitives::script::ScriptHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::script::ScriptHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::script::ScriptHash::try_from(redeem_script: &bitcoin_primitives::Script) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_primitives::script::ScriptHash::try_from(redeem_script: &bitcoin_primitives::ScriptBuf) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_primitives::script::ScriptHash::try_from(redeem_script: bitcoin_primitives::ScriptBuf) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_primitives::script::WScriptHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::script::WScriptHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::script::WScriptHash::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::script::WScriptHash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::script::WScriptHash::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::script::WScriptHash::clone(&self) -> bitcoin_primitives::script::WScriptHash
+pub fn bitcoin_primitives::script::WScriptHash::cmp(&self, other: &bitcoin_primitives::script::WScriptHash) -> core::cmp::Ordering
+pub fn bitcoin_primitives::script::WScriptHash::eq(&self, other: &bitcoin_primitives::script::WScriptHash) -> bool
+pub fn bitcoin_primitives::script::WScriptHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::script::WScriptHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::script::WScriptHash::from_script(witness_script: &bitcoin_primitives::Script) -> core::result::Result<Self, bitcoin_primitives::script::WitnessScriptSizeError>
+pub fn bitcoin_primitives::script::WScriptHash::from_script_unchecked(script: &bitcoin_primitives::Script) -> Self
+pub fn bitcoin_primitives::script::WScriptHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::script::WScriptHash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_primitives::script::WScriptHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::script::WScriptHash::partial_cmp(&self, other: &bitcoin_primitives::script::WScriptHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::script::WScriptHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::script::WScriptHash::try_from(witness_script: &bitcoin_primitives::Script) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_primitives::script::WScriptHash::try_from(witness_script: &bitcoin_primitives::ScriptBuf) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_primitives::script::WScriptHash::try_from(witness_script: bitcoin_primitives::ScriptBuf) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_primitives::script::WitnessScriptSizeError::clone(&self) -> bitcoin_primitives::script::WitnessScriptSizeError
+pub fn bitcoin_primitives::script::WitnessScriptSizeError::eq(&self, other: &bitcoin_primitives::script::WitnessScriptSizeError) -> bool
+pub fn bitcoin_primitives::script::WitnessScriptSizeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::script::WitnessScriptSizeError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_primitives::script::WitnessScriptSizeError::invalid_size(&self) -> usize
+pub fn bitcoin_primitives::transaction::OutPoint::clone(&self) -> bitcoin_primitives::transaction::OutPoint
+pub fn bitcoin_primitives::transaction::OutPoint::cmp(&self, other: &bitcoin_primitives::transaction::OutPoint) -> core::cmp::Ordering
+pub fn bitcoin_primitives::transaction::OutPoint::eq(&self, other: &bitcoin_primitives::transaction::OutPoint) -> bool
+pub fn bitcoin_primitives::transaction::OutPoint::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::OutPoint::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::transaction::OutPoint::partial_cmp(&self, other: &bitcoin_primitives::transaction::OutPoint) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::Transaction::clone(&self) -> bitcoin_primitives::transaction::Transaction
+pub fn bitcoin_primitives::transaction::Transaction::cmp(&self, other: &Self) -> core::cmp::Ordering
+pub fn bitcoin_primitives::transaction::Transaction::compute_ntxid(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_primitives::transaction::Transaction::compute_txid(&self) -> bitcoin_primitives::transaction::Txid
+pub fn bitcoin_primitives::transaction::Transaction::compute_wtxid(&self) -> bitcoin_primitives::transaction::Wtxid
+pub fn bitcoin_primitives::transaction::Transaction::eq(&self, other: &bitcoin_primitives::transaction::Transaction) -> bool
+pub fn bitcoin_primitives::transaction::Transaction::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::Transaction::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::transaction::Transaction::inputs(&self) -> &[bitcoin_primitives::transaction::TxIn]
+pub fn bitcoin_primitives::transaction::Transaction::inputs_mut(&mut self) -> &mut [bitcoin_primitives::transaction::TxIn]
+pub fn bitcoin_primitives::transaction::Transaction::outputs(&self) -> &[bitcoin_primitives::transaction::TxOut]
+pub fn bitcoin_primitives::transaction::Transaction::outputs_mut(&mut self) -> &mut [bitcoin_primitives::transaction::TxOut]
+pub fn bitcoin_primitives::transaction::Transaction::partial_cmp(&self, other: &Self) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::TxIn::clone(&self) -> bitcoin_primitives::transaction::TxIn
+pub fn bitcoin_primitives::transaction::TxIn::cmp(&self, other: &bitcoin_primitives::transaction::TxIn) -> core::cmp::Ordering
+pub fn bitcoin_primitives::transaction::TxIn::eq(&self, other: &bitcoin_primitives::transaction::TxIn) -> bool
+pub fn bitcoin_primitives::transaction::TxIn::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::TxIn::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::transaction::TxIn::partial_cmp(&self, other: &bitcoin_primitives::transaction::TxIn) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::TxOut::clone(&self) -> bitcoin_primitives::transaction::TxOut
+pub fn bitcoin_primitives::transaction::TxOut::cmp(&self, other: &bitcoin_primitives::transaction::TxOut) -> core::cmp::Ordering
+pub fn bitcoin_primitives::transaction::TxOut::eq(&self, other: &bitcoin_primitives::transaction::TxOut) -> bool
+pub fn bitcoin_primitives::transaction::TxOut::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::TxOut::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::transaction::TxOut::partial_cmp(&self, other: &bitcoin_primitives::transaction::TxOut) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::Txid::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::transaction::Txid::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::transaction::Txid::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::transaction::Txid::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::transaction::Txid::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::transaction::Txid::clone(&self) -> bitcoin_primitives::transaction::Txid
+pub fn bitcoin_primitives::transaction::Txid::cmp(&self, other: &bitcoin_primitives::transaction::Txid) -> core::cmp::Ordering
+pub fn bitcoin_primitives::transaction::Txid::eq(&self, other: &bitcoin_primitives::transaction::Txid) -> bool
+pub fn bitcoin_primitives::transaction::Txid::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::Txid::from(tx: &bitcoin_primitives::transaction::Transaction) -> bitcoin_primitives::transaction::Txid
+pub fn bitcoin_primitives::transaction::Txid::from(tx: bitcoin_primitives::transaction::Transaction) -> bitcoin_primitives::transaction::Txid
+pub fn bitcoin_primitives::transaction::Txid::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::transaction::Txid::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::transaction::Txid, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_primitives::transaction::Txid::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::transaction::Txid::partial_cmp(&self, other: &bitcoin_primitives::transaction::Txid) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::Txid::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::transaction::Version::clone(&self) -> bitcoin_primitives::transaction::Version
+pub fn bitcoin_primitives::transaction::Version::cmp(&self, other: &bitcoin_primitives::transaction::Version) -> core::cmp::Ordering
+pub fn bitcoin_primitives::transaction::Version::eq(&self, other: &bitcoin_primitives::transaction::Version) -> bool
+pub fn bitcoin_primitives::transaction::Version::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::Version::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::transaction::Version::partial_cmp(&self, other: &bitcoin_primitives::transaction::Version) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::Wtxid::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::transaction::Wtxid::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::transaction::Wtxid::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::transaction::Wtxid::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::transaction::Wtxid::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::transaction::Wtxid::clone(&self) -> bitcoin_primitives::transaction::Wtxid
+pub fn bitcoin_primitives::transaction::Wtxid::cmp(&self, other: &bitcoin_primitives::transaction::Wtxid) -> core::cmp::Ordering
+pub fn bitcoin_primitives::transaction::Wtxid::eq(&self, other: &bitcoin_primitives::transaction::Wtxid) -> bool
+pub fn bitcoin_primitives::transaction::Wtxid::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::Wtxid::from(tx: &bitcoin_primitives::transaction::Transaction) -> bitcoin_primitives::transaction::Wtxid
+pub fn bitcoin_primitives::transaction::Wtxid::from(tx: bitcoin_primitives::transaction::Transaction) -> bitcoin_primitives::transaction::Wtxid
+pub fn bitcoin_primitives::transaction::Wtxid::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::transaction::Wtxid::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::transaction::Wtxid, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_primitives::transaction::Wtxid::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::transaction::Wtxid::partial_cmp(&self, other: &bitcoin_primitives::transaction::Wtxid) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::Wtxid::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::witness::Iter<'a>::clone(&self) -> bitcoin_primitives::witness::Iter<'a>
+pub fn bitcoin_primitives::witness::Iter<'a>::next(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin_primitives::witness::Iter<'a>::size_hint(&self) -> (usize, core::option::Option<usize>)
+pub fn bitcoin_primitives::witness::Witness::clear(&mut self)
+pub fn bitcoin_primitives::witness::Witness::clone(&self) -> bitcoin_primitives::witness::Witness
+pub fn bitcoin_primitives::witness::Witness::cmp(&self, other: &bitcoin_primitives::witness::Witness) -> core::cmp::Ordering
+pub fn bitcoin_primitives::witness::Witness::default() -> Self
+pub fn bitcoin_primitives::witness::Witness::eq(&self, other: &bitcoin_primitives::witness::Witness) -> bool
+pub fn bitcoin_primitives::witness::Witness::eq(&self, rhs: &&[T; N]) -> bool
+pub fn bitcoin_primitives::witness::Witness::eq(&self, rhs: &&[T]) -> bool
+pub fn bitcoin_primitives::witness::Witness::eq(&self, rhs: &[T; N]) -> bool
+pub fn bitcoin_primitives::witness::Witness::eq(&self, rhs: &[T]) -> bool
+pub fn bitcoin_primitives::witness::Witness::eq(&self, rhs: &alloc::boxed::Box<[T]>) -> bool
+pub fn bitcoin_primitives::witness::Witness::eq(&self, rhs: &alloc::rc::Rc<[T]>) -> bool
+pub fn bitcoin_primitives::witness::Witness::eq(&self, rhs: &alloc::sync::Arc<[T]>) -> bool
+pub fn bitcoin_primitives::witness::Witness::eq(&self, rhs: &alloc::vec::Vec<T>) -> bool
+pub fn bitcoin_primitives::witness::Witness::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::witness::Witness::from(arr: &[&[u8]; N]) -> Self
+pub fn bitcoin_primitives::witness::Witness::from(arr: [&[u8]; N]) -> Self
+pub fn bitcoin_primitives::witness::Witness::from(slice: &[&[u8; M]; N]) -> Self
+pub fn bitcoin_primitives::witness::Witness::from(slice: &[&[u8; N]]) -> Self
+pub fn bitcoin_primitives::witness::Witness::from(slice: &[&[u8]]) -> Self
+pub fn bitcoin_primitives::witness::Witness::from(slice: &[[u8; M]; N]) -> Self
+pub fn bitcoin_primitives::witness::Witness::from(slice: &[[u8; N]]) -> Self
+pub fn bitcoin_primitives::witness::Witness::from(slice: &[alloc::vec::Vec<u8>]) -> Self
+pub fn bitcoin_primitives::witness::Witness::from(slice: [&[u8; M]; N]) -> Self
+pub fn bitcoin_primitives::witness::Witness::from(slice: [[u8; M]; N]) -> Self
+pub fn bitcoin_primitives::witness::Witness::from(vec: alloc::vec::Vec<&[u8]>) -> Self
+pub fn bitcoin_primitives::witness::Witness::from(vec: alloc::vec::Vec<alloc::vec::Vec<u8>>) -> Self
+pub fn bitcoin_primitives::witness::Witness::from_iter<I: core::iter::traits::collect::IntoIterator<Item = T>>(iter: I) -> Self
+pub fn bitcoin_primitives::witness::Witness::from_slice<T: core::convert::AsRef<[u8]>>(slice: &[T]) -> Self
+pub fn bitcoin_primitives::witness::Witness::get(&self, index: usize) -> core::option::Option<&[u8]>
+pub fn bitcoin_primitives::witness::Witness::get_back(&self, index: usize) -> core::option::Option<&[u8]>
+pub fn bitcoin_primitives::witness::Witness::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::witness::Witness::index(&self, index: usize) -> &Self::Output
+pub fn bitcoin_primitives::witness::Witness::is_empty(&self) -> bool
+pub fn bitcoin_primitives::witness::Witness::iter(&self) -> bitcoin_primitives::witness::Iter<'_>
+pub fn bitcoin_primitives::witness::Witness::last(&self) -> core::option::Option<&[u8]>
+pub fn bitcoin_primitives::witness::Witness::len(&self) -> usize
+pub fn bitcoin_primitives::witness::Witness::partial_cmp(&self, other: &bitcoin_primitives::witness::Witness) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::witness::Witness::push<T: core::convert::AsRef<[u8]>>(&mut self, new_element: T)
+pub fn bitcoin_primitives::witness::Witness::size(&self) -> usize
+pub fn bitcoin_primitives::witness::Witness::to_vec(&self) -> alloc::vec::Vec<alloc::vec::Vec<u8>>
+pub fn u32::from(version: bitcoin_primitives::transaction::Version) -> Self
+pub mod bitcoin_primitives
+pub mod bitcoin_primitives::block
+pub mod bitcoin_primitives::merkle_tree
+pub mod bitcoin_primitives::pow
+pub mod bitcoin_primitives::script
+pub mod bitcoin_primitives::transaction
+pub mod bitcoin_primitives::witness
+pub struct bitcoin_primitives::Block<V> where V: bitcoin_primitives::block::Validation
+pub struct bitcoin_primitives::BlockHash(_)
+pub struct bitcoin_primitives::BlockHeader
+pub struct bitcoin_primitives::BlockVersion(_)
+pub struct bitcoin_primitives::CompactTarget(_)
+pub struct bitcoin_primitives::OutPoint
+pub struct bitcoin_primitives::ScriptBuf(_)
+pub struct bitcoin_primitives::Transaction
+pub struct bitcoin_primitives::TransactionVersion(_)
+pub struct bitcoin_primitives::TxIn
+pub struct bitcoin_primitives::TxMerkleNode(_)
+pub struct bitcoin_primitives::TxOut
+pub struct bitcoin_primitives::Txid(_)
+pub struct bitcoin_primitives::Witness
+pub struct bitcoin_primitives::WitnessCommitment(_)
+pub struct bitcoin_primitives::WitnessMerkleNode(_)
+pub struct bitcoin_primitives::Wtxid(_)
+pub struct bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation
+pub struct bitcoin_primitives::block::BlockHash(_)
+pub struct bitcoin_primitives::block::Header
+pub struct bitcoin_primitives::block::Version(_)
+pub struct bitcoin_primitives::block::WitnessCommitment(_)
+pub struct bitcoin_primitives::merkle_tree::TxMerkleNode(_)
+pub struct bitcoin_primitives::merkle_tree::WitnessMerkleNode(_)
+pub struct bitcoin_primitives::pow::CompactTarget(_)
+pub struct bitcoin_primitives::script::RedeemScriptSizeError
+pub struct bitcoin_primitives::script::ScriptBuf(_)
+pub struct bitcoin_primitives::script::ScriptHash(_)
+pub struct bitcoin_primitives::script::WScriptHash(_)
+pub struct bitcoin_primitives::script::WitnessScriptSizeError
+pub struct bitcoin_primitives::transaction::OutPoint
+pub struct bitcoin_primitives::transaction::Transaction
+pub struct bitcoin_primitives::transaction::TxIn
+pub struct bitcoin_primitives::transaction::TxOut
+pub struct bitcoin_primitives::transaction::Txid(_)
+pub struct bitcoin_primitives::transaction::Version(_)
+pub struct bitcoin_primitives::transaction::Wtxid(_)
+pub struct bitcoin_primitives::witness::Iter<'a>
+pub struct bitcoin_primitives::witness::Witness
+pub trait bitcoin_primitives::BlockValidation: bitcoin_primitives::block::sealed::Validation + core::marker::Sync + core::marker::Send + core::marker::Sized + core::marker::Unpin
+pub trait bitcoin_primitives::block::Validation: bitcoin_primitives::block::sealed::Validation + core::marker::Sync + core::marker::Send + core::marker::Sized + core::marker::Unpin
+pub type &'a bitcoin_primitives::witness::Witness::IntoIter = bitcoin_primitives::witness::Iter<'a>
+pub type &'a bitcoin_primitives::witness::Witness::Item = &'a [u8]
+pub type bitcoin_primitives::Script::Output = bitcoin_primitives::Script
+pub type bitcoin_primitives::Script::Owned = bitcoin_primitives::ScriptBuf
+pub type bitcoin_primitives::ScriptBuf::Target = bitcoin_primitives::Script
+pub type bitcoin_primitives::block::BlockHash::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::block::WitnessCommitment::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::merkle_tree::TxMerkleNode::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::merkle_tree::WitnessMerkleNode::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::script::ScriptHash::Bytes = <bitcoin_hashes::hash160::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::script::ScriptHash::Error = bitcoin_primitives::script::RedeemScriptSizeError
+pub type bitcoin_primitives::script::WScriptHash::Bytes = <bitcoin_hashes::sha256::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::script::WScriptHash::Error = bitcoin_primitives::script::WitnessScriptSizeError
+pub type bitcoin_primitives::transaction::Txid::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::transaction::Wtxid::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::witness::Iter<'a>::Item = &'a [u8]
+pub type bitcoin_primitives::witness::Witness::Output = [u8]
+pub use bitcoin_primitives::Amount
+pub use bitcoin_primitives::BlockHeight
+pub use bitcoin_primitives::BlockHeightInterval
+pub use bitcoin_primitives::BlockMtp
+pub use bitcoin_primitives::BlockMtpInterval
+pub use bitcoin_primitives::BlockTime
+pub use bitcoin_primitives::FeeRate
+pub use bitcoin_primitives::Sequence
+pub use bitcoin_primitives::SignedAmount
+pub use bitcoin_primitives::Weight
+pub use bitcoin_primitives::absolute
+pub use bitcoin_primitives::amount
+pub use bitcoin_primitives::fee_rate
+pub use bitcoin_primitives::locktime
+pub use bitcoin_primitives::relative
+pub use bitcoin_primitives::sequence
+pub use bitcoin_primitives::time
+pub use bitcoin_primitives::weight

--- a/api/primitives/no-features.txt
+++ b/api/primitives/no-features.txt
@@ -1,0 +1,443 @@
+impl bitcoin_hashes::Hash for bitcoin_primitives::block::BlockHash
+impl bitcoin_hashes::Hash for bitcoin_primitives::block::WitnessCommitment
+impl bitcoin_hashes::Hash for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl bitcoin_hashes::Hash for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl bitcoin_hashes::Hash for bitcoin_primitives::transaction::Txid
+impl bitcoin_hashes::Hash for bitcoin_primitives::transaction::Wtxid
+impl bitcoin_primitives::block::BlockHash
+impl bitcoin_primitives::block::Header
+impl bitcoin_primitives::block::Version
+impl bitcoin_primitives::block::WitnessCommitment
+impl bitcoin_primitives::merkle_tree::TxMerkleNode
+impl bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl bitcoin_primitives::pow::CompactTarget
+impl bitcoin_primitives::transaction::OutPoint
+impl bitcoin_primitives::transaction::Txid
+impl bitcoin_primitives::transaction::Version
+impl bitcoin_primitives::transaction::Wtxid
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::block::BlockHash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::block::WitnessCommitment
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::transaction::Txid
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::transaction::Wtxid
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::block::BlockHash
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::block::WitnessCommitment
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::transaction::Txid
+impl core::borrow::Borrow<[u8]> for bitcoin_primitives::transaction::Wtxid
+impl core::clone::Clone for bitcoin_primitives::block::BlockHash
+impl core::clone::Clone for bitcoin_primitives::block::Header
+impl core::clone::Clone for bitcoin_primitives::block::Version
+impl core::clone::Clone for bitcoin_primitives::block::WitnessCommitment
+impl core::clone::Clone for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::clone::Clone for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::clone::Clone for bitcoin_primitives::pow::CompactTarget
+impl core::clone::Clone for bitcoin_primitives::transaction::OutPoint
+impl core::clone::Clone for bitcoin_primitives::transaction::Txid
+impl core::clone::Clone for bitcoin_primitives::transaction::Version
+impl core::clone::Clone for bitcoin_primitives::transaction::Wtxid
+impl core::cmp::Eq for bitcoin_primitives::block::BlockHash
+impl core::cmp::Eq for bitcoin_primitives::block::Header
+impl core::cmp::Eq for bitcoin_primitives::block::Version
+impl core::cmp::Eq for bitcoin_primitives::block::WitnessCommitment
+impl core::cmp::Eq for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::cmp::Eq for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::cmp::Eq for bitcoin_primitives::pow::CompactTarget
+impl core::cmp::Eq for bitcoin_primitives::transaction::OutPoint
+impl core::cmp::Eq for bitcoin_primitives::transaction::Txid
+impl core::cmp::Eq for bitcoin_primitives::transaction::Version
+impl core::cmp::Eq for bitcoin_primitives::transaction::Wtxid
+impl core::cmp::Ord for bitcoin_primitives::block::BlockHash
+impl core::cmp::Ord for bitcoin_primitives::block::Header
+impl core::cmp::Ord for bitcoin_primitives::block::Version
+impl core::cmp::Ord for bitcoin_primitives::block::WitnessCommitment
+impl core::cmp::Ord for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::cmp::Ord for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::cmp::Ord for bitcoin_primitives::pow::CompactTarget
+impl core::cmp::Ord for bitcoin_primitives::transaction::OutPoint
+impl core::cmp::Ord for bitcoin_primitives::transaction::Txid
+impl core::cmp::Ord for bitcoin_primitives::transaction::Version
+impl core::cmp::Ord for bitcoin_primitives::transaction::Wtxid
+impl core::cmp::PartialEq for bitcoin_primitives::block::BlockHash
+impl core::cmp::PartialEq for bitcoin_primitives::block::Header
+impl core::cmp::PartialEq for bitcoin_primitives::block::Version
+impl core::cmp::PartialEq for bitcoin_primitives::block::WitnessCommitment
+impl core::cmp::PartialEq for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::cmp::PartialEq for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::cmp::PartialEq for bitcoin_primitives::pow::CompactTarget
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::OutPoint
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::Txid
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::Version
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::Wtxid
+impl core::cmp::PartialOrd for bitcoin_primitives::block::BlockHash
+impl core::cmp::PartialOrd for bitcoin_primitives::block::Header
+impl core::cmp::PartialOrd for bitcoin_primitives::block::Version
+impl core::cmp::PartialOrd for bitcoin_primitives::block::WitnessCommitment
+impl core::cmp::PartialOrd for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::cmp::PartialOrd for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::cmp::PartialOrd for bitcoin_primitives::pow::CompactTarget
+impl core::cmp::PartialOrd for bitcoin_primitives::transaction::OutPoint
+impl core::cmp::PartialOrd for bitcoin_primitives::transaction::Txid
+impl core::cmp::PartialOrd for bitcoin_primitives::transaction::Version
+impl core::cmp::PartialOrd for bitcoin_primitives::transaction::Wtxid
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::block::BlockHash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::block::WitnessCommitment
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::transaction::Txid
+impl core::convert::AsRef<[u8; 32]> for bitcoin_primitives::transaction::Wtxid
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::block::BlockHash
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::block::WitnessCommitment
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::transaction::Txid
+impl core::convert::AsRef<[u8]> for bitcoin_primitives::transaction::Wtxid
+impl core::convert::From<&bitcoin_primitives::block::Header> for bitcoin_primitives::block::BlockHash
+impl core::convert::From<bitcoin_primitives::block::Header> for bitcoin_primitives::block::BlockHash
+impl core::convert::From<bitcoin_primitives::transaction::Version> for u32
+impl core::default::Default for bitcoin_primitives::block::Version
+impl core::fmt::Debug for bitcoin_primitives::block::BlockHash
+impl core::fmt::Debug for bitcoin_primitives::block::Header
+impl core::fmt::Debug for bitcoin_primitives::block::Version
+impl core::fmt::Debug for bitcoin_primitives::block::WitnessCommitment
+impl core::fmt::Debug for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::fmt::Debug for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::fmt::Debug for bitcoin_primitives::pow::CompactTarget
+impl core::fmt::Debug for bitcoin_primitives::transaction::OutPoint
+impl core::fmt::Debug for bitcoin_primitives::transaction::Txid
+impl core::fmt::Debug for bitcoin_primitives::transaction::Version
+impl core::fmt::Debug for bitcoin_primitives::transaction::Wtxid
+impl core::fmt::Display for bitcoin_primitives::transaction::Version
+impl core::fmt::LowerHex for bitcoin_primitives::pow::CompactTarget
+impl core::fmt::UpperHex for bitcoin_primitives::pow::CompactTarget
+impl core::hash::Hash for bitcoin_primitives::block::BlockHash
+impl core::hash::Hash for bitcoin_primitives::block::Header
+impl core::hash::Hash for bitcoin_primitives::block::Version
+impl core::hash::Hash for bitcoin_primitives::block::WitnessCommitment
+impl core::hash::Hash for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::hash::Hash for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::hash::Hash for bitcoin_primitives::pow::CompactTarget
+impl core::hash::Hash for bitcoin_primitives::transaction::OutPoint
+impl core::hash::Hash for bitcoin_primitives::transaction::Txid
+impl core::hash::Hash for bitcoin_primitives::transaction::Version
+impl core::hash::Hash for bitcoin_primitives::transaction::Wtxid
+impl core::marker::Copy for bitcoin_primitives::block::BlockHash
+impl core::marker::Copy for bitcoin_primitives::block::Header
+impl core::marker::Copy for bitcoin_primitives::block::Version
+impl core::marker::Copy for bitcoin_primitives::block::WitnessCommitment
+impl core::marker::Copy for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::marker::Copy for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::marker::Copy for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Copy for bitcoin_primitives::transaction::OutPoint
+impl core::marker::Copy for bitcoin_primitives::transaction::Txid
+impl core::marker::Copy for bitcoin_primitives::transaction::Version
+impl core::marker::Copy for bitcoin_primitives::transaction::Wtxid
+impl core::marker::Freeze for bitcoin_primitives::block::BlockHash
+impl core::marker::Freeze for bitcoin_primitives::block::Header
+impl core::marker::Freeze for bitcoin_primitives::block::Version
+impl core::marker::Freeze for bitcoin_primitives::block::WitnessCommitment
+impl core::marker::Freeze for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::marker::Freeze for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::marker::Freeze for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Freeze for bitcoin_primitives::transaction::OutPoint
+impl core::marker::Freeze for bitcoin_primitives::transaction::Txid
+impl core::marker::Freeze for bitcoin_primitives::transaction::Version
+impl core::marker::Freeze for bitcoin_primitives::transaction::Wtxid
+impl core::marker::Send for bitcoin_primitives::block::BlockHash
+impl core::marker::Send for bitcoin_primitives::block::Header
+impl core::marker::Send for bitcoin_primitives::block::Version
+impl core::marker::Send for bitcoin_primitives::block::WitnessCommitment
+impl core::marker::Send for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::marker::Send for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::marker::Send for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Send for bitcoin_primitives::transaction::OutPoint
+impl core::marker::Send for bitcoin_primitives::transaction::Txid
+impl core::marker::Send for bitcoin_primitives::transaction::Version
+impl core::marker::Send for bitcoin_primitives::transaction::Wtxid
+impl core::marker::StructuralPartialEq for bitcoin_primitives::block::BlockHash
+impl core::marker::StructuralPartialEq for bitcoin_primitives::block::Header
+impl core::marker::StructuralPartialEq for bitcoin_primitives::block::Version
+impl core::marker::StructuralPartialEq for bitcoin_primitives::block::WitnessCommitment
+impl core::marker::StructuralPartialEq for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::marker::StructuralPartialEq for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::marker::StructuralPartialEq for bitcoin_primitives::pow::CompactTarget
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::OutPoint
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::Txid
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::Version
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::Wtxid
+impl core::marker::Sync for bitcoin_primitives::block::BlockHash
+impl core::marker::Sync for bitcoin_primitives::block::Header
+impl core::marker::Sync for bitcoin_primitives::block::Version
+impl core::marker::Sync for bitcoin_primitives::block::WitnessCommitment
+impl core::marker::Sync for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::marker::Sync for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::marker::Sync for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Sync for bitcoin_primitives::transaction::OutPoint
+impl core::marker::Sync for bitcoin_primitives::transaction::Txid
+impl core::marker::Sync for bitcoin_primitives::transaction::Version
+impl core::marker::Sync for bitcoin_primitives::transaction::Wtxid
+impl core::marker::Unpin for bitcoin_primitives::block::BlockHash
+impl core::marker::Unpin for bitcoin_primitives::block::Header
+impl core::marker::Unpin for bitcoin_primitives::block::Version
+impl core::marker::Unpin for bitcoin_primitives::block::WitnessCommitment
+impl core::marker::Unpin for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::marker::Unpin for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::marker::Unpin for bitcoin_primitives::pow::CompactTarget
+impl core::marker::Unpin for bitcoin_primitives::transaction::OutPoint
+impl core::marker::Unpin for bitcoin_primitives::transaction::Txid
+impl core::marker::Unpin for bitcoin_primitives::transaction::Version
+impl core::marker::Unpin for bitcoin_primitives::transaction::Wtxid
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::BlockHash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::Header
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::Version
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::WitnessCommitment
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::pow::CompactTarget
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::OutPoint
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::Txid
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::Version
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::Wtxid
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::BlockHash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::Header
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::Version
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::WitnessCommitment
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::pow::CompactTarget
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::OutPoint
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::Txid
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::Version
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::Wtxid
+pub bitcoin_primitives::BlockHeader::bits: bitcoin_primitives::pow::CompactTarget
+pub bitcoin_primitives::BlockHeader::merkle_root: bitcoin_primitives::merkle_tree::TxMerkleNode
+pub bitcoin_primitives::BlockHeader::nonce: u32
+pub bitcoin_primitives::BlockHeader::prev_blockhash: bitcoin_primitives::block::BlockHash
+pub bitcoin_primitives::BlockHeader::time: bitcoin_units::time::encapsulate::BlockTime
+pub bitcoin_primitives::BlockHeader::version: bitcoin_primitives::block::Version
+pub bitcoin_primitives::OutPoint::txid: bitcoin_primitives::transaction::Txid
+pub bitcoin_primitives::OutPoint::vout: u32
+pub bitcoin_primitives::block::Header::bits: bitcoin_primitives::pow::CompactTarget
+pub bitcoin_primitives::block::Header::merkle_root: bitcoin_primitives::merkle_tree::TxMerkleNode
+pub bitcoin_primitives::block::Header::nonce: u32
+pub bitcoin_primitives::block::Header::prev_blockhash: bitcoin_primitives::block::BlockHash
+pub bitcoin_primitives::block::Header::time: bitcoin_units::time::encapsulate::BlockTime
+pub bitcoin_primitives::block::Header::version: bitcoin_primitives::block::Version
+pub bitcoin_primitives::transaction::OutPoint::txid: bitcoin_primitives::transaction::Txid
+pub bitcoin_primitives::transaction::OutPoint::vout: u32
+pub const bitcoin_primitives::block::BlockHash::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::block::BlockHash::GENESIS_PREVIOUS_BLOCK_HASH: Self
+pub const bitcoin_primitives::block::Header::SIZE: usize
+pub const bitcoin_primitives::block::Version::NO_SOFT_FORK_SIGNALLING: Self
+pub const bitcoin_primitives::block::Version::ONE: Self
+pub const bitcoin_primitives::block::Version::TWO: Self
+pub const bitcoin_primitives::block::WitnessCommitment::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::merkle_tree::TxMerkleNode::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::merkle_tree::WitnessMerkleNode::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::transaction::OutPoint::COINBASE_PREVOUT: Self
+pub const bitcoin_primitives::transaction::OutPoint::SIZE: usize
+pub const bitcoin_primitives::transaction::Txid::COINBASE_PREVOUT: Self
+pub const bitcoin_primitives::transaction::Txid::DISPLAY_BACKWARD: bool
+pub const bitcoin_primitives::transaction::Version::ONE: Self
+pub const bitcoin_primitives::transaction::Version::THREE: Self
+pub const bitcoin_primitives::transaction::Version::TWO: Self
+pub const bitcoin_primitives::transaction::Wtxid::COINBASE: Self
+pub const bitcoin_primitives::transaction::Wtxid::DISPLAY_BACKWARD: bool
+pub const fn bitcoin_primitives::block::BlockHash::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::block::BlockHash::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::block::BlockHash::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::block::Version::from_consensus(v: i32) -> Self
+pub const fn bitcoin_primitives::block::WitnessCommitment::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::block::WitnessCommitment::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::block::WitnessCommitment::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::merkle_tree::TxMerkleNode::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::merkle_tree::TxMerkleNode::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::merkle_tree::TxMerkleNode::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::transaction::Txid::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::transaction::Txid::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::transaction::Txid::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::transaction::Version::is_standard(self) -> bool
+pub const fn bitcoin_primitives::transaction::Version::maybe_non_standard(version: u32) -> bitcoin_primitives::transaction::Version
+pub const fn bitcoin_primitives::transaction::Version::to_u32(self) -> u32
+pub const fn bitcoin_primitives::transaction::Wtxid::as_byte_array(&self) -> &<bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub const fn bitcoin_primitives::transaction::Wtxid::from_byte_array(bytes: <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes) -> Self
+pub const fn bitcoin_primitives::transaction::Wtxid::to_byte_array(self) -> <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub fn bitcoin_primitives::block::BlockHash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::block::BlockHash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::block::BlockHash::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::block::BlockHash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::block::BlockHash::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::block::BlockHash::clone(&self) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::BlockHash::cmp(&self, other: &bitcoin_primitives::block::BlockHash) -> core::cmp::Ordering
+pub fn bitcoin_primitives::block::BlockHash::eq(&self, other: &bitcoin_primitives::block::BlockHash) -> bool
+pub fn bitcoin_primitives::block::BlockHash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::block::BlockHash::from(header: &bitcoin_primitives::block::Header) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::BlockHash::from(header: bitcoin_primitives::block::Header) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::BlockHash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::block::BlockHash::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::block::BlockHash, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_primitives::block::BlockHash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::block::BlockHash::partial_cmp(&self, other: &bitcoin_primitives::block::BlockHash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::block::BlockHash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::block::Header::block_hash(&self) -> bitcoin_primitives::block::BlockHash
+pub fn bitcoin_primitives::block::Header::clone(&self) -> bitcoin_primitives::block::Header
+pub fn bitcoin_primitives::block::Header::cmp(&self, other: &bitcoin_primitives::block::Header) -> core::cmp::Ordering
+pub fn bitcoin_primitives::block::Header::eq(&self, other: &bitcoin_primitives::block::Header) -> bool
+pub fn bitcoin_primitives::block::Header::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::block::Header::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::block::Header::partial_cmp(&self, other: &bitcoin_primitives::block::Header) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::block::Version::clone(&self) -> bitcoin_primitives::block::Version
+pub fn bitcoin_primitives::block::Version::cmp(&self, other: &bitcoin_primitives::block::Version) -> core::cmp::Ordering
+pub fn bitcoin_primitives::block::Version::default() -> bitcoin_primitives::block::Version
+pub fn bitcoin_primitives::block::Version::eq(&self, other: &bitcoin_primitives::block::Version) -> bool
+pub fn bitcoin_primitives::block::Version::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::block::Version::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::block::Version::is_signalling_soft_fork(self, bit: u8) -> bool
+pub fn bitcoin_primitives::block::Version::partial_cmp(&self, other: &bitcoin_primitives::block::Version) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::block::Version::to_consensus(self) -> i32
+pub fn bitcoin_primitives::block::WitnessCommitment::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::block::WitnessCommitment::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::block::WitnessCommitment::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::block::WitnessCommitment::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::block::WitnessCommitment::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::block::WitnessCommitment::clone(&self) -> bitcoin_primitives::block::WitnessCommitment
+pub fn bitcoin_primitives::block::WitnessCommitment::cmp(&self, other: &bitcoin_primitives::block::WitnessCommitment) -> core::cmp::Ordering
+pub fn bitcoin_primitives::block::WitnessCommitment::eq(&self, other: &bitcoin_primitives::block::WitnessCommitment) -> bool
+pub fn bitcoin_primitives::block::WitnessCommitment::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::block::WitnessCommitment::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::block::WitnessCommitment::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::block::WitnessCommitment, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_primitives::block::WitnessCommitment::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::block::WitnessCommitment::partial_cmp(&self, other: &bitcoin_primitives::block::WitnessCommitment) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::block::WitnessCommitment::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::clone(&self) -> bitcoin_primitives::merkle_tree::TxMerkleNode
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::cmp(&self, other: &bitcoin_primitives::merkle_tree::TxMerkleNode) -> core::cmp::Ordering
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::eq(&self, other: &bitcoin_primitives::merkle_tree::TxMerkleNode) -> bool
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::merkle_tree::TxMerkleNode, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::partial_cmp(&self, other: &bitcoin_primitives::merkle_tree::TxMerkleNode) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::clone(&self) -> bitcoin_primitives::merkle_tree::WitnessMerkleNode
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::cmp(&self, other: &bitcoin_primitives::merkle_tree::WitnessMerkleNode) -> core::cmp::Ordering
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::eq(&self, other: &bitcoin_primitives::merkle_tree::WitnessMerkleNode) -> bool
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::merkle_tree::WitnessMerkleNode, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::partial_cmp(&self, other: &bitcoin_primitives::merkle_tree::WitnessMerkleNode) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::pow::CompactTarget::clone(&self) -> bitcoin_primitives::pow::CompactTarget
+pub fn bitcoin_primitives::pow::CompactTarget::cmp(&self, other: &bitcoin_primitives::pow::CompactTarget) -> core::cmp::Ordering
+pub fn bitcoin_primitives::pow::CompactTarget::eq(&self, other: &bitcoin_primitives::pow::CompactTarget) -> bool
+pub fn bitcoin_primitives::pow::CompactTarget::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::pow::CompactTarget::from_consensus(bits: u32) -> Self
+pub fn bitcoin_primitives::pow::CompactTarget::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::pow::CompactTarget::partial_cmp(&self, other: &bitcoin_primitives::pow::CompactTarget) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::pow::CompactTarget::to_consensus(self) -> u32
+pub fn bitcoin_primitives::transaction::OutPoint::clone(&self) -> bitcoin_primitives::transaction::OutPoint
+pub fn bitcoin_primitives::transaction::OutPoint::cmp(&self, other: &bitcoin_primitives::transaction::OutPoint) -> core::cmp::Ordering
+pub fn bitcoin_primitives::transaction::OutPoint::eq(&self, other: &bitcoin_primitives::transaction::OutPoint) -> bool
+pub fn bitcoin_primitives::transaction::OutPoint::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::OutPoint::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::transaction::OutPoint::partial_cmp(&self, other: &bitcoin_primitives::transaction::OutPoint) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::Txid::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::transaction::Txid::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::transaction::Txid::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::transaction::Txid::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::transaction::Txid::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::transaction::Txid::clone(&self) -> bitcoin_primitives::transaction::Txid
+pub fn bitcoin_primitives::transaction::Txid::cmp(&self, other: &bitcoin_primitives::transaction::Txid) -> core::cmp::Ordering
+pub fn bitcoin_primitives::transaction::Txid::eq(&self, other: &bitcoin_primitives::transaction::Txid) -> bool
+pub fn bitcoin_primitives::transaction::Txid::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::Txid::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::transaction::Txid::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::transaction::Txid, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_primitives::transaction::Txid::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::transaction::Txid::partial_cmp(&self, other: &bitcoin_primitives::transaction::Txid) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::Txid::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_primitives::transaction::Version::clone(&self) -> bitcoin_primitives::transaction::Version
+pub fn bitcoin_primitives::transaction::Version::cmp(&self, other: &bitcoin_primitives::transaction::Version) -> core::cmp::Ordering
+pub fn bitcoin_primitives::transaction::Version::eq(&self, other: &bitcoin_primitives::transaction::Version) -> bool
+pub fn bitcoin_primitives::transaction::Version::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::Version::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::transaction::Version::partial_cmp(&self, other: &bitcoin_primitives::transaction::Version) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::Wtxid::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_primitives::transaction::Wtxid::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::transaction::Wtxid::as_ref(&self) -> &[u8]
+pub fn bitcoin_primitives::transaction::Wtxid::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_primitives::transaction::Wtxid::borrow(&self) -> &[u8]
+pub fn bitcoin_primitives::transaction::Wtxid::clone(&self) -> bitcoin_primitives::transaction::Wtxid
+pub fn bitcoin_primitives::transaction::Wtxid::cmp(&self, other: &bitcoin_primitives::transaction::Wtxid) -> core::cmp::Ordering
+pub fn bitcoin_primitives::transaction::Wtxid::eq(&self, other: &bitcoin_primitives::transaction::Wtxid) -> bool
+pub fn bitcoin_primitives::transaction::Wtxid::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::transaction::Wtxid::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_primitives::transaction::Wtxid::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_primitives::transaction::Wtxid, bitcoin_hashes::FromSliceError>
+pub fn bitcoin_primitives::transaction::Wtxid::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_primitives::transaction::Wtxid::partial_cmp(&self, other: &bitcoin_primitives::transaction::Wtxid) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::transaction::Wtxid::to_byte_array(self) -> Self::Bytes
+pub fn u32::from(version: bitcoin_primitives::transaction::Version) -> Self
+pub mod bitcoin_primitives
+pub mod bitcoin_primitives::block
+pub mod bitcoin_primitives::merkle_tree
+pub mod bitcoin_primitives::pow
+pub mod bitcoin_primitives::transaction
+pub struct bitcoin_primitives::BlockHash(_)
+pub struct bitcoin_primitives::BlockHeader
+pub struct bitcoin_primitives::BlockVersion(_)
+pub struct bitcoin_primitives::CompactTarget(_)
+pub struct bitcoin_primitives::OutPoint
+pub struct bitcoin_primitives::TransactionVersion(_)
+pub struct bitcoin_primitives::TxMerkleNode(_)
+pub struct bitcoin_primitives::Txid(_)
+pub struct bitcoin_primitives::WitnessCommitment(_)
+pub struct bitcoin_primitives::WitnessMerkleNode(_)
+pub struct bitcoin_primitives::Wtxid(_)
+pub struct bitcoin_primitives::block::BlockHash(_)
+pub struct bitcoin_primitives::block::Header
+pub struct bitcoin_primitives::block::Version(_)
+pub struct bitcoin_primitives::block::WitnessCommitment(_)
+pub struct bitcoin_primitives::merkle_tree::TxMerkleNode(_)
+pub struct bitcoin_primitives::merkle_tree::WitnessMerkleNode(_)
+pub struct bitcoin_primitives::pow::CompactTarget(_)
+pub struct bitcoin_primitives::transaction::OutPoint
+pub struct bitcoin_primitives::transaction::Txid(_)
+pub struct bitcoin_primitives::transaction::Version(_)
+pub struct bitcoin_primitives::transaction::Wtxid(_)
+pub type bitcoin_primitives::block::BlockHash::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::block::WitnessCommitment::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::merkle_tree::TxMerkleNode::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::merkle_tree::WitnessMerkleNode::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::transaction::Txid::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_primitives::transaction::Wtxid::Bytes = <bitcoin_hashes::sha256d::Hash as bitcoin_hashes::Hash>::Bytes
+pub use bitcoin_primitives::Amount
+pub use bitcoin_primitives::BlockHeight
+pub use bitcoin_primitives::BlockHeightInterval
+pub use bitcoin_primitives::BlockMtp
+pub use bitcoin_primitives::BlockMtpInterval
+pub use bitcoin_primitives::BlockTime
+pub use bitcoin_primitives::FeeRate
+pub use bitcoin_primitives::Sequence
+pub use bitcoin_primitives::SignedAmount
+pub use bitcoin_primitives::Weight
+pub use bitcoin_primitives::absolute
+pub use bitcoin_primitives::amount
+pub use bitcoin_primitives::fee_rate
+pub use bitcoin_primitives::locktime
+pub use bitcoin_primitives::relative
+pub use bitcoin_primitives::sequence
+pub use bitcoin_primitives::time
+pub use bitcoin_primitives::weight

--- a/contrib/check-for-api-changes.sh
+++ b/contrib/check-for-api-changes.sh
@@ -26,6 +26,7 @@ main() {
 
     # Just check crates that are stabilising.
     generate_api_files "units"
+    generate_api_files "primitives"
 
     check_for_changes
 }


### PR DESCRIPTION
I had to do this anyways to use the text files while doing the checklist (https://github.com/rust-bitcoin/rust-bitcoin/issues/3827) so here it is. Draft until we are closer.

In preparation for 1.0-ing `primitives` update the API checker script to include `primitives` and introduce the API text files.

This implicitly enforces in CI because of the current API job.

Close: #4792

 REMEMBER TOBIN TO RE-RUN THE SCRIPT BEFORE TAKING OFF DRAFT.