### PR TITLE
fix: grammar

### DIFF
--- a/fuzz/fuzz-util.sh
+++ b/fuzz/fuzz-util.sh
@@ -43,7 +43,7 @@ checkWindowsFiles() {
   fi
 }
 
-# Checks whether a fuzz case output some report, and dumps it in hex
+# Checks whether a fuzz case outputs some report, and dumps it in hex
 checkReport() {
   reportFile="hfuzz_workspace/$1/HONGGFUZZ.REPORT.TXT"
   if [ -f "$reportFile" ]; then

--- a/internals/src/array.rs
+++ b/internals/src/array.rs
@@ -23,7 +23,7 @@ pub trait ArrayExt {
     ///
     /// Fails to compile if the array is empty.
     ///
-    /// Note that this method's name is intentionally shadowing the `std`'s `first` method which
+    /// Note that this method's name intentionally shadows the `std`'s `first` method which
     /// returns `Option`. The rationale is that given the known length of the array, we always know
     /// that this will not return `None` so trying to keep the `std` method around is pointless.
     /// Importing the trait will also cause compile failures - that's also intentional to expose
@@ -44,7 +44,7 @@ pub trait ArrayExt {
     ///
     /// Fails to compile if the array is empty.
     ///
-    /// Note that this method's name is intentionally shadowing the `std`'s `split_first` method which
+    /// Note that this method's name intentionally shadows the `std`'s `split_first` method which
     /// returns `Option`. The rationale is that given the known length of the array, we always know
     /// that this will not return `None` so trying to keep the `std` method around is pointless.
     /// Importing the trait will also cause compile failures - that's also intentional to expose
@@ -58,7 +58,7 @@ pub trait ArrayExt {
     ///
     /// Fails to compile if the array is empty.
     ///
-    /// Note that this method's name is intentionally shadowing the `std`'s `split_last` method which
+    /// Note that this method's name intentionally shadows the `std`'s `split_last` method which
     /// returns `Option`. The rationale is that given the known length of the array, we always know
     /// that this will not return `None` so trying to keep the `std` method around is pointless.
     /// Importing the trait will also cause compile failures - that's also intentional to expose


### PR DESCRIPTION
I changed “output” to “outputs” to make the verb agree with the singular subject “a fuzz case”.

I changed it to “intentionally shadows” to match doc style — present simple states a fact, not an ongoing action.