### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/units/CHANGELOG.md
+++ b/units/CHANGELOG.md
@@ -29,7 +29,7 @@ This changelog is a rolling description of everything that will eventually end u
 * Remove `InputString` from the public API [#3905](https://github.com/rust-bitcoin/rust-bitcoin/pull/3905)
 * Hide the remaining public macros [#3867](https://github.com/rust-bitcoin/rust-bitcoin/pull/3867)
 * Change method return type for `to_unsigned()` [#3769](https://github.com/rust-bitcoin/rust-bitcoin/pull/3769)
-* Change paramater type used for whole bitcoin [#3744](https://github.com/rust-bitcoin/rust-bitcoin/pull/3744)
+* Change parameter type used for whole bitcoin [#3744](https://github.com/rust-bitcoin/rust-bitcoin/pull/3744)
 * Add `Weight::to_kwu_ceil` [#3740](https://github.com/rust-bitcoin/rust-bitcoin/pull/3740)
 * Replace `String` with `InputString` [#3559](https://github.com/rust-bitcoin/rust-bitcoin/pull/3559)
 


### PR DESCRIPTION


- **Bug Fixes:**
  - Fix typo: "paramater" → "parameter" ([#3744])

