### PR TITLE
Drop the Either sum type in favor of trait bounds + phantom data for decoders

### DIFF
--- a/consensus_encoding/src/lib.rs
+++ b/consensus_encoding/src/lib.rs
@@ -23,7 +23,7 @@ mod decode;
 mod encode;
 
 pub use self::decode::decoders::{
-    ArrayDecoder, Decoder2, Decoder3, Decoder4, Decoder6, Either, UnexpectedEof,
+    ArrayDecoder, Decoder2, Decoder3, Decoder4, Decoder6, UnexpectedEof,
 };
 pub use self::decode::{Decodable, Decoder};
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
Tobin told me to get over my uneasiness with phantom data, so here it is! This is built on https://github.com/rust-bitcoin/rust-bitcoin/pull/4974, but entirely drops the `Either` type in the last patch in favor of trait bounds plus some phantom data in the composite decoders.

If a caller uses a custom error type with a composite decoder, they have to implement `From`'s on the error type for all the possible inner error types. This does drop some info compared to the nested `Either`s, like exactly where in the chain a decoder failed. But not sure how important that is for a caller, my guess is not much, they just want the type.

I think an alternative to this trait bounds+phantom data approach could be runtime conversion functions, which would be more flexible since they are per-decoder, but possibly overkill with more complexity?

```rust
pub struct Decoder2<A, B, E>
where
    A: Decoder,
    B: Decoder,
{
    state: Decoder2State<A, B>,
    convert_a_error: fn(A::Error) -> E,
    convert_b_error: fn(B::Error) -> E,
}
```
