### PR TITLE
chore: remove redundant .to_string() call in embedded example

### DIFF
--- a/bitcoin/embedded/src/main.rs
+++ b/bitcoin/embedded/src/main.rs
@@ -46,7 +46,7 @@ fn main() -> ! {
     let address = Address::p2wpkh(pubkey, Network::Bitcoin);
     hprintln!("Address: {}", address).unwrap();
 
-    assert_eq!(address.to_string(), "bc1qpx9t9pzzl4qsydmhyt6ctrxxjd4ep549np9993".to_string());
+    assert_eq!(address.to_string(), "bc1qpx9t9pzzl4qsydmhyt6ctrxxjd4ep549np9993");
     // exit QEMU
     // NOTE do not run this on hardware; it can corrupt OpenOCD state
     debug::exit(debug::EXIT_SUCCESS);


### PR DESCRIPTION
Remove unnecessary .to_string() call on string literal in assert_eq! macro. The assert_eq! macro can compare String and &str directly through PartialEq<&str> for String, making the .to_string() call redundant and creating an unnecessary allocation