### PR TITLE
Add rustfmt skip to macro call

### DIFF
--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -41,15 +41,8 @@ pub type BlockInterval = BlockHeightInterval;
 
 internal_macros::impl_hashencode!(BlockHash);
 
-internal_macros::impl_consensus_encoding!(
-    Header,
-    version,
-    prev_blockhash,
-    merkle_root,
-    time,
-    bits,
-    nonce
-);
+#[rustfmt::skip]
+internal_macros::impl_consensus_encoding!(Header, version, prev_blockhash, merkle_root, time, bits, nonce);
 
 internal_macros::define_extension_trait! {
     /// Extension functionality for the [`Header`] type.


### PR DESCRIPTION
The multi-line foramt is not clearer and takes up a bunch of lines, just go over the usual column with on this one.