### PR TITLE
perf: optimize Vec creation in bip152 tests

### DIFF
--- a/bitcoin/src/bip152.rs
+++ b/bitcoin/src/bip152.rs
@@ -544,7 +544,7 @@ mod test {
         for testcase in testcases {
             {
                 // test deserialization
-                let mut raw: Vec<u8> = [0u8; 32].to_vec();
+                let mut raw: Vec<u8> = vec![0u8; 32];
                 raw.extend(testcase.0.clone());
                 let btr: BlockTransactionsRequest = deserialize(&raw.to_vec()).unwrap();
                 assert_eq!(testcase.1, btr.indexes);


### PR DESCRIPTION
Replace `[0u8; 32].to_vec()` with `vec![0u8; 32]` to avoid unnecessary intermediate array allocation on the stack. The `vec!` macro directly allocates on the heap, eliminating the copy operation and improving both memory usage and performance.