### PR TITLE
primitives: Implement `Encodable` for `&Script<T>`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -209,6 +209,7 @@ dependencies = [
 name = "consensus-encoding"
 version = "0.0.0"
 dependencies = [
+ "bitcoin-internals",
  "bitcoin_hashes 0.16.0",
 ]
 

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -211,6 +211,7 @@ dependencies = [
 name = "consensus-encoding"
 version = "0.0.0"
 dependencies = [
+ "bitcoin-internals",
  "bitcoin_hashes 0.16.0",
 ]
 

--- a/consensus_encoding/Cargo.toml
+++ b/consensus_encoding/Cargo.toml
@@ -14,11 +14,12 @@ exclude = ["tests", "contrib"]
 
 [features]
 default = ["std"]
-std = ["alloc"]
-alloc = []
+std = ["alloc", "internals/std"]
+alloc = ["internals/alloc"]
 
 [dependencies]
 hashes = { package = "bitcoin_hashes", path = "../hashes", default-features = false }
+internals = { package = "bitcoin-internals", path = "../internals" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/consensus_encoding/src/encode/encoders.rs
+++ b/consensus_encoding/src/encode/encoders.rs
@@ -155,3 +155,41 @@ impl<
     fn current_chunk(&self) -> Option<&[u8]> { self.inner.current_chunk() }
     fn advance(&mut self) -> bool { self.inner.advance() }
 }
+
+#[cfg(test)]
+#[cfg(feature = "alloc")]
+mod tests {
+    use alloc::vec::Vec;
+
+    use super::*;
+
+    // Run the encoder i.e., use it to encode into a vector.
+    fn run_encoder<'e>(mut encoder: impl Encoder<'e>) -> Vec<u8> {
+        let mut vec = Vec::new();
+        while let Some(chunk) = encoder.current_chunk() {
+            vec.extend_from_slice(chunk);
+            encoder.advance();
+        }
+        vec
+    }
+
+    #[test]
+    fn encode_byte_slice_without_prefix() {
+        let obj = [1u8, 2, 3];
+
+        let encoder = BytesEncoder::without_length_prefix(&obj);
+        let got = run_encoder(encoder);
+
+        assert_eq!(got, obj);
+    }
+
+    #[test]
+    fn encode_empty_byte_slice_without_prefix() {
+        let obj = [];
+
+        let encoder = BytesEncoder::without_length_prefix(&obj);
+        let got = run_encoder(encoder);
+
+        assert_eq!(got, obj);
+    }
+}

--- a/consensus_encoding/src/encode/encoders.rs
+++ b/consensus_encoding/src/encode/encoders.rs
@@ -11,24 +11,49 @@
 //! For implementing these newtypes, we provide the [`encoder_newtype`] macro.
 //!
 
+use internals::array_vec::ArrayVec;
+use internals::compact_size;
+
 use super::Encoder;
+
+/// The maximum length of a compact size encoding.
+const SIZE: usize = compact_size::MAX_ENCODING_SIZE;
 
 /// An encoder for a single byte slice.
 pub struct BytesEncoder<'sl> {
     sl: Option<&'sl [u8]>,
+    compact_size: Option<ArrayVec<u8, SIZE>>,
 }
 
 impl<'sl> BytesEncoder<'sl> {
     /// Constructs a byte encoder which encodes the given byte slice, with no length prefix.
-    pub fn without_length_prefix(sl: &'sl [u8]) -> Self { Self { sl: Some(sl) } }
+    pub fn without_length_prefix(sl: &'sl [u8]) -> Self {
+        Self { sl: Some(sl), compact_size: None }
+    }
+
+    /// Constructs a byte encoder which encodes the given byte slice, with the length prefix.
+    pub fn with_length_prefix(sl: &'sl [u8]) -> Self {
+        Self { sl: Some(sl), compact_size: Some(compact_size::encode(sl.len())) }
+    }
 }
 
 impl<'e, 'sl> Encoder<'e> for BytesEncoder<'sl> {
-    fn current_chunk(&self) -> Option<&[u8]> { self.sl }
+    fn current_chunk(&self) -> Option<&[u8]> {
+        if let Some(compact_size) = self.compact_size.as_ref() {
+            Some(compact_size)
+        } else {
+            self.sl
+        }
+    }
 
     fn advance(&mut self) -> bool {
-        self.sl = None;
-        false
+        if self.compact_size.is_some() {
+            self.compact_size = None;
+            true
+        } else {
+            self.sl = None;
+            false
+        }
     }
 }
 
@@ -191,5 +216,27 @@ mod tests {
         let got = run_encoder(encoder);
 
         assert_eq!(got, obj);
+    }
+
+    #[test]
+    fn encode_byte_slice_with_prefix() {
+        let obj = [1u8, 2, 3];
+
+        let encoder = BytesEncoder::with_length_prefix(&obj);
+        let got = run_encoder(encoder);
+
+        let want = [3u8, 1, 2, 3];
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn encode_empty_byte_slice_with_prefix() {
+        let obj = [];
+
+        let encoder = BytesEncoder::with_length_prefix(&obj);
+        let got = run_encoder(encoder);
+
+        let want = [0u8];
+        assert_eq!(got, want);
     }
 }

--- a/consensus_encoding/src/encode/mod.rs
+++ b/consensus_encoding/src/encode/mod.rs
@@ -69,7 +69,11 @@ macro_rules! encoder_newtype{
 ///
 /// Consumes and returns the hash engine to make it easier to call
 /// [`hashes::HashEngine::finalize`] directly on the result.
-pub fn encode_to_hash_engine<T: Encodable, H: hashes::HashEngine>(object: &T, mut engine: H) -> H {
+pub fn encode_to_hash_engine<T, H>(object: &T, mut engine: H) -> H
+where
+    T: Encodable + ?Sized,
+    H: hashes::HashEngine,
+{
     let mut encoder = object.encoder();
     while let Some(sl) = encoder.current_chunk() {
         engine.input(sl);
@@ -80,7 +84,10 @@ pub fn encode_to_hash_engine<T: Encodable, H: hashes::HashEngine>(object: &T, mu
 
 /// Encodes an object into a vector.
 #[cfg(feature = "alloc")]
-pub fn encode_to_vec<T: Encodable>(object: &T) -> Vec<u8> {
+pub fn encode_to_vec<T>(object: &T) -> Vec<u8>
+where
+    T: Encodable + ?Sized,
+{
     let mut encoder = object.encoder();
     let mut vec = Vec::new();
     while let Some(chunk) = encoder.current_chunk() {
@@ -103,10 +110,11 @@ pub fn encode_to_vec<T: Encodable>(object: &T) -> Vec<u8> {
 ///
 /// Returns any I/O error encountered while writing to the writer.
 #[cfg(feature = "std")]
-pub fn encode_to_writer<T: Encodable, W: std::io::Write>(
-    object: &T,
-    mut writer: W,
-) -> Result<(), std::io::Error> {
+pub fn encode_to_writer<T, W>(object: &T, mut writer: W) -> Result<(), std::io::Error>
+where
+    T: Encodable + ?Sized,
+    W: std::io::Write,
+{
     let mut encoder = object.encoder();
     while let Some(chunk) = encoder.current_chunk() {
         writer.write_all(chunk)?;

--- a/consensus_encoding/src/encode/mod.rs
+++ b/consensus_encoding/src/encode/mod.rs
@@ -55,7 +55,7 @@ macro_rules! encoder_newtype{
         $(#[$($struct_attr)*])*
         pub struct $name$(<$lt>)?($encoder);
 
-        impl<'e $(, $lt)?> $crate::Encoder<'e> for $name$(<$lt>)? {
+        impl<'e> $crate::Encoder<'e> for $name$(<$lt>)? {
             #[inline]
             fn current_chunk(&self) -> Option<&[u8]> { self.0.current_chunk() }
 

--- a/internals/src/compact_size.rs
+++ b/internals/src/compact_size.rs
@@ -18,7 +18,7 @@ use crate::ToU64;
 pub const MAX_ENCODABLE_VALUE: u64 = 0x0200_0000;
 
 /// The maximum length of an encoding.
-const MAX_ENCODING_SIZE: usize = 9;
+pub const MAX_ENCODING_SIZE: usize = 9;
 
 /// Returns the number of bytes used to encode this `CompactSize` value.
 ///

--- a/primitives/src/script/mod.rs
+++ b/primitives/src/script/mod.rs
@@ -26,7 +26,7 @@ use crate::prelude::{Borrow, BorrowMut, Box, Cow, ToOwned, Vec};
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
 pub use self::{
-    borrowed::Script,
+    borrowed::{Script, ScriptEncoder},
     owned::ScriptBuf,
     tag::{Tag, RedeemScriptTag, ScriptPubKeyTag, ScriptSigTag, TapScriptTag, WitnessScriptTag},
 };


### PR DESCRIPTION
Includes a bunch of preparatory clean up as well as a patch to add support to `BytesEncoder` to encode with length prefix.
