### PR TITLE
chore: improve test panic messages

### DIFF
--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -1825,7 +1825,7 @@ mod tests {
             assert_eq!(err.invalid_char(), b'g');
             assert_eq!(err.pos(), 129);
         } else {
-            panic!("Expected Invalid char error");
+            panic!("expected ParsePublicKeyError::InvalidChar");
         }
 
         let s = "032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1ag";
@@ -1836,7 +1836,7 @@ mod tests {
             assert_eq!(err.invalid_char(), b'g');
             assert_eq!(err.pos(), 65);
         } else {
-            panic!("Expected Invalid char error");
+            panic!("expected ParsePublicKeyError::InvalidChar");
         }
     }
 

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -1447,7 +1447,7 @@ mod tests {
             .extract_tx_with_fee_rate_limit(FeeRate::from_sat_per_vb(1))
             .map_err(|e| match e {
                 ExtractTxError::AbsurdFeeRate { fee_rate, .. } => fee_rate,
-                _ => panic!(""),
+                other => panic!("expected AbsurdFeeRate error, got {other:?}"),
             })
             .unwrap_err();
 
@@ -1459,14 +1459,14 @@ mod tests {
         assert_eq!(
             psbt.clone().extract_tx().map_err(|e| match e {
                 ExtractTxError::AbsurdFeeRate { fee_rate, .. } => fee_rate,
-                _ => panic!(""),
+                other => panic!("expected AbsurdFeeRate error, got {other:?}"),
             }),
             Err(error_fee_rate)
         );
         assert_eq!(
             psbt.clone().extract_tx_fee_rate_limit().map_err(|e| match e {
                 ExtractTxError::AbsurdFeeRate { fee_rate, .. } => fee_rate,
-                _ => panic!(""),
+                other => panic!("expected AbsurdFeeRate error, got {other:?}"),
             }),
             Err(error_fee_rate)
         );
@@ -1480,7 +1480,7 @@ mod tests {
         assert_eq!(
             psbt_with_amounts(2076001, 1000).extract_tx().map_err(|e| match e {
                 ExtractTxError::AbsurdFeeRate { fee_rate, .. } => fee_rate,
-                _ => panic!(""),
+                other => panic!("expected AbsurdFeeRate error, got {other:?}"),
             }),
             Err(FeeRate::from_sat_per_kwu(6250003)) // 6250000 is 25k sat/vbyte
         );


### PR DESCRIPTION
In psbt_high_fee_checks, the fallback panic now reports the unexpected ExtractTxError variant instead of failing silently, so regressions immediately tell reviewers what went wrong. In public_key_from_str_invalid_str, the panic string now names the exact ParsePublicKeyError::InvalidChar variant we’re checking for, removing ambiguity when behavior changes. The assertions stay the same, but the failures are far more actionable.