### PR TITLE
Clean up encoders unit tests and fix empty SliceEncoder

### DIFF
--- a/consensus_encoding/src/encode/encoders.rs
+++ b/consensus_encoding/src/encode/encoders.rs
@@ -343,4 +343,45 @@ mod tests {
         assert!(!encoder.advance());
         assert_eq!(encoder.current_chunk(), None);
     }
+
+    #[test]
+    fn encode_slice_with_elements() {
+        // Should have length prefix chunk, then element chunks, then exhausted.
+        let slice = &[TestArray([0x34, 0x12, 0x00, 0x00]), TestArray([0x78, 0x56, 0x00, 0x00])];
+        let mut encoder = SliceEncoder::with_length_prefix(slice);
+
+        assert_eq!(encoder.current_chunk(), Some(&[2u8][..]));
+        assert!(encoder.advance());
+        assert_eq!(encoder.current_chunk(), Some(&[0x34, 0x12, 0x00, 0x00][..]));
+        assert!(encoder.advance());
+        assert_eq!(encoder.current_chunk(), Some(&[0x78, 0x56, 0x00, 0x00][..]));
+        assert!(!encoder.advance());
+        assert_eq!(encoder.current_chunk(), None);
+    }
+
+    #[test]
+    fn encode_empty_slice() {
+        // Should have only length prefix chunk (0), then exhausted.
+        let slice: &[TestArray<4>] = &[];
+        let mut encoder = SliceEncoder::with_length_prefix(slice);
+
+        assert_eq!(encoder.current_chunk(), Some(&[0u8][..]));
+        assert!(!encoder.advance());
+        assert_eq!(encoder.current_chunk(), None);
+    }
+
+    #[test]
+    fn encode_slice_with_zero_sized_arrays() {
+        // Should have length prefix chunk, then empty array chunks, then exhausted.
+        let slice = &[TestArray([]), TestArray([])];
+        let mut encoder = SliceEncoder::with_length_prefix(slice);
+
+        assert_eq!(encoder.current_chunk(), Some(&[2u8][..]));
+        assert!(encoder.advance());
+        assert_eq!(encoder.current_chunk(), Some(&[][..]));
+        assert!(encoder.advance());
+        assert_eq!(encoder.current_chunk(), Some(&[][..]));
+        assert!(!encoder.advance());
+        assert_eq!(encoder.current_chunk(), None);
+    }
 }


### PR DESCRIPTION
Cleaning up the `encoders` unit tests and adding some helper types for further testing. But posting now because adding a few SliceEncoder tests like `encode_empty_slice` exposed a bug in the `SliceEncoder::advance` method. For an empty slice, the compact size is never cleared. I added a fix in the second commit and tests in the third, but I know a lot of iterations were just spent on this so don't have full confidence it didn't hurt some other goal (at one point branch prediction was brought up).

Separately, the `encode_slice_with_zero_sized_arrays` test is kinda weird, but I think logically checks out...just don't think we will ever be sending zero-byte arrays in real life.