### PR TITLE
Chore: fix typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -254,7 +254,7 @@ the [readme](./README.md) for more information.
 
 ## Going further
 
-You may be interested in the guide by Jon Atack on
+You may be interested in the guide by Jon Attack on
 [How to review Bitcoin Core PRs](https://github.com/jonatack/bitcoin-development/blob/master/how-to-review-bitcoin-core-prs.md)
 and [How to make Bitcoin Core PRs](https://github.com/jonatack/bitcoin-development/blob/master/how-to-make-bitcoin-core-prs.md).
 While there are differences between the projects in terms of context and

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -137,7 +137,7 @@ internal_macros::define_extension_trait! {
         ///
         /// # Panics
         ///
-        /// If the coversion overflows.
+        /// If the conversion overflows.
         fn legacy_weight(&self) -> Weight {
             Weight::from_vb(self.base_size().to_u64()).unwrap()
         }
@@ -156,7 +156,7 @@ internal_macros::define_extension_trait! {
         ///
         /// # Panics
         ///
-        /// If the coversion overflows.
+        /// If the conversion overflows.
         fn segwit_weight(&self) -> Weight {
             Weight::from_vb(self.base_size().to_u64())
             .and_then(|w| w.checked_add(Weight::from_wu(self.witness.size().to_u64()))).unwrap()


### PR DESCRIPTION
Fixed two small spelling mistakes: changed “Atack” to “Attack” in the documentation link, and “coversion” to “conversion” in the code comment. 