### PR TITLE
Fix CI: Update `arbitrary` and update lock files 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -311,6 +311,8 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
+      matrix:
+        dep: [recent]
     steps:
       - name: "Checkout repo"
         uses: actions/checkout@v5
@@ -320,6 +322,8 @@ jobs:
           toolchain: ${{ needs.Prepare.outputs.nightly_version }}
       - name: "Install cargo-public-api"
         run: cargo install --locked cargo-public-api --version 0.49.0
+      - name: "Set dependencies"
+        run: cp Cargo-${{ matrix.dep }}.lock Cargo.lock
       - name: "Run API checker script"
         run: ./contrib/check-for-api-changes.sh
 

--- a/contrib/check-for-api-changes.sh
+++ b/contrib/check-for-api-changes.sh
@@ -65,12 +65,12 @@ check_for_changes() {
 
 # Run cargo when --all-features is not used.
 run_cargo() {
-    RUSTDOCFLAGS="$RUSTDOCFLAGS" cargo +"$NIGHTLY" public-api --simplified "$@"
+    RUSTDOCFLAGS="$RUSTDOCFLAGS" cargo +"$NIGHTLY" --locked public-api --simplified "$@"
 }
 
 # Run cargo with all features enabled.
 run_cargo_all_features() {
-    cargo +"$NIGHTLY" public-api --simplified --all-features
+    cargo +"$NIGHTLY" --locked public-api --simplified --all-features
 }
 
 need_nightly() {

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -25,7 +25,7 @@ internals = { package = "bitcoin-internals", path = "../internals", default-feat
 io = { package = "bitcoin-io", path = "../io", default-features = false }
 units = { package = "bitcoin-units", path = "../units", default-features = false }
 
-arbitrary = { version = "1.4", optional = true }
+arbitrary = { version = "1.4.1", optional = true }
 
 [dev-dependencies]
 hex_lit = "0.1.1"


### PR DESCRIPTION
CI is currently broken on `master` because a series of recent `serde` updated changed the paths to parts of their API that appear in our API files. Fix this by using our recent lockfile in our check-API CI job.

Also add a patch to fix `just update-lock-files`, which felt that the `arbitrary` dep in `p2p` was underspecified.

(Description written by apoelstra)