### PR TITLE
chore: fix incorrect comment in sign-tx-taproot.rs

### DIFF
--- a/bitcoin/examples/sign-tx-taproot.rs
+++ b/bitcoin/examples/sign-tx-taproot.rs
@@ -103,7 +103,7 @@ fn receivers_address() -> Address {
         .expect("valid address for mainnet")
 }
 
-/// Constructs a new p2wpkh output locked to the key associated with `wpkh`.
+/// Constructs a new p2tr output locked to the key associated with `internal_key`.
 ///
 /// An utxo is described by the `OutPoint` (txid and index within the transaction that it was
 /// created). Using the out point one can get the transaction by `txid` and using the `vout` get the


### PR DESCRIPTION
Correct function documentation to reflect that it creates a P2TR output using new_p2tr(), not a P2WPKH output as previously stated. Also fix parameter reference from non-existent `wpkh` to actual `internal_key` parameter.