### PR TITLE
fix: clone psbt_b before second combine call in fuzz test

### DIFF
--- a/fuzz/fuzz_targets/bitcoin/deserialize_psbt.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_psbt.rs
@@ -19,7 +19,11 @@ fn do_test(data: &[u8]) {
             match psbt_b {
                 Err(_) => {}
                 Ok(mut psbt_b) => {
-                    assert_eq!(psbt_b.combine(psbt.clone()).is_ok(), psbt.combine(psbt_b).is_ok());
+                    let psbt_b_clone = psbt_b.clone();
+                    assert_eq!(
+                        psbt_b.combine(psbt.clone()).is_ok(),
+                        psbt.combine(psbt_b_clone).is_ok()
+                    );
                 }
             }
         }


### PR DESCRIPTION
Fixes ownership issue in PSBT combine commutativity test. The test was using a mutated psbt_b in the second combine call, which broke the test's intent to verify commutativity. 
Now both PSBTs are cloned before use, matching the pattern used in the official unit tests.