### PR TITLE
Release tracking PR: `bitcoin-hashes v0.17.0`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -19,7 +19,7 @@ name = "base58ck"
 version = "0.2.0"
 dependencies = [
  "bitcoin-internals",
- "bitcoin_hashes 0.16.0",
+ "bitcoin_hashes 0.17.0",
  "hex_lit",
 ]
 
@@ -58,7 +58,7 @@ dependencies = [
  "bitcoin-io 0.2.0",
  "bitcoin-primitives",
  "bitcoin-units",
- "bitcoin_hashes 0.16.0",
+ "bitcoin_hashes 0.17.0",
  "bitcoinconsensus",
  "hex-conservative 0.3.0",
  "hex_lit",
@@ -77,7 +77,7 @@ name = "bitcoin-consensus-encoding"
 version = "1.0.0-rc.0"
 dependencies = [
  "bitcoin-internals",
- "bitcoin_hashes 0.16.0",
+ "bitcoin_hashes 0.17.0",
 ]
 
 [[package]]
@@ -113,7 +113,7 @@ name = "bitcoin-io"
 version = "0.2.0"
 dependencies = [
  "bitcoin-internals",
- "bitcoin_hashes 0.16.0",
+ "bitcoin_hashes 0.17.0",
 ]
 
 [[package]]
@@ -125,7 +125,7 @@ dependencies = [
  "bitcoin-internals",
  "bitcoin-io 0.2.0",
  "bitcoin-units",
- "bitcoin_hashes 0.16.0",
+ "bitcoin_hashes 0.17.0",
  "hex-conservative 0.3.0",
  "hex_lit",
 ]
@@ -140,7 +140,7 @@ dependencies = [
  "bitcoin-consensus-encoding",
  "bitcoin-internals",
  "bitcoin-units",
- "bitcoin_hashes 0.16.0",
+ "bitcoin_hashes 0.17.0",
  "hex-conservative 0.3.0",
  "hex_lit",
  "serde",
@@ -172,7 +172,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "bitcoin-internals",
  "hex-conservative 0.3.0",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -19,7 +19,7 @@ name = "base58ck"
 version = "0.2.0"
 dependencies = [
  "bitcoin-internals",
- "bitcoin_hashes 0.16.0",
+ "bitcoin_hashes 0.17.0",
  "hex_lit",
 ]
 
@@ -57,7 +57,7 @@ dependencies = [
  "bitcoin-io 0.2.0",
  "bitcoin-primitives",
  "bitcoin-units",
- "bitcoin_hashes 0.16.0",
+ "bitcoin_hashes 0.17.0",
  "bitcoinconsensus",
  "hex-conservative 0.3.0",
  "hex_lit",
@@ -76,7 +76,7 @@ name = "bitcoin-consensus-encoding"
 version = "1.0.0-rc.0"
 dependencies = [
  "bitcoin-internals",
- "bitcoin_hashes 0.16.0",
+ "bitcoin_hashes 0.17.0",
 ]
 
 [[package]]
@@ -112,7 +112,7 @@ name = "bitcoin-io"
 version = "0.2.0"
 dependencies = [
  "bitcoin-internals",
- "bitcoin_hashes 0.16.0",
+ "bitcoin_hashes 0.17.0",
 ]
 
 [[package]]
@@ -124,7 +124,7 @@ dependencies = [
  "bitcoin-internals",
  "bitcoin-io 0.2.0",
  "bitcoin-units",
- "bitcoin_hashes 0.16.0",
+ "bitcoin_hashes 0.17.0",
  "hex-conservative 0.3.0",
  "hex_lit",
 ]
@@ -139,7 +139,7 @@ dependencies = [
  "bitcoin-consensus-encoding",
  "bitcoin-internals",
  "bitcoin-units",
- "bitcoin_hashes 0.16.0",
+ "bitcoin_hashes 0.17.0",
  "hex-conservative 0.3.0",
  "hex_lit",
  "serde",
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "bitcoin-internals",
  "hex-conservative 0.3.0",

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -28,7 +28,7 @@ arbitrary = ["dep:arbitrary", "units/arbitrary", "primitives/arbitrary"]
 [dependencies]
 base58 = { package = "base58ck", path = "../base58", default-features = false, features = ["alloc"] }
 bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
-hashes = { package = "bitcoin_hashes", path = "../hashes", default-features = false, features = ["alloc", "hex"] }
+hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.17.0", default-features = false, features = ["alloc", "hex"] }
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false, features = ["alloc"] }
 internals = { package = "bitcoin-internals", path = "../internals", features = ["alloc", "hex"] }
 io = { package = "bitcoin-io", path = "../io", default-features = false, features = ["alloc", "hashes"] }

--- a/consensus_encoding/Cargo.toml
+++ b/consensus_encoding/Cargo.toml
@@ -18,7 +18,7 @@ std = ["alloc", "internals/std"]
 alloc = ["internals/alloc"]
 
 [dependencies]
-hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.16.0", default-features = false }
+hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.17.0", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.4.0" }
 
 [package.metadata.docs.rs]

--- a/hashes/CHANGELOG.md
+++ b/hashes/CHANGELOG.md
@@ -1,3 +1,18 @@
+# 0.17.0 - 2025-10-17
+
+* Bump MSRV from 1.63.0 to 1.74.0 for all crates in the repo [#4926](https://github.com/rust-bitcoin/rust-bitcoin/pull/4926)
+* Add a `sha3_256` module with `SHA3-256` [#4919](https://github.com/rust-bitcoin/rust-bitcoin/pull/4919)
+* Remove code deprecated in `v0.15.0` [#4840](https://github.com/rust-bitcoin/rust-bitcoin/pull/4840)
+* Update `serde` dependency to match workspace [#4321](https://github.com/rust-bitcoin/rust-bitcoin/pull/4321)
+* Remove `From<hash>` for not-general-hash types [#4128 ](https://github.com/rust-bitcoin/rust-bitcoin/pull/4128)
+* Remove the `GeneralHash` trait [#4085](https://github.com/rust-bitcoin/rust-bitcoin/pull/4085)
+* Only enable `hex`/`std`, and `hex`/`alloc` when `hex` is [#4055](https://github.com/rust-bitcoin/rust-bitcoin/pull/4055)
+* Derive `Debug` for all hash engines [#4015](https://github.com/rust-bitcoin/rust-bitcoin/pull/4015)
+* Add a tagged hash engine [#4010](https://github.com/rust-bitcoin/rust-bitcoin/pull/4010)
+* Add engine function to `siphash24::Hash` [#4003](https://github.com/rust-bitcoin/rust-bitcoin/pull/4003)
+* Do not implement `Default` for `HmacEngine` [#3981](https://github.com/rust-bitcoin/rust-bitcoin/pull/3981)
+* Invert dependency between `io` and `hashes` [#3961](https://github.com/rust-bitcoin/rust-bitcoin/pull/3961)
+
 # 0.16.0 - 2024-12-12
 
 * Make `hex-conservative` an optional dependency [#3611](https://github.com/rust-bitcoin/rust-bitcoin/pull/3611)

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin_hashes"
-version = "0.16.0"
+version = "0.17.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin"

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -24,7 +24,7 @@ hex = ["dep:hex", "hashes/hex", "internals/hex"]
 
 [dependencies]
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0-rc.0", default-features = false }
-hashes = { package = "bitcoin_hashes", path = "../hashes", default-features = false }
+hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.17.0", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals" }
 units = { package = "bitcoin-units", path = "../units", version = "1.0.0-rc.1", default-features = false, features = [ "encoding" ] }
 arrayvec = { version = "0.7.2", default-features = false }


### PR DESCRIPTION
In preparation for release bump the version, add a changelog entry, and update the lock files.
    
Set explicit version in deps list as needed.
 
