### PR TITLE
io: Move pub re-export

### DIFF
--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -41,14 +41,14 @@ mod hash;
 use alloc::vec::Vec;
 use core::cmp;
 
-#[cfg(feature = "std")]
-pub use bridge::{FromStd, ToStd};
 use encoding::Encoder;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 pub use self::error::{Error, ErrorKind};
 #[cfg(feature = "hashes")]
 pub use self::hash::hash_reader;
+#[cfg(feature = "std")]
+pub use self::bridge::{FromStd, ToStd};
 
 /// Result type returned by functions in this crate.
 pub type Result<T> = core::result::Result<T, Error>;


### PR DESCRIPTION
Prefix with `self::` and group the pub re-export with the others.

Done because in #5233 the formatter bot munged the public and private imports together.

No logic change.