### PR TITLE
Add decoder I/O drivers

### DIFF
--- a/api/units/all-features.txt
+++ b/api/units/all-features.txt
@@ -1893,6 +1893,7 @@ pub fn bitcoin_units::Weight::try_from(s: alloc::boxed::Box<str>) -> core::resul
 pub fn bitcoin_units::Weight::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_units::amount::AmountDecoder::default() -> Self
 pub fn bitcoin_units::amount::AmountDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
+pub fn bitcoin_units::amount::AmountDecoder::min_bytes_needed(&self) -> usize
 pub fn bitcoin_units::amount::AmountDecoder::new() -> Self
 pub fn bitcoin_units::amount::AmountDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bool, Self::Error>
 pub fn bitcoin_units::amount::Denomination::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
@@ -2004,6 +2005,7 @@ pub fn bitcoin_units::block::BlockHeight::try_from(s: alloc::boxed::Box<str>) ->
 pub fn bitcoin_units::block::BlockHeight::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_units::block::BlockHeightDecoder::default() -> Self
 pub fn bitcoin_units::block::BlockHeightDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
+pub fn bitcoin_units::block::BlockHeightDecoder::min_bytes_needed(&self) -> usize
 pub fn bitcoin_units::block::BlockHeightDecoder::new() -> Self
 pub fn bitcoin_units::block::BlockHeightDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bool, Self::Error>
 pub fn bitcoin_units::block::BlockHeightDecoderError::clone(&self) -> bitcoin_units::block::BlockHeightDecoderError
@@ -2153,6 +2155,7 @@ pub fn bitcoin_units::locktime::absolute::LockTime::try_from(s: alloc::boxed::Bo
 pub fn bitcoin_units::locktime::absolute::LockTime::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_units::locktime::absolute::LockTimeDecoder::default() -> Self
 pub fn bitcoin_units::locktime::absolute::LockTimeDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
+pub fn bitcoin_units::locktime::absolute::LockTimeDecoder::min_bytes_needed(&self) -> usize
 pub fn bitcoin_units::locktime::absolute::LockTimeDecoder::new() -> Self
 pub fn bitcoin_units::locktime::absolute::LockTimeDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bool, Self::Error>
 pub fn bitcoin_units::locktime::absolute::LockTimeEncoder::advance(&mut self) -> bool
@@ -2418,6 +2421,7 @@ pub fn bitcoin_units::sequence::Sequence::try_from(s: alloc::boxed::Box<str>) ->
 pub fn bitcoin_units::sequence::Sequence::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_units::sequence::SequenceDecoder::default() -> Self
 pub fn bitcoin_units::sequence::SequenceDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
+pub fn bitcoin_units::sequence::SequenceDecoder::min_bytes_needed(&self) -> usize
 pub fn bitcoin_units::sequence::SequenceDecoder::new() -> Self
 pub fn bitcoin_units::sequence::SequenceDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bool, Self::Error>
 pub fn bitcoin_units::sequence::SequenceDecoderError::clone(&self) -> bitcoin_units::sequence::SequenceDecoderError
@@ -2429,6 +2433,7 @@ pub fn bitcoin_units::sequence::SequenceEncoder::advance(&mut self) -> bool
 pub fn bitcoin_units::sequence::SequenceEncoder::current_chunk(&self) -> core::option::Option<&[u8]>
 pub fn bitcoin_units::time::BlockTimeDecoder::default() -> Self
 pub fn bitcoin_units::time::BlockTimeDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
+pub fn bitcoin_units::time::BlockTimeDecoder::min_bytes_needed(&self) -> usize
 pub fn bitcoin_units::time::BlockTimeDecoder::new() -> Self
 pub fn bitcoin_units::time::BlockTimeDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bool, Self::Error>
 pub fn bitcoin_units::time::BlockTimeDecoderError::clone(&self) -> bitcoin_units::time::BlockTimeDecoderError

--- a/consensus_encoding/src/decode/decoders.rs
+++ b/consensus_encoding/src/decode/decoders.rs
@@ -47,6 +47,9 @@ impl<const N: usize> Decoder for ArrayDecoder<N> {
             Err(UnexpectedEofError { missing: N - self.bytes_written })
         }
     }
+
+    #[inline]
+    fn min_bytes_needed(&self) -> usize { N - self.bytes_written }
 }
 
 /// A decoder which wraps two inner decoders and returns the output of both.
@@ -165,6 +168,17 @@ where
             }
         }
     }
+
+    #[inline]
+    fn min_bytes_needed(&self) -> usize {
+        match &self.state {
+            Decoder2State::First(first_decoder, second_decoder) =>
+                first_decoder.min_bytes_needed() + second_decoder.min_bytes_needed(),
+            Decoder2State::Second(_, second_decoder) => second_decoder.min_bytes_needed(),
+            Decoder2State::Errored => 0,
+            Decoder2State::Transitioning => 0,
+        }
+    }
 }
 
 /// A decoder which decodes three objects, one after the other.
