### PR TITLE
primitives: Implement decoding traits 

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -134,6 +134,7 @@ dependencies = [
  "bitcoin_hashes 0.16.0",
  "consensus-encoding",
  "hex-conservative 0.3.0",
+ "hex_lit",
  "serde",
  "serde_json",
 ]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -133,6 +133,7 @@ dependencies = [
  "bitcoin_hashes 0.16.0",
  "consensus-encoding",
  "hex-conservative 0.3.0",
+ "hex_lit",
  "serde",
  "serde_json",
 ]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -36,6 +36,7 @@ serde = { version = "1.0.195", default-features = false, features = ["derive", "
 [dev-dependencies]
 serde_json = "1.0.68"
 bincode = "1.3.1"
+hex_lit = "0.1.1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/primitives/src/hash_types/mod.rs
+++ b/primitives/src/hash_types/mod.rs
@@ -19,10 +19,10 @@ mod wtxid;
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
 pub use self::{
-    block_hash::{BlockHash, BlockHashEncoder},
+    block_hash::{BlockHash, BlockHashDecoder, BlockHashDecoderError, BlockHashEncoder},
     ntxid::Ntxid,
-    transaction_merkle_node::{TxMerkleNode, TxMerkleNodeEncoder},
-    txid::Txid,
+    transaction_merkle_node::{TxMerkleNode, TxMerkleNodeEncoder, TxMerkleNodeDecoder, TxMerkleNodeDecoderError},
+    txid::{Txid},
     wtxid::Wtxid,
     witness_commitment::WitnessCommitment,
     witness_merkle_node::WitnessMerkleNode,

--- a/primitives/src/hash_types/transaction_merkle_node.rs
+++ b/primitives/src/hash_types/transaction_merkle_node.rs
@@ -2,7 +2,7 @@
 
 //! The `TxMerkleNode` type.
 
-#[cfg(not(feature = "hex"))]
+use core::convert::Infallible;
 use core::fmt;
 #[cfg(feature = "hex")]
 use core::str;
@@ -12,6 +12,7 @@ use arbitrary::{Arbitrary, Unstructured};
 use hashes::sha256d;
 #[cfg(feature = "hex")]
 use hex::FromHex as _;
+use internals::write_err;
 
 /// A hash of the Merkle tree branch or root for transactions.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -34,4 +35,63 @@ impl encoding::Encodable for TxMerkleNode {
     fn encoder(&self) -> Self::Encoder<'_> {
         TxMerkleNodeEncoder(encoding::ArrayEncoder::without_length_prefix(self.to_byte_array()))
     }
+}
+
+/// The decoder for the [`TxMerkleNode`] type.
+pub struct TxMerkleNodeDecoder(encoding::ArrayDecoder<32>);
+
+impl TxMerkleNodeDecoder {
+    /// Constructs a new [`TxMerkleNode`] decoder.
+    pub fn new() -> Self { Self(encoding::ArrayDecoder::new()) }
+}
+
+impl Default for TxMerkleNodeDecoder {
+    fn default() -> Self { Self::new() }
+}
+
+impl encoding::Decoder for TxMerkleNodeDecoder {
+    type Output = TxMerkleNode;
+    type Error = TxMerkleNodeDecoderError;
+
+    #[inline]
+    fn push_bytes(&mut self, bytes: &mut &[u8]) -> Result<bool, Self::Error> {
+        Ok(self.0.push_bytes(bytes)?)
+    }
+
+    #[inline]
+    fn end(self) -> Result<Self::Output, Self::Error> {
+        let a = self.0.end()?;
+        Ok(TxMerkleNode::from_byte_array(a))
+    }
+
+    #[inline]
+    fn read_limit(&self) -> usize { self.0.read_limit() }
+}
+
+impl encoding::Decodable for TxMerkleNode {
+    type Decoder = TxMerkleNodeDecoder;
+    fn decoder() -> Self::Decoder { TxMerkleNodeDecoder(encoding::ArrayDecoder::<32>::new()) }
+}
+
+/// An error consensus decoding an `TxMerkleNode`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TxMerkleNodeDecoderError(encoding::UnexpectedEofError);
+
+impl From<Infallible> for TxMerkleNodeDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+impl From<encoding::UnexpectedEofError> for TxMerkleNodeDecoderError {
+    fn from(e: encoding::UnexpectedEofError) -> Self { Self(e) }
+}
+
+impl fmt::Display for TxMerkleNodeDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write_err!(f, "sequence decoder error"; self.0)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for TxMerkleNodeDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
 }

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -62,7 +62,7 @@ pub use units::{
     parse_int,
     result::{self, NumOpResult},
     sequence::{self, Sequence},
-    time::{self, BlockTime},
+    time::{self, BlockTime, BlockTimeDecoder, BlockTimeDecoderError},
     weight::{self, Weight},
 };
 

--- a/primitives/src/script/borrowed.rs
+++ b/primitives/src/script/borrowed.rs
@@ -165,12 +165,10 @@ impl<T> Encodable for Script<T> {
         Self: 'a;
 
     fn encoder(&self) -> Self::Encoder<'_> {
-        ScriptEncoder(
-            Encoder2::new(
-                CompactSizeEncoder::new(self.as_bytes().len()),
-                BytesEncoder::without_length_prefix(self.as_bytes())
-            )
-        )
+        ScriptEncoder(Encoder2::new(
+            CompactSizeEncoder::new(self.as_bytes().len()),
+            BytesEncoder::without_length_prefix(self.as_bytes()),
+        ))
     }
 }
 

--- a/primitives/src/script/mod.rs
+++ b/primitives/src/script/mod.rs
@@ -24,7 +24,7 @@ use crate::prelude::{Borrow, BorrowMut, Box, Cow, ToOwned, Vec};
 #[doc(inline)]
 pub use self::{
     borrowed::{Script, ScriptEncoder},
-    owned::ScriptBuf,
+    owned::{ScriptBuf, ScriptBufDecoder, ScriptBufDecoderError},
     tag::{Tag, RedeemScriptTag, ScriptPubKeyTag, ScriptSigTag, TapScriptTag, WitnessScriptTag},
 };
 #[doc(inline)]
@@ -47,8 +47,14 @@ pub type ScriptSig = Script<ScriptSigTag>;
 /// A `scriptPubKey` (locking script).
 pub type ScriptPubKeyBuf = ScriptBuf<ScriptPubKeyTag>;
 
+/// A `scriptPubKey` decoder.
+pub type ScriptPubKeyBufDecoder = ScriptBufDecoder<ScriptPubKeyTag>;
+
 /// A script signature (scriptSig).
 pub type ScriptSigBuf = ScriptBuf<ScriptSigTag>;
+
+/// A `scriptSig` decoder.
+pub type ScriptSigBufDecoder = ScriptBufDecoder<ScriptSigTag>;
 
 /// A Segwit v1 Taproot script.
 pub type TapScriptBuf = ScriptBuf<TapScriptTag>;


### PR DESCRIPTION
Things that need careful attention please:

- The state machine in `TransactionDecoder`
- The `WitnessDecoder::empty` kludge

