### PR TITLE
io: Make traits dyn compatible

### DIFF
--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -418,7 +418,7 @@ impl Decodable for Block<Unchecked> {
 
     #[inline]
     fn consensus_decode<R: io::BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
-        let mut r = r.take(internals::ToU64::to_u64(encode::MAX_VEC_SIZE));
+        let mut r = io::Read::take(r, internals::ToU64::to_u64(encode::MAX_VEC_SIZE));
         let header = Decodable::consensus_decode(&mut r)?;
         let transactions = Decodable::consensus_decode(&mut r)?;
 

--- a/bitcoin/src/internal_macros.rs
+++ b/bitcoin/src/internal_macros.rs
@@ -33,7 +33,7 @@ macro_rules! impl_consensus_encoding {
             fn consensus_decode<R: $crate::io::BufRead + ?Sized>(
                 r: &mut R,
             ) -> core::result::Result<$thing, $crate::consensus::encode::Error> {
-                let mut r = r.take(internals::ToU64::to_u64($crate::consensus::encode::MAX_VEC_SIZE));
+                let mut r = $crate::io::Read::take(r, internals::ToU64::to_u64($crate::consensus::encode::MAX_VEC_SIZE));
                 Ok($thing {
                     $($field: $crate::consensus::Decodable::consensus_decode(&mut r)?),+
                 })

--- a/bitcoin/src/psbt/raw.rs
+++ b/bitcoin/src/psbt/raw.rs
@@ -157,7 +157,7 @@ where
         // The limit is a DOS protection mechanism the exact value is not
         // important, 1024 bytes is bigger than any key should be.
         let mut key = vec![];
-        let _ = r.read_to_limit(&mut key, 1024)?;
+        let _ = io::Read::read_to_limit(r, &mut key, 1024)?;
 
         Ok(Self { prefix, subtype, key })
     }

--- a/io/tests/api.rs
+++ b/io/tests/api.rs
@@ -54,8 +54,8 @@ impl Structs {
 }
 
 #[derive(Debug)] // `Take` implements Debug (C-DEBUG).
-struct Taker<'a> {
-    a: Take<'a, Dummy>,
+struct Taker<Dummy> {
+    a: Take<Dummy>,
 }
 
 /// An arbitrary `Dummy` instance.
@@ -141,4 +141,20 @@ fn all_non_error_types_implement_send_sync() {
     // Error types are meaningful and well-behaved (C-GOOD-ERR)
     assert_send::<Errors>();
     assert_sync::<Errors>();
+}
+
+#[test]
+fn dyn_compatible() {
+    // Sanity check, these are all dyn compatible.
+    struct StdlibTraits {
+        p: Box<dyn std::io::Read>,
+        q: Box<dyn std::io::Write>,
+        r: Box<dyn std::io::BufRead>,
+    }
+    // If this builds then our three traits are dyn compatible also.
+    struct OurTraits {
+        p: Box<dyn Read>,
+        q: Box<dyn Write>,
+        r: Box<dyn BufRead>,
+    }
 }

--- a/p2p/src/consensus.rs
+++ b/p2p/src/consensus.rs
@@ -46,7 +46,7 @@ macro_rules! impl_consensus_encoding {
             fn consensus_decode<R: io::BufRead + ?Sized>(
                 r: &mut R,
             ) -> core::result::Result<$thing, bitcoin::consensus::encode::Error> {
-                let mut r = r.take(internals::ToU64::to_u64(bitcoin::consensus::encode::MAX_VEC_SIZE));
+                let mut r = io::Read::take(r, internals::ToU64::to_u64(bitcoin::consensus::encode::MAX_VEC_SIZE));
                 Ok($thing {
                     $($field: bitcoin::consensus::Decodable::consensus_decode(&mut r)?),+
                 })


### PR DESCRIPTION
Add an API test that shows dyn compatibility of std io traits and the same for ours. Patch the crate to make the test pass.

This is API breaking for `io`, that means that this cannot be backported to `0.1.0` (depended on by `bitcoin v0.32`).

Close: #3833

