### PR TITLE
bip158: Return no match for empty query

### DIFF
--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -306,7 +306,7 @@ impl GcsFilterReader {
         // sort
         mapped.sort_unstable();
         if mapped.is_empty() {
-            return Ok(true);
+            return Ok(false);
         }
         if n_elements == 0 {
             return Ok(false);


### PR DESCRIPTION
Perhaps this is up for debate, but considering the use case of checking for inclusions in a block, an empty query should not return `true` for any element, as no elements exist in the query. If the user happens to have no scripts to query for whatever reason, they will think every block is relevant.