### PR TITLE
justfile: include `bitcoin-consensus-encoding` in gen-dep-tree

### DIFF
--- a/docs/dep-tree
+++ b/docs/dep-tree
@@ -39,11 +39,31 @@ bitcoin
 ├── bitcoin_primitives
 │   ├── arbitrary
 │   ├── arrayvec
+│   ├── bitcoin_consensus_encoding
+│   │   ├── bitcoin_internals
+│   │   │   └── hex_conservative
+│   │   │       └── arrayvec
+│   │   └── bitcoin_hashes
+│   │       ├── bitcoin_internals
+│   │       │   └── hex_conservative
+│   │       │       └── arrayvec
+│   │       └── hex_conservative
+│   │           └── arrayvec
 │   ├── bitcoin_internals
 │   │   └── hex_conservative
 │   │       └── arrayvec
 │   ├── bitcoin_units
 │   │   ├── arbitrary
+│   │   ├── bitcoin_consensus_encoding
+│   │   │   ├── bitcoin_internals
+│   │   │   │   └── hex_conservative
+│   │   │   │       └── arrayvec
+│   │   │   └── bitcoin_hashes
+│   │   │       ├── bitcoin_internals
+│   │   │       │   └── hex_conservative
+│   │   │       │       └── arrayvec
+│   │   │       └── hex_conservative
+│   │   │           └── arrayvec
 │   │   └── bitcoin_internals
 │   │       └── hex_conservative
 │   │           └── arrayvec
@@ -57,6 +77,16 @@ bitcoin
 │       └── arrayvec
 ├── bitcoin_units
 │   ├── arbitrary
+│   ├── bitcoin_consensus_encoding
+│   │   ├── bitcoin_internals
+│   │   │   └── hex_conservative
+│   │   │       └── arrayvec
+│   │   └── bitcoin_hashes
+│   │       ├── bitcoin_internals
+│   │       │   └── hex_conservative
+│   │       │       └── arrayvec
+│   │       └── hex_conservative
+│   │           └── arrayvec
 │   └── bitcoin_internals
 │       └── hex_conservative
 │           └── arrayvec
@@ -78,6 +108,17 @@ bitcoin
 
 bitcoin_addresses
 
+bitcoin_consensus_encoding
+├── bitcoin_internals
+│   └── hex_conservative
+│       └── arrayvec
+└── bitcoin_hashes
+    ├── bitcoin_internals
+    │   └── hex_conservative
+    │       └── arrayvec
+    └── hex_conservative
+        └── arrayvec
+
 bitcoin_internals
 └── hex_conservative
     └── arrayvec
@@ -96,11 +137,31 @@ bitcoin_io
 bitcoin_primitives
 ├── arbitrary
 ├── arrayvec
+├── bitcoin_consensus_encoding
+│   ├── bitcoin_internals
+│   │   └── hex_conservative
+│   │       └── arrayvec
+│   └── bitcoin_hashes
+│       ├── bitcoin_internals
+│       │   └── hex_conservative
+│       │       └── arrayvec
+│       └── hex_conservative
+│           └── arrayvec
 ├── bitcoin_internals
 │   └── hex_conservative
 │       └── arrayvec
 ├── bitcoin_units
 │   ├── arbitrary
+│   ├── bitcoin_consensus_encoding
+│   │   ├── bitcoin_internals
+│   │   │   └── hex_conservative
+│   │   │       └── arrayvec
+│   │   └── bitcoin_hashes
+│   │       ├── bitcoin_internals
+│   │       │   └── hex_conservative
+│   │       │       └── arrayvec
+│   │       └── hex_conservative
+│   │           └── arrayvec
 │   └── bitcoin_internals
 │       └── hex_conservative
 │           └── arrayvec
@@ -115,6 +176,16 @@ bitcoin_primitives
 
 bitcoin_units
 ├── arbitrary
+├── bitcoin_consensus_encoding
+│   ├── bitcoin_internals
+│   │   └── hex_conservative
+│   │       └── arrayvec
+│   └── bitcoin_hashes
+│       ├── bitcoin_internals
+│       │   └── hex_conservative
+│       │       └── arrayvec
+│       └── hex_conservative
+│           └── arrayvec
 └── bitcoin_internals
     └── hex_conservative
         └── arrayvec

--- a/justfile
+++ b/justfile
@@ -65,5 +65,6 @@ gen-dep-tree:
         cargo tree --all-features --edges=no-dev,no-build --format={lib} --no-dedupe \
         --prune=serde_json --prune=rand --prune=bincode --prune=serde \
         -p bitcoin -p bitcoin-internals -p bitcoin_hashes@0.16.0 -p bitcoin-units \
-        -p bitcoin-primitives -p chacha20-poly1305 -p base58ck -p bitcoin-addresses -p bitcoin-io@0.2.0
+        -p bitcoin-primitives -p chacha20-poly1305 -p base58ck -p bitcoin-addresses -p bitcoin-io@0.2.0 \
+        -p bitcoin-consensus-encoding
        


### PR DESCRIPTION
On top of https://github.com/rust-bitcoin/rust-bitcoin/pull/5090

Add `bitcoin-consensus-encoding` to the dependency tree