### PR TITLE
fix: remove xtrace flag from release script bash options

### DIFF
--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -3,7 +3,7 @@
 # Check that we can publish crates in their current form if there are changes on top of the tip of
 # master that imply that we are about to do a release.
 
-set -euox pipefail
+set -euo pipefail
 
 main () {
     for crate in "bitcoin" "hashes" "internals" "units"; do


### PR DESCRIPTION
Remove the -x flag from 'set -euox pipefail' to align with the project's standard bash configuration used in 9 other scripts. The xtrace flag creates unnecessary verbose output in release scripts and may expose sensitive information in CI/CD logs.