### PR TITLE
chore: remove obsolete clippy lint configuration

### DIFF
--- a/consensus_encoding/Cargo.toml
+++ b/consensus_encoding/Cargo.toml
@@ -95,7 +95,6 @@ manual_string_new = "warn"
 many_single_char_names = "warn"
 map_unwrap_or = "warn"
 match_bool = "allow" # Adds extra indentation and LOC.
-match_on_vec_items = "warn"
 match_same_arms = "allow" # Collapses things that are conceptually unrelated to each other.
 match_wild_err_arm = "warn"
 match_wildcard_for_single_variants = "warn"


### PR DESCRIPTION
Drop the match_on_vec_items override from consensus_encoding/Cargo.toml because the lint no longer exists in Clippy, eliminating spurious warnings without affecting behavior.