### PR TITLE
Release tracking PR: `units 1.0.0-rc.2`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-units"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-units"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -34,7 +34,7 @@ internals = { package = "bitcoin-internals", path = "../internals", features = [
 io = { package = "bitcoin-io", path = "../io", default-features = false, features = ["alloc", "hashes"] }
 primitives = { package = "bitcoin-primitives", path = "../primitives", default-features = false, features = ["alloc", "hex"] }
 secp256k1 = { version = "0.30.0", default-features = false, features = ["hashes", "alloc"] }
-units = { package = "bitcoin-units", path = "../units", version = "1.0.0-rc.1", default-features = false, features = ["alloc"] }
+units = { package = "bitcoin-units", path = "../units", version = "1.0.0-rc.2", default-features = false, features = ["alloc"] }
 
 arbitrary = { version = "1.4.1", optional = true }
 base64 = { version = "0.22.0", optional = true, default-features = false, features = ["alloc"] }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -23,7 +23,7 @@ hashes = { package = "bitcoin_hashes", path = "../hashes", default-features = fa
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", default-features = false }
 io = { package = "bitcoin-io", path = "../io", default-features = false }
-units = { package = "bitcoin-units", path = "../units", version = "1.0.0-rc.1", default-features = false }
+units = { package = "bitcoin-units", path = "../units", version = "1.0.0-rc.2", default-features = false }
 
 arbitrary = { version = "1.4.1", optional = true }
 

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -26,7 +26,7 @@ hex = ["dep:hex", "hashes/hex", "internals/hex"]
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0-rc.1", default-features = false }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.17.0", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals" }
-units = { package = "bitcoin-units", path = "../units", version = "1.0.0-rc.1", default-features = false, features = [ "encoding" ] }
+units = { package = "bitcoin-units", path = "../units", version = "1.0.0-rc.2", default-features = false, features = [ "encoding" ] }
 arrayvec = { version = "0.7.2", default-features = false }
 
 arbitrary = { version = "1.4.1", optional = true }

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-units"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>", "Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"


### PR DESCRIPTION
We just bumped the `hashes` version, requires another release here.