### PR TITLE
Remove doc_auto_cfg

### DIFF
--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -31,7 +31,6 @@
 
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 // Experimental features we need.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(bench, feature(test))]
 // Coding conventions.
 #![warn(missing_docs)]


### PR DESCRIPTION
It breaks the build and we are electing to just remove any attributes required by docs.rs for now.