### PR TITLE
hashes: Remove code deprecated in `v0.15.0`

### DIFF
--- a/hashes/src/hmac/mod.rs
+++ b/hashes/src/hmac/mod.rs
@@ -123,11 +123,6 @@ impl<T: Hash> Hash for Hmac<T> {
 
     fn from_byte_array(bytes: T::Bytes) -> Self { Hmac(T::from_byte_array(bytes)) }
 
-    #[allow(deprecated_in_future)] // Because of `FromSliceError`.
-    fn from_slice(sl: &[u8]) -> Result<Hmac<T>, crate::FromSliceError> {
-        T::from_slice(sl).map(Hmac)
-    }
-
     fn to_byte_array(self) -> Self::Bytes { self.0.to_byte_array() }
 
     fn as_byte_array(&self) -> &Self::Bytes { self.0.as_byte_array() }

--- a/hashes/src/internal_macros.rs
+++ b/hashes/src/internal_macros.rs
@@ -34,12 +34,6 @@ macro_rules! hash_trait_impls {
 
             fn from_byte_array(bytes: Self::Bytes) -> Self { Self::from_byte_array(bytes) }
 
-            #[allow(deprecated_in_future)] // Because of `FromSliceError`.
-            #[allow(deprecated)]           // Because of `from_slice`.
-            fn from_slice(sl: &[u8]) -> $crate::_export::_core::result::Result<Hash<$($gen),*>, $crate::FromSliceError> {
-                Self::from_slice(sl)
-            }
-
             fn to_byte_array(self) -> Self::Bytes { self.to_byte_array() }
 
             fn as_byte_array(&self) -> &Self::Bytes { self.as_byte_array() }
@@ -132,24 +126,6 @@ macro_rules! hash_type_no_default {
         impl Hash {
             /// Constructs a new hash from the underlying byte array.
             pub const fn from_byte_array(bytes: [u8; $bits / 8]) -> Self { Hash(bytes) }
-
-            /// Copies a byte slice into a hash object.
-            #[deprecated(since = "0.15.0", note = "use `from_byte_array` instead")]
-            #[allow(deprecated_in_future)] // Because of `FromSliceError`.
-            pub fn from_slice(
-                sl: &[u8],
-            ) -> $crate::_export::_core::result::Result<Hash, $crate::FromSliceError> {
-                if sl.len() != $bits / 8 {
-                    Err($crate::error::FromSliceError($crate::error::FromSliceErrorInner {
-                        expected: $bits / 8,
-                        got: sl.len(),
-                    }))
-                } else {
-                    let mut ret = [0; $bits / 8];
-                    ret.copy_from_slice(sl);
-                    Ok(Self::from_byte_array(ret))
-                }
-            }
 
             /// Returns the underlying byte array.
             pub const fn to_byte_array(self) -> [u8; $bits / 8] { self.0 }

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -117,17 +117,6 @@ pub mod sha512;
 pub mod sha512_256;
 pub mod siphash24;
 
-#[deprecated(since = "0.15.0", note = "use crate::macros instead")]
-pub mod serde_macros {
-    //! Macros for serde trait implementations, and supporting code.
-
-    #[cfg(feature = "serde")]
-    pub mod serde_details {
-        //! Functions used by serde impls of all hashes.
-        pub use crate::macros::serde_details::*;
-    }
-}
-
 use core::fmt::{self, Write as _};
 use core::{convert, hash};
 
@@ -226,11 +215,6 @@ pub trait Hash:
 
     /// Constructs a new hash from the underlying byte array.
     fn from_byte_array(bytes: Self::Bytes) -> Self;
-
-    /// Copies a byte slice into a hash object.
-    #[allow(deprecated_in_future)] // Because of `FromSliceError`.
-    #[deprecated(since = "TBD", note = "use `from_byte_array` instead")]
-    fn from_slice(sl: &[u8]) -> Result<Self, FromSliceError>;
 
     /// Returns the underlying byte array.
     fn to_byte_array(self) -> Self::Bytes;

--- a/hashes/src/macros.rs
+++ b/hashes/src/macros.rs
@@ -139,14 +139,6 @@ macro_rules! hash_newtype {
                 $newtype(<$hash>::from_byte_array(bytes))
             }
 
-            /// Copies a byte slice into a hash object.
-            #[deprecated(since = "0.15.0", note = "use `from_byte_array` instead")]
-            #[allow(deprecated_in_future)] // Because of `FromSliceError`.
-            #[allow(deprecated)]           // Because of `from_slice`.
-            pub fn from_slice(sl: &[u8]) -> $crate::_export::_core::result::Result<$newtype, $crate::FromSliceError> {
-                Ok($newtype(<$hash as $crate::Hash>::from_slice(sl)?))
-            }
-
             /// Returns the underlying byte array.
             pub const fn to_byte_array(self) -> <$hash as $crate::Hash>::Bytes {
                 self.0.to_byte_array()
@@ -164,13 +156,6 @@ macro_rules! hash_newtype {
             const DISPLAY_BACKWARD: bool = $crate::hash_newtype_get_direction!($hash, $(#[$($type_attrs)*])*);
 
             fn from_byte_array(bytes: Self::Bytes) -> Self { Self::from_byte_array(bytes) }
-
-            #[inline]
-            #[allow(deprecated_in_future)] // Because of `FromSliceError`.
-            #[allow(deprecated)]           // Because of `from_slice`.
-            fn from_slice(sl: &[u8]) -> $crate::_export::_core::result::Result<$newtype, $crate::FromSliceError> {
-                Self::from_slice(sl)
-            }
 
             fn to_byte_array(self) -> Self::Bytes { self.to_byte_array() }
 
@@ -506,7 +491,7 @@ macro_rules! serde_impl(
 
         impl<'de $(, $gen: $gent)*> $crate::serde::Deserialize<'de> for $t<$($gen),*> {
             fn deserialize<D: $crate::serde::Deserializer<'de>>(d: D) -> core::result::Result<$t<$($gen),*>, D::Error> {
-                use $crate::serde_macros::serde_details::{BytesVisitor, HexVisitor};
+                use $crate::macros::serde_details::{BytesVisitor, HexVisitor};
 
                 if d.is_human_readable() {
                     d.deserialize_str(HexVisitor::<Self>::default())

--- a/hashes/src/sha256/mod.rs
+++ b/hashes/src/sha256/mod.rs
@@ -150,12 +150,6 @@ impl Hash {
     /// Computes hash from `bytes` in `const` context.
     ///
     /// Warning: this function is inefficient. It should be only used in `const` context.
-    #[deprecated(since = "0.15.0", note = "use `Self::hash_unoptimized` instead")]
-    pub const fn const_hash(bytes: &[u8]) -> Self { Hash::hash_unoptimized(bytes) }
-
-    /// Computes hash from `bytes` in `const` context.
-    ///
-    /// Warning: this function is inefficient. It should be only used in `const` context.
     pub const fn hash_unoptimized(bytes: &[u8]) -> Self {
         Hash(Midstate::compute_midstate_unoptimized(bytes, true).bytes)
     }

--- a/hashes/src/sha256t/mod.rs
+++ b/hashes/src/sha256t/mod.rs
@@ -65,21 +65,6 @@ where
     /// Constructs a new hash from the underlying byte array.
     pub const fn from_byte_array(bytes: [u8; 32]) -> Self { Self(PhantomData, bytes) }
 
-    /// Copies a byte slice into a hash object.
-    #[deprecated(since = "0.15.0", note = "use `from_byte_array` instead")]
-    #[allow(deprecated_in_future)] // Because of `FromSliceError`.
-    pub fn from_slice(sl: &[u8]) -> Result<Hash<T>, crate::FromSliceError> {
-        use crate::error::FromSliceErrorInner;
-
-        if sl.len() != 32 {
-            Err(crate::error::FromSliceError(FromSliceErrorInner { expected: 32, got: sl.len() }))
-        } else {
-            let mut ret = [0; 32];
-            ret.copy_from_slice(sl);
-            Ok(Self::from_byte_array(ret))
-        }
-    }
-
     /// Produces a hash from the current state of a given engine.
     pub fn from_engine(e: HashEngine<T>) -> Self {
         Hash::from_byte_array(sha256::Hash::from_engine(e.0).to_byte_array())

--- a/hashes/src/siphash24/mod.rs
+++ b/hashes/src/siphash24/mod.rs
@@ -208,10 +208,6 @@ impl Hash {
     }
 
     /// Returns the (little endian) 64-bit integer representation of the hash value.
-    #[deprecated(since = "0.15.0", note = "use `to_u64` instead")]
-    pub fn as_u64(&self) -> u64 { self.to_u64() }
-
-    /// Returns the (little endian) 64-bit integer representation of the hash value.
     pub fn to_u64(self) -> u64 { u64::from_le_bytes(self.0) }
 
     /// Constructs a new hash from its (little endian) 64-bit integer representation.


### PR DESCRIPTION
Policy is to keep deprecated stuff for two releases. We have released 0.16.0 already so we can remove stuff deprecated in 0.15.0 (assuming 0.17.0 is out next).

Furthermore this assists with the `primitives` stable release because it removes `FromSliceError` from the API of crates that call public macros across crate boundaries from `hashes`.