### PR TITLE
Expand import style policy to cover more low-level crates

### DIFF
--- a/contrib/check-for-policy-violations.sh
+++ b/contrib/check-for-policy-violations.sh
@@ -21,7 +21,7 @@ main() {
 # Greps patch for imports that violate the policy, returns true if an
 # violations are found.
 low_level_import_usage() {
-    local crates=("units" "primitives")
+    local crates=("units" "primitives" "hashes" "internals" "io" "base58")
     local found_violation=false
     local violations;
 


### PR DESCRIPTION
 This PR expands the import style policy enforcement to cover additional low-level workspace crates (`hashes`, `internals`, `io`, `base58`) beyond the currently enforced `units` and `primitives`.

closes #4867 