### PR TITLE
fix: resolve clippy::len_zero lint in Instructions::size_hint

### DIFF
--- a/bitcoin/src/blockdata/script/instruction.rs
+++ b/bitcoin/src/blockdata/script/instruction.rs
@@ -190,7 +190,7 @@ impl<'a> Iterator for Instructions<'a> {
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        if self.data.len() == 0 {
+        if self.data.as_slice().is_empty() {
             (0, Some(0))
         } else {
             // There will not be more instructions than bytes


### PR DESCRIPTION
Replace `self.data.len() == 0` with `self.data.as_slice().is_empty()` to fix clippy::len_zero warning in the size_hint implementation for Instructions iterator.

This addresses the Clippy lint that recommends using is_empty() instead of comparing len() to zero, which is more idiomatic Rust. Uses stable slice.is_empty() via as_slice() to avoid unstable exact_size_is_empty feature.

Fixes: clippy::len_zero warning in bitcoin/src/blockdata/script/instruction.rs:193