### PR TITLE
primitives: Implement BlockDecoder for Block

### DIFF
--- a/api/primitives/all-features.txt
+++ b/api/primitives/all-features.txt
@@ -3,6 +3,7 @@
 #[repr(transparent)] pub struct bitcoin_primitives::script::Script<T>(_, _)
 impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::BlockHash
 impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::TxMerkleNode
+impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::block::Block
 impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::block::Header
 impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::block::Version
 impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::pow::CompactTarget
@@ -12,6 +13,7 @@ impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::trans
 impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::transaction::TxOut
 impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::transaction::Version
 impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::witness::Witness
+impl bitcoin_consensus_encoding::decode::Decoder for bitcoin_primitives::block::BlockDecoder
 impl bitcoin_consensus_encoding::decode::Decoder for bitcoin_primitives::block::BlockHashDecoder
 impl bitcoin_consensus_encoding::decode::Decoder for bitcoin_primitives::block::HeaderDecoder
 impl bitcoin_consensus_encoding::decode::Decoder for bitcoin_primitives::block::VersionDecoder
@@ -106,6 +108,7 @@ impl core::clone::Clone for bitcoin_primitives::Txid
 impl core::clone::Clone for bitcoin_primitives::WitnessCommitment
 impl core::clone::Clone for bitcoin_primitives::WitnessMerkleNode
 impl core::clone::Clone for bitcoin_primitives::Wtxid
+impl core::clone::Clone for bitcoin_primitives::block::BlockDecoderError
 impl core::clone::Clone for bitcoin_primitives::block::BlockHashDecoderError
 impl core::clone::Clone for bitcoin_primitives::block::Checked
 impl core::clone::Clone for bitcoin_primitives::block::Header
@@ -147,6 +150,7 @@ impl core::cmp::Eq for bitcoin_primitives::Txid
 impl core::cmp::Eq for bitcoin_primitives::WitnessCommitment
 impl core::cmp::Eq for bitcoin_primitives::WitnessMerkleNode
 impl core::cmp::Eq for bitcoin_primitives::Wtxid
+impl core::cmp::Eq for bitcoin_primitives::block::BlockDecoderError
 impl core::cmp::Eq for bitcoin_primitives::block::BlockHashDecoderError
 impl core::cmp::Eq for bitcoin_primitives::block::Checked
 impl core::cmp::Eq for bitcoin_primitives::block::Header
@@ -213,6 +217,7 @@ impl core::cmp::PartialEq for bitcoin_primitives::Txid
 impl core::cmp::PartialEq for bitcoin_primitives::WitnessCommitment
 impl core::cmp::PartialEq for bitcoin_primitives::WitnessMerkleNode
 impl core::cmp::PartialEq for bitcoin_primitives::Wtxid
+impl core::cmp::PartialEq for bitcoin_primitives::block::BlockDecoderError
 impl core::cmp::PartialEq for bitcoin_primitives::block::BlockHashDecoderError
 impl core::cmp::PartialEq for bitcoin_primitives::block::Checked
 impl core::cmp::PartialEq for bitcoin_primitives::block::Header
@@ -313,6 +318,7 @@ impl core::convert::From<bitcoin_primitives::transaction::Version> for u32
 impl core::convert::From<bitcoin_primitives::transaction::VersionDecoderError> for bitcoin_primitives::transaction::TransactionDecoderError
 impl core::convert::From<bitcoin_primitives::witness::WitnessDecoderError> for bitcoin_primitives::transaction::TransactionDecoderError
 impl core::convert::From<bitcoin_units::locktime::absolute::error::LockTimeDecoderError> for bitcoin_primitives::transaction::TransactionDecoderError
+impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::block::BlockDecoderError
 impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::block::BlockHashDecoderError
 impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::block::HeaderDecoderError
 impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::block::VersionDecoderError
@@ -340,6 +346,7 @@ impl core::default::Default for bitcoin_primitives::transaction::TxMerkleNodeDec
 impl core::default::Default for bitcoin_primitives::transaction::VersionDecoder
 impl core::default::Default for bitcoin_primitives::witness::Witness
 impl core::default::Default for bitcoin_primitives::witness::WitnessDecoder
