### PR TITLE
Fix typo: SIGHASH_SIGNLE → SIGHASH_SINGLE

### DIFF
--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -1591,7 +1591,7 @@ mod tests {
             "SIGHASH_SINGLE| SIGHASH_ANYONECANPAY",
             "SIGHASH_ALL SIGHASH_ANYONECANPAY",
             "SIGHASH_NONE |",
-            "SIGHASH_SIGNLE",
+            "SIGHASH_SINGLE",
             "sighash_none",
             "Sighash_none",
             "SigHash_None",


### PR DESCRIPTION


**Fixed:** Typo in `SIGHASH_SIGNLE` constant name in transaction.rs

