### PR TITLE
docs: fix inconsistent terminology in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ for review yet please mark it by prefixing the title with `WIP: `.
 
 ### CI Pipeline
 
-The CI pipeline requires approval before being run on each MR.
+The CI pipeline requires approval before being run on each PR.
 
 In order to speed up the review process the CI pipeline can be run locally using
 [act](https://github.com/nektos/act). The `fuzz` and `Cross` jobs will be skipped when using `act`


### PR DESCRIPTION
Change "MR" to "PR" in CI Pipeline section to maintain consistent terminology throughout the documentation. The project uses GitHub where they are called "Pull Requests", not "Merge Requests".