### PR TITLE
Introduce encode_to_writer for bitcoin io Write trait

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -112,6 +112,7 @@ checksum = "17e5b76b88667412087beea1882980ad843b660490bbf6cce0a6cfc999c5b989"
 name = "bitcoin-io"
 version = "0.2.0"
 dependencies = [
+ "bitcoin-consensus-encoding",
  "bitcoin-internals",
  "bitcoin_hashes 0.17.0",
 ]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -111,6 +111,7 @@ checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
 name = "bitcoin-io"
 version = "0.2.0"
 dependencies = [
+ "bitcoin-consensus-encoding",
  "bitcoin-internals",
  "bitcoin_hashes 0.17.0",
 ]

--- a/io/Cargo.toml
+++ b/io/Cargo.toml
@@ -20,6 +20,7 @@ alloc = ["hashes?/alloc", "internals/alloc"]
 
 [dependencies]
 internals = { package = "bitcoin-internals", path = "../internals" }
+encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0-rc.1", default-features = false }
 
 hashes = { package = "bitcoin_hashes", path = "../hashes", default-features = false, optional = true }
 


### PR DESCRIPTION
The encode_to_writer function in consensus_encoding provides an easy way to write Encodable data to std::io::Write objects. For no-std code making use of the bitcoin-io crate, there is no equivalent.

Introduce an encode_to_writer function in bitcoin-io that directly mirrors the std implementation originally from consensus_encoding.