### PR TITLE
unit: kill new mutants

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -26,6 +26,7 @@ exclude_re = [
     "NumberOf512Seconds::to_consensus_u32", # Deprecated
     "MedianTimePast::to_consensus_u32", # Deprecated
     "Height::to_consensus_u32", # Deprecated
+    "Sequence::to_hex", # Deprecated
 
     # primitives
     "Sequence::from_512_second_intervals", # Mutant from replacing | with ^, this returns the same value since the XOR is taken against the u16 with an all-zero bitmask
@@ -36,4 +37,7 @@ exclude_re = [
     "decode_cursor", # Mutating operations in decode_cursor can result in an infinite loop
     "fmt_debug", # Mutants from formatting/display changes
     "fmt_debug_pretty", # Mutants from formatting/display changes
+    "CompactTarget::to_hex", # Deprecated
+    "Script::to_hex", # Deprecated
+    "ScriptBuf::to_hex", # Deprecated
 ]

--- a/units/src/amount/result.rs
+++ b/units/src/amount/result.rs
@@ -298,3 +298,55 @@ impl<'a> core::iter::Sum<&'a NumOpResult<SignedAmount>> for NumOpResult<SignedAm
         })
     }
 }
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sum_amount_results() {
+        let amounts = [
+            NumOpResult::Valid(Amount::from_sat_u32(100)),
+            NumOpResult::Valid(Amount::from_sat_u32(200)),
+            NumOpResult::Valid(Amount::from_sat_u32(300)),
+        ];
+
+        let sum: NumOpResult<Amount> = amounts.into_iter().sum();
+        assert_eq!(sum, NumOpResult::Valid(Amount::from_sat_u32(600)));
+    }
+
+    #[test]
+    fn test_sum_amount_results_with_references() {
+        let amounts = [
+            NumOpResult::Valid(Amount::from_sat_u32(100)),
+            NumOpResult::Valid(Amount::from_sat_u32(200)),
+            NumOpResult::Valid(Amount::from_sat_u32(300)),
+        ];
+
+        let sum: NumOpResult<Amount> = amounts.iter().sum();
+        assert_eq!(sum, NumOpResult::Valid(Amount::from_sat_u32(600)));
+    }
+
+    #[test]
+    fn test_sum_signed_amount_results() {
+        let amounts = [
+            NumOpResult::Valid(SignedAmount::from_sat_i32(100)),
+            NumOpResult::Valid(SignedAmount::from_sat_i32(-50)),
+            NumOpResult::Valid(SignedAmount::from_sat_i32(200)),
+        ];
+
+        let sum: NumOpResult<SignedAmount> = amounts.into_iter().sum();
+        assert_eq!(sum, NumOpResult::Valid(SignedAmount::from_sat_i32(250)));
+    }
+
+    #[test]
+    fn test_sum_with_error_propagation() {
+        let amounts = [
+            NumOpResult::Valid(Amount::from_sat_u32(100)),
+            NumOpResult::Error(NumOpError::while_doing(MathOp::Add)),
+            NumOpResult::Valid(Amount::from_sat_u32(200)),
+        ];
+
+        let sum: NumOpResult<Amount> = amounts.into_iter().sum();
+        assert!(matches!(sum, NumOpResult::Error(_)));
+    }
+}


### PR DESCRIPTION
### Description 
Closes #4766

- Add unit tests for `core::iter::Sum`
- Exclude deprecated `to_hex` functions that have uncaught mutants.