### PR TITLE
Kill new mutants

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -11,6 +11,7 @@ exclude_re = [
     "deserialize", # Skip serde mutation tests
     "serde_details::<impl de::Visitor<'_>", # Skip serde mutation tests
     "Iterator", # Mutating operations in an iterator can result in an infinite loop
+    "impl encoding::Decodable", # Mutant replacing Default::default() is equivalent to returning new()
 
     # ----------------------------------Crate-specific exclusions----------------------------------
     # Units


### PR DESCRIPTION
Recently added `impl encoding::Decodable` construct a new `Decoder`. Mutation testing replaces these with `Default::default()`, which is equivalent to the intended `new()`.

Exclude these from mutation testing to avoid false positives.

Closes #5047