+impl core::error::Error for bitcoin_primitives::block::BlockDecoderError
 impl core::error::Error for bitcoin_primitives::block::BlockHashDecoderError
 impl core::error::Error for bitcoin_primitives::block::HeaderDecoderError
 impl core::error::Error for bitcoin_primitives::block::VersionDecoderError
@@ -363,6 +370,7 @@ impl core::fmt::Debug for bitcoin_primitives::Txid
 impl core::fmt::Debug for bitcoin_primitives::WitnessCommitment
 impl core::fmt::Debug for bitcoin_primitives::WitnessMerkleNode
 impl core::fmt::Debug for bitcoin_primitives::Wtxid
+impl core::fmt::Debug for bitcoin_primitives::block::BlockDecoderError
 impl core::fmt::Debug for bitcoin_primitives::block::BlockHashDecoderError
 impl core::fmt::Debug for bitcoin_primitives::block::Checked
 impl core::fmt::Debug for bitcoin_primitives::block::Header
@@ -399,6 +407,7 @@ impl core::fmt::Display for bitcoin_primitives::Txid
 impl core::fmt::Display for bitcoin_primitives::WitnessCommitment
 impl core::fmt::Display for bitcoin_primitives::WitnessMerkleNode
 impl core::fmt::Display for bitcoin_primitives::Wtxid
+impl core::fmt::Display for bitcoin_primitives::block::BlockDecoderError
 impl core::fmt::Display for bitcoin_primitives::block::BlockHashDecoderError
 impl core::fmt::Display for bitcoin_primitives::block::Header
 impl core::fmt::Display for bitcoin_primitives::block::HeaderDecoderError
@@ -487,6 +496,8 @@ impl core::marker::Freeze for bitcoin_primitives::Txid
 impl core::marker::Freeze for bitcoin_primitives::WitnessCommitment
 impl core::marker::Freeze for bitcoin_primitives::WitnessMerkleNode
 impl core::marker::Freeze for bitcoin_primitives::Wtxid
+impl core::marker::Freeze for bitcoin_primitives::block::BlockDecoder
+impl core::marker::Freeze for bitcoin_primitives::block::BlockDecoderError
 impl core::marker::Freeze for bitcoin_primitives::block::BlockHashDecoder
 impl core::marker::Freeze for bitcoin_primitives::block::BlockHashDecoderError
 impl core::marker::Freeze for bitcoin_primitives::block::BlockHashEncoder
@@ -545,6 +556,8 @@ impl core::marker::Send for bitcoin_primitives::Txid
 impl core::marker::Send for bitcoin_primitives::WitnessCommitment
 impl core::marker::Send for bitcoin_primitives::WitnessMerkleNode
 impl core::marker::Send for bitcoin_primitives::Wtxid
+impl core::marker::Send for bitcoin_primitives::block::BlockDecoder
+impl core::marker::Send for bitcoin_primitives::block::BlockDecoderError
 impl core::marker::Send for bitcoin_primitives::block::BlockHashDecoder
 impl core::marker::Send for bitcoin_primitives::block::BlockHashDecoderError
 impl core::marker::Send for bitcoin_primitives::block::BlockHashEncoder
@@ -603,6 +616,7 @@ impl core::marker::StructuralPartialEq for bitcoin_primitives::Txid
 impl core::marker::StructuralPartialEq for bitcoin_primitives::WitnessCommitment
 impl core::marker::StructuralPartialEq for bitcoin_primitives::WitnessMerkleNode
 impl core::marker::StructuralPartialEq for bitcoin_primitives::Wtxid
+impl core::marker::StructuralPartialEq for bitcoin_primitives::block::BlockDecoderError
 impl core::marker::StructuralPartialEq for bitcoin_primitives::block::BlockHashDecoderError
 impl core::marker::StructuralPartialEq for bitcoin_primitives::block::Checked
 impl core::marker::StructuralPartialEq for bitcoin_primitives::block::Header
@@ -644,6 +658,8 @@ impl core::marker::Sync for bitcoin_primitives::Txid
 impl core::marker::Sync for bitcoin_primitives::WitnessCommitment
 impl core::marker::Sync for bitcoin_primitives::WitnessMerkleNode
 impl core::marker::Sync for bitcoin_primitives::Wtxid
