### PR TITLE
Move encode_to_hash_engine to hashes from consensus_encoding

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -77,7 +77,6 @@ name = "bitcoin-consensus-encoding"
 version = "1.0.0-rc.1"
 dependencies = [
  "bitcoin-internals",
- "bitcoin_hashes 0.17.0",
 ]
 
 [[package]]
@@ -174,6 +173,7 @@ dependencies = [
 name = "bitcoin_hashes"
 version = "0.17.0"
 dependencies = [
+ "bitcoin-consensus-encoding",
  "bitcoin-internals",
  "hex-conservative 0.3.0",
  "serde",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -76,7 +76,6 @@ name = "bitcoin-consensus-encoding"
 version = "1.0.0-rc.1"
 dependencies = [
  "bitcoin-internals",
- "bitcoin_hashes 0.17.0",
 ]
 
 [[package]]
@@ -173,6 +172,7 @@ dependencies = [
 name = "bitcoin_hashes"
 version = "0.17.0"
 dependencies = [
+ "bitcoin-consensus-encoding",
  "bitcoin-internals",
  "hex-conservative 0.3.0",
  "serde",

--- a/consensus_encoding/Cargo.toml
+++ b/consensus_encoding/Cargo.toml
@@ -18,7 +18,6 @@ std = ["alloc", "internals/std"]
 alloc = ["internals/alloc"]
 
 [dependencies]
-hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.17.0", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.4.0" }
 
 [package.metadata.docs.rs]

--- a/consensus_encoding/src/encode/mod.rs
+++ b/consensus_encoding/src/encode/mod.rs
@@ -64,25 +64,6 @@ macro_rules! encoder_newtype{
     }
 }
 
-/// Encodes an object into a hash engine.
-///
-/// Consumes and returns the hash engine to make it easier to call
-/// [`hashes::HashEngine::finalize`] directly on the result.
-pub fn encode_to_hash_engine<T, H>(object: &T, mut engine: H) -> H
-where
-    T: Encodable + ?Sized,
-    H: hashes::HashEngine,
-{
-    let mut encoder = object.encoder();
-    loop {
-        engine.input(encoder.current_chunk());
-        if !encoder.advance() {
-            break;
-        }
-    }
-    engine
-}
-
 /// Encodes an object into a vector.
 #[cfg(feature = "alloc")]
 pub fn encode_to_vec<T>(object: &T) -> Vec<u8>

--- a/consensus_encoding/src/lib.rs
+++ b/consensus_encoding/src/lib.rs
@@ -17,9 +17,6 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
-/// Rust implementation of cryptographic hash function algorithms.
-pub extern crate hashes;
-
 mod decode;
 mod encode;
 
@@ -45,4 +42,4 @@ pub use self::encode::encoders::{
     ArrayEncoder, BytesEncoder, CompactSizeEncoder, Encoder2, Encoder3, Encoder4, Encoder6,
     SliceEncoder,
 };
-pub use self::encode::{encode_to_hash_engine, Encodable, Encoder};
+pub use self::encode::{Encodable, Encoder};

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -23,6 +23,7 @@ small-hash = []
 
 [dependencies]
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.4.1" }
+encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0-rc.1", default-features = false }
 
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false, optional = true }
 serde = { version = "1.0.195", default-features = false, optional = true }

--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -235,7 +235,7 @@ impl Header {
     /// Returns the block hash.
     // This is the same as `Encodable` but done manually because `Encodable` isn't in `primitives`.
     pub fn block_hash(&self) -> BlockHash {
-        let bare_hash = encoding::encode_to_hash_engine(self, sha256d::Hash::engine()).finalize();
+        let bare_hash = hashes::encode_to_hash_engine(self, sha256d::Hash::engine()).finalize();
         BlockHash::from_byte_array(bare_hash.to_byte_array())
     }
 }


### PR DESCRIPTION
The encode_to_hash_engine function created a dependency on hashes from consensus_encoding. Since consensus_encoding is moving to 1.0, it is best to remove the dependency on the pre-1.0 hashes crate.

This patch moves the encode_to_hash_engine function to the hashes crate, and reverses the dependency so that hashes now depends on consensus_encoding instead of vice-versa.