### PR TITLE
Remove `BytesEncoder::without_length_prefix`

### DIFF
--- a/consensus_encoding/examples/encoder.rs
+++ b/consensus_encoding/examples/encoder.rs
@@ -40,7 +40,7 @@ impl Encodable for Adt {
 
     fn encoder(&self) -> Self::Encoder<'_> {
         let a = SliceEncoder::with_length_prefix(&self.v);
-        let b = BytesEncoder::without_length_prefix(self.b.as_ref());
+        let b = BytesEncoder::with_length_prefix(self.b.as_ref());
 
         AdtEncoder(Encoder2::new(a, b))
     }

--- a/consensus_encoding/tests/encode.rs
+++ b/consensus_encoding/tests/encode.rs
@@ -107,9 +107,12 @@ fn encode_newtype_lifetime_flexibility() {
     }
 
     let test_data = b"hello world";
-    let custom_encoder = CustomEncoder(BytesEncoder::without_length_prefix(test_data));
+    let mut custom_encoder = CustomEncoder(BytesEncoder::with_length_prefix(test_data));
     let no_lifetime_encoder = NoLifetimeEncoder(ArrayEncoder::without_length_prefix([1, 2, 3, 4]));
 
+    assert_eq!(custom_encoder.current_chunk(), Some(&[11][..]));
+    custom_encoder.advance();
     assert_eq!(custom_encoder.current_chunk(), Some(test_data.as_slice()));
+
     assert_eq!(no_lifetime_encoder.current_chunk(), Some(&[1, 2, 3, 4][..]));
 }


### PR DESCRIPTION
This constructor is a bit confusing because it means when seeing the `BytesEncoder` in nested encoders it is not obvious if there is a length prefix or not.

We can remove this ambiguity by only ever using an `ArrayEncoder` when there is not a length prefix. The cost is a tiny wee hit to performance because we may have to copy bytes around due to the `Encodable` trait definition. As we do for `Txid` inside an `OutPointEncoder`.

This complexity was observed by jrakibi and described in #5097. This is an alternate to his proposed solution.

