### PR TITLE
chore: fix typos in code comments

### DIFF
--- a/bitcoin/src/psbt/map/input.rs
+++ b/bitcoin/src/psbt/map/input.rs
@@ -250,7 +250,7 @@ impl Input {
     ///
     /// # Errors
     ///
-    /// If the `sighash_type` field is set to a invalid Taproot sighash value.
+    /// If the `sighash_type` field is set to an invalid Taproot sighash value.
     pub fn taproot_hash_ty(&self) -> Result<TapSighashType, InvalidSighashTypeError> {
         self.sighash_type
             .map(|sighash_type| sighash_type.taproot_hash_ty())

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -2632,7 +2632,7 @@ mod tests {
         let (priv_key, pk, secp) = gen_keys();
 
         // key_map implements `GetKey` using KeyRequest::Pubkey. A pubkey key request does not use
-        // keysource so we use default `KeySource` (fingreprint and derivation path) below.
+        // keysource so we use default `KeySource` (fingerprint and derivation path) below.
         let mut key_map = BTreeMap::new();
         key_map.insert(pk, priv_key);
 

--- a/bitcoin/src/taproot/mod.rs
+++ b/bitcoin/src/taproot/mod.rs
@@ -610,7 +610,7 @@ impl TaprootBuilder {
     /// Inserts a leaf at `depth`.
     fn insert(mut self, mut node: NodeInfo, mut depth: u8) -> Result<Self, TaprootBuilderError> {
         // early error on invalid depth. Though this will be checked later
-        // while constructing TaprootMerkelBranch
+        // while constructing TaprootMerkleBranch
         if depth as usize > TAPROOT_CONTROL_MAX_NODE_COUNT {
             return Err(InvalidMerkleTreeDepthError(depth as usize).into());
         }
@@ -1473,7 +1473,7 @@ pub enum TaprootBuilderError {
     NodeNotInDfsOrder,
     /// Two nodes at depth 0 are not allowed.
     OverCompleteTree,
-    /// Called finalize on a empty tree.
+    /// Called finalize on an empty tree.
     EmptyTree,
 }
 


### PR DESCRIPTION
a invalid -> an invalid
a empty -> an empty
TaprootMerkelBranch -> TaprootMerkleBranch
fingreprint -> fingerprint