### PR TITLE
Implement `SliceEncoder`

### DIFF
--- a/consensus_encoding/Cargo.toml
+++ b/consensus_encoding/Cargo.toml
@@ -25,6 +25,10 @@ internals = { package = "bitcoin-internals", path = "../internals" }
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
+[[example]]
+name = "encoder"
+required-features = ["alloc"]
+
 [lints.rust]
 unexpected_cfgs = { level = "deny", check-cfg = [] }
 

--- a/consensus_encoding/contrib/test_vars.sh
+++ b/consensus_encoding/contrib/test_vars.sh
@@ -11,4 +11,4 @@ FEATURES_WITH_STD=""
 FEATURES_WITHOUT_STD="alloc"
 
 # Run these examples.
-EXAMPLES=""
+EXAMPLES="encoder:alloc"

--- a/consensus_encoding/examples/encoder.rs
+++ b/consensus_encoding/examples/encoder.rs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Example of creating an encoder that encodes a slice of encodable objects.
+
+use consensus_encoding as encoding;
+use encoding::{ArrayEncoder, BytesEncoder, Encodable, Encoder2, SliceEncoder};
+
+fn main() {
+    let v = vec![Inner::new(0xcafe_babe), Inner::new(0xdead_beef)];
+    let b = vec![0xab, 0xcd];
+
+    let adt = Adt::new(v, b);
+    let encoded = encoding::encode_to_vec(&adt);
+
+    let want = [0x02, 0xca, 0xfe, 0xba, 0xbe, 0xde, 0xad, 0xbe, 0xef, 0xab, 0xcd];
+    assert_eq!(encoded, want);
+}
+
+/// Some abstract data type.
+struct Adt {
+    v: Vec<Inner>,
+    b: Vec<u8>,
+}
+
+impl Adt {
+    /// Constructs a new `Adt`.
+    pub fn new(v: Vec<Inner>, b: Vec<u8>) -> Self { Self { v, b } }
+}
+
+encoding::encoder_newtype! {
+    /// The encoder for the [`Adt`] type.
+    pub struct AdtEncoder<'e>(Encoder2<SliceEncoder<'e, Inner>, BytesEncoder<'e>>);
+}
+
+impl Encodable for Adt {
+    type Encoder<'a>
+        = AdtEncoder<'a>
+    where
+        Self: 'a;
+
+    fn encoder(&self) -> Self::Encoder<'_> {
+        let a = SliceEncoder::with_length_prefix(&self.v);
+        let b = BytesEncoder::without_length_prefix(self.b.as_ref());
+
+        AdtEncoder(Encoder2::new(a, b))
+    }
+}
+
+/// A simple data type to use as list item.
+#[derive(Debug, Default, Clone)]
+pub struct Inner(u32);
+
+impl Inner {
+    /// Constructs a new `Inner`.
+    pub fn new(x: u32) -> Self { Self(x) }
+
+    /// Returns some meaningful 4 byte array for this type.
+    pub fn to_array(&self) -> [u8; 4] { self.0.to_be_bytes() }
+}
+
+encoding::encoder_newtype! {
+    /// The encoder for the [`Inner`] type.
+    pub struct InnerEncoder(ArrayEncoder<4>);
+}
+
+impl Encodable for Inner {
+    type Encoder<'e> = InnerEncoder;
+    fn encoder(&self) -> Self::Encoder<'_> {
+        InnerEncoder(ArrayEncoder::without_length_prefix(self.to_array()))
+    }
+}

--- a/consensus_encoding/src/lib.rs
+++ b/consensus_encoding/src/lib.rs
@@ -31,6 +31,6 @@ pub use self::encode::encode_to_vec;
 #[cfg(feature = "std")]
 pub use self::encode::encode_to_writer;
 pub use self::encode::encoders::{
-    ArrayEncoder, BytesEncoder, Encoder2, Encoder3, Encoder4, Encoder6,
+    ArrayEncoder, BytesEncoder, Encoder2, Encoder3, Encoder4, Encoder6, SliceEncoder,
 };
 pub use self::encode::{encode_to_hash_engine, Encodable, Encoder};

