### PR TITLE
fix grammar in API test comments

### DIFF
--- a/hashes/tests/api.rs
+++ b/hashes/tests/api.rs
@@ -2,7 +2,7 @@
 
 //! Test the API surface of `units`.
 //!
-//! The point of these tests are to check the API surface as opposed to test the API functionality.
+//! The point of these tests is to check the API surface as opposed to test the API functionality.
 //!
 //! ref: <https://rust-lang.github.io/api-guidelines/about.html>
 

--- a/io/tests/api.rs
+++ b/io/tests/api.rs
@@ -1,6 +1,6 @@
 //! Test the API surface of `io`.
 //!
-//! The point of these tests are to check the API surface as opposed to test the API functionality.
+//! The point of these tests is to check the API surface as opposed to test the API functionality.
 //!
 //! ref: <https://rust-lang.github.io/api-guidelines/about.html>
 

--- a/primitives/tests/api.rs
+++ b/primitives/tests/api.rs
@@ -2,7 +2,7 @@
 
 //! Test the API surface of `primitives`.
 //!
-//! The point of these tests are to check the API surface as opposed to test the API functionality.
+//! The point of these tests is to check the API surface as opposed to test the API functionality.
 //!
 //! ref: <https://rust-lang.github.io/api-guidelines/about.html>
 


### PR DESCRIPTION

```markdown

Fixed subject-verb agreement in API test documentation comments.

### Changes
- **Files affected:** `hashes/tests/api.rs`, `io/tests/api.rs`, `primitives/tests/api.rs`
- **Fix:** Changed "The point of these tests **are**" → "The point of these tests **is**"

### Why
The subject "The point" is singular, requiring the singular verb "is" instead of "are".

```


