### PR TITLE
docs: fix grammatical issues in code comments

### DIFF
--- a/bitcoin/src/blockdata/script/push_bytes.rs
+++ b/bitcoin/src/blockdata/script/push_bytes.rs
@@ -9,7 +9,7 @@ use crate::script;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
-// This is not the usual re-export, `primitive` here is an code audit thing.
+// This is not the usual re-export, `primitive` here is a code audit thing.
 pub use self::primitive::{PushBytes, PushBytesBuf};
 
 /// This module only contains required operations so that outside functions wouldn't accidentally

--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -623,7 +623,7 @@ fn script_buf_collect() {
 }
 
 #[test]
-fn script_p2sh_p2p2k_template() {
+fn script_p2sh_p2pkh_template() {
     // random outputs I picked out of the mempool
     assert!(ScriptPubKeyBuf::from_hex_no_length_prefix(
         "76a91402306a7c23f3e8010de41e9e591348bb83f11daa88ac"

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -1144,7 +1144,7 @@ impl fmt::Display for FromWifError {
             InvalidAddressVersion(ref e) =>
                 write_err!(f, "decoded base58 data contained an invalid address version byte"; e),
             Secp256k1(ref e) => write_err!(f, "private key validation failed"; e),
-            InvalidWifCompressionFlag(ref e) => write_err!(f, "invalid WIF compression flag";e),
+            InvalidWifCompressionFlag(ref e) => write_err!(f, "invalid WIF compression flag"; e),
         }
     }
 }


### PR DESCRIPTION
Corrected some moments in code comments
1) an code -> a code
2) script_p2sh_p2p2k_template -> script_p2sh_p2pkh_template (p2p2k -> p2pkh)

3) And looking at other similar examples i thought there should be a whitespace between ';' and e
