### PR TITLE
docs: fix typo in comment

### DIFF
--- a/docs/policy.md
+++ b/docs/policy.md
@@ -94,7 +94,7 @@ pub mod foo {
 
     /// Some function.
     pub some_function() -> SomeError { 
-        // Example rror logic
+        // Example error logic
         SomeError::Foo(FooError { ... })
     }
     


### PR DESCRIPTION
rror -> error