### PR TITLE
Rename `min_bytes_needed` cargo mutants exclude

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -12,7 +12,7 @@ exclude_re = [
     "serde_details::<impl de::Visitor<'_>", # Skip serde mutation tests
     "Iterator", # Mutating operations in an iterator can result in an infinite loop
     "<impl encoding::Decodable for .*>::decoder", # Mutant replacing Default::default() is equivalent to returning new()
-    "<impl encoding::Decoder for .*>::min_bytes_needed", # Function is just a cast for optimization.
+    "<impl encoding::Decoder for .*>::read_limit", # Function is just a cast for optimization.
 
 
     # ----------------------------------Crate-specific exclusions----------------------------------


### PR DESCRIPTION
Got missed during rebase, merge, rename, I'd guess.

Use the new name when excluding.