### PR TITLE
Rename encode_to_hash_engine to encode_to_engine

### DIFF
--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -201,7 +201,7 @@ pub trait HashEngine: Clone {
 ///
 /// Consumes and returns the hash engine to make it easier to call
 /// [`HashEngine::finalize`] directly on the result.
-pub fn encode_to_hash_engine<T, H>(object: &T, mut engine: H) -> H
+pub fn encode_to_engine<T, H>(object: &T, mut engine: H) -> H
 where
     T: encoding::Encodable + ?Sized,
     H: HashEngine,

--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -235,7 +235,7 @@ impl Header {
     /// Returns the block hash.
     // This is the same as `Encodable` but done manually because `Encodable` isn't in `primitives`.
     pub fn block_hash(&self) -> BlockHash {
-        let bare_hash = hashes::encode_to_hash_engine(self, sha256d::Hash::engine()).finalize();
+        let bare_hash = hashes::encode_to_engine(self, sha256d::Hash::engine()).finalize();
         BlockHash::from_byte_array(bare_hash.to_byte_array())
     }
 }


### PR DESCRIPTION
Other encode_to_* functions utilise a single noun. With this function moved to hashes, engine is sufficiently clear as a reference to the hashes::HashEngine without needing the full name in the function.

Follow-up from #5181