### PR TITLE
chore: keep SliceExt polyfill import for MSRV

### DIFF
--- a/base58/src/lib.rs
+++ b/base58/src/lib.rs
@@ -44,7 +44,6 @@ pub use std::{string::String, vec::Vec};
 use hashes::sha256d;
 use internals::array::ArrayExt;
 use internals::array_vec::ArrayVec;
-#[allow(unused)] // MSRV polyfill
 use internals::slice::SliceExt;
 
 use crate::error::{IncorrectChecksumError, TooShortError};


### PR DESCRIPTION
keep the SliceExt polyfill import so base58 builds on the MSRV toolchain