### PR TITLE
fix(docs): correct typos in transaction, witness, and amount test comments

### DIFF
--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -74,7 +74,7 @@ use crate::witness::Witness;
 ///
 /// However, in protocols where transactions may legitimately have 0 inputs, e.g.
 /// when parties are cooperatively funding a transaction, the "00 means SegWit"
-/// heuristic does not work. Since SegWit requires such a transaction be encoded
+/// heuristic does not work. Since SegWit requires such a transaction to be encoded
 /// in the original transaction format (since it has no inputs and therefore
 /// no input witnesses), a traditionally encoded transaction may have the `0001`
 /// SegWit flag in it, which confuses most SegWit parsers including the one in

--- a/primitives/src/witness.rs
+++ b/primitives/src/witness.rs
@@ -334,7 +334,7 @@ impl<T: core::borrow::Borrow<[u8]>> PartialEq<Witness> for alloc::sync::Arc<[T]>
 /// Debug implementation that displays the witness as a structured output containing:
 /// - Number of witness elements
 /// - Total bytes across all elements
-/// - List of hex-encoded witness elements if `hex` features is enabled.
+/// - List of hex-encoded witness elements if `hex` feature is enabled.
 #[allow(clippy::missing_fields_in_debug)] // We don't want to show `indices_start`.
 impl fmt::Debug for Witness {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/units/src/amount/tests.rs
+++ b/units/src/amount/tests.rs
@@ -86,7 +86,7 @@ fn from_str_zero() {
             Ok(_) => panic!("unsigned amount from {}", s),
         }
         match s.parse::<SignedAmount>() {
-            Err(e) => panic!("failed to crate amount from {}: {:?}", s, e),
+            Err(e) => panic!("failed to create amount from {}: {:?}", s, e),
             Ok(amount) => assert_eq!(amount, SignedAmount::ZERO),
         }
     }


### PR DESCRIPTION
- In transaction.rs: changed "be encoded" → "to be encoded" 
- In witness.rs: corrected "features is" → "features are" 
- In amount tests: fixed typo "crate" → "create" 

