### PR TITLE
Change PushBytes::read_scriptint to i32 return type

### DIFF
--- a/bitcoin/src/blockdata/script/instruction.rs
+++ b/bitcoin/src/blockdata/script/instruction.rs
@@ -48,7 +48,7 @@ impl Instruction<'_> {
                 }
             }
             Instruction::PushBytes(bytes) =>
-                super::read_scriptint_non_minimal(bytes.as_bytes()).ok(),
+                super::read_scriptint_non_minimal(bytes.as_bytes()).ok().map(i64::from),
         }
     }
 
@@ -77,7 +77,7 @@ impl Instruction<'_> {
                     _ => None,
                 }
             }
-            Instruction::PushBytes(bytes) => bytes.read_scriptint().ok(),
+            Instruction::PushBytes(bytes) => bytes.read_cltv_scriptint().ok(),
         }
     }
 }

--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -155,7 +155,7 @@ pub fn write_scriptint(out: &mut [u8; 8], n: i64) -> usize {
 ///
 /// See [`push_bytes::PushBytes::read_scriptint`] for a description of some subtleties of
 /// this function.
-pub fn read_scriptint_non_minimal(v: &[u8]) -> Result<i64, Error> {
+pub fn read_scriptint_non_minimal(v: &[u8]) -> Result<i32, Error> {
     if v.is_empty() {
         return Ok(0);
     }
@@ -163,7 +163,8 @@ pub fn read_scriptint_non_minimal(v: &[u8]) -> Result<i64, Error> {
         return Err(Error::NumericOverflow);
     }
 
-    Ok(scriptint_parse(v))
+    let ret = scriptint_parse(v);
+    Ok(i32::try_from(ret).expect("4 bytes or less fits in an i32"))
 }
 
 // Caller to guarantee that `v` is not empty.

--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -395,16 +395,16 @@ fn scriptint_round_trip() {
             Ok(i),
             PushBytes::read_scriptint(
                 <&PushBytes>::try_from(build_scriptint(i).as_slice()).unwrap()
-            )
+            ).map(i64::from)
         );
         assert_eq!(
             Ok(-i),
             PushBytes::read_scriptint(
                 <&PushBytes>::try_from(build_scriptint(-i).as_slice()).unwrap()
-            )
+            ).map(i64::from)
         );
-        assert_eq!(Ok(i), read_scriptint_non_minimal(&build_scriptint(i)));
-        assert_eq!(Ok(-i), read_scriptint_non_minimal(&build_scriptint(-i)));
+        assert_eq!(Ok(i), read_scriptint_non_minimal(&build_scriptint(i)).map(i64::from));
+        assert_eq!(Ok(-i), read_scriptint_non_minimal(&build_scriptint(-i)).map(i64::from));
     }
     assert!(PushBytes::read_scriptint(
         <&PushBytes>::try_from(build_scriptint(1 << 31).as_slice()).unwrap()


### PR DESCRIPTION
The PushBytes::read_scriptint function currently returns an i64 value. This is due to values in scripts potentially reaching 5 bytes in size after various operations (e.g. ADD) have been applied. Despite this, the function implementation currently prevents any value greater than 32 bits in size from being returned.

Change read_scriptint to return an i32, and introduce read_cltv_scriptint to read up to 5 byte values into an i64.

Contributes to #5268 