### PR TITLE
fix: correct function names in deprecation notes

### DIFF
--- a/bitcoin/examples/script.rs
+++ b/bitcoin/examples/script.rs
@@ -51,7 +51,7 @@ fn main() {
     let hex_inherent = script_code.to_hex_string_prefixed(); // Defined in `ScriptExt`.
     println!("hex created using inherent `to_hex_string_prefixed`: {hex_inherent}");
 
-    // The inverse of `to_hex_string_prefixed` is `from_hex_string_prefixed`.
+    // The inverse of `to_hex_string_prefixed` is `from_hex_prefixed`.
     let decoded = WitnessScriptBuf::from_hex_prefixed(&hex_inherent).unwrap(); // Defined in `ScriptBufExt`.
     assert_eq!(decoded, script_code);
     // We can also parse the output of `to_hex_string_prefixed` using `deserialize_hex`.

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -105,7 +105,7 @@ internal_macros::define_extension_trait! {
         }
 
         /// Constructs a new [`ScriptBuf`] from a hex string.
-        #[deprecated(since = "TBD", note = "use `from_hex_string_no_length_prefix()` instead")]
+        #[deprecated(since = "TBD", note = "use `from_hex_no_length_prefix()` instead")]
         fn from_hex(s: &str) -> Result<Self, hex::HexToBytesError>
             where Self: Sized
         {


### PR DESCRIPTION
While reviewing the code to better understand `script::Builder` (issue #4917), I noticed we referenced functions in deprecation notes and comments that don't exist

This PR: 
- Fix deprecation note: `from_hex_string_no_length_prefix()` → `from_hex_no_length_prefix()`
- Fix comment in script example: `from_hex_string_prefixed` → `from_hex_prefixed`