### PR TITLE
Rename `units::parse` to `parse_int`

### DIFF
--- a/api/units/all-features.txt
+++ b/api/units/all-features.txt
@@ -10,7 +10,7 @@
 #[non_exhaustive] pub struct bitcoin_units::fee_rate::serde::OverflowError
 #[non_exhaustive] pub struct bitcoin_units::locktime::absolute::ConversionError
 #[non_exhaustive] pub struct bitcoin_units::locktime::absolute::error::ConversionError
-#[non_exhaustive] pub struct bitcoin_units::parse::ParseIntError
+#[non_exhaustive] pub struct bitcoin_units::parse_int::ParseIntError
 #[non_exhaustive] pub struct bitcoin_units::result::NumOpError(_)
 impl bitcoin_units::Amount
 impl bitcoin_units::BlockTime
@@ -33,16 +33,16 @@ impl bitcoin_units::locktime::relative::LockTime
 impl bitcoin_units::locktime::relative::NumberOf512Seconds
 impl bitcoin_units::locktime::relative::NumberOfBlocks
 impl bitcoin_units::locktime::relative::error::DisabledLockTimeError
-impl bitcoin_units::parse::Integer for i128
-impl bitcoin_units::parse::Integer for i16
-impl bitcoin_units::parse::Integer for i32
-impl bitcoin_units::parse::Integer for i64
-impl bitcoin_units::parse::Integer for i8
-impl bitcoin_units::parse::Integer for u128
-impl bitcoin_units::parse::Integer for u16
-impl bitcoin_units::parse::Integer for u32
-impl bitcoin_units::parse::Integer for u64
-impl bitcoin_units::parse::Integer for u8
+impl bitcoin_units::parse_int::Integer for i128
+impl bitcoin_units::parse_int::Integer for i16
+impl bitcoin_units::parse_int::Integer for i32
+impl bitcoin_units::parse_int::Integer for i64
+impl bitcoin_units::parse_int::Integer for i8
+impl bitcoin_units::parse_int::Integer for u128
+impl bitcoin_units::parse_int::Integer for u16
+impl bitcoin_units::parse_int::Integer for u32
+impl bitcoin_units::parse_int::Integer for u64
+impl bitcoin_units::parse_int::Integer for u8
 impl bitcoin_units::result::MathOp
 impl bitcoin_units::result::NumOpError
 impl bitcoin_units::sequence::Sequence
@@ -88,9 +88,9 @@ impl core::clone::Clone for bitcoin_units::locktime::relative::error::IsSatisfie
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::TimeOverflowError
-impl core::clone::Clone for bitcoin_units::parse::ParseIntError
-impl core::clone::Clone for bitcoin_units::parse::PrefixedHexError
-impl core::clone::Clone for bitcoin_units::parse::UnprefixedHexError
+impl core::clone::Clone for bitcoin_units::parse_int::ParseIntError
+impl core::clone::Clone for bitcoin_units::parse_int::PrefixedHexError
+impl core::clone::Clone for bitcoin_units::parse_int::UnprefixedHexError
 impl core::clone::Clone for bitcoin_units::result::MathOp
 impl core::clone::Clone for bitcoin_units::result::NumOpError
 impl core::clone::Clone for bitcoin_units::sequence::Sequence
@@ -135,9 +135,9 @@ impl core::cmp::Eq for bitcoin_units::locktime::relative::error::IsSatisfiedByEr
 impl core::cmp::Eq for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl core::cmp::Eq for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 impl core::cmp::Eq for bitcoin_units::locktime::relative::error::TimeOverflowError
-impl core::cmp::Eq for bitcoin_units::parse::ParseIntError
-impl core::cmp::Eq for bitcoin_units::parse::PrefixedHexError
-impl core::cmp::Eq for bitcoin_units::parse::UnprefixedHexError
+impl core::cmp::Eq for bitcoin_units::parse_int::ParseIntError
+impl core::cmp::Eq for bitcoin_units::parse_int::PrefixedHexError
+impl core::cmp::Eq for bitcoin_units::parse_int::UnprefixedHexError
 impl core::cmp::Eq for bitcoin_units::result::MathOp
 impl core::cmp::Eq for bitcoin_units::result::NumOpError
 impl core::cmp::Eq for bitcoin_units::sequence::Sequence
@@ -196,9 +196,9 @@ impl core::cmp::PartialEq for bitcoin_units::locktime::relative::error::IsSatisf
 impl core::cmp::PartialEq for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl core::cmp::PartialEq for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 impl core::cmp::PartialEq for bitcoin_units::locktime::relative::error::TimeOverflowError
-impl core::cmp::PartialEq for bitcoin_units::parse::ParseIntError
-impl core::cmp::PartialEq for bitcoin_units::parse::PrefixedHexError
-impl core::cmp::PartialEq for bitcoin_units::parse::UnprefixedHexError
+impl core::cmp::PartialEq for bitcoin_units::parse_int::ParseIntError
+impl core::cmp::PartialEq for bitcoin_units::parse_int::PrefixedHexError
+impl core::cmp::PartialEq for bitcoin_units::parse_int::UnprefixedHexError
 impl core::cmp::PartialEq for bitcoin_units::result::MathOp
 impl core::cmp::PartialEq for bitcoin_units::result::NumOpError
 impl core::cmp::PartialEq for bitcoin_units::sequence::Sequence
@@ -216,7 +216,7 @@ impl core::cmp::PartialOrd for bitcoin_units::locktime::absolute::MedianTimePast
 impl core::cmp::PartialOrd for bitcoin_units::locktime::relative::NumberOf512Seconds
 impl core::cmp::PartialOrd for bitcoin_units::locktime::relative::NumberOfBlocks
 impl core::cmp::PartialOrd for bitcoin_units::sequence::Sequence
-impl core::convert::AsRef<core::num::error::ParseIntError> for bitcoin_units::parse::ParseIntError
+impl core::convert::AsRef<core::num::error::ParseIntError> for bitcoin_units::parse_int::ParseIntError
 impl core::convert::From<&bitcoin_units::Amount> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
 impl core::convert::From<&bitcoin_units::SignedAmount> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
 impl core::convert::From<bitcoin_units::Amount> for bitcoin_units::SignedAmount
@@ -249,16 +249,16 @@ impl core::convert::From<bitcoin_units::locktime::relative::NumberOf512Seconds> 
 impl core::convert::From<bitcoin_units::locktime::relative::NumberOf512Seconds> for bitcoin_units::locktime::relative::LockTime
 impl core::convert::From<bitcoin_units::locktime::relative::NumberOfBlocks> for bitcoin_units::block::BlockHeightInterval
 impl core::convert::From<bitcoin_units::locktime::relative::NumberOfBlocks> for bitcoin_units::locktime::relative::LockTime
-impl core::convert::From<bitcoin_units::parse::ParseIntError> for bitcoin_units::parse::PrefixedHexError
-impl core::convert::From<bitcoin_units::parse::ParseIntError> for bitcoin_units::parse::UnprefixedHexError
-impl core::convert::From<bitcoin_units::parse::ParseIntError> for core::num::error::ParseIntError
+impl core::convert::From<bitcoin_units::parse_int::ParseIntError> for bitcoin_units::parse_int::PrefixedHexError
+impl core::convert::From<bitcoin_units::parse_int::ParseIntError> for bitcoin_units::parse_int::UnprefixedHexError
+impl core::convert::From<bitcoin_units::parse_int::ParseIntError> for core::num::error::ParseIntError
 impl core::convert::From<bitcoin_units::sequence::Sequence> for u32
 impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::error::ParseAmountError
 impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::error::ParseDenominationError
 impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::error::ParseError
 impl core::convert::From<core::convert::Infallible> for bitcoin_units::fee_rate::serde::OverflowError
-impl core::convert::From<core::convert::Infallible> for bitcoin_units::parse::PrefixedHexError
-impl core::convert::From<core::convert::Infallible> for bitcoin_units::parse::UnprefixedHexError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::parse_int::PrefixedHexError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::parse_int::UnprefixedHexError
 impl core::convert::From<u16> for bitcoin_units::locktime::relative::NumberOfBlocks
 impl core::convert::From<u32> for bitcoin_units::BlockTime
 impl core::convert::From<u32> for bitcoin_units::block::BlockHeight
@@ -334,9 +334,9 @@ impl core::error::Error for bitcoin_units::locktime::relative::error::IsSatisfie
 impl core::error::Error for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl core::error::Error for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 impl core::error::Error for bitcoin_units::locktime::relative::error::TimeOverflowError
-impl core::error::Error for bitcoin_units::parse::ParseIntError
-impl core::error::Error for bitcoin_units::parse::PrefixedHexError
-impl core::error::Error for bitcoin_units::parse::UnprefixedHexError
+impl core::error::Error for bitcoin_units::parse_int::ParseIntError
+impl core::error::Error for bitcoin_units::parse_int::PrefixedHexError
+impl core::error::Error for bitcoin_units::parse_int::UnprefixedHexError
 impl core::error::Error for bitcoin_units::result::NumOpError
 impl core::fmt::Debug for bitcoin_units::Amount
 impl core::fmt::Debug for bitcoin_units::BlockTime
@@ -380,9 +380,9 @@ impl core::fmt::Debug for bitcoin_units::locktime::relative::error::IsSatisfiedB
 impl core::fmt::Debug for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl core::fmt::Debug for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 impl core::fmt::Debug for bitcoin_units::locktime::relative::error::TimeOverflowError
-impl core::fmt::Debug for bitcoin_units::parse::ParseIntError
-impl core::fmt::Debug for bitcoin_units::parse::PrefixedHexError
-impl core::fmt::Debug for bitcoin_units::parse::UnprefixedHexError
+impl core::fmt::Debug for bitcoin_units::parse_int::ParseIntError
+impl core::fmt::Debug for bitcoin_units::parse_int::PrefixedHexError
+impl core::fmt::Debug for bitcoin_units::parse_int::UnprefixedHexError
 impl core::fmt::Debug for bitcoin_units::result::MathOp
 impl core::fmt::Debug for bitcoin_units::result::NumOpError
 impl core::fmt::Debug for bitcoin_units::sequence::Sequence
@@ -425,9 +425,9 @@ impl core::fmt::Display for bitcoin_units::locktime::relative::error::IsSatisfie
 impl core::fmt::Display for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl core::fmt::Display for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 impl core::fmt::Display for bitcoin_units::locktime::relative::error::TimeOverflowError
-impl core::fmt::Display for bitcoin_units::parse::ParseIntError
-impl core::fmt::Display for bitcoin_units::parse::PrefixedHexError
-impl core::fmt::Display for bitcoin_units::parse::UnprefixedHexError
+impl core::fmt::Display for bitcoin_units::parse_int::ParseIntError
+impl core::fmt::Display for bitcoin_units::parse_int::PrefixedHexError
+impl core::fmt::Display for bitcoin_units::parse_int::UnprefixedHexError
 impl core::fmt::Display for bitcoin_units::result::MathOp
 impl core::fmt::Display for bitcoin_units::result::NumOpError
 impl core::fmt::Display for bitcoin_units::sequence::Sequence
@@ -518,9 +518,9 @@ impl core::marker::Freeze for bitcoin_units::locktime::relative::error::IsSatisf
 impl core::marker::Freeze for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl core::marker::Freeze for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 impl core::marker::Freeze for bitcoin_units::locktime::relative::error::TimeOverflowError
-impl core::marker::Freeze for bitcoin_units::parse::ParseIntError
-impl core::marker::Freeze for bitcoin_units::parse::PrefixedHexError
-impl core::marker::Freeze for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::Freeze for bitcoin_units::parse_int::ParseIntError
+impl core::marker::Freeze for bitcoin_units::parse_int::PrefixedHexError
+impl core::marker::Freeze for bitcoin_units::parse_int::UnprefixedHexError
 impl core::marker::Freeze for bitcoin_units::result::MathOp
 impl core::marker::Freeze for bitcoin_units::result::NumOpError
 impl core::marker::Freeze for bitcoin_units::sequence::Sequence
@@ -566,9 +566,9 @@ impl core::marker::Send for bitcoin_units::locktime::relative::error::IsSatisfie
 impl core::marker::Send for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl core::marker::Send for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 impl core::marker::Send for bitcoin_units::locktime::relative::error::TimeOverflowError
-impl core::marker::Send for bitcoin_units::parse::ParseIntError
-impl core::marker::Send for bitcoin_units::parse::PrefixedHexError
-impl core::marker::Send for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::Send for bitcoin_units::parse_int::ParseIntError
+impl core::marker::Send for bitcoin_units::parse_int::PrefixedHexError
+impl core::marker::Send for bitcoin_units::parse_int::UnprefixedHexError
 impl core::marker::Send for bitcoin_units::result::MathOp
 impl core::marker::Send for bitcoin_units::result::NumOpError
 impl core::marker::Send for bitcoin_units::sequence::Sequence
@@ -613,9 +613,9 @@ impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::er
 impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::error::TimeOverflowError
-impl core::marker::StructuralPartialEq for bitcoin_units::parse::ParseIntError
-impl core::marker::StructuralPartialEq for bitcoin_units::parse::PrefixedHexError
-impl core::marker::StructuralPartialEq for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::StructuralPartialEq for bitcoin_units::parse_int::ParseIntError
+impl core::marker::StructuralPartialEq for bitcoin_units::parse_int::PrefixedHexError
+impl core::marker::StructuralPartialEq for bitcoin_units::parse_int::UnprefixedHexError
 impl core::marker::StructuralPartialEq for bitcoin_units::result::MathOp
 impl core::marker::StructuralPartialEq for bitcoin_units::result::NumOpError
 impl core::marker::StructuralPartialEq for bitcoin_units::sequence::Sequence
@@ -661,9 +661,9 @@ impl core::marker::Sync for bitcoin_units::locktime::relative::error::IsSatisfie
 impl core::marker::Sync for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl core::marker::Sync for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 impl core::marker::Sync for bitcoin_units::locktime::relative::error::TimeOverflowError
-impl core::marker::Sync for bitcoin_units::parse::ParseIntError
-impl core::marker::Sync for bitcoin_units::parse::PrefixedHexError
-impl core::marker::Sync for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::Sync for bitcoin_units::parse_int::ParseIntError
+impl core::marker::Sync for bitcoin_units::parse_int::PrefixedHexError
+impl core::marker::Sync for bitcoin_units::parse_int::UnprefixedHexError
 impl core::marker::Sync for bitcoin_units::result::MathOp
 impl core::marker::Sync for bitcoin_units::result::NumOpError
 impl core::marker::Sync for bitcoin_units::sequence::Sequence
@@ -709,9 +709,9 @@ impl core::marker::Unpin for bitcoin_units::locktime::relative::error::IsSatisfi
 impl core::marker::Unpin for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl core::marker::Unpin for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 impl core::marker::Unpin for bitcoin_units::locktime::relative::error::TimeOverflowError
-impl core::marker::Unpin for bitcoin_units::parse::ParseIntError
-impl core::marker::Unpin for bitcoin_units::parse::PrefixedHexError
-impl core::marker::Unpin for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::Unpin for bitcoin_units::parse_int::ParseIntError
+impl core::marker::Unpin for bitcoin_units::parse_int::PrefixedHexError
+impl core::marker::Unpin for bitcoin_units::parse_int::UnprefixedHexError
 impl core::marker::Unpin for bitcoin_units::result::MathOp
 impl core::marker::Unpin for bitcoin_units::result::NumOpError
 impl core::marker::Unpin for bitcoin_units::sequence::Sequence
