### PR TITLE
Fix overflows in `Weight` and add fuzz target

### DIFF
--- a/.github/workflows/cron-daily-fuzz.yml
+++ b/.github/workflows/cron-daily-fuzz.yml
@@ -35,6 +35,7 @@ jobs:
           hashes_sha256,
           hashes_sha512,
           hashes_sha512_256,
+          units_arbitrary_weight,
           units_parse_amount,
         ]
     steps:

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -90,5 +90,9 @@ name = "hashes_sha512_256"
 path = "fuzz_targets/hashes/sha512_256.rs"
 
 [[bin]]
+name = "units_arbitrary_weight"
+path = "fuzz_targets/units/arbitrary_weight.rs"
+
+[[bin]]
 name = "units_parse_amount"
 path = "fuzz_targets/units/parse_amount.rs"

--- a/fuzz/fuzz_targets/units/arbitrary_weight.rs
+++ b/fuzz/fuzz_targets/units/arbitrary_weight.rs
@@ -1,0 +1,87 @@
+use arbitrary::{Arbitrary, Unstructured};
+use honggfuzz::fuzz;
+use bitcoin::Weight;
+
+fn do_test(data: &[u8]) {
+    let mut u = Unstructured::new(data);
+    let w = Weight::arbitrary(&mut u);
+
+    if let Ok(weight) = w {
+        weight.to_wu();
+        weight.to_kwu_ceil();
+        weight.to_kwu_floor();
+        weight.to_vbytes_ceil();
+        weight.to_vbytes_floor();
+
+        // Operations that take u64 as the rhs
+        for operation in [Weight::checked_mul, Weight::checked_div] {
+            if let Ok(val) = u.arbitrary() {
+                let _ = operation(weight, val);
+            } else {
+                return;
+            }
+        }
+
+        // Operations that take Weight as the rhs
+        for operation in [Weight::checked_add, Weight::checked_sub] {
+            if let Ok(val) = u.arbitrary() {
+                let _ = operation(weight, val);
+            } else {
+                return;
+            }
+        }
+    }
+
+    // Constructors that return a Weight
+    for constructor in [Weight::from_wu, Weight::from_witness_data_size,  Weight::from_non_witness_data_size] {
+        if let Ok(val) = u.arbitrary() {
+            constructor(val);
+        } else {
+            return;
+        }
+    }
+
+    // Constructors that return an Option<Weight>
+    for constructor in [Weight::from_vb, Weight::from_kwu] {
+        if let Ok(val) = u.arbitrary() {
+            constructor(val);
+        } else {
+            return;
+        }
+    }
+}
+
+fn main() {
+    loop {
+        fuzz!(|data| {
+            do_test(data);
+        });
+    }
+}
+
+#[cfg(all(test, fuzzing))]
+mod tests {
+    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
+        let mut b = 0;
+        for (idx, c) in hex.as_bytes().iter().enumerate() {
+            b <<= 4;
+            match *c {
+                b'A'..=b'F' => b |= c - b'A' + 10,
+                b'a'..=b'f' => b |= c - b'a' + 10,
+                b'0'..=b'9' => b |= c - b'0',
+                _ => panic!("Bad hex"),
+            }
+            if (idx & 1) == 1 {
+                out.push(b);
+                b = 0;
+            }
+        }
+    }
+
+    #[test]
+    fn duplicate_crash() {
+        let mut a = Vec::new();
+        extend_vec_from_hex("00", &mut a);
+        super::do_test(&a);
+    }
+}

--- a/fuzz/generate-files.sh
+++ b/fuzz/generate-files.sh
@@ -102,7 +102,7 @@ $(for name in $(listTargetNames); do echo "          $name,"; done)
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
       - name: Display structure of downloaded files
         run: ls -R
       - run: find executed_* -type f -exec cat {} + | sort > executed

--- a/units/src/weight.rs
+++ b/units/src/weight.rs
@@ -91,7 +91,7 @@ impl Weight {
     }
 
     /// Constructs a new [`Weight`] from virtual bytes without an overflow check.
-    pub const fn from_vb_unchecked(vb: u64) -> Self { Weight::from_wu(vb * 4) }
+    pub const fn from_vb_unchecked(vb: u64) -> Self { Weight::from_wu(vb * Self::WITNESS_SCALE_FACTOR) }
 
     /// Constructs a new [`Weight`] from witness size.
     pub const fn from_witness_data_size(witness_size: u64) -> Self { Weight::from_wu(witness_size) }

--- a/units/src/weight.rs
+++ b/units/src/weight.rs
@@ -105,14 +105,14 @@ impl Weight {
     pub const fn to_kwu_floor(self) -> u64 { self.to_wu() / 1000 }
 
     /// Converts to kilo weight units rounding up.
-    pub const fn to_kwu_ceil(self) -> u64 { (self.to_wu() + 999) / 1000 }
+    pub const fn to_kwu_ceil(self) -> u64 { self.to_wu().saturating_add(999) / 1000 }
 
     /// Converts to vB rounding down.
     pub const fn to_vbytes_floor(self) -> u64 { self.to_wu() / Self::WITNESS_SCALE_FACTOR }
 
     /// Converts to vB rounding up.
     pub const fn to_vbytes_ceil(self) -> u64 {
-        (self.to_wu() + Self::WITNESS_SCALE_FACTOR - 1) / Self::WITNESS_SCALE_FACTOR
+        self.to_wu().saturating_add(Self::WITNESS_SCALE_FACTOR - 1) / Self::WITNESS_SCALE_FACTOR
     }
 
     /// Checked addition.
@@ -387,6 +387,7 @@ mod tests {
     fn to_kwu_ceil() {
         assert_eq!(Weight::from_wu(1_000).to_kwu_ceil(), 1);
         assert_eq!(Weight::from_wu(1_001).to_kwu_ceil(), 2);
+        assert_eq!(Weight::MAX.to_kwu_ceil(), u64::MAX / 1_000);
     }
 
     #[test]
@@ -399,6 +400,7 @@ mod tests {
     fn to_vb_ceil() {
         assert_eq!(Weight::from_wu(4).to_vbytes_ceil(), 1);
         assert_eq!(Weight::from_wu(5).to_vbytes_ceil(), 2);
+        assert_eq!(Weight::MAX.to_vbytes_ceil(), u64::MAX / Weight::WITNESS_SCALE_FACTOR);
     }
 
     #[test]


### PR DESCRIPTION
Pulling on the same thread from #4838, I started looking into `units` where a similar bugs may have happened and found a few for `Weight`. Found a few instances of the overflow bug in a few constructors so fixing them here