### PR TITLE
consensus_encoding: update `Encoder::advance()` documentation

### DIFF
--- a/consensus_encoding/src/encode/encoders.rs
+++ b/consensus_encoding/src/encode/encoders.rs
@@ -620,4 +620,54 @@ mod tests {
         );
         assert!(!e.advance());
     }
+
+    #[test]
+    fn encode_encoder2_with_option_none_some() {
+        let enc1: Option<ArrayEncoder<2>> = None;
+        let enc2 = Some(ArrayEncoder::without_length_prefix([0x42, 0x43]));
+        let mut encoder = Encoder2::new(enc1, enc2);
+
+        assert_eq!(encoder.current_chunk(), None);
+        assert!(encoder.advance());
+        assert_eq!(encoder.current_chunk(), Some(&[0x42, 0x43][..]));
+        assert!(!encoder.advance());
+        assert_eq!(encoder.current_chunk(), None);
+    }
+
+    #[test]
+    fn encode_encoder2_with_option_some_none() {
+        let enc1 = Some(ArrayEncoder::without_length_prefix([0x40, 0x41]));
+        let enc2: Option<ArrayEncoder<2>> = None;
+        let mut encoder = Encoder2::new(enc1, enc2);
+
+        assert_eq!(encoder.current_chunk(), Some(&[0x40, 0x41][..]));
+        assert!(encoder.advance());
+        assert_eq!(encoder.current_chunk(), None);
+        assert!(!encoder.advance());
+    }
+
+    #[test]
+    fn encode_encoder2_with_option_none_none() {
+        let enc1: Option<ArrayEncoder<2>> = None;
+        let enc2: Option<ArrayEncoder<2>> = None;
+        let mut encoder = Encoder2::new(enc1, enc2);
+
+        assert_eq!(encoder.current_chunk(), None);
+        assert!(encoder.advance());
+        assert_eq!(encoder.current_chunk(), None);
+        assert!(!encoder.advance());
+    }
+
+    #[test]
+    fn encode_encoder2_with_option_some_some() {
+        let enc1 = Some(ArrayEncoder::without_length_prefix([0x40, 0x41]));
+        let enc2 = Some(ArrayEncoder::without_length_prefix([0x42, 0x43]));
+        let mut encoder = Encoder2::new(enc1, enc2);
+
+        assert_eq!(encoder.current_chunk(), Some(&[0x40, 0x41][..]));
+        assert!(encoder.advance());
+        assert_eq!(encoder.current_chunk(), Some(&[0x42, 0x43][..]));
+        assert!(!encoder.advance());
+        assert_eq!(encoder.current_chunk(), None);
+    }
 }

--- a/consensus_encoding/src/encode/mod.rs
+++ b/consensus_encoding/src/encode/mod.rs
@@ -38,7 +38,7 @@ pub trait Encoder {
     /// Does not need to be called when the encoder is first created. (In fact, if it
     /// is called, this will discard the first chunk of encoded data.)
     ///
-    /// Returns `true` if the next call to [`Self::current_chunk`] will return data.
+    /// Returns `true` if the encoder state advanced.
     /// Returns `false` otherwise. It is fine to ignore the return value of this method
     /// and just call `current_chunk` to see if it works.
     fn advance(&mut self) -> bool;


### PR DESCRIPTION
EDITED:

The Encoder trait documentation for `advance()` previously stated ```Returns `true` if the next call to [`Self::current_chunk`] will return data```.

However, the actual implementation returns `true` when the encoder state advances, which is the behavior that existing code depends on.

This change updates the doc to reflect this behavior.
