### PR TITLE
chore: remove unused std import from bitcoin-addresses

### DIFF
--- a/addresses/src/lib.rs
+++ b/addresses/src/lib.rs
@@ -25,5 +25,3 @@
 
 extern crate alloc;
 
-#[cfg(feature = "std")]
-extern crate std;


### PR DESCRIPTION
Removed the redundant `extern crate std` from `addresses/src/lib.rs` so the crate stays strictly no-std and free of dead imports. This keeps the codebase cleaner and avoids confusing dependency signals during reviews.