### PR TITLE
bitcoin: Improve import statements

### DIFF
--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -13,7 +13,6 @@ use core::fmt;
 use hashes::{sha256d, HashEngine};
 use internals::{compact_size, ToU64};
 use io::{BufRead, Write};
-use units::BlockTime;
 
 use super::transaction::Coinbase;
 use super::Weight;
@@ -26,6 +25,7 @@ use crate::pow::{Target, Work};
 use crate::prelude::Vec;
 use crate::script::{self, ScriptExt as _};
 use crate::transaction::{Transaction, TransactionExt as _, Wtxid};
+use crate::BlockTime;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]

--- a/bitcoin/src/blockdata/script/builder.rs
+++ b/bitcoin/src/blockdata/script/builder.rs
@@ -2,8 +2,6 @@
 
 use core::fmt;
 
-use primitives::relative;
-
 use super::{opcode_to_verify, write_scriptint, Error, PushBytes, Script, ScriptBuf};
 use crate::key::{PublicKey, XOnlyPublicKey};
 use crate::locktime::absolute;
@@ -11,7 +9,7 @@ use crate::opcodes::all::*;
 use crate::opcodes::Opcode;
 use crate::prelude::Vec;
 use crate::script::{ScriptBufExt as _, ScriptBufExtPriv as _, ScriptExtPriv as _};
-use crate::Sequence;
+use crate::{relative, Sequence};
 
 /// An Object which can be used to construct a script piece by piece.
 #[derive(PartialEq, Eq, Clone)]

--- a/bitcoin/src/blockdata/script/witness_version.rs
+++ b/bitcoin/src/blockdata/script/witness_version.rs
@@ -12,10 +12,10 @@ use core::fmt;
 use core::str::FromStr;
 
 use internals::write_err;
-use units::parse::{self, ParseIntError};
 
 use crate::opcodes::all::*;
 use crate::opcodes::Opcode;
+use crate::parse::{self, ParseIntError};
 use crate::script::Instruction;
 
 /// Version of the segregated witness program.

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -17,7 +17,6 @@ use arbitrary::{Arbitrary, Unstructured};
 use hashes::sha256d;
 use internals::{compact_size, const_casts, write_err, ToU64};
 use io::{BufRead, Write};
-use primitives::Sequence;
 
 use super::Weight;
 use crate::consensus::{self, encode, Decodable, Encodable};
@@ -27,7 +26,7 @@ use crate::script::{Script, ScriptBuf, ScriptExt as _, ScriptExtPriv as _};
 #[cfg(doc)]
 use crate::sighash::{EcdsaSighashType, TapSighashType};
 use crate::witness::Witness;
-use crate::{internal_macros, Amount, FeeRate, SignedAmount};
+use crate::{internal_macros, Amount, FeeRate, Sequence, SignedAmount};
 
 #[rustfmt::skip]            // Keep public re-exports separate.
 #[doc(inline)]

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -282,10 +282,9 @@ mod encode_impls {
     //! Encodable/Decodable implementations.
     // While we are deprecating, re-exporting, and generally moving things around just put these here.
 
-    use units::{BlockHeight, BlockHeightInterval};
-
     use crate::consensus::{encode, Decodable, Encodable};
     use crate::io::{BufRead, Write};
+    use crate::{BlockHeight, BlockHeightInterval};
 
     /// Implements Encodable and Decodable for a simple wrapper type.
     ///

--- a/bitcoin/src/network/params.rs
+++ b/bitcoin/src/network/params.rs
@@ -60,12 +60,11 @@
 //! # }
 //! ```
 
-use units::{BlockHeight, BlockHeightInterval};
-
 use super::{Network, TestnetVersion};
 #[cfg(doc)]
 use crate::pow::CompactTarget;
 use crate::pow::Target;
+use crate::{BlockHeight, BlockHeightInterval};
 
 /// Parameters that influence chain consensus.
 #[non_exhaustive]

--- a/bitcoin/tests/psbt-sign-taproot.rs
+++ b/bitcoin/tests/psbt-sign-taproot.rs
@@ -10,11 +10,10 @@ use bitcoin::script::ScriptExt as _;
 use bitcoin::taproot::{LeafVersion, TaprootBuilder, TaprootSpendInfo};
 use bitcoin::transaction::Version;
 use bitcoin::{
-    absolute, script, Address, Network, OutPoint, PrivateKey, Psbt, ScriptBuf, Sequence,
+    absolute, script, Address, Amount, Network, OutPoint, PrivateKey, Psbt, ScriptBuf, Sequence,
     Transaction, TxIn, TxOut, Witness, XOnlyPublicKey,
 };
 use secp256k1::{Keypair, Secp256k1, Signing};
-use units::Amount;
 
 #[test]
 fn psbt_sign_taproot() {


### PR DESCRIPTION
In days gone past we decided try to minimize merge conflicts by keeping use statements really separate, over time we moved more and more towards combining them (ie., not reaching into modules all the time but using re-exports).

Now, in a push to make our codebase's imports mirror downstream usage while still keeping our aims don't reach into `units` or `primitives`, just grab things by way of their re-export.