@@ -215,6 +229,9 @@ where
         let ((first, second), third) = self.inner.end()?;
         Ok((first, second, third))
     }
+
+    #[inline]
+    fn min_bytes_needed(&self) -> usize { self.inner.min_bytes_needed() }
 }
 
 /// A decoder which decodes four objects, one after the other.
@@ -268,6 +285,9 @@ where
         let ((first, second), (third, fourth)) = self.inner.end()?;
         Ok((first, second, third, fourth))
     }
+
+    #[inline]
+    fn min_bytes_needed(&self) -> usize { self.inner.min_bytes_needed() }
 }
 
 /// A decoder which decodes six objects, one after the other.
@@ -346,6 +366,9 @@ where
         let ((first, second, third), (fourth, fifth, sixth)) = self.inner.end()?;
         Ok((first, second, third, fourth, fifth, sixth))
     }
+
+    #[inline]
+    fn min_bytes_needed(&self) -> usize { self.inner.min_bytes_needed() }
 }
 
 /// Not enough bytes given to decoder.

--- a/consensus_encoding/src/decode/mod.rs
+++ b/consensus_encoding/src/decode/mod.rs
@@ -59,3 +59,215 @@ pub trait Decoder: Sized {
     #[must_use = "must check result to avoid panics on subsequent calls"]
     fn end(self) -> Result<Self::Output, Self::Error>;
 }
