### PR TITLE
feat(p2p): implement BIP-0183 (Utreexo Peer Services)

### DIFF
--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -155,6 +155,14 @@ impl ServiceFlags {
     /// See BIP-0324 for details on how this is implemented.
     pub const P2P_V2: ServiceFlags = ServiceFlags(1 << 11);
 
+    /// NODE_UTREEXO indicates that the node supports Utreexo inclusion proof propagation
+    /// for new blocks and transactions.
+    pub const NODE_UTREEXO: ServiceFlags = ServiceFlags(1 << 12);
+
+    /// NODE_UTREEXO_ARCHIVE indicates that the node supports Utreexo inclusion proof propagation
+    /// for all blocks.
+    pub const NODE_UTREEXO_ARCHIVE: ServiceFlags = ServiceFlags(1 << 13);
+
     // NOTE: When adding new flags, remember to update the Display impl accordingly.
 
     /// Add [ServiceFlags] together.
@@ -219,6 +227,8 @@ impl fmt::Display for ServiceFlags {
         write_flag!(COMPACT_FILTERS);
         write_flag!(NETWORK_LIMITED);
         write_flag!(P2P_V2);
+        write_flag!(NODE_UTREEXO);
+        write_flag!(NODE_UTREEXO_ARCHIVE);
         // If there are unknown flags left, we append them in hex.
         if flags != ServiceFlags::NONE {
             if !first {
@@ -521,6 +531,8 @@ mod tests {
             ServiceFlags::COMPACT_FILTERS,
             ServiceFlags::NETWORK_LIMITED,
             ServiceFlags::P2P_V2,
+            ServiceFlags::NODE_UTREEXO,
+            ServiceFlags::NODE_UTREEXO_ARCHIVE,
         ];
 
         let mut flags = ServiceFlags::NONE;
@@ -547,11 +559,14 @@ mod tests {
         assert_eq!("ServiceFlags(NONE)", ServiceFlags::NONE.to_string());
         assert_eq!("ServiceFlags(WITNESS)", ServiceFlags::WITNESS.to_string());
         assert_eq!("ServiceFlags(P2P_V2)", ServiceFlags::P2P_V2.to_string());
+        assert_eq!("ServiceFlags(NODE_UTREEXO)", ServiceFlags::NODE_UTREEXO.to_string());
+        assert_eq!("ServiceFlags(NODE_UTREEXO_ARCHIVE)", ServiceFlags::NODE_UTREEXO_ARCHIVE.to_string());
         let flag = ServiceFlags::WITNESS
             | ServiceFlags::BLOOM
             | ServiceFlags::NETWORK
-            | ServiceFlags::P2P_V2;
-        assert_eq!("ServiceFlags(NETWORK|BLOOM|WITNESS|P2P_V2)", flag.to_string());
+            | ServiceFlags::P2P_V2
+            | ServiceFlags::NODE_UTREEXO;
+        assert_eq!("ServiceFlags(NETWORK|BLOOM|WITNESS|P2P_V2|NODE_UTREEXO)", flag.to_string());
         let flag = ServiceFlags::WITNESS | 0xf0.into();
         assert_eq!("ServiceFlags(WITNESS|COMPACT_FILTERS|0xb0)", flag.to_string());
     }

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -29,6 +29,7 @@ pub mod message_compact_blocks;
 pub mod message_filter;
 #[cfg(feature = "std")]
 pub mod message_network;
+pub mod message_utreexo;
 
 extern crate alloc;
 #[cfg(feature = "std")]
@@ -560,7 +561,10 @@ mod tests {
         assert_eq!("ServiceFlags(WITNESS)", ServiceFlags::WITNESS.to_string());
         assert_eq!("ServiceFlags(P2P_V2)", ServiceFlags::P2P_V2.to_string());
         assert_eq!("ServiceFlags(NODE_UTREEXO)", ServiceFlags::NODE_UTREEXO.to_string());
-        assert_eq!("ServiceFlags(NODE_UTREEXO_ARCHIVE)", ServiceFlags::NODE_UTREEXO_ARCHIVE.to_string());
+        assert_eq!(
+            "ServiceFlags(NODE_UTREEXO_ARCHIVE)",
+            ServiceFlags::NODE_UTREEXO_ARCHIVE.to_string()
+        );
         let flag = ServiceFlags::WITNESS
             | ServiceFlags::BLOOM
             | ServiceFlags::NETWORK

--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -25,7 +25,7 @@ use crate::address::{AddrV2Message, Address};
 use crate::consensus::{impl_consensus_encoding, impl_vec_wrapper};
 use crate::{
     message_blockdata, message_bloom, message_compact_blocks, message_filter, message_network,
-    Magic,
+    message_utreexo, Magic,
 };
 
 /// The maximum number of [super::message_blockdata::Inventory] items in an `inv` message.
@@ -277,6 +277,22 @@ pub enum NetworkMessage {
     AddrV2(AddrV2Payload),
     /// `sendaddrv2`
     SendAddrV2,
+    /// BIP-0183 `uproof`
+    UtreexoProof(message_utreexo::UtreexoProof),
+    /// BIP-0183 `getuproof`
+    GetUtreexoProof(message_utreexo::GetUtreexoProof),
+    /// BIP-0183 `uttls`
+    UtreexoTTLs(message_utreexo::UtreexoTTLs),
+    /// BIP-0183 `getuttls`
+    GetUtreexoTTLs(message_utreexo::GetUtreexoTTLs),
+    /// BIP-0183 `usummary`
+    UtreexoSummary(message_utreexo::UtreexoSummary),
+    /// BIP-0183 `utreexotx`
+    UtreexoTx(message_utreexo::UtreexoTx),
+    /// BIP-0183 `uroot`
+    UtreexoRoot(message_utreexo::UtreexoRoot),
+    /// BIP-0183 `geturoot`
+    GetUtreexoRoot(message_utreexo::GetUtreexoRoot),
 
     /// Any other message.
     Unknown {
@@ -331,6 +347,14 @@ impl NetworkMessage {
             NetworkMessage::WtxidRelay => "wtxidrelay",
             NetworkMessage::AddrV2(_) => "addrv2",
             NetworkMessage::SendAddrV2 => "sendaddrv2",
+            NetworkMessage::UtreexoProof(_) => "uproof",
+            NetworkMessage::GetUtreexoProof(_) => "getuproof",
+            NetworkMessage::UtreexoTTLs(_) => "uttls",
+            NetworkMessage::GetUtreexoTTLs(_) => "getuttls",
+            NetworkMessage::UtreexoSummary(_) => "usummary",
+            NetworkMessage::UtreexoTx(_) => "utreexotx",
+            NetworkMessage::UtreexoRoot(_) => "uroot",
+            NetworkMessage::GetUtreexoRoot(_) => "geturoot",
             NetworkMessage::Unknown { .. } => "unknown",
         }
     }
@@ -450,6 +474,14 @@ impl Encodable for NetworkMessage {
             | NetworkMessage::WtxidRelay
             | NetworkMessage::FilterClear
             | NetworkMessage::SendAddrV2 => Ok(0),
+            NetworkMessage::UtreexoProof(ref dat) => dat.consensus_encode(writer),
+            NetworkMessage::GetUtreexoProof(ref dat) => dat.consensus_encode(writer),
+            NetworkMessage::UtreexoTTLs(ref dat) => dat.consensus_encode(writer),
+            NetworkMessage::GetUtreexoTTLs(ref dat) => dat.consensus_encode(writer),
+            NetworkMessage::UtreexoSummary(ref dat) => dat.consensus_encode(writer),
+            NetworkMessage::UtreexoTx(ref dat) => dat.consensus_encode(writer),
+            NetworkMessage::UtreexoRoot(ref dat) => dat.consensus_encode(writer),
+            NetworkMessage::GetUtreexoRoot(ref dat) => dat.consensus_encode(writer),
             NetworkMessage::Unknown { payload: ref data, .. } => data.consensus_encode(writer),
         }
     }
@@ -500,6 +532,14 @@ impl Encodable for V2NetworkMessage {
             NetworkMessage::BlockTxn(_) => (3u8, None),
             NetworkMessage::FeeFilter(_) => (5u8, None),
             NetworkMessage::AddrV2(_) => (28u8, None),
+            NetworkMessage::UtreexoProof(_) => (29u8, None),
+            NetworkMessage::GetUtreexoProof(_) => (30u8, None),
+            NetworkMessage::UtreexoTTLs(_) => (31u8, None),
+            NetworkMessage::GetUtreexoTTLs(_) => (32u8, None),
+            NetworkMessage::UtreexoSummary(_) => (33u8, None),
+            NetworkMessage::UtreexoTx(_) => (34u8, None),
+            NetworkMessage::UtreexoRoot(_) => (35u8, None),
+            NetworkMessage::GetUtreexoRoot(_) => (36u8, None),
             NetworkMessage::Version(_)
             | NetworkMessage::Verack
             | NetworkMessage::SendHeaders
@@ -673,6 +713,7 @@ impl Decodable for RawNetworkMessage {
             "addrv2" =>
                 NetworkMessage::AddrV2(Decodable::consensus_decode_from_finite_reader(&mut mem_d)?),
             "sendaddrv2" => NetworkMessage::SendAddrV2,
+            // TODO(@luisschwab): utreexo
             _ => NetworkMessage::Unknown { command: cmd, payload: raw_payload },
         };
         Ok(RawNetworkMessage { magic, payload, payload_len, checksum })
@@ -749,6 +790,7 @@ impl Decodable for V2NetworkMessage {
                 NetworkMessage::GetCFCheckpt(Decodable::consensus_decode_from_finite_reader(r)?),
             27u8 => NetworkMessage::CFCheckpt(Decodable::consensus_decode_from_finite_reader(r)?),
             28u8 => NetworkMessage::AddrV2(Decodable::consensus_decode_from_finite_reader(r)?),
+            // TODO(@luisschwab): utreexo
             _ =>
                 return Err(encode::Error::Parse(encode::ParseError::ParseFailed(
                     "Unknown short ID",
@@ -1009,6 +1051,7 @@ mod test {
             }),
             NetworkMessage::BlockTxn(blocktxn),
             NetworkMessage::SendCmpct(SendCmpct { send_compact: true, version: 8333 }),
+            // TODO(@luisschwab): utreexo
         ];
 
         for msg in &msgs {

--- a/p2p/src/message_blockdata.rs
+++ b/p2p/src/message_blockdata.rs
@@ -33,6 +33,11 @@ pub enum Inventory {
     WitnessTransaction(Txid),
     /// Witness Block
     WitnessBlock(BlockHash),
+    //UtreexoProofHash(?)
+    //UtreexoSummary(?)
+    //UtreexoFlag(?)
+    //UtreexoTx(?)
+    //WitnessUtreexoTx(?)
     /// Unknown inventory type
     Unknown {
         /// The inventory item type.

--- a/p2p/src/message_utreexo.rs
+++ b/p2p/src/message_utreexo.rs
@@ -1,0 +1,395 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! BIP-0183: Utreexo Peer Services network messages.
+
+// TODO(@luisschwab): should a `Vec<u8>` be used in the place of the [`Script`]/[`ScriptBuf`]?
+
+use alloc::vec::Vec;
+
+use bitcoin::consensus::{encode, Decodable, Encodable};
+use bitcoin::{BlockHash, Transaction};
+use io::{BufRead, Write};
+use units::{Amount, BlockHeight};
+
+/// The [`ReconstructableScriptTag`] encodes the type of locking script
+/// and instructs how it should be reconstructed. If the locking script
+/// cannot be reconstructed from the transaction, the actual script must
+/// be sent (in this case, the `Other` variant is used).
+#[derive(PartialEq, Eq, Clone, PartialOrd, Ord, Hash, Debug)]
+pub enum ReconstructableScriptTag {
+    /// Other (0x00): used for Taproot outputs.
+    Other,
+    /// P2PKH (0x01).
+    PubkeyHash,
+    /// P2WPKH (0x02).
+    WitnessV0PubkeyHash,
+    /// P2SH (0x03).
+    ScriptHash,
+    /// P2WSH (0x04).
+    WitnessV0ScriptHash,
+}
+
+impl Encodable for ReconstructableScriptTag {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        let rst = match self {
+            ReconstructableScriptTag::Other => 0u8,
+            ReconstructableScriptTag::PubkeyHash => 1u8,
+            ReconstructableScriptTag::WitnessV0PubkeyHash => 2u8,
+            ReconstructableScriptTag::ScriptHash => 3u8,
+            ReconstructableScriptTag::WitnessV0ScriptHash => 4u8,
+        };
+        rst.consensus_encode(w)
+    }
+}
+
+impl Decodable for ReconstructableScriptTag {
+    fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        let rst = u8::consensus_decode(r)?;
+        match rst {
+            0 => Ok(ReconstructableScriptTag::Other),
+            1 => Ok(ReconstructableScriptTag::PubkeyHash),
+            2 => Ok(ReconstructableScriptTag::WitnessV0PubkeyHash),
+            3 => Ok(ReconstructableScriptTag::ScriptHash),
+            4 => Ok(ReconstructableScriptTag::WitnessV0ScriptHash),
+            _ => Err(crate::consensus::parse_failed_error("Invalid ReconstructableScriptTag")),
+        }
+    }
+}
+
+/// The [`ReconstructableScript`] type allows nodes to rebuild
+/// the locking script without relaying redundant information.
+///
+/// Since the [`ScriptHash`], [`PubkeyHash`], [`WScriptHash`]
+/// and [`WPubkeyHash`] script types hide their scripts behind
+/// a hash, it's useless to relay that hash, as the actual script
+/// can be recovered from the `scriptSig` or `witness` fields in
+/// the moment the UTXO is spent.
+#[derive(PartialEq, Eq, Clone, PartialOrd, Ord, Hash, Debug)]
+pub struct ReconstructableScript {
+    /// The kind of locking script the UTXO is locked to.
+    pub tag: ReconstructableScriptTag,
+    /// The actual script, if [`ReconstructableScriptTag`] is of kind `Other`.
+    pub script: Option<Vec<u8>>,
+}
+
+impl Encodable for ReconstructableScript {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        let mut rs = self.tag.consensus_encode(w)?;
+        if self.tag == ReconstructableScriptTag::Other {
+            if let Some(ref script) = self.script {
+                rs += script.consensus_encode(w)?;
+            } else {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "Script required when tag is Other"
+                ));
+            }
+        }
+        Ok(rs)
+    }
+}
+
+impl Decodable for ReconstructableScript {
+    fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        let tag = ReconstructableScriptTag::consensus_decode(r)?;
+        let script = if tag == ReconstructableScriptTag::Other {
+            Some(Vec::<u8>::consensus_decode(r)?)
+        } else {
+            None
+        };
+        Ok(ReconstructableScript { tag, script })
+    }
+}
+
+/// The [`CompactLeafData`] type contains all the information needed
+/// for a node to rebuild the full leaf data for a given UTXO.
+#[derive(PartialEq, Eq, Clone, PartialOrd, Ord, Hash, Debug)]
+pub struct CompactLeafData {
+    /// The header code is obtained by doing a left shift of
+    /// the block height the UTXO was confirmed in. If the UTXO
+    /// is an output of a coinbase transaction, it gets OR-ed with 1.
+    pub header_code: u32,
+    /// The amount of satoshis locked on the UTXO.
+    pub amount: Amount,
+    /// The UTXO's scriptPubKey in the [`ReconstructableScript`] format.
+    pub script_pubkey: ReconstructableScript,
+}
+
+impl Encodable for CompactLeafData {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        unimplemented!()
+    }
+}
+
+impl Decodable for CompactLeafData {
+    fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        unimplemented!()
+    }
+}
+
+/// The [`TTLInfo`] type informs a node about how long to hold a proof in it's cache.
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct TTLInfo {
+    /// The TTL value of a leaf in the Utreexo Merkle forest,
+    /// determined by the amount of leaves that were added to the
+    /// accumulator since it's inception.
+    pub ttl: usize,
+    /// The position of the leaf in the Utreexo Merkle forest at
+    /// the moment it was removed.
+    pub death_position: usize,
+}
+
+impl Encodable for TTLInfo {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        unimplemented!()
+    }
+}
+
+impl Decodable for TTLInfo {
+    fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        unimplemented!()
+    }
+}
+
+/// The [`UtreexoTTL`] type... TODO
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct UtreexoTTL {
+    /// The [`BlockHeigh`] denotes the block that these [`TTInfo`]s refer to.
+    pub block_height: BlockHeight,
+    /// The set of [`TTLInfo`]s at height `block_height`.
+    pub ttls: Vec<TTLInfo>,
+}
+
+impl Encodable for UtreexoTTL {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        unimplemented!()
+    }
+}
+
+impl Decodable for UtreexoTTL {
+    fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        unimplemented!()
+    }
+}
+
+/// The `uproof` message (BIP-0324 type 29).
+///
+/// The [`UtreexoProof`] (`uproof`) message has all the data needed for a Utreexo
+/// Compact State Node (CSN) or archive node to validate a block.
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct UtreexoProof {
+    /// The hash of the block this Utreexo proof proves.
+    pub blockhash: BlockHash,
+    /// The hashes requested via the `getuproof` message. These hashes must be in tree order.
+    pub proof_hashes: Vec<[u8; 32]>,
+    /// The locations of the leaf datas on the Utreexo Merkle tree. These locations must
+    /// be in blockchain order and include either all locations or no locations at all.
+    pub target_locations: Vec<usize>,
+    /// The preimage of the commited UTXOs ([`CompactLeafData`]) requested via the `getuproof` message.
+    /// These [`CompactLeafData`]s must be in blockchain order.
+    pub leaf_datas: Vec<CompactLeafData>,
+}
+
+impl Encodable for UtreexoProof {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        unimplemented!()
+    }
+}
+
+impl Decodable for UtreexoProof {
+    fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        unimplemented!()
+    }
+}
+
+/// The `getuproof` message (BIP-0324 type 30).
+///
+/// The [`GetUtreexoProof`] (`getuproof`) message is a request for a block's inclusion proof.
+///
+/// The bitmaps must be in Big-Endian and padded to the nearest byte, with 1 indicating a
+/// request and 0 indicating an omission of the proof hash or leaf data. Use the
+/// `proof_positions` function to generate the bitmaps from a given set of targets
+/// (see the 'Utility Functions' sections from BIP-0181).
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct GetUtreexoProof {
+    /// The hash of the block which inclusion proofs are requested.
+    pub blockhash: BlockHash,
+    /// Indicates if the complete proof or only a subset of it is requested.
+    pub include_all: bool,
+    /// A bitmap of the requested proof hashes.
+    pub proof_request_bitmap: Vec<u8>,
+    /// A bitmap of the requested leaf datas.
+    pub leaf_data_request_bitmap: Vec<u8>,
+}
+
+impl Encodable for GetUtreexoProof {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        unimplemented!()
+    }
+}
+
+impl Decodable for GetUtreexoProof {
+    fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        unimplemented!()
+    }
+}
+
+/// The `uttls` message (BIP-0324 type 31).
+///
+/// The [`UtreexoTTLs`] (`uttls`) message has the requested [`UtreexoTTL`]s and proof hashes
+/// needed to validate that the given TTLs were commited in the provided binary. <- TODO check this
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct UtreexoTTLs {
+    /// The requested [`UtreexoTTL`]s.
+    pub utreexo_ttls: Vec<UtreexoTTL>,
+    /// The requested proof hashes.
+    pub proof_hashes: Vec<[u8; 32]>,
+}
+
+impl Encodable for UtreexoTTLs {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        unimplemented!()
+    }
+}
+
+impl Decodable for UtreexoTTLs {
+    fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        unimplemented!()
+    }
+}
+
+/// The `getuttls` message (BIP-0324 type 32).
+///
+/// The [`GetUtreexoTTLs] (`getuttls`) message is a request for [`UtreexoTTL`]s and proof hashes.
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct GetUtreexoTTLs {
+    /// The block height of the commited TTL accumulator,
+    /// used to specify which accumulator the TTL should be proved against.
+    pub version: BlockHeight,
+    /// The block height which the first TTL message will be provided for.
+    pub start_height: BlockHeight,
+    /// Indicates the maximum number of TTLs that should be provided, as an exponent of 2 (2^max_receive_exponent).
+    max_receive_exponent: u8,
+}
+
+impl Encodable for GetUtreexoTTLs {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        unimplemented!()
+    }
+}
+
+impl Decodable for GetUtreexoTTLs {
+    fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        unimplemented!()
+    }
+}
+
+/// The `usummary` message (BIP-0324 type 33).
+///
+/// The [`UtreexoSummary`] (`usummary`) message has all the data needed to
+/// calculate the missing Merkle forest positions required to validate any given block.
+#[derive(PartialEq, Eq, Clone, PartialOrd, Ord, Hash, Debug)]
+pub struct UtreexoSummary {
+    /// The hash of the block this [`UtreexoSummary`] relates to.
+    pub blockhash: BlockHash,
+    /// The number of leaves added to the accumulator on the block this [`UtreexoSummary`] relates to.
+    pub num_additions: usize,
+    /// The Utreexo Merkle tree locations of the leaf datas.
+    /// These locations must be in blockchain order and must include all locations.
+    pub target_locations: Vec<u64>,
+}
+
+impl Encodable for UtreexoSummary {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        unimplemented!()
+    }
+}
+
+impl Decodable for UtreexoSummary {
+    fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        unimplemented!()
+    }
+}
+
+#[derive(PartialEq, Eq, Clone, PartialOrd, Ord, Hash, Debug)]
+pub struct TxMessage(pub Transaction);
+
+/// The `utreexotx` message (BIP-0324 type 34).
+///
+/// The [`UtreexoTx`] (`utreexotx`) message is the
+/// non-Utreexo transaction appended with it's inclusion proof.
+#[derive(PartialEq, Eq, Clone, PartialOrd, Ord, Hash, Debug)]
+pub struct UtreexoTx {
+    /// The non-Utreexo transaction. Unconfirmed inputs
+    /// are marked by (TODO: left or right?) shifting the index by 1 and setting the LSB to 1.
+    pub transaction: TxMessage,
+    /// The requested Utreexo summaries.
+    pub proof_hashes: Vec<UtreexoSummary>,
+    /// The preimage of the leaf datas referenced in the transaction. These preimages must be in
+    /// the order of the referenced inputs. A unconfirmed input does not have a corresponding
+    /// leaf data.
+    pub leaf_datas: Vec<CompactLeafData>,
+}
+
+impl Encodable for UtreexoTx {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        unimplemented!()
+    }
+}
+
+impl Decodable for UtreexoTx {
+    fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        unimplemented!()
+    }
+}
+
+/// The `uroot` message (BIP-0324 type 35).
+///
+/// The [`UtreexoRoot`] (`uroot`) message is the Utreexo accumulator state at a given height
+/// with a proof to a Utreexo accumulator of the Utreexo roots.
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct UtreexoRoot {
+    /// The number of leaves that were added to the accumulator at this block hash.
+    pub num_leaves: usize,
+    /// The position of the Utreexo root in the optional accumulator of Utreexo roots.
+    pub target: usize,
+    /// The blockhash for this Utreexo accumulator.
+    pub blockhash: BlockHash,
+    /// The roots of the Utreexo Merkle forest at this block hash.
+    pub root_hashes: Vec<[u8; 32]>,
+    /// The proof hashes necessary to validate with the pre-commited Utreexo accumulator of the Utreexo roots.
+    pub proof_hashes: Vec<[u8; 32]>,
+}
+
+impl Encodable for UtreexoRoot {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        unimplemented!()
+    }
+}
+
+impl Decodable for UtreexoRoot {
+    fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        unimplemented!()
+    }
+}
+
+/// The `geturoot` message (BIP-0324 type 36).
+///
+/// The [`GetUtreexoRoot`] (`geturoot`) message is a request for the accumulator state at the given block hash.
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct GetUtreexoRoot {
+    /// The block hash that the accumulator state is being requested for.
+    pub blockhash: BlockHash,
+}
+
+impl Encodable for GetUtreexoRoot {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        unimplemented!()
+    }
+}
+
+impl Decodable for GetUtreexoRoot {
+    fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        unimplemented!()
+    }
+}


### PR DESCRIPTION
This (draft) PR implements [BIP-0183: Utreexo - Peer Services](https://github.com/bitcoin/bips/blob/bd1e2425872450b4b9d80cdcb47874d9659a3bda/bip-0183.md) on the `p2p` crate.

Still missing some `Encodable` and `Decodable` implementations and a few TODOs. I'll probably keep this as a draft until the Utreexo BIPs get finalized.

## Changelog
- Add `NODE_UTREEXO` service bit
- Add `NODE_UTREEXO_ARCHIVE` service bit
- Add `CompactLeafData` data structure
- Add `ReconstructableScriptTag` data structure
- Add `ReconstructableScript` data structure 
- Add `TTLInfo` data structure
- Add `UtreexoTTL` data structure
- Add `uproof` message
- Add `getuproof` message
- Add `uttls` message
- Add `getuttls` message
- Add `usummary` message
- Add `utreexotx` message
- Add `uroot` message
- Add `geturoot` message