### PR TITLE
Remove pub(crate) export of macro

### DIFF
--- a/io/src/hash.rs
+++ b/io/src/hash.rs
@@ -30,7 +30,6 @@ macro_rules! impl_write {
         }
     }
 }
-pub(crate) use impl_write;
 
 impl_write!(
     hash160::HashEngine,


### PR DESCRIPTION
This macro is only used in the file it is defined, remove the unnecessary re-export.

Found by `clippy`.