### PR TITLE
Remove length prefix from `SliceEncoder`

### DIFF
--- a/consensus_encoding/examples/encoder.rs
+++ b/consensus_encoding/examples/encoder.rs
@@ -3,7 +3,7 @@
 //! Example of creating an encoder that encodes a slice of encodable objects.
 
 use consensus_encoding as encoding;
-use encoding::{ArrayEncoder, BytesEncoder, Encodable, Encoder2, SliceEncoder};
+use encoding::{ArrayEncoder, BytesEncoder, CompactSizeEncoder, Encodable, Encoder2, SliceEncoder};
 
 fn main() {
     let v = vec![Inner::new(0xcafe_babe), Inner::new(0xdead_beef)];
@@ -29,7 +29,7 @@ impl Adt {
 
 encoding::encoder_newtype! {
     /// The encoder for the [`Adt`] type.
-    pub struct AdtEncoder<'e>(Encoder2<SliceEncoder<'e, Inner>, BytesEncoder<'e>>);
+    pub struct AdtEncoder<'e>(Encoder2<Encoder2<CompactSizeEncoder, SliceEncoder<'e, Inner>>, BytesEncoder<'e>>);
 }
 
 impl Encodable for Adt {
@@ -39,7 +39,10 @@ impl Encodable for Adt {
         Self: 'a;
 
     fn encoder(&self) -> Self::Encoder<'_> {
-        let a = SliceEncoder::with_length_prefix(&self.v);
+        let a = Encoder2::new(
+            CompactSizeEncoder::new(self.v.len()),
+            SliceEncoder::without_length_prefix(&self.v),
+        );
         let b = BytesEncoder::without_length_prefix(self.b.as_ref());
 
         AdtEncoder(Encoder2::new(a, b))

--- a/consensus_encoding/tests/wrappers.rs
+++ b/consensus_encoding/tests/wrappers.rs
@@ -3,7 +3,7 @@
 #![cfg(feature = "std")]
 
 use consensus_encoding as encoding;
-use encoding::{ArrayEncoder, BytesEncoder, Encodable, Encoder2, SliceEncoder};
+use encoding::{ArrayEncoder, BytesEncoder, CompactSizeEncoder, Encodable, Encoder2, SliceEncoder};
 
 encoding::encoder_newtype! {
     /// An encoder that uses an inner `ArrayEncoder`.
@@ -93,7 +93,7 @@ fn slice_encoder() {
 
     encoding::encoder_newtype! {
         /// An encoder that uses an inner `SliceEncoder`.
-        pub struct TestEncoder<'e>(SliceEncoder<'e, Inner>);
+        pub struct TestEncoder<'e>(Encoder2<CompactSizeEncoder, SliceEncoder<'e, Inner>>);
     }
 
     impl Encodable for Test {
@@ -103,7 +103,10 @@ fn slice_encoder() {
             Self: 'a;
 
         fn encoder(&self) -> Self::Encoder<'_> {
-            TestEncoder(SliceEncoder::with_length_prefix(&self.0))
+            TestEncoder(Encoder2::new(
+                CompactSizeEncoder::new(self.0.len()),
+                SliceEncoder::without_length_prefix(&self.0),
+            ))
         }
     }
 

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -21,7 +21,7 @@ use core::fmt;
 use arbitrary::{Arbitrary, Unstructured};
 use encoding::{ArrayEncoder, BytesEncoder, Encodable, Encoder2};
 #[cfg(feature = "alloc")]
-use encoding::{Encoder, Encoder3, Encoder6, SliceEncoder};
+use encoding::{CompactSizeEncoder, Encoder, Encoder3, Encoder6, SliceEncoder};
 #[cfg(feature = "alloc")]
 use hashes::sha256d;
 #[cfg(feature = "alloc")]
@@ -311,8 +311,8 @@ encoding::encoder_newtype! {
         Encoder6<
             VersionEncoder,
         Option<ArrayEncoder<2>>,
-        SliceEncoder<'e, TxIn>,
-        SliceEncoder<'e, TxOut>,
+        Encoder2<CompactSizeEncoder, SliceEncoder<'e, TxIn>>,
+        Encoder2<CompactSizeEncoder, SliceEncoder<'e, TxOut>>,
         Option<WitnessesEncoder<'e>>,
         LockTimeEncoder,
         >
@@ -328,8 +328,14 @@ impl Encodable for Transaction {
 
     fn encoder(&self) -> Self::Encoder<'_> {
         let version = self.version.encoder();
-        let inputs = SliceEncoder::with_length_prefix(self.inputs.as_ref());
-        let outputs = SliceEncoder::with_length_prefix(self.outputs.as_ref());
+        let inputs = Encoder2::new(
+            CompactSizeEncoder::new(self.inputs.len() as u64),
+            SliceEncoder::without_length_prefix(self.inputs.as_ref()),
+        );
+        let outputs = Encoder2::new(
+            CompactSizeEncoder::new(self.outputs.len() as u64),
+            SliceEncoder::without_length_prefix(self.outputs.as_ref()),
+        );
         let lock_time = self.lock_time.encoder();
 
         if self.uses_segwit_serialization() {


### PR DESCRIPTION
Currently we hide the length prefix inside the `SliceEncoder`. While technically correct the usage of the `SliceEncoder` can be made more clear by forcing users to combine a compact size encoder and a slice encoder using an `Encoder2` instead of the current abstraction.

Original idea from jrakibi in #5104. I gave you a co-developed-by tag mate. Pushing this up because I'm itching to get `primitives 1.0.0-rc.0` out.