### PR TITLE
test: remove obsolete debug output tests

### DIFF
--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -2092,12 +2092,7 @@ mod tests {
     }
 
     #[test]
-    fn sequence_debug_output() {
-        let seq = Sequence::from_seconds_floor(1000);
-        println!("{:?}", seq)
-    }
 
-    #[test]
     fn outpoint_format() {
         let outpoint = OutPoint::COINBASE_PREVOUT;
 

--- a/primitives/src/witness.rs
+++ b/primitives/src/witness.rs
@@ -577,9 +577,6 @@ impl<'a> Arbitrary<'a> for Witness {
 mod test {
     #[cfg(feature = "alloc")]
     use alloc::vec;
-    #[cfg(feature = "std")]
-    use std::println;
-
     use super::*;
 
     // Appends all the indices onto the end of a list of elements.
@@ -595,13 +592,7 @@ mod test {
     fn single_empty_element() -> Witness { Witness::from([[0u8; 0]]) }
 
     #[test]
-    #[cfg(feature = "std")]
-    fn witness_debug_can_display_empty_element() {
-        let witness = single_empty_element();
-        println!("{:?}", witness);
-    }
 
-    #[test]
     fn witness_single_empty_element() {
         let mut got = Witness::new();
         got.push([]);


### PR DESCRIPTION
Removed two debug output tests that became obsolete after Debug implementation changes:

- `witness_debug_can_display_empty_element` - no longer relevant since Witness Debug logic was rewritten
- `sequence_debug_output` - redundant coverage already provided by test/api.rs