### PR TITLE
Use correct name in rustdocs

### DIFF
--- a/primitives/src/pow.rs
+++ b/primitives/src/pow.rs
@@ -49,7 +49,7 @@ impl fmt::UpperHex for CompactTarget {
 }
 
 encoding::encoder_newtype! {
-    /// The encoder for the [`TxMerkleNode`] type.
+    /// The encoder for the [`CompactTarget`] type.
     pub struct CompactTargetEncoder(encoding::ArrayEncoder<4>);
 }
 


### PR DESCRIPTION
Cut'n'pasta error slipped in, notice during review of #4998.