### PR TITLE
Clarify feature gate on impl_to_hex_from_lower_hex macro

### DIFF
--- a/internals/src/macros.rs
+++ b/internals/src/macros.rs
@@ -15,12 +15,9 @@ macro_rules! const_assert {
     }
 }
 
-/// Adds an implementation of `pub fn to_hex(&self) -> String` if `alloc` feature is enabled.
+/// Adds an implementation of `pub fn to_hex(&self) -> String`.
 ///
 /// The added function allocates a `String` then calls through to [`core::fmt::LowerHex`].
-///
-/// Note: Calling this macro assumes that the calling crate has an `alloc` feature that also activates the
-/// `alloc` crate. Calling this macro without the `alloc` feature enabled is a no-op.
 #[macro_export]
 macro_rules! impl_to_hex_from_lower_hex {
     ($t:ident, $hex_len_fn:expr) => {


### PR DESCRIPTION
The docs on `internals::impl_to_hex_from_lower_hex` macro state that the calling crate must have an "alloc" feature. If this feature is not enabled, the macro is a no-op. In practice, the macro has no such feature gate as it is primarily used in the `bitcoin` crate, which has no "alloc" feature.

Adjust the wording of the `internals::impl_to_hex_from_lower_hex` macro to clarify the true behaviour.

Closes #5275 