### PR TITLE
fix: correct grammar in block and transaction docs

### DIFF
--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -261,7 +261,7 @@ impl From<&Header> for BlockHash {
 ///
 /// Originally used as a protocol version, but repurposed for soft-fork signaling.
 ///
-/// The inner value is a signed integer in Bitcoin Core for historical reasons, if version bits is
+/// The inner value is a signed integer in Bitcoin Core for historical reasons, if the version bits are
 /// being used the top three bits must be 001, this gives us a useful range of [0x20000000...0x3FFFFFFF].
 ///
 /// > When a block nVersion does not have top bits 001, it is treated as if all bits are 0 for the purposes of deployments.

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -50,7 +50,7 @@ use crate::witness::Witness;
 ///
 /// # Bitcoin Core References
 ///
-/// * [CTtransaction definition](https://github.com/bitcoin/bitcoin/blob/345457b542b6a980ccfbc868af0970a6f91d1b82/src/primitives/transaction.h#L279)
+/// * [CTransaction definition](https://github.com/bitcoin/bitcoin/blob/345457b542b6a980ccfbc868af0970a6f91d1b82/src/primitives/transaction.h#L279)
 ///
 /// # Serialization notes
 ///


### PR DESCRIPTION
Fixed grammar: "if version bits is" → "if version bits are" 
also 'CTtransaction' to 'CTransaction'