### PR TITLE
Pin cargo public-api version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -319,6 +319,6 @@ jobs:
         with:
           toolchain: ${{ needs.Prepare.outputs.nightly_version }}
       - name: "Install cargo-public-api"
-        run: cargo install --locked cargo-public-api
+        run: cargo install --locked cargo-public-api --version 0.49.0
       - name: "Run API checker script"
         run: ./contrib/check-for-api-changes.sh


### PR DESCRIPTION
When cargo-public-api releases a new version with a super new nightly requirement it breaks our CI for not a lot of added value. Lets pin the version and go right ahead and remember to update `cargo-public-api` at some stage.