### PR TITLE
Standard I/O ops for encoders

### DIFF
--- a/consensus_encoding/src/lib.rs
+++ b/consensus_encoding/src/lib.rs
@@ -14,8 +14,17 @@
 #![warn(deprecated_in_future)]
 #![doc(test(attr(warn(unused))))]
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
+
 mod encode;
 
+#[cfg(feature = "alloc")]
+pub use self::encode::encode_to_vec;
+#[cfg(feature = "std")]
+pub use self::encode::encode_to_writer;
 pub use self::encode::encoders::{
     ArrayEncoder, BytesEncoder, Encoder2, Encoder3, Encoder4, Encoder6,
 };

--- a/consensus_encoding/tests/encode.rs
+++ b/consensus_encoding/tests/encode.rs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Tests for encoder free functions.
+
+#[cfg(feature = "std")]
+use std::io::{Cursor, Write};
+
+use consensus_encoding::{ArrayEncoder, Encodable};
+
+// Simple test type that implements Encodable.
+struct TestData(u32);
+
+impl Encodable for TestData {
+    type Encoder<'s>
+        = ArrayEncoder<4>
+    where
+        Self: 's;
+
+    fn encoder(&self) -> Self::Encoder<'_> {
+        ArrayEncoder::without_length_prefix(self.0.to_le_bytes())
+    }
+}
+
+// Test with a type that creates an empty encoder.
+struct EmptyData;
+
+impl Encodable for EmptyData {
+    type Encoder<'s>
+        = ArrayEncoder<0>
+    where
+        Self: 's;
+
+    fn encoder(&self) -> Self::Encoder<'_> { ArrayEncoder::without_length_prefix([]) }
+}
+
+#[test]
+#[cfg(feature = "std")]
+fn encode_std_writer() {
+    let data = TestData(0x1234_5678);
+
+    let mut cursor = Cursor::new(Vec::new());
+    consensus_encoding::encode_to_writer(&data, &mut cursor).unwrap();
+
+    let result = cursor.into_inner();
+    assert_eq!(result, vec![0x78, 0x56, 0x34, 0x12]);
+}
+
+#[test]
+#[cfg(feature = "alloc")]
+fn encode_vec() {
+    let data = TestData(0xDEAD_BEEF);
+    let vec = consensus_encoding::encode_to_vec(&data);
+    assert_eq!(vec, vec![0xEF, 0xBE, 0xAD, 0xDE]);
+}
+
+#[test]
+#[cfg(feature = "alloc")]
+fn encode_vec_empty_data() {
+    let data = EmptyData;
+    let result = consensus_encoding::encode_to_vec(&data);
+    assert!(result.is_empty());
+}
+
+#[test]
+#[cfg(feature = "std")]
+fn encode_std_writer_empty_data() {
+    let data = EmptyData;
+    let mut cursor = Cursor::new(Vec::new());
+    consensus_encoding::encode_to_writer(&data, &mut cursor).unwrap();
+
+    let result = cursor.into_inner();
+    assert!(result.is_empty());
+}
+
+#[test]
+#[cfg(feature = "std")]
+fn encode_std_writer_io_error() {
+    // Test writer that always fails.
+    struct FailingWriter;
+
+    impl Write for FailingWriter {
+        fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::other("test error"))
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> { Ok(()) }
+    }
+
+    let data = TestData(0x1234_5678);
+    let mut writer = FailingWriter;
+
+    let result = consensus_encoding::encode_to_writer(&data, &mut writer);
+
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::Other);
+}

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -14,11 +14,11 @@ exclude = ["tests", "contrib"]
 
 [features]
 default = ["std"]
-std = ["alloc", "internals/std"]
-alloc = ["internals/alloc","serde?/alloc"]
+std = ["alloc", "internals/std", "encoding?/std"]
+alloc = ["internals/alloc", "serde?/alloc", "encoding?/alloc"]
 
 [dependencies]
-encoding = { package = "consensus-encoding", path = "../consensus_encoding", optional = true }
+encoding = { package = "consensus-encoding", path = "../consensus_encoding", default-features = false, optional = true }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.4.0" }
 
 serde = { version = "1.0.195", default-features = false, features = ["derive"], optional = true }


### PR DESCRIPTION
Another little addition to the new encoders, I am not sure how controversial some of this is, so opening as a draft in case better as just food for thought.

* first patch fixes up the units dependency on consensus_encoding which wasn't exercising std dependent code before.
* second patch adds helper methods for allocation and std I/O write operations which allows encoders to easily dump bytes into a vector or writer

This is largely inspired by Kix's I/O driver, but slimmed down. I initially switched it to an extension trait for Encoder instead of adding more methods to encoder itself. Was convinced the hit on discover-ablity wasn't worth it. Plus a little awkward to have on all `Encoder` implementing types which are never directly called to be encoded (usually nested in a transaction of block).

push_decode's version has a marker trait, [BufWrite](https://github.com/Kixunil/push_decode/blob/df28e2bdab14d30323a5375cc6cbcd59f60a1d7c/src/lib.rs#L395), which I dropped in favor of documentation. This makes the interface simple, but potential foot guns for callers.

Looking a bit further ahead, I figure stuff like async drivers would live in a separate crate to avoid even the optional dependency here?