### PR TITLE
docs: fix typos 

### DIFF
--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -10,7 +10,7 @@ GitHub discussion: https://github.com/rust-bitcoin/rust-bitcoin/discussions/4856
 
 Pull encoding done in: https://github.com/rust-bitcoin/rust-bitcoin/pull/4912
 
-<!-- TODO: Add a consenus-encoding.md file? -->
+<!-- TODO: Add a consensus-encoding.md file? -->
 
 ### Remove `hashes` from the public API.
 

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -845,7 +845,7 @@ mod tests {
     fn out_point_serde_deserialize_non_human_readable() {
         #[rustfmt::skip]
         let bytes = [
-            // Length, pre-pended by the `serde` infrastructure because we use
+            // Length, prepended by the `serde` infrastructure because we use
             // slice serialization instead of array even though we know the length.
             32, 0, 0, 0, 0, 0, 0, 0,
             // The txid bytes


### PR DESCRIPTION

```markdown
## Summary
Minor documentation improvements and typo fixes across the codebase.

- **`docs/primitives.md`**:
  - Fix typo: `consenus-encoding` → `consensus-encoding`

- **`primitives/src/transaction.rs`**:
  - Fix typo: `pre-pended` → `prepended` in serde comment

```

