### PR TITLE
Add excludes for new mutants

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -46,4 +46,6 @@ exclude_re = [
     "Script<T>::to_hex", # Deprecated
     "ScriptBuf::to_hex", # Deprecated
     "ScriptBuf<T>::to_hex", # Deprecated
+    "<impl Encoder for WitnessEncoder<'a>>::current_chunk", # Replacing the return with Some(vec![]) causes an infinite loop.
+    "<impl Encoder for WitnessEncoder<'a>>::advance", # Replacing the return with true causes an infinite loop.
 ]


### PR DESCRIPTION
New mutants were found in the weekly mutation testing. One set is from a function that is for optimization and testing it is unnecessary, the other causes a timeout by changing the return of functions which are used in testing to exit loops.

- Edit an existing exclude to make it more specific and only exclude the needed function.
- Exclude the optimization functions `min_bytes_needed`.
- Exclude the `WitnessEncoder` functions that cause an infinite loop in mutation testing.

Closes #5088