+
+/// Decodes an object from a byte slice.
+///
+/// # Errors
+///
+/// Returns an error if the decoder encounters an error while
+/// parsing the data, including insufficient data.
+pub fn decode_from_slice<T>(bytes: &[u8]) -> Result<T, <T::Decoder as Decoder>::Error>
+where
+    T: Decodable,
+{
+    let mut decoder = T::decoder();
+    let mut remaining = bytes;
+
+    while !remaining.is_empty() {
+        if !decoder.push_bytes(&mut remaining)? {
+            break;
+        }
+    }
+
+    decoder.end()
+}
+
+/// Decodes an object from a buffered reader.
+///
+/// # Performance
+///
+/// For unbuffered readers (like [`std::fs::File`] or [`std::net::TcpStream`]),
+/// consider wrapping your reader with [`std::io::BufReader`] in order to use
+/// this function. This avoids frequent small reads, which can significantly
+/// impact performance.
+///
+/// # Errors
+///
+/// Returns [`ReadError::Decode`] if the decoder encounters an error while parsing
+/// the data, or [`ReadError::Io`] if an I/O error occurs while reading.
+#[cfg(feature = "std")]
+pub fn decode_from_read<T, R>(mut reader: R) -> Result<T, ReadError<<T::Decoder as Decoder>::Error>>
+where
+    T: Decodable,
+    R: std::io::BufRead,
+{
+    let mut decoder = T::decoder();
+
+    loop {
+        let mut buffer = match reader.fill_buf() {
+            Ok(buffer) => buffer,
+            // Auto retry read for non-fatal error.
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(error) => return Err(ReadError::Io(error)),
+        };
+
+        if buffer.is_empty() {
+            // EOF, but still try to finalize the decoder.
+            return decoder.end().map_err(ReadError::Decode);
+        }
+
+        let original_len = buffer.len();
+        let need_more = decoder.push_bytes(&mut buffer).map_err(ReadError::Decode)?;
+        let consumed = original_len - buffer.len();
+        reader.consume(consumed);
+
+        if !need_more {
+            return decoder.end().map_err(ReadError::Decode);
+        }
+    }
+}
+
+/// An error that can occur when reading and decoding from a buffered reader.
+#[cfg(feature = "std")]
+#[derive(Debug)]
+pub enum ReadError<D> {
+    /// An I/O error occurred while reading from the reader.
+    Io(std::io::Error),
+    /// The decoder encountered an error while parsing the data.
+    Decode(D),
+}
+
+#[cfg(feature = "std")]
+impl<D: core::fmt::Display> core::fmt::Display for ReadError<D> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            ReadError::Io(e) => write!(f, "I/O error: {}", e),
+            ReadError::Decode(e) => write!(f, "decode error: {}", e),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<D> std::error::Error for ReadError<D>
+where
+    D: core::fmt::Debug + core::fmt::Display + std::error::Error + 'static,
+{
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ReadError::Io(e) => Some(e),
+            ReadError::Decode(e) => Some(e),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<D> From<std::io::Error> for ReadError<D> {
+    fn from(e: std::io::Error) -> Self { ReadError::Io(e) }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "alloc")]
+    use alloc::vec::Vec;
+    #[cfg(feature = "std")]
+    use std::io::{Cursor, Read};
+
+    use super::*;
+    use crate::decode::decoders::{ArrayDecoder, UnexpectedEofError};
+
+    #[derive(Debug, PartialEq)]
+    struct TestArray([u8; 4]);
+
+    impl Decodable for TestArray {
+        type Decoder = TestArrayDecoder;
+        fn decoder() -> Self::Decoder { TestArrayDecoder { inner: ArrayDecoder::new() } }
+    }
+
+    struct TestArrayDecoder {
+        inner: ArrayDecoder<4>,
+    }
+
+    impl Decoder for TestArrayDecoder {
+        type Output = TestArray;
+        type Error = UnexpectedEofError;
+
+        fn push_bytes(&mut self, bytes: &mut &[u8]) -> Result<bool, Self::Error> {
+            self.inner.push_bytes(bytes)
+        }
+
+        fn end(self) -> Result<Self::Output, Self::Error> { self.inner.end().map(TestArray) }
+    }
+
+    #[test]
+    fn decode_from_slice_success() {
+        let data = [1, 2, 3, 4];
+        let result: Result<TestArray, _> = decode_from_slice(&data);
+        assert!(result.is_ok());
+        let decoded = result.unwrap();
+        assert_eq!(decoded.0, [1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn decode_from_slice_unexpected_eof() {
+        let data = [1, 2, 3];
+        let result: Result<TestArray, _> = decode_from_slice(&data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn decode_from_slice_extra_data() {
+        let data = [1, 2, 3, 4, 5];
+        let result: Result<TestArray, _> = decode_from_slice(&data);
+        assert!(result.is_ok());
+        let decoded = result.unwrap();
+        assert_eq!(decoded.0, [1, 2, 3, 4]);
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn decode_from_read_success() {
+        let data = [1, 2, 3, 4];
+        let cursor = Cursor::new(&data);
+        let result: Result<TestArray, _> = decode_from_read(cursor);
+        assert!(result.is_ok());
+        let decoded = result.unwrap();
+        assert_eq!(decoded.0, [1, 2, 3, 4]);
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn decode_from_read_unexpected_eof() {
+        let data = [1, 2, 3];
+        let cursor = Cursor::new(&data);
+        let result: Result<TestArray, _> = decode_from_read(cursor);
+        assert!(matches!(result, Err(ReadError::Decode(_))));
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn decode_from_read_trait_object() {
+        let data = [1, 2, 3, 4];
+        let mut cursor = Cursor::new(&data);
+        // Test that we can pass a trait object (&mut dyn BufRead implements BufRead).
+        let reader: &mut dyn std::io::BufRead = &mut cursor;
+        let result: Result<TestArray, _> = decode_from_read(reader);
+        assert!(result.is_ok());
+        let decoded = result.unwrap();
+        assert_eq!(decoded.0, [1, 2, 3, 4]);
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn decode_from_read_by_reference() {
+        let data = [1, 2, 3, 4];
+        let mut cursor = Cursor::new(&data);
+        // Test that we can pass by reference (&mut T implements BufRead when T: BufRead).
+        let result: Result<TestArray, _> = decode_from_read(&mut cursor);
+        assert!(result.is_ok());
+        let decoded = result.unwrap();
+        assert_eq!(decoded.0, [1, 2, 3, 4]);
+
+        let mut buf = Vec::new();
+        let _ = cursor.read_to_end(&mut buf);
+    }
+}

--- a/consensus_encoding/src/lib.rs
+++ b/consensus_encoding/src/lib.rs
@@ -26,7 +26,9 @@ pub use self::decode::decoders::{
     ArrayDecoder, Decoder2, Decoder3, Decoder4, Decoder6, UnexpectedEofError,
 };
 #[cfg(feature = "std")]
-pub use self::decode::{decode_from_read, ReadError};
+pub use self::decode::{
+    decode_from_read, decode_from_read_unbuffered, decode_from_read_unbuffered_with, ReadError,
+};
 pub use self::decode::{decode_from_slice, Decodable, Decoder};
 #[cfg(feature = "alloc")]
 pub use self::encode::encode_to_vec;

--- a/consensus_encoding/src/lib.rs
+++ b/consensus_encoding/src/lib.rs
@@ -25,7 +25,9 @@ mod encode;
 pub use self::decode::decoders::{
     ArrayDecoder, Decoder2, Decoder3, Decoder4, Decoder6, UnexpectedEofError,
 };
-pub use self::decode::{Decodable, Decoder};
+#[cfg(feature = "std")]
+pub use self::decode::{decode_from_read, ReadError};
+pub use self::decode::{decode_from_slice, Decodable, Decoder};
 #[cfg(feature = "alloc")]
 pub use self::encode::encode_to_vec;
 #[cfg(feature = "std")]

--- a/consensus_encoding/tests/composition.rs
+++ b/consensus_encoding/tests/composition.rs
@@ -68,6 +68,8 @@ impl Decoder for CompositeDataDecoder {
         let (first, second) = self.inner.end()?;
         Ok(CompositeData { first, second })
     }
+
+    fn min_bytes_needed(&self) -> usize { self.inner.min_bytes_needed() }
 }
 
 impl Decodable for CompositeData {
@@ -217,6 +219,8 @@ fn composition_error_unification() {
             let (first, second) = self.inner.end()?;
             Ok((first, second))
         }
+
+        fn min_bytes_needed(&self) -> usize { self.inner.min_bytes_needed() }
     }
 
     /// Another test composite decoder.
@@ -240,6 +244,8 @@ fn composition_error_unification() {
             let result = self.inner.end()?;
             Ok(result)
         }
+
+        fn min_bytes_needed(&self) -> usize { self.inner.min_bytes_needed() }
     }
 
     /// A decoder which can fail.
@@ -267,6 +273,8 @@ fn composition_error_unification() {
                 self.inner.end().map_err(NestedError::from)
             }
         }
+
+        fn min_bytes_needed(&self) -> usize { self.inner.min_bytes_needed() }
     }
 
     // A multi-layer, nested, decoder structure with a unified top level error type.

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -608,6 +608,9 @@ impl encoding::Decoder for AmountDecoder {
         let a = u64::from_le_bytes(self.0.end().map_err(AmountDecoderError::eof)?);
         Amount::from_sat(a).map_err(AmountDecoderError::out_of_range)
     }
+
+    #[inline]
+    fn min_bytes_needed(&self) -> usize { self.0.min_bytes_needed() }
 }
 
 #[cfg(feature = "encoding")]

--- a/units/src/block.rs
+++ b/units/src/block.rs
@@ -191,6 +191,9 @@ impl encoding::Decoder for BlockHeightDecoder {
         let n = u32::from_le_bytes(self.0.end().map_err(BlockHeightDecoderError)?);
         Ok(BlockHeight::from_u32(n))
     }
+
+    #[inline]
+    fn min_bytes_needed(&self) -> usize { self.0.min_bytes_needed() }
 }
 
 #[cfg(feature = "encoding")]

--- a/units/src/locktime/absolute/mod.rs
+++ b/units/src/locktime/absolute/mod.rs
@@ -449,6 +449,9 @@ impl encoding::Decoder for LockTimeDecoder {
         let n = u32::from_le_bytes(self.0.end().map_err(LockTimeDecoderError)?);
         Ok(LockTime::from_consensus(n))
     }
+
+    #[inline]
+    fn min_bytes_needed(&self) -> usize { self.0.min_bytes_needed() }
 }
 
 #[cfg(feature = "encoding")]

--- a/units/src/sequence.rs
+++ b/units/src/sequence.rs
@@ -314,6 +314,9 @@ impl encoding::Decoder for SequenceDecoder {
         let n = u32::from_le_bytes(self.0.end().map_err(SequenceDecoderError)?);
         Ok(Sequence::from_consensus(n))
     }
+
+    #[inline]
+    fn min_bytes_needed(&self) -> usize { self.0.min_bytes_needed() }
 }
 
 #[cfg(feature = "encoding")]

--- a/units/src/time.rs
+++ b/units/src/time.rs
@@ -124,6 +124,9 @@ impl encoding::Decoder for BlockTimeDecoder {
         let t = u32::from_le_bytes(self.0.end().map_err(BlockTimeDecoderError)?);
         Ok(BlockTime::from_u32(t))
     }
+
+    #[inline]
+    fn min_bytes_needed(&self) -> usize { self.0.min_bytes_needed() }
 }
 
 #[cfg(feature = "encoding")]


### PR DESCRIPTION
Getting the ball rolling on I/O drivers for the decode side, which I think is going to be more interesting than the encode side since the buffered interface is different.

## First Patch

The simple drivers for slice and bufreader.

These are water'd down versions of push_decode. Some simplifications were made like making `ReadError` less generic by hard-coding to the std::io error type.

But this does get right to the chase for the decode-side complexity: is it cool to have a separate driver for `BufReader` and `Read`?

## Second Patch

The complex driver for `Read`.

Following push_decode's design, introduced a new requirement on the `Decoder`'s to expose a `min_bytes_needed`. This allows the read driver to efficiently manage its internal buffer. I just put this requirement straight on `Decoder` because I think we can assume all bitcoin decodables will know their min bytes.