### PR TITLE
simplify is_op_return() using map_or instead of match

### DIFF
--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -401,10 +401,7 @@ internal_macros::define_extension_trait! {
         /// [`is_standard_op_return()`](Self::is_standard_op_return) instead.
         #[inline]
         fn is_op_return(&self) -> bool {
-            match self.as_bytes().first() {
-                Some(b) => *b == OP_RETURN.to_u8(),
-                None => false,
-            }
+            self.as_bytes().first().is_some_and(|&b| b == OP_RETURN.to_u8())
         }
 
         /// Check if this is an OP_RETURN that obeys Bitcoin Core standardness policy.


### PR DESCRIPTION
Replace explicit match expression with more idiomatic map_or method in Script::is_op_return(). This change maintains identical semantics while making the code more concise and following Rust best practices