### PR TITLE
backport part of 4915: Deprecate weight constructors

### DIFF
--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -255,6 +255,7 @@ impl TxIn {
     /// Keep in mind that when adding a TxIn to a transaction, the total weight of the transaction
     /// might increase more than `TxIn::legacy_weight`. This happens when the new input added causes
     /// the input length `VarInt` to increase its encoding length.
+    #[deprecated(since = "0.32.8", note = "deprecated so we can change the function signature or delete in future")]
     pub fn legacy_weight(&self) -> Weight {
         Weight::from_non_witness_data_size(self.base_size() as u64)
     }
@@ -270,6 +271,7 @@ impl TxIn {
     /// - the new input added causes the input length `VarInt` to increase its encoding length
     /// - the new input is the first segwit input added - this will add an additional 2WU to the
     ///   transaction weight to take into account the segwit marker
+    #[deprecated(since = "0.32.8", note = "deprecated so we can change the function signature or delete in future")]
     pub fn segwit_weight(&self) -> Weight {
         Weight::from_non_witness_data_size(self.base_size() as u64)
             + Weight::from_witness_data_size(self.witness.size() as u64)


### PR DESCRIPTION
Deprecation in trait methods is painful and these two weight constructors are now defined in `TxInExt`.

In #4915 we deprecate `Weight::from_non_witness_data_size` and `Weight::from_witness_data_size` in favour of `Weight::from_vb` and `Weight::from_wu` respectively but doing so messes with the APIs of these to `TxIn` methods because the return value changes from `Weight` to `Option<Weight>`.

Deprecate the functions here so we can either break the API in 0.33 or delete the functions entirely.

Note this only does the stuff from 4915 in `bitcoin` not in `units`.