### PR TITLE
fuzz: Update generate_files.sh for current targets

### DIFF
--- a/.github/workflows/cron-daily-fuzz.yml
+++ b/.github/workflows/cron-daily-fuzz.yml
@@ -34,6 +34,10 @@ jobs:
           bitcoin_parse_address,
           bitcoin_parse_outpoint,
           bitcoin_script_bytes_to_asm_fmt,
+          consensus_encoding_decode_array,
+          consensus_encoding_decode_byte_vec,
+          consensus_encoding_decode_compact_size,
+          consensus_encoding_decode_decoder2,
           hashes_json,
           hashes_ripemd160,
           hashes_sha1,
@@ -55,6 +59,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+
         id: cache-fuzz
         with:
           path: |

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -80,6 +80,22 @@ name = "bitcoin_script_bytes_to_asm_fmt"
 path = "fuzz_targets/bitcoin/script_bytes_to_asm_fmt.rs"
 
 [[bin]]
+name = "consensus_encoding_decode_array"
+path = "fuzz_targets/consensus_encoding/decode_array.rs"
+
+[[bin]]
+name = "consensus_encoding_decode_byte_vec"
+path = "fuzz_targets/consensus_encoding/decode_byte_vec.rs"
+
+[[bin]]
+name = "consensus_encoding_decode_compact_size"
+path = "fuzz_targets/consensus_encoding/decode_compact_size.rs"
+
+[[bin]]
+name = "consensus_encoding_decode_decoder2"
+path = "fuzz_targets/consensus_encoding/decode_decoder2.rs"
+
+[[bin]]
 name = "hashes_json"
 path = "fuzz_targets/hashes/json.rs"
 
@@ -126,22 +142,6 @@ path = "fuzz_targets/units/parse_amount.rs"
 [[bin]]
 name = "units_parse_int"
 path = "fuzz_targets/units/parse_int.rs"
-
-[[bin]]
-name = "consensus_encoding_decode_array"
-path = "fuzz_targets/consensus_encoding/decode_array.rs"
-
-[[bin]]
-name = "consensus_encoding_decode_compact_size"
-path = "fuzz_targets/consensus_encoding/decode_compact_size.rs"
-
-[[bin]]
-name = "consensus_encoding_decode_decoder2"
-path = "fuzz_targets/consensus_encoding/decode_decoder2.rs"
-
-[[bin]]
-name = "consensus_encoding_decode_byte_vec"
-path = "fuzz_targets/consensus_encoding/decode_byte_vec.rs"
 
 [[bin]]
 name = "units_standard_checks"

--- a/fuzz/generate-files.sh
+++ b/fuzz/generate-files.sh
@@ -25,6 +25,7 @@ cargo-fuzz = true
 honggfuzz = { version = "0.5.58", default-features = false }
 bitcoin = { path = "../bitcoin", features = [ "serde", "arbitrary" ] }
 p2p = { path = "../p2p", package = "bitcoin-p2p-messages", features = ["arbitrary"] }
+bitcoin_consensus_encoding = { path = "../consensus_encoding", package = "bitcoin-consensus-encoding" }
 arbitrary = { version = "1.4.1" }
 
 serde = { version = "1.0.195", features = [ "derive" ] }
@@ -33,6 +34,10 @@ standard_test = "0.1.0"
 
 [lints.rust]
 unexpected_cfgs = { level = "deny", check-cfg = ['cfg(fuzzing)'] }
+
+[lints.clippy]
+redundant_clone = "warn"
+use_self = "warn"
 EOF
 
 for targetFile in $(listTargetFiles); do
@@ -89,7 +94,7 @@ $(for name in $(listTargetNames); do echo "          $name,"; done)
           key: cache-\${{ matrix.target }}-\${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
       - uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6 # stable
         with:
-          toolchain: '1.65.0'
+          toolchain: '1.74.0'
       - name: fuzz
         run: |
           if [[ "\${{ matrix.fuzz_target }}" =~ ^bitcoin ]]; then
@@ -107,6 +112,8 @@ $(for name in $(listTargetNames); do echo "          $name,"; done)
     if: \${{ !github.event.act }}
     needs: fuzz
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:


### PR DESCRIPTION
In a2c809b, several new fuzz targets were introduced for consensus_encoding. The fuzz crate's Cargo.toml was updated, but the corresponding changes to generate-files.sh were not made. Since the fuzz Cargo.toml is generated by generate-files.sh, it should be kept up to date with any new changes.

Add consensus_encoding dependency and new Clippy lints to generate-files.sh, and update the Cargo.toml and daily fuzz files by running generate-files.sh.