### PR TITLE
docs: fix scriptcode typo

### DIFF
--- a/docs/crypto.md
+++ b/docs/crypto.md
@@ -57,7 +57,7 @@ Currently we are using `bitcoin::network::NetworkKind` in `PrivateKey`.
 
 #### `ScriptBuf`
 
-Possibly ok if we have a dependency on `primitives`. Only used for sciptcode.
+Possibly ok if we have a dependency on `primitives`. Only used for scriptcode.
 
 #### Taproot stuff
 

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -56,7 +56,7 @@ Currently we are using `bitcoin::network::NetworkKind` in `PrivateKey`.
 
 #### `ScriptBuf`
 
-Possibly ok if we have a dependency on `primitives`. Only used for sciptcode.
+Possibly ok if we have a dependency on `primitives`. Only used for scriptcode.
 
 #### Taproot stuff
 


### PR DESCRIPTION
correct the scriptcode spelling in docs/crypto.md and docs/keys.md