### PR TITLE
Resolve minimal versions in Cargo-minimal.lock on dependency changes

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -284,18 +284,18 @@ checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.63"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -384,18 +384,18 @@ checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.156"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "314b5b092c0ade17c00142951e50ced110ec27cea304b1037c6969246c2469a4"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.156"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7e29c4601e36bcec74a223228dce795f4cd3616341a4af93520ca1a837c087d"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -424,9 +424,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.109"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -10,9 +10,9 @@ checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.4"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "base58ck"
@@ -96,9 +96,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-io"
-version = "0.1.3"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
+checksum = "17e5b76b88667412087beea1882980ad843b660490bbf6cce0a6cfc999c5b989"
 
 [[package]]
 name = "bitcoin-io"
@@ -154,7 +154,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
 dependencies = [
- "bitcoin-io 0.1.3",
+ "bitcoin-io 0.1.1",
  "hex-conservative 0.2.0",
 ]
 
@@ -263,15 +263,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "edc207893e85c5d6be840e969b496b53d94cec8be2d501b214f50daa97fa8024"
 
 [[package]]
 name = "memmap2"
-version = "0.9.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
+checksum = "deaba38d7abf1d4cca21cc89e932e542ba2b9258664d2a9ef0e61512039c9375"
 dependencies = [
  "libc",
 ]
@@ -284,18 +284,18 @@ checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "2de98502f212cfcea8d0bb305bd0f49d7ebdd75b64ba0a68f937d888f4e0d6db"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -378,24 +378,24 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.17"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+checksum = "76b5842e81eb9bbea19276a9dbbda22ac042532f390a67ab08b895617978abf3"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -424,9 +424,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "89456b690ff72fddcecf231caedbe615c59480c93358a93dfae7fc29e3ebbf0e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -435,9 +435,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
 
 [[package]]
 name = "wasi"

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -36,15 +36,15 @@ primitives = { package = "bitcoin-primitives", path = "../primitives", default-f
 secp256k1 = { version = "0.30.0", default-features = false, features = ["hashes", "alloc", "rand"] }
 units = { package = "bitcoin-units", path = "../units", default-features = false, features = ["alloc"] }
 
-arbitrary = { version = "1.4", optional = true }
+arbitrary = { version = "1.4.1", optional = true }
 base64 = { version = "0.22.0", optional = true, default-features = false, features = ["alloc"] }
 # `bitcoinconsensus` version includes metadata which indicates the version of Core. Use `cargo tree` to see it.
 bitcoinconsensus = { version = "0.106.0", default-features = false, optional = true }
-serde = { version = "1.0.103", default-features = false, features = [ "derive", "alloc" ], optional = true }
+serde = { version = "1.0.195", default-features = false, features = [ "derive", "alloc" ], optional = true }
 
 [dev-dependencies]
 internals = { package = "bitcoin-internals", path = "../internals", features = ["test-serde"] }
-serde_json = "1.0.0"
+serde_json = "1.0.68"
 serde_test = "1.0.19"
 bincode = "1.3.1"
 hex_lit = "0.1.1"

--- a/contrib/update-lock-files.sh
+++ b/contrib/update-lock-files.sh
@@ -1,11 +1,30 @@
 #!/usr/bin/env bash
 #
-# Update the minimal/recent lock file
+# Update the minimal and recent lock files.
 
 set -euo pipefail
 
-for file in Cargo-minimal.lock Cargo-recent.lock; do
-    cp -f "$file" Cargo.lock
-    cargo check
-    cp -f Cargo.lock "$file"
-done
+NIGHTLY=$(cat nightly-version)
+
+# The `direct-minimal-versions` and `minimal-versions` dependency
+# resolution strategy flags each have a little quirk. `direct-minimal-versions`
+# allows transitive versions to upgrade, so we are not testing against
+# the actual minimum tree. `minimal-versions` allows the direct dependency
+# versions to resolve upward due to transitive requirements, so we are
+# not testing the manifest's versions. Combo'd together though, we
+# can get the best of both worlds to ensure the actual minimum dependencies
+# listed in the crate manifests build.
+
+# Check that all explicit direct dependency versions are not lying,
+# as in, they are not being bumped up by transitive dependency constraints.
+rm -f Cargo.lock && cargo +"$NIGHTLY" check -Z direct-minimal-versions
+# Now that our own direct dependency versions can be trusted, check
+# against the lowest versions of the dependency tree which still
+# satisfy constraints. Use this as the minimal version lock file.
+rm -f Cargo.lock && cargo +"$NIGHTLY" check -Z minimal-versions
+cp -f Cargo.lock Cargo-minimal.lock
+
+# Conservatively bump of recent dependencies.
+cp -f Cargo-recent.lock Cargo.lock
+cargo check
+cp -f Cargo.lock Cargo-recent.lock

--- a/contrib/update-lock-files.sh
+++ b/contrib/update-lock-files.sh
@@ -17,14 +17,14 @@ NIGHTLY=$(cat nightly-version)
 
 # Check that all explicit direct dependency versions are not lying,
 # as in, they are not being bumped up by transitive dependency constraints.
-rm -f Cargo.lock && cargo +"$NIGHTLY" check -Z direct-minimal-versions
+rm -f Cargo.lock && cargo +"$NIGHTLY" check --all-features -Z direct-minimal-versions
 # Now that our own direct dependency versions can be trusted, check
 # against the lowest versions of the dependency tree which still
 # satisfy constraints. Use this as the minimal version lock file.
-rm -f Cargo.lock && cargo +"$NIGHTLY" check -Z minimal-versions
+rm -f Cargo.lock && cargo +"$NIGHTLY" check --all-features -Z minimal-versions
 cp -f Cargo.lock Cargo-minimal.lock
 
 # Conservatively bump of recent dependencies.
 cp -f Cargo-recent.lock Cargo.lock
-cargo check
+cargo check --all-features
 cp -f Cargo.lock Cargo-recent.lock

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,10 +13,10 @@ cargo-fuzz = true
 honggfuzz = { version = "0.5.56", default-features = false }
 bitcoin = { path = "../bitcoin", features = [ "serde", "arbitrary" ] }
 p2p = { path = "../p2p", package = "bitcoin-p2p-messages" }
-arbitrary = { version = "1.4" }
+arbitrary = { version = "1.4.1" }
 
-serde = { version = "1.0.103", features = [ "derive" ] }
-serde_json = "1.0"
+serde = { version = "1.0.195", features = [ "derive" ] }
+serde_json = "1.0.68"
 
 [lints.rust]
 unexpected_cfgs = { level = "deny", check-cfg = ['cfg(fuzzing)'] }

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -25,10 +25,10 @@ small-hash = []
 internals = { package = "bitcoin-internals", path = "../internals" }
 
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false, optional = true }
-serde = { version = "1.0.103", default-features = false, optional = true }
+serde = { version = "1.0.195", default-features = false, optional = true }
 
 [dev-dependencies]
