### PR TITLE
Add as_str method to Opcode

### DIFF
--- a/bitcoin/src/blockdata/opcodes.rs
+++ b/bitcoin/src/blockdata/opcodes.rs
@@ -9,9 +9,6 @@
 
 use core::fmt;
 
-#[cfg(feature = "serde")]
-use crate::prelude::ToString;
-
 /// A script Opcode.
 ///
 /// We do not implement Ord on this type because there is no natural ordering on opcodes, but there
@@ -47,6 +44,30 @@ macro_rules! all_opcodes {
                 #[doc = $doc]
                 pub const $op: Opcode = Opcode { code: $val};
             )*
+
+            impl Opcode {
+                /// Returns the string representation of the opcode.
+                ///
+                /// This function maps the `Opcode`'s `code` value (a `u8`) to its corresponding
+                /// Bitcoin Script opcode name.
+                ///
+                /// # Example
+                /// ```
+                /// use bitcoin::opcodes::all::*;
+                ///
+                /// assert_eq!(OP_1.as_str(), "OP_1");
+                /// assert_eq!(OP_1NEGATE.as_str(), "OP_1NEGATE");
+                /// assert_eq!(OP_CHECKMULTISIG.as_str(), "OP_CHECKMULTISIG");
+                /// ```
+                #[inline]
+                pub fn as_str(&self) -> &'static str {
+                    match *self {
+                        $(
+                            $op => stringify!($op),
+                        )+
+                    }
+                }
+            }
 
             /// Push an empty array onto the stack.
             pub const OP_0: Opcode = OP_PUSHBYTES_0;
@@ -114,11 +135,7 @@ macro_rules! all_opcodes {
 
         impl fmt::Display for Opcode {
             fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-                 match *self {
-                   $(
-                        $op => core::fmt::Display::fmt(stringify!($op), f),
-                    )+
-                }
+                core::fmt::Display::fmt(self.as_str(), f)
             }
         }
     }
@@ -501,7 +518,7 @@ impl serde::Serialize for Opcode {
     where
         S: serde::Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        serializer.serialize_str(self.as_str())
     }
 }
 


### PR DESCRIPTION
Currently, serde's serialize_str uses to_string, which requires an expensive allocation on each call. as_str, by definition, produces the same result, but does not require an allocation.

Introduce the as_str method in the Opcode implementation and change the serialize_str call to use as_str in place of to_string.

Original work by rockcoolsaint in PR #4147
This closes #4145