--- a/consensus_encoding/tests/wrappers.rs
+++ b/consensus_encoding/tests/wrappers.rs
@@ -1,0 +1,111 @@
+//! Test using wrapper types as we expect the lib to be used.
+
+#![cfg(feature = "std")]
+
+use consensus_encoding as encoding;
+use encoding::{ArrayEncoder, BytesEncoder, Encodable, Encoder2};
+
+encoding::encoder_newtype! {
+    /// An encoder that uses an inner `ArrayEncoder`.
+    pub struct TestArrayEncoder(ArrayEncoder<4>);
+}
+
+encoding::encoder_newtype! {
+    /// An encoder that uses an inner `BytesEncoder`.
+    pub struct TestBytesEncoder<'e>(BytesEncoder<'e>);
+}
+
+#[test]
+fn array_encoder() {
+    #[derive(Debug, Default, Clone)]
+    pub struct Test(u32);
+
+    impl Encodable for Test {
+        type Encoder<'e> = TestArrayEncoder;
+        fn encoder(&self) -> Self::Encoder<'_> {
+            TestArrayEncoder(ArrayEncoder::without_length_prefix(self.0.to_le_bytes()))
+        }
+    }
+
+    let t = Test(0xcafe_babe); // Encodes using an array.
+
+    let want = [0xbe, 0xba, 0xfe, 0xca];
+    let got = encoding::encode_to_vec(&t);
+
+    assert_eq!(got, want);
+}
+
+#[test]
+fn bytes_encoder_without_length_prefix() {
+    #[derive(Debug, Default, Clone)]
+    pub struct Test(Vec<u8>);
+
+    impl Encodable for Test {
+        type Encoder<'e>
+            = TestBytesEncoder<'e>
+        where
+            Self: 'e;
+
+        fn encoder(&self) -> Self::Encoder<'_> {
+            TestBytesEncoder(BytesEncoder::without_length_prefix(self.0.as_ref()))
+        }
+    }
+
+    let t = Test(vec![0xca, 0xfe]);
+
+    let want = [0xca, 0xfe];
+    let got = encoding::encode_to_vec(&t);
+
+    assert_eq!(got, want);
+}
+
+#[test]
+fn bytes_encoder_with_length_prefix() {
+    #[derive(Debug, Default, Clone)]
+    pub struct Test(Vec<u8>);
+
+    impl Encodable for Test {
+        type Encoder<'e>
+            = TestBytesEncoder<'e>
+        where
+            Self: 'e;
+
+        fn encoder(&self) -> Self::Encoder<'_> {
+            TestBytesEncoder(BytesEncoder::with_length_prefix(self.0.as_ref()))
+        }
+    }
+
+    let t = Test(vec![0xca, 0xfe]);
+
+    let want = [0x02, 0xca, 0xfe];
+    let got = encoding::encode_to_vec(&t);
+
+    assert_eq!(got, want);
+}
+
+#[test]
+fn two_encoder() {
+    #[derive(Debug, Default, Clone)]
+    pub struct Test {
+        a: Vec<u8>, // Encode without prefix.
+        b: Vec<u8>, // Encode with prefix.
+    }
+
+    impl Encodable for Test {
+        type Encoder<'e> = Encoder2<TestBytesEncoder<'e>, TestBytesEncoder<'e>>;
+
+        fn encoder(&self) -> Self::Encoder<'_> {
+            let a = TestBytesEncoder(BytesEncoder::without_length_prefix(self.a.as_ref()));
+            let b = TestBytesEncoder(BytesEncoder::with_length_prefix(self.b.as_ref()));
+
+            Encoder2::new(a, b)
+        }
+    }
+
+    let t = Test { a: vec![0xca, 0xfe], b: (vec![0xba, 0xbe]) };
+
+    let want = [0xca, 0xfe, 0x02, 0xba, 0xbe];
+    let got = encoding::encode_to_vec(&t);
+
+    assert_eq!(got, want);
+}


### PR DESCRIPTION
Add some integration test for how we expect the `consensus_encoding` crate to be used (i.e., with wrapper encoder types). Then implement a `SliceEncoder` - BOOM!