### PR TITLE
fix: FromStd::inner_mut deprecation note

### DIFF
--- a/io/src/bridge.rs
+++ b/io/src/bridge.rs
@@ -40,7 +40,7 @@ impl<T> FromStd<T> {
 
     /// Returns a mutable reference to the wrapped value.
     #[inline]
-    #[deprecated(since = "TBD", note = "use `get_ref()` instead")]
+    #[deprecated(since = "TBD", note = "use `get_mut()` instead")]
     pub fn inner_mut(&mut self) -> &mut T { &mut self.0 }
 }
 


### PR DESCRIPTION
Update the deprecation note on FromStd::inner_mut() to recommend get_mut() instead of get_ref(). This aligns with the intended API where inner() maps to get_ref() and the mutable variant maps to get_mut().