### PR TITLE
bitcoin: remove `From<Message>` for `TapSighash`

### DIFF
--- a/bitcoin/examples/sign-tx-taproot.rs
+++ b/bitcoin/examples/sign-tx-taproot.rs
@@ -5,7 +5,7 @@
 use bitcoin::ext::*;
 use bitcoin::key::{Keypair, TapTweak, TweakedKeypair, UntweakedPublicKey};
 use bitcoin::locktime::absolute;
-use bitcoin::secp256k1::{rand, Message, Secp256k1, SecretKey, Signing, Verification};
+use bitcoin::secp256k1::{rand, Secp256k1, SecretKey, Signing, Verification};
 use bitcoin::sighash::{Prevouts, SighashCache, TapSighashType};
 use bitcoin::{
     transaction, Address, Amount, Network, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut,
@@ -69,8 +69,7 @@ fn main() {
 
     // Sign the sighash using the secp256k1 library (exported by rust-bitcoin).
     let tweaked: TweakedKeypair = keypair.tap_tweak(&secp, None);
-    let msg = Message::from(sighash);
-    let signature = secp.sign_schnorr(msg.as_ref(), tweaked.as_keypair());
+    let signature = secp.sign_schnorr(&sighash.to_byte_array(), tweaked.as_keypair());
 
     // Update the witness stack.
     let signature = bitcoin::taproot::Signature { signature, sighash_type };

--- a/bitcoin/examples/taproot-psbt.rs
+++ b/bitcoin/examples/taproot-psbt.rs
@@ -750,8 +750,7 @@ fn sign_psbt_taproot(
         Some(_) => keypair, // no tweak for script spend
     };
 
-    let msg = secp256k1::Message::from(hash);
-    let signature = secp.sign_schnorr(msg.as_ref(), &keypair);
+    let signature = secp.sign_schnorr(&hash.to_byte_array(), &keypair);
 
     let final_signature = taproot::Signature { signature, sighash_type };
 

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -91,8 +91,6 @@ hashes::impl_hex_for_newtype!(TapSighash);
 #[cfg(feature = "serde")]
 hashes::impl_serde_for_newtype!(TapSighash);
 
-impl_message_from_hash!(TapSighash);
-
 /// Efficiently calculates signature hash message for legacy, SegWit and Taproot inputs.
 #[derive(Debug)]
 pub struct SighashCache<T: Borrow<Transaction>> {
@@ -2026,9 +2024,8 @@ mod tests {
                 .taproot_signature_hash(tx_ind, &Prevouts::All(&utxos), None, None, hash_ty)
                 .unwrap();
 
-            let msg = secp256k1::Message::from(sighash);
             let key_spend_sig =
-                secp.sign_schnorr_with_aux_rand(msg.as_ref(), &tweaked_keypair, &[0u8; 32]);
+                secp.sign_schnorr_with_aux_rand(&sighash.to_byte_array(), &tweaked_keypair, &[0u8; 32]);
 
             assert_eq!(expected.internal_pubkey, internal_key);
             assert_eq!(expected.tweak, tweak);


### PR DESCRIPTION
The `Message` type is specific to ECDSA and should not be used for Taproot sighashes. Taproot sighashes are just 32 bytes long. With these changes, `From<Message>` is only used for legacy and SegWit v0 sighashes, not for Taproot

Fixes https://github.com/rust-bitcoin/rust-bitcoin/issues/4872