### PR TITLE
Use libfuzzer instead of honggfuzz

### DIFF
--- a/.github/docker/Dockerfile.cross
+++ b/.github/docker/Dockerfile.cross
@@ -1,0 +1,53 @@
+FROM ubuntu:24.04
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    gcc g++ \
+    gcc-14-s390x-linux-gnu \
+    g++-14-s390x-linux-gnu \
+    libc6-dev-s390x-cross \
+    libstdc++-14-dev-s390x-cross \
+    gcc-14-aarch64-linux-gnu \
+    g++-14-aarch64-linux-gnu \
+    libc6-dev-arm64-cross \
+    libstdc++-14-dev-arm64-cross \
+    qemu-user-static \
+    binfmt-support \
+    curl \
+    ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN update-alternatives --install /usr/bin/s390x-linux-gnu-gcc s390x-linux-gnu-gcc /usr/bin/s390x-linux-gnu-gcc-14 100 && \
+    update-alternatives --install /usr/bin/s390x-linux-gnu-g++ s390x-linux-gnu-g++ /usr/bin/s390x-linux-gnu-g++-14 100
+
+RUN update-alternatives --install /usr/bin/aarch64-linux-gnu-gcc aarch64-linux-gnu-gcc /usr/bin/aarch64-linux-gnu-gcc-14 100 && \
+    update-alternatives --install /usr/bin/aarch64-linux-gnu-g++ aarch64-linux-gnu-g++ /usr/bin/aarch64-linux-gnu-g++-14 100
+
+RUN update-binfmts --enable qemu-s390x || true
+
+RUN update-binfmts --enable qemu-aarch64 || true
+
+RUN gcc --version && \
+    s390x-linux-gnu-gcc --version && \
+    s390x-linux-gnu-g++ --version
+
+RUN aarch64-linux-gnu-gcc --version && \
+    aarch64-linux-gnu-g++ --version
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+ENV PATH="/root/.cargo/bin:${PATH}"
+RUN rustup target add s390x-unknown-linux-gnu
+
+RUN rustup target add aarch64-unknown-linux-gnu
+
+ENV CARGO_TARGET_S390X_UNKNOWN_LINUX_GNU_LINKER=s390x-linux-gnu-gcc \
+    CARGO_TARGET_S390X_UNKNOWN_LINUX_GNU_RUNNER="qemu-s390x-static -L /usr/s390x-linux-gnu" \
+    CC_s390x_unknown_linux_gnu=s390x-linux-gnu-gcc \
+    CXX_s390x_unknown_linux_gnu=s390x-linux-gnu-g++ \
+    CXXFLAGS_s390x_unknown_linux_gnu="-std=c++17"
+
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER="qemu-aarch64-static -L /usr/aarch64-linux-gnu" \
+    CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
+    CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++ \
+    CXXFLAGS_aarch64_unknown_linux_gnu="-std=c++17"

--- a/.github/workflows/cron-daily-fuzz.yml
+++ b/.github/workflows/cron-daily-fuzz.yml
@@ -59,7 +59,6 @@ jobs:
         with:
           persist-credentials: false
       - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-
         id: cache-fuzz
         with:
           path: |
@@ -97,4 +96,4 @@ jobs:
       - name: Display structure of downloaded files
         run: ls -R
       - run: find executed_* -type f -exec cat {} + | sort > executed
-      - run: source ./fuzz/fuzz-util.sh && listTargetNames | sort | diff - executed
+      - run: cargo fuzz list | sort | diff - executed

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -173,8 +173,15 @@ jobs:
           persist-credentials: false
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6 # stable
-      - name: "Add architecture i386"
-        run: sudo dpkg --add-architecture i386
+      - name: "Add architecture i386 and install dependencies"
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo apt-get update -y
+          sudo apt-get install -y \
+            gcc-multilib \
+            g++-multilib \
+            libc6-dev-i386 \
+            lib32stdc++-13-dev
       - name: "Install i686 gcc"
         run: sudo apt-get update -y && sudo apt-get install -y gcc-multilib
       - name: "Install target"

--- a/.gitignore
+++ b/.gitignore
@@ -15,10 +15,7 @@ hashes/target
 # Test artifacts
 bitcoin/dep_test
 mutants.out*
-
-# Fuzz artifacts
-hfuzz_target
-hfuzz_workspace
+fuzz/coverage
 
 # Local tooling
 .maintainer-tools

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -314,7 +314,7 @@ the project to enable fine-grained unit testing is also an ongoing effort.
 Unit and integration tests are available for those interested, along with benchmarks. For project
 developers, especially new contributors looking for something to work on, we do:
 
