### PR TITLE
Manually print `InvalidChecksum`

### DIFF
--- a/bitcoin/src/consensus/error.rs
+++ b/bitcoin/src/consensus/error.rs
@@ -257,3 +257,44 @@ impl From<OddLengthStringError> for FromHexError {
 pub(crate) fn parse_failed_error(msg: &'static str) -> Error {
     Error::Parse(ParseError::ParseFailed(msg))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_checksum_display() {
+        let e = ParseError::InvalidChecksum {
+            expected: [0xde, 0xad, 0xbe, 0xef],
+            actual: [0xca, 0xfe, 0xba, 0xbe],
+        };
+
+        let want = "invalid checksum: expected deadbeef, actual cafebabe";
+        let got = format!("{}", e);
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn invalid_checksum_display_expected_leading_zeros() {
+        let e = ParseError::InvalidChecksum {
+            expected: [0x00, 0x00, 0x00, 0x0f],
+            actual: [0xca, 0xfe, 0xba, 0xbe],
+        };
+
+        let want = "invalid checksum: expected 0000000f, actual cafebabe";
+        let got = format!("{}", e);
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn invalid_checksum_display_actual_leading_zeros() {
+        let e = ParseError::InvalidChecksum {
+            expected: [0xde, 0xad, 0xbe, 0xef],
+            actual: [0x00, 0x00, 0x00, 0x0e],
+        };
+
+        let want = "invalid checksum: expected deadbeef, actual 0000000e";
+        let got = format!("{}", e);
+        assert_eq!(got, want);
+    }
+}

--- a/bitcoin/src/consensus/error.rs
+++ b/bitcoin/src/consensus/error.rs
@@ -6,7 +6,6 @@ use core::convert::Infallible;
 use core::fmt;
 
 use hex::error::{InvalidCharError, OddLengthStringError};
-use hex::DisplayHex as _;
 use internals::write_err;
 
 #[cfg(doc)]
@@ -188,8 +187,11 @@ impl fmt::Display for ParseError {
             MissingData => write!(f, "missing data (early end of file or slice too short)"),
             OversizedVectorAllocation { requested: ref r, max: ref m } =>
                 write!(f, "allocation of oversized vector: requested {}, maximum {}", r, m),
-            InvalidChecksum { expected: ref e, actual: ref a } =>
-                write!(f, "invalid checksum: expected {:x}, actual {:x}", e.as_hex(), a.as_hex()),
+            InvalidChecksum { expected: ref e, actual: ref a } => write!(
+                f,
+                "invalid checksum: expected {:02x}{:02x}{:02x}{:02x}, actual {:02x}{:02x}{:02x}{:02x}",
+                e[0], e[1], e[2], e[3], a[0], a[1], a[2], a[3],
+            ),
             NonMinimalCompactSize => write!(f, "non-minimal compact size"),
             ParseFailed(ref s) => write!(f, "parse failed: {}", s),
             UnsupportedSegwitFlag(ref swflag) =>


### PR DESCRIPTION
Currently the `ParseError` is a mess. The correct fix is likely to use an associated type in `Decodable` for the error but that can wait.

Right now we are using `hex` in the `Display` impl for `ParseError`. This will cause trouble when we move the error type to `consenus_encoding` because `hex` is a feature. Even if we do not do so this code is a mainitenance burden.

Just manually print hex characters by accessing the array. Logic is already tested with a static string, this patch does not change the output.
