### PR TITLE
fix: correct typo in comment in crypto.rs

### DIFF
--- a/hashes/src/ripemd160/crypto.rs
+++ b/hashes/src/ripemd160/crypto.rs
@@ -99,7 +99,7 @@ macro_rules! process_block(
                   $data[$pdata_index1], $pbits1, 0x50a28be6,
                   bbb[$pj1] ^ (bbb[$pj2] | !bbb[$pj3])); )*
 
-        // Porallel Round 2
+        // Parallel Round 2
         $( round!(bbb[$pi0], bbb[$pi1], bbb[$pi2], bbb[$pi3], bbb[$pi4],
                   $data[$pdata_index2], $pbits2, 0x5c4dd124,
                   (bbb[$pi1] & bbb[$pi3]) | (bbb[$pi2] & !bbb[$pi3])); )*


### PR DESCRIPTION
Fixed typo in comment: Porallel Round 2 → Parallel Round 2 in hashes/src/ripemd160/crypto.rs.