+impl core::marker::Sync for bitcoin_primitives::block::BlockDecoder
+impl core::marker::Sync for bitcoin_primitives::block::BlockDecoderError
 impl core::marker::Sync for bitcoin_primitives::block::BlockHashDecoder
 impl core::marker::Sync for bitcoin_primitives::block::BlockHashDecoderError
 impl core::marker::Sync for bitcoin_primitives::block::BlockHashEncoder
@@ -702,6 +718,8 @@ impl core::marker::Unpin for bitcoin_primitives::Txid
 impl core::marker::Unpin for bitcoin_primitives::WitnessCommitment
 impl core::marker::Unpin for bitcoin_primitives::WitnessMerkleNode
 impl core::marker::Unpin for bitcoin_primitives::Wtxid
+impl core::marker::Unpin for bitcoin_primitives::block::BlockDecoder
+impl core::marker::Unpin for bitcoin_primitives::block::BlockDecoderError
 impl core::marker::Unpin for bitcoin_primitives::block::BlockHashDecoder
 impl core::marker::Unpin for bitcoin_primitives::block::BlockHashDecoderError
 impl core::marker::Unpin for bitcoin_primitives::block::BlockHashEncoder
@@ -761,6 +779,8 @@ impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::Txid
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::WitnessCommitment
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::WitnessMerkleNode
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::Wtxid
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::BlockDecoder
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::BlockDecoderError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::BlockHashDecoder
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::BlockHashDecoderError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::BlockHashEncoder
@@ -819,6 +839,8 @@ impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::Txid
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::WitnessCommitment
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::WitnessMerkleNode
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::Wtxid
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::BlockDecoder
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::BlockDecoderError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::BlockHashDecoder
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::BlockHashDecoderError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::BlockHashEncoder
@@ -1368,6 +1390,7 @@ pub fn bitcoin_primitives::Wtxid::hash<__H: core::hash::Hasher>(&self, state: &m
 pub fn bitcoin_primitives::Wtxid::partial_cmp(&self, other: &bitcoin_primitives::Wtxid) -> core::option::Option<core::cmp::Ordering>
 pub fn bitcoin_primitives::Wtxid::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
 pub fn bitcoin_primitives::block::Block::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
+pub fn bitcoin_primitives::block::Block::decoder() -> Self::Decoder
 pub fn bitcoin_primitives::block::Block::encoder(&self) -> Self::Encoder
 pub fn bitcoin_primitives::block::Block<V>::block_hash(&self) -> bitcoin_primitives::BlockHash
 pub fn bitcoin_primitives::block::Block<V>::clone(&self) -> bitcoin_primitives::block::Block<V>
@@ -1379,6 +1402,14 @@ pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Checked>::tra
 pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::assume_checked(self, witness_root: core::option::Option<bitcoin_primitives::WitnessMerkleNode>) -> bitcoin_primitives::block::Block<bitcoin_primitives::block::Checked>
 pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::into_parts(self) -> (bitcoin_primitives::block::Header, alloc::vec::Vec<bitcoin_primitives::transaction::Transaction>)
 pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::new_unchecked(header: bitcoin_primitives::block::Header, transactions: alloc::vec::Vec<bitcoin_primitives::transaction::Transaction>) -> Self
+pub fn bitcoin_primitives::block::BlockDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
+pub fn bitcoin_primitives::block::BlockDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bool, Self::Error>
+pub fn bitcoin_primitives::block::BlockDecoder::read_limit(&self) -> usize
+pub fn bitcoin_primitives::block::BlockDecoderError::clone(&self) -> bitcoin_primitives::block::BlockDecoderError
+pub fn bitcoin_primitives::block::BlockDecoderError::eq(&self, other: &bitcoin_primitives::block::BlockDecoderError) -> bool
+pub fn bitcoin_primitives::block::BlockDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::block::BlockDecoderError::from(never: core::convert::Infallible) -> Self
+pub fn bitcoin_primitives::block::BlockDecoderError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 pub fn bitcoin_primitives::block::BlockEncoder<'e>::advance(&mut self) -> bool
 pub fn bitcoin_primitives::block::BlockEncoder<'e>::current_chunk(&self) -> &[u8]
 pub fn bitcoin_primitives::block::BlockHashDecoder::default() -> Self
@@ -1849,6 +1880,8 @@ pub struct bitcoin_primitives::WitnessCommitment(_)
 pub struct bitcoin_primitives::WitnessMerkleNode(_)
 pub struct bitcoin_primitives::Wtxid(_)
 pub struct bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation
+pub struct bitcoin_primitives::block::BlockDecoder(_)
+pub struct bitcoin_primitives::block::BlockDecoderError(_)
 pub struct bitcoin_primitives::block::BlockEncoder<'e>(_)
 pub struct bitcoin_primitives::block::BlockHash(_)
 pub struct bitcoin_primitives::block::BlockHashDecoder(_)
@@ -1938,7 +1971,10 @@ pub type bitcoin_primitives::WitnessMerkleNode::Err = hex_conservative::error::D
 pub type bitcoin_primitives::WitnessScript = bitcoin_primitives::script::Script<bitcoin_primitives::script::WitnessScriptTag>
 pub type bitcoin_primitives::WitnessScriptBuf = bitcoin_primitives::script::ScriptBuf<bitcoin_primitives::script::WitnessScriptTag>
 pub type bitcoin_primitives::Wtxid::Err = hex_conservative::error::DecodeFixedLengthBytesError
+pub type bitcoin_primitives::block::Block::Decoder = bitcoin_primitives::block::BlockDecoder
 pub type bitcoin_primitives::block::Block::Encoder<'e> where Self: 'e = bitcoin_consensus_encoding::encode::encoders::Encoder2<bitcoin_primitives::block::HeaderEncoder, bitcoin_consensus_encoding::encode::encoders::Encoder2<bitcoin_consensus_encoding::encode::encoders::CompactSizeEncoder, bitcoin_consensus_encoding::encode::encoders::SliceEncoder<'e, bitcoin_primitives::transaction::Transaction>>>
+pub type bitcoin_primitives::block::BlockDecoder::Error = bitcoin_primitives::block::BlockDecoderError
+pub type bitcoin_primitives::block::BlockDecoder::Output = bitcoin_primitives::block::Block
 pub type bitcoin_primitives::block::BlockHashDecoder::Error = bitcoin_primitives::block::BlockHashDecoderError
 pub type bitcoin_primitives::block::BlockHashDecoder::Output = bitcoin_primitives::BlockHash
 pub type bitcoin_primitives::block::Header::Decoder = bitcoin_primitives::block::HeaderDecoder

--- a/api/primitives/alloc-only.txt
+++ b/api/primitives/alloc-only.txt
@@ -2,6 +2,7 @@
 #[repr(transparent)] pub struct bitcoin_primitives::script::Script<T>(_, _)
 impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::BlockHash
 impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::TxMerkleNode
+impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::block::Block
 impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::block::Header
 impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::block::Version
 impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::pow::CompactTarget
@@ -11,6 +12,7 @@ impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::trans
 impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::transaction::TxOut
 impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::transaction::Version
 impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::witness::Witness
+impl bitcoin_consensus_encoding::decode::Decoder for bitcoin_primitives::block::BlockDecoder
 impl bitcoin_consensus_encoding::decode::Decoder for bitcoin_primitives::block::BlockHashDecoder
 impl bitcoin_consensus_encoding::decode::Decoder for bitcoin_primitives::block::HeaderDecoder
 impl bitcoin_consensus_encoding::decode::Decoder for bitcoin_primitives::block::VersionDecoder
@@ -105,6 +107,7 @@ impl core::clone::Clone for bitcoin_primitives::Txid
 impl core::clone::Clone for bitcoin_primitives::WitnessCommitment
 impl core::clone::Clone for bitcoin_primitives::WitnessMerkleNode
 impl core::clone::Clone for bitcoin_primitives::Wtxid
+impl core::clone::Clone for bitcoin_primitives::block::BlockDecoderError
 impl core::clone::Clone for bitcoin_primitives::block::BlockHashDecoderError
 impl core::clone::Clone for bitcoin_primitives::block::Checked
 impl core::clone::Clone for bitcoin_primitives::block::Header
@@ -145,6 +148,7 @@ impl core::cmp::Eq for bitcoin_primitives::Txid
 impl core::cmp::Eq for bitcoin_primitives::WitnessCommitment
 impl core::cmp::Eq for bitcoin_primitives::WitnessMerkleNode
 impl core::cmp::Eq for bitcoin_primitives::Wtxid
+impl core::cmp::Eq for bitcoin_primitives::block::BlockDecoderError
 impl core::cmp::Eq for bitcoin_primitives::block::BlockHashDecoderError
 impl core::cmp::Eq for bitcoin_primitives::block::Checked
 impl core::cmp::Eq for bitcoin_primitives::block::Header
@@ -210,6 +214,7 @@ impl core::cmp::PartialEq for bitcoin_primitives::Txid
 impl core::cmp::PartialEq for bitcoin_primitives::WitnessCommitment
 impl core::cmp::PartialEq for bitcoin_primitives::WitnessMerkleNode
 impl core::cmp::PartialEq for bitcoin_primitives::Wtxid
+impl core::cmp::PartialEq for bitcoin_primitives::block::BlockDecoderError
 impl core::cmp::PartialEq for bitcoin_primitives::block::BlockHashDecoderError
 impl core::cmp::PartialEq for bitcoin_primitives::block::Checked
 impl core::cmp::PartialEq for bitcoin_primitives::block::Header
@@ -309,6 +314,7 @@ impl core::convert::From<bitcoin_primitives::transaction::Version> for u32
 impl core::convert::From<bitcoin_primitives::transaction::VersionDecoderError> for bitcoin_primitives::transaction::TransactionDecoderError
 impl core::convert::From<bitcoin_primitives::witness::WitnessDecoderError> for bitcoin_primitives::transaction::TransactionDecoderError
 impl core::convert::From<bitcoin_units::locktime::absolute::error::LockTimeDecoderError> for bitcoin_primitives::transaction::TransactionDecoderError
+impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::block::BlockDecoderError
 impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::block::BlockHashDecoderError
 impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::block::HeaderDecoderError
 impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::block::VersionDecoderError
@@ -342,6 +348,7 @@ impl core::fmt::Debug for bitcoin_primitives::Txid
 impl core::fmt::Debug for bitcoin_primitives::WitnessCommitment
 impl core::fmt::Debug for bitcoin_primitives::WitnessMerkleNode
 impl core::fmt::Debug for bitcoin_primitives::Wtxid
+impl core::fmt::Debug for bitcoin_primitives::block::BlockDecoderError
 impl core::fmt::Debug for bitcoin_primitives::block::BlockHashDecoderError
 impl core::fmt::Debug for bitcoin_primitives::block::Checked
 impl core::fmt::Debug for bitcoin_primitives::block::Header
@@ -370,6 +377,7 @@ impl core::fmt::Debug for bitcoin_primitives::transaction::VersionDecoderError
 impl core::fmt::Debug for bitcoin_primitives::witness::UnexpectedEofError
 impl core::fmt::Debug for bitcoin_primitives::witness::Witness
 impl core::fmt::Debug for bitcoin_primitives::witness::WitnessDecoderError
+impl core::fmt::Display for bitcoin_primitives::block::BlockDecoderError
 impl core::fmt::Display for bitcoin_primitives::block::BlockHashDecoderError
 impl core::fmt::Display for bitcoin_primitives::block::HeaderDecoderError
 impl core::fmt::Display for bitcoin_primitives::block::VersionDecoderError
@@ -435,6 +443,8 @@ impl core::marker::Freeze for bitcoin_primitives::Txid
 impl core::marker::Freeze for bitcoin_primitives::WitnessCommitment
 impl core::marker::Freeze for bitcoin_primitives::WitnessMerkleNode
 impl core::marker::Freeze for bitcoin_primitives::Wtxid
+impl core::marker::Freeze for bitcoin_primitives::block::BlockDecoder
+impl core::marker::Freeze for bitcoin_primitives::block::BlockDecoderError
 impl core::marker::Freeze for bitcoin_primitives::block::BlockHashDecoder
 impl core::marker::Freeze for bitcoin_primitives::block::BlockHashDecoderError
 impl core::marker::Freeze for bitcoin_primitives::block::BlockHashEncoder
@@ -492,6 +502,8 @@ impl core::marker::Send for bitcoin_primitives::Txid
 impl core::marker::Send for bitcoin_primitives::WitnessCommitment
 impl core::marker::Send for bitcoin_primitives::WitnessMerkleNode
 impl core::marker::Send for bitcoin_primitives::Wtxid
+impl core::marker::Send for bitcoin_primitives::block::BlockDecoder
+impl core::marker::Send for bitcoin_primitives::block::BlockDecoderError
 impl core::marker::Send for bitcoin_primitives::block::BlockHashDecoder
 impl core::marker::Send for bitcoin_primitives::block::BlockHashDecoderError
 impl core::marker::Send for bitcoin_primitives::block::BlockHashEncoder
@@ -549,6 +561,7 @@ impl core::marker::StructuralPartialEq for bitcoin_primitives::Txid
 impl core::marker::StructuralPartialEq for bitcoin_primitives::WitnessCommitment
 impl core::marker::StructuralPartialEq for bitcoin_primitives::WitnessMerkleNode
 impl core::marker::StructuralPartialEq for bitcoin_primitives::Wtxid
+impl core::marker::StructuralPartialEq for bitcoin_primitives::block::BlockDecoderError
 impl core::marker::StructuralPartialEq for bitcoin_primitives::block::BlockHashDecoderError
 impl core::marker::StructuralPartialEq for bitcoin_primitives::block::Checked
 impl core::marker::StructuralPartialEq for bitcoin_primitives::block::Header
@@ -589,6 +602,8 @@ impl core::marker::Sync for bitcoin_primitives::Txid
 impl core::marker::Sync for bitcoin_primitives::WitnessCommitment
 impl core::marker::Sync for bitcoin_primitives::WitnessMerkleNode
 impl core::marker::Sync for bitcoin_primitives::Wtxid
+impl core::marker::Sync for bitcoin_primitives::block::BlockDecoder
+impl core::marker::Sync for bitcoin_primitives::block::BlockDecoderError
 impl core::marker::Sync for bitcoin_primitives::block::BlockHashDecoder
 impl core::marker::Sync for bitcoin_primitives::block::BlockHashDecoderError
 impl core::marker::Sync for bitcoin_primitives::block::BlockHashEncoder
@@ -646,6 +661,8 @@ impl core::marker::Unpin for bitcoin_primitives::Txid
 impl core::marker::Unpin for bitcoin_primitives::WitnessCommitment
 impl core::marker::Unpin for bitcoin_primitives::WitnessMerkleNode
 impl core::marker::Unpin for bitcoin_primitives::Wtxid
+impl core::marker::Unpin for bitcoin_primitives::block::BlockDecoder
+impl core::marker::Unpin for bitcoin_primitives::block::BlockDecoderError
 impl core::marker::Unpin for bitcoin_primitives::block::BlockHashDecoder
 impl core::marker::Unpin for bitcoin_primitives::block::BlockHashDecoderError
 impl core::marker::Unpin for bitcoin_primitives::block::BlockHashEncoder
@@ -704,6 +721,8 @@ impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::Txid
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::WitnessCommitment
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::WitnessMerkleNode
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::Wtxid
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::BlockDecoder
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::BlockDecoderError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::BlockHashDecoder
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::BlockHashDecoderError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::block::BlockHashEncoder
@@ -761,6 +780,8 @@ impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::Txid
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::WitnessCommitment
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::WitnessMerkleNode
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::Wtxid
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::BlockDecoder
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::BlockDecoderError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::BlockHashDecoder
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::BlockHashDecoderError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::block::BlockHashEncoder
@@ -1206,6 +1227,7 @@ pub fn bitcoin_primitives::Wtxid::from(tx: &bitcoin_primitives::transaction::Tra
 pub fn bitcoin_primitives::Wtxid::from(tx: bitcoin_primitives::transaction::Transaction) -> Self
 pub fn bitcoin_primitives::Wtxid::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 pub fn bitcoin_primitives::Wtxid::partial_cmp(&self, other: &bitcoin_primitives::Wtxid) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_primitives::block::Block::decoder() -> Self::Decoder
 pub fn bitcoin_primitives::block::Block::encoder(&self) -> Self::Encoder
 pub fn bitcoin_primitives::block::Block<V>::block_hash(&self) -> bitcoin_primitives::BlockHash
 pub fn bitcoin_primitives::block::Block<V>::clone(&self) -> bitcoin_primitives::block::Block<V>
@@ -1217,6 +1239,13 @@ pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Checked>::tra
 pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::assume_checked(self, witness_root: core::option::Option<bitcoin_primitives::WitnessMerkleNode>) -> bitcoin_primitives::block::Block<bitcoin_primitives::block::Checked>
 pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::into_parts(self) -> (bitcoin_primitives::block::Header, alloc::vec::Vec<bitcoin_primitives::transaction::Transaction>)
 pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::new_unchecked(header: bitcoin_primitives::block::Header, transactions: alloc::vec::Vec<bitcoin_primitives::transaction::Transaction>) -> Self
+pub fn bitcoin_primitives::block::BlockDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
+pub fn bitcoin_primitives::block::BlockDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bool, Self::Error>
+pub fn bitcoin_primitives::block::BlockDecoder::read_limit(&self) -> usize
+pub fn bitcoin_primitives::block::BlockDecoderError::clone(&self) -> bitcoin_primitives::block::BlockDecoderError
+pub fn bitcoin_primitives::block::BlockDecoderError::eq(&self, other: &bitcoin_primitives::block::BlockDecoderError) -> bool
+pub fn bitcoin_primitives::block::BlockDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_primitives::block::BlockDecoderError::from(never: core::convert::Infallible) -> Self
 pub fn bitcoin_primitives::block::BlockEncoder<'e>::advance(&mut self) -> bool
 pub fn bitcoin_primitives::block::BlockEncoder<'e>::current_chunk(&self) -> &[u8]
 pub fn bitcoin_primitives::block::BlockHashDecoder::default() -> Self
@@ -1636,6 +1665,8 @@ pub struct bitcoin_primitives::WitnessCommitment(_)
 pub struct bitcoin_primitives::WitnessMerkleNode(_)
 pub struct bitcoin_primitives::Wtxid(_)
 pub struct bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation
+pub struct bitcoin_primitives::block::BlockDecoder(_)
+pub struct bitcoin_primitives::block::BlockDecoderError(_)
 pub struct bitcoin_primitives::block::BlockEncoder<'e>(_)
 pub struct bitcoin_primitives::block::BlockHash(_)
 pub struct bitcoin_primitives::block::BlockHashDecoder(_)
@@ -1718,7 +1749,10 @@ pub type bitcoin_primitives::TxMerkleNode::Decoder = bitcoin_primitives::transac
 pub type bitcoin_primitives::TxMerkleNode::Encoder<'e> = bitcoin_primitives::merkle_tree::TxMerkleNodeEncoder
 pub type bitcoin_primitives::WitnessScript = bitcoin_primitives::script::Script<bitcoin_primitives::script::WitnessScriptTag>
 pub type bitcoin_primitives::WitnessScriptBuf = bitcoin_primitives::script::ScriptBuf<bitcoin_primitives::script::WitnessScriptTag>
+pub type bitcoin_primitives::block::Block::Decoder = bitcoin_primitives::block::BlockDecoder
 pub type bitcoin_primitives::block::Block::Encoder<'e> where Self: 'e = bitcoin_consensus_encoding::encode::encoders::Encoder2<bitcoin_primitives::block::HeaderEncoder, bitcoin_consensus_encoding::encode::encoders::Encoder2<bitcoin_consensus_encoding::encode::encoders::CompactSizeEncoder, bitcoin_consensus_encoding::encode::encoders::SliceEncoder<'e, bitcoin_primitives::transaction::Transaction>>>
+pub type bitcoin_primitives::block::BlockDecoder::Error = bitcoin_primitives::block::BlockDecoderError
+pub type bitcoin_primitives::block::BlockDecoder::Output = bitcoin_primitives::block::Block
 pub type bitcoin_primitives::block::BlockHashDecoder::Error = bitcoin_primitives::block::BlockHashDecoderError
 pub type bitcoin_primitives::block::BlockHashDecoder::Output = bitcoin_primitives::BlockHash
 pub type bitcoin_primitives::block::Header::Decoder = bitcoin_primitives::block::HeaderDecoder


### PR DESCRIPTION
The Block type in primitives implements Encodable through the BlockEncoder type, but is missing a complementary decoder type.

Implement a BlockDecoder type that decodes Block types from bytes and implement Decodable on Block to create BlockDecoder instances.

This closes #5271 