### PR TITLE
fix: remove circular reference in WITNESS_SCALE_FACTOR constant

### DIFF
--- a/units/src/weight.rs
+++ b/units/src/weight.rs
@@ -51,7 +51,7 @@ impl Weight {
     pub const MAX: Weight = Weight::from_wu(u64::MAX);
 
     /// The factor that non-witness serialization data is multiplied by during weight calculation.
-    pub const WITNESS_SCALE_FACTOR: u64 = WITNESS_SCALE_FACTOR as u64; // this value is 4
+    pub const WITNESS_SCALE_FACTOR: u64 = 4;
 
     /// The maximum allowed weight for a block, see BIP-0141 (network rule).
     pub const MAX_BLOCK: Weight = Weight::from_wu(4_000_000);


### PR DESCRIPTION
Fixes technical debt from PR [2569](https://github.com/rust-bitcoin/rust-bitcoin/pull/2569) where constant accidentally
referenced itself during units crate refactoring

The problematic line was:
pub const WITNESS_SCALE_FACTOR: u64 = WITNESS_SCALE_FACTOR as u64; // this value is 4

Replaced with explicit value: 4