### PR TITLE
Further cleanup of justfile

### DIFF
--- a/contrib/gen-dep-tree.sh
+++ b/contrib/gen-dep-tree.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# 
+# Generate dependency tree for all workspace packages except fuzz.
+set -euo pipefail
+
+exec cargo tree \
+    --workspace \
+    --exclude bitcoin-fuzz \
+    --all-features \
+    --edges=no-dev,no-build \
+    --format='{lib}' \
+    --no-dedupe \
+    --prune=serde_json \
+    --prune=rand \
+    --prune=bincode \
+    --prune=serde

--- a/justfile
+++ b/justfile
@@ -58,10 +58,6 @@ githooks-install:
 githooks-remove:
  {{justfile_directory()}}/contrib/copy-githooks.sh -r
 
-# Generate a dependency tree
+# Generate a dependency tree for workspace crates.
 gen-dep-tree:
-        cargo tree --all-features --edges=no-dev,no-build --format={lib} --no-dedupe \
-        --prune=serde_json --prune=rand --prune=bincode --prune=serde \
-        -p bitcoin -p bitcoin-internals -p bitcoin_hashes@0.16.0 -p bitcoin-units \
-        -p bitcoin-primitives -p chacha20-poly1305 -p base58ck -p bitcoin-addresses -p bitcoin-io@0.2.0 \
-        -p bitcoin-consensus-encoding
+  {{justfile_directory()}}/contrib/gen-dep-tree.sh


### PR DESCRIPTION
Some follow up to #5158.

First patch drops some recipes which I added and don't work without some more settings (e.g. MSRV) getting into the justfile. I think they are low value so instead dropping for now.

Second patch makes the recipes more robust by allowing all to be called from anywhere in the workspace.

The third patch is a little more interesting, trying to capture the local dev flow (based on a vibe check irl) with the `check` and `fmt` recipes. We often run `fmt` if there are some format issues on `master` and toss that commit to the front of our patch sets. Or after working on a crate locally. The `check` command is what we want to check really quick if we are hacking on a crate before running a more thorough `test-stable` on the workspace. Happy to take suggestions here though.

Forth patch is fixing up a broken recipe. It was no longer working because hashes is no longer on v0.16.0. I tried to make the script a little more robust to future changes, but hopefully I am not missing the point of the original recipe.