### PR TITLE
CI: migrate workflows to checkout v5

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout Crate
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Checkout Toolchain
         # https://github.com/dtolnay/rust-toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/cron-daily-fuzz.yml
+++ b/.github/workflows/cron-daily-fuzz.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - name: Install test dependencies
         run: sudo apt-get update -y && sudo apt-get install -y binutils-dev libunwind8-dev libcurl4-openssl-dev libelf-dev libdw-dev cmake gcc libiberty-dev
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/cache@v4
         id: cache-fuzz
         with:
@@ -70,7 +70,7 @@ jobs:
     needs: fuzz
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/download-artifact@v5
       - name: Display structure of downloaded files
         run: ls -R

--- a/.github/workflows/cron-daily-kani.yml
+++ b/.github/workflows/cron-daily-kani.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: 'Checkout your code.'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 'Run Kani on your code.'
         uses: model-checking/kani-github-action@v1.1

--- a/.github/workflows/cron-weekly-cargo-mutants.yml
+++ b/.github/workflows/cron-weekly-cargo-mutants.yml
@@ -7,7 +7,7 @@ jobs:
   cargo-mutants:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-mutants

--- a/.github/workflows/cron-weekly-rustfmt.yml
+++ b/.github/workflows/cron-weekly-rustfmt.yml
@@ -8,7 +8,7 @@ jobs:
     name: Nightly rustfmt
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt

--- a/.github/workflows/cron-weekly-update-cargo-semver-checks.yml
+++ b/.github/workflows/cron-weekly-update-cargo-semver-checks.yml
@@ -8,7 +8,7 @@ jobs:
     name: Update cargo-semver-checks
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Update semver-checks to use latest crates.io published version
         run: |
           set -x

--- a/.github/workflows/cron-weekly-update-nightly.yml
+++ b/.github/workflows/cron-weekly-update-nightly.yml
@@ -8,7 +8,7 @@ jobs:
     name: Update nightly rustc
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@nightly
       - name: Update rust.yml to use latest nightly
         run: |

--- a/.github/workflows/cron-weekly-update-stable.yml
+++ b/.github/workflows/cron-weekly-update-stable.yml
@@ -8,7 +8,7 @@ jobs:
     name: Update stable rustc
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - name: Update semver-checks.yml to use latest stable
         run: |

--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - uses: ncipollo/release-action@v1
       with:
         generateReleaseNotes: true

--- a/.github/workflows/manage-pr.yml
+++ b/.github/workflows/manage-pr.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout master
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: master
       - name: Checkout merge commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: merge
           ref: "refs/pull/${{ github.event.number }}/merge"

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Read nightly version"
         id: read_toolchain
         run: echo "nightly_version=$(cat nightly-version)" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Crate
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Checkout Toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: run cargo

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
       nightly_version: ${{ steps.read_toolchain.outputs.nightly_version }}
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Read nightly version"
         id: read_toolchain
         run: echo "nightly_version=$(cat nightly-version)" >> $GITHUB_OUTPUT
@@ -29,9 +29,9 @@ jobs:
         dep: [minimal, recent]
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Checkout maintainer tools"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
           ref: c3324024ced9bb1eb854397686919c3ff7d97e1e
@@ -53,9 +53,9 @@ jobs:
         dep: [minimal, recent]
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Checkout maintainer tools"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
           ref: c3324024ced9bb1eb854397686919c3ff7d97e1e
@@ -78,9 +78,9 @@ jobs:
         dep: [minimal, recent]
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Checkout maintainer tools"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
           ref: c3324024ced9bb1eb854397686919c3ff7d97e1e
@@ -104,9 +104,9 @@ jobs:
         dep: [recent]
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Checkout maintainer tools"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
           ref: c3324024ced9bb1eb854397686919c3ff7d97e1e
@@ -131,9 +131,9 @@ jobs:
         dep: [recent]
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Checkout maintainer tools"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
           ref: c3324024ced9bb1eb854397686919c3ff7d97e1e
@@ -155,9 +155,9 @@ jobs:
         dep: [recent]
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Checkout maintainer tools"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
           ref: c3324024ced9bb1eb854397686919c3ff7d97e1e
@@ -181,9 +181,9 @@ jobs:
         dep: [recent]
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Checkout maintainer tools"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
           ref: c3324024ced9bb1eb854397686919c3ff7d97e1e
@@ -202,7 +202,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@stable
       - name: "Add architecture i386"
@@ -220,7 +220,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@stable
       - name: "Install target"
@@ -239,7 +239,7 @@ jobs:
       CARGO_TARGET_THUMBV7M_NONE_EABI_RUNNER: "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Set up QEMU"
         run: sudo apt update && sudo apt install -y qemu-system-arm gcc-arm-none-eabi
       - name: "Select toolchain"
@@ -268,7 +268,7 @@ jobs:
         dep: [recent]
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@v1
         with:
@@ -288,7 +288,7 @@ jobs:
       # Note we do not use the recent lock file for wasm testing.
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@stable
       - name: "Run wasm script"
@@ -299,7 +299,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Build Kani proofs"
         uses: model-checking/kani-github-action@v1.1
         with:
@@ -313,7 +313,7 @@ jobs:
       fail-fast: false
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@v1
         with:

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0 # we need full history for cargo semver-checks
       - name: "Install Rustup"
@@ -50,7 +50,7 @@ jobs:
       fail-fast: false
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Install Rustup"
         uses: dtolnay/rust-toolchain@stable
       - name: "Select stable-version"

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -8,7 +8,7 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Run ShellCheck
       uses: ludeeus/action-shellcheck@2.0.0
       env:


### PR DESCRIPTION
Node 24 compatibility: switch all jobs to actions/checkout@v5. Requires runner v2.327.1+. Pure maintenance, behavior unchanged.

Ref: https://github.com/actions/checkout/releases/tag/v5.0.0