### PR TITLE
chore: fix typos in code comments

### DIFF
--- a/bitcoin/src/consensus/error.rs
+++ b/bitcoin/src/consensus/error.rs
@@ -54,7 +54,7 @@ impl From<ParseError> for DeserializeError {
 
 /// Error when consensus decoding from an `[IterReader]`.
 ///
-/// This is the same as a `DeserializeError` with an additional variant to return any error yealded
+/// This is the same as a `DeserializeError` with an additional variant to return any error yielded
 /// by the inner bytes iterator.
 #[derive(Debug)]
 pub enum DecodeError<E> {

--- a/bitcoin/src/taproot/mod.rs
+++ b/bitcoin/src/taproot/mod.rs
@@ -417,7 +417,7 @@ pub struct TaprootBuilder {
     // 128 entries (as that would mean more than 128 levels in the tree). The depth of newly added
     // entries will always be at least equal to the current size of branch (otherwise it does not
     // correspond to a depth-first traversal of a tree). A branch is only empty if no entries have
-    // ever be processed. A branch having length 1 corresponds to being done.
+    // ever been processed. A branch having length 1 corresponds to being done.
     branch: Vec<Option<NodeInfo>>,
 }
 

--- a/hashes/src/macros.rs
+++ b/hashes/src/macros.rs
@@ -67,7 +67,7 @@ macro_rules! sha256t_tag {
 /// This will display the hash backwards regardless of what the inner type does. Use `forward`
 /// instead of `backward` to force displaying forward.
 ///
-/// You can add arbitrary doc comments or other attributes to the struct or it's field. Note that
+/// You can add arbitrary doc comments or other attributes to the struct or its field. Note that
 /// the macro already derives [`Copy`], [`Clone`], [`Eq`], [`PartialEq`],
 /// [`Hash`](core::hash::Hash), [`Ord`], [`PartialOrd`].
 ///
@@ -96,7 +96,7 @@ macro_rules! sha256t_tag {
 // one. The following code is written the way it is for some specific reasons. If you think you can
 // simplify it, I suggest spending your time elsewhere.
 //
-// If you looks at the code carefully you might ask these questions:
+// If you look at the code carefully you might ask these questions:
 //
 // * Why are attributes using `tt` and not `meta`?!
 // * Why are the macros split like that?!


### PR DESCRIPTION
yealded -> yielded
no entries have ever be -> no entries have ever been
it's field -> its field
If you looks -> If you look