### PR TITLE
primitives/lib: fix comment typo and set deprecation version

### DIFF
--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -20,7 +20,7 @@
 #![warn(deprecated_in_future)]
 #![doc(test(attr(warn(unused))))]
 // Exclude lints we don't think are valuable.
-#![allow(clippy::uninlined_format_args)] // Allow `format!("{}", x)`instead of enforcing `format!("{x}")`
+#![allow(clippy::uninlined_format_args)] // Allow `format!("{}", x)` instead of enforcing `format!("{x}")`
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
@@ -64,7 +64,7 @@ pub use units::{
     weight::{self, Weight},
 };
 
-#[deprecated(since = "TBD", note = "use `BlockHeightInterval` instead")]
+#[deprecated(since = "0.101.0", note = "use `BlockHeightInterval` instead")]
 #[doc(hidden)]
 pub type BlockInterval = BlockHeightInterval;
 


### PR DESCRIPTION
Fix missing space in Clippy allow comment for uninlined_format_args
Replace #[deprecated] since = "TBD" with "0.101.0" for BlockInterval alias