### PR TITLE
fix function name in panic message for chain_hash_and_genesis_block

### DIFF
--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -388,7 +388,7 @@ mod test {
             Network::Testnet(TestnetVersion::V4) => {},
             Network::Signet => {},
             Network::Regtest => {},
-            _ => panic!("update ChainHash::using_genesis_block and chain_hash_genesis_block with new variants"),
+            _ => panic!("update ChainHash::using_genesis_block and chain_hash_and_genesis_block with new variants"),
         }
     }
 


### PR DESCRIPTION
Correct the function name reference in the panic message 
from `chain_hash_genesis_block` to `chain_hash_and_genesis_block` to match the actual function name