### PR TITLE
fix: IsSatisfiedByTimeError::Incompatible wording to lock-by-time

### DIFF
--- a/units/src/locktime/relative/error.rs
+++ b/units/src/locktime/relative/error.rs
@@ -116,7 +116,7 @@ impl fmt::Display for IsSatisfiedByTimeError {
         match *self {
             E::Satisfaction(ref e) => write_err!(f, "satisfaction"; e),
             E::Incompatible(blocks) =>
-                write!(f, "tried to satisfy a lock-by-height locktime using blocks {}", blocks),
+                write!(f, "tried to satisfy a lock-by-time locktime using blocks {}", blocks),
         }
     }
 }


### PR DESCRIPTION
Updated the error text to say “lock-by-time” for IsSatisfiedByTimeError::Incompatible.