### PR TITLE
chore: fix typos

### DIFF
--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -438,7 +438,7 @@ mod tests {
     use crate::script::ScriptBufExt as _;
     use crate::TapScriptBuf;
 
-    // Composes tree matching a given depth map, filled with dumb script leafs,
+    // Composes tree matching a given depth map, filled with dumb script leaves,
     // each of which consists of a single push-int op code, with int value
     // increased for each consecutive leaf.
     pub fn compose_taproot_builder<'map>(

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -4,7 +4,7 @@ tab_spaces = 4
 newline_style = "Auto"
 indent_style = "Block"
 
-max_width = 100 # This is number of characters.
+max_width = 100 # This is the number of characters.
 # `use_small_heuristics` is ignored if the granular width config values are explicitly set.
 use_small_heuristics = "Max"    # "Max" == All granular width settings same as `max_width`.
 # # Granular width configuration settings. These are percentages of `max_width`.


### PR DESCRIPTION
Fix `This is number of characters.` to `This is the number of characters.`
Fix `leafs` to `leaves`