### PR TITLE
fix: Use local variable instead of macro parameter in concat_bytes_to…

### DIFF
--- a/internals/src/const_tools.rs
+++ b/internals/src/const_tools.rs
@@ -41,7 +41,7 @@ macro_rules! concat_bytes_to_arr {
         let mut output = [0u8; $len];
         let mut i = 0;
         while i < a.len() {
-            output[i] = $a[i];
+            output[i] = a[i];
             i += 1;
         }
         while i < a.len() + b.len() {


### PR DESCRIPTION
Fix inconsistent variable usage in concat_bytes_to_arr macro where line 44 was using the macro parameter `$a[i]` instead of the local variable `a[i]`. This was inconsistent with the macro's design which creates local variables `a` and `b` to avoid repeated evaluation of the macro parameters, and with line 48 which correctly uses the local variable `b[i - a.len()]`