### PR TITLE
fix: remove assertion in Cursor when reading past end

### DIFF
--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -299,13 +299,13 @@ impl<T: AsRef<[u8]>> BufRead for Cursor<T> {
     #[inline]
     fn fill_buf(&mut self) -> Result<&[u8]> {
         let inner: &[u8] = self.inner.as_ref();
-        Ok(&inner[self.pos as usize..])
+        let pos = self.pos.min(inner.len() as u64) as usize;
+        Ok(&inner[pos..])
     }
 
     #[inline]
     fn consume(&mut self, amount: usize) {
-        assert!(amount <= self.inner.as_ref().len());
-        self.pos += amount as u64;
+        self.pos = self.pos.saturating_add(amount as u64);
     }
 }
 

--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -517,4 +517,24 @@ mod tests {
         assert_eq!(read, 32);
         assert_eq!(data[0..32], v[0..32]);
     }
+
+    #[test]
+    fn cursor_fill_buf_past_end() {
+        let data = [1, 2, 3];
+        let mut cursor = Cursor::new(&data);
+        cursor.set_position(10);
+
+        let buf = cursor.fill_buf().unwrap();
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn cursor_consume_past_end() {
+        let data = [1, 2, 3];
+        let mut cursor = Cursor::new(&data);
+        cursor.set_position(10);
+
+        cursor.consume(5);
+        assert_eq!(cursor.position(), 15);
+    }
 }


### PR DESCRIPTION
The current behavior of Cursor doesn't match what we have in `std` we need to:

- Remove assertion in `consume()` that panics when amount > buffer length (now it just increment position)
- Fix `fill_buf()` to return empty slice when positioned past end

Closes #5019 