@@ -983,9 +983,9 @@ impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relati
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::error::TimeOverflowError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::parse::ParseIntError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::parse::PrefixedHexError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::parse::UnprefixedHexError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::parse_int::ParseIntError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::parse_int::PrefixedHexError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::parse_int::UnprefixedHexError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::result::MathOp
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::result::NumOpError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::sequence::Sequence
@@ -1031,9 +1031,9 @@ impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative:
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::error::TimeOverflowError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::parse::ParseIntError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::parse::PrefixedHexError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::parse::UnprefixedHexError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::parse_int::ParseIntError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::parse_int::PrefixedHexError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::parse_int::UnprefixedHexError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::result::MathOp
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::result::NumOpError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::sequence::Sequence
@@ -1956,10 +1956,10 @@ pub fn bitcoin_units::locktime::absolute::LockTime::from(h: bitcoin_units::lockt
 pub fn bitcoin_units::locktime::absolute::LockTime::from(t: bitcoin_units::locktime::absolute::MedianTimePast) -> Self
 pub fn bitcoin_units::locktime::absolute::LockTime::from_consensus(n: u32) -> Self
 pub fn bitcoin_units::locktime::absolute::LockTime::from_height(n: u32) -> core::result::Result<Self, bitcoin_units::locktime::absolute::error::ConversionError>
-pub fn bitcoin_units::locktime::absolute::LockTime::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse::PrefixedHexError>
+pub fn bitcoin_units::locktime::absolute::LockTime::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::PrefixedHexError>
 pub fn bitcoin_units::locktime::absolute::LockTime::from_mtp(n: u32) -> core::result::Result<Self, bitcoin_units::locktime::absolute::error::ConversionError>
 pub fn bitcoin_units::locktime::absolute::LockTime::from_str(s: &str) -> core::result::Result<Self, Self::Err>
-pub fn bitcoin_units::locktime::absolute::LockTime::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse::UnprefixedHexError>
+pub fn bitcoin_units::locktime::absolute::LockTime::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::UnprefixedHexError>
 pub fn bitcoin_units::locktime::absolute::LockTime::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin_units::locktime::absolute::LockTime::is_implied_by(self, other: bitcoin_units::locktime::absolute::LockTime) -> bool
 pub fn bitcoin_units::locktime::absolute::LockTime::is_satisfied_by(self, height: bitcoin_units::locktime::absolute::Height, mtp: bitcoin_units::locktime::absolute::MedianTimePast) -> bool
@@ -2078,36 +2078,36 @@ pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError::source(
 pub fn bitcoin_units::locktime::relative::error::TimeOverflowError::clone(&self) -> bitcoin_units::locktime::relative::error::TimeOverflowError
 pub fn bitcoin_units::locktime::relative::error::TimeOverflowError::eq(&self, other: &bitcoin_units::locktime::relative::error::TimeOverflowError) -> bool
 pub fn bitcoin_units::locktime::relative::error::TimeOverflowError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::parse::ParseIntError::as_ref(&self) -> &core::num::error::ParseIntError
-pub fn bitcoin_units::parse::ParseIntError::clone(&self) -> bitcoin_units::parse::ParseIntError
-pub fn bitcoin_units::parse::ParseIntError::eq(&self, other: &bitcoin_units::parse::ParseIntError) -> bool
-pub fn bitcoin_units::parse::ParseIntError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::parse::ParseIntError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
-pub fn bitcoin_units::parse::PrefixedHexError::clone(&self) -> bitcoin_units::parse::PrefixedHexError
-pub fn bitcoin_units::parse::PrefixedHexError::eq(&self, other: &bitcoin_units::parse::PrefixedHexError) -> bool
-pub fn bitcoin_units::parse::PrefixedHexError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::parse::PrefixedHexError::from(e: bitcoin_units::parse::ParseIntError) -> Self
-pub fn bitcoin_units::parse::PrefixedHexError::from(never: core::convert::Infallible) -> Self
-pub fn bitcoin_units::parse::PrefixedHexError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
-pub fn bitcoin_units::parse::UnprefixedHexError::clone(&self) -> bitcoin_units::parse::UnprefixedHexError
-pub fn bitcoin_units::parse::UnprefixedHexError::eq(&self, other: &bitcoin_units::parse::UnprefixedHexError) -> bool
-pub fn bitcoin_units::parse::UnprefixedHexError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::parse::UnprefixedHexError::from(e: bitcoin_units::parse::ParseIntError) -> Self
-pub fn bitcoin_units::parse::UnprefixedHexError::from(never: core::convert::Infallible) -> Self
-pub fn bitcoin_units::parse::UnprefixedHexError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
-pub fn bitcoin_units::parse::hex_check_unprefixed(s: &str) -> core::result::Result<&str, bitcoin_units::parse::UnprefixedHexError>
-pub fn bitcoin_units::parse::hex_remove_prefix(s: &str) -> core::result::Result<&str, bitcoin_units::parse::PrefixedHexError>
-pub fn bitcoin_units::parse::hex_u128(s: &str) -> core::result::Result<u128, bitcoin_units::parse::ParseIntError>
-pub fn bitcoin_units::parse::hex_u128_prefixed(s: &str) -> core::result::Result<u128, bitcoin_units::parse::PrefixedHexError>
-pub fn bitcoin_units::parse::hex_u128_unchecked(s: &str) -> core::result::Result<u128, bitcoin_units::parse::ParseIntError>
-pub fn bitcoin_units::parse::hex_u128_unprefixed(s: &str) -> core::result::Result<u128, bitcoin_units::parse::UnprefixedHexError>
-pub fn bitcoin_units::parse::hex_u32(s: &str) -> core::result::Result<u32, bitcoin_units::parse::ParseIntError>
-pub fn bitcoin_units::parse::hex_u32_prefixed(s: &str) -> core::result::Result<u32, bitcoin_units::parse::PrefixedHexError>
-pub fn bitcoin_units::parse::hex_u32_unchecked(s: &str) -> core::result::Result<u32, bitcoin_units::parse::ParseIntError>
-pub fn bitcoin_units::parse::hex_u32_unprefixed(s: &str) -> core::result::Result<u32, bitcoin_units::parse::UnprefixedHexError>
-pub fn bitcoin_units::parse::int_from_box<T: bitcoin_units::parse::Integer>(s: alloc::boxed::Box<str>) -> core::result::Result<T, bitcoin_units::parse::ParseIntError>
-pub fn bitcoin_units::parse::int_from_str<T: bitcoin_units::parse::Integer>(s: &str) -> core::result::Result<T, bitcoin_units::parse::ParseIntError>
-pub fn bitcoin_units::parse::int_from_string<T: bitcoin_units::parse::Integer>(s: alloc::string::String) -> core::result::Result<T, bitcoin_units::parse::ParseIntError>
+pub fn bitcoin_units::parse_int::ParseIntError::as_ref(&self) -> &core::num::error::ParseIntError
+pub fn bitcoin_units::parse_int::ParseIntError::clone(&self) -> bitcoin_units::parse_int::ParseIntError
+pub fn bitcoin_units::parse_int::ParseIntError::eq(&self, other: &bitcoin_units::parse_int::ParseIntError) -> bool
+pub fn bitcoin_units::parse_int::ParseIntError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::parse_int::ParseIntError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_units::parse_int::PrefixedHexError::clone(&self) -> bitcoin_units::parse_int::PrefixedHexError
+pub fn bitcoin_units::parse_int::PrefixedHexError::eq(&self, other: &bitcoin_units::parse_int::PrefixedHexError) -> bool
+pub fn bitcoin_units::parse_int::PrefixedHexError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::parse_int::PrefixedHexError::from(e: bitcoin_units::parse_int::ParseIntError) -> Self
+pub fn bitcoin_units::parse_int::PrefixedHexError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::parse_int::PrefixedHexError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_units::parse_int::UnprefixedHexError::clone(&self) -> bitcoin_units::parse_int::UnprefixedHexError
+pub fn bitcoin_units::parse_int::UnprefixedHexError::eq(&self, other: &bitcoin_units::parse_int::UnprefixedHexError) -> bool
+pub fn bitcoin_units::parse_int::UnprefixedHexError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::parse_int::UnprefixedHexError::from(e: bitcoin_units::parse_int::ParseIntError) -> Self
+pub fn bitcoin_units::parse_int::UnprefixedHexError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::parse_int::UnprefixedHexError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+pub fn bitcoin_units::parse_int::hex_check_unprefixed(s: &str) -> core::result::Result<&str, bitcoin_units::parse_int::UnprefixedHexError>
+pub fn bitcoin_units::parse_int::hex_remove_prefix(s: &str) -> core::result::Result<&str, bitcoin_units::parse_int::PrefixedHexError>
+pub fn bitcoin_units::parse_int::hex_u128(s: &str) -> core::result::Result<u128, bitcoin_units::parse_int::ParseIntError>
+pub fn bitcoin_units::parse_int::hex_u128_prefixed(s: &str) -> core::result::Result<u128, bitcoin_units::parse_int::PrefixedHexError>
+pub fn bitcoin_units::parse_int::hex_u128_unchecked(s: &str) -> core::result::Result<u128, bitcoin_units::parse_int::ParseIntError>
+pub fn bitcoin_units::parse_int::hex_u128_unprefixed(s: &str) -> core::result::Result<u128, bitcoin_units::parse_int::UnprefixedHexError>
+pub fn bitcoin_units::parse_int::hex_u32(s: &str) -> core::result::Result<u32, bitcoin_units::parse_int::ParseIntError>
+pub fn bitcoin_units::parse_int::hex_u32_prefixed(s: &str) -> core::result::Result<u32, bitcoin_units::parse_int::PrefixedHexError>
+pub fn bitcoin_units::parse_int::hex_u32_unchecked(s: &str) -> core::result::Result<u32, bitcoin_units::parse_int::ParseIntError>
+pub fn bitcoin_units::parse_int::hex_u32_unprefixed(s: &str) -> core::result::Result<u32, bitcoin_units::parse_int::UnprefixedHexError>
+pub fn bitcoin_units::parse_int::int_from_box<T: bitcoin_units::parse_int::Integer>(s: alloc::boxed::Box<str>) -> core::result::Result<T, bitcoin_units::parse_int::ParseIntError>
+pub fn bitcoin_units::parse_int::int_from_str<T: bitcoin_units::parse_int::Integer>(s: &str) -> core::result::Result<T, bitcoin_units::parse_int::ParseIntError>
+pub fn bitcoin_units::parse_int::int_from_string<T: bitcoin_units::parse_int::Integer>(s: alloc::string::String) -> core::result::Result<T, bitcoin_units::parse_int::ParseIntError>
 pub fn bitcoin_units::result::MathOp::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
 pub fn bitcoin_units::result::MathOp::clone(&self) -> bitcoin_units::result::MathOp
 pub fn bitcoin_units::result::MathOp::eq(&self, other: &bitcoin_units::result::MathOp) -> bool
@@ -2203,11 +2203,11 @@ pub fn bitcoin_units::sequence::Sequence::from(lt: bitcoin_units::locktime::rela
 pub fn bitcoin_units::sequence::Sequence::from_512_second_intervals(intervals: u16) -> Self
 pub fn bitcoin_units::sequence::Sequence::from_consensus(n: u32) -> Self
 pub fn bitcoin_units::sequence::Sequence::from_height(height: u16) -> Self
-pub fn bitcoin_units::sequence::Sequence::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse::PrefixedHexError>
+pub fn bitcoin_units::sequence::Sequence::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::PrefixedHexError>
 pub fn bitcoin_units::sequence::Sequence::from_seconds_ceil(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::TimeOverflowError>
 pub fn bitcoin_units::sequence::Sequence::from_seconds_floor(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::TimeOverflowError>
 pub fn bitcoin_units::sequence::Sequence::from_str(s: &str) -> core::result::Result<Self, Self::Err>
-pub fn bitcoin_units::sequence::Sequence::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse::UnprefixedHexError>
+pub fn bitcoin_units::sequence::Sequence::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::UnprefixedHexError>
 pub fn bitcoin_units::sequence::Sequence::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin_units::sequence::Sequence::is_final(self) -> bool
 pub fn bitcoin_units::sequence::Sequence::is_height_locked(self) -> bool
@@ -2222,7 +2222,7 @@ pub fn bitcoin_units::sequence::Sequence::to_relative_lock_time(self) -> core::o
 pub fn bitcoin_units::sequence::Sequence::try_from(s: &str) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_units::sequence::Sequence::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_units::sequence::Sequence::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
-pub fn core::num::error::ParseIntError::from(value: bitcoin_units::parse::ParseIntError) -> Self
+pub fn core::num::error::ParseIntError::from(value: bitcoin_units::parse_int::ParseIntError) -> Self
 pub fn i64::mul(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output
 pub fn i64::mul(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
 pub fn i64::mul(self, rhs: bitcoin_units::SignedAmount) -> Self::Output
@@ -2266,7 +2266,7 @@ pub mod bitcoin_units::locktime::absolute
 pub mod bitcoin_units::locktime::absolute::error
 pub mod bitcoin_units::locktime::relative
 pub mod bitcoin_units::locktime::relative::error
-pub mod bitcoin_units::parse
+pub mod bitcoin_units::parse_int
 pub mod bitcoin_units::relative
 pub mod bitcoin_units::relative::error
 pub mod bitcoin_units::result
@@ -2332,8 +2332,8 @@ pub struct bitcoin_units::locktime::relative::error::DisabledLockTimeError(_)
 pub struct bitcoin_units::locktime::relative::error::InvalidHeightError
 pub struct bitcoin_units::locktime::relative::error::InvalidTimeError
 pub struct bitcoin_units::locktime::relative::error::TimeOverflowError
-pub struct bitcoin_units::parse::PrefixedHexError(_)
-pub struct bitcoin_units::parse::UnprefixedHexError(_)
+pub struct bitcoin_units::parse_int::PrefixedHexError(_)
+pub struct bitcoin_units::parse_int::UnprefixedHexError(_)
 pub struct bitcoin_units::relative::DisabledLockTimeError(_)
 pub struct bitcoin_units::relative::InvalidHeightError
 pub struct bitcoin_units::relative::InvalidTimeError
@@ -2347,7 +2347,7 @@ pub struct bitcoin_units::relative::error::TimeOverflowError
 pub struct bitcoin_units::sequence::Sequence(pub u32)
 pub struct bitcoin_units::time::BlockTime(_)
 pub struct bitcoin_units::weight::Weight(_)
-pub trait bitcoin_units::parse::Integer: core::str::traits::FromStr<Err = core::num::error::ParseIntError> + core::convert::TryFrom<i8> + core::marker::Sized + bitcoin_units::parse::sealed::Sealed
+pub trait bitcoin_units::parse_int::Integer: core::str::traits::FromStr<Err = core::num::error::ParseIntError> + core::convert::TryFrom<i8> + core::marker::Sized + bitcoin_units::parse_int::sealed::Sealed
 pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Add<bitcoin_units::result::NumOpResult<bitcoin_units::Amount>>>::Output
 pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Add>::Output
 pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<bitcoin_units::FeeRate>>::Output
@@ -2458,8 +2458,8 @@ pub type bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as c
 pub type bitcoin_units::SignedAmount::Output = bitcoin_units::SignedAmount
 pub type bitcoin_units::SignedAmount::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
 pub type bitcoin_units::SignedAmount::Output = bitcoin_units::result::NumOpResult<i64>
-pub type bitcoin_units::Weight::Err = bitcoin_units::parse::ParseIntError
-pub type bitcoin_units::Weight::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::Weight::Err = bitcoin_units::parse_int::ParseIntError
+pub type bitcoin_units::Weight::Error = bitcoin_units::parse_int::ParseIntError
 pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Add>::Output
 pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output
 pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Div<u64>>::Output
@@ -2474,44 +2474,44 @@ pub type bitcoin_units::Weight::Output = bitcoin_units::Weight
 pub type bitcoin_units::Weight::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
 pub type bitcoin_units::Weight::Output = u64
 pub type bitcoin_units::amount::Denomination::Err = bitcoin_units::amount::error::ParseDenominationError
-pub type bitcoin_units::block::BlockHeight::Err = bitcoin_units::parse::ParseIntError
-pub type bitcoin_units::block::BlockHeight::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockHeight::Err = bitcoin_units::parse_int::ParseIntError
+pub type bitcoin_units::block::BlockHeight::Error = bitcoin_units::parse_int::ParseIntError
 pub type bitcoin_units::block::BlockHeight::Output = <bitcoin_units::block::BlockHeight as core::ops::arith::Add<bitcoin_units::block::BlockHeightInterval>>::Output
 pub type bitcoin_units::block::BlockHeight::Output = <bitcoin_units::block::BlockHeight as core::ops::arith::Sub<bitcoin_units::block::BlockHeightInterval>>::Output
 pub type bitcoin_units::block::BlockHeight::Output = <bitcoin_units::block::BlockHeight as core::ops::arith::Sub>::Output
 pub type bitcoin_units::block::BlockHeight::Output = bitcoin_units::block::BlockHeight
 pub type bitcoin_units::block::BlockHeight::Output = bitcoin_units::block::BlockHeightInterval
-pub type bitcoin_units::block::BlockHeightInterval::Err = bitcoin_units::parse::ParseIntError
-pub type bitcoin_units::block::BlockHeightInterval::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockHeightInterval::Err = bitcoin_units::parse_int::ParseIntError
+pub type bitcoin_units::block::BlockHeightInterval::Error = bitcoin_units::parse_int::ParseIntError
 pub type bitcoin_units::block::BlockHeightInterval::Output = <bitcoin_units::block::BlockHeightInterval as core::ops::arith::Add>::Output
 pub type bitcoin_units::block::BlockHeightInterval::Output = <bitcoin_units::block::BlockHeightInterval as core::ops::arith::Sub>::Output
 pub type bitcoin_units::block::BlockHeightInterval::Output = bitcoin_units::block::BlockHeightInterval
-pub type bitcoin_units::block::BlockMtp::Err = bitcoin_units::parse::ParseIntError
-pub type bitcoin_units::block::BlockMtp::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockMtp::Err = bitcoin_units::parse_int::ParseIntError
+pub type bitcoin_units::block::BlockMtp::Error = bitcoin_units::parse_int::ParseIntError
 pub type bitcoin_units::block::BlockMtp::Output = <bitcoin_units::block::BlockMtp as core::ops::arith::Add<bitcoin_units::block::BlockMtpInterval>>::Output
 pub type bitcoin_units::block::BlockMtp::Output = <bitcoin_units::block::BlockMtp as core::ops::arith::Sub<bitcoin_units::block::BlockMtpInterval>>::Output
 pub type bitcoin_units::block::BlockMtp::Output = <bitcoin_units::block::BlockMtp as core::ops::arith::Sub>::Output
 pub type bitcoin_units::block::BlockMtp::Output = bitcoin_units::block::BlockMtp
 pub type bitcoin_units::block::BlockMtp::Output = bitcoin_units::block::BlockMtpInterval
-pub type bitcoin_units::block::BlockMtpInterval::Err = bitcoin_units::parse::ParseIntError
-pub type bitcoin_units::block::BlockMtpInterval::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockMtpInterval::Err = bitcoin_units::parse_int::ParseIntError
+pub type bitcoin_units::block::BlockMtpInterval::Error = bitcoin_units::parse_int::ParseIntError
 pub type bitcoin_units::block::BlockMtpInterval::Output = <bitcoin_units::block::BlockMtpInterval as core::ops::arith::Add>::Output
 pub type bitcoin_units::block::BlockMtpInterval::Output = <bitcoin_units::block::BlockMtpInterval as core::ops::arith::Sub>::Output
 pub type bitcoin_units::block::BlockMtpInterval::Output = bitcoin_units::block::BlockMtpInterval
 pub type bitcoin_units::locktime::absolute::Height::Err = bitcoin_units::locktime::absolute::error::ParseHeightError
 pub type bitcoin_units::locktime::absolute::Height::Error = bitcoin_units::locktime::absolute::error::ConversionError
 pub type bitcoin_units::locktime::absolute::Height::Error = bitcoin_units::locktime::absolute::error::ParseHeightError
-pub type bitcoin_units::locktime::absolute::LockTime::Err = bitcoin_units::parse::ParseIntError
-pub type bitcoin_units::locktime::absolute::LockTime::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::locktime::absolute::LockTime::Err = bitcoin_units::parse_int::ParseIntError
+pub type bitcoin_units::locktime::absolute::LockTime::Error = bitcoin_units::parse_int::ParseIntError
 pub type bitcoin_units::locktime::absolute::MedianTimePast::Err = bitcoin_units::locktime::absolute::error::ParseTimeError
 pub type bitcoin_units::locktime::absolute::MedianTimePast::Error = bitcoin_units::locktime::absolute::error::ConversionError
 pub type bitcoin_units::locktime::absolute::MedianTimePast::Error = bitcoin_units::locktime::absolute::error::ParseTimeError
 pub type bitcoin_units::locktime::relative::LockTime::Error = bitcoin_units::locktime::relative::error::DisabledLockTimeError
-pub type bitcoin_units::locktime::relative::NumberOf512Seconds::Err = bitcoin_units::parse::ParseIntError
-pub type bitcoin_units::locktime::relative::NumberOf512Seconds::Error = bitcoin_units::parse::ParseIntError
-pub type bitcoin_units::locktime::relative::NumberOfBlocks::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::locktime::relative::NumberOf512Seconds::Err = bitcoin_units::parse_int::ParseIntError
+pub type bitcoin_units::locktime::relative::NumberOf512Seconds::Error = bitcoin_units::parse_int::ParseIntError
+pub type bitcoin_units::locktime::relative::NumberOfBlocks::Err = bitcoin_units::parse_int::ParseIntError
 pub type bitcoin_units::locktime::relative::NumberOfBlocks::Error = bitcoin_units::block::TooBigForRelativeHeightError
-pub type bitcoin_units::locktime::relative::NumberOfBlocks::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::locktime::relative::NumberOfBlocks::Error = bitcoin_units::parse_int::ParseIntError
 pub type bitcoin_units::result::NumOpResult<T>::Output = <bitcoin_units::result::NumOpResult<T> as core::ops::arith::Add<T>>::Output
 pub type bitcoin_units::result::NumOpResult<T>::Output = <bitcoin_units::result::NumOpResult<T> as core::ops::arith::Add>::Output
 pub type bitcoin_units::result::NumOpResult<T>::Output = <bitcoin_units::result::NumOpResult<T> as core::ops::arith::Sub<T>>::Output
@@ -2537,8 +2537,8 @@ pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output
 pub type bitcoin_units::result::NumOpResult<bitcoin_units::Weight>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Weight> as core::ops::arith::Mul<bitcoin_units::FeeRate>>::Output
 pub type bitcoin_units::result::NumOpResult<bitcoin_units::Weight>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Weight> as core::ops::arith::Mul<bitcoin_units::result::NumOpResult<bitcoin_units::FeeRate>>>::Output
 pub type bitcoin_units::result::NumOpResult<bitcoin_units::Weight>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
-pub type bitcoin_units::sequence::Sequence::Err = bitcoin_units::parse::ParseIntError
-pub type bitcoin_units::sequence::Sequence::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::sequence::Sequence::Err = bitcoin_units::parse_int::ParseIntError
+pub type bitcoin_units::sequence::Sequence::Error = bitcoin_units::parse_int::ParseIntError
 pub type i64::Output = <i64 as core::ops::arith::Mul<bitcoin_units::SignedAmount>>::Output
 pub type i64::Output = <i64 as core::ops::arith::Mul<bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>>>::Output
 pub type i64::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>

--- a/api/units/alloc-only.txt
+++ b/api/units/alloc-only.txt
@@ -9,7 +9,7 @@
 #[non_exhaustive] pub struct bitcoin_units::amount::error::UnknownDenominationError(_)
 #[non_exhaustive] pub struct bitcoin_units::locktime::absolute::ConversionError
 #[non_exhaustive] pub struct bitcoin_units::locktime::absolute::error::ConversionError
-#[non_exhaustive] pub struct bitcoin_units::parse::ParseIntError
+#[non_exhaustive] pub struct bitcoin_units::parse_int::ParseIntError
 #[non_exhaustive] pub struct bitcoin_units::result::NumOpError(_)
 impl bitcoin_units::Amount
 impl bitcoin_units::BlockTime
@@ -32,16 +32,16 @@ impl bitcoin_units::locktime::relative::LockTime
 impl bitcoin_units::locktime::relative::NumberOf512Seconds
 impl bitcoin_units::locktime::relative::NumberOfBlocks
 impl bitcoin_units::locktime::relative::error::DisabledLockTimeError
-impl bitcoin_units::parse::Integer for i128
-impl bitcoin_units::parse::Integer for i16
-impl bitcoin_units::parse::Integer for i32
-impl bitcoin_units::parse::Integer for i64
-impl bitcoin_units::parse::Integer for i8
-impl bitcoin_units::parse::Integer for u128
-impl bitcoin_units::parse::Integer for u16
-impl bitcoin_units::parse::Integer for u32
-impl bitcoin_units::parse::Integer for u64
-impl bitcoin_units::parse::Integer for u8
+impl bitcoin_units::parse_int::Integer for i128
+impl bitcoin_units::parse_int::Integer for i16
+impl bitcoin_units::parse_int::Integer for i32
+impl bitcoin_units::parse_int::Integer for i64
+impl bitcoin_units::parse_int::Integer for i8
+impl bitcoin_units::parse_int::Integer for u128
+impl bitcoin_units::parse_int::Integer for u16
+impl bitcoin_units::parse_int::Integer for u32
+impl bitcoin_units::parse_int::Integer for u64
+impl bitcoin_units::parse_int::Integer for u8
 impl bitcoin_units::result::MathOp
 impl bitcoin_units::result::NumOpError
 impl bitcoin_units::sequence::Sequence
@@ -86,9 +86,9 @@ impl core::clone::Clone for bitcoin_units::locktime::relative::error::IsSatisfie
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::TimeOverflowError
-impl core::clone::Clone for bitcoin_units::parse::ParseIntError
-impl core::clone::Clone for bitcoin_units::parse::PrefixedHexError
-impl core::clone::Clone for bitcoin_units::parse::UnprefixedHexError
+impl core::clone::Clone for bitcoin_units::parse_int::ParseIntError
+impl core::clone::Clone for bitcoin_units::parse_int::PrefixedHexError
+impl core::clone::Clone for bitcoin_units::parse_int::UnprefixedHexError
 impl core::clone::Clone for bitcoin_units::result::MathOp
 impl core::clone::Clone for bitcoin_units::result::NumOpError
 impl core::clone::Clone for bitcoin_units::sequence::Sequence
@@ -132,9 +132,9 @@ impl core::cmp::Eq for bitcoin_units::locktime::relative::error::IsSatisfiedByEr
 impl core::cmp::Eq for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl core::cmp::Eq for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 impl core::cmp::Eq for bitcoin_units::locktime::relative::error::TimeOverflowError
-impl core::cmp::Eq for bitcoin_units::parse::ParseIntError
-impl core::cmp::Eq for bitcoin_units::parse::PrefixedHexError
-impl core::cmp::Eq for bitcoin_units::parse::UnprefixedHexError
+impl core::cmp::Eq for bitcoin_units::parse_int::ParseIntError
+impl core::cmp::Eq for bitcoin_units::parse_int::PrefixedHexError
+impl core::cmp::Eq for bitcoin_units::parse_int::UnprefixedHexError
 impl core::cmp::Eq for bitcoin_units::result::MathOp
 impl core::cmp::Eq for bitcoin_units::result::NumOpError
 impl core::cmp::Eq for bitcoin_units::sequence::Sequence
@@ -192,9 +192,9 @@ impl core::cmp::PartialEq for bitcoin_units::locktime::relative::error::IsSatisf
 impl core::cmp::PartialEq for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl core::cmp::PartialEq for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 impl core::cmp::PartialEq for bitcoin_units::locktime::relative::error::TimeOverflowError
-impl core::cmp::PartialEq for bitcoin_units::parse::ParseIntError
-impl core::cmp::PartialEq for bitcoin_units::parse::PrefixedHexError
-impl core::cmp::PartialEq for bitcoin_units::parse::UnprefixedHexError
+impl core::cmp::PartialEq for bitcoin_units::parse_int::ParseIntError
+impl core::cmp::PartialEq for bitcoin_units::parse_int::PrefixedHexError
+impl core::cmp::PartialEq for bitcoin_units::parse_int::UnprefixedHexError
 impl core::cmp::PartialEq for bitcoin_units::result::MathOp
 impl core::cmp::PartialEq for bitcoin_units::result::NumOpError
 impl core::cmp::PartialEq for bitcoin_units::sequence::Sequence
@@ -212,7 +212,7 @@ impl core::cmp::PartialOrd for bitcoin_units::locktime::absolute::MedianTimePast
 impl core::cmp::PartialOrd for bitcoin_units::locktime::relative::NumberOf512Seconds
 impl core::cmp::PartialOrd for bitcoin_units::locktime::relative::NumberOfBlocks
 impl core::cmp::PartialOrd for bitcoin_units::sequence::Sequence
-impl core::convert::AsRef<core::num::error::ParseIntError> for bitcoin_units::parse::ParseIntError
+impl core::convert::AsRef<core::num::error::ParseIntError> for bitcoin_units::parse_int::ParseIntError
 impl core::convert::From<&bitcoin_units::Amount> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
 impl core::convert::From<&bitcoin_units::SignedAmount> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
 impl core::convert::From<bitcoin_units::Amount> for bitcoin_units::SignedAmount
@@ -245,15 +245,15 @@ impl core::convert::From<bitcoin_units::locktime::relative::NumberOf512Seconds> 
 impl core::convert::From<bitcoin_units::locktime::relative::NumberOf512Seconds> for bitcoin_units::locktime::relative::LockTime
 impl core::convert::From<bitcoin_units::locktime::relative::NumberOfBlocks> for bitcoin_units::block::BlockHeightInterval
 impl core::convert::From<bitcoin_units::locktime::relative::NumberOfBlocks> for bitcoin_units::locktime::relative::LockTime
-impl core::convert::From<bitcoin_units::parse::ParseIntError> for bitcoin_units::parse::PrefixedHexError
-impl core::convert::From<bitcoin_units::parse::ParseIntError> for bitcoin_units::parse::UnprefixedHexError
-impl core::convert::From<bitcoin_units::parse::ParseIntError> for core::num::error::ParseIntError
+impl core::convert::From<bitcoin_units::parse_int::ParseIntError> for bitcoin_units::parse_int::PrefixedHexError
+impl core::convert::From<bitcoin_units::parse_int::ParseIntError> for bitcoin_units::parse_int::UnprefixedHexError
+impl core::convert::From<bitcoin_units::parse_int::ParseIntError> for core::num::error::ParseIntError
 impl core::convert::From<bitcoin_units::sequence::Sequence> for u32
 impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::error::ParseAmountError
 impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::error::ParseDenominationError
 impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::error::ParseError
-impl core::convert::From<core::convert::Infallible> for bitcoin_units::parse::PrefixedHexError
-impl core::convert::From<core::convert::Infallible> for bitcoin_units::parse::UnprefixedHexError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::parse_int::PrefixedHexError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::parse_int::UnprefixedHexError
 impl core::convert::From<u16> for bitcoin_units::locktime::relative::NumberOfBlocks
 impl core::convert::From<u32> for bitcoin_units::BlockTime
 impl core::convert::From<u32> for bitcoin_units::block::BlockHeight
@@ -346,9 +346,9 @@ impl core::fmt::Debug for bitcoin_units::locktime::relative::error::IsSatisfiedB
 impl core::fmt::Debug for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl core::fmt::Debug for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 impl core::fmt::Debug for bitcoin_units::locktime::relative::error::TimeOverflowError
-impl core::fmt::Debug for bitcoin_units::parse::ParseIntError
-impl core::fmt::Debug for bitcoin_units::parse::PrefixedHexError
-impl core::fmt::Debug for bitcoin_units::parse::UnprefixedHexError
+impl core::fmt::Debug for bitcoin_units::parse_int::ParseIntError
+impl core::fmt::Debug for bitcoin_units::parse_int::PrefixedHexError
+impl core::fmt::Debug for bitcoin_units::parse_int::UnprefixedHexError
 impl core::fmt::Debug for bitcoin_units::result::MathOp
 impl core::fmt::Debug for bitcoin_units::result::NumOpError
 impl core::fmt::Debug for bitcoin_units::sequence::Sequence
@@ -390,9 +390,9 @@ impl core::fmt::Display for bitcoin_units::locktime::relative::error::IsSatisfie
 impl core::fmt::Display for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl core::fmt::Display for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 impl core::fmt::Display for bitcoin_units::locktime::relative::error::TimeOverflowError
-impl core::fmt::Display for bitcoin_units::parse::ParseIntError
-impl core::fmt::Display for bitcoin_units::parse::PrefixedHexError
-impl core::fmt::Display for bitcoin_units::parse::UnprefixedHexError
+impl core::fmt::Display for bitcoin_units::parse_int::ParseIntError
+impl core::fmt::Display for bitcoin_units::parse_int::PrefixedHexError
+impl core::fmt::Display for bitcoin_units::parse_int::UnprefixedHexError
 impl core::fmt::Display for bitcoin_units::result::MathOp
 impl core::fmt::Display for bitcoin_units::result::NumOpError
 impl core::fmt::Display for bitcoin_units::sequence::Sequence
@@ -482,9 +482,9 @@ impl core::marker::Freeze for bitcoin_units::locktime::relative::error::IsSatisf
 impl core::marker::Freeze for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl core::marker::Freeze for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 impl core::marker::Freeze for bitcoin_units::locktime::relative::error::TimeOverflowError
-impl core::marker::Freeze for bitcoin_units::parse::ParseIntError
-impl core::marker::Freeze for bitcoin_units::parse::PrefixedHexError
-impl core::marker::Freeze for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::Freeze for bitcoin_units::parse_int::ParseIntError
+impl core::marker::Freeze for bitcoin_units::parse_int::PrefixedHexError
+impl core::marker::Freeze for bitcoin_units::parse_int::UnprefixedHexError
 impl core::marker::Freeze for bitcoin_units::result::MathOp
 impl core::marker::Freeze for bitcoin_units::result::NumOpError
 impl core::marker::Freeze for bitcoin_units::sequence::Sequence
@@ -529,9 +529,9 @@ impl core::marker::Send for bitcoin_units::locktime::relative::error::IsSatisfie
 impl core::marker::Send for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl core::marker::Send for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 impl core::marker::Send for bitcoin_units::locktime::relative::error::TimeOverflowError
-impl core::marker::Send for bitcoin_units::parse::ParseIntError
-impl core::marker::Send for bitcoin_units::parse::PrefixedHexError
-impl core::marker::Send for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::Send for bitcoin_units::parse_int::ParseIntError
+impl core::marker::Send for bitcoin_units::parse_int::PrefixedHexError
+impl core::marker::Send for bitcoin_units::parse_int::UnprefixedHexError
 impl core::marker::Send for bitcoin_units::result::MathOp
 impl core::marker::Send for bitcoin_units::result::NumOpError
 impl core::marker::Send for bitcoin_units::sequence::Sequence
@@ -575,9 +575,9 @@ impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::er
 impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::error::TimeOverflowError
-impl core::marker::StructuralPartialEq for bitcoin_units::parse::ParseIntError
-impl core::marker::StructuralPartialEq for bitcoin_units::parse::PrefixedHexError
-impl core::marker::StructuralPartialEq for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::StructuralPartialEq for bitcoin_units::parse_int::ParseIntError
+impl core::marker::StructuralPartialEq for bitcoin_units::parse_int::PrefixedHexError
+impl core::marker::StructuralPartialEq for bitcoin_units::parse_int::UnprefixedHexError
 impl core::marker::StructuralPartialEq for bitcoin_units::result::MathOp
 impl core::marker::StructuralPartialEq for bitcoin_units::result::NumOpError
 impl core::marker::StructuralPartialEq for bitcoin_units::sequence::Sequence
@@ -622,9 +622,9 @@ impl core::marker::Sync for bitcoin_units::locktime::relative::error::IsSatisfie
 impl core::marker::Sync for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl core::marker::Sync for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 impl core::marker::Sync for bitcoin_units::locktime::relative::error::TimeOverflowError
-impl core::marker::Sync for bitcoin_units::parse::ParseIntError
-impl core::marker::Sync for bitcoin_units::parse::PrefixedHexError
-impl core::marker::Sync for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::Sync for bitcoin_units::parse_int::ParseIntError
+impl core::marker::Sync for bitcoin_units::parse_int::PrefixedHexError
+impl core::marker::Sync for bitcoin_units::parse_int::UnprefixedHexError
 impl core::marker::Sync for bitcoin_units::result::MathOp
 impl core::marker::Sync for bitcoin_units::result::NumOpError
 impl core::marker::Sync for bitcoin_units::sequence::Sequence
@@ -669,9 +669,9 @@ impl core::marker::Unpin for bitcoin_units::locktime::relative::error::IsSatisfi
 impl core::marker::Unpin for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl core::marker::Unpin for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 impl core::marker::Unpin for bitcoin_units::locktime::relative::error::TimeOverflowError
-impl core::marker::Unpin for bitcoin_units::parse::ParseIntError
-impl core::marker::Unpin for bitcoin_units::parse::PrefixedHexError
-impl core::marker::Unpin for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::Unpin for bitcoin_units::parse_int::ParseIntError
+impl core::marker::Unpin for bitcoin_units::parse_int::PrefixedHexError
+impl core::marker::Unpin for bitcoin_units::parse_int::UnprefixedHexError
 impl core::marker::Unpin for bitcoin_units::result::MathOp
 impl core::marker::Unpin for bitcoin_units::result::NumOpError
 impl core::marker::Unpin for bitcoin_units::sequence::Sequence
@@ -942,9 +942,9 @@ impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relati
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::error::TimeOverflowError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::parse::ParseIntError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::parse::PrefixedHexError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::parse::UnprefixedHexError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::parse_int::ParseIntError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::parse_int::PrefixedHexError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::parse_int::UnprefixedHexError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::result::MathOp
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::result::NumOpError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::sequence::Sequence
@@ -989,9 +989,9 @@ impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative:
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::error::TimeOverflowError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::parse::ParseIntError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::parse::PrefixedHexError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::parse::UnprefixedHexError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::parse_int::ParseIntError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::parse_int::PrefixedHexError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::parse_int::UnprefixedHexError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::result::MathOp
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::result::NumOpError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::sequence::Sequence
@@ -1820,10 +1820,10 @@ pub fn bitcoin_units::locktime::absolute::LockTime::from(h: bitcoin_units::lockt
 pub fn bitcoin_units::locktime::absolute::LockTime::from(t: bitcoin_units::locktime::absolute::MedianTimePast) -> Self
 pub fn bitcoin_units::locktime::absolute::LockTime::from_consensus(n: u32) -> Self
 pub fn bitcoin_units::locktime::absolute::LockTime::from_height(n: u32) -> core::result::Result<Self, bitcoin_units::locktime::absolute::error::ConversionError>
-pub fn bitcoin_units::locktime::absolute::LockTime::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse::PrefixedHexError>
+pub fn bitcoin_units::locktime::absolute::LockTime::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::PrefixedHexError>
 pub fn bitcoin_units::locktime::absolute::LockTime::from_mtp(n: u32) -> core::result::Result<Self, bitcoin_units::locktime::absolute::error::ConversionError>
 pub fn bitcoin_units::locktime::absolute::LockTime::from_str(s: &str) -> core::result::Result<Self, Self::Err>
-pub fn bitcoin_units::locktime::absolute::LockTime::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse::UnprefixedHexError>
+pub fn bitcoin_units::locktime::absolute::LockTime::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::UnprefixedHexError>
 pub fn bitcoin_units::locktime::absolute::LockTime::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin_units::locktime::absolute::LockTime::is_implied_by(self, other: bitcoin_units::locktime::absolute::LockTime) -> bool
 pub fn bitcoin_units::locktime::absolute::LockTime::is_satisfied_by(self, height: bitcoin_units::locktime::absolute::Height, mtp: bitcoin_units::locktime::absolute::MedianTimePast) -> bool
@@ -1930,33 +1930,33 @@ pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError::fmt(&se
 pub fn bitcoin_units::locktime::relative::error::TimeOverflowError::clone(&self) -> bitcoin_units::locktime::relative::error::TimeOverflowError
 pub fn bitcoin_units::locktime::relative::error::TimeOverflowError::eq(&self, other: &bitcoin_units::locktime::relative::error::TimeOverflowError) -> bool
 pub fn bitcoin_units::locktime::relative::error::TimeOverflowError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::parse::ParseIntError::as_ref(&self) -> &core::num::error::ParseIntError
-pub fn bitcoin_units::parse::ParseIntError::clone(&self) -> bitcoin_units::parse::ParseIntError
-pub fn bitcoin_units::parse::ParseIntError::eq(&self, other: &bitcoin_units::parse::ParseIntError) -> bool
-pub fn bitcoin_units::parse::ParseIntError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::parse::PrefixedHexError::clone(&self) -> bitcoin_units::parse::PrefixedHexError
-pub fn bitcoin_units::parse::PrefixedHexError::eq(&self, other: &bitcoin_units::parse::PrefixedHexError) -> bool
-pub fn bitcoin_units::parse::PrefixedHexError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::parse::PrefixedHexError::from(e: bitcoin_units::parse::ParseIntError) -> Self
-pub fn bitcoin_units::parse::PrefixedHexError::from(never: core::convert::Infallible) -> Self
-pub fn bitcoin_units::parse::UnprefixedHexError::clone(&self) -> bitcoin_units::parse::UnprefixedHexError
-pub fn bitcoin_units::parse::UnprefixedHexError::eq(&self, other: &bitcoin_units::parse::UnprefixedHexError) -> bool
-pub fn bitcoin_units::parse::UnprefixedHexError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::parse::UnprefixedHexError::from(e: bitcoin_units::parse::ParseIntError) -> Self
-pub fn bitcoin_units::parse::UnprefixedHexError::from(never: core::convert::Infallible) -> Self
-pub fn bitcoin_units::parse::hex_check_unprefixed(s: &str) -> core::result::Result<&str, bitcoin_units::parse::UnprefixedHexError>
-pub fn bitcoin_units::parse::hex_remove_prefix(s: &str) -> core::result::Result<&str, bitcoin_units::parse::PrefixedHexError>
-pub fn bitcoin_units::parse::hex_u128(s: &str) -> core::result::Result<u128, bitcoin_units::parse::ParseIntError>
-pub fn bitcoin_units::parse::hex_u128_prefixed(s: &str) -> core::result::Result<u128, bitcoin_units::parse::PrefixedHexError>
-pub fn bitcoin_units::parse::hex_u128_unchecked(s: &str) -> core::result::Result<u128, bitcoin_units::parse::ParseIntError>
-pub fn bitcoin_units::parse::hex_u128_unprefixed(s: &str) -> core::result::Result<u128, bitcoin_units::parse::UnprefixedHexError>
-pub fn bitcoin_units::parse::hex_u32(s: &str) -> core::result::Result<u32, bitcoin_units::parse::ParseIntError>
-pub fn bitcoin_units::parse::hex_u32_prefixed(s: &str) -> core::result::Result<u32, bitcoin_units::parse::PrefixedHexError>
-pub fn bitcoin_units::parse::hex_u32_unchecked(s: &str) -> core::result::Result<u32, bitcoin_units::parse::ParseIntError>
-pub fn bitcoin_units::parse::hex_u32_unprefixed(s: &str) -> core::result::Result<u32, bitcoin_units::parse::UnprefixedHexError>
-pub fn bitcoin_units::parse::int_from_box<T: bitcoin_units::parse::Integer>(s: alloc::boxed::Box<str>) -> core::result::Result<T, bitcoin_units::parse::ParseIntError>
-pub fn bitcoin_units::parse::int_from_str<T: bitcoin_units::parse::Integer>(s: &str) -> core::result::Result<T, bitcoin_units::parse::ParseIntError>
-pub fn bitcoin_units::parse::int_from_string<T: bitcoin_units::parse::Integer>(s: alloc::string::String) -> core::result::Result<T, bitcoin_units::parse::ParseIntError>
+pub fn bitcoin_units::parse_int::ParseIntError::as_ref(&self) -> &core::num::error::ParseIntError
+pub fn bitcoin_units::parse_int::ParseIntError::clone(&self) -> bitcoin_units::parse_int::ParseIntError
+pub fn bitcoin_units::parse_int::ParseIntError::eq(&self, other: &bitcoin_units::parse_int::ParseIntError) -> bool
+pub fn bitcoin_units::parse_int::ParseIntError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::parse_int::PrefixedHexError::clone(&self) -> bitcoin_units::parse_int::PrefixedHexError
+pub fn bitcoin_units::parse_int::PrefixedHexError::eq(&self, other: &bitcoin_units::parse_int::PrefixedHexError) -> bool
+pub fn bitcoin_units::parse_int::PrefixedHexError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::parse_int::PrefixedHexError::from(e: bitcoin_units::parse_int::ParseIntError) -> Self
+pub fn bitcoin_units::parse_int::PrefixedHexError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::parse_int::UnprefixedHexError::clone(&self) -> bitcoin_units::parse_int::UnprefixedHexError
+pub fn bitcoin_units::parse_int::UnprefixedHexError::eq(&self, other: &bitcoin_units::parse_int::UnprefixedHexError) -> bool
+pub fn bitcoin_units::parse_int::UnprefixedHexError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::parse_int::UnprefixedHexError::from(e: bitcoin_units::parse_int::ParseIntError) -> Self
+pub fn bitcoin_units::parse_int::UnprefixedHexError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::parse_int::hex_check_unprefixed(s: &str) -> core::result::Result<&str, bitcoin_units::parse_int::UnprefixedHexError>
+pub fn bitcoin_units::parse_int::hex_remove_prefix(s: &str) -> core::result::Result<&str, bitcoin_units::parse_int::PrefixedHexError>
+pub fn bitcoin_units::parse_int::hex_u128(s: &str) -> core::result::Result<u128, bitcoin_units::parse_int::ParseIntError>
+pub fn bitcoin_units::parse_int::hex_u128_prefixed(s: &str) -> core::result::Result<u128, bitcoin_units::parse_int::PrefixedHexError>
+pub fn bitcoin_units::parse_int::hex_u128_unchecked(s: &str) -> core::result::Result<u128, bitcoin_units::parse_int::ParseIntError>
+pub fn bitcoin_units::parse_int::hex_u128_unprefixed(s: &str) -> core::result::Result<u128, bitcoin_units::parse_int::UnprefixedHexError>
+pub fn bitcoin_units::parse_int::hex_u32(s: &str) -> core::result::Result<u32, bitcoin_units::parse_int::ParseIntError>
+pub fn bitcoin_units::parse_int::hex_u32_prefixed(s: &str) -> core::result::Result<u32, bitcoin_units::parse_int::PrefixedHexError>
+pub fn bitcoin_units::parse_int::hex_u32_unchecked(s: &str) -> core::result::Result<u32, bitcoin_units::parse_int::ParseIntError>
+pub fn bitcoin_units::parse_int::hex_u32_unprefixed(s: &str) -> core::result::Result<u32, bitcoin_units::parse_int::UnprefixedHexError>
+pub fn bitcoin_units::parse_int::int_from_box<T: bitcoin_units::parse_int::Integer>(s: alloc::boxed::Box<str>) -> core::result::Result<T, bitcoin_units::parse_int::ParseIntError>
+pub fn bitcoin_units::parse_int::int_from_str<T: bitcoin_units::parse_int::Integer>(s: &str) -> core::result::Result<T, bitcoin_units::parse_int::ParseIntError>
+pub fn bitcoin_units::parse_int::int_from_string<T: bitcoin_units::parse_int::Integer>(s: alloc::string::String) -> core::result::Result<T, bitcoin_units::parse_int::ParseIntError>
 pub fn bitcoin_units::result::MathOp::clone(&self) -> bitcoin_units::result::MathOp
 pub fn bitcoin_units::result::MathOp::eq(&self, other: &bitcoin_units::result::MathOp) -> bool
 pub fn bitcoin_units::result::MathOp::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -2048,11 +2048,11 @@ pub fn bitcoin_units::sequence::Sequence::from(lt: bitcoin_units::locktime::rela
 pub fn bitcoin_units::sequence::Sequence::from_512_second_intervals(intervals: u16) -> Self
 pub fn bitcoin_units::sequence::Sequence::from_consensus(n: u32) -> Self
 pub fn bitcoin_units::sequence::Sequence::from_height(height: u16) -> Self
-pub fn bitcoin_units::sequence::Sequence::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse::PrefixedHexError>
+pub fn bitcoin_units::sequence::Sequence::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::PrefixedHexError>
 pub fn bitcoin_units::sequence::Sequence::from_seconds_ceil(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::TimeOverflowError>
 pub fn bitcoin_units::sequence::Sequence::from_seconds_floor(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::TimeOverflowError>
 pub fn bitcoin_units::sequence::Sequence::from_str(s: &str) -> core::result::Result<Self, Self::Err>
-pub fn bitcoin_units::sequence::Sequence::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse::UnprefixedHexError>
+pub fn bitcoin_units::sequence::Sequence::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::UnprefixedHexError>
 pub fn bitcoin_units::sequence::Sequence::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin_units::sequence::Sequence::is_final(self) -> bool
 pub fn bitcoin_units::sequence::Sequence::is_height_locked(self) -> bool
@@ -2066,7 +2066,7 @@ pub fn bitcoin_units::sequence::Sequence::to_relative_lock_time(self) -> core::o
 pub fn bitcoin_units::sequence::Sequence::try_from(s: &str) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_units::sequence::Sequence::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_units::sequence::Sequence::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
-pub fn core::num::error::ParseIntError::from(value: bitcoin_units::parse::ParseIntError) -> Self
+pub fn core::num::error::ParseIntError::from(value: bitcoin_units::parse_int::ParseIntError) -> Self
 pub fn i64::mul(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output
 pub fn i64::mul(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
 pub fn i64::mul(self, rhs: bitcoin_units::SignedAmount) -> Self::Output
@@ -2096,7 +2096,7 @@ pub mod bitcoin_units::locktime::absolute
 pub mod bitcoin_units::locktime::absolute::error
 pub mod bitcoin_units::locktime::relative
 pub mod bitcoin_units::locktime::relative::error
-pub mod bitcoin_units::parse
+pub mod bitcoin_units::parse_int
 pub mod bitcoin_units::relative
 pub mod bitcoin_units::relative::error
 pub mod bitcoin_units::result
@@ -2162,8 +2162,8 @@ pub struct bitcoin_units::locktime::relative::error::DisabledLockTimeError(_)
 pub struct bitcoin_units::locktime::relative::error::InvalidHeightError
 pub struct bitcoin_units::locktime::relative::error::InvalidTimeError
 pub struct bitcoin_units::locktime::relative::error::TimeOverflowError
-pub struct bitcoin_units::parse::PrefixedHexError(_)
-pub struct bitcoin_units::parse::UnprefixedHexError(_)
+pub struct bitcoin_units::parse_int::PrefixedHexError(_)
+pub struct bitcoin_units::parse_int::UnprefixedHexError(_)
 pub struct bitcoin_units::relative::DisabledLockTimeError(_)
 pub struct bitcoin_units::relative::InvalidHeightError
 pub struct bitcoin_units::relative::InvalidTimeError
@@ -2177,7 +2177,7 @@ pub struct bitcoin_units::relative::error::TimeOverflowError
 pub struct bitcoin_units::sequence::Sequence(pub u32)
 pub struct bitcoin_units::time::BlockTime(_)
 pub struct bitcoin_units::weight::Weight(_)
-pub trait bitcoin_units::parse::Integer: core::str::traits::FromStr<Err = core::num::error::ParseIntError> + core::convert::TryFrom<i8> + core::marker::Sized + bitcoin_units::parse::sealed::Sealed
+pub trait bitcoin_units::parse_int::Integer: core::str::traits::FromStr<Err = core::num::error::ParseIntError> + core::convert::TryFrom<i8> + core::marker::Sized + bitcoin_units::parse_int::sealed::Sealed
 pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Add<bitcoin_units::result::NumOpResult<bitcoin_units::Amount>>>::Output
 pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Add>::Output
 pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<bitcoin_units::FeeRate>>::Output
@@ -2288,8 +2288,8 @@ pub type bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as c
 pub type bitcoin_units::SignedAmount::Output = bitcoin_units::SignedAmount
 pub type bitcoin_units::SignedAmount::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
 pub type bitcoin_units::SignedAmount::Output = bitcoin_units::result::NumOpResult<i64>
-pub type bitcoin_units::Weight::Err = bitcoin_units::parse::ParseIntError
-pub type bitcoin_units::Weight::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::Weight::Err = bitcoin_units::parse_int::ParseIntError
+pub type bitcoin_units::Weight::Error = bitcoin_units::parse_int::ParseIntError
 pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Add>::Output
 pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output
 pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Div<u64>>::Output
@@ -2304,44 +2304,44 @@ pub type bitcoin_units::Weight::Output = bitcoin_units::Weight
 pub type bitcoin_units::Weight::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
 pub type bitcoin_units::Weight::Output = u64
 pub type bitcoin_units::amount::Denomination::Err = bitcoin_units::amount::error::ParseDenominationError
-pub type bitcoin_units::block::BlockHeight::Err = bitcoin_units::parse::ParseIntError
-pub type bitcoin_units::block::BlockHeight::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockHeight::Err = bitcoin_units::parse_int::ParseIntError
+pub type bitcoin_units::block::BlockHeight::Error = bitcoin_units::parse_int::ParseIntError
 pub type bitcoin_units::block::BlockHeight::Output = <bitcoin_units::block::BlockHeight as core::ops::arith::Add<bitcoin_units::block::BlockHeightInterval>>::Output
 pub type bitcoin_units::block::BlockHeight::Output = <bitcoin_units::block::BlockHeight as core::ops::arith::Sub<bitcoin_units::block::BlockHeightInterval>>::Output
 pub type bitcoin_units::block::BlockHeight::Output = <bitcoin_units::block::BlockHeight as core::ops::arith::Sub>::Output
 pub type bitcoin_units::block::BlockHeight::Output = bitcoin_units::block::BlockHeight
 pub type bitcoin_units::block::BlockHeight::Output = bitcoin_units::block::BlockHeightInterval
-pub type bitcoin_units::block::BlockHeightInterval::Err = bitcoin_units::parse::ParseIntError
-pub type bitcoin_units::block::BlockHeightInterval::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockHeightInterval::Err = bitcoin_units::parse_int::ParseIntError
+pub type bitcoin_units::block::BlockHeightInterval::Error = bitcoin_units::parse_int::ParseIntError
 pub type bitcoin_units::block::BlockHeightInterval::Output = <bitcoin_units::block::BlockHeightInterval as core::ops::arith::Add>::Output
 pub type bitcoin_units::block::BlockHeightInterval::Output = <bitcoin_units::block::BlockHeightInterval as core::ops::arith::Sub>::Output
 pub type bitcoin_units::block::BlockHeightInterval::Output = bitcoin_units::block::BlockHeightInterval
-pub type bitcoin_units::block::BlockMtp::Err = bitcoin_units::parse::ParseIntError
-pub type bitcoin_units::block::BlockMtp::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockMtp::Err = bitcoin_units::parse_int::ParseIntError
+pub type bitcoin_units::block::BlockMtp::Error = bitcoin_units::parse_int::ParseIntError
 pub type bitcoin_units::block::BlockMtp::Output = <bitcoin_units::block::BlockMtp as core::ops::arith::Add<bitcoin_units::block::BlockMtpInterval>>::Output
 pub type bitcoin_units::block::BlockMtp::Output = <bitcoin_units::block::BlockMtp as core::ops::arith::Sub<bitcoin_units::block::BlockMtpInterval>>::Output
 pub type bitcoin_units::block::BlockMtp::Output = <bitcoin_units::block::BlockMtp as core::ops::arith::Sub>::Output
 pub type bitcoin_units::block::BlockMtp::Output = bitcoin_units::block::BlockMtp
 pub type bitcoin_units::block::BlockMtp::Output = bitcoin_units::block::BlockMtpInterval
-pub type bitcoin_units::block::BlockMtpInterval::Err = bitcoin_units::parse::ParseIntError
-pub type bitcoin_units::block::BlockMtpInterval::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockMtpInterval::Err = bitcoin_units::parse_int::ParseIntError
+pub type bitcoin_units::block::BlockMtpInterval::Error = bitcoin_units::parse_int::ParseIntError
 pub type bitcoin_units::block::BlockMtpInterval::Output = <bitcoin_units::block::BlockMtpInterval as core::ops::arith::Add>::Output
 pub type bitcoin_units::block::BlockMtpInterval::Output = <bitcoin_units::block::BlockMtpInterval as core::ops::arith::Sub>::Output
 pub type bitcoin_units::block::BlockMtpInterval::Output = bitcoin_units::block::BlockMtpInterval
 pub type bitcoin_units::locktime::absolute::Height::Err = bitcoin_units::locktime::absolute::error::ParseHeightError
 pub type bitcoin_units::locktime::absolute::Height::Error = bitcoin_units::locktime::absolute::error::ConversionError
 pub type bitcoin_units::locktime::absolute::Height::Error = bitcoin_units::locktime::absolute::error::ParseHeightError
-pub type bitcoin_units::locktime::absolute::LockTime::Err = bitcoin_units::parse::ParseIntError
-pub type bitcoin_units::locktime::absolute::LockTime::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::locktime::absolute::LockTime::Err = bitcoin_units::parse_int::ParseIntError
+pub type bitcoin_units::locktime::absolute::LockTime::Error = bitcoin_units::parse_int::ParseIntError
 pub type bitcoin_units::locktime::absolute::MedianTimePast::Err = bitcoin_units::locktime::absolute::error::ParseTimeError
 pub type bitcoin_units::locktime::absolute::MedianTimePast::Error = bitcoin_units::locktime::absolute::error::ConversionError
 pub type bitcoin_units::locktime::absolute::MedianTimePast::Error = bitcoin_units::locktime::absolute::error::ParseTimeError
 pub type bitcoin_units::locktime::relative::LockTime::Error = bitcoin_units::locktime::relative::error::DisabledLockTimeError
-pub type bitcoin_units::locktime::relative::NumberOf512Seconds::Err = bitcoin_units::parse::ParseIntError
-pub type bitcoin_units::locktime::relative::NumberOf512Seconds::Error = bitcoin_units::parse::ParseIntError
-pub type bitcoin_units::locktime::relative::NumberOfBlocks::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::locktime::relative::NumberOf512Seconds::Err = bitcoin_units::parse_int::ParseIntError
+pub type bitcoin_units::locktime::relative::NumberOf512Seconds::Error = bitcoin_units::parse_int::ParseIntError
+pub type bitcoin_units::locktime::relative::NumberOfBlocks::Err = bitcoin_units::parse_int::ParseIntError
 pub type bitcoin_units::locktime::relative::NumberOfBlocks::Error = bitcoin_units::block::TooBigForRelativeHeightError
-pub type bitcoin_units::locktime::relative::NumberOfBlocks::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::locktime::relative::NumberOfBlocks::Error = bitcoin_units::parse_int::ParseIntError
 pub type bitcoin_units::result::NumOpResult<T>::Output = <bitcoin_units::result::NumOpResult<T> as core::ops::arith::Add<T>>::Output
 pub type bitcoin_units::result::NumOpResult<T>::Output = <bitcoin_units::result::NumOpResult<T> as core::ops::arith::Add>::Output
 pub type bitcoin_units::result::NumOpResult<T>::Output = <bitcoin_units::result::NumOpResult<T> as core::ops::arith::Sub<T>>::Output
@@ -2367,8 +2367,8 @@ pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output
 pub type bitcoin_units::result::NumOpResult<bitcoin_units::Weight>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Weight> as core::ops::arith::Mul<bitcoin_units::FeeRate>>::Output
 pub type bitcoin_units::result::NumOpResult<bitcoin_units::Weight>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Weight> as core::ops::arith::Mul<bitcoin_units::result::NumOpResult<bitcoin_units::FeeRate>>>::Output
 pub type bitcoin_units::result::NumOpResult<bitcoin_units::Weight>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
-pub type bitcoin_units::sequence::Sequence::Err = bitcoin_units::parse::ParseIntError
-pub type bitcoin_units::sequence::Sequence::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::sequence::Sequence::Err = bitcoin_units::parse_int::ParseIntError
+pub type bitcoin_units::sequence::Sequence::Error = bitcoin_units::parse_int::ParseIntError
 pub type i64::Output = <i64 as core::ops::arith::Mul<bitcoin_units::SignedAmount>>::Output
 pub type i64::Output = <i64 as core::ops::arith::Mul<bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>>>::Output
 pub type i64::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>

--- a/api/units/no-features.txt
+++ b/api/units/no-features.txt
@@ -9,7 +9,7 @@
 #[non_exhaustive] pub struct bitcoin_units::amount::error::UnknownDenominationError(_)
 #[non_exhaustive] pub struct bitcoin_units::locktime::absolute::ConversionError
 #[non_exhaustive] pub struct bitcoin_units::locktime::absolute::error::ConversionError
-#[non_exhaustive] pub struct bitcoin_units::parse::ParseIntError
+#[non_exhaustive] pub struct bitcoin_units::parse_int::ParseIntError
 #[non_exhaustive] pub struct bitcoin_units::result::NumOpError(_)
 impl bitcoin_units::Amount
 impl bitcoin_units::BlockTime
@@ -32,16 +32,16 @@ impl bitcoin_units::locktime::relative::LockTime
 impl bitcoin_units::locktime::relative::NumberOf512Seconds
 impl bitcoin_units::locktime::relative::NumberOfBlocks
 impl bitcoin_units::locktime::relative::error::DisabledLockTimeError
-impl bitcoin_units::parse::Integer for i128
-impl bitcoin_units::parse::Integer for i16
-impl bitcoin_units::parse::Integer for i32
-impl bitcoin_units::parse::Integer for i64
-impl bitcoin_units::parse::Integer for i8
-impl bitcoin_units::parse::Integer for u128
-impl bitcoin_units::parse::Integer for u16
-impl bitcoin_units::parse::Integer for u32
-impl bitcoin_units::parse::Integer for u64
-impl bitcoin_units::parse::Integer for u8
+impl bitcoin_units::parse_int::Integer for i128
+impl bitcoin_units::parse_int::Integer for i16
+impl bitcoin_units::parse_int::Integer for i32
+impl bitcoin_units::parse_int::Integer for i64
+impl bitcoin_units::parse_int::Integer for i8
+impl bitcoin_units::parse_int::Integer for u128
+impl bitcoin_units::parse_int::Integer for u16
+impl bitcoin_units::parse_int::Integer for u32
+impl bitcoin_units::parse_int::Integer for u64
+impl bitcoin_units::parse_int::Integer for u8
 impl bitcoin_units::result::MathOp
 impl bitcoin_units::result::NumOpError
 impl bitcoin_units::sequence::Sequence
@@ -86,9 +86,9 @@ impl core::clone::Clone for bitcoin_units::locktime::relative::error::IsSatisfie
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::TimeOverflowError
-impl core::clone::Clone for bitcoin_units::parse::ParseIntError
-impl core::clone::Clone for bitcoin_units::parse::PrefixedHexError
-impl core::clone::Clone for bitcoin_units::parse::UnprefixedHexError
+impl core::clone::Clone for bitcoin_units::parse_int::ParseIntError
+impl core::clone::Clone for bitcoin_units::parse_int::PrefixedHexError
+impl core::clone::Clone for bitcoin_units::parse_int::UnprefixedHexError
 impl core::clone::Clone for bitcoin_units::result::MathOp
 impl core::clone::Clone for bitcoin_units::result::NumOpError
 impl core::clone::Clone for bitcoin_units::sequence::Sequence
@@ -132,9 +132,9 @@ impl core::cmp::Eq for bitcoin_units::locktime::relative::error::IsSatisfiedByEr
 impl core::cmp::Eq for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl core::cmp::Eq for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 impl core::cmp::Eq for bitcoin_units::locktime::relative::error::TimeOverflowError
-impl core::cmp::Eq for bitcoin_units::parse::ParseIntError
-impl core::cmp::Eq for bitcoin_units::parse::PrefixedHexError
-impl core::cmp::Eq for bitcoin_units::parse::UnprefixedHexError
+impl core::cmp::Eq for bitcoin_units::parse_int::ParseIntError
+impl core::cmp::Eq for bitcoin_units::parse_int::PrefixedHexError
+impl core::cmp::Eq for bitcoin_units::parse_int::UnprefixedHexError
 impl core::cmp::Eq for bitcoin_units::result::MathOp
 impl core::cmp::Eq for bitcoin_units::result::NumOpError
 impl core::cmp::Eq for bitcoin_units::sequence::Sequence
@@ -192,9 +192,9 @@ impl core::cmp::PartialEq for bitcoin_units::locktime::relative::error::IsSatisf
 impl core::cmp::PartialEq for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl core::cmp::PartialEq for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 impl core::cmp::PartialEq for bitcoin_units::locktime::relative::error::TimeOverflowError
-impl core::cmp::PartialEq for bitcoin_units::parse::ParseIntError
-impl core::cmp::PartialEq for bitcoin_units::parse::PrefixedHexError
-impl core::cmp::PartialEq for bitcoin_units::parse::UnprefixedHexError
+impl core::cmp::PartialEq for bitcoin_units::parse_int::ParseIntError
+impl core::cmp::PartialEq for bitcoin_units::parse_int::PrefixedHexError
+impl core::cmp::PartialEq for bitcoin_units::parse_int::UnprefixedHexError
 impl core::cmp::PartialEq for bitcoin_units::result::MathOp
 impl core::cmp::PartialEq for bitcoin_units::result::NumOpError
 impl core::cmp::PartialEq for bitcoin_units::sequence::Sequence
@@ -212,7 +212,7 @@ impl core::cmp::PartialOrd for bitcoin_units::locktime::absolute::MedianTimePast
 impl core::cmp::PartialOrd for bitcoin_units::locktime::relative::NumberOf512Seconds
 impl core::cmp::PartialOrd for bitcoin_units::locktime::relative::NumberOfBlocks
 impl core::cmp::PartialOrd for bitcoin_units::sequence::Sequence
-impl core::convert::AsRef<core::num::error::ParseIntError> for bitcoin_units::parse::ParseIntError
+impl core::convert::AsRef<core::num::error::ParseIntError> for bitcoin_units::parse_int::ParseIntError
 impl core::convert::From<&bitcoin_units::Amount> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
 impl core::convert::From<&bitcoin_units::SignedAmount> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
 impl core::convert::From<bitcoin_units::Amount> for bitcoin_units::SignedAmount
@@ -245,15 +245,15 @@ impl core::convert::From<bitcoin_units::locktime::relative::NumberOf512Seconds> 
 impl core::convert::From<bitcoin_units::locktime::relative::NumberOf512Seconds> for bitcoin_units::locktime::relative::LockTime
 impl core::convert::From<bitcoin_units::locktime::relative::NumberOfBlocks> for bitcoin_units::block::BlockHeightInterval
 impl core::convert::From<bitcoin_units::locktime::relative::NumberOfBlocks> for bitcoin_units::locktime::relative::LockTime
-impl core::convert::From<bitcoin_units::parse::ParseIntError> for bitcoin_units::parse::PrefixedHexError
-impl core::convert::From<bitcoin_units::parse::ParseIntError> for bitcoin_units::parse::UnprefixedHexError
-impl core::convert::From<bitcoin_units::parse::ParseIntError> for core::num::error::ParseIntError
+impl core::convert::From<bitcoin_units::parse_int::ParseIntError> for bitcoin_units::parse_int::PrefixedHexError
+impl core::convert::From<bitcoin_units::parse_int::ParseIntError> for bitcoin_units::parse_int::UnprefixedHexError
+impl core::convert::From<bitcoin_units::parse_int::ParseIntError> for core::num::error::ParseIntError
 impl core::convert::From<bitcoin_units::sequence::Sequence> for u32
 impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::error::ParseAmountError
 impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::error::ParseDenominationError
 impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::error::ParseError
-impl core::convert::From<core::convert::Infallible> for bitcoin_units::parse::PrefixedHexError
-impl core::convert::From<core::convert::Infallible> for bitcoin_units::parse::UnprefixedHexError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::parse_int::PrefixedHexError
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::parse_int::UnprefixedHexError
 impl core::convert::From<u16> for bitcoin_units::locktime::relative::NumberOfBlocks
 impl core::convert::From<u32> for bitcoin_units::BlockTime
 impl core::convert::From<u32> for bitcoin_units::block::BlockHeight
@@ -323,9 +323,9 @@ impl core::fmt::Debug for bitcoin_units::locktime::relative::error::IsSatisfiedB
 impl core::fmt::Debug for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl core::fmt::Debug for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 impl core::fmt::Debug for bitcoin_units::locktime::relative::error::TimeOverflowError
-impl core::fmt::Debug for bitcoin_units::parse::ParseIntError
-impl core::fmt::Debug for bitcoin_units::parse::PrefixedHexError
-impl core::fmt::Debug for bitcoin_units::parse::UnprefixedHexError
+impl core::fmt::Debug for bitcoin_units::parse_int::ParseIntError
+impl core::fmt::Debug for bitcoin_units::parse_int::PrefixedHexError
+impl core::fmt::Debug for bitcoin_units::parse_int::UnprefixedHexError
 impl core::fmt::Debug for bitcoin_units::result::MathOp
 impl core::fmt::Debug for bitcoin_units::result::NumOpError
 impl core::fmt::Debug for bitcoin_units::sequence::Sequence
@@ -367,9 +367,9 @@ impl core::fmt::Display for bitcoin_units::locktime::relative::error::IsSatisfie
 impl core::fmt::Display for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl core::fmt::Display for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 impl core::fmt::Display for bitcoin_units::locktime::relative::error::TimeOverflowError
-impl core::fmt::Display for bitcoin_units::parse::ParseIntError
-impl core::fmt::Display for bitcoin_units::parse::PrefixedHexError
-impl core::fmt::Display for bitcoin_units::parse::UnprefixedHexError
+impl core::fmt::Display for bitcoin_units::parse_int::ParseIntError
+impl core::fmt::Display for bitcoin_units::parse_int::PrefixedHexError
+impl core::fmt::Display for bitcoin_units::parse_int::UnprefixedHexError
 impl core::fmt::Display for bitcoin_units::result::MathOp
 impl core::fmt::Display for bitcoin_units::result::NumOpError
 impl core::fmt::Display for bitcoin_units::sequence::Sequence
@@ -459,9 +459,9 @@ impl core::marker::Freeze for bitcoin_units::locktime::relative::error::IsSatisf
 impl core::marker::Freeze for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl core::marker::Freeze for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 impl core::marker::Freeze for bitcoin_units::locktime::relative::error::TimeOverflowError
-impl core::marker::Freeze for bitcoin_units::parse::ParseIntError
-impl core::marker::Freeze for bitcoin_units::parse::PrefixedHexError
-impl core::marker::Freeze for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::Freeze for bitcoin_units::parse_int::ParseIntError
+impl core::marker::Freeze for bitcoin_units::parse_int::PrefixedHexError
+impl core::marker::Freeze for bitcoin_units::parse_int::UnprefixedHexError
 impl core::marker::Freeze for bitcoin_units::result::MathOp
 impl core::marker::Freeze for bitcoin_units::result::NumOpError
 impl core::marker::Freeze for bitcoin_units::sequence::Sequence
@@ -506,9 +506,9 @@ impl core::marker::Send for bitcoin_units::locktime::relative::error::IsSatisfie
 impl core::marker::Send for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl core::marker::Send for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 impl core::marker::Send for bitcoin_units::locktime::relative::error::TimeOverflowError
-impl core::marker::Send for bitcoin_units::parse::ParseIntError
-impl core::marker::Send for bitcoin_units::parse::PrefixedHexError
-impl core::marker::Send for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::Send for bitcoin_units::parse_int::ParseIntError
+impl core::marker::Send for bitcoin_units::parse_int::PrefixedHexError
+impl core::marker::Send for bitcoin_units::parse_int::UnprefixedHexError
 impl core::marker::Send for bitcoin_units::result::MathOp
 impl core::marker::Send for bitcoin_units::result::NumOpError
 impl core::marker::Send for bitcoin_units::sequence::Sequence
@@ -552,9 +552,9 @@ impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::er
 impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::error::TimeOverflowError
-impl core::marker::StructuralPartialEq for bitcoin_units::parse::ParseIntError
-impl core::marker::StructuralPartialEq for bitcoin_units::parse::PrefixedHexError
-impl core::marker::StructuralPartialEq for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::StructuralPartialEq for bitcoin_units::parse_int::ParseIntError
+impl core::marker::StructuralPartialEq for bitcoin_units::parse_int::PrefixedHexError
+impl core::marker::StructuralPartialEq for bitcoin_units::parse_int::UnprefixedHexError
 impl core::marker::StructuralPartialEq for bitcoin_units::result::MathOp
 impl core::marker::StructuralPartialEq for bitcoin_units::result::NumOpError
 impl core::marker::StructuralPartialEq for bitcoin_units::sequence::Sequence
@@ -599,9 +599,9 @@ impl core::marker::Sync for bitcoin_units::locktime::relative::error::IsSatisfie
 impl core::marker::Sync for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl core::marker::Sync for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 impl core::marker::Sync for bitcoin_units::locktime::relative::error::TimeOverflowError
-impl core::marker::Sync for bitcoin_units::parse::ParseIntError
-impl core::marker::Sync for bitcoin_units::parse::PrefixedHexError
-impl core::marker::Sync for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::Sync for bitcoin_units::parse_int::ParseIntError
+impl core::marker::Sync for bitcoin_units::parse_int::PrefixedHexError
+impl core::marker::Sync for bitcoin_units::parse_int::UnprefixedHexError
 impl core::marker::Sync for bitcoin_units::result::MathOp
 impl core::marker::Sync for bitcoin_units::result::NumOpError
 impl core::marker::Sync for bitcoin_units::sequence::Sequence
@@ -646,9 +646,9 @@ impl core::marker::Unpin for bitcoin_units::locktime::relative::error::IsSatisfi
 impl core::marker::Unpin for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl core::marker::Unpin for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 impl core::marker::Unpin for bitcoin_units::locktime::relative::error::TimeOverflowError
-impl core::marker::Unpin for bitcoin_units::parse::ParseIntError
-impl core::marker::Unpin for bitcoin_units::parse::PrefixedHexError
-impl core::marker::Unpin for bitcoin_units::parse::UnprefixedHexError
+impl core::marker::Unpin for bitcoin_units::parse_int::ParseIntError
+impl core::marker::Unpin for bitcoin_units::parse_int::PrefixedHexError
+impl core::marker::Unpin for bitcoin_units::parse_int::UnprefixedHexError
 impl core::marker::Unpin for bitcoin_units::result::MathOp
 impl core::marker::Unpin for bitcoin_units::result::NumOpError
 impl core::marker::Unpin for bitcoin_units::sequence::Sequence
@@ -919,9 +919,9 @@ impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relati
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::error::TimeOverflowError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::parse::ParseIntError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::parse::PrefixedHexError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::parse::UnprefixedHexError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::parse_int::ParseIntError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::parse_int::PrefixedHexError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::parse_int::UnprefixedHexError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::result::MathOp
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::result::NumOpError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::sequence::Sequence
@@ -966,9 +966,9 @@ impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative:
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::error::TimeOverflowError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::parse::ParseIntError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::parse::PrefixedHexError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::parse::UnprefixedHexError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::parse_int::ParseIntError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::parse_int::PrefixedHexError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::parse_int::UnprefixedHexError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::result::MathOp
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::result::NumOpError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::sequence::Sequence
@@ -1772,10 +1772,10 @@ pub fn bitcoin_units::locktime::absolute::LockTime::from(h: bitcoin_units::lockt
 pub fn bitcoin_units::locktime::absolute::LockTime::from(t: bitcoin_units::locktime::absolute::MedianTimePast) -> Self
 pub fn bitcoin_units::locktime::absolute::LockTime::from_consensus(n: u32) -> Self
 pub fn bitcoin_units::locktime::absolute::LockTime::from_height(n: u32) -> core::result::Result<Self, bitcoin_units::locktime::absolute::error::ConversionError>
-pub fn bitcoin_units::locktime::absolute::LockTime::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse::PrefixedHexError>
+pub fn bitcoin_units::locktime::absolute::LockTime::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::PrefixedHexError>
 pub fn bitcoin_units::locktime::absolute::LockTime::from_mtp(n: u32) -> core::result::Result<Self, bitcoin_units::locktime::absolute::error::ConversionError>
 pub fn bitcoin_units::locktime::absolute::LockTime::from_str(s: &str) -> core::result::Result<Self, Self::Err>
-pub fn bitcoin_units::locktime::absolute::LockTime::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse::UnprefixedHexError>
+pub fn bitcoin_units::locktime::absolute::LockTime::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::UnprefixedHexError>
 pub fn bitcoin_units::locktime::absolute::LockTime::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin_units::locktime::absolute::LockTime::is_implied_by(self, other: bitcoin_units::locktime::absolute::LockTime) -> bool
 pub fn bitcoin_units::locktime::absolute::LockTime::is_satisfied_by(self, height: bitcoin_units::locktime::absolute::Height, mtp: bitcoin_units::locktime::absolute::MedianTimePast) -> bool
@@ -1874,31 +1874,31 @@ pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError::fmt(&se
 pub fn bitcoin_units::locktime::relative::error::TimeOverflowError::clone(&self) -> bitcoin_units::locktime::relative::error::TimeOverflowError
 pub fn bitcoin_units::locktime::relative::error::TimeOverflowError::eq(&self, other: &bitcoin_units::locktime::relative::error::TimeOverflowError) -> bool
 pub fn bitcoin_units::locktime::relative::error::TimeOverflowError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::parse::ParseIntError::as_ref(&self) -> &core::num::error::ParseIntError
-pub fn bitcoin_units::parse::ParseIntError::clone(&self) -> bitcoin_units::parse::ParseIntError
-pub fn bitcoin_units::parse::ParseIntError::eq(&self, other: &bitcoin_units::parse::ParseIntError) -> bool
-pub fn bitcoin_units::parse::ParseIntError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::parse::PrefixedHexError::clone(&self) -> bitcoin_units::parse::PrefixedHexError
-pub fn bitcoin_units::parse::PrefixedHexError::eq(&self, other: &bitcoin_units::parse::PrefixedHexError) -> bool
-pub fn bitcoin_units::parse::PrefixedHexError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::parse::PrefixedHexError::from(e: bitcoin_units::parse::ParseIntError) -> Self
-pub fn bitcoin_units::parse::PrefixedHexError::from(never: core::convert::Infallible) -> Self
-pub fn bitcoin_units::parse::UnprefixedHexError::clone(&self) -> bitcoin_units::parse::UnprefixedHexError
-pub fn bitcoin_units::parse::UnprefixedHexError::eq(&self, other: &bitcoin_units::parse::UnprefixedHexError) -> bool
-pub fn bitcoin_units::parse::UnprefixedHexError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_units::parse::UnprefixedHexError::from(e: bitcoin_units::parse::ParseIntError) -> Self
-pub fn bitcoin_units::parse::UnprefixedHexError::from(never: core::convert::Infallible) -> Self
-pub fn bitcoin_units::parse::hex_check_unprefixed(s: &str) -> core::result::Result<&str, bitcoin_units::parse::UnprefixedHexError>
-pub fn bitcoin_units::parse::hex_remove_prefix(s: &str) -> core::result::Result<&str, bitcoin_units::parse::PrefixedHexError>
-pub fn bitcoin_units::parse::hex_u128(s: &str) -> core::result::Result<u128, bitcoin_units::parse::ParseIntError>
-pub fn bitcoin_units::parse::hex_u128_prefixed(s: &str) -> core::result::Result<u128, bitcoin_units::parse::PrefixedHexError>
-pub fn bitcoin_units::parse::hex_u128_unchecked(s: &str) -> core::result::Result<u128, bitcoin_units::parse::ParseIntError>
-pub fn bitcoin_units::parse::hex_u128_unprefixed(s: &str) -> core::result::Result<u128, bitcoin_units::parse::UnprefixedHexError>
-pub fn bitcoin_units::parse::hex_u32(s: &str) -> core::result::Result<u32, bitcoin_units::parse::ParseIntError>
-pub fn bitcoin_units::parse::hex_u32_prefixed(s: &str) -> core::result::Result<u32, bitcoin_units::parse::PrefixedHexError>
-pub fn bitcoin_units::parse::hex_u32_unchecked(s: &str) -> core::result::Result<u32, bitcoin_units::parse::ParseIntError>
-pub fn bitcoin_units::parse::hex_u32_unprefixed(s: &str) -> core::result::Result<u32, bitcoin_units::parse::UnprefixedHexError>
-pub fn bitcoin_units::parse::int_from_str<T: bitcoin_units::parse::Integer>(s: &str) -> core::result::Result<T, bitcoin_units::parse::ParseIntError>
+pub fn bitcoin_units::parse_int::ParseIntError::as_ref(&self) -> &core::num::error::ParseIntError
+pub fn bitcoin_units::parse_int::ParseIntError::clone(&self) -> bitcoin_units::parse_int::ParseIntError
+pub fn bitcoin_units::parse_int::ParseIntError::eq(&self, other: &bitcoin_units::parse_int::ParseIntError) -> bool
+pub fn bitcoin_units::parse_int::ParseIntError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::parse_int::PrefixedHexError::clone(&self) -> bitcoin_units::parse_int::PrefixedHexError
+pub fn bitcoin_units::parse_int::PrefixedHexError::eq(&self, other: &bitcoin_units::parse_int::PrefixedHexError) -> bool
+pub fn bitcoin_units::parse_int::PrefixedHexError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::parse_int::PrefixedHexError::from(e: bitcoin_units::parse_int::ParseIntError) -> Self
+pub fn bitcoin_units::parse_int::PrefixedHexError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::parse_int::UnprefixedHexError::clone(&self) -> bitcoin_units::parse_int::UnprefixedHexError
+pub fn bitcoin_units::parse_int::UnprefixedHexError::eq(&self, other: &bitcoin_units::parse_int::UnprefixedHexError) -> bool
+pub fn bitcoin_units::parse_int::UnprefixedHexError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_units::parse_int::UnprefixedHexError::from(e: bitcoin_units::parse_int::ParseIntError) -> Self
+pub fn bitcoin_units::parse_int::UnprefixedHexError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_units::parse_int::hex_check_unprefixed(s: &str) -> core::result::Result<&str, bitcoin_units::parse_int::UnprefixedHexError>
+pub fn bitcoin_units::parse_int::hex_remove_prefix(s: &str) -> core::result::Result<&str, bitcoin_units::parse_int::PrefixedHexError>
+pub fn bitcoin_units::parse_int::hex_u128(s: &str) -> core::result::Result<u128, bitcoin_units::parse_int::ParseIntError>
+pub fn bitcoin_units::parse_int::hex_u128_prefixed(s: &str) -> core::result::Result<u128, bitcoin_units::parse_int::PrefixedHexError>
+pub fn bitcoin_units::parse_int::hex_u128_unchecked(s: &str) -> core::result::Result<u128, bitcoin_units::parse_int::ParseIntError>
+pub fn bitcoin_units::parse_int::hex_u128_unprefixed(s: &str) -> core::result::Result<u128, bitcoin_units::parse_int::UnprefixedHexError>
+pub fn bitcoin_units::parse_int::hex_u32(s: &str) -> core::result::Result<u32, bitcoin_units::parse_int::ParseIntError>
+pub fn bitcoin_units::parse_int::hex_u32_prefixed(s: &str) -> core::result::Result<u32, bitcoin_units::parse_int::PrefixedHexError>
+pub fn bitcoin_units::parse_int::hex_u32_unchecked(s: &str) -> core::result::Result<u32, bitcoin_units::parse_int::ParseIntError>
+pub fn bitcoin_units::parse_int::hex_u32_unprefixed(s: &str) -> core::result::Result<u32, bitcoin_units::parse_int::UnprefixedHexError>
+pub fn bitcoin_units::parse_int::int_from_str<T: bitcoin_units::parse_int::Integer>(s: &str) -> core::result::Result<T, bitcoin_units::parse_int::ParseIntError>
 pub fn bitcoin_units::result::MathOp::clone(&self) -> bitcoin_units::result::MathOp
 pub fn bitcoin_units::result::MathOp::eq(&self, other: &bitcoin_units::result::MathOp) -> bool
 pub fn bitcoin_units::result::MathOp::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -1990,10 +1990,10 @@ pub fn bitcoin_units::sequence::Sequence::from(lt: bitcoin_units::locktime::rela
 pub fn bitcoin_units::sequence::Sequence::from_512_second_intervals(intervals: u16) -> Self
 pub fn bitcoin_units::sequence::Sequence::from_consensus(n: u32) -> Self
 pub fn bitcoin_units::sequence::Sequence::from_height(height: u16) -> Self
-pub fn bitcoin_units::sequence::Sequence::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse::PrefixedHexError>
+pub fn bitcoin_units::sequence::Sequence::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::PrefixedHexError>
 pub fn bitcoin_units::sequence::Sequence::from_seconds_ceil(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::TimeOverflowError>
 pub fn bitcoin_units::sequence::Sequence::from_seconds_floor(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::TimeOverflowError>
-pub fn bitcoin_units::sequence::Sequence::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse::UnprefixedHexError>
+pub fn bitcoin_units::sequence::Sequence::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::UnprefixedHexError>
 pub fn bitcoin_units::sequence::Sequence::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin_units::sequence::Sequence::is_final(self) -> bool
 pub fn bitcoin_units::sequence::Sequence::is_height_locked(self) -> bool
@@ -2003,7 +2003,7 @@ pub fn bitcoin_units::sequence::Sequence::is_time_locked(self) -> bool
 pub fn bitcoin_units::sequence::Sequence::partial_cmp(&self, other: &bitcoin_units::sequence::Sequence) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_units::sequence::Sequence::to_consensus_u32(self) -> u32
 pub fn bitcoin_units::sequence::Sequence::to_relative_lock_time(self) -> core::option::Option<bitcoin_units::locktime::relative::LockTime>
-pub fn core::num::error::ParseIntError::from(value: bitcoin_units::parse::ParseIntError) -> Self
+pub fn core::num::error::ParseIntError::from(value: bitcoin_units::parse_int::ParseIntError) -> Self
 pub fn i64::mul(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output
 pub fn i64::mul(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>) -> Self::Output
 pub fn i64::mul(self, rhs: bitcoin_units::SignedAmount) -> Self::Output
@@ -2033,7 +2033,7 @@ pub mod bitcoin_units::locktime::absolute
 pub mod bitcoin_units::locktime::absolute::error
 pub mod bitcoin_units::locktime::relative
 pub mod bitcoin_units::locktime::relative::error
-pub mod bitcoin_units::parse
+pub mod bitcoin_units::parse_int
 pub mod bitcoin_units::relative
 pub mod bitcoin_units::relative::error
 pub mod bitcoin_units::result
@@ -2099,8 +2099,8 @@ pub struct bitcoin_units::locktime::relative::error::DisabledLockTimeError(_)
 pub struct bitcoin_units::locktime::relative::error::InvalidHeightError
 pub struct bitcoin_units::locktime::relative::error::InvalidTimeError
 pub struct bitcoin_units::locktime::relative::error::TimeOverflowError
-pub struct bitcoin_units::parse::PrefixedHexError(_)
-pub struct bitcoin_units::parse::UnprefixedHexError(_)
+pub struct bitcoin_units::parse_int::PrefixedHexError(_)
+pub struct bitcoin_units::parse_int::UnprefixedHexError(_)
 pub struct bitcoin_units::relative::DisabledLockTimeError(_)
 pub struct bitcoin_units::relative::InvalidHeightError
 pub struct bitcoin_units::relative::InvalidTimeError
@@ -2114,7 +2114,7 @@ pub struct bitcoin_units::relative::error::TimeOverflowError
 pub struct bitcoin_units::sequence::Sequence(pub u32)
 pub struct bitcoin_units::time::BlockTime(_)
 pub struct bitcoin_units::weight::Weight(_)
-pub trait bitcoin_units::parse::Integer: core::str::traits::FromStr<Err = core::num::error::ParseIntError> + core::convert::TryFrom<i8> + core::marker::Sized + bitcoin_units::parse::sealed::Sealed
+pub trait bitcoin_units::parse_int::Integer: core::str::traits::FromStr<Err = core::num::error::ParseIntError> + core::convert::TryFrom<i8> + core::marker::Sized + bitcoin_units::parse_int::sealed::Sealed
 pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Add<bitcoin_units::result::NumOpResult<bitcoin_units::Amount>>>::Output
 pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Add>::Output
 pub type &bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Div<bitcoin_units::FeeRate>>::Output
@@ -2225,8 +2225,8 @@ pub type bitcoin_units::SignedAmount::Output = <bitcoin_units::SignedAmount as c
 pub type bitcoin_units::SignedAmount::Output = bitcoin_units::SignedAmount
 pub type bitcoin_units::SignedAmount::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
 pub type bitcoin_units::SignedAmount::Output = bitcoin_units::result::NumOpResult<i64>
-pub type bitcoin_units::Weight::Err = bitcoin_units::parse::ParseIntError
-pub type bitcoin_units::Weight::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::Weight::Err = bitcoin_units::parse_int::ParseIntError
+pub type bitcoin_units::Weight::Error = bitcoin_units::parse_int::ParseIntError
 pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Add>::Output
 pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output
 pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Div<u64>>::Output
@@ -2241,44 +2241,44 @@ pub type bitcoin_units::Weight::Output = bitcoin_units::Weight
 pub type bitcoin_units::Weight::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
 pub type bitcoin_units::Weight::Output = u64
 pub type bitcoin_units::amount::Denomination::Err = bitcoin_units::amount::error::ParseDenominationError
-pub type bitcoin_units::block::BlockHeight::Err = bitcoin_units::parse::ParseIntError
-pub type bitcoin_units::block::BlockHeight::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockHeight::Err = bitcoin_units::parse_int::ParseIntError
+pub type bitcoin_units::block::BlockHeight::Error = bitcoin_units::parse_int::ParseIntError
 pub type bitcoin_units::block::BlockHeight::Output = <bitcoin_units::block::BlockHeight as core::ops::arith::Add<bitcoin_units::block::BlockHeightInterval>>::Output
 pub type bitcoin_units::block::BlockHeight::Output = <bitcoin_units::block::BlockHeight as core::ops::arith::Sub<bitcoin_units::block::BlockHeightInterval>>::Output
 pub type bitcoin_units::block::BlockHeight::Output = <bitcoin_units::block::BlockHeight as core::ops::arith::Sub>::Output
 pub type bitcoin_units::block::BlockHeight::Output = bitcoin_units::block::BlockHeight
 pub type bitcoin_units::block::BlockHeight::Output = bitcoin_units::block::BlockHeightInterval
-pub type bitcoin_units::block::BlockHeightInterval::Err = bitcoin_units::parse::ParseIntError
-pub type bitcoin_units::block::BlockHeightInterval::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockHeightInterval::Err = bitcoin_units::parse_int::ParseIntError
+pub type bitcoin_units::block::BlockHeightInterval::Error = bitcoin_units::parse_int::ParseIntError
 pub type bitcoin_units::block::BlockHeightInterval::Output = <bitcoin_units::block::BlockHeightInterval as core::ops::arith::Add>::Output
 pub type bitcoin_units::block::BlockHeightInterval::Output = <bitcoin_units::block::BlockHeightInterval as core::ops::arith::Sub>::Output
 pub type bitcoin_units::block::BlockHeightInterval::Output = bitcoin_units::block::BlockHeightInterval
-pub type bitcoin_units::block::BlockMtp::Err = bitcoin_units::parse::ParseIntError
-pub type bitcoin_units::block::BlockMtp::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockMtp::Err = bitcoin_units::parse_int::ParseIntError
+pub type bitcoin_units::block::BlockMtp::Error = bitcoin_units::parse_int::ParseIntError
 pub type bitcoin_units::block::BlockMtp::Output = <bitcoin_units::block::BlockMtp as core::ops::arith::Add<bitcoin_units::block::BlockMtpInterval>>::Output
 pub type bitcoin_units::block::BlockMtp::Output = <bitcoin_units::block::BlockMtp as core::ops::arith::Sub<bitcoin_units::block::BlockMtpInterval>>::Output
 pub type bitcoin_units::block::BlockMtp::Output = <bitcoin_units::block::BlockMtp as core::ops::arith::Sub>::Output
 pub type bitcoin_units::block::BlockMtp::Output = bitcoin_units::block::BlockMtp
 pub type bitcoin_units::block::BlockMtp::Output = bitcoin_units::block::BlockMtpInterval
-pub type bitcoin_units::block::BlockMtpInterval::Err = bitcoin_units::parse::ParseIntError
-pub type bitcoin_units::block::BlockMtpInterval::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::block::BlockMtpInterval::Err = bitcoin_units::parse_int::ParseIntError
+pub type bitcoin_units::block::BlockMtpInterval::Error = bitcoin_units::parse_int::ParseIntError
 pub type bitcoin_units::block::BlockMtpInterval::Output = <bitcoin_units::block::BlockMtpInterval as core::ops::arith::Add>::Output
 pub type bitcoin_units::block::BlockMtpInterval::Output = <bitcoin_units::block::BlockMtpInterval as core::ops::arith::Sub>::Output
 pub type bitcoin_units::block::BlockMtpInterval::Output = bitcoin_units::block::BlockMtpInterval
 pub type bitcoin_units::locktime::absolute::Height::Err = bitcoin_units::locktime::absolute::error::ParseHeightError
 pub type bitcoin_units::locktime::absolute::Height::Error = bitcoin_units::locktime::absolute::error::ConversionError
 pub type bitcoin_units::locktime::absolute::Height::Error = bitcoin_units::locktime::absolute::error::ParseHeightError
-pub type bitcoin_units::locktime::absolute::LockTime::Err = bitcoin_units::parse::ParseIntError
-pub type bitcoin_units::locktime::absolute::LockTime::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::locktime::absolute::LockTime::Err = bitcoin_units::parse_int::ParseIntError
+pub type bitcoin_units::locktime::absolute::LockTime::Error = bitcoin_units::parse_int::ParseIntError
 pub type bitcoin_units::locktime::absolute::MedianTimePast::Err = bitcoin_units::locktime::absolute::error::ParseTimeError
 pub type bitcoin_units::locktime::absolute::MedianTimePast::Error = bitcoin_units::locktime::absolute::error::ConversionError
 pub type bitcoin_units::locktime::absolute::MedianTimePast::Error = bitcoin_units::locktime::absolute::error::ParseTimeError
 pub type bitcoin_units::locktime::relative::LockTime::Error = bitcoin_units::locktime::relative::error::DisabledLockTimeError
-pub type bitcoin_units::locktime::relative::NumberOf512Seconds::Err = bitcoin_units::parse::ParseIntError
-pub type bitcoin_units::locktime::relative::NumberOf512Seconds::Error = bitcoin_units::parse::ParseIntError
-pub type bitcoin_units::locktime::relative::NumberOfBlocks::Err = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::locktime::relative::NumberOf512Seconds::Err = bitcoin_units::parse_int::ParseIntError
+pub type bitcoin_units::locktime::relative::NumberOf512Seconds::Error = bitcoin_units::parse_int::ParseIntError
+pub type bitcoin_units::locktime::relative::NumberOfBlocks::Err = bitcoin_units::parse_int::ParseIntError
 pub type bitcoin_units::locktime::relative::NumberOfBlocks::Error = bitcoin_units::block::TooBigForRelativeHeightError
-pub type bitcoin_units::locktime::relative::NumberOfBlocks::Error = bitcoin_units::parse::ParseIntError
+pub type bitcoin_units::locktime::relative::NumberOfBlocks::Error = bitcoin_units::parse_int::ParseIntError
 pub type bitcoin_units::result::NumOpResult<T>::Output = <bitcoin_units::result::NumOpResult<T> as core::ops::arith::Add<T>>::Output
 pub type bitcoin_units::result::NumOpResult<T>::Output = <bitcoin_units::result::NumOpResult<T> as core::ops::arith::Add>::Output
 pub type bitcoin_units::result::NumOpResult<T>::Output = <bitcoin_units::result::NumOpResult<T> as core::ops::arith::Sub<T>>::Output

--- a/bitcoin/src/blockdata/script/witness_version.rs
+++ b/bitcoin/src/blockdata/script/witness_version.rs
@@ -15,7 +15,7 @@ use internals::write_err;
 
 use crate::opcodes::all::*;
 use crate::opcodes::Opcode;
-use crate::parse::{self, ParseIntError};
+use crate::parse_int::{self, ParseIntError};
 use crate::script::Instruction;
 
 /// Version of the segregated witness program.
@@ -82,7 +82,7 @@ impl FromStr for WitnessVersion {
     type Err = FromStrError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let version: u8 = parse::int_from_str(s)?;
+        let version: u8 = parse_int::int_from_str(s)?;
         Ok(WitnessVersion::try_from(version)?)
     }
 }

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -1246,13 +1246,13 @@ impl<'a> Arbitrary<'a> for InputWeightPrediction {
 mod tests {
     use hex::FromHex;
     use hex_lit::hex;
-    use units::parse;
 
     use super::*;
     use crate::consensus::encode::{deserialize, serialize};
     use crate::constants::WITNESS_SCALE_FACTOR;
     use crate::script::ScriptSigBuf;
     use crate::sighash::EcdsaSighashType;
+    use crate::parse_int;
 
     const SOME_TX: &str = "0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000";
 
@@ -1310,7 +1310,7 @@ mod tests {
         assert_eq!(
             "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456:lol"
                 .parse::<OutPoint>(),
-            Err(ParseOutPointError::Vout(parse::int_from_str::<u32>("lol").unwrap_err()))
+            Err(ParseOutPointError::Vout(parse_int::int_from_str::<u32>("lol").unwrap_err()))
         );
 
         assert_eq!(

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -165,6 +165,7 @@ pub use units::{
     amount::{Amount, SignedAmount},
     block::{BlockHeight, BlockHeightInterval, BlockMtp, BlockMtpInterval},
     fee_rate::FeeRate,
+    parse_int,
     time::{self, BlockTime},
     weight::Weight,
 };
@@ -268,17 +269,6 @@ pub mod amount {
             self.to_sat().consensus_encode(w)
         }
     }
-}
-
-/// Unit parsing utilities.
-pub mod parse {
-    /// Re-export everything from the [`units::parse`] module.
-    #[doc(inline)]
-    pub use units::parse::{
-        hex_check_unprefixed, hex_remove_prefix, hex_u128, hex_u128_unchecked, hex_u128_unprefixed,
-        hex_u32, hex_u32_unchecked, hex_u32_unprefixed, int_from_box, int_from_str,
-        int_from_string, ParseIntError, PrefixedHexError, UnprefixedHexError,
-    };
 }
 
 mod encode_impls {

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -10,7 +10,7 @@ use core::{cmp, fmt};
 
 use internals::impl_to_hex_from_lower_hex;
 use io::{BufRead, Write};
-use units::parse::{self, ParseIntError, PrefixedHexError, UnprefixedHexError};
+use units::parse_int::{self, ParseIntError, PrefixedHexError, UnprefixedHexError};
 
 use crate::block::{BlockHash, Header};
 use crate::consensus::encode::{self, Decodable, Encodable};
@@ -337,13 +337,13 @@ internal_macros::define_extension_trait! {
     pub trait CompactTargetExt impl for CompactTarget {
         /// Constructs a new `CompactTarget` from a prefixed hex string.
         fn from_hex(s: &str) -> Result<CompactTarget, PrefixedHexError> {
-            let target = parse::hex_u32_prefixed(s)?;
+            let target = parse_int::hex_u32_prefixed(s)?;
             Ok(Self::from_consensus(target))
         }
 
         /// Constructs a new `CompactTarget` from an unprefixed hex string.
         fn from_unprefixed_hex(s: &str) -> Result<CompactTarget, UnprefixedHexError> {
-            let target = parse::hex_u32_unprefixed(s)?;
+            let target = parse_int::hex_u32_unprefixed(s)?;
             Ok(Self::from_consensus(target))
         }
 
@@ -465,28 +465,28 @@ impl U256 {
 
     /// Constructs a new `U256` from a prefixed hex string.
     fn from_hex(s: &str) -> Result<Self, PrefixedHexError> {
-        let checked = parse::hex_remove_prefix(s)?;
+        let checked = parse_int::hex_remove_prefix(s)?;
         Ok(U256::from_hex_internal(checked)?)
     }
 
     /// Constructs a new `U256` from an unprefixed hex string.
     fn from_unprefixed_hex(s: &str) -> Result<Self, UnprefixedHexError> {
-        let checked = parse::hex_check_unprefixed(s)?;
+        let checked = parse_int::hex_check_unprefixed(s)?;
         Ok(U256::from_hex_internal(checked)?)
     }
 
     // Caller to ensure `s` does not contain a prefix.
     fn from_hex_internal(s: &str) -> Result<Self, ParseIntError> {
         let (high, low) = if s.len() <= 32 {
-            let low = parse::hex_u128_unchecked(s)?;
+            let low = parse_int::hex_u128_unchecked(s)?;
             (0, low)
         } else {
             let high_len = s.len() - 32;
             let high_s = &s[..high_len];
             let low_s = &s[high_len..];
 
-            let high = parse::hex_u128_unchecked(high_s)?;
-            let low = parse::hex_u128_unchecked(low_s)?;
+            let high = parse_int::hex_u128_unchecked(high_s)?;
+            let low = parse_int::hex_u128_unchecked(low_s)?;
             (high, low)
         };
 

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -57,7 +57,7 @@ pub use units::{
     block::{BlockHeight, BlockHeightInterval, BlockMtp, BlockMtpInterval},
     fee_rate::{self, FeeRate},
     locktime::{self, absolute, relative},
-    parse,
+    parse_int,
     result::{self, NumOpResult},
     sequence::{self, Sequence},
     time::{self, BlockTime},

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -27,7 +27,7 @@ use internals::write_err;
 #[cfg(feature = "alloc")]
 use units::locktime::absolute;
 #[cfg(feature = "hex")]
-use units::parse;
+use units::parse_int;
 #[cfg(feature = "alloc")]
 use units::sequence::Sequence;
 #[cfg(feature = "alloc")]
@@ -424,7 +424,7 @@ fn parse_vout(s: &str) -> Result<u32, ParseOutPointError> {
             return Err(ParseOutPointError::VoutNotCanonical);
         }
     }
-    parse::int_from_str(s).map_err(ParseOutPointError::Vout)
+    parse_int::int_from_str(s).map_err(ParseOutPointError::Vout)
 }
 
 /// An error in parsing an [`OutPoint`].
@@ -436,7 +436,7 @@ pub enum ParseOutPointError {
     /// Error in TXID part.
     Txid(hex::HexToArrayError),
     /// Error in vout part.
-    Vout(parse::ParseIntError),
+    Vout(parse_int::ParseIntError),
     /// Error in general format.
     Format,
     /// Size exceeds max.

--- a/units/CHANGELOG.md
+++ b/units/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Do not re-export doc hidden macros
+
 # 1.0.0 - 2025-02-24
 
 BOOM! A long time in the making but here goes, our first 1.0 crate release.

--- a/units/src/block.rs
+++ b/units/src/block.rs
@@ -34,7 +34,7 @@ macro_rules! impl_u32_wrapper {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(&self.0, f) }
         }
 
-        crate::parse::impl_parse_str_from_int_infallible!($newtype, u32, from);
+        crate::parse_int::impl_parse_str_from_int_infallible!($newtype, u32, from);
 
         impl From<u32> for $newtype {
             fn from(inner: u32) -> Self { Self::from_u32(inner) }

--- a/units/src/block.rs
+++ b/units/src/block.rs
@@ -34,7 +34,7 @@ macro_rules! impl_u32_wrapper {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(&self.0, f) }
         }
 
-        crate::impl_parse_str_from_int_infallible!($newtype, u32, from);
+        crate::parse::impl_parse_str_from_int_infallible!($newtype, u32, from);
 
         impl From<u32> for $newtype {
             fn from(inner: u32) -> Self { Self::from_u32(inner) }

--- a/units/src/lib.rs
+++ b/units/src/lib.rs
@@ -49,7 +49,7 @@ pub mod amount;
 pub mod block;
 pub mod fee_rate;
 pub mod locktime;
-pub mod parse;
+pub mod parse_int;
 pub mod result;
 pub mod sequence;
 pub mod time;

--- a/units/src/locktime/absolute/error.rs
+++ b/units/src/locktime/absolute/error.rs
@@ -8,7 +8,7 @@ use core::fmt;
 use internals::error::InputString;
 
 use super::{Height, MedianTimePast, LOCK_TIME_THRESHOLD};
-use crate::parse::ParseIntError;
+use crate::parse_int::ParseIntError;
 
 /// Tried to satisfy a lock-by-time lock using a height value.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/units/src/locktime/absolute/mod.rs
+++ b/units/src/locktime/absolute/mod.rs
@@ -17,7 +17,7 @@ use internals::error::InputString;
 use self::error::ParseError;
 #[cfg(doc)]
 use crate::absolute;
-use crate::parse::{self, PrefixedHexError, UnprefixedHexError};
+use crate::parse_int::{self, PrefixedHexError, UnprefixedHexError};
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(no_inline)]
@@ -120,16 +120,16 @@ impl LockTime {
     /// # Examples
     ///
     /// ```
-    /// # use bitcoin_units::{absolute, parse};
+    /// # use bitcoin_units::{absolute, parse_int};
     /// let hex_str = "0x61cf9980"; // Unix timestamp for January 1, 2022
     /// let lock_time = absolute::LockTime::from_hex(hex_str)?;
     /// assert_eq!(lock_time.to_consensus_u32(), 0x61cf9980);
     ///
-    /// # Ok::<_, parse::PrefixedHexError>(())
+    /// # Ok::<_, parse_int::PrefixedHexError>(())
     /// ```
     #[inline]
     pub fn from_hex(s: &str) -> Result<Self, PrefixedHexError> {
-        let lock_time = parse::hex_u32_prefixed(s)?;
+        let lock_time = parse_int::hex_u32_prefixed(s)?;
         Ok(Self::from_consensus(lock_time))
     }
 
@@ -143,16 +143,16 @@ impl LockTime {
     /// # Examples
     ///
     /// ```
-    /// # use bitcoin_units::{absolute, parse};
+    /// # use bitcoin_units::{absolute, parse_int};
     /// let hex_str = "61cf9980"; // Unix timestamp for January 1, 2022
     /// let lock_time = absolute::LockTime::from_unprefixed_hex(hex_str)?;
     /// assert_eq!(lock_time.to_consensus_u32(), 0x61cf9980);
     ///
-    /// # Ok::<_, parse::UnprefixedHexError>(())
+    /// # Ok::<_, parse_int::UnprefixedHexError>(())
     /// ```
     #[inline]
     pub fn from_unprefixed_hex(s: &str) -> Result<Self, UnprefixedHexError> {
-        let lock_time = parse::hex_u32_unprefixed(s)?;
+        let lock_time = parse_int::hex_u32_unprefixed(s)?;
         Ok(Self::from_consensus(lock_time))
     }
 
@@ -399,7 +399,7 @@ impl LockTime {
     }
 }
 
-parse::impl_parse_str_from_int_infallible!(LockTime, u32, from_consensus);
+parse_int::impl_parse_str_from_int_infallible!(LockTime, u32, from_consensus);
 
 impl From<Height> for LockTime {
     #[inline]
@@ -546,7 +546,7 @@ impl fmt::Display for Height {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(&self.0, f) }
 }
 
-parse::impl_parse_str!(Height, ParseHeightError, parser(Height::from_u32));
+parse_int::impl_parse_str!(Height, ParseHeightError, parser(Height::from_u32));
 
 #[deprecated(since = "TBD", note = "use `MedianTimePast` instead")]
 #[doc(hidden)]
@@ -661,7 +661,7 @@ impl fmt::Display for MedianTimePast {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(&self.0, f) }
 }
 
-parse::impl_parse_str!(MedianTimePast, ParseTimeError, parser(MedianTimePast::from_u32));
+parse_int::impl_parse_str!(MedianTimePast, ParseTimeError, parser(MedianTimePast::from_u32));
 
 fn parser<T, E, S, F>(f: F) -> impl FnOnce(S) -> Result<T, E>
 where
@@ -682,7 +682,7 @@ where
     S: AsRef<str> + Into<InputString>,
     F: FnOnce(u32) -> Result<T, ConversionError>,
 {
-    let n = i64::from_str_radix(parse::hex_remove_optional_prefix(s.as_ref()), 16)
+    let n = i64::from_str_radix(parse_int::hex_remove_optional_prefix(s.as_ref()), 16)
         .map_err(ParseError::invalid_int(s))?;
     let n = u32::try_from(n).map_err(|_| ParseError::Conversion(n))?;
     f(n).map_err(ParseError::from).map_err(Into::into)

--- a/units/src/locktime/absolute/mod.rs
+++ b/units/src/locktime/absolute/mod.rs
@@ -399,7 +399,7 @@ impl LockTime {
     }
 }
 
-crate::impl_parse_str_from_int_infallible!(LockTime, u32, from_consensus);
+parse::impl_parse_str_from_int_infallible!(LockTime, u32, from_consensus);
 
 impl From<Height> for LockTime {
     #[inline]
@@ -546,7 +546,7 @@ impl fmt::Display for Height {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(&self.0, f) }
 }
 
-crate::impl_parse_str!(Height, ParseHeightError, parser(Height::from_u32));
+parse::impl_parse_str!(Height, ParseHeightError, parser(Height::from_u32));
 
 #[deprecated(since = "TBD", note = "use `MedianTimePast` instead")]
 #[doc(hidden)]
@@ -661,7 +661,7 @@ impl fmt::Display for MedianTimePast {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(&self.0, f) }
 }
 
-crate::impl_parse_str!(MedianTimePast, ParseTimeError, parser(MedianTimePast::from_u32));
+parse::impl_parse_str!(MedianTimePast, ParseTimeError, parser(MedianTimePast::from_u32));
 
 fn parser<T, E, S, F>(f: F) -> impl FnOnce(S) -> Result<T, E>
 where

--- a/units/src/locktime/relative/mod.rs
+++ b/units/src/locktime/relative/mod.rs
@@ -16,7 +16,7 @@ use internals::const_casts;
 
 #[cfg(doc)]
 use crate::relative;
-use crate::{parse, BlockHeight, BlockMtp, Sequence};
+use crate::{parse_int, BlockHeight, BlockMtp, Sequence};
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(no_inline)]
@@ -473,7 +473,7 @@ impl From<u16> for NumberOfBlocks {
     fn from(value: u16) -> Self { NumberOfBlocks(value) }
 }
 
-parse::impl_parse_str_from_int_infallible!(NumberOfBlocks, u16, from);
+parse_int::impl_parse_str_from_int_infallible!(NumberOfBlocks, u16, from);
 
 impl fmt::Display for NumberOfBlocks {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(&self.0, f) }
@@ -587,7 +587,7 @@ impl NumberOf512Seconds {
     }
 }
 
-parse::impl_parse_str_from_int_infallible!(NumberOf512Seconds, u16, from_512_second_intervals);
+parse_int::impl_parse_str_from_int_infallible!(NumberOf512Seconds, u16, from_512_second_intervals);
 
 impl fmt::Display for NumberOf512Seconds {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(&self.0, f) }

--- a/units/src/locktime/relative/mod.rs
+++ b/units/src/locktime/relative/mod.rs
@@ -16,7 +16,7 @@ use internals::const_casts;
 
 #[cfg(doc)]
 use crate::relative;
-use crate::{BlockHeight, BlockMtp, Sequence};
+use crate::{parse, BlockHeight, BlockMtp, Sequence};
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(no_inline)]
@@ -473,7 +473,7 @@ impl From<u16> for NumberOfBlocks {
     fn from(value: u16) -> Self { NumberOfBlocks(value) }
 }
 
-crate::impl_parse_str_from_int_infallible!(NumberOfBlocks, u16, from);
+parse::impl_parse_str_from_int_infallible!(NumberOfBlocks, u16, from);
 
 impl fmt::Display for NumberOfBlocks {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(&self.0, f) }
@@ -587,7 +587,7 @@ impl NumberOf512Seconds {
     }
 }
 
-crate::impl_parse_str_from_int_infallible!(NumberOf512Seconds, u16, from_512_second_intervals);
+parse::impl_parse_str_from_int_infallible!(NumberOf512Seconds, u16, from_512_second_intervals);
 
 impl fmt::Display for NumberOf512Seconds {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(&self.0, f) }

--- a/units/src/parse.rs
+++ b/units/src/parse.rs
@@ -148,8 +148,6 @@ fn int<T: Integer, S: AsRef<str> + Into<InputString>>(s: S) -> Result<T, ParseIn
 /// # Errors
 ///
 /// If parsing the string fails then a `units::parse::ParseIntError` is returned.
-#[macro_export]
-#[doc(hidden)] // This macro is stable but is considered internal to the `rust-bitcoin` repository.
 macro_rules! impl_parse_str_from_int_infallible {
     ($to:ident, $inner:ident, $fn:ident) => {
         impl $crate::_export::_core::str::FromStr for $to {
@@ -191,6 +189,7 @@ macro_rules! impl_parse_str_from_int_infallible {
         }
     };
 }
+pub(crate) use impl_parse_str_from_int_infallible;
 
 /// Implements standard parsing traits for `$type` by calling through to `$inner_fn`.
 ///
@@ -213,13 +212,11 @@ macro_rules! impl_parse_str_from_int_infallible {
 /// # Errors
 ///
 /// All functions use the error returned by `$inner_fn`.
-#[macro_export]
-#[doc(hidden)] // This macro is stable but is considered internal to the `rust-bitcoin` repository.
 macro_rules! impl_parse_str {
     ($to:ty, $err:ty, $inner_fn:expr) => {
-        $crate::impl_tryfrom_str!(&str, $to, $err, $inner_fn);
+        $crate::parse::impl_tryfrom_str!(&str, $to, $err, $inner_fn);
         #[cfg(feature = "alloc")]
-        $crate::impl_tryfrom_str!(alloc::string::String, $to, $err, $inner_fn; alloc::boxed::Box<str>, $to, $err, $inner_fn);
+        $crate::parse::impl_tryfrom_str!(alloc::string::String, $to, $err, $inner_fn; alloc::boxed::Box<str>, $to, $err, $inner_fn);
 
         impl $crate::_export::_core::str::FromStr for $to {
             type Err = $err;
@@ -230,10 +227,9 @@ macro_rules! impl_parse_str {
         }
     }
 }
+pub(crate) use impl_parse_str;
 
 /// Implements `TryFrom<$from> for $to`.
-#[macro_export]
-#[doc(hidden)] // Helper macro called by `impl_parse_str`.
 macro_rules! impl_tryfrom_str {
     ($($from:ty, $to:ty, $err:ty, $inner_fn:expr);*) => {
         $(
@@ -247,6 +243,7 @@ macro_rules! impl_tryfrom_str {
         )*
     }
 }
+pub(crate) use impl_tryfrom_str;
 
 /// Removes the prefix `0x` (or `0X`) from a hex string.
 ///

--- a/units/src/parse_int.rs
+++ b/units/src/parse_int.rs
@@ -83,10 +83,10 @@ mod sealed {
 /// string is lost.
 ///
 /// If the caller has a `String` or `Box<str>` which is not used later it's better to call
-/// [`parse::int_from_string`] or [`parse::int_from_box`] respectively.
+/// [`parse_int::int_from_string`] or [`parse_int::int_from_box`] respectively.
 ///
-/// [`parse::int_from_string`]: crate::parse::int_from_string
-/// [`parse::int_from_box`]: crate::parse::int_from_box
+/// [`parse_int::int_from_string`]: crate::parse_int::int_from_string
+/// [`parse_int::int_from_box`]: crate::parse_int::int_from_box
 ///
 /// # Errors
 ///
@@ -151,7 +151,7 @@ fn int<T: Integer, S: AsRef<str> + Into<InputString>>(s: S) -> Result<T, ParseIn
 macro_rules! impl_parse_str_from_int_infallible {
     ($to:ident, $inner:ident, $fn:ident) => {
         impl $crate::_export::_core::str::FromStr for $to {
-            type Err = $crate::parse::ParseIntError;
+            type Err = $crate::parse_int::ParseIntError;
 
             fn from_str(s: &str) -> $crate::_export::_core::result::Result<Self, Self::Err> {
                 $crate::_export::_core::convert::TryFrom::try_from(s)
@@ -159,32 +159,32 @@ macro_rules! impl_parse_str_from_int_infallible {
         }
 
         impl $crate::_export::_core::convert::TryFrom<&str> for $to {
-            type Error = $crate::parse::ParseIntError;
+            type Error = $crate::parse_int::ParseIntError;
 
             fn try_from(s: &str) -> $crate::_export::_core::result::Result<Self, Self::Error> {
-                $crate::parse::int_from_str::<$inner>(s).map($to::$fn)
+                $crate::parse_int::int_from_str::<$inner>(s).map($to::$fn)
             }
         }
 
         #[cfg(feature = "alloc")]
         impl $crate::_export::_core::convert::TryFrom<alloc::string::String> for $to {
-            type Error = $crate::parse::ParseIntError;
+            type Error = $crate::parse_int::ParseIntError;
 
             fn try_from(
                 s: alloc::string::String,
             ) -> $crate::_export::_core::result::Result<Self, Self::Error> {
-                $crate::parse::int_from_string::<$inner>(s).map($to::$fn)
+                $crate::parse_int::int_from_string::<$inner>(s).map($to::$fn)
             }
         }
 
         #[cfg(feature = "alloc")]
         impl $crate::_export::_core::convert::TryFrom<alloc::boxed::Box<str>> for $to {
-            type Error = $crate::parse::ParseIntError;
+            type Error = $crate::parse_int::ParseIntError;
 
             fn try_from(
                 s: alloc::boxed::Box<str>,
             ) -> $crate::_export::_core::result::Result<Self, Self::Error> {
-                $crate::parse::int_from_box::<$inner>(s).map($to::$fn)
+                $crate::parse_int::int_from_box::<$inner>(s).map($to::$fn)
             }
         }
     };
@@ -214,9 +214,9 @@ pub(crate) use impl_parse_str_from_int_infallible;
 /// All functions use the error returned by `$inner_fn`.
 macro_rules! impl_parse_str {
     ($to:ty, $err:ty, $inner_fn:expr) => {
-        $crate::parse::impl_tryfrom_str!(&str, $to, $err, $inner_fn);
+        $crate::parse_int::impl_tryfrom_str!(&str, $to, $err, $inner_fn);
         #[cfg(feature = "alloc")]
-        $crate::parse::impl_tryfrom_str!(alloc::string::String, $to, $err, $inner_fn; alloc::boxed::Box<str>, $to, $err, $inner_fn);
+        $crate::parse_int::impl_tryfrom_str!(alloc::string::String, $to, $err, $inner_fn; alloc::boxed::Box<str>, $to, $err, $inner_fn);
 
         impl $crate::_export::_core::str::FromStr for $to {
             type Err = $err;

--- a/units/src/sequence.rs
+++ b/units/src/sequence.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::locktime::relative::error::TimeOverflowError;
 use crate::locktime::relative::{self, NumberOf512Seconds};
-use crate::parse::{self, PrefixedHexError, UnprefixedHexError};
+use crate::parse_int::{self, PrefixedHexError, UnprefixedHexError};
 
 /// Bitcoin transaction input sequence number.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -129,7 +129,7 @@ impl Sequence {
     /// the `0x` prefix.
     #[inline]
     pub fn from_hex(s: &str) -> Result<Self, PrefixedHexError> {
-        let lock_time = parse::hex_u32_prefixed(s)?;
+        let lock_time = parse_int::hex_u32_prefixed(s)?;
         Ok(Self::from_consensus(lock_time))
     }
 
@@ -141,7 +141,7 @@ impl Sequence {
     /// `0x` prefix.
     #[inline]
     pub fn from_unprefixed_hex(s: &str) -> Result<Self, UnprefixedHexError> {
-        let lock_time = parse::hex_u32_unprefixed(s)?;
+        let lock_time = parse_int::hex_u32_unprefixed(s)?;
         Ok(Self::from_consensus(lock_time))
     }
 
@@ -262,7 +262,7 @@ impl fmt::Debug for Sequence {
 }
 
 #[cfg(feature = "alloc")]
-parse::impl_parse_str_from_int_infallible!(Sequence, u32, from_consensus);
+parse_int::impl_parse_str_from_int_infallible!(Sequence, u32, from_consensus);
 
 #[cfg(feature = "arbitrary")]
 #[cfg(feature = "alloc")]

--- a/units/src/sequence.rs
+++ b/units/src/sequence.rs
@@ -262,7 +262,7 @@ impl fmt::Debug for Sequence {
 }
 
 #[cfg(feature = "alloc")]
-crate::impl_parse_str_from_int_infallible!(Sequence, u32, from_consensus);
+parse::impl_parse_str_from_int_infallible!(Sequence, u32, from_consensus);
 
 #[cfg(feature = "arbitrary")]
 #[cfg(feature = "alloc")]

--- a/units/src/weight.rs
+++ b/units/src/weight.rs
@@ -10,7 +10,7 @@ use arbitrary::{Arbitrary, Unstructured};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::{parse, Amount, FeeRate, NumOpResult};
+use crate::{parse_int, Amount, FeeRate, NumOpResult};
 
 /// The factor that non-witness serialization data is multiplied by during weight calculation.
 pub const WITNESS_SCALE_FACTOR: usize = 4;
@@ -271,7 +271,7 @@ impl<'a> core::iter::Sum<&'a Weight> for Weight {
     }
 }
 
-parse::impl_parse_str_from_int_infallible!(Weight, u64, from_wu);
+parse_int::impl_parse_str_from_int_infallible!(Weight, u64, from_wu);
 
 #[cfg(feature = "serde")]
 impl Serialize for Weight {

--- a/units/src/weight.rs
+++ b/units/src/weight.rs
@@ -10,7 +10,7 @@ use arbitrary::{Arbitrary, Unstructured};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::{Amount, FeeRate, NumOpResult};
+use crate::{parse, Amount, FeeRate, NumOpResult};
 
 /// The factor that non-witness serialization data is multiplied by during weight calculation.
 pub const WITNESS_SCALE_FACTOR: usize = 4;
@@ -271,7 +271,7 @@ impl<'a> core::iter::Sum<&'a Weight> for Weight {
     }
 }
 
-crate::impl_parse_str_from_int_infallible!(Weight, u64, from_wu);
+parse::impl_parse_str_from_int_infallible!(Weight, u64, from_wu);
 
 #[cfg(feature = "serde")]
 impl Serialize for Weight {

--- a/units/tests/api.rs
+++ b/units/tests/api.rs
@@ -14,7 +14,7 @@ use arbitrary::{Arbitrary, Unstructured};
 // These imports test "typical" usage by user code.
 use bitcoin_units::locktime::{absolute, relative}; // Typical usage is `absolute::LockTime`.
 use bitcoin_units::{
-    amount, block, fee_rate, locktime, parse, result, time, weight, Amount, BlockHeight,
+    amount, block, fee_rate, locktime, parse_int, result, time, weight, Amount, BlockHeight,
     BlockHeightInterval, BlockMtp, BlockMtpInterval, BlockTime, FeeRate, NumOpResult, SignedAmount,
     Weight,
 };
@@ -145,14 +145,14 @@ struct Errors {
     q: locktime::relative::InvalidHeightError,
     r: locktime::relative::InvalidTimeError,
     s: locktime::relative::TimeOverflowError,
-    t: parse::ParseIntError,
-    u: parse::PrefixedHexError,
-    v: parse::UnprefixedHexError,
+    t: parse_int::ParseIntError,
+    u: parse_int::PrefixedHexError,
+    v: parse_int::UnprefixedHexError,
 }
 
 #[test]
 fn api_can_use_modules_from_crate_root() {
-    use bitcoin_units::{amount, block, fee_rate, locktime, parse, time, weight};
+    use bitcoin_units::{amount, block, fee_rate, locktime, parse_int, time, weight};
 }
 
 #[test]
@@ -217,7 +217,7 @@ fn api_can_use_all_types_from_module_locktime_relative() {
 
 #[test]
 fn api_can_use_all_types_from_module_parse() {
-    use bitcoin_units::parse::{ParseIntError, PrefixedHexError, UnprefixedHexError};
+    use bitcoin_units::parse_int::{ParseIntError, PrefixedHexError, UnprefixedHexError};
 }
 
 #[test]


### PR DESCRIPTION
Patch 1 removes the hidden macros from `units` and then it makes sense to rename the `parse` module to `parse_int`. With this all done, fix the re-export in `primitives` and add one in `bitcoin` (all in patch 2).
