### PR TITLE
docs: Add rustdocs link policy section

### DIFF
--- a/docs/policy.md
+++ b/docs/policy.md
@@ -226,6 +226,18 @@ panics that could theoretically occur because of bugs in our code must not be do
 Example code within the rustdocs should compile and lint with `just lint` without any errors or
 warnings.
 
+### Links
+
+We favour links at the bottom of the docs section:
+
+```rust
+    /// it is a real Taproot script spend (and not some other kind of output contrived
+    /// to have a Taproot-shaped witness). See [BIP-0341] in particular footnote 7, for
+    /// more information.
+    ///
+    /// [BIP-0341]: <https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki>
+```
+
 ## Derives
 
 We try to use standard set of derives if it makes sense:


### PR DESCRIPTION
With comment

https://github.com/rust-bitcoin/rust-bitcoin/issues/4859#issuecomment-3190333850

we decided to favour links at the bottom of a docs section instead of inline.

Document this policy.