### PR TITLE
Add new error type for PushBytes::read_scriptint

### DIFF
--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -76,7 +76,7 @@ pub use self::{
     builder::Builder,
     instruction::{Instruction, Instructions, InstructionIndices},
     owned::{ScriptBufExt, ScriptPubKeyBufExt},
-    push_bytes::{PushBytes, PushBytesBuf, PushBytesError, PushBytesErrorReport},
+    push_bytes::{PushBytes, PushBytesBuf, PushBytesError, PushBytesErrorReport, ScriptIntError},
 };
 #[doc(inline)]
 pub use primitives::script::{
@@ -155,12 +155,12 @@ pub fn write_scriptint(out: &mut [u8; 8], n: i64) -> usize {
 ///
 /// See [`push_bytes::PushBytes::read_scriptint`] for a description of some subtleties of
 /// this function.
-pub fn read_scriptint_non_minimal(v: &[u8]) -> Result<i32, Error> {
+pub fn read_scriptint_non_minimal(v: &[u8]) -> Result<i32, ScriptIntError> {
     if v.is_empty() {
         return Ok(0);
     }
     if v.len() > 4 {
-        return Err(Error::NumericOverflow);
+        return Err(ScriptIntError::NumericOverflow);
     }
 
     let ret = scriptint_parse(v);

--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -430,11 +430,11 @@ fn non_minimal_scriptints() {
     );
     assert_eq!(
         PushBytes::read_scriptint(<[_; 3] as AsRef<PushBytes>>::as_ref(&[0x8f, 0x00, 0x00])),
-        Err(Error::NonMinimalPush)
+        Err(ScriptIntError::NonMinimal)
     );
     assert_eq!(
         PushBytes::read_scriptint(<[_; 2] as AsRef<PushBytes>>::as_ref(&[0x7f, 0x00])),
-        Err(Error::NonMinimalPush)
+        Err(ScriptIntError::NonMinimal)
     );
 
     assert_eq!(read_scriptint_non_minimal(&[0x80, 0x00]), Ok(0x80));


### PR DESCRIPTION
The error type currently returned by the  PushBytes::read_scriptint function is fairly general, shared by various other script functionality. Most of the error type is not applicable, making the error less meaningful for describing error states of this function than it should be.

Introduce a ScriptIntError type to cover the error types that can be thrown by PushBytes::read_scriptint.

Closes #5263 