### PR TITLE
fix: improve comment accuracy in ecdsa-psbt example

### DIFF
--- a/bitcoin/examples/ecdsa-psbt.rs
+++ b/bitcoin/examples/ecdsa-psbt.rs
@@ -90,7 +90,7 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-// We cache the pubkeys for convenience because it requires a scep context to convert the private key.
+// We cache the pubkeys for convenience because it requires a secp context to convert the private key.
 /// An example of an offline signer i.e., a cold-storage device.
 struct ColdStorage {
     /// The master extended private key.
@@ -150,7 +150,7 @@ impl ColdStorage {
     }
 }
 
-/// An example of an watch-only online wallet.
+/// An example of a watch-only online wallet.
 struct WatchOnly {
     /// The xpub for account 0 derived from derivation path "m/84h/0h/0h".
     account_0_xpub: Xpub,


### PR DESCRIPTION
Correct `scep context `to `secp context` on line 93
Fix article usage: `an watch-only` to `a watch-only` on line 153