### PR TITLE
Do not exclude benches from workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,5 @@
 [workspace]
-members = ["addresses", "base58", "bitcoin", "chacha20_poly1305", "consensus_encoding", "fuzz", "hashes", "internals", "io", "p2p", "primitives", "units"]
-exclude = ["benches"]
+members = ["addresses", "base58", "benches", "bitcoin", "chacha20_poly1305", "consensus_encoding", "fuzz", "hashes", "internals", "io", "p2p", "primitives", "units"]
 resolver = "2"
 
 # Keep this patch for hashes because secp256k1 depends on bitcoin-hashes via crates.io

--- a/benches/bitcoin/block.rs
+++ b/benches/bitcoin/block.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: CC0-1.0
 
-use std::time::Duration;
 use std::hint::black_box;
+use std::time::Duration;
 
 use bitcoin::blockdata::block::Block;
 use bitcoin::consensus::{deserialize, Decodable, Encodable};

--- a/benches/chacha20_poly1305/chacha20.rs
+++ b/benches/chacha20_poly1305/chacha20.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: CC0-1.0
 
 use std::hint::black_box;
-
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use std::time::Duration;
 
-use chacha20_poly1305::{chacha20::ChaCha20, Key, Nonce};
+use chacha20_poly1305::chacha20::ChaCha20;
+use chacha20_poly1305::{Key, Nonce};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 
 fn bench_chacha20(c: &mut Criterion) {
     let mut g = c.benchmark_group("chacha20");

--- a/benches/hashes/cmp.rs
+++ b/benches/hashes/cmp.rs
@@ -2,8 +2,8 @@
 
 use std::hint::black_box;
 
-use bitcoin_hashes::{sha256, sha512};
 use bitcoin_hashes::cmp::fixed_time_eq;
+use bitcoin_hashes::{sha256, sha512};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
 fn bench_cmp(c: &mut Criterion) {


### PR DESCRIPTION
If we exclude `benches` repo level `cargo` commands don't hit it (at a minimum the formatter bot skips the crate).

I don't see any reason to exclude it but lets see what CI thinks.