### PR TITLE
Convert encoder/decoder constructors to const

### DIFF
--- a/consensus_encoding/src/decode/decoders.rs
+++ b/consensus_encoding/src/decode/decoders.rs
@@ -32,9 +32,9 @@ pub struct ByteVecDecoder {
 #[cfg(feature = "alloc")]
 impl ByteVecDecoder {
     /// Constructs a new byte decoder.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
-            prefix_decoder: Some(CompactSizeDecoder::default()),
+            prefix_decoder: Some(CompactSizeDecoder::new()),
             buffer: Vec::new(),
             bytes_expected: 0,
             bytes_written: 0,
@@ -116,7 +116,7 @@ pub struct VecDecoder<T: Decodable> {
 #[cfg(feature = "alloc")]
 impl<T: Decodable> VecDecoder<T> {
     /// Constructs a new byte decoder.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             prefix_decoder: Some(CompactSizeDecoder::new()),
             length: 0,
@@ -235,7 +235,7 @@ pub struct ArrayDecoder<const N: usize> {
 
 impl<const N: usize> ArrayDecoder<N> {
     /// Constructs a new array decoder that expects exactly N bytes.
-    pub fn new() -> Self { Self { buffer: [0; N], bytes_written: 0 } }
+    pub const fn new() -> Self { Self { buffer: [0; N], bytes_written: 0 } }
 }
 
 impl<const N: usize> Default for ArrayDecoder<N> {
@@ -299,7 +299,7 @@ where
     B: Decoder,
 {
     /// Constructs a new composite decoder.
-    pub fn new(first: A, second: B) -> Self { Self { state: Decoder2State::First(first, second) } }
+    pub const fn new(first: A, second: B) -> Self { Self { state: Decoder2State::First(first, second) } }
 }
 
 impl<A, B> Decoder for Decoder2<A, B>
@@ -392,7 +392,7 @@ where
     C: Decoder,
 {
     /// Constructs a new composite decoder.
-    pub fn new(dec_1: A, dec_2: B, dec_3: C) -> Self {
+    pub const fn new(dec_1: A, dec_2: B, dec_3: C) -> Self {
         Self { inner: Decoder2::new(Decoder2::new(dec_1, dec_2), dec_3) }
     }
 }
@@ -450,7 +450,7 @@ where
     D: Decoder,
 {
     /// Constructs a new composite decoder.
-    pub fn new(dec_1: A, dec_2: B, dec_3: C, dec_4: D) -> Self {
+    pub const fn new(dec_1: A, dec_2: B, dec_3: C, dec_4: D) -> Self {
         Self { inner: Decoder2::new(Decoder2::new(dec_1, dec_2), Decoder2::new(dec_3, dec_4)) }
     }
 }
@@ -516,7 +516,7 @@ where
     F: Decoder,
 {
     /// Constructs a new composite decoder.
-    pub fn new(dec_1: A, dec_2: B, dec_3: C, dec_4: D, dec_5: E, dec_6: F) -> Self {
+    pub const fn new(dec_1: A, dec_2: B, dec_3: C, dec_4: D, dec_5: E, dec_6: F) -> Self {
         Self {
             inner: Decoder2::new(
                 Decoder3::new(dec_1, dec_2, dec_3),
@@ -579,7 +579,7 @@ pub struct CompactSizeDecoder {
 
 impl CompactSizeDecoder {
     /// Constructs a new compact size decoder.
-    pub fn new() -> Self { Self { buf: internals::array_vec::ArrayVec::new() } }
+    pub const fn new() -> Self { Self { buf: internals::array_vec::ArrayVec::new() } }
 }
 
 impl Default for CompactSizeDecoder {

--- a/consensus_encoding/src/encode/encoders.rs
+++ b/consensus_encoding/src/encode/encoders.rs
@@ -26,7 +26,7 @@ pub struct BytesEncoder<'sl> {
 
 impl<'sl> BytesEncoder<'sl> {
     /// Constructs a byte encoder which encodes the given byte slice, with no length prefix.
-    pub fn without_length_prefix(sl: &'sl [u8]) -> Self { Self { sl: Some(sl) } }
+    pub const fn without_length_prefix(sl: &'sl [u8]) -> Self { Self { sl: Some(sl) } }
 }
 
 impl Encoder for BytesEncoder<'_> {
@@ -45,7 +45,7 @@ pub struct ArrayEncoder<const N: usize> {
 
 impl<const N: usize> ArrayEncoder<N> {
     /// Constructs an encoder which encodes the array with no length prefix.
-    pub fn without_length_prefix(arr: [u8; N]) -> Self { Self { arr: Some(arr) } }
+    pub const fn without_length_prefix(arr: [u8; N]) -> Self { Self { arr: Some(arr) } }
 }
 
 impl<const N: usize> Encoder for ArrayEncoder<N> {
@@ -124,7 +124,7 @@ pub struct Encoder2<A, B> {
 
 impl<A, B> Encoder2<A, B> {
     /// Constructs a new composite encoder.
-    pub fn new(enc_1: A, enc_2: B) -> Self { Self { enc_idx: 0, enc_1, enc_2 } }
+    pub const fn new(enc_1: A, enc_2: B) -> Self { Self { enc_idx: 0, enc_1, enc_2 } }
 }
 
 impl<A: Encoder, B: Encoder> Encoder for Encoder2<A, B> {
@@ -162,7 +162,7 @@ pub struct Encoder3<A, B, C> {
 
 impl<A, B, C> Encoder3<A, B, C> {
     /// Constructs a new composite encoder.
-    pub fn new(enc_1: A, enc_2: B, enc_3: C) -> Self {
+    pub const fn new(enc_1: A, enc_2: B, enc_3: C) -> Self {
         Self { inner: Encoder2::new(Encoder2::new(enc_1, enc_2), enc_3) }
     }
 }
@@ -181,7 +181,7 @@ pub struct Encoder4<A, B, C, D> {
 
 impl<A, B, C, D> Encoder4<A, B, C, D> {
     /// Constructs a new composite encoder.
-    pub fn new(enc_1: A, enc_2: B, enc_3: C, enc_4: D) -> Self {
+    pub const fn new(enc_1: A, enc_2: B, enc_3: C, enc_4: D) -> Self {
         Self { inner: Encoder2::new(Encoder2::new(enc_1, enc_2), Encoder2::new(enc_3, enc_4)) }
     }
 }
@@ -200,7 +200,7 @@ pub struct Encoder6<A, B, C, D, E, F> {
 
 impl<A, B, C, D, E, F> Encoder6<A, B, C, D, E, F> {
     /// Constructs a new composite encoder.
-    pub fn new(enc_1: A, enc_2: B, enc_3: C, enc_4: D, enc_5: E, enc_6: F) -> Self {
+    pub const fn new(enc_1: A, enc_2: B, enc_3: C, enc_4: D, enc_5: E, enc_6: F) -> Self {
         Self {
             inner: Encoder2::new(
                 Encoder3::new(enc_1, enc_2, enc_3),


### PR DESCRIPTION
Using const functions allows the compiler to make certain optimisations by precomputing some values during compilation, instead of at runtime.

Convert all constructors in the consensus_encoding crate to const, with the following exceptions:
SliceEncoder::without_length_prefix - This needs to call T::encoder,
  which would require making the Encodable trait use a const fn.
CompactSizeEncoder::new - Requires various ArrayVec functions to be
  const, which requires a cascade of const functions elsewhere.

Contributes to #4980 