### PR TITLE
p2p: fix BIP0031_VERSION to use correct protocol version 60001

### DIFF
--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -87,7 +87,7 @@ impl ProtocolVersion {
     /// Support `sendheaders` message and announce new blocks via headers rather than inv
     pub const SENDHEADERS_VERSION: ProtocolVersion = ProtocolVersion(70012);
     /// Support `pong` message and nonce in `ping` message
-    pub const BIP0031_VERSION: ProtocolVersion = ProtocolVersion(60000);
+    pub const BIP0031_VERSION: ProtocolVersion = ProtocolVersion(60001);
     /// All connections will be terminated below this version.
     pub const MIN_PEER_PROTO_VERSION: ProtocolVersion = ProtocolVersion(31800);
 }


### PR DESCRIPTION
The BIP0031_VERSION constant was set to 60000, but according to BIP-31 spec, ping/pong with nonce is supported when protocol version is *greater than* 60000.

So 60000 doesn't actually support the feature, minimum should be 60001.

Fixed by changing ProtocolVersion(60000) to ProtocolVersion(60001).

Ref: https://github.com/bitcoin/bips/blob/master/bip-0031.mediawiki#specification