### PR TITLE
consensus_encoding: Add `CompactSizeEncoder` and refactor `WitnessEncoder` 

### DIFF
--- a/consensus_encoding/src/lib.rs
+++ b/consensus_encoding/src/lib.rs
@@ -41,6 +41,7 @@ pub use self::encode::encode_to_vec;
 #[cfg(feature = "std")]
 pub use self::encode::encode_to_writer;
 pub use self::encode::encoders::{
-    ArrayEncoder, BytesEncoder, Encoder2, Encoder3, Encoder4, Encoder6, SliceEncoder,
+    ArrayEncoder, BytesEncoder, CompactSizeEncoder, Encoder2, Encoder3, Encoder4, Encoder6,
+    SliceEncoder,
 };
 pub use self::encode::{encode_to_hash_engine, Encodable, Encoder};


### PR DESCRIPTION
Add `CompactSizeEncoder` implementation and simplify `WitnessEncoder` by using the new `CompactSizeEncoder` + `Encoder2` composition.

Discussed in: https://github.com/rust-bitcoin/rust-bitcoin/pull/4992#issuecomment-3362279460

Closes: #5077