### PR TITLE
remove redundant variable in compact_size encoding

### DIFF
--- a/internals/src/compact_size.rs
+++ b/internals/src/compact_size.rs
@@ -69,9 +69,8 @@ pub fn encode(value: impl ToU64) -> ArrayVec<u8, MAX_ENCODING_SIZE> {
             res.extend_from_slice(&v.to_le_bytes());
         }
         _ => {
-            let v = value;
             res.push(0xFF);
-            res.extend_from_slice(&v.to_le_bytes());
+            res.extend_from_slice(&value.to_le_bytes());
         }
     }
     res


### PR DESCRIPTION
Remove unnecessary intermediate variable `v` in the 9-byte encoding branch of `compact_size::encode()`. The variable was assigned `value` and used immediately, adding no functional value