### PR TITLE
Remove misleading FIXME in SliceEncoder test

### DIFF
--- a/consensus_encoding/src/encode/encoders.rs
+++ b/consensus_encoding/src/encode/encoders.rs
@@ -337,14 +337,12 @@ mod tests {
 
     #[test]
     fn encode_slice_with_zero_sized_arrays() {
-        // Should have empty array chunks, then exhausted.
+        // Should skip empty array chunks and be immediately exhausted.
+        // This is an optimization - empty chunks don't provide meaningful data.
         let slice = &[TestArray([]), TestArray([])];
         let mut encoder = SliceEncoder::without_length_prefix(slice);
 
         assert!(encoder.current_chunk().is_empty());
-        // FIXME: Its strange the we can't do this?
-        // assert!(encoder.advance());
-        // assert!(encoder.current_chunk().is_empty());
         assert!(!encoder.advance());
         assert!(encoder.current_chunk().is_empty());
     }


### PR DESCRIPTION
## Description

`SliceEncoder` skips all empty chunks; 
`advance()` returns false when no non‑empty chunk remains, so it returning a single false is not strange.
Discussion: [#5136](https://github.com/rust-bitcoin/rust-bitcoin/pull/5136).