### PR TITLE
fix: update stack terminology in OP_2ROT documentation

### DIFF
--- a/bitcoin/src/blockdata/opcodes.rs
+++ b/bitcoin/src/blockdata/opcodes.rs
@@ -239,7 +239,7 @@ all_opcodes! {
     OP_2DUP => 0x6e, "Duplicates the top two stack items as `AB` -> `ABAB`.";
     OP_3DUP => 0x6f, "Duplicates the top three stack items as `ABC` -> `ABCABC`.";
     OP_2OVER => 0x70, "Duplicates the third and fourth items from the top of the stack.";
-    OP_2ROT => 0x71, "Moves the two stack items four spaces back to the front, as `xxxxAB` -> `ABxxxx`.";
+    OP_2ROT => 0x71, "Moves the two stack items four spaces below to the top, as `xxxxAB` -> `ABxxxx`.";
     OP_2SWAP => 0x72, "Swaps the top two pairs, as `ABCD` -> `CDAB`.";
     OP_IFDUP => 0x73, "Duplicate the top stack element unless it is zero.";
     OP_DEPTH => 0x74, "Push the current number of stack items onto the stack.";


### PR DESCRIPTION
Change "back to the front" to "below to the top" in OP_2ROT opcode documentation to use consistent spatial terminology. This aligns with the established pattern of using "top"/"bottom" references for stack operations rather than "front"/"back"

Reopened https://github.com/rust-bitcoin/rust-bitcoin/pull/5032