### PR TITLE
Enforce at least 32 bits

### DIFF
--- a/p2p/README.md
+++ b/p2p/README.md
@@ -2,6 +2,11 @@
 
 This crate provides data types used in the Bitcoin peer-to-peer protocol.
 
+### Support for 16-bit pointer sizes
+
+16-bit pointer sizes are not supported, and we can't promise they will be. If you care about them
+please let us know, so we can know how large the interest is and possibly decide to support them.
+
 ## Minimum Supported Rust Version (MSRV)
 
 This library should always compile with any combination of features on **Rust 1.74.0**.

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -16,6 +16,21 @@
 #![allow(clippy::manual_range_contains)] // More readable than clippy's format.
 #![allow(clippy::uninlined_format_args)] // Allow `format!("{}", x)` instead of enforcing `format!("{x}")`
 
+// We only support machines with index size of 4 bytes or more.
+//
+// Bitcoin consensus code relies on being able to have containers with more than 65536 (2^16)
+// entries in them so we cannot support consensus logic on machines that only have 16-bit memory
+// addresses.
+//
+// We specifically do not use `target_pointer_width` because of the possibility that pointer width
+// does not equal index size.
+//
+// ref: https://github.com/rust-bitcoin/rust-bitcoin/pull/2929#discussion_r1661848565
+internals::const_assert!(
+    core::mem::size_of::<usize>() >= 4;
+    "platforms that have usize less than 32 bits are not supported"
+);
+
 mod consensus;
 mod network_ext;
 

--- a/primitives/README.md
+++ b/primitives/README.md
@@ -3,6 +3,11 @@
 This crate provides primitive data types that are used throughout the
 [`rust-bitcoin`](https://github.com/rust-bitcoin) ecosystem.
 
+### Support for 16-bit pointer sizes
+
+16-bit pointer sizes are not supported, and we can't promise they will be. If you care about them
+please let us know, so we can know how large the interest is and possibly decide to support them.
+
 ## Semver compliance
 
 Functions marked as unstable (e.g. `foo__unstable`) are not guaranteed to uphold semver compliance.

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -22,6 +22,21 @@
 // Exclude lints we don't think are valuable.
 #![allow(clippy::uninlined_format_args)] // Allow `format!("{}", x)`instead of enforcing `format!("{x}")`
 
+// We only support machines with index size of 4 bytes or more.
+//
+// Bitcoin consensus code relies on being able to have containers with more than 65536 (2^16)
+// entries in them so we cannot support consensus logic on machines that only have 16-bit memory
+// addresses.
+//
+// We specifically do not use `target_pointer_width` because of the possibility that pointer width
+// does not equal index size.
+//
+// ref: https://github.com/rust-bitcoin/rust-bitcoin/pull/2929#discussion_r1661848565
+internals::const_assert!(
+    core::mem::size_of::<usize>() >= 4;
+    "platforms that have usize less than 32 bits are not supported"
+);
+
 #[cfg(feature = "alloc")]
 extern crate alloc;
 


### PR DESCRIPTION
Both `primitives` and `p2p` use vectors of consensus objects which implies to use the libs one requires at least 32 bit wide pointers.

Copy the compile time assertion from `bitcoin` to enforce and document this.

It is already documented in the repo level README; copy the docs from the repo readme into the two respective readmes.

Close: #5005