### PR TITLE
primitives: Use new import policy

### DIFF
--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -14,16 +14,12 @@ use core::marker::PhantomData;
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
 use hashes::{sha256d, HashEngine as _};
-use units::BlockTime;
 
-use crate::merkle_tree::TxMerkleNode;
-#[cfg(feature = "alloc")]
-use crate::merkle_tree::WitnessMerkleNode;
-use crate::pow::CompactTarget;
 #[cfg(feature = "alloc")]
 use crate::prelude::Vec;
 #[cfg(feature = "alloc")]
-use crate::transaction::Transaction;
+use crate::{Transaction, WitnessMerkleNode};
+use crate::{BlockTime, CompactTarget, TxMerkleNode};
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -24,21 +24,13 @@ use hashes::sha256d;
 use internals::compact_size;
 #[cfg(feature = "hex")]
 use internals::write_err;
-#[cfg(feature = "alloc")]
-use units::locktime::absolute;
 #[cfg(feature = "hex")]
 use units::parse_int;
-#[cfg(feature = "alloc")]
-use units::sequence::Sequence;
-#[cfg(feature = "alloc")]
-use units::{Amount, Weight};
 
 #[cfg(feature = "alloc")]
 use crate::prelude::Vec;
 #[cfg(feature = "alloc")]
-use crate::script::{ScriptPubKeyBuf, ScriptSigBuf};
-#[cfg(feature = "alloc")]
-use crate::witness::Witness;
+use crate::{absolute, Amount, ScriptPubKeyBuf, ScriptSigBuf, Sequence, Weight, Witness};
 
 /// Bitcoin transaction.
 ///


### PR DESCRIPTION
Now we want to only import using crate re-exports if possible in `bitcoin` and `primitives`. We fixed `bitcoin` already, now do `primitives`.