### PR TITLE
Update mutant exclude for lifetime syntax change

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -46,6 +46,6 @@ exclude_re = [
     "Script<T>::to_hex", # Deprecated
     "ScriptBuf::to_hex", # Deprecated
     "ScriptBuf<T>::to_hex", # Deprecated
-    "<impl Encoder for WitnessEncoder<'a>>::current_chunk", # Replacing the return with Some(vec![]) causes an infinite loop.
-    "<impl Encoder for WitnessEncoder<'a>>::advance", # Replacing the return with true causes an infinite loop.
+    "<impl Encoder for WitnessEncoder<'_>>::current_chunk", # Replacing the return with Some(vec![]) causes an infinite loop.
+    "<impl Encoder for WitnessEncoder<'_>>::advance", # Replacing the return with true causes an infinite loop.
 ]


### PR DESCRIPTION
Two mutant excludes stopped working and caused a timeout in the weekly mutation testing. The lifetimes are now elided to fix a clippy error. And an existing comment needs to be updated in response to a review comment on previous PR.

- Fix the comment for a mutant exclude as a follow up to #5094.
- Change the excludes to match the new syntax and kill the mutants.

Together with #5119 Closes #5121