### PR TITLE
docs: update deprecated hash_types::Txid imports to direct Txid imports

### DIFF
--- a/bitcoin/src/merkle_tree/block.rs
+++ b/bitcoin/src/merkle_tree/block.rs
@@ -201,7 +201,7 @@ impl PartialMerkleTree {
     /// # Examples
     ///
     /// ```rust
-    /// use bitcoin::hash_types::Txid;
+    /// use bitcoin::Txid;
     /// use bitcoin::merkle_tree::PartialMerkleTree;
     ///
     /// // Block 80000
@@ -540,7 +540,7 @@ mod tests {
     use super::*;
     use crate::block::{BlockUncheckedExt as _, Unchecked};
     use crate::consensus::encode;
-    use crate::hash_types::Txid;
+    use crate::Txid;
 
     #[cfg(feature = "rand-std")]
     macro_rules! pmt_tests {


### PR DESCRIPTION
Replace deprecated `hash_types::Txid` imports with direct `Txid` imports in merkle_tree/block.rs documentation and tests.

The public re-export of Txid through hash_types is deprecated in favor of direct imports from the crate root.
This change:

- Updates doc example from `use bitcoin::hash_types::Txid;` to `use bitcoin::Txid;`
- Updates test import from `use crate::hash_types::Txid;` to `use crate::Txid;` 