-serde_test = "1.0"
+serde_test = "1.0.19"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/internals/Cargo.toml
+++ b/internals/Cargo.toml
@@ -22,7 +22,7 @@ test-serde = ["serde", "serde_json", "bincode"]
 
 [dependencies]
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false, optional = true }
-serde = { version = "1.0.103", default-features = false, optional = true }
+serde = { version = "1.0.195", default-features = false, optional = true }
 
 # Don't enable these directly, use `test-serde` feature instead.
 serde_json = { version = "1.0.68", optional = true }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -26,14 +26,14 @@ hex = ["dep:hex", "hashes/hex", "internals/hex"]
 hashes = { package = "bitcoin_hashes", path = "../hashes", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals" }
 units = { package = "bitcoin-units", path = "../units", default-features = false }
-arrayvec = { version = "0.7", default-features = false }
+arrayvec = { version = "0.7.2", default-features = false }
 
-arbitrary = { version = "1.4", optional = true }
+arbitrary = { version = "1.4.1", optional = true }
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false, optional = true }
-serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"], optional = true }
+serde = { version = "1.0.195", default-features = false, features = ["derive", "alloc"], optional = true }
 
 [dev-dependencies]
-serde_json = "1.0.0"
+serde_json = "1.0.68"
 bincode = "1.3.1"
 
 [package.metadata.docs.rs]

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -20,15 +20,15 @@ alloc = ["internals/alloc","serde?/alloc"]
 [dependencies]
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.4.0" }
 
-serde = { version = "1.0.103", default-features = false, features = ["derive"], optional = true }
-arbitrary = { version = "1.4", optional = true }
+serde = { version = "1.0.195", default-features = false, features = ["derive"], optional = true }
+arbitrary = { version = "1.4.1", optional = true }
 
 [dev-dependencies]
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.4.0", features = ["test-serde"] }
 bincode = "1.3.1"
-serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-serde_test = "1.0"
-serde_json = "1.0"
+serde = { version = "1.0.195", default-features = false, features = ["derive"] }
+serde_test = "1.0.19"
+serde_json = "1.0.68"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Attempt two to close #4313 

I first attempted to iron out dependency drift in #4330, but wasn't quite able to check all the boxes. I think I might have now though by just running the two cargo flags, `direct-minimal-versions` and `minimal-versions`, one after the other in the update lock file script. Running `direct` first checks for the issue where direct dependencies might be lying. And running `minimal-versions` after that forces all transitive versions down to their minimums, fixing any drift (can see this in the lock file change). We can trust that `minimal-versions` won't bump our own direct deps because we just checked them.

The first commit is ironing out little issues required to use `direct-minimal-versions`. Essentially fixing manifests which are out of date and lying about the required version. The `serde` bump might be a large one, but I was running into an issue where it was pulling in an old `proc-macro2` which required a rust compiler option, `proc_macro_span_shrink`, that is no longer available.

The second commit updates the lock file script to use the new flags and generates the new lock files.

The third commit might be drop-able, but I found it kinda of strange that only the default features where being used to generate the dependency lock files. Now, granted, the rust-bitcoin dependency tree is so lean that it appears enabling all features doesn't add any new dependencies, but still makes me feel better for the future.