### PR TITLE
Remove doc_auto_cfg

### DIFF
--- a/addresses/src/lib.rs
+++ b/addresses/src/lib.rs
@@ -13,7 +13,6 @@
 #![cfg(feature = "alloc")]
 #![no_std]
 // Experimental features we need.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc(test(attr(warn(unused))))]
 // Coding conventions.
 #![warn(deprecated_in_future)]

--- a/base58/src/lib.rs
+++ b/base58/src/lib.rs
@@ -8,7 +8,6 @@
 #![cfg(feature = "alloc")]
 #![no_std]
 // Experimental features we need.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(bench, feature(test))]
 // Coding conventions.
 #![warn(missing_docs)]

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -25,7 +25,6 @@
 
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 // Experimental features we need.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(docsrs, feature(doc_notable_trait))]
 // Coding conventions.
 #![warn(missing_docs)]

--- a/chacha20_poly1305/src/lib.rs
+++ b/chacha20_poly1305/src/lib.rs
@@ -6,8 +6,6 @@
 //! to form an authenticated encryption with additional data (AEAD) algorithm.
 
 #![no_std]
-// Experimental features we need.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Coding conventions.
 #![warn(missing_docs)]
 #![warn(deprecated_in_future)]

--- a/consensus_encoding/src/lib.rs
+++ b/consensus_encoding/src/lib.rs
@@ -7,8 +7,6 @@
 //!
 
 #![no_std]
-// Experimental features we need.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Coding conventions.
 #![warn(missing_docs)]
 #![warn(deprecated_in_future)]

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -51,8 +51,6 @@
 //! ```
 
 #![no_std]
-// Experimental features we need.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Coding conventions.
 #![warn(missing_docs)]
 #![warn(deprecated_in_future)]

--- a/internals/src/lib.rs
+++ b/internals/src/lib.rs
@@ -6,8 +6,6 @@
 //! [rust-bitcoin](https://github.com/rust-bitcoin) ecosystem.
 
 #![no_std]
-// Experimental features we need.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Coding conventions.
 #![warn(missing_docs)]
 #![warn(deprecated_in_future)]

--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -14,8 +14,6 @@
 //! `github.com/rust-bitcoin/rust-bitcoin/bitcoin/examples/` directory.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-// Experimental features we need.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Coding conventions.
 #![warn(missing_docs)]
 #![doc(test(attr(warn(unused))))]

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -3,8 +3,6 @@
 //! Rust Bitcoin Peer to Peer Message Types
 
 #![no_std]
-// Experimental features we need.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Coding conventions.
 #![warn(missing_docs)]
 #![warn(deprecated_in_future)]

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -13,8 +13,6 @@
 //! [`rust-bitcoin`]: <https://github.com/rust-bitcoin>
 
 #![no_std]
-// Experimental features we need.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Coding conventions.
 #![warn(missing_docs)]
 #![warn(deprecated_in_future)]

--- a/units/src/lib.rs
+++ b/units/src/lib.rs
@@ -19,8 +19,6 @@
 //! ```
 
 #![no_std]
-// Experimental features we need.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Coding conventions.
 #![warn(missing_docs)]
 #![warn(deprecated_in_future)]


### PR DESCRIPTION
This was removed in recent nightly and is breaking all the docs builds when we try and publish crates.

Fix: #5155 