### PR TITLE
consensus_encoding: tag composers with inline

### DIFF
--- a/consensus_encoding/src/decode/decoders.rs
+++ b/consensus_encoding/src/decode/decoders.rs
@@ -39,6 +39,7 @@ impl<const N: usize> Decoder for ArrayDecoder<N> {
         Ok(self.bytes_written < N)
     }
 
+    #[inline]
     fn end(self) -> Result<Self::Output, Self::Error> {
         if self.bytes_written == N {
             Ok(self.buffer)
@@ -141,6 +142,7 @@ where
         }
     }
 
+    #[inline]
     fn end(self) -> Result<Self::Output, Self::Error> {
         match self.state {
             Decoder2State::First(first_decoder, second_decoder) => {
@@ -203,10 +205,12 @@ where
     type Output = (A::Output, B::Output, C::Output);
     type Error = Err;
 
+    #[inline]
     fn push_bytes(&mut self, bytes: &mut &[u8]) -> Result<bool, Self::Error> {
         self.inner.push_bytes(bytes)
     }
 
+    #[inline]
     fn end(self) -> Result<Self::Output, Self::Error> {
         let ((first, second), third) = self.inner.end()?;
         Ok((first, second, third))
@@ -254,10 +258,12 @@ where
     type Output = (A::Output, B::Output, C::Output, D::Output);
     type Error = Err;
 
+    #[inline]
     fn push_bytes(&mut self, bytes: &mut &[u8]) -> Result<bool, Self::Error> {
         self.inner.push_bytes(bytes)
     }
 
+    #[inline]
     fn end(self) -> Result<Self::Output, Self::Error> {
         let ((first, second), (third, fourth)) = self.inner.end()?;
         Ok((first, second, third, fourth))
@@ -330,10 +336,12 @@ where
     type Output = (A::Output, B::Output, C::Output, D::Output, E::Output, F::Output);
     type Error = Err;
 
+    #[inline]
     fn push_bytes(&mut self, bytes: &mut &[u8]) -> Result<bool, Self::Error> {
         self.inner.push_bytes(bytes)
     }
 
+    #[inline]
     fn end(self) -> Result<Self::Output, Self::Error> {
         let ((first, second, third), (fourth, fifth, sixth)) = self.inner.end()?;
         Ok((first, second, third, fourth, fifth, sixth))

--- a/consensus_encoding/src/encode/encoders.rs
+++ b/consensus_encoding/src/encode/encoders.rs
@@ -68,8 +68,10 @@ impl<const N: usize> ArrayEncoder<N> {
 }
 
 impl<const N: usize> Encoder for ArrayEncoder<N> {
+    #[inline]
     fn current_chunk(&self) -> Option<&[u8]> { self.arr.as_ref().map(|x| &x[..]) }
 
+    #[inline]
     fn advance(&mut self) -> bool {
         self.arr = None;
         false
@@ -161,6 +163,7 @@ impl<A, B> Encoder2<A, B> {
 }
 
 impl<A: Encoder, B: Encoder> Encoder for Encoder2<A, B> {
+    #[inline]
     fn current_chunk(&self) -> Option<&[u8]> {
         if self.enc_idx == 0 {
             self.enc_1.current_chunk()
@@ -169,6 +172,7 @@ impl<A: Encoder, B: Encoder> Encoder for Encoder2<A, B> {
         }
     }
 
+    #[inline]
     fn advance(&mut self) -> bool {
         if self.enc_idx == 0 {
             if !self.enc_1.advance() {
@@ -199,7 +203,9 @@ impl<A, B, C> Encoder3<A, B, C> {
 }
 
 impl<A: Encoder, B: Encoder, C: Encoder> Encoder for Encoder3<A, B, C> {
+    #[inline]
     fn current_chunk(&self) -> Option<&[u8]> { self.inner.current_chunk() }
+    #[inline]
     fn advance(&mut self) -> bool { self.inner.advance() }
 }
 
@@ -216,7 +222,9 @@ impl<A, B, C, D> Encoder4<A, B, C, D> {
 }
 
 impl<A: Encoder, B: Encoder, C: Encoder, D: Encoder> Encoder for Encoder4<A, B, C, D> {
+    #[inline]
     fn current_chunk(&self) -> Option<&[u8]> { self.inner.current_chunk() }
+    #[inline]
     fn advance(&mut self) -> bool { self.inner.advance() }
 }
 
@@ -240,7 +248,9 @@ impl<A, B, C, D, E, F> Encoder6<A, B, C, D, E, F> {
 impl<A: Encoder, B: Encoder, C: Encoder, D: Encoder, E: Encoder, F: Encoder> Encoder
     for Encoder6<A, B, C, D, E, F>
 {
+    #[inline]
     fn current_chunk(&self) -> Option<&[u8]> { self.inner.current_chunk() }
+    #[inline]
     fn advance(&mut self) -> bool { self.inner.advance() }
 }
 


### PR DESCRIPTION
The encoder/decoder composers just delegate to an inner encoder/decoder, inlining these simple calls might help the compiler optimize things. Working on the `Read` driver for decoders got me thinking that this might help the compiler optimize the buffer a bit better.