### PR TITLE
Fuzz with latest MSRV

### DIFF
--- a/.github/workflows/cron-daily-fuzz.yml
+++ b/.github/workflows/cron-daily-fuzz.yml
@@ -58,7 +58,7 @@ jobs:
           key: cache-${{ matrix.target }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: '1.65.0'
+          toolchain: '1.74.0'
       - name: fuzz
         run: |
           if [[ "${{ matrix.fuzz_target }}" =~ ^bitcoin ]]; then


### PR DESCRIPTION
The daily fuzzing job is borked

error: package `syn v2.0.108` cannot be built because it requires rustc 1.68 or newer, while the currently active rustc version is 1.65.0 Either upgrade to rustc 1.68 or newer, or use
cargo update -p syn@2.0.108 --precise ver
where `ver` is the latest version of `syn` supporting rustc 1.65.0

Use the latest MSRV when fuzzing.
