### PR TITLE
Do not enable secp rand feature

### DIFF
--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -33,7 +33,7 @@ hex = { package = "hex-conservative", version = "0.3.0", default-features = fals
 internals = { package = "bitcoin-internals", path = "../internals", features = ["alloc", "hex"] }
 io = { package = "bitcoin-io", path = "../io", default-features = false, features = ["alloc", "hashes"] }
 primitives = { package = "bitcoin-primitives", path = "../primitives", default-features = false, features = ["alloc", "hex"] }
-secp256k1 = { version = "0.30.0", default-features = false, features = ["hashes", "alloc", "rand"] }
+secp256k1 = { version = "0.30.0", default-features = false, features = ["hashes", "alloc"] }
 units = { package = "bitcoin-units", path = "../units", default-features = false, features = ["alloc"] }
 
 arbitrary = { version = "1.4.1", optional = true }


### PR DESCRIPTION
Patch f80cf2cb2aa318978da3a6c5df49d82c49344763 (PR #4154) somehow got past review with a change that unconditionally enabled `rand` feature for `secp256k1` - this is incorrect.

There is no mention of the change in the PR description or review comments - review fail.