-- Fuzz testing with [`Honggfuzz`](https://github.com/rust-fuzz/honggfuzz-rs)
+- Fuzz testing with [`libfuzzer`](https://github.com/rust-fuzz/libfuzzer)
 - Mutation testing with [`cargo-mutants`](https://github.com/sourcefrog/cargo-mutants)
 - Code verification with [`Kani`](https://github.com/model-checking/kani)
 

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -99,7 +99,7 @@ dependencies = [
  "bitcoin",
  "bitcoin-consensus-encoding",
  "bitcoin-p2p-messages",
- "honggfuzz",
+ "libfuzzer-sys",
  "serde",
  "serde_json",
  "standard_test",
@@ -276,28 +276,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
 
 [[package]]
-name = "honggfuzz"
-version = "0.5.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e8319f3cc8fe416e7aa1ab95dcc04fd49f35397a47d0b2f0f225f6dba346a07"
-dependencies = [
- "lazy_static",
- "memmap2",
- "rustc_version",
- "semver",
-]
-
-[[package]]
 name = "itoa"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -306,12 +288,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
-name = "memmap2"
-version = "0.9.0"
+name = "libfuzzer-sys"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deaba38d7abf1d4cca21cc89e932e542ba2b9258664d2a9ef0e61512039c9375"
+checksum = "86c975d637bc2a2f99440932b731491fc34c7f785d239e38af3addd3c2fd0e46"
 dependencies = [
- "libc",
+ "arbitrary",
+ "cc",
 ]
 
 [[package]]
@@ -370,15 +353,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,12 +377,6 @@ checksum = "6d3be00697c88c00fe102af8dc316038cc2062eab8da646e7463f4c0e70ca9fd"
 dependencies = [
  "cc",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76b5842e81eb9bbea19276a9dbbda22ac042532f390a67ab08b895617978abf3"
 
 [[package]]
 name = "serde"

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -98,7 +98,7 @@ dependencies = [
  "bitcoin",
  "bitcoin-consensus-encoding",
  "bitcoin-p2p-messages",
- "honggfuzz",
+ "libfuzzer-sys",
  "serde",
  "serde_json",
  "standard_test",
@@ -213,6 +213,8 @@ version = "1.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9540e661f81799159abee814118cc139a2004b3a3aa3ea37724a1b66530b90e0"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -272,28 +274,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
 
 [[package]]
-name = "honggfuzz"
-version = "0.5.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e8319f3cc8fe416e7aa1ab95dcc04fd49f35397a47d0b2f0f225f6dba346a07"
-dependencies = [
- "lazy_static",
- "memmap2",
- "rustc_version",
- "semver",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
+name = "jobserver"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "libc"
@@ -302,19 +295,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
+name = "libfuzzer-sys"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5037190e1f70cbeef565bd267599242926f724d3b8a9f510fd7e0b540cfa4404"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "memmap2"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "ppv-lite86"
@@ -379,15 +373,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,12 +397,6 @@ checksum = "6d3be00697c88c00fe102af8dc316038cc2062eab8da646e7463f4c0e70ca9fd"
 dependencies = [
  "cc",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,5 @@
+[target.s390x-unknown-linux-gnu]
+dockerfile = ".github/docker/Dockerfile.cross"
+
+[target.aarch64-unknown-linux-gnu]
+dockerfile = ".github/docker/Dockerfile.cross"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,12 +10,12 @@ publish = false
 cargo-fuzz = true
 
 [dependencies]
-honggfuzz = { version = "0.5.58", default-features = false }
 bitcoin = { path = "../bitcoin", features = [ "serde", "arbitrary" ] }
-p2p = { path = "../p2p", package = "bitcoin-p2p-messages", features = ["arbitrary"] }
 bitcoin_consensus_encoding = { path = "../consensus_encoding", package = "bitcoin-consensus-encoding" }
-arbitrary = { version = "1.4.1" }
+p2p = { path = "../p2p", package = "bitcoin-p2p-messages", features = ["arbitrary"] }
 
+arbitrary = { version = "1.4.1" }
+libfuzzer-sys = { version = "0.4.0" }
 serde = { version = "1.0.195", features = [ "derive" ] }
 serde_json = "1.0.68"
 standard_test = "0.1.0"
@@ -30,119 +30,209 @@ use_self = "warn"
 [[bin]]
 name = "bitcoin_arbitrary_block"
 path = "fuzz_targets/bitcoin/arbitrary_block.rs"
+test = false
+doc = false
+bench = false
 
 [[bin]]
 name = "bitcoin_arbitrary_script"
 path = "fuzz_targets/bitcoin/arbitrary_script.rs"
+test = false
+doc = false
+bench = false
 
 [[bin]]
 name = "bitcoin_arbitrary_transaction"
 path = "fuzz_targets/bitcoin/arbitrary_transaction.rs"
+test = false
+doc = false
+bench = false
 
 [[bin]]
 name = "bitcoin_arbitrary_witness"
 path = "fuzz_targets/bitcoin/arbitrary_witness.rs"
+test = false
+doc = false
+bench = false
 
 [[bin]]
 name = "bitcoin_deserialize_block"
 path = "fuzz_targets/bitcoin/deserialize_block.rs"
+test = false
+doc = false
+bench = false
 
 [[bin]]
 name = "bitcoin_deserialize_prefilled_transaction"
 path = "fuzz_targets/bitcoin/deserialize_prefilled_transaction.rs"
+test = false
+doc = false
+bench = false
 
 [[bin]]
 name = "bitcoin_deserialize_psbt"
 path = "fuzz_targets/bitcoin/deserialize_psbt.rs"
+test = false
+doc = false
+bench = false
 
 [[bin]]
 name = "bitcoin_deserialize_script"
 path = "fuzz_targets/bitcoin/deserialize_script.rs"
+test = false
+doc = false
+bench = false
 
 [[bin]]
 name = "bitcoin_deserialize_transaction"
 path = "fuzz_targets/bitcoin/deserialize_transaction.rs"
+test = false
+doc = false
+bench = false
 
 [[bin]]
 name = "bitcoin_deserialize_witness"
 path = "fuzz_targets/bitcoin/deserialize_witness.rs"
+test = false
+doc = false
+bench = false
 
 [[bin]]
 name = "bitcoin_parse_address"
 path = "fuzz_targets/bitcoin/parse_address.rs"
+test = false
+doc = false
+bench = false
 
 [[bin]]
 name = "bitcoin_parse_outpoint"
 path = "fuzz_targets/bitcoin/parse_outpoint.rs"
+test = false
+doc = false
+bench = false
 
 [[bin]]
 name = "bitcoin_script_bytes_to_asm_fmt"
 path = "fuzz_targets/bitcoin/script_bytes_to_asm_fmt.rs"
+test = false
+doc = false
+bench = false
 
 [[bin]]
 name = "consensus_encoding_decode_array"
 path = "fuzz_targets/consensus_encoding/decode_array.rs"
+test = false
+doc = false
+bench = false
 
 [[bin]]
 name = "consensus_encoding_decode_byte_vec"
 path = "fuzz_targets/consensus_encoding/decode_byte_vec.rs"
+test = false
+doc = false
+bench = false
 
 [[bin]]
 name = "consensus_encoding_decode_compact_size"
 path = "fuzz_targets/consensus_encoding/decode_compact_size.rs"
+test = false
+doc = false
+bench = false
 
 [[bin]]
 name = "consensus_encoding_decode_decoder2"
 path = "fuzz_targets/consensus_encoding/decode_decoder2.rs"
+test = false
+doc = false
+bench = false
 
 [[bin]]
 name = "hashes_json"
 path = "fuzz_targets/hashes/json.rs"
+test = false
+doc = false
+bench = false
 
 [[bin]]
 name = "hashes_ripemd160"
 path = "fuzz_targets/hashes/ripemd160.rs"
+test = false
+doc = false
+bench = false
 
 [[bin]]
 name = "hashes_sha1"
 path = "fuzz_targets/hashes/sha1.rs"
+test = false
+doc = false
+bench = false
 
 [[bin]]
 name = "hashes_sha256"
 path = "fuzz_targets/hashes/sha256.rs"
+test = false
+doc = false
+bench = false
 
 [[bin]]
 name = "hashes_sha512"
 path = "fuzz_targets/hashes/sha512.rs"
+test = false
+doc = false
+bench = false
 
 [[bin]]
 name = "hashes_sha512_256"
 path = "fuzz_targets/hashes/sha512_256.rs"
+test = false
+doc = false
+bench = false
 
 [[bin]]
 name = "p2p_arbitrary_addrv2"
 path = "fuzz_targets/p2p/arbitrary_addrv2.rs"
+test = false
+doc = false
+bench = false
 
 [[bin]]
 name = "p2p_deserialize_addrv2"
 path = "fuzz_targets/p2p/deserialize_addrv2.rs"
+test = false
+doc = false
+bench = false
 
 [[bin]]
 name = "p2p_deserialize_raw_net_msg"
 path = "fuzz_targets/p2p/deserialize_raw_net_msg.rs"
+test = false
+doc = false
+bench = false
 
 [[bin]]
 name = "units_arbitrary_weight"
 path = "fuzz_targets/units/arbitrary_weight.rs"
+test = false
+doc = false
+bench = false
 
 [[bin]]
 name = "units_parse_amount"
 path = "fuzz_targets/units/parse_amount.rs"
+test = false
+doc = false
+bench = false
 
 [[bin]]
 name = "units_parse_int"
 path = "fuzz_targets/units/parse_int.rs"
+test = false
+doc = false
+bench = false
 
 [[bin]]
 name = "units_standard_checks"
 path = "fuzz_targets/units/standard_checks.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,7 +1,7 @@
 # Fuzzing
 
-`bitcoin` and `bitcoin_hashes` have fuzzing harnesses setup for use with
-honggfuzz.
+`rust-bitcoin` has fuzzing harnesses setup for use with
+`cargo-fuzz`.
 
 To run the fuzz-tests as in CI -- briefly fuzzing every target -- simply
 run
@@ -12,18 +12,6 @@ run
 
 in this directory.
 
-To build honggfuzz, you must have libunwind on your system, as well as
-libopcodes and libbfd from binutils **2.38** on your system. The most
-recently-released binutils 2.39 has changed their API in a breaking way.
-
-On Nix, you can obtain these libraries by running
-
-```bash
-nix-shell -p libopcodes_2_38 -p libunwind
-```
-
-and then run `fuzz.sh` as above.
-
 ## Fuzzing with weak cryptography
 
 You may wish to replace the hashing and signing code with broken crypto,
@@ -32,7 +20,7 @@ things such as forging signatures or finding preimages to hashes.
 
 Doing so may result in spurious bug reports since the broken crypto does
 not respect the encoding or algebraic invariants upheld by the real crypto. We
-would like to improve this but it's a nontrivial problem -- though not
+would like to improve this, but it's a nontrivial problem -- though not
 beyond the abilities of a motivated student with a few months of time.
 Please let us know if you are interested in taking this on!
 
@@ -54,8 +42,7 @@ fuzzer can break your crypto, so can anybody.
 To see the full list of targets, the most straightforward way is to run
 
 ```bash
-source ./fuzz-util.sh
-listTargetNames
+cargo fuzz list
 ```
 
 To run each of them for an hour, run
@@ -63,17 +50,16 @@ To run each of them for an hour, run
 ```bash
 ./cycle.sh
 ```
-
-To run a single fuzztest indefinitely, run
-
-```bash
-HFUZZ_BUILD_ARGS='--features honggfuzz_fuzz' cargo hfuzz run <target>
-```
-
 This script uses the `chrt` utility to try to reduce the priority of the
 jobs. If you would like to run for longer, the most straightforward way
 is to edit `cycle.sh` before starting. To run the fuzz-tests in parallel,
 you will need to implement a custom harness.
+
+To run a single fuzztest indefinitely, run
+
+```bash
+cargo +nightly fuzz run "<target>" 
+```
 
 ## Adding fuzz tests
 
@@ -82,7 +68,7 @@ one is as simple as copying an existing one and editing the `do_test`
 function to do what you want.
 
 If your test clearly belongs to a specific crate, please put it in that
-crate's directory. Otherwise you can put it directly in `fuzz_target/`.
+crate's directory. Otherwise, you can put it directly in `fuzz_target/`.
 
 If you need to add dependencies, edit the file `generate-files.sh` to add
 it to the generated `Cargo.toml`.
@@ -101,32 +87,68 @@ Then to test your fuzztest, run
 ```
 
 If it is working, you will see a rapid stream of data for many seconds
-(you can hit Ctrl+C to stop it early). If not, you should quickly see
-an error.
+(you can hit Ctrl+C to stop it early) that looks something like this:
+```text
+INFO: Running with entropic power schedule (0xFF, 100).
+INFO: Seed: 2953319389
+INFO: Loaded 1 modules   (9121 inline 8-bit counters): 9121 [0x104132ea0, 0x104135241),
+INFO: Loaded 1 PC tables (9121 PCs): 9121 [0x104135248,0x104158c58),
+INFO:        0 files found in /some/path/to/rust-bitcoin/fuzz/corpus/units_arbitrary_weight
+INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes
+INFO: A corpus is not provided, starting from an empty corpus
+#2	INITED cov: 42 ft: 42 corp: 1/1b exec/s: 0 rss: 36Mb
+#411	NEW    cov: 43 ft: 43 corp: 2/9b lim: 8 exec/s: 0 rss: 37Mb L: 8/8 MS: 4 ChangeBinInt-ShuffleBytes-ShuffleBytes-InsertRepeatedBytes-
+#1329	NEW    cov: 43 ft: 44 corp: 3/26b lim: 17 exec/s: 0 rss: 37Mb L: 17/17 MS: 3 InsertRepeatedBytes-CMP-CopyPart- DE: "\001\000\000\000"-
+#1357	REDUCE cov: 43 ft: 44 corp: 3/25b lim: 17 exec/s: 0 rss: 37Mb L: 16/16 MS: 3 CopyPart-CMP-EraseBytes- DE: "\000\000\000\000\000\000\000\000"-
+...
+```
+If you don't see this, you should quickly see an error.
 
 ## Reproducing Failures
 
 If a fuzztest fails, it will exit with a summary which looks something like
+```text
+...
+thread '<unnamed>' (3001874) panicked at units/src/weight.rs:103:25:
+attempt to multiply with overflow
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+==66478== ERROR: libFuzzer: deadly signal
+    #0 0x0001049fd3c4 in __sanitizer_print_stack_trace+0x28 (librustc-nightly_rt.asan.dylib:arm64+0x5d3c4)
+    #1 0x000104078b90 in fuzzer::PrintStackTrace()+0x30 (units_arbitrary_weight:arm64+0x100070b90)
+    #2 0x00010406d074 in fuzzer::Fuzzer::CrashCallback()+0x54 (units_arbitrary_weight:arm64+0x100065074)
+    #3 0x000180d26740 in _sigtramp+0x34 (libsystem_platform.dylib:arm64+0x3740)
+    ...
+```
+This will tell you where the test failed and is followed by information about how to reproduce the crash.
+It will look something like this:
 
 ```text
 ...
- fuzzTarget      : hfuzz_target/x86_64-unknown-linux-gnu/release/hashes_sha256 
-CRASH:
-DESCRIPTION: 
-ORIG_FNAME: 00000000000000000000000000000000.00000000.honggfuzz.cov
-FUZZ_FNAME: hfuzz_workspace/hashes_sha256/SIGABRT.PC.7ffff7c8abc7.STACK.18826d9b64.CODE.-6.ADDR.0.INSTR.mov____%eax,%ebp.fuzz
-...
-=====================================================================
-fff400610004
+NOTE: libFuzzer has rudimentary signal handlers.
+      Combine libFuzzer with AddressSanitizer or similar for better crash reports.
+SUMMARY: libFuzzer: deadly signal
+MS: 2 ChangeByte-CopyPart-; base unit: 25058c6b0d02cd1d71a030ad61c46b7396ddcdb9
+0x5e,0x5e,0x5e,0x5e,0x5e,0x44,0x0,0x0,0x0,0x0,0x0,0x5d,0x1,0x0,0x0,0x0,0x0,0x0,0x0,0x5e,0xa,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0x1,0xa5,0x1,0x1,0x1,
+^^^^^D\000\000\000\000\000]\001\000\000\000\000\000\000^\012\001\001\001\001\001\001\001\001\001\001\001\001\001\001\001\001\001\001\001\001\001\001\001\001\001\001\001\001\001\001\001\001\001\001\001\001\001\001\001\001\001\001\245\001\001\001
+artifact_prefix='/some/path/to/rust-bitcoin/fuzz/artifacts/units_arbitrary_weight/'; Test unit written to /some/path/to/rust-bitcoin/fuzz/artifacts/units_arbitrary_weight/crash-1b454523d38a6c3f45d453dfea4099f3cb574822
+Base64: Xl5eXl5EAAAAAABdAQAAAAAAAF4KAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBpQEBAQ==
+────────────────────────────────────────────────────────────────────────────────
+
+Failing input:
+
+	fuzz/artifacts/units_arbitrary_weight/crash-1b454523d38a6c3f45d453dfea4099f3cb574822
+
+Output of `std::fmt::Debug`:
+
+	[94, 94, 94, 94, 94, 68, 0, 0, 0, 0, 0, 93, 1, 0, 0, 0, 0, 0, 0, 94, 10, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 165, 1, 1, 1]
+
+Reproduce with:
+
+	cargo fuzz run units_arbitrary_weight fuzz/artifacts/units_arbitrary_weight/crash-1b454523d38a6c3f45d453dfea4099f3cb574822
+
+Minimize test case with:
+
+	cargo fuzz tmin units_arbitrary_weight fuzz/artifacts/units_arbitrary_weight/crash-1b454523d38a6c3f45d453dfea4099f3cb574822
+
+────────────────────────────────────────────────────────────────────────────────
 ```
-
-The final line is a hex-encoded version of the input that caused the crash. You
-can test this directly by editing the `duplicate_crash` test to copy/paste the
-hex output into the call to `extend_vec_from_hex`. Then run the test with
-
-```bash
-cargo test
-```
-
-Note that if you set your `RUSTFLAGS` while fuzzing (see above) you must make
-sure they are set the same way when running `cargo test`.

--- a/fuzz/cycle.sh
+++ b/fuzz/cycle.sh
@@ -3,7 +3,7 @@
 # Continuously cycle over fuzz targets running each for 1 hour.
 # It uses chrt SCHED_IDLE so that other process takes priority.
 #
-# For hfuzz options see https://github.com/google/honggfuzz/blob/master/docs/USAGE.md
+# For cargo-fuzz usage see https://github.com/rust-fuzz/cargo-fuzz?tab=readme-ov-file#usage
 
 set -euo pipefail
 
@@ -19,9 +19,8 @@ do
     echo "Fuzzing target $targetName ($targetFile)"
 
     # fuzz for one hour
-    HFUZZ_RUN_ARGS='--run_time 3600' chrt -i 0 cargo hfuzz run "$targetName"
-    # minimize the corpus
-    HFUZZ_RUN_ARGS="-i hfuzz_workspace/$targetName/input/ -P -M" chrt -i 0 cargo hfuzz run "$targetName"
+    chrt -i 0 cargo +nightly fuzz run "$targetName" -- -max_total_time=3600
+    cargo +nightly fuzz cmin "$targetName" 
   done
 done
 

--- a/fuzz/fuzz_targets/bitcoin/arbitrary_block.rs
+++ b/fuzz/fuzz_targets/bitcoin/arbitrary_block.rs
@@ -1,7 +1,14 @@
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use libfuzzer_sys::fuzz_target;
 use arbitrary::{Arbitrary, Unstructured};
+
 use bitcoin::block::{self, Block, BlockCheckedExt as _};
 use bitcoin::consensus::{deserialize, serialize};
-use honggfuzz::fuzz;
+
+#[cfg(not(fuzzing))]
+fn main() {}
 
 fn do_test(data: &[u8]) {
     let mut u = Unstructured::new(data);
@@ -28,37 +35,6 @@ fn do_test(data: &[u8]) {
     }
 }
 
-fn main() {
-    loop {
-        fuzz!(|data| {
-            do_test(data);
-        });
-    }
-}
-
-#[cfg(all(test, fuzzing))]
-mod tests {
-    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
-        let mut b = 0;
-        for (idx, c) in hex.as_bytes().iter().enumerate() {
-            b <<= 4;
-            match *c {
-                b'A'..=b'F' => b |= c - b'A' + 10,
-                b'a'..=b'f' => b |= c - b'a' + 10,
-                b'0'..=b'9' => b |= c - b'0',
-                _ => panic!("Bad hex"),
-            }
-            if (idx & 1) == 1 {
-                out.push(b);
-                b = 0;
-            }
-        }
-    }
-
-    #[test]
-    fn duplicate_crash() {
-        let mut a = Vec::new();
-        extend_vec_from_hex("00", &mut a);
-        super::do_test(&a);
-    }
-}
+fuzz_target!(|data| {
+    do_test(data);
+});

--- a/fuzz/fuzz_targets/bitcoin/arbitrary_script.rs
+++ b/fuzz/fuzz_targets/bitcoin/arbitrary_script.rs
@@ -1,9 +1,16 @@
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use libfuzzer_sys::fuzz_target;
 use arbitrary::{Arbitrary, Unstructured};
+
 use bitcoin::address::Address;
 use bitcoin::consensus::serialize;
 use bitcoin::script::{self, ScriptBuf, ScriptExt as _, ScriptPubKeyExt as _};
 use bitcoin::Network;
-use honggfuzz::fuzz;
+
+#[cfg(not(fuzzing))]
+fn main() {}
 
 fn do_test(data: &[u8]) {
     let mut u = Unstructured::new(data);
@@ -48,37 +55,6 @@ fn do_test(data: &[u8]) {
     }
 }
 
-fn main() {
-    loop {
-        fuzz!(|data| {
-            do_test(data);
-        });
-    }
-}
-
-#[cfg(all(test, fuzzing))]
-mod tests {
-    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
-        let mut b = 0;
-        for (idx, c) in hex.as_bytes().iter().enumerate() {
-            b <<= 4;
-            match *c {
-                b'A'..=b'F' => b |= c - b'A' + 10,
-                b'a'..=b'f' => b |= c - b'a' + 10,
-                b'0'..=b'9' => b |= c - b'0',
-                _ => panic!("Bad hex"),
-            }
-            if (idx & 1) == 1 {
-                out.push(b);
-                b = 0;
-            }
-        }
-    }
-
-    #[test]
-    fn duplicate_crash() {
-        let mut a = Vec::new();
-        extend_vec_from_hex("00", &mut a);
-        super::do_test(&a);
-    }
-}
+fuzz_target!(|data| {
+    do_test(data);
+});

--- a/fuzz/fuzz_targets/bitcoin/arbitrary_transaction.rs
+++ b/fuzz/fuzz_targets/bitcoin/arbitrary_transaction.rs
@@ -1,8 +1,15 @@
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use libfuzzer_sys::fuzz_target;
 use arbitrary::{Arbitrary, Unstructured};
+
 use bitcoin::consensus::{deserialize, serialize};
 use bitcoin::transaction::TransactionExt as _;
 use bitcoin::Transaction;
-use honggfuzz::fuzz;
+
+#[cfg(not(fuzzing))]
+fn main() {}
 
 fn do_test(data: &[u8]) {
     let mut u = Unstructured::new(data);
@@ -31,37 +38,6 @@ fn do_test(data: &[u8]) {
     }
 }
 
-fn main() {
-    loop {
-        fuzz!(|data| {
-            do_test(data);
-        });
-    }
-}
-
-#[cfg(all(test, fuzzing))]
-mod tests {
-    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
-        let mut b = 0;
-        for (idx, c) in hex.as_bytes().iter().enumerate() {
-            b <<= 4;
-            match *c {
-                b'A'..=b'F' => b |= c - b'A' + 10,
-                b'a'..=b'f' => b |= c - b'a' + 10,
-                b'0'..=b'9' => b |= c - b'0',
-                _ => panic!("Bad hex"),
-            }
-            if (idx & 1) == 1 {
-                out.push(b);
-                b = 0;
-            }
-        }
-    }
-
-    #[test]
-    fn duplicate_crash() {
-        let mut a = Vec::new();
-        extend_vec_from_hex("00", &mut a);
-        super::do_test(&a);
-    }
-}
+fuzz_target!(|data| {
+    do_test(data);
+});

--- a/fuzz/fuzz_targets/bitcoin/arbitrary_witness.rs
+++ b/fuzz/fuzz_targets/bitcoin/arbitrary_witness.rs
@@ -1,8 +1,15 @@
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use libfuzzer_sys::fuzz_target;
 use arbitrary::{Arbitrary, Unstructured};
-use bitcoin::blockdata::witness::WitnessExt;
+
 use bitcoin::consensus::{deserialize, serialize};
 use bitcoin::Witness;
-use honggfuzz::fuzz;
+use bitcoin::blockdata::witness::WitnessExt;
+
+#[cfg(not(fuzzing))]
+fn main() {}
 
 fn do_test(data: &[u8]) {
     let mut u = Unstructured::new(data);
@@ -22,37 +29,6 @@ fn do_test(data: &[u8]) {
     }
 }
 
-fn main() {
-    loop {
-        fuzz!(|data| {
-            do_test(data);
-        });
-    }
-}
-
-#[cfg(all(test, fuzzing))]
-mod tests {
-    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
-        let mut b = 0;
-        for (idx, c) in hex.as_bytes().iter().enumerate() {
-            b <<= 4;
-            match *c {
-                b'A'..=b'F' => b |= c - b'A' + 10,
-                b'a'..=b'f' => b |= c - b'a' + 10,
-                b'0'..=b'9' => b |= c - b'0',
-                _ => panic!("Bad hex"),
-            }
-            if (idx & 1) == 1 {
-                out.push(b);
-                b = 0;
-            }
-        }
-    }
-
-    #[test]
-    fn duplicate_crash() {
-        let mut a = Vec::new();
-        extend_vec_from_hex("00", &mut a);
-        super::do_test(&a);
-    }
-}
+fuzz_target!(|data| {
+    do_test(data);
+});

--- a/fuzz/fuzz_targets/bitcoin/deserialize_block.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_block.rs
@@ -1,4 +1,10 @@
-use honggfuzz::fuzz;
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use libfuzzer_sys::fuzz_target;
+
+#[cfg(not(fuzzing))]
+fn main() {}
 
 fn do_test(data: &[u8]) {
     let block_result: Result<bitcoin::Block, _> = bitcoin::consensus::encode::deserialize(data);
@@ -12,37 +18,6 @@ fn do_test(data: &[u8]) {
     }
 }
 
-fn main() {
-    loop {
-        fuzz!(|data| {
-            do_test(data);
-        });
-    }
-}
-
-#[cfg(all(test, fuzzing))]
-mod tests {
-    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
-        let mut b = 0;
-        for (idx, c) in hex.as_bytes().iter().enumerate() {
-            b <<= 4;
-            match *c {
-                b'A'..=b'F' => b |= c - b'A' + 10,
-                b'a'..=b'f' => b |= c - b'a' + 10,
-                b'0'..=b'9' => b |= c - b'0',
-                _ => panic!("Bad hex"),
-            }
-            if (idx & 1) == 1 {
-                out.push(b);
-                b = 0;
-            }
-        }
-    }
-
-    #[test]
-    fn duplicate_crash() {
-        let mut a = Vec::new();
-        extend_vec_from_hex("000700000001000000010000", &mut a);
-        super::do_test(&a);
-    }
-}
+fuzz_target!(|data| {
+    do_test(data);
+});

--- a/fuzz/fuzz_targets/bitcoin/deserialize_prefilled_transaction.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_prefilled_transaction.rs
@@ -1,4 +1,10 @@
-use honggfuzz::fuzz;
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use libfuzzer_sys::fuzz_target;
+
+#[cfg(not(fuzzing))]
+fn main() {}
 
 fn do_test(data: &[u8]) {
     // We already fuzz Transactions in `./deserialize_transaction.rs`.
@@ -14,37 +20,6 @@ fn do_test(data: &[u8]) {
     }
 }
 
-fn main() {
-    loop {
-        fuzz!(|data| {
-            do_test(data);
-        });
-    }
-}
-
-#[cfg(all(test, fuzzing))]
-mod tests {
-    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
-        let mut b = 0;
-        for (idx, c) in hex.as_bytes().iter().enumerate() {
-            b <<= 4;
-            match *c {
-                b'A'..=b'F' => b |= c - b'A' + 10,
-                b'a'..=b'f' => b |= c - b'a' + 10,
-                b'0'..=b'9' => b |= c - b'0',
-                _ => panic!("Bad hex"),
-            }
-            if (idx & 1) == 1 {
-                out.push(b);
-                b = 0;
-            }
-        }
-    }
-
-    #[test]
-    fn duplicate_crash() {
-        let mut a = Vec::new();
-        extend_vec_from_hex("00000000", &mut a);
-        super::do_test(&a);
-    }
-}
+fuzz_target!(|data| {
+    do_test(data);
+});

--- a/fuzz/fuzz_targets/bitcoin/deserialize_psbt.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_psbt.rs
@@ -1,5 +1,11 @@
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use libfuzzer_sys::fuzz_target;
 use arbitrary::{Arbitrary, Unstructured};
-use honggfuzz::fuzz;
+
+#[cfg(not(fuzzing))]
+fn main() {}
 
 fn do_test(data: &[u8]) {
     let mut unstructured = Unstructured::new(data);
@@ -27,37 +33,6 @@ fn do_test(data: &[u8]) {
     assert_eq!(psbt_b.combine(psbt_a).is_ok(), psbt_a_clone.combine(psbt_b).is_ok());
 }
 
-fn main() {
-    loop {
-        fuzz!(|data| {
-            do_test(data);
-        });
-    }
-}
-
-#[cfg(all(test, fuzzing))]
-mod tests {
-    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
-        let mut b = 0;
-        for (idx, c) in hex.as_bytes().iter().enumerate() {
-            b <<= 4;
-            match *c {
-                b'A'..=b'F' => b |= c - b'A' + 10,
-                b'a'..=b'f' => b |= c - b'a' + 10,
-                b'0'..=b'9' => b |= c - b'0',
-                _ => panic!("Bad hex"),
-            }
-            if (idx & 1) == 1 {
-                out.push(b);
-                b = 0;
-            }
-        }
-    }
-
-    #[test]
-    fn duplicate_crash() {
-        let mut a = Vec::new();
-        extend_vec_from_hex("00", &mut a);
-        super::do_test(&a);
-    }
-}
+fuzz_target!(|data| {
+    do_test(data);
+});

--- a/fuzz/fuzz_targets/bitcoin/deserialize_script.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_script.rs
@@ -1,4 +1,10 @@
-use honggfuzz::fuzz;
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use libfuzzer_sys::fuzz_target;
+
+#[cfg(not(fuzzing))]
+fn main() {}
 
 fn do_test(data: &[u8]) {
     let script_result: Result<bitcoin::ScriptPubKeyBuf, _> =
@@ -13,37 +19,6 @@ fn do_test(data: &[u8]) {
     }
 }
 
-fn main() {
-    loop {
-        fuzz!(|data| {
-            do_test(data);
-        });
-    }
-}
-
-#[cfg(all(test, fuzzing))]
-mod tests {
-    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
-        let mut b = 0;
-        for (idx, c) in hex.as_bytes().iter().enumerate() {
-            b <<= 4;
-            match *c {
-                b'A'..=b'F' => b |= c - b'A' + 10,
-                b'a'..=b'f' => b |= c - b'a' + 10,
-                b'0'..=b'9' => b |= c - b'0',
-                _ => panic!("Bad hex"),
-            }
-            if (idx & 1) == 1 {
-                out.push(b);
-                b = 0;
-            }
-        }
-    }
-
-    #[test]
-    fn duplicate_crash() {
-        let mut a = Vec::new();
-        extend_vec_from_hex("00", &mut a);
-        super::do_test(&a);
-    }
-}
+fuzz_target!(|data| {
+    do_test(data);
+});

--- a/fuzz/fuzz_targets/bitcoin/deserialize_transaction.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_transaction.rs
@@ -1,4 +1,10 @@
-use honggfuzz::fuzz;
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use libfuzzer_sys::fuzz_target;
+
+#[cfg(not(fuzzing))]
+fn main() {}
 
 fn do_test(data: &[u8]) {
     let tx_result: Result<bitcoin::Transaction, _> = bitcoin::consensus::encode::deserialize(data);
@@ -12,37 +18,6 @@ fn do_test(data: &[u8]) {
     }
 }
 
-fn main() {
-    loop {
-        fuzz!(|data| {
-            do_test(data);
-        });
-    }
-}
-
-#[cfg(all(test, fuzzing))]
-mod tests {
-    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
-        let mut b = 0;
-        for (idx, c) in hex.as_bytes().iter().enumerate() {
-            b <<= 4;
-            match *c {
-                b'A'..=b'F' => b |= c - b'A' + 10,
-                b'a'..=b'f' => b |= c - b'a' + 10,
-                b'0'..=b'9' => b |= c - b'0',
-                _ => panic!("Bad hex"),
-            }
-            if (idx & 1) == 1 {
-                out.push(b);
-                b = 0;
-            }
-        }
-    }
-
-    #[test]
-    fn duplicate_crash() {
-        let mut a = Vec::new();
-        extend_vec_from_hex("00", &mut a);
-        super::do_test(&a);
-    }
-}
+fuzz_target!(|data| {
+    do_test(data);
+});

--- a/fuzz/fuzz_targets/bitcoin/deserialize_witness.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_witness.rs
@@ -1,5 +1,12 @@
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use libfuzzer_sys::fuzz_target;
+
 use bitcoin::witness::Witness;
-use honggfuzz::fuzz;
+
+#[cfg(not(fuzzing))]
+fn main() {}
 
 fn do_test(data: &[u8]) {
     let witness_result: Result<Witness, _> = bitcoin::consensus::encode::deserialize(data);
@@ -13,37 +20,6 @@ fn do_test(data: &[u8]) {
     }
 }
 
-fn main() {
-    loop {
-        fuzz!(|data| {
-            do_test(data);
-        });
-    }
-}
-
-#[cfg(all(test, fuzzing))]
-mod tests {
-    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
-        let mut b = 0;
-        for (idx, c) in hex.as_bytes().iter().enumerate() {
-            b <<= 4;
-            match *c {
-                b'A'..=b'F' => b |= c - b'A' + 10,
-                b'a'..=b'f' => b |= c - b'a' + 10,
-                b'0'..=b'9' => b |= c - b'0',
-                _ => panic!("Bad hex"),
-            }
-            if (idx & 1) == 1 {
-                out.push(b);
-                b = 0;
-            }
-        }
-    }
-
-    #[test]
-    fn duplicate_crash() {
-        let mut a = Vec::new();
-        extend_vec_from_hex("00", &mut a);
-        super::do_test(&a);
-    }
-}
+fuzz_target!(|data| {
+    do_test(data);
+});

--- a/fuzz/fuzz_targets/bitcoin/parse_address.rs
+++ b/fuzz/fuzz_targets/bitcoin/parse_address.rs
@@ -1,4 +1,10 @@
-use honggfuzz::fuzz;
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use libfuzzer_sys::fuzz_target;
+
+#[cfg(not(fuzzing))]
+fn main() {}
 
 fn do_test(data: &[u8]) {
     let data_str = String::from_utf8_lossy(data);
@@ -9,37 +15,6 @@ fn do_test(data: &[u8]) {
     assert_eq!(addr.to_string(), data_str);
 }
 
-fn main() {
-    loop {
-        fuzz!(|data| {
-            do_test(data);
-        });
-    }
-}
-
-#[cfg(all(test, fuzzing))]
-mod tests {
-    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
-        let mut b = 0;
-        for (idx, c) in hex.as_bytes().iter().enumerate() {
-            b <<= 4;
-            match *c {
-                b'A'..=b'F' => b |= c - b'A' + 10,
-                b'a'..=b'f' => b |= c - b'a' + 10,
-                b'0'..=b'9' => b |= c - b'0',
-                _ => panic!("Bad hex"),
-            }
-            if (idx & 1) == 1 {
-                out.push(b);
-                b = 0;
-            }
-        }
-    }
-
-    #[test]
-    fn duplicate_crash() {
-        let mut a = Vec::new();
-        extend_vec_from_hex("00000000", &mut a);
-        super::do_test(&a);
-    }
-}
+fuzz_target!(|data| {
+    do_test(data);
+});

--- a/fuzz/fuzz_targets/bitcoin/parse_outpoint.rs
+++ b/fuzz/fuzz_targets/bitcoin/parse_outpoint.rs
@@ -1,6 +1,13 @@
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use libfuzzer_sys::fuzz_target;
+
 use bitcoin::consensus::encode;
 use bitcoin::transaction::OutPoint;
-use honggfuzz::fuzz;
+
+#[cfg(not(fuzzing))]
+fn main() {}
 
 fn do_test(data: &[u8]) {
     let lowercase: Vec<u8> = data
@@ -39,37 +46,6 @@ fn do_test(data: &[u8]) {
     }
 }
 
-fn main() {
-    loop {
-        fuzz!(|data| {
-            do_test(data);
-        });
-    }
-}
-
-#[cfg(all(test, fuzzing))]
-mod tests {
-    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
-        let mut b = 0;
-        for (idx, c) in hex.as_bytes().iter().enumerate() {
-            b <<= 4;
-            match *c {
-                b'A'..=b'F' => b |= c - b'A' + 10,
-                b'a'..=b'f' => b |= c - b'a' + 10,
-                b'0'..=b'9' => b |= c - b'0',
-                _ => panic!("Bad hex"),
-            }
-            if (idx & 1) == 1 {
-                out.push(b);
-                b = 0;
-            }
-        }
-    }
-
-    #[test]
-    fn duplicate_crash() {
-        let mut a = Vec::new();
-        extend_vec_from_hex("00", &mut a);
-        super::do_test(&a);
-    }
-}
+fuzz_target!(|data| {
+    do_test(data);
+});

--- a/fuzz/fuzz_targets/bitcoin/script_bytes_to_asm_fmt.rs
+++ b/fuzz/fuzz_targets/bitcoin/script_bytes_to_asm_fmt.rs
@@ -1,6 +1,8 @@
-use std::fmt::{self, Write as _};
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
 
-use honggfuzz::fuzz;
+use libfuzzer_sys::fuzz_target;
+use std::fmt::{self, Write as _};
 
 // faster than String, we don't need to actually produce the value, just check absence of panics
 struct NullWriter;
@@ -11,43 +13,15 @@ impl fmt::Write for NullWriter {
     fn write_char(&mut self, _c: char) -> fmt::Result { Ok(()) }
 }
 
+#[cfg(not(fuzzing))]
+fn main() {}
+
 fn do_test(data: &[u8]) {
     let mut writer = NullWriter;
     let script = bitcoin::WitnessScript::from_bytes(data);
     write!(writer, "{script}").unwrap();
 }
 
-fn main() {
-    loop {
-        fuzz!(|data| {
-            do_test(data);
-        });
-    }
-}
-
-#[cfg(all(test, fuzzing))]
-mod tests {
-    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
-        let mut b = 0;
-        for (idx, c) in hex.as_bytes().iter().enumerate() {
-            b <<= 4;
-            match *c {
-                b'A'..=b'F' => b |= c - b'A' + 10,
-                b'a'..=b'f' => b |= c - b'a' + 10,
-                b'0'..=b'9' => b |= c - b'0',
-                _ => panic!("Bad hex"),
-            }
-            if (idx & 1) == 1 {
-                out.push(b);
-                b = 0;
-            }
-        }
-    }
-
-    #[test]
-    fn duplicate_crash() {
-        let mut a = Vec::new();
-        extend_vec_from_hex("00000", &mut a);
-        super::do_test(&a);
-    }
-}
+fuzz_target!(|data| {
+    do_test(data);
+});

--- a/fuzz/fuzz_targets/consensus_encoding/decode_array.rs
+++ b/fuzz/fuzz_targets/consensus_encoding/decode_array.rs
@@ -1,5 +1,12 @@
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use libfuzzer_sys::fuzz_target;
+
 use bitcoin_consensus_encoding::{ArrayDecoder, Decoder};
-use honggfuzz::fuzz;
+
+#[cfg(not(fuzzing))]
+fn main() {}
 
 fn do_test(data: &[u8]) {
     test_array_decoder::<1>(data);
@@ -49,37 +56,6 @@ fn test_array_decoder<const N: usize>(data: &[u8]) {
     }
 }
 
-fn main() {
-    loop {
-        fuzz!(|data| {
-            do_test(data);
-        });
-    }
-}
-
-#[cfg(all(test, fuzzing))]
-mod tests {
-    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
-        let mut b = 0;
-        for (idx, c) in hex.as_bytes().iter().enumerate() {
-            b <<= 4;
-            match *c {
-                b'A'..=b'F' => b |= c - b'A' + 10,
-                b'a'..=b'f' => b |= c - b'a' + 10,
-                b'0'..=b'9' => b |= c - b'0',
-                _ => panic!("Bad hex"),
-            }
-            if (idx & 1) == 1 {
-                out.push(b);
-                b = 0;
-            }
-        }
-    }
-
-    #[test]
-    fn duplicate_crash() {
-        let mut a = Vec::new();
-        extend_vec_from_hex("deadbeef", &mut a);
-        super::do_test(&a);
-    }
-}
+fuzz_target!(|data| {
+    do_test(data);
+});

--- a/fuzz/fuzz_targets/consensus_encoding/decode_byte_vec.rs
+++ b/fuzz/fuzz_targets/consensus_encoding/decode_byte_vec.rs
@@ -1,5 +1,12 @@
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use libfuzzer_sys::fuzz_target;
+
 use bitcoin_consensus_encoding::{ByteVecDecoder, Decoder};
-use honggfuzz::fuzz;
+
+#[cfg(not(fuzzing))]
+fn main() {}
 
 fn do_test(data: &[u8]) {
     let mut decoder = ByteVecDecoder::new();
@@ -38,37 +45,6 @@ fn do_test(data: &[u8]) {
     }
 }
 
-fn main() {
-    loop {
-        fuzz!(|data| {
-            do_test(data);
-        });
-    }
-}
-
-#[cfg(all(test, fuzzing))]
-mod tests {
-    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
-        let mut b = 0;
-        for (idx, c) in hex.as_bytes().iter().enumerate() {
-            b <<= 4;
-            match *c {
-                b'A'..=b'F' => b |= c - b'A' + 10,
-                b'a'..=b'f' => b |= c - b'a' + 10,
-                b'0'..=b'9' => b |= c - b'0',
-                _ => panic!("Bad hex"),
-            }
-            if (idx & 1) == 1 {
-                out.push(b);
-                b = 0;
-            }
-        }
-    }
-
-    #[test]
-    fn duplicate_crash() {
-        let mut a = Vec::new();
-        extend_vec_from_hex("03010203", &mut a);
-        super::do_test(&a);
-    }
-}
+fuzz_target!(|data| {
+    do_test(data);
+});

--- a/fuzz/fuzz_targets/consensus_encoding/decode_compact_size.rs
+++ b/fuzz/fuzz_targets/consensus_encoding/decode_compact_size.rs
@@ -1,5 +1,12 @@
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use libfuzzer_sys::fuzz_target;
+
 use bitcoin_consensus_encoding::{CompactSizeDecoder, Decoder};
-use honggfuzz::fuzz;
+
+#[cfg(not(fuzzing))]
+fn main() {}
 
 fn do_test(data: &[u8]) {
     let mut decoder = CompactSizeDecoder::new();
@@ -48,37 +55,6 @@ fn do_test(data: &[u8]) {
     }
 }
 
-fn main() {
-    loop {
-        fuzz!(|data| {
-            do_test(data);
-        });
-    }
-}
-
-#[cfg(all(test, fuzzing))]
-mod tests {
-    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
-        let mut b = 0;
-        for (idx, c) in hex.as_bytes().iter().enumerate() {
-            b <<= 4;
-            match *c {
-                b'A'..=b'F' => b |= c - b'A' + 10,
-                b'a'..=b'f' => b |= c - b'a' + 10,
-                b'0'..=b'9' => b |= c - b'0',
-                _ => panic!("Bad hex"),
-            }
-            if (idx & 1) == 1 {
-                out.push(b);
-                b = 0;
-            }
-        }
-    }
-
-    #[test]
-    fn duplicate_crash() {
-        let mut a = Vec::new();
-        extend_vec_from_hex("fd0000", &mut a);
-        super::do_test(&a);
-    }
-}
+fuzz_target!(|data| {
+    do_test(data);
+});

--- a/fuzz/fuzz_targets/consensus_encoding/decode_decoder2.rs
+++ b/fuzz/fuzz_targets/consensus_encoding/decode_decoder2.rs
@@ -1,5 +1,12 @@
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use libfuzzer_sys::fuzz_target;
+
 use bitcoin_consensus_encoding::{ArrayDecoder, Decoder, Decoder2};
-use honggfuzz::fuzz;
+
+#[cfg(not(fuzzing))]
+fn main() {}
 
 fn do_test(data: &[u8]) {
     let mut decoder = Decoder2::new(ArrayDecoder::<2>::new(), ArrayDecoder::<3>::new());
@@ -39,37 +46,7 @@ fn do_test(data: &[u8]) {
     }
 }
 
-fn main() {
-    loop {
-        fuzz!(|data| {
-            do_test(data);
-        });
-    }
-}
+fuzz_target!(|data| {
+    do_test(data);
+});
 
-#[cfg(all(test, fuzzing))]
-mod tests {
-    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
-        let mut b = 0;
-        for (idx, c) in hex.as_bytes().iter().enumerate() {
-            b <<= 4;
-            match *c {
-                b'A'..=b'F' => b |= c - b'A' + 10,
-                b'a'..=b'f' => b |= c - b'a' + 10,
-                b'0'..=b'9' => b |= c - b'0',
-                _ => panic!("Bad hex"),
-            }
-            if (idx & 1) == 1 {
-                out.push(b);
-                b = 0;
-            }
-        }
-    }
-
-    #[test]
-    fn duplicate_crash() {
-        let mut a = Vec::new();
-        extend_vec_from_hex("0102030405", &mut a);
-        super::do_test(&a);
-    }
-}

--- a/fuzz/fuzz_targets/hashes/json.rs
+++ b/fuzz/fuzz_targets/hashes/json.rs
@@ -1,6 +1,10 @@
-use bitcoin::hashes::{ripemd160, sha1, sha256d, sha512, Hmac};
-use honggfuzz::fuzz;
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use libfuzzer_sys::fuzz_target;
 use serde::{Deserialize, Serialize};
+
+use bitcoin::hashes::{ripemd160, sha1, sha256d, sha512, Hmac};
 
 #[derive(Deserialize, Serialize)]
 struct Hmacs {
@@ -15,6 +19,9 @@ struct Main {
     sha2d: sha256d::Hash,
 }
 
+#[cfg(not(fuzzing))]
+fn main() {}
+
 fn do_test(data: &[u8]) {
     if let Ok(m) = serde_json::from_slice::<Main>(data) {
         let vec = serde_json::to_vec(&m).unwrap();
@@ -22,35 +29,6 @@ fn do_test(data: &[u8]) {
     }
 }
 
-fn main() {
-    loop {
-        fuzz!(|d| { do_test(d) });
-    }
-}
-
-#[cfg(all(test, fuzzing))]
-mod tests {
-    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
-        let mut b = 0;
-        for (idx, c) in hex.as_bytes().iter().enumerate() {
-            b <<= 4;
-            match *c {
-                b'A'..=b'F' => b |= c - b'A' + 10,
-                b'a'..=b'f' => b |= c - b'a' + 10,
-                b'0'..=b'9' => b |= c - b'0',
-                _ => panic!("Bad hex"),
-            }
-            if (idx & 1) == 1 {
-                out.push(b);
-                b = 0;
-            }
-        }
-    }
-
-    #[test]
-    fn duplicate_crash() {
-        let mut a = Vec::new();
-        extend_vec_from_hex("00000", &mut a);
-        super::do_test(&a);
-    }
-}
+fuzz_target!(|data| {
+    do_test(data)
+});

--- a/fuzz/fuzz_targets/hashes/ripemd160.rs
+++ b/fuzz/fuzz_targets/hashes/ripemd160.rs
@@ -1,5 +1,12 @@
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use libfuzzer_sys::fuzz_target;
+
 use bitcoin::hashes::{ripemd160, HashEngine};
-use honggfuzz::fuzz;
+
+#[cfg(not(fuzzing))]
+fn main() {}
 
 fn do_test(data: &[u8]) {
     let mut engine = ripemd160::Hash::engine();
@@ -10,35 +17,6 @@ fn do_test(data: &[u8]) {
     assert_eq!(hash.as_byte_array(), eng_hash.as_byte_array());
 }
 
-fn main() {
-    loop {
-        fuzz!(|d| { do_test(d) });
-    }
-}
-
-#[cfg(all(test, fuzzing))]
-mod tests {
-    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
-        let mut b = 0;
-        for (idx, c) in hex.as_bytes().iter().enumerate() {
-            b <<= 4;
-            match *c {
-                b'A'..=b'F' => b |= c - b'A' + 10,
-                b'a'..=b'f' => b |= c - b'a' + 10,
-                b'0'..=b'9' => b |= c - b'0',
-                _ => panic!("Bad hex"),
-            }
-            if (idx & 1) == 1 {
-                out.push(b);
-                b = 0;
-            }
-        }
-    }
-
-    #[test]
-    fn duplicate_crash() {
-        let mut a = Vec::new();
-        extend_vec_from_hex("00000", &mut a);
-        super::do_test(&a);
-    }
-}
+fuzz_target!(|data| {
+    do_test(data)
+});

--- a/fuzz/fuzz_targets/hashes/sha1.rs
+++ b/fuzz/fuzz_targets/hashes/sha1.rs
@@ -1,5 +1,12 @@
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use libfuzzer_sys::fuzz_target;
+
 use bitcoin::hashes::{sha1, HashEngine};
-use honggfuzz::fuzz;
+
+#[cfg(not(fuzzing))]
+fn main() {}
 
 fn do_test(data: &[u8]) {
     let mut engine = sha1::Hash::engine();
@@ -10,35 +17,6 @@ fn do_test(data: &[u8]) {
     assert_eq!(hash.as_byte_array(), eng_hash.as_byte_array());
 }
 
-fn main() {
-    loop {
-        fuzz!(|d| { do_test(d) });
-    }
-}
-
-#[cfg(all(test, fuzzing))]
-mod tests {
-    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
-        let mut b = 0;
-        for (idx, c) in hex.as_bytes().iter().enumerate() {
-            b <<= 4;
-            match *c {
-                b'A'..=b'F' => b |= c - b'A' + 10,
-                b'a'..=b'f' => b |= c - b'a' + 10,
-                b'0'..=b'9' => b |= c - b'0',
-                _ => panic!("Bad hex"),
-            }
-            if (idx & 1) == 1 {
-                out.push(b);
-                b = 0;
-            }
-        }
-    }
-
-    #[test]
-    fn duplicate_crash() {
-        let mut a = Vec::new();
-        extend_vec_from_hex("00000", &mut a);
-        super::do_test(&a);
-    }
-}
+fuzz_target!(|data| {
+    do_test(data)
+});

--- a/fuzz/fuzz_targets/hashes/sha256.rs
+++ b/fuzz/fuzz_targets/hashes/sha256.rs
@@ -1,5 +1,12 @@
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use libfuzzer_sys::fuzz_target;
+
 use bitcoin::hashes::{sha256, HashEngine};
-use honggfuzz::fuzz;
+
+#[cfg(not(fuzzing))]
+fn main() {}
 
 fn do_test(data: &[u8]) {
     let mut engine = sha256::Hash::engine();
@@ -10,35 +17,6 @@ fn do_test(data: &[u8]) {
     assert_eq!(hash.as_byte_array(), eng_hash.as_byte_array());
 }
 
-fn main() {
-    loop {
-        fuzz!(|d| { do_test(d) });
-    }
-}
-
-#[cfg(all(test, fuzzing))]
-mod tests {
-    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
-        let mut b = 0;
-        for (idx, c) in hex.as_bytes().iter().enumerate() {
-            b <<= 4;
-            match *c {
-                b'A'..=b'F' => b |= c - b'A' + 10,
-                b'a'..=b'f' => b |= c - b'a' + 10,
-                b'0'..=b'9' => b |= c - b'0',
-                _ => panic!("Bad hex"),
-            }
-            if (idx & 1) == 1 {
-                out.push(b);
-                b = 0;
-            }
-        }
-    }
-
-    #[test]
-    fn duplicate_crash() {
-        let mut a = Vec::new();
-        extend_vec_from_hex("fff400610004", &mut a);
-        super::do_test(&a);
-    }
-}
+fuzz_target!(|data| {
+    do_test(data)
+});

--- a/fuzz/fuzz_targets/hashes/sha512.rs
+++ b/fuzz/fuzz_targets/hashes/sha512.rs
@@ -1,5 +1,12 @@
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use libfuzzer_sys::fuzz_target;
+
 use bitcoin::hashes::{sha512, HashEngine};
-use honggfuzz::fuzz;
+
+#[cfg(not(fuzzing))]
+fn main() {}
 
 fn do_test(data: &[u8]) {
     let mut engine = sha512::Hash::engine();
@@ -10,35 +17,6 @@ fn do_test(data: &[u8]) {
     assert_eq!(hash.as_byte_array(), eng_hash.as_byte_array());
 }
 
-fn main() {
-    loop {
-        fuzz!(|d| { do_test(d) });
-    }
-}
-
-#[cfg(all(test, fuzzing))]
-mod tests {
-    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
-        let mut b = 0;
-        for (idx, c) in hex.as_bytes().iter().enumerate() {
-            b <<= 4;
-            match *c {
-                b'A'..=b'F' => b |= c - b'A' + 10,
-                b'a'..=b'f' => b |= c - b'a' + 10,
-                b'0'..=b'9' => b |= c - b'0',
-                _ => panic!("Bad hex"),
-            }
-            if (idx & 1) == 1 {
-                out.push(b);
-                b = 0;
-            }
-        }
-    }
-
-    #[test]
-    fn duplicate_crash() {
-        let mut a = Vec::new();
-        extend_vec_from_hex("00000", &mut a);
-        super::do_test(&a);
-    }
-}
+fuzz_target!(|data| {
+    do_test(data)
+});

--- a/fuzz/fuzz_targets/hashes/sha512_256.rs
+++ b/fuzz/fuzz_targets/hashes/sha512_256.rs
@@ -1,5 +1,12 @@
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use libfuzzer_sys::fuzz_target;
+
 use bitcoin::hashes::{sha512_256, HashEngine};
-use honggfuzz::fuzz;
+
+#[cfg(not(fuzzing))]
+fn main() {}
 
 fn do_test(data: &[u8]) {
     let mut engine = sha512_256::Hash::engine();
@@ -10,35 +17,6 @@ fn do_test(data: &[u8]) {
     assert_eq!(hash.as_byte_array(), eng_hash.as_byte_array());
 }
 
-fn main() {
-    loop {
-        fuzz!(|d| { do_test(d) });
-    }
-}
-
-#[cfg(all(test, fuzzing))]
-mod tests {
-    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
-        let mut b = 0;
-        for (idx, c) in hex.as_bytes().iter().enumerate() {
-            b <<= 4;
-            match *c {
-                b'A'..=b'F' => b |= c - b'A' + 10,
-                b'a'..=b'f' => b |= c - b'a' + 10,
-                b'0'..=b'9' => b |= c - b'0',
-                _ => panic!("Bad hex"),
-            }
-            if (idx & 1) == 1 {
-                out.push(b);
-                b = 0;
-            }
-        }
-    }
-
-    #[test]
-    fn duplicate_crash() {
-        let mut a = Vec::new();
-        extend_vec_from_hex("00000", &mut a);
-        super::do_test(&a);
-    }
-}
+fuzz_target!(|data| {
+    do_test(data)
+});

--- a/fuzz/fuzz_targets/p2p/arbitrary_addrv2.rs
+++ b/fuzz/fuzz_targets/p2p/arbitrary_addrv2.rs
@@ -1,9 +1,16 @@
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use libfuzzer_sys::fuzz_target;
+
+use arbitrary::{Arbitrary, Unstructured};
 use std::convert::TryFrom;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-use arbitrary::{Arbitrary, Unstructured};
-use honggfuzz::fuzz;
 use p2p::address::AddrV2;
+
+#[cfg(not(fuzzing))]
+fn main() {}
 
 fn do_test(data: &[u8]) {
     let mut u = Unstructured::new(data);
@@ -36,37 +43,6 @@ fn do_test(data: &[u8]) {
     }
 }
 
-fn main() {
-    loop {
-        fuzz!(|data| {
-            do_test(data);
-        });
-    }
-}
-
-#[cfg(all(test, fuzzing))]
-mod tests {
-    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
-        let mut b = 0;
-        for (idx, c) in hex.as_bytes().iter().enumerate() {
-            b <<= 4;
-            match *c {
-                b'A'..=b'F' => b |= c - b'A' + 10,
-                b'a'..=b'f' => b |= c - b'a' + 10,
-                b'0'..=b'9' => b |= c - b'0',
-                _ => panic!("Bad hex"),
-            }
-            if (idx & 1) == 1 {
-                out.push(b);
-                b = 0;
-            }
-        }
-    }
-
-    #[test]
-    fn duplicate_crash() {
-        let mut a = Vec::new();
-        extend_vec_from_hex("00", &mut a);
-        super::do_test(&a);
-    }
-}
+fuzz_target!(|data| {
+    do_test(data);
+});

--- a/fuzz/fuzz_targets/p2p/deserialize_addrv2.rs
+++ b/fuzz/fuzz_targets/p2p/deserialize_addrv2.rs
@@ -1,40 +1,15 @@
-use honggfuzz::fuzz;
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use libfuzzer_sys::fuzz_target;
+
+#[cfg(not(fuzzing))]
+fn main() {}
 
 fn do_test(data: &[u8]) {
     let _: Result<p2p::address::AddrV2, _> = bitcoin::consensus::encode::deserialize(data);
 }
 
-fn main() {
-    loop {
-        fuzz!(|data| {
-            do_test(data);
-        });
-    }
-}
-
-#[cfg(all(test, fuzzing))]
-mod tests {
-    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
-        let mut b = 0;
-        for (idx, c) in hex.as_bytes().iter().enumerate() {
-            b <<= 4;
-            match *c {
-                b'A'..=b'F' => b |= c - b'A' + 10,
-                b'a'..=b'f' => b |= c - b'a' + 10,
-                b'0'..=b'9' => b |= c - b'0',
-                _ => panic!("Bad hex"),
-            }
-            if (idx & 1) == 1 {
-                out.push(b);
-                b = 0;
-            }
-        }
-    }
-
-    #[test]
-    fn duplicate_crash() {
-        let mut a = Vec::new();
-        extend_vec_from_hex("00", &mut a);
-        super::do_test(&a);
-    }
-}
+fuzz_target!(|data| {
+    do_test(data);
+});

--- a/fuzz/fuzz_targets/p2p/deserialize_raw_net_msg.rs
+++ b/fuzz/fuzz_targets/p2p/deserialize_raw_net_msg.rs
@@ -1,41 +1,16 @@
-use honggfuzz::fuzz;
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use libfuzzer_sys::fuzz_target;
+
+#[cfg(not(fuzzing))]
+fn main() {}
 
 fn do_test(data: &[u8]) {
     let _: Result<p2p::message::V1NetworkMessage, _> =
         bitcoin::consensus::encode::deserialize(data);
 }
 
-fn main() {
-    loop {
-        fuzz!(|data| {
-            do_test(data);
-        });
-    }
-}
-
-#[cfg(all(test, fuzzing))]
-mod tests {
-    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
-        let mut b = 0;
-        for (idx, c) in hex.as_bytes().iter().enumerate() {
-            b <<= 4;
-            match *c {
-                b'A'..=b'F' => b |= c - b'A' + 10,
-                b'a'..=b'f' => b |= c - b'a' + 10,
-                b'0'..=b'9' => b |= c - b'0',
-                _ => panic!("Bad hex"),
-            }
-            if (idx & 1) == 1 {
-                out.push(b);
-                b = 0;
-            }
-        }
-    }
-
-    #[test]
-    fn duplicate_crash() {
-        let mut a = Vec::new();
-        extend_vec_from_hex("00", &mut a);
-        super::do_test(&a);
-    }
-}
+fuzz_target!(|data| {
+    do_test(data);
+});

--- a/fuzz/fuzz_targets/units/arbitrary_weight.rs
+++ b/fuzz/fuzz_targets/units/arbitrary_weight.rs
@@ -1,6 +1,13 @@
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use libfuzzer_sys::fuzz_target;
 use arbitrary::{Arbitrary, Unstructured};
+
 use bitcoin::Weight;
-use honggfuzz::fuzz;
+
+#[cfg(not(fuzzing))]
+fn main() {}
 
 fn do_test(data: &[u8]) {
     let mut u = Unstructured::new(data);
@@ -51,37 +58,6 @@ fn do_test(data: &[u8]) {
     }
 }
 
-fn main() {
-    loop {
-        fuzz!(|data| {
-            do_test(data);
-        });
-    }
-}
-
-#[cfg(all(test, fuzzing))]
-mod tests {
-    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
-        let mut b = 0;
-        for (idx, c) in hex.as_bytes().iter().enumerate() {
-            b <<= 4;
-            match *c {
-                b'A'..=b'F' => b |= c - b'A' + 10,
-                b'a'..=b'f' => b |= c - b'a' + 10,
-                b'0'..=b'9' => b |= c - b'0',
-                _ => panic!("Bad hex"),
-            }
-            if (idx & 1) == 1 {
-                out.push(b);
-                b = 0;
-            }
-        }
-    }
-
-    #[test]
-    fn duplicate_crash() {
-        let mut a = Vec::new();
-        extend_vec_from_hex("00", &mut a);
-        super::do_test(&a);
-    }
-}
+fuzz_target!(|data| {
+    do_test(data);
+});

--- a/fuzz/fuzz_targets/units/parse_amount.rs
+++ b/fuzz/fuzz_targets/units/parse_amount.rs
@@ -1,4 +1,10 @@
-use honggfuzz::fuzz;
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use libfuzzer_sys::fuzz_target;
+
+#[cfg(not(fuzzing))]
+fn main() {}
 
 fn do_test(data: &[u8]) {
     let data_str = String::from_utf8_lossy(data);
@@ -26,37 +32,6 @@ fn do_test(data: &[u8]) {
     assert_eq!(amt, amt_roundtrip);
 }
 
-fn main() {
-    loop {
-        fuzz!(|data| {
-            do_test(data);
-        });
-    }
-}
-
-#[cfg(all(test, fuzzing))]
-mod tests {
-    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
-        let mut b = 0;
-        for (idx, c) in hex.as_bytes().iter().enumerate() {
-            b <<= 4;
-            match *c {
-                b'A'..=b'F' => b |= c - b'A' + 10,
-                b'a'..=b'f' => b |= c - b'a' + 10,
-                b'0'..=b'9' => b |= c - b'0',
-                _ => panic!("Bad hex"),
-            }
-            if (idx & 1) == 1 {
-                out.push(b);
-                b = 0;
-            }
-        }
-    }
-
-    #[test]
-    fn duplicate_crash() {
-        let mut a = Vec::new();
-        extend_vec_from_hex("00000000", &mut a);
-        super::do_test(&a);
-    }
-}
+fuzz_target!(|data| {
+    do_test(data);
+});

--- a/fuzz/fuzz_targets/units/parse_int.rs
+++ b/fuzz/fuzz_targets/units/parse_int.rs
@@ -1,6 +1,13 @@
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use libfuzzer_sys::fuzz_target;
 use arbitrary::Unstructured;
+
 use bitcoin::parse_int;
-use honggfuzz::fuzz;
+
+#[cfg(not(fuzzing))]
+fn main() {}
 
 fn do_test(data: &[u8]) {
     let mut u = Unstructured::new(data);
@@ -70,37 +77,6 @@ fn do_test(data: &[u8]) {
     }
 }
 
-fn main() {
-    loop {
-        fuzz!(|data| {
-            do_test(data);
-        });
-    }
-}
-
-#[cfg(all(test, fuzzing))]
-mod tests {
-    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
-        let mut b = 0;
-        for (idx, c) in hex.as_bytes().iter().enumerate() {
-            b <<= 4;
-            match *c {
-                b'A'..=b'F' => b |= c - b'A' + 10,
-                b'a'..=b'f' => b |= c - b'a' + 10,
-                b'0'..=b'9' => b |= c - b'0',
-                _ => panic!("Bad hex"),
-            }
-            if (idx & 1) == 1 {
-                out.push(b);
-                b = 0;
-            }
-        }
-    }
-
-    #[test]
-    fn duplicate_crash() {
-        let mut a = Vec::new();
-        extend_vec_from_hex("00", &mut a);
-        super::do_test(&a);
-    }
-}
+fuzz_target!(|data| {
+    do_test(data);
+});

--- a/fuzz/fuzz_targets/units/standard_checks.rs
+++ b/fuzz/fuzz_targets/units/standard_checks.rs
@@ -1,10 +1,13 @@
-use bitcoin::absolute::{Height, MedianTimePast};
-use bitcoin::relative::{NumberOf512Seconds, NumberOfBlocks};
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use libfuzzer_sys::fuzz_target;
 use bitcoin::{
     Amount, BlockHeight, BlockHeightInterval, BlockMtp, BlockMtpInterval, BlockTime, FeeRate,
     Sequence, SignedAmount, Weight,
 };
-use honggfuzz::fuzz;
+use bitcoin::absolute::{Height, MedianTimePast};
+use bitcoin::relative::{NumberOf512Seconds, NumberOfBlocks};
 use standard_test::StandardChecks as _;
 
 /// Implements the traits on the wrapper type $ty. Intended only to be called from inside wrap_for_checks!
@@ -68,6 +71,9 @@ mod fuzz {
     wrap_for_checks!(Weight, super::Weight::MIN_TRANSACTION);
 }
 
+#[cfg(not(fuzzing))]
+fn main() {}
+
 fn do_test(data: &[u8]) {
     fuzz::Amount::one_iteration(data);
     fuzz::BlockHeight::one_iteration(data);
@@ -85,37 +91,6 @@ fn do_test(data: &[u8]) {
     fuzz::Weight::one_iteration(data);
 }
 
-fn main() {
-    loop {
-        fuzz!(|data| {
-            do_test(data);
-        });
-    }
-}
-
-#[cfg(all(test, fuzzing))]
-mod tests {
-    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
-        let mut b = 0;
-        for (idx, c) in hex.as_bytes().iter().enumerate() {
-            b <<= 4;
-            match *c {
-                b'A'..=b'F' => b |= c - b'A' + 10,
-                b'a'..=b'f' => b |= c - b'a' + 10,
-                b'0'..=b'9' => b |= c - b'0',
-                _ => panic!("Bad hex"),
-            }
-            if (idx & 1) == 1 {
-                out.push(b);
-                b = 0;
-            }
-        }
-    }
-
-    #[test]
-    fn duplicate_crash() {
-        let mut a = Vec::new();
-        extend_vec_from_hex("00000000", &mut a);
-        super::do_test(&a);
-    }
-}
+fuzz_target!(|data| {
+    do_test(data);
+});

--- a/fuzz/generate-files.sh
+++ b/fuzz/generate-files.sh
@@ -22,12 +22,12 @@ publish = false
 cargo-fuzz = true
 
 [dependencies]
-honggfuzz = { version = "0.5.58", default-features = false }
 bitcoin = { path = "../bitcoin", features = [ "serde", "arbitrary" ] }
-p2p = { path = "../p2p", package = "bitcoin-p2p-messages", features = ["arbitrary"] }
 bitcoin_consensus_encoding = { path = "../consensus_encoding", package = "bitcoin-consensus-encoding" }
-arbitrary = { version = "1.4.1" }
+p2p = { path = "../p2p", package = "bitcoin-p2p-messages", features = ["arbitrary"] }
 
+arbitrary = { version = "1.4.1" }
+libfuzzer-sys = { version = "0.4.0" }
 serde = { version = "1.0.195", features = [ "derive" ] }
 serde_json = "1.0.68"
 standard_test = "0.1.0"
@@ -47,6 +47,9 @@ for targetFile in $(listTargetFiles); do
 [[bin]]
 name = "$targetName"
 path = "$targetFile"
+test = false
+doc = false
+bench = false
 EOF
 done
 
@@ -75,7 +78,7 @@ jobs:
         # We only get 20 jobs at a time, we probably don't want to go
         # over that limit with fuzzing because of the hour run time.
         fuzz_target: [
-$(for name in $(listTargetNames); do echo "          $name,"; done)
+$(for name in $(cargo fuzz list); do echo "          $name,"; done)
         ]
     steps:
       - name: Install test dependencies
@@ -84,7 +87,6 @@ $(for name in $(listTargetNames); do echo "          $name,"; done)
         with:
           persist-credentials: false
       - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-
         id: cache-fuzz
         with:
           path: |
@@ -122,6 +124,6 @@ $(for name in $(listTargetNames); do echo "          $name,"; done)
       - name: Display structure of downloaded files
         run: ls -R
       - run: find executed_* -type f -exec cat {} + | sort > executed
-      - run: source ./fuzz/fuzz-util.sh && listTargetNames | sort | diff - executed
+      - run: cargo fuzz list | sort | diff - executed
 EOF
 


### PR DESCRIPTION
This commit has a few main parts:

- Update CI to install required dependencies for libfuzzer
The default Cross s390x image uses an older version of GCC (Ubuntu
20.04), which lacks std::clamp needed by libfuzzer-sys. The s390x
Dockerfile provides Cross with a container with GCC 13, native build
tools, and QEMU for running s390x tests. Cross.toml configures Cross to
use this custom image instead of the default.

- Update the lock files
- Update the fuzz targets to use libfuzzer
- Update the fuzz helper scripts and documentation
- Update the duplicate dependency whitelist to include libc

I was able to test that the fuzz scripts were working locally on my Mac and on a Docker container running Ubuntu.

Closes #3265