### PR TITLE
Fix `arbitrary_transaction` fuzz target

### DIFF
--- a/fuzz/fuzz_targets/bitcoin/arbitrary_block.rs
+++ b/fuzz/fuzz_targets/bitcoin/arbitrary_block.rs
@@ -23,7 +23,6 @@ fn do_test(data: &[u8]) {
         }
 
         let deserialized: Result<Block, _> = deserialize(serialized.as_slice());
-        assert!(deserialized.is_ok(), "Deserialization error: {:?}", deserialized.err().unwrap());
         assert_eq!(deserialized.unwrap(), block);
     }
 }

--- a/fuzz/fuzz_targets/bitcoin/arbitrary_transaction.rs
+++ b/fuzz/fuzz_targets/bitcoin/arbitrary_transaction.rs
@@ -10,6 +10,10 @@ fn do_test(data: &[u8]) {
 
     if let Ok(mut tx) = t {
         let serialized = serialize(&tx);
+        let deserialized: Result<Transaction, _> = deserialize(serialized.as_slice());
+        assert!(deserialized.is_ok(), "Deserialization error: {:?}", deserialized.err().unwrap());
+        assert_eq!(deserialized.unwrap(), tx);
+
         let len = serialized.len();
         let calculated_weight = tx.weight().to_wu() as usize;
         for input in &mut tx.inputs {
@@ -25,10 +29,6 @@ fn do_test(data: &[u8]) {
         } else {
             assert_eq!(no_witness_len * 3 + len, calculated_weight);
         }
-
-        let deserialized: Result<Transaction, _> = deserialize(serialized.as_slice());
-        assert!(deserialized.is_ok(), "Deserialization error: {:?}", deserialized.err().unwrap());
-        assert_eq!(deserialized.unwrap(), tx);
     }
 }
 

--- a/fuzz/fuzz_targets/bitcoin/arbitrary_transaction.rs
+++ b/fuzz/fuzz_targets/bitcoin/arbitrary_transaction.rs
@@ -11,7 +11,6 @@ fn do_test(data: &[u8]) {
     if let Ok(mut tx) = t {
         let serialized = serialize(&tx);
         let deserialized: Result<Transaction, _> = deserialize(serialized.as_slice());
-        assert!(deserialized.is_ok(), "Deserialization error: {:?}", deserialized.err().unwrap());
         assert_eq!(deserialized.unwrap(), tx);
 
         let len = serialized.len();

--- a/fuzz/fuzz_targets/bitcoin/arbitrary_witness.rs
+++ b/fuzz/fuzz_targets/bitcoin/arbitrary_witness.rs
@@ -14,7 +14,6 @@ fn do_test(data: &[u8]) {
         let _ = witness.taproot_leaf_script();
 
         let deserialized: Result<Witness, _> = deserialize(serialized.as_slice());
-        assert!(deserialized.is_ok(), "Deserialization error: {:?}", deserialized.err().unwrap());
         assert_eq!(deserialized.unwrap(), witness);
 
         if let Ok(element_bytes) = Vec::<u8>::arbitrary(&mut u) {


### PR DESCRIPTION
I thought I tested all of the targets I updated before I published them, but this one slipped through the cracks. Updated to move the serialization before object mutation [like before](https://github.com/rust-bitcoin/rust-bitcoin/blob/66c4ea20ff30cfa3e20f3073bd3beca3117177fd/fuzz/fuzz_targets/bitcoin/deserialize_transaction.rs#L10-L11), and I ran `cycle.sh` to make sure that there weren't any glaringly obvious bugs like the one that I pushed. Also remove some unnecessary `assert`s mentioned in #5029 

