### PR TITLE
Fix clippy lint with `no-default-features` in `primitives` and `units`

### DIFF
--- a/consensus_encoding/src/encode/encoders.rs
+++ b/consensus_encoding/src/encode/encoders.rs
@@ -101,7 +101,7 @@ impl<'e, T: Encodable> SliceEncoder<'e, T> {
     }
 }
 
-impl<'e, T: Encodable> Encoder for SliceEncoder<'e, T> {
+impl<T: Encodable> Encoder for SliceEncoder<'_, T> {
     fn current_chunk(&self) -> Option<&[u8]> {
         if let Some(compact_size) = self.compact_size.as_ref() {
             return Some(compact_size);

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -41,6 +41,7 @@ pub mod _export {
 }
 
 mod hash_types;
+#[cfg(feature = "alloc")]
 mod opcodes;
 
 pub mod block;

--- a/units/src/amount/tests.rs
+++ b/units/src/amount/tests.rs
@@ -11,7 +11,9 @@ use core::num::{NonZeroI64, NonZeroU64};
 use std::panic;
 
 use super::*;
-use crate::result::{MathOp, NumOpResult};
+use crate::result::NumOpResult;
+#[cfg(feature = "alloc")]
+use crate::result::MathOp;
 #[cfg(feature = "alloc")]
 use crate::{FeeRate, Weight};
 


### PR DESCRIPTION
There are a few lint errors in `units` and `primitives` with `no-default-features`.

Fix the lint errors in `units` and `primitives` with `no-default-features`.

