### PR TITLE
base58: Remove hex dependency

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -20,7 +20,7 @@ version = "0.2.0"
 dependencies = [
  "bitcoin-internals",
  "bitcoin_hashes 0.16.0",
- "hex-conservative 0.3.0",
+ "hex_lit",
 ]
 
 [[package]]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -20,7 +20,7 @@ version = "0.2.0"
 dependencies = [
  "bitcoin-internals",
  "bitcoin_hashes 0.16.0",
- "hex-conservative 0.3.0",
+ "hex_lit",
 ]
 
 [[package]]

--- a/base58/Cargo.toml
+++ b/base58/Cargo.toml
@@ -22,7 +22,7 @@ hashes = { package = "bitcoin_hashes", path = "../hashes", default-features = fa
 internals = { package = "bitcoin-internals", path = "../internals" }
 
 [dev-dependencies]
-hex = { package = "hex-conservative", version = "0.3.0", default-features = false, features = ["alloc"] }
+hex_lit = "0.1.1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/base58/src/lib.rs
+++ b/base58/src/lib.rs
@@ -253,7 +253,7 @@ where
 mod tests {
     use alloc::vec;
 
-    use hex::FromHex as _;
+    use hex_lit::hex;
 
     use super::*;
 
@@ -282,7 +282,7 @@ mod tests {
         assert_eq!(&res, exp);
 
         // Addresses
-        let addr = Vec::from_hex("00f8917303bfa8ef24f292e8fa1419b20460ba064d").unwrap();
+        let addr = hex!("00f8917303bfa8ef24f292e8fa1419b20460ba064d");
         assert_eq!(&encode_check(&addr[..]), "1PfJpZsjreyVrqeoAfabrRwwjQyoSQMmHH");
     }
 
@@ -300,8 +300,8 @@ mod tests {
 
         // Addresses
         assert_eq!(
-            decode_check("1PfJpZsjreyVrqeoAfabrRwwjQyoSQMmHH").ok(),
-            Some(Vec::from_hex("00f8917303bfa8ef24f292e8fa1419b20460ba064d").unwrap())
+            decode_check("1PfJpZsjreyVrqeoAfabrRwwjQyoSQMmHH").ok().unwrap().as_slice(),
+            hex!("00f8917303bfa8ef24f292e8fa1419b20460ba064d")
         );
         // Non Base58 char.
         assert_eq!(decode("¢").unwrap_err(), InvalidCharacterError::new(194));


### PR DESCRIPTION
The `hex` dev dependency is only used in tests, we have a crate for that lets use it.

Remove `hex-conservative` dev dependency and use `hex_lit`.