### PR TITLE
bitcoin: Add explicit version numbers to deps

### DIFF
--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -26,13 +26,13 @@ secp-recovery = ["secp256k1/recovery"]
 arbitrary = ["dep:arbitrary", "units/arbitrary", "primitives/arbitrary"]
 
 [dependencies]
-base58 = { package = "base58ck", path = "../base58", default-features = false, features = ["alloc"] }
+base58 = { package = "base58ck", path = "../base58", version = "0.2.0", default-features = false, features = ["alloc"] }
 bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.17.0", default-features = false, features = ["alloc", "hex"] }
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false, features = ["alloc"] }
-internals = { package = "bitcoin-internals", path = "../internals", features = ["alloc", "hex"] }
-io = { package = "bitcoin-io", path = "../io", default-features = false, features = ["alloc", "hashes"] }
-primitives = { package = "bitcoin-primitives", path = "../primitives", default-features = false, features = ["alloc", "hex"] }
+internals = { package = "bitcoin-internals", path = "../internals", verison = "0.4.1", features = ["alloc", "hex"] }
+io = { package = "bitcoin-io", path = "../io", version = "0.2.0", default-features = false, features = ["alloc", "hashes"] }
+primitives = { package = "bitcoin-primitives", path = "../primitives", version = "1.0.0-rc.0", default-features = false, features = ["alloc", "hex"] }
 secp256k1 = { version = "0.30.0", default-features = false, features = ["hashes", "alloc"] }
 units = { package = "bitcoin-units", path = "../units", version = "1.0.0-rc.2", default-features = false, features = ["alloc"] }
 


### PR DESCRIPTION
In order to release we have to have explicit version numbers for all dependencies.