### PR TITLE
Add bench for `sha3_256`

### DIFF
--- a/hashes/src/sha3_256/benches.rs
+++ b/hashes/src/sha3_256/benches.rs
@@ -1,0 +1,33 @@
+use test::Bencher;
+
+use crate::{Hash, HashEngine};
+
+#[bench]
+pub fn sha3_256_10(bh: &mut Bencher) {
+    let mut engine = crate::sha3_256::Hash::engine();
+    let bytes = [1u8; 10];
+    bh.iter(|| {
+        engine.input(&bytes);
+    });
+    bh.bytes = bytes.len() as u64;
+}
+
+#[bench]
+pub fn sha3_256_1k(bh: &mut Bencher) {
+    let mut engine = crate::sha3_256::Hash::engine();
+    let bytes = [1u8; 1024];
+    bh.iter(|| {
+        engine.input(&bytes);
+    });
+    bh.bytes = bytes.len() as u64;
+}
+
+#[bench]
+pub fn sha3_256_64k(bh: &mut Bencher) {
+    let mut engine = crate::sha3_256::Hash::engine();
+    let bytes = [1u8; 65536];
+    bh.iter(|| {
+        engine.input(&bytes);
+    });
+    bh.bytes = bytes.len() as u64;
+}

--- a/hashes/src/sha3_256/mod.rs
+++ b/hashes/src/sha3_256/mod.rs
@@ -17,6 +17,8 @@
 //
 // To read this file, follow the example code: https://keccak.team/keccak_specs_summary.html
 // For a detailed specification: https://keccak.team/files/Keccak-reference-3.0.pdf
+#[cfg(bench)]
+mod benches;
 use core::fmt;
 
 crate::internal_macros::general_hash_type! {


### PR DESCRIPTION
Following up on the addition of the SHA3-256 hash, it may be worthwhile to strive for improvements. In my runs of the benchmark, small slices perform poorly, indicating to me there may be something wrong with the padding. As input size increases the hash is on the order of the slower hashes in the library, which is acceptable for the use case. Those that want to try to improve the hash will need this bench.