### PR TITLE
bitcoin: refuse to compute block and witness merkle roots which would be ambiguous

### DIFF
--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -149,6 +149,14 @@ impl BlockUncheckedExt for Block<Unchecked> {
 }
 
 /// Computes the Merkle root for a list of transactions.
+///
+/// Returns `None` if the iterator was empty, or if the transaction list contains
+/// consecutive duplicates which would trigger CVE 2012-2459. Blocks with duplicate
+/// transactions will always be invalid, so there is no harm in us refusing to
+/// compute their merkle roots.
+///
+/// Unless you are certain your transaction list is nonempty and has no duplicates,
+/// you should not unwrap the `Option` returned by this method!
 pub fn compute_merkle_root(transactions: &[Transaction]) -> Option<TxMerkleNode> {
     let hashes = transactions.iter().map(|obj| obj.compute_txid());
     TxMerkleNode::calculate_root(hashes)
@@ -170,6 +178,14 @@ pub fn compute_witness_commitment(
 }
 
 /// Computes the Merkle root of transactions hashed for witness.
+///
+/// Returns `None` if the iterator was empty, or if the transaction list contains
+/// consecutive duplicates which would trigger CVE 2012-2459. Blocks with duplicate
+/// transactions will always be invalid, so there is no harm in us refusing to
+/// compute their merkle roots.
+///
+/// Unless you are certain your transaction list is nonempty and has no duplicates,
+/// you should not unwrap the `Option` returned by this method!
 pub fn compute_witness_root(transactions: &[Transaction]) -> Option<WitnessMerkleNode> {
     let hashes = transactions.iter().enumerate().map(|(i, t)| {
         if i == 0 {
@@ -938,6 +954,6 @@ mod tests {
         let forged_block = Block::new_unchecked(header, transactions);
 
         assert!(valid_block.validate().is_ok());
-        assert!(forged_block.validate().is_ok()); // FIXME fixed in next commit
+        assert!(forged_block.validate().is_err());
     }
 }


### PR DESCRIPTION
In Bitcoin it is possible to produce invalid blocks with the same transaction Merkle root (and therefore same blockhash) as a valid block. This has historically caused confusion for nodes, leading to CVE 2012-2459.

Core fixed the CVE by refusing to compute Merkle roots when it detects this ambiguity. We copy their approach.

This subtly changes the API of `compute_merkle_root` and `compute_witness_root` to now return `None` when the transaction list contains duplicates. Previously it would only return `None` when the transaction list was empty. It is possible that users were unwrapping this option (we do this in all of our unit tests) in which case they may now get panics when they encounter an invalid transaction list. However, if they were obtaining their list of transactions from a working bitcoin node, there will be no duplicates and they are fine to keep unwrapping.

Fixes #5023