### PR TITLE
Create an empty `crypto` crate

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -80,6 +80,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin-crypto"
+version = "0.0.0"
+
+[[package]]
 name = "bitcoin-fuzz"
 version = "0.0.1"
 dependencies = [

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -79,6 +79,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin-crypto"
+version = "0.0.0"
+
+[[package]]
 name = "bitcoin-fuzz"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["addresses", "base58", "bitcoin", "chacha20_poly1305", "consensus_encoding", "fuzz", "hashes", "internals", "io", "p2p", "primitives", "units"]
+members = ["addresses", "base58", "bitcoin", "chacha20_poly1305", "consensus_encoding", "crypto", "fuzz", "hashes", "internals", "io", "p2p", "primitives", "units"]
 exclude = ["benches"]
 resolver = "2"
 

--- a/crypto/CHANGELOG.md
+++ b/crypto/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.0.0 - Initial dummy release
+
+- Empty crate to reserve the name on crates.io

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "bitcoin-crypto"
+version = "0.0.0"
+authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
+license = "CC0-1.0"
+repository = "https://github.com/rust-bitcoin/rust-bitcoin"
+description = "Crypto support for the rust-bitcoin ecosystem"
+categories = ["cryptography::cryptocurrencies"]
+keywords = ["bitcoin", "types"]
+readme = "README.md"
+edition = "2021"
+rust-version = "1.74.0"
+exclude = ["tests", "contrib"]
+
+[features]
+default = ["std"]
+std = ["alloc"]
+alloc = []
+
+[dependencies]
+
+[dev-dependencies]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[lints.clippy]
+redundant_clone = "warn"
+use_self = "warn"

--- a/crypto/README.md
+++ b/crypto/README.md
@@ -1,0 +1,7 @@
+# Cryptography
+
+Types and logic required to support cryptography i.e., bitcoin keys.
+
+## Minimum Supported Rust Version (MSRV)
+
+This library should always compile with any combination of features on **Rust 1.74.0**.

--- a/crypto/contrib/extra_lints.sh
+++ b/crypto/contrib/extra_lints.sh
@@ -1,0 +1,4 @@
+# No shebang, this file should not be executed.
+# shellcheck disable=SC2148
+
+cargo clippy --all-targets --no-default-features --keep-going -- -D warnings

--- a/crypto/contrib/test_vars.sh
+++ b/crypto/contrib/test_vars.sh
@@ -1,0 +1,14 @@
+# No shebang, this file should not be executed.
+# shellcheck disable=SC2148
+#
+# disable verify unused vars, despite the fact that they are used when sourced
+# shellcheck disable=SC2034
+
+# Test all these features with "std" enabled.
+FEATURES_WITH_STD=""
+
+# Test all these features without "std" enabled.
+FEATURES_WITHOUT_STD="alloc"
+
+# Run these examples.
+EXAMPLES=""

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Cryptography support for the rust-bitcoin ecosystem.
+
+// NB: This crate is empty if `alloc` is not enabled.
+#![cfg(feature = "alloc")]
+#![no_std]
+// Experimental features we need.
+#![doc(test(attr(warn(unused))))]
+// Coding conventions.
+#![warn(deprecated_in_future)]
+#![warn(missing_docs)]
+// Exclude lints we don't think are valuable.
+#![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
+#![allow(clippy::manual_range_contains)] // More readable than clippy's format.
+#![allow(clippy::uninlined_format_args)] // Allow `format!("{}", x)` instead of enforcing `format!("{x}")`
+
+extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;


### PR DESCRIPTION
In preparation for crate smashing the `crypto` module create an empty crate so we can grab the name on crates.io.

I don't currently know whats the pros and cons of moving just keys to moving everything in the `crypto` module. So the manifest description is a bit vague.

FTR `bitcoin-key` and `bitcoin_keys` are both taken on crates.io

`bitcoin-key` is however owned by klebs6 who has given us names in the past. `bitcoin_keys` is owned by Maxim.