### PR TITLE
Release tracking PR: `bitcoin-consensus-encoding v1.0.0-rc.0`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -74,7 +74,7 @@ version = "0.0.0"
 
 [[package]]
 name = "bitcoin-consensus-encoding"
-version = "0.1.0"
+version = "1.0.0-rc.0"
 dependencies = [
  "bitcoin-internals",
  "bitcoin_hashes 0.16.0",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -73,7 +73,7 @@ version = "0.0.0"
 
 [[package]]
 name = "bitcoin-consensus-encoding"
-version = "0.1.0"
+version = "1.0.0-rc.0"
 dependencies = [
  "bitcoin-internals",
  "bitcoin_hashes 0.16.0",

--- a/consensus_encoding/CHANGELOG.md
+++ b/consensus_encoding/CHANGELOG.md
@@ -1,3 +1,30 @@
+# 1.0.0-rc.0 - 2025-09-20
+
+This changelog is a rolling description of everything that will eventually end up in `v1.0`.
+
+This was truly a team effort, notably @nyonson and @jrakibi. Also please note that many of the ideas
+and a bunch of the code, pulled out of a draft PR by @kixunil. Initial implementation was put up by
+@apoelstra, then the crew hacked on it while we all reviewed. Good effort team. Also it should be
+noted that Kix was pushing for this work for a long time and we all resisted doing it. Now he is not
+around but the work got done. Props to him for many of the ideas.
+
+- Fix `consensus-encoding` package name [#5090](https://github.com/rust-bitcoin/rust-bitcoin/pull/5090)
+- Introduce pull encoding and use it for blockhash computation [#4912](https://github.com/rust-bitcoin/rust-bitcoin/pull/4912)
+- Implement `SliceEncoder` [#4982](https://github.com/rust-bitcoin/rust-bitcoin/pull/4982)
+- Add decoder I/O drivers [#5030](https://github.com/rust-bitcoin/rust-bitcoin/pull/5030)
+- Tag composers with inline [#5037](https://github.com/rust-bitcoin/rust-bitcoin/pull/5037)
+- Clean up encoders unit tests and fix empty `SliceEncoder` [#5039](https://github.com/rust-bitcoin/rust-bitcoin/pull/5039)
+- Add encoder composition unit tests [#5045](https://github.com/rust-bitcoin/rust-bitcoin/pull/5045)
+- Implement additional decoders [#5057](https://github.com/rust-bitcoin/rust-bitcoin/pull/5057)
+- Add `CompactSizeEncoder` and refactor `WitnessEncoder` [#5086](https://github.com/rust-bitcoin/rust-bitcoin/pull/5086)
+- Add `new()` constructor to `CompactSizeDecoder` [#5089](https://github.com/rust-bitcoin/rust-bitcoin/pull/5089)
+- Remove `prefix_read` field [#5079](https://github.com/rust-bitcoin/rust-bitcoin/pull/5079)
+- Remove length prefix from the `BytesEncoder` [#5103](https://github.com/rust-bitcoin/rust-bitcoin/pull/5103)
+- Remove length prefix from `SliceEncoder` [#5108](https://github.com/rust-bitcoin/rust-bitcoin/pull/5108)
+- Rename `min_bytes_needed` to `read_limit` [#5107](https://github.com/rust-bitcoin/rust-bitcoin/pull/5107)
+- Remove transitioning state [#5130](https://github.com/rust-bitcoin/rust-bitcoin/pull/5130)
+- Composite decoder errors [#5131](https://github.com/rust-bitcoin/rust-bitcoin/pull/5131)
+
 ## 0.0.0 - Placeholder release
 
 Empty crate to reserve the name on crates.io

--- a/consensus_encoding/Cargo.toml
+++ b/consensus_encoding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-consensus-encoding"
-version = "0.1.0"
+version = "1.0.0-rc.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>", "Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -23,7 +23,7 @@ arbitrary = ["dep:arbitrary", "units/arbitrary"]
 hex = ["dep:hex", "hashes/hex", "internals/hex"]
 
 [dependencies]
-encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", default-features = false }
+encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0-rc.0", default-features = false }
 hashes = { package = "bitcoin_hashes", path = "../hashes", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals" }
 units = { package = "bitcoin-units", path = "../units", default-features = false, features = [ "encoding" ] }

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -18,7 +18,7 @@ std = ["alloc", "internals/std", "encoding?/std"]
 alloc = ["internals/alloc", "serde?/alloc", "encoding?/alloc"]
 
 [dependencies]
-encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", default-features = false, optional = true }
+encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0-rc.0", default-features = false, optional = true }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.4.0" }
 
 serde = { version = "1.0.195", default-features = false, features = ["derive"], optional = true }


### PR DESCRIPTION
In preparation for release bump the version, add a changelog entry, and update the lock files.

From the changelog:

> This was truly a team effort, notably nyonson and jrakibi. Also please note that many of the ideas
and a bunch of the code, pulled out of a draft PR by kixunil. Initial implementation was put up by
apoelstra, then the crew hacked on it while we all reviewed. Good effort team. Also it should be
noted that Kix was pushing for this work for a long time and we all resisted doing it, now he is not
around but the work got done. Props to him for many of the ideas.
