### PR TITLE
refactor: remove redundant type casts in push_bytes macro

### DIFF
--- a/bitcoin/src/blockdata/script/push_bytes.rs
+++ b/bitcoin/src/blockdata/script/push_bytes.rs
@@ -167,13 +167,13 @@ mod primitive {
 
                 impl From<[u8; $len]> for PushBytesBuf {
                     fn from(bytes: [u8; $len]) -> Self {
-                        PushBytesBuf(Vec::from(&bytes as &[_]))
+                        PushBytesBuf(Vec::from(&bytes))
                     }
                 }
 
                 impl<'a> From<&'a [u8; $len]> for PushBytesBuf {
                     fn from(bytes: &'a [u8; $len]) -> Self {
-                        PushBytesBuf(Vec::from(bytes as &[_]))
+                        PushBytesBuf(Vec::from(bytes))
                     }
                 }
             )*


### PR DESCRIPTION
Rust's automatic type coercion handles array-to-slice conversion, making the explicit `as &[_]` casts redundant. This change makes the code more idiomatic while maintaining identical functionality.