### PR TITLE
psbt: correct typo in consensus deserialization error message

### DIFF
--- a/bitcoin/src/psbt/error.rs
+++ b/bitcoin/src/psbt/error.rs
@@ -159,7 +159,7 @@ impl fmt::Display for Error {
             }
             ConsensusEncoding(ref e) => write_err!(f, "bitcoin consensus encoding error"; e),
             ConsensusDeserialize(ref e) =>
-                write_err!(f, "bitcoin consensus deserializaton error"; e),
+                write_err!(f, "bitcoin consensus deserialization error"; e),
             ConsensusParse(ref e) =>
                 write_err!(f, "error parsing bitcoin consensus encoded object"; e),
             NegativeFee => f.write_str("PSBT has a negative fee which is not allowed"),


### PR DESCRIPTION
bitcoin/src/psbt/error.rs:typo fix in `Display` output of `Error`

*LLM slop deleted by apoelstra*