### PR TITLE
Release tracking PR: `bitcoin-primitives 1.0.0-rc.0`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -123,7 +123,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-primitives"
-version = "0.101.0"
+version = "1.0.0-rc.0"
 dependencies = [
  "arbitrary",
  "arrayvec",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-primitives"
-version = "0.101.0"
+version = "1.0.0-rc.0"
 dependencies = [
  "arbitrary",
  "arrayvec",

--- a/primitives/CHANGELOG.md
+++ b/primitives/CHANGELOG.md
@@ -1,3 +1,56 @@
+# 1.0.0 - 2025-08-20
+
+This changelog is a rolling description of everything that will eventually end up in `v1.0`.
+
+- Pluralize transaction fields [#4788](https://github.com/rust-bitcoin/rust-bitcoin/pull/4788)
+- Use ``CompactSize` instead of `VarInt` [#4790](https://github.com/rust-bitcoin/rust-bitcoin/pull/4790)
+- Do not derive `Default` on `CompactTarget` [#4561](https://github.com/rust-bitcoin/rust-bitcoin/pull/4561)
+- Deserialize witness from a list of hex strings [#4366](https://github.com/rust-bitcoin/rust-bitcoin/pull/4366)
+- Implement `FromIterator` for `Witness` [#4365](https://github.com/rust-bitcoin/rust-bitcoin/pull/4365)
+- Return `ControlBlock` from `Witness::taproot_control_block` [#4281](https://github.com/rust-bitcoin/rust-bitcoin/pull/4281)
+- Witness api improvements and test cleanups [#4279](https://github.com/rust-bitcoin/rust-bitcoin/pull/4279)
+- Implement `Display` for `Header` [#4269](https://github.com/rust-bitcoin/rust-bitcoin/pull/4269)
+- Make hex optional [#4262](https://github.com/rust-bitcoin/rust-bitcoin/pull/4262)
+- Clean up Witness API [#4186](https://github.com/rust-bitcoin/rust-bitcoin/pull/4186)
+- Move `taproot` back to `bitcoin` crate [#4129](https://github.com/rust-bitcoin/rust-bitcoin/pull/4129)
+- Make `transaction::Version` field private [#4099](https://github.com/rust-bitcoin/rust-bitcoin/pull/4099)
+- Hide error internals [#4091](https://github.com/rust-bitcoin/rust-bitcoin/pull/4091)
+- locktimes: Remove `PartialOrd` and `ArbitraryOrd` [#4065](https://github.com/rust-bitcoin/rust-bitcoin/pull/4065)
+- Make `Debug` representation of `Witness` to be slice of hex-encoded
+  bytes strings to improve readability [#4061](https://github.com/rust-bitcoin/rust-bitcoin/pull/4061)
+- Implement `Default` for `Script` [#4043](https://github.com/rust-bitcoin/rust-bitcoin/pull/4043)
+- Store `transaction::Version` as `u32` instead of `i32` [#4040](https://github.com/rust-bitcoin/rust-bitcoin/pull/4040)
+- Delete `TxOut::NULL` [#3978](https://github.com/rust-bitcoin/rust-bitcoin/pull/3978)
+- Reduce alloc requirements [#3711](https://github.com/rust-bitcoin/rust-bitcoin/pull/3711)
+- Remove `serde` from amounts [#3672](https://github.com/rust-bitcoin/rust-bitcoin/pull/3672)
+- Fix bug in witness stack getters [#3601](https://github.com/rust-bitcoin/rust-bitcoin/pull/3601)
+- Re-design and move `Block` to `primitives` [#3582](https://github.com/rust-bitcoin/rust-bitcoin/pull/3582)
+- Re-export `block::Header` as `BlockHeader` [#3562](https://github.com/rust-bitcoin/rust-bitcoin/pull/3562)
+- Favour `to_vec` over `to_bytes` [#3544](https://github.com/rust-bitcoin/rust-bitcoin/pull/3544)
+
+## Locktimes
+
+Lock times got a bit of work, a big win was:
+
+- Improve lock times - fix off-by-one bug #4468
+
+There was a bit of churn so we are not listing all the PRs, better
+just to take a look at the new and improved API.
+
+If you persist locktimes using `serde` you may want to look at because
+we changed the format:
+
+- Modify locktime serde implementations #4511
+
+## Arbitrary
+
+- Add Arbitrary impl for BlockHash, TxMerkleNode, and Wtxid #4720
+- Add Arbitrary impl for relative::LockTime #4689
+
+## Mutation testing
+
+The whole crate is mutation tested using `cargo-mutants` - BOOM!
+
 # 0.101.0 - 2024-11-15
 
 This is the first "real" release of the `primitives` crate, as such it

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,8 +1,6 @@
 [package]
 name = "bitcoin-primitives"
-# Arbitrary high version number so as to not clash with the original
-# `bitcoin-primitives` crate that we replaced `v0.1.16-alpha`.
-version = "0.101.0"
+version = "1.0.0-rc.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin"


### PR DESCRIPTION
In preparation for releasing the first release candidate bump the version number, add an extensive changelog entry, and update the lockfiles.

FTR this is still a ways off but I got motivated to write the changelog, turns out we did quite a bit.