### PR TITLE
p2p: Extend `BlockHash` with all zeros

### DIFF
--- a/p2p/src/message_blockdata.rs
+++ b/p2p/src/message_blockdata.rs
@@ -130,6 +130,19 @@ impl_consensus_encoding!(GetBlocksMessage, version, locator_hashes, stop_hash);
 
 impl_consensus_encoding!(GetHeadersMessage, version, locator_hashes, stop_hash);
 
+/// Extend a [`BlockHash`] for requesting data from peers.
+pub trait BlockHashExt {
+    /// Return an all-zero hash. Which is used to indicate you would like the maximum amount of
+    /// data.
+    fn all_zeros() -> Self;
+}
+
+impl BlockHashExt for BlockHash {
+    fn all_zeros() -> Self {
+        BlockHash::from_byte_array([0; 32]) 
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use bitcoin::consensus::encode::{deserialize, serialize};


### PR DESCRIPTION
The beloved `all_zeros` constructor was removed at some point. The all zero hash does have a use case over the p2p network however. It is used to indicate that we would like to receive the maximum amount of data this peer has to offer. For instance, when used as the `stop_hash` when requesting blocks, the peer will simply respond with 500 blocks.

ref: https://en.bitcoin.it/wiki/Protocol_documentation#getblocks
ref: https://github.com/bitcoin/bitcoin/blob/v29.1rc1/src/net_processing.cpp#L4047