### PR TITLE
Change extension trait function return types to Self

### DIFF
--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -293,7 +293,7 @@ impl BlockCheckedExt for Block<Checked> {
     fn new_checked(
         header: Header,
         transactions: Vec<Transaction>,
-    ) -> Result<Block<Checked>, InvalidBlockError> {
+    ) -> Result<Self, InvalidBlockError> {
         let block = Block::new_unchecked(header, transactions);
         block.validate()
     }

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -222,7 +222,7 @@ internal_macros::define_extension_trait! {
         /// To use a custom value, use [`minimal_non_dust_custom`].
         ///
         /// [`minimal_non_dust_custom`]: TxOut::minimal_non_dust_custom
-        fn minimal_non_dust(script_pubkey: ScriptPubKeyBuf) -> TxOut {
+        fn minimal_non_dust(script_pubkey: ScriptPubKeyBuf) -> Self {
             TxOut { amount: script_pubkey.minimal_non_dust(), script_pubkey }
         }
 
@@ -237,7 +237,10 @@ internal_macros::define_extension_trait! {
         /// To use the default Bitcoin Core value, use [`minimal_non_dust`].
         ///
         /// [`minimal_non_dust`]: TxOut::minimal_non_dust
-        fn minimal_non_dust_custom(script_pubkey: ScriptPubKeyBuf, dust_relay_fee: FeeRate) -> Option<TxOut> {
+        fn minimal_non_dust_custom(script_pubkey: ScriptPubKeyBuf, dust_relay_fee: FeeRate) -> Option<Self>
+        where
+            Self: Sized
+        {
             Some(TxOut { amount: script_pubkey.minimal_non_dust_custom(dust_relay_fee)?, script_pubkey })
         }
     }

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -119,7 +119,7 @@ internal_macros::define_extension_trait! {
         /// serialized public key. Also useful for spending a P2SH-P2WPKH output.
         ///
         /// It is expected that `pubkey` is related to the secret key used to create `signature`.
-        fn p2wpkh(signature: ecdsa::Signature, pubkey: secp256k1::PublicKey) -> Witness {
+        fn p2wpkh(signature: ecdsa::Signature, pubkey: secp256k1::PublicKey) -> Self {
             let mut witness = Witness::new();
             witness.push(signature.serialize());
             witness.push(pubkey.serialize());
@@ -127,7 +127,7 @@ internal_macros::define_extension_trait! {
         }
 
         /// Constructs a new witness required to do a key path spend of a P2TR output.
-        fn p2tr_key_spend(signature: &taproot::Signature) -> Witness {
+        fn p2tr_key_spend(signature: &taproot::Signature) -> Self {
             let mut witness = Witness::new();
             witness.push(signature.serialize());
             witness

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -336,13 +336,19 @@ internal_macros::define_extension_trait! {
     /// Extension functionality for the [`CompactTarget`] type.
     pub trait CompactTargetExt impl for CompactTarget {
         /// Constructs a new `CompactTarget` from a prefixed hex string.
-        fn from_hex(s: &str) -> Result<CompactTarget, PrefixedHexError> {
+        fn from_hex(s: &str) -> Result<Self, PrefixedHexError>
+        where
+            Self: Sized
+        {
             let target = parse_int::hex_u32_prefixed(s)?;
             Ok(Self::from_consensus(target))
         }
 
         /// Constructs a new `CompactTarget` from an unprefixed hex string.
-        fn from_unprefixed_hex(s: &str) -> Result<CompactTarget, UnprefixedHexError> {
+        fn from_unprefixed_hex(s: &str) -> Result<Self, UnprefixedHexError>
+        where
+            Self: Sized
+        {
             let target = parse_int::hex_u32_unprefixed(s)?;
             Ok(Self::from_consensus(target))
         }
@@ -375,7 +381,7 @@ internal_macros::define_extension_trait! {
             last: CompactTarget,
             timespan: i64,
             params: impl AsRef<Params>,
-        ) -> CompactTarget {
+        ) -> Self {
             let params = params.as_ref();
             if params.no_pow_retargeting {
                 return last;
@@ -419,7 +425,7 @@ internal_macros::define_extension_trait! {
             last_epoch_boundary: Header,
             current: Header,
             params: impl AsRef<Params>,
-        ) -> CompactTarget {
+        ) -> Self {
             let timespan = i64::from(current.time.to_u32()) - i64::from(last_epoch_boundary.time.to_u32());
             let bits = current.bits;
             CompactTarget::from_next_work_required(bits, timespan, params)


### PR DESCRIPTION
Within the extension traits in the bitcoin crate, some functions use a Self return type, while others use the specific type name. Use of a specific type name causes non-uniformity in the code, is longer, and is semantically less clear for distinguishing return of a trait implementor's type vs an instance of a specific type.

Closes #4661