### PR TITLE
consensus_encoding: Use correct MSRV

### DIFF
--- a/consensus_encoding/Cargo.toml
+++ b/consensus_encoding/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["cryptography::cryptocurrencies"]
 keywords = ["bitcoin", "no-std"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.63.0"
+rust-version = "1.74.0"
 exclude = ["tests", "contrib"]
 
 [features]


### PR DESCRIPTION
We somehow missed updating the MSRV of this crate. Found by clippy, not sure why this lint warning wasn't picked up by CI?

However clippy is still warning:

```bash
just lint

cargo +$(cat ./nightly-version) clippy --workspace --all-targets --all-features -- --deny warnings
warning: the MSRV in `clippy.toml` and `Cargo.toml` differ; using `1.74.0` from `clippy.toml`
...
```

But I don't see any usage of the old MSRV in any toml file?