### PR TITLE
fuzz: fix shell script bugs and remove dead code

### DIFF
--- a/fuzz/fuzz-util.sh
+++ b/fuzz/fuzz-util.sh
@@ -20,14 +20,6 @@ targetFileToName() {
     | sed 's/^_//g'
 }
 
-targetFileToHFuzzInputArg() {
-  baseName=$(basename "$1")
-  dirName="${baseName%.*}"
-  if [ -d "hfuzz_input/$dirName" ]; then
-    echo "HFUZZ_INPUT_ARGS=\"-f hfuzz_input/$FILE/input\""
-  fi
-}
-
 listTargetNames() {
   for target in $(listTargetFiles); do
     targetFileToName "$target"

--- a/fuzz/fuzz.sh
+++ b/fuzz/fuzz.sh
@@ -25,7 +25,7 @@ for targetFile in $targetFiles; do
   targetName=$(targetFileToName "$targetFile")
   echo "Fuzzing target $targetName ($targetFile)"
   if [ -d "hfuzz_input/$targetName" ]; then
-    HFUZZ_INPUT_ARGS="-f hfuzz_input/$targetName/input\""
+    HFUZZ_INPUT_ARGS="-f hfuzz_input/$targetName/input"
   else
     HFUZZ_INPUT_ARGS=""
   fi


### PR DESCRIPTION
Fixes two shell script issues in fuzz utilities:

1. Remove unused function `targetFileToHFuzzInputArg()` with undefined variable `$FILE`
2. Fix syntax error: remove extra quote in `HFUZZ_INPUT_ARGS` assignment

Added in 2023 as a stub but never used due to the $FILE bug. Logic was implemented inline instead, leaving this as forgotten dead code.