### PR TITLE
chore(docs): remove `act` from CI Pipeline section on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,11 +187,6 @@ for review yet please mark it by prefixing the title with `WIP: `.
 
 The CI pipeline requires approval before being run on each PR.
 
-In order to speed up the review process the CI pipeline can be run locally using
-[act](https://github.com/nektos/act). The `fuzz` and `Cross` jobs will be skipped when using `act`
-due to caching being unsupported at this time. We do not *actively* support `act` but will merge PRs
-fixing `act` issues.
-
 ### Githooks
 
 To assist devs in catching errors _before_ running CI we provide some githooks. Copy the hooks in `githooks/`


### PR DESCRIPTION
Remove act from README since `.actrc` was removed in #4533.