### PR TITLE
io: Enable features in internals crate

### DIFF
--- a/io/Cargo.toml
+++ b/io/Cargo.toml
@@ -15,8 +15,8 @@ exclude = ["tests", "contrib"]
 
 [features]
 default = ["std"]
-std = ["alloc", "hashes?/std"]
-alloc = ["hashes?/alloc"]
+std = ["alloc", "hashes?/std", "internals/std"]
+alloc = ["hashes?/alloc", "internals/alloc"]
 
 [dependencies]
 internals = { package = "bitcoin-internals", path = "../internals" }


### PR DESCRIPTION
In `io` we use a macro from `internals` that has feature gated code dependent on "alloc" but currently we are not enabling "alloc". This is a bug -

Repeat after me: calling macros across crate boundries is an incessant source of bugs.