### PR TITLE
Remove unused std extern crate from addresses crate

### DIFF
--- a/addresses/src/lib.rs
+++ b/addresses/src/lib.rs
@@ -23,6 +23,3 @@
 #![allow(clippy::uninlined_format_args)] // Allow `format!("{}", x)` instead of enforcing `format!("{x}")`
 
 extern crate alloc;
-
-#[cfg(feature = "std")]
-extern crate std;


### PR DESCRIPTION
Drop #[cfg(feature = "std")] extern crate std; from addresses/src/lib.rs because it is never referenced in this no_std crate rely on the implicit prelude from the 2021 edition, avoiding a needless lint warning when the std feature is enabled