### PR TITLE
Use recent lock file when checking API files

### DIFF
--- a/contrib/check-for-api-changes.sh
+++ b/contrib/check-for-api-changes.sh
@@ -24,8 +24,17 @@ main() {
     need_nightly
     need_cargo_public_api
 
+    # If script is running in CI the recent lock file is copied into place
+    # already by the github action job. Locally be kind to the environment.
+    if [ "${GITHUB_ACTIONS:-}" != "true" ]; then
+        [ -f "Cargo.lock" ] && mv Cargo.lock Cargo.lock.tmp
+        cp Cargo-recent.lock Cargo.lock
+    fi
+
     # Just check crates that are stabilising.
     generate_api_files "units"
+
+    [ -f "Cargo.lock.tmp" ] && mv Cargo.lock.tmp Cargo.lock
 
     check_for_changes
 }


### PR DESCRIPTION
Recently we added `--locked` to all the `cargo` invocations in the script to check API text files. But if one has an updated lock file (newer than recent) then this achieves nothing. I.e., if one has run `cargo` _without_ `--locked` then the local lock file will have deps that are too new (*cough* serde I'm looking at you).

Copy the recent lock file into place when the script is run locally but preserve the lock file state once the script is finished running.
