### PR TITLE
primitives: fix doc comment for OutPointEncoder

### DIFF
--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -1108,7 +1108,7 @@ impl OutPoint {
 }
 
 encoding::encoder_newtype! {
-    /// The encoder for the [`TxOut`] type.
+    /// The encoder for the [`OutPoint`] type.
     pub struct OutPointEncoder<'e>(Encoder2<BytesEncoder<'e>, ArrayEncoder<4>>);
 }
 


### PR DESCRIPTION
Correct doc to reference OutPoint instead of TxOut for OutPointEncoder