### PR TITLE
Change secp256k1 format in docs

### DIFF
--- a/bitcoin/examples/ecdsa-psbt.rs
+++ b/bitcoin/examples/ecdsa-psbt.rs
@@ -90,7 +90,7 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-// We cache the pubkeys for convenience because it requires a secp context to convert the private key.
+// We cache the pubkeys for convenience because it requires a secp256k1 context to convert the private key.
 /// An example of an offline signer i.e., a cold-storage device.
 struct ColdStorage {
     /// The master extended private key.

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -36,7 +36,7 @@ pub use serialized_x_only::SerializedXOnlyPublicKey;
 pub struct XOnlyPublicKey(secp256k1::XOnlyPublicKey);
 
 impl XOnlyPublicKey {
-    /// Constructs a new x-only public key from the provided generic Secp256k1 x-only public key.
+    /// Constructs a new x-only public key from the provided generic secp256k1 x-only public key.
     pub fn new(key: impl Into<secp256k1::XOnlyPublicKey>) -> XOnlyPublicKey {
         XOnlyPublicKey(key.into())
     }
@@ -149,12 +149,12 @@ pub struct PublicKey {
 }
 
 impl PublicKey {
-    /// Constructs a new compressed ECDSA public key from the provided generic Secp256k1 public key.
+    /// Constructs a new compressed ECDSA public key from the provided generic secp256k1 public key.
     pub fn new(key: impl Into<secp256k1::PublicKey>) -> PublicKey {
         PublicKey { compressed: true, inner: key.into() }
     }
 
-    /// Constructs a new uncompressed (legacy) ECDSA public key from the provided generic Secp256k1
+    /// Constructs a new uncompressed (legacy) ECDSA public key from the provided generic secp256k1
     /// public key.
     pub fn new_uncompressed(key: impl Into<secp256k1::PublicKey>) -> PublicKey {
         PublicKey { compressed: false, inner: key.into() }
@@ -547,13 +547,13 @@ impl PrivateKey {
         let secret_key = secp256k1::SecretKey::new(&mut rand::thread_rng());
         PrivateKey::new(secret_key, network.into())
     }
-    /// Constructs a new compressed ECDSA private key from the provided generic Secp256k1 private key
+    /// Constructs a new compressed ECDSA private key from the provided generic secp256k1 private key
     /// and the specified network.
     pub fn new(key: secp256k1::SecretKey, network: impl Into<NetworkKind>) -> PrivateKey {
         PrivateKey { compressed: true, network: network.into(), inner: key }
     }
 
-    /// Constructs a new uncompressed (legacy) ECDSA private key from the provided generic Secp256k1
+    /// Constructs a new uncompressed (legacy) ECDSA private key from the provided generic secp256k1
     /// private key and the specified network.
     pub fn new_uncompressed(
         key: secp256k1::SecretKey,
@@ -1075,7 +1075,7 @@ impl From<TweakedKeypair> for TweakedPublicKey {
 pub enum FromSliceError {
     /// Invalid key prefix error.
     InvalidKeyPrefix(u8),
-    /// A Secp256k1 error.
+    /// A secp256k1 error.
     Secp256k1(secp256k1::Error),
     /// Invalid Length of the slice.
     InvalidLength(usize),
@@ -1235,7 +1235,7 @@ impl From<FromSliceError> for ParsePublicKeyError {
 /// Error returned when parsing a [`CompressedPublicKey`] from a string.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ParseCompressedPublicKeyError {
-    /// Secp256k1 Error.
+    /// secp256k1 Error.
     Secp256k1(secp256k1::Error),
     /// hex to array conversion error.
     Hex(hex::HexToArrayError),


### PR DESCRIPTION
The docs occasionally use 'secp', 'Secp256k1' and 'secp256k1' all to refer to the secp256k1 library. This is inconsistent and conflicts with the naming of the Secp256k1 context object.

Change instances of 'Secp256k1' to lowercase and use full name in place of 'secp' shorthand.

Closes #5204 