### PR TITLE
fix: correct grammatical errors in example code comments

### DIFF
--- a/bitcoin/examples/script.rs
+++ b/bitcoin/examples/script.rs
@@ -65,7 +65,7 @@ fn main() {
     let decoded: WitnessScriptBuf = encode::deserialize_hex(&encoded).unwrap();
     assert_eq!(decoded, script_code);
 
-    // And we can mix these to calls because both include the length prefix.
+    // And we can mix these two calls because both include the length prefix.
     let encoded = encode::serialize_hex(&script_code);
     let decoded = WitnessScriptBuf::from_hex_prefixed(&encoded).unwrap();
     assert_eq!(decoded, script_code);

--- a/bitcoin/examples/serde.rs
+++ b/bitcoin/examples/serde.rs
@@ -19,7 +19,7 @@ pub struct Foo {
 
     /// This works but it's little-endian which may be hard to read.
     ///
-    /// Integer wrapper types are more readable if the explicitly use a unit.
+    /// Integer wrapper types are more readable if they explicitly use a unit.
     #[serde(with = "consensus::serde::With::<Hex>")]
     this: Amount,
 


### PR DESCRIPTION
- Fix missing `w` in `these two calls` in script.rs
- Fix pronoun `the` to `they` in serde.rs comment