### PR TITLE
Kill 

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -39,5 +39,7 @@ exclude_re = [
     "fmt_debug_pretty", # Mutants from formatting/display changes
     "CompactTarget::to_hex", # Deprecated
     "Script::to_hex", # Deprecated
+    "Script<T>::to_hex", # Deprecated
     "ScriptBuf::to_hex", # Deprecated
+    "ScriptBuf<T>::to_hex", # Deprecated
 ]

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -9,6 +9,7 @@ exclude_re = [
     "impl fmt::Debug",
     ".*Error",
     "deserialize", # Skip serde mutation tests
+    "serde_details::<impl de::Visitor<'_>", # Skip serde mutation tests
     "Iterator", # Mutating operations in an iterator can result in an infinite loop
 
     # ----------------------------------Crate-specific exclusions----------------------------------

--- a/units/src/amount/result.rs
+++ b/units/src/amount/result.rs
@@ -349,4 +349,28 @@ mod tests {
         let sum: NumOpResult<SignedAmount> = amounts.into_iter().sum();
         assert_eq!(sum, NumOpResult::Valid(SignedAmount::from_sat_i32(250)));
     }
+
+    #[test]
+    fn test_sum_signed_amount_results_with_references() {
+        let amounts = [
+            NumOpResult::Valid(SignedAmount::from_sat_i32(100)),
+            NumOpResult::Valid(SignedAmount::from_sat_i32(-50)),
+            NumOpResult::Valid(SignedAmount::from_sat_i32(200)),
+        ];
+
+        let sum: NumOpResult<SignedAmount> = amounts.iter().sum();
+        assert_eq!(sum, NumOpResult::Valid(SignedAmount::from_sat_i32(250)));
+    }
+
+    #[test]
+    fn test_sum_signed_amount_with_error_propagation() {
+        let amounts = [
+            NumOpResult::Valid(SignedAmount::from_sat_i32(100)),
+            NumOpResult::Error(NumOpError::while_doing(MathOp::Add)),
+            NumOpResult::Valid(SignedAmount::from_sat_i32(200)),
+        ];
+
+        let sum: NumOpResult<SignedAmount> = amounts.into_iter().sum();
+        assert!(matches!(sum, NumOpResult::Error(_)));
+    }
 }

--- a/units/src/amount/result.rs
+++ b/units/src/amount/result.rs
@@ -327,6 +327,18 @@ mod tests {
     }
 
     #[test]
+    fn test_sum_amount_with_error_propagation() {
+        let amounts = [
+            NumOpResult::Valid(Amount::from_sat_u32(100)),
+            NumOpResult::Error(NumOpError::while_doing(MathOp::Add)),
+            NumOpResult::Valid(Amount::from_sat_u32(200)),
+        ];
+
+        let sum: NumOpResult<Amount> = amounts.into_iter().sum();
+        assert!(matches!(sum, NumOpResult::Error(_)));
+    }
+
+    #[test]
     fn test_sum_signed_amount_results() {
         let amounts = [
             NumOpResult::Valid(SignedAmount::from_sat_i32(100)),
@@ -336,17 +348,5 @@ mod tests {
 
         let sum: NumOpResult<SignedAmount> = amounts.into_iter().sum();
         assert_eq!(sum, NumOpResult::Valid(SignedAmount::from_sat_i32(250)));
-    }
-
-    #[test]
-    fn test_sum_with_error_propagation() {
-        let amounts = [
-            NumOpResult::Valid(Amount::from_sat_u32(100)),
-            NumOpResult::Error(NumOpError::while_doing(MathOp::Add)),
-            NumOpResult::Valid(Amount::from_sat_u32(200)),
-        ];
-
-        let sum: NumOpResult<Amount> = amounts.into_iter().sum();
-        assert!(matches!(sum, NumOpResult::Error(_)));
     }
 }


### PR DESCRIPTION
Weekly mutation testing found new mutants. There are also two in primitives found locally from changes since the last weekly run.

- Move a test for `Amount` to be with the others instead of under the `SignedAmount` test.
- Add two tests for `SignedAmount` that were previously only done for `Amount`.
- Exclude two deprecated `to_hex` functions that created mutants.
- Add an exclude that covers two `serde` `expecting` messages that created mutants.

Closes #4987