### PR TITLE
hashes: fix off-by-one in SHA256 test error message

### DIFF
--- a/hashes/src/sha256/tests.rs
+++ b/hashes/src/sha256/tests.rs
@@ -172,7 +172,7 @@ fn hash_unoptimized() {
             Hash::hash(bytes),
             Hash::hash_unoptimized(bytes),
             "hashes don't match for n_bytes_hashed {}",
-            i + 1
+            i
         );
     }
 }


### PR DESCRIPTION
Fixed incorrect byte count in test failure message. The loop uses `&bytes[0..i]` which contains `i` bytes, not `i + 1`. When debugging test failures, the error message was showing wrong numbers - like "6 bytes" when actually processing 5 bytes.

Simple fix: changed `i + 1` to `i` in the assert message.