### PR TITLE
doc: Add agents.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# Note for Automated Agents
+
+## Commit attribution
+
+If you generate code for this repository, append a commit trailer:
+
+Format:
+```
+Assisted-by: <AI model> <version>
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
As an attempt to catch bots/low-quality contributions we add AGENTS.md that tells LLMs to identify themselves.  

disclosed via commit message:
`> assisted-by-llm `

