### PR TITLE
Move internals::compact_size to consensus_encoding

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -54,6 +54,7 @@ dependencies = [
  "base64",
  "bech32",
  "bincode",
+ "bitcoin-consensus-encoding",
  "bitcoin-internals",
  "bitcoin-io",
  "bitcoin-primitives",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -53,6 +53,7 @@ dependencies = [
  "base64",
  "bech32",
  "bincode",
+ "bitcoin-consensus-encoding",
  "bitcoin-internals",
  "bitcoin-io",
  "bitcoin-primitives",

--- a/api/consensus_encoding/all-features.txt
+++ b/api/consensus_encoding/all-features.txt
@@ -5,6 +5,7 @@ impl bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ByteVec
 impl bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::CompactSizeDecoder
 impl bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::BytesEncoder<'_>
 impl bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::CompactSizeEncoder
+impl bitcoin_consensus_encoding::compact_size::CompactSizeSlice
 impl core::clone::Clone for bitcoin_consensus_encoding::ByteVecDecoderError
 impl core::clone::Clone for bitcoin_consensus_encoding::CompactSizeDecoder
 impl core::clone::Clone for bitcoin_consensus_encoding::CompactSizeDecoderError
@@ -41,6 +42,7 @@ impl core::marker::Freeze for bitcoin_consensus_encoding::CompactSizeDecoderErro
 impl core::marker::Freeze for bitcoin_consensus_encoding::CompactSizeEncoder
 impl core::marker::Freeze for bitcoin_consensus_encoding::LengthPrefixExceedsMaxError
 impl core::marker::Freeze for bitcoin_consensus_encoding::UnexpectedEofError
+impl core::marker::Freeze for bitcoin_consensus_encoding::compact_size::CompactSizeSlice
 impl core::marker::Send for bitcoin_consensus_encoding::ByteVecDecoder
 impl core::marker::Send for bitcoin_consensus_encoding::ByteVecDecoderError
 impl core::marker::Send for bitcoin_consensus_encoding::CompactSizeDecoder
@@ -48,6 +50,7 @@ impl core::marker::Send for bitcoin_consensus_encoding::CompactSizeDecoderError
 impl core::marker::Send for bitcoin_consensus_encoding::CompactSizeEncoder
 impl core::marker::Send for bitcoin_consensus_encoding::LengthPrefixExceedsMaxError
 impl core::marker::Send for bitcoin_consensus_encoding::UnexpectedEofError
+impl core::marker::Send for bitcoin_consensus_encoding::compact_size::CompactSizeSlice
 impl core::marker::StructuralPartialEq for bitcoin_consensus_encoding::ByteVecDecoderError
 impl core::marker::StructuralPartialEq for bitcoin_consensus_encoding::CompactSizeDecoderError
 impl core::marker::StructuralPartialEq for bitcoin_consensus_encoding::LengthPrefixExceedsMaxError
@@ -59,6 +62,7 @@ impl core::marker::Sync for bitcoin_consensus_encoding::CompactSizeDecoderError
 impl core::marker::Sync for bitcoin_consensus_encoding::CompactSizeEncoder
 impl core::marker::Sync for bitcoin_consensus_encoding::LengthPrefixExceedsMaxError
 impl core::marker::Sync for bitcoin_consensus_encoding::UnexpectedEofError
+impl core::marker::Sync for bitcoin_consensus_encoding::compact_size::CompactSizeSlice
 impl core::marker::Unpin for bitcoin_consensus_encoding::ByteVecDecoder
 impl core::marker::Unpin for bitcoin_consensus_encoding::ByteVecDecoderError
 impl core::marker::Unpin for bitcoin_consensus_encoding::CompactSizeDecoder
@@ -66,6 +70,8 @@ impl core::marker::Unpin for bitcoin_consensus_encoding::CompactSizeDecoderError
 impl core::marker::Unpin for bitcoin_consensus_encoding::CompactSizeEncoder
 impl core::marker::Unpin for bitcoin_consensus_encoding::LengthPrefixExceedsMaxError
 impl core::marker::Unpin for bitcoin_consensus_encoding::UnexpectedEofError
+impl core::marker::Unpin for bitcoin_consensus_encoding::compact_size::CompactSizeSlice
+impl core::ops::deref::Deref for bitcoin_consensus_encoding::compact_size::CompactSizeSlice
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::ByteVecDecoder
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::ByteVecDecoderError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::CompactSizeDecoder
@@ -73,6 +79,7 @@ impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::Com
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::CompactSizeEncoder
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::LengthPrefixExceedsMaxError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::UnexpectedEofError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::compact_size::CompactSizeSlice
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::ByteVecDecoder
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::ByteVecDecoderError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::CompactSizeDecoder
@@ -80,6 +87,7 @@ impl core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::Compac
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::CompactSizeEncoder
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::LengthPrefixExceedsMaxError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::UnexpectedEofError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::compact_size::CompactSizeSlice
 impl<'e, T: bitcoin_consensus_encoding::Encodable> bitcoin_consensus_encoding::SliceEncoder<'e, T>
 impl<'e, T> core::marker::Freeze for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::marker::Freeze
 impl<'e, T> core::marker::Send for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::marker::Send, T: core::marker::Sync
@@ -287,6 +295,8 @@ pub bitcoin_consensus_encoding::Decoder6Error::Sixth(F)
 pub bitcoin_consensus_encoding::Decoder6Error::Third(C)
 pub bitcoin_consensus_encoding::ReadError::Decode(D)
 pub bitcoin_consensus_encoding::ReadError::Io(std::io::error::Error)
+pub const bitcoin_consensus_encoding::compact_size::MAX_ENCODABLE_VALUE: u64
+pub const bitcoin_consensus_encoding::compact_size::MAX_ENCODING_SIZE: usize
 pub const fn bitcoin_consensus_encoding::ArrayDecoder<N>::new() -> Self
 pub const fn bitcoin_consensus_encoding::ArrayEncoder<N>::without_length_prefix(arr: [u8; N]) -> Self
 pub const fn bitcoin_consensus_encoding::ByteVecDecoder::new() -> Self
@@ -301,6 +311,7 @@ pub const fn bitcoin_consensus_encoding::Encoder3<A, B, C>::new(enc_1: A, enc_2:
 pub const fn bitcoin_consensus_encoding::Encoder4<A, B, C, D>::new(enc_1: A, enc_2: B, enc_3: C, enc_4: D) -> Self
 pub const fn bitcoin_consensus_encoding::Encoder6<A, B, C, D, E, F>::new(enc_1: A, enc_2: B, enc_3: C, enc_4: D, enc_5: E, enc_6: F) -> Self
 pub const fn bitcoin_consensus_encoding::VecDecoder<T>::new() -> Self
+pub const fn bitcoin_consensus_encoding::compact_size::encoded_size_const(value: u64) -> usize
 pub enum bitcoin_consensus_encoding::Decoder2Error<A, B>
 pub enum bitcoin_consensus_encoding::Decoder3Error<A, B, C>
 pub enum bitcoin_consensus_encoding::Decoder4Error<A, B, C, D>
@@ -402,6 +413,11 @@ pub fn bitcoin_consensus_encoding::VecDecoderError<Err>::fmt(&self, f: &mut core
 pub fn bitcoin_consensus_encoding::VecDecoderError<Err>::from(never: core::convert::Infallible) -> Self
 pub fn bitcoin_consensus_encoding::VecDecoderError<Err>::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 pub fn bitcoin_consensus_encoding::cast_to_usize_if_valid(n: u64) -> core::result::Result<usize, bitcoin_consensus_encoding::LengthPrefixExceedsMaxError>
+pub fn bitcoin_consensus_encoding::compact_size::CompactSizeSlice::as_slice(&self) -> &[u8]
+pub fn bitcoin_consensus_encoding::compact_size::CompactSizeSlice::deref(&self) -> &Self::Target
+pub fn bitcoin_consensus_encoding::compact_size::decode_unchecked(slice: &mut &[u8]) -> u64
+pub fn bitcoin_consensus_encoding::compact_size::encode(value: usize) -> bitcoin_consensus_encoding::compact_size::CompactSizeSlice
+pub fn bitcoin_consensus_encoding::compact_size::encoded_size(value: usize) -> usize
 pub fn bitcoin_consensus_encoding::decode_from_read<T, R>(reader: R) -> core::result::Result<T, bitcoin_consensus_encoding::ReadError<<<T as bitcoin_consensus_encoding::Decodable>::Decoder as bitcoin_consensus_encoding::Decoder>::Error>> where T: bitcoin_consensus_encoding::Decodable, R: std::io::BufRead
 pub fn bitcoin_consensus_encoding::decode_from_read_unbuffered<T, R>(reader: R) -> core::result::Result<T, bitcoin_consensus_encoding::ReadError<<<T as bitcoin_consensus_encoding::Decodable>::Decoder as bitcoin_consensus_encoding::Decoder>::Error>> where T: bitcoin_consensus_encoding::Decodable, R: std::io::Read
 pub fn bitcoin_consensus_encoding::decode_from_read_unbuffered_with<T, R, const BUFFER_SIZE: usize>(reader: R) -> core::result::Result<T, bitcoin_consensus_encoding::ReadError<<<T as bitcoin_consensus_encoding::Decodable>::Decoder as bitcoin_consensus_encoding::Decoder>::Error>> where T: bitcoin_consensus_encoding::Decodable, R: std::io::Read
@@ -412,6 +428,7 @@ pub fn core::option::Option<T>::advance(&mut self) -> bool
 pub fn core::option::Option<T>::current_chunk(&self) -> &[u8]
 pub macro bitcoin_consensus_encoding::encoder_newtype!
 pub mod bitcoin_consensus_encoding
+pub mod bitcoin_consensus_encoding::compact_size
 pub struct bitcoin_consensus_encoding::ArrayDecoder<const N: usize>
 pub struct bitcoin_consensus_encoding::ArrayEncoder<const N: usize>
 pub struct bitcoin_consensus_encoding::ByteVecDecoder
@@ -434,6 +451,7 @@ pub struct bitcoin_consensus_encoding::SliceEncoder<'e, T: bitcoin_consensus_enc
 pub struct bitcoin_consensus_encoding::UnexpectedEofError
 pub struct bitcoin_consensus_encoding::VecDecoder<T: bitcoin_consensus_encoding::Decodable>
 pub struct bitcoin_consensus_encoding::VecDecoderError<Err>(_)
+pub struct bitcoin_consensus_encoding::compact_size::CompactSizeSlice(_, _)
 pub trait bitcoin_consensus_encoding::Decodable
 pub trait bitcoin_consensus_encoding::Decoder: core::marker::Sized
 pub trait bitcoin_consensus_encoding::Encodable
@@ -459,3 +477,4 @@ pub type bitcoin_consensus_encoding::Encodable::Encoder<'s> where Self: 's: bitc
 pub type bitcoin_consensus_encoding::EncodableByteIter<'s, T>::Item = u8
 pub type bitcoin_consensus_encoding::VecDecoder<T>::Error = bitcoin_consensus_encoding::VecDecoderError<<<T as bitcoin_consensus_encoding::Decodable>::Decoder as bitcoin_consensus_encoding::Decoder>::Error>
 pub type bitcoin_consensus_encoding::VecDecoder<T>::Output = alloc::vec::Vec<T>
+pub type bitcoin_consensus_encoding::compact_size::CompactSizeSlice::Target = [u8]

--- a/api/consensus_encoding/alloc-only.txt
+++ b/api/consensus_encoding/alloc-only.txt
@@ -5,6 +5,7 @@ impl bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ByteVec
 impl bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::CompactSizeDecoder
 impl bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::BytesEncoder<'_>
 impl bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::CompactSizeEncoder
+impl bitcoin_consensus_encoding::compact_size::CompactSizeSlice
 impl core::clone::Clone for bitcoin_consensus_encoding::ByteVecDecoderError
 impl core::clone::Clone for bitcoin_consensus_encoding::CompactSizeDecoder
 impl core::clone::Clone for bitcoin_consensus_encoding::CompactSizeDecoderError
@@ -37,6 +38,7 @@ impl core::marker::Freeze for bitcoin_consensus_encoding::CompactSizeDecoderErro
 impl core::marker::Freeze for bitcoin_consensus_encoding::CompactSizeEncoder
 impl core::marker::Freeze for bitcoin_consensus_encoding::LengthPrefixExceedsMaxError
 impl core::marker::Freeze for bitcoin_consensus_encoding::UnexpectedEofError
+impl core::marker::Freeze for bitcoin_consensus_encoding::compact_size::CompactSizeSlice
 impl core::marker::Send for bitcoin_consensus_encoding::ByteVecDecoder
 impl core::marker::Send for bitcoin_consensus_encoding::ByteVecDecoderError
 impl core::marker::Send for bitcoin_consensus_encoding::CompactSizeDecoder
@@ -44,6 +46,7 @@ impl core::marker::Send for bitcoin_consensus_encoding::CompactSizeDecoderError
 impl core::marker::Send for bitcoin_consensus_encoding::CompactSizeEncoder
 impl core::marker::Send for bitcoin_consensus_encoding::LengthPrefixExceedsMaxError
 impl core::marker::Send for bitcoin_consensus_encoding::UnexpectedEofError
+impl core::marker::Send for bitcoin_consensus_encoding::compact_size::CompactSizeSlice
 impl core::marker::StructuralPartialEq for bitcoin_consensus_encoding::ByteVecDecoderError
 impl core::marker::StructuralPartialEq for bitcoin_consensus_encoding::CompactSizeDecoderError
 impl core::marker::StructuralPartialEq for bitcoin_consensus_encoding::LengthPrefixExceedsMaxError
@@ -55,6 +58,7 @@ impl core::marker::Sync for bitcoin_consensus_encoding::CompactSizeDecoderError
 impl core::marker::Sync for bitcoin_consensus_encoding::CompactSizeEncoder
 impl core::marker::Sync for bitcoin_consensus_encoding::LengthPrefixExceedsMaxError
 impl core::marker::Sync for bitcoin_consensus_encoding::UnexpectedEofError
+impl core::marker::Sync for bitcoin_consensus_encoding::compact_size::CompactSizeSlice
 impl core::marker::Unpin for bitcoin_consensus_encoding::ByteVecDecoder
 impl core::marker::Unpin for bitcoin_consensus_encoding::ByteVecDecoderError
 impl core::marker::Unpin for bitcoin_consensus_encoding::CompactSizeDecoder
@@ -62,6 +66,8 @@ impl core::marker::Unpin for bitcoin_consensus_encoding::CompactSizeDecoderError
 impl core::marker::Unpin for bitcoin_consensus_encoding::CompactSizeEncoder
 impl core::marker::Unpin for bitcoin_consensus_encoding::LengthPrefixExceedsMaxError
 impl core::marker::Unpin for bitcoin_consensus_encoding::UnexpectedEofError
+impl core::marker::Unpin for bitcoin_consensus_encoding::compact_size::CompactSizeSlice
+impl core::ops::deref::Deref for bitcoin_consensus_encoding::compact_size::CompactSizeSlice
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::ByteVecDecoder
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::ByteVecDecoderError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::CompactSizeDecoder
@@ -69,6 +75,7 @@ impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::Com
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::CompactSizeEncoder
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::LengthPrefixExceedsMaxError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::UnexpectedEofError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::compact_size::CompactSizeSlice
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::ByteVecDecoder
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::ByteVecDecoderError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::CompactSizeDecoder
@@ -76,6 +83,7 @@ impl core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::Compac
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::CompactSizeEncoder
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::LengthPrefixExceedsMaxError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::UnexpectedEofError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::compact_size::CompactSizeSlice
 impl<'e, T: bitcoin_consensus_encoding::Encodable> bitcoin_consensus_encoding::SliceEncoder<'e, T>
 impl<'e, T> core::marker::Freeze for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::marker::Freeze
 impl<'e, T> core::marker::Send for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::marker::Send, T: core::marker::Sync
@@ -266,6 +274,8 @@ pub bitcoin_consensus_encoding::Decoder6Error::Fourth(D)
 pub bitcoin_consensus_encoding::Decoder6Error::Second(B)
 pub bitcoin_consensus_encoding::Decoder6Error::Sixth(F)
 pub bitcoin_consensus_encoding::Decoder6Error::Third(C)
+pub const bitcoin_consensus_encoding::compact_size::MAX_ENCODABLE_VALUE: u64
+pub const bitcoin_consensus_encoding::compact_size::MAX_ENCODING_SIZE: usize
 pub const fn bitcoin_consensus_encoding::ArrayDecoder<N>::new() -> Self
 pub const fn bitcoin_consensus_encoding::ArrayEncoder<N>::without_length_prefix(arr: [u8; N]) -> Self
 pub const fn bitcoin_consensus_encoding::ByteVecDecoder::new() -> Self
@@ -280,6 +290,7 @@ pub const fn bitcoin_consensus_encoding::Encoder3<A, B, C>::new(enc_1: A, enc_2:
 pub const fn bitcoin_consensus_encoding::Encoder4<A, B, C, D>::new(enc_1: A, enc_2: B, enc_3: C, enc_4: D) -> Self
 pub const fn bitcoin_consensus_encoding::Encoder6<A, B, C, D, E, F>::new(enc_1: A, enc_2: B, enc_3: C, enc_4: D, enc_5: E, enc_6: F) -> Self
 pub const fn bitcoin_consensus_encoding::VecDecoder<T>::new() -> Self
+pub const fn bitcoin_consensus_encoding::compact_size::encoded_size_const(value: u64) -> usize
 pub enum bitcoin_consensus_encoding::Decoder2Error<A, B>
 pub enum bitcoin_consensus_encoding::Decoder3Error<A, B, C>
 pub enum bitcoin_consensus_encoding::Decoder4Error<A, B, C, D>
@@ -371,12 +382,18 @@ pub fn bitcoin_consensus_encoding::VecDecoderError<Err>::eq(&self, other: &bitco
 pub fn bitcoin_consensus_encoding::VecDecoderError<Err>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_consensus_encoding::VecDecoderError<Err>::from(never: core::convert::Infallible) -> Self
 pub fn bitcoin_consensus_encoding::cast_to_usize_if_valid(n: u64) -> core::result::Result<usize, bitcoin_consensus_encoding::LengthPrefixExceedsMaxError>
+pub fn bitcoin_consensus_encoding::compact_size::CompactSizeSlice::as_slice(&self) -> &[u8]
+pub fn bitcoin_consensus_encoding::compact_size::CompactSizeSlice::deref(&self) -> &Self::Target
+pub fn bitcoin_consensus_encoding::compact_size::decode_unchecked(slice: &mut &[u8]) -> u64
+pub fn bitcoin_consensus_encoding::compact_size::encode(value: usize) -> bitcoin_consensus_encoding::compact_size::CompactSizeSlice
+pub fn bitcoin_consensus_encoding::compact_size::encoded_size(value: usize) -> usize
 pub fn bitcoin_consensus_encoding::decode_from_slice<T>(bytes: &[u8]) -> core::result::Result<T, <<T as bitcoin_consensus_encoding::Decodable>::Decoder as bitcoin_consensus_encoding::Decoder>::Error> where T: bitcoin_consensus_encoding::Decodable
 pub fn bitcoin_consensus_encoding::encode_to_vec<T>(object: &T) -> alloc::vec::Vec<u8> where T: bitcoin_consensus_encoding::Encodable + ?core::marker::Sized
 pub fn core::option::Option<T>::advance(&mut self) -> bool
 pub fn core::option::Option<T>::current_chunk(&self) -> &[u8]
 pub macro bitcoin_consensus_encoding::encoder_newtype!
 pub mod bitcoin_consensus_encoding
+pub mod bitcoin_consensus_encoding::compact_size
 pub struct bitcoin_consensus_encoding::ArrayDecoder<const N: usize>
 pub struct bitcoin_consensus_encoding::ArrayEncoder<const N: usize>
 pub struct bitcoin_consensus_encoding::ByteVecDecoder
@@ -399,6 +416,7 @@ pub struct bitcoin_consensus_encoding::SliceEncoder<'e, T: bitcoin_consensus_enc
 pub struct bitcoin_consensus_encoding::UnexpectedEofError
 pub struct bitcoin_consensus_encoding::VecDecoder<T: bitcoin_consensus_encoding::Decodable>
 pub struct bitcoin_consensus_encoding::VecDecoderError<Err>(_)
+pub struct bitcoin_consensus_encoding::compact_size::CompactSizeSlice(_, _)
 pub trait bitcoin_consensus_encoding::Decodable
 pub trait bitcoin_consensus_encoding::Decoder: core::marker::Sized
 pub trait bitcoin_consensus_encoding::Encodable
@@ -424,3 +442,4 @@ pub type bitcoin_consensus_encoding::Encodable::Encoder<'s> where Self: 's: bitc
 pub type bitcoin_consensus_encoding::EncodableByteIter<'s, T>::Item = u8
 pub type bitcoin_consensus_encoding::VecDecoder<T>::Error = bitcoin_consensus_encoding::VecDecoderError<<<T as bitcoin_consensus_encoding::Decodable>::Decoder as bitcoin_consensus_encoding::Decoder>::Error>
 pub type bitcoin_consensus_encoding::VecDecoder<T>::Output = alloc::vec::Vec<T>
+pub type bitcoin_consensus_encoding::compact_size::CompactSizeSlice::Target = [u8]

--- a/api/consensus_encoding/no-features.txt
+++ b/api/consensus_encoding/no-features.txt
@@ -3,6 +3,7 @@ impl bitcoin_consensus_encoding::CompactSizeEncoder
 impl bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::CompactSizeDecoder
 impl bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::BytesEncoder<'_>
 impl bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::CompactSizeEncoder
+impl bitcoin_consensus_encoding::compact_size::CompactSizeSlice
 impl core::clone::Clone for bitcoin_consensus_encoding::CompactSizeDecoder
 impl core::clone::Clone for bitcoin_consensus_encoding::CompactSizeDecoderError
 impl core::clone::Clone for bitcoin_consensus_encoding::UnexpectedEofError
@@ -20,28 +21,35 @@ impl core::marker::Freeze for bitcoin_consensus_encoding::CompactSizeDecoder
 impl core::marker::Freeze for bitcoin_consensus_encoding::CompactSizeDecoderError
 impl core::marker::Freeze for bitcoin_consensus_encoding::CompactSizeEncoder
 impl core::marker::Freeze for bitcoin_consensus_encoding::UnexpectedEofError
+impl core::marker::Freeze for bitcoin_consensus_encoding::compact_size::CompactSizeSlice
 impl core::marker::Send for bitcoin_consensus_encoding::CompactSizeDecoder
 impl core::marker::Send for bitcoin_consensus_encoding::CompactSizeDecoderError
 impl core::marker::Send for bitcoin_consensus_encoding::CompactSizeEncoder
 impl core::marker::Send for bitcoin_consensus_encoding::UnexpectedEofError
+impl core::marker::Send for bitcoin_consensus_encoding::compact_size::CompactSizeSlice
 impl core::marker::StructuralPartialEq for bitcoin_consensus_encoding::CompactSizeDecoderError
 impl core::marker::StructuralPartialEq for bitcoin_consensus_encoding::UnexpectedEofError
 impl core::marker::Sync for bitcoin_consensus_encoding::CompactSizeDecoder
 impl core::marker::Sync for bitcoin_consensus_encoding::CompactSizeDecoderError
 impl core::marker::Sync for bitcoin_consensus_encoding::CompactSizeEncoder
 impl core::marker::Sync for bitcoin_consensus_encoding::UnexpectedEofError
+impl core::marker::Sync for bitcoin_consensus_encoding::compact_size::CompactSizeSlice
 impl core::marker::Unpin for bitcoin_consensus_encoding::CompactSizeDecoder
 impl core::marker::Unpin for bitcoin_consensus_encoding::CompactSizeDecoderError
 impl core::marker::Unpin for bitcoin_consensus_encoding::CompactSizeEncoder
 impl core::marker::Unpin for bitcoin_consensus_encoding::UnexpectedEofError
+impl core::marker::Unpin for bitcoin_consensus_encoding::compact_size::CompactSizeSlice
+impl core::ops::deref::Deref for bitcoin_consensus_encoding::compact_size::CompactSizeSlice
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::CompactSizeDecoder
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::CompactSizeDecoderError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::CompactSizeEncoder
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::UnexpectedEofError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::compact_size::CompactSizeSlice
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::CompactSizeDecoder
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::CompactSizeDecoderError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::CompactSizeEncoder
 impl core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::UnexpectedEofError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::compact_size::CompactSizeSlice
 impl<'e, T: bitcoin_consensus_encoding::Encodable> bitcoin_consensus_encoding::SliceEncoder<'e, T>
 impl<'e, T> core::marker::Freeze for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::marker::Freeze
 impl<'e, T> core::marker::Send for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::marker::Send, T: core::marker::Sync
@@ -210,6 +218,8 @@ pub bitcoin_consensus_encoding::Decoder6Error::Fourth(D)
 pub bitcoin_consensus_encoding::Decoder6Error::Second(B)
 pub bitcoin_consensus_encoding::Decoder6Error::Sixth(F)
 pub bitcoin_consensus_encoding::Decoder6Error::Third(C)
+pub const bitcoin_consensus_encoding::compact_size::MAX_ENCODABLE_VALUE: u64
+pub const bitcoin_consensus_encoding::compact_size::MAX_ENCODING_SIZE: usize
 pub const fn bitcoin_consensus_encoding::ArrayDecoder<N>::new() -> Self
 pub const fn bitcoin_consensus_encoding::ArrayEncoder<N>::without_length_prefix(arr: [u8; N]) -> Self
 pub const fn bitcoin_consensus_encoding::BytesEncoder<'sl>::without_length_prefix(sl: &'sl [u8]) -> Self
@@ -222,6 +232,7 @@ pub const fn bitcoin_consensus_encoding::Encoder2<A, B>::new(enc_1: A, enc_2: B)
 pub const fn bitcoin_consensus_encoding::Encoder3<A, B, C>::new(enc_1: A, enc_2: B, enc_3: C) -> Self
 pub const fn bitcoin_consensus_encoding::Encoder4<A, B, C, D>::new(enc_1: A, enc_2: B, enc_3: C, enc_4: D) -> Self
 pub const fn bitcoin_consensus_encoding::Encoder6<A, B, C, D, E, F>::new(enc_1: A, enc_2: B, enc_3: C, enc_4: D, enc_5: E, enc_6: F) -> Self
+pub const fn bitcoin_consensus_encoding::compact_size::encoded_size_const(value: u64) -> usize
 pub enum bitcoin_consensus_encoding::Decoder2Error<A, B>
 pub enum bitcoin_consensus_encoding::Decoder3Error<A, B, C>
 pub enum bitcoin_consensus_encoding::Decoder4Error<A, B, C, D>
@@ -293,11 +304,17 @@ pub fn bitcoin_consensus_encoding::SliceEncoder<'e, T>::without_length_prefix(sl
 pub fn bitcoin_consensus_encoding::UnexpectedEofError::clone(&self) -> bitcoin_consensus_encoding::UnexpectedEofError
 pub fn bitcoin_consensus_encoding::UnexpectedEofError::eq(&self, other: &bitcoin_consensus_encoding::UnexpectedEofError) -> bool
 pub fn bitcoin_consensus_encoding::UnexpectedEofError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_consensus_encoding::compact_size::CompactSizeSlice::as_slice(&self) -> &[u8]
+pub fn bitcoin_consensus_encoding::compact_size::CompactSizeSlice::deref(&self) -> &Self::Target
+pub fn bitcoin_consensus_encoding::compact_size::decode_unchecked(slice: &mut &[u8]) -> u64
+pub fn bitcoin_consensus_encoding::compact_size::encode(value: usize) -> bitcoin_consensus_encoding::compact_size::CompactSizeSlice
+pub fn bitcoin_consensus_encoding::compact_size::encoded_size(value: usize) -> usize
 pub fn bitcoin_consensus_encoding::decode_from_slice<T>(bytes: &[u8]) -> core::result::Result<T, <<T as bitcoin_consensus_encoding::Decodable>::Decoder as bitcoin_consensus_encoding::Decoder>::Error> where T: bitcoin_consensus_encoding::Decodable
 pub fn core::option::Option<T>::advance(&mut self) -> bool
 pub fn core::option::Option<T>::current_chunk(&self) -> &[u8]
 pub macro bitcoin_consensus_encoding::encoder_newtype!
 pub mod bitcoin_consensus_encoding
+pub mod bitcoin_consensus_encoding::compact_size
 pub struct bitcoin_consensus_encoding::ArrayDecoder<const N: usize>
 pub struct bitcoin_consensus_encoding::ArrayEncoder<const N: usize>
 pub struct bitcoin_consensus_encoding::BytesEncoder<'sl>
@@ -315,6 +332,7 @@ pub struct bitcoin_consensus_encoding::Encoder4<A, B, C, D>
 pub struct bitcoin_consensus_encoding::Encoder6<A, B, C, D, E, F>
 pub struct bitcoin_consensus_encoding::SliceEncoder<'e, T: bitcoin_consensus_encoding::Encodable>
 pub struct bitcoin_consensus_encoding::UnexpectedEofError
+pub struct bitcoin_consensus_encoding::compact_size::CompactSizeSlice(_, _)
 pub trait bitcoin_consensus_encoding::Decodable
 pub trait bitcoin_consensus_encoding::Decoder: core::marker::Sized
 pub trait bitcoin_consensus_encoding::Encodable
@@ -336,3 +354,4 @@ pub type bitcoin_consensus_encoding::Decoder::Error
 pub type bitcoin_consensus_encoding::Decoder::Output
 pub type bitcoin_consensus_encoding::Encodable::Encoder<'s> where Self: 's: bitcoin_consensus_encoding::Encoder
 pub type bitcoin_consensus_encoding::EncodableByteIter<'s, T>::Item = u8
+pub type bitcoin_consensus_encoding::compact_size::CompactSizeSlice::Target = [u8]

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -28,6 +28,7 @@ arbitrary = ["dep:arbitrary", "units/arbitrary", "primitives/arbitrary"]
 base58 = { package = "base58ck", path = "../base58", version = "0.2.0", default-features = false, features = ["alloc"] }
 bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.18.0", default-features = false, features = ["alloc", "hex"] }
+encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0-rc.1", default-features = false }
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false, features = ["alloc"] }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.4.1", features = ["alloc", "hex"] }
 io = { package = "bitcoin-io", path = "../io", version = "0.3.0", default-features = false, features = ["alloc", "hashes"] }

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -10,7 +10,8 @@
 use core::convert::Infallible;
 use core::fmt;
 
-use internals::{compact_size, ToU64};
+use encoding::compact_size;
+use internals::ToU64;
 use io::{BufRead, Write};
 
 use crate::consensus::encode::{self, Decodable, Encodable, WriteExt as _};

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -14,7 +14,8 @@ use core::fmt;
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
-use internals::{compact_size, const_casts, write_err, ToU64};
+use encoding::compact_size;
+use internals::{const_casts, write_err, ToU64};
 use io::{BufRead, Write};
 
 use super::Weight;

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -4,7 +4,7 @@
 //!
 //! This module contains the [`Witness`] struct and related methods to operate on it
 
-use internals::compact_size;
+use encoding::compact_size;
 use io::{BufRead, Write};
 
 use crate::consensus::encode::{self, Error, ReadExt, WriteExt, MAX_VEC_SIZE};

--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -6,7 +6,7 @@
 //! according to the BIP-0174 specification.
 
 use hashes::{hash160, ripemd160, sha256, sha256d};
-use internals::compact_size;
+use encoding::compact_size;
 #[allow(unused)] // MSRV polyfill
 use internals::slice::SliceExt;
 

--- a/consensus_encoding/src/compact_size.rs
+++ b/consensus_encoding/src/compact_size.rs
@@ -7,9 +7,6 @@
 //!
 //! [`CompactSize`]: <https://en.bitcoin.it/wiki/Protocol_documentation#Variable_length_integer>
 
-use crate::array_vec::ArrayVec;
-use crate::ToU64;
-
 /// The maximum size of a serialized object in bytes or number of elements
 /// (for eg vectors) when the size is encoded as `CompactSize`.
 ///
@@ -29,7 +26,14 @@ pub const MAX_ENCODING_SIZE: usize = 9;
 /// - 5 for 0x10000..=(2^32-1)
 /// - 9 otherwise.
 #[inline]
-pub fn encoded_size(value: impl ToU64) -> usize { encoded_size_const(value.to_u64()) }
+pub fn encoded_size(value: usize) -> usize {
+    encoded_size_const(to_u64(value))
+}
+
+/// Convert a usize to a u64, saturating to [`u64::MAX`] if it exceeds the available range.
+fn to_u64(value: usize) -> u64 {
+    value.try_into().unwrap_or(u64::MAX)
+}
 
 /// Returns the number of bytes used to encode this `CompactSize` value (in const context).
 ///
@@ -44,36 +48,57 @@ pub const fn encoded_size_const(value: u64) -> usize {
     match value {
         0..=0xFC => 1,
         0xFD..=0xFFFF => 3,
-        0x10000..=0xFFFFFFFF => 5,
+        0x10000..=0xFFFF_FFFF => 5,
         _ => 9,
     }
 }
 
 /// Encodes `CompactSize` without allocating.
+///
+/// Encodings are defined only for the range of u64. On systems where usize is
+/// larger than u64, it will be possible to call this method with out-of-range
+/// values. In such cases we will ignore the passed value and encode [`u64::MAX`].
+/// But even on such exotic systems, we expect users to pass the length of an
+/// in-memory object, meaning that such large values are impossible to obtain.
 #[inline]
-pub fn encode(value: impl ToU64) -> ArrayVec<u8, MAX_ENCODING_SIZE> {
-    let value = value.to_u64();
-    let mut res = ArrayVec::<u8, MAX_ENCODING_SIZE>::new();
+pub fn encode(value: usize) -> CompactSizeSlice {
+    let mut res = [0u8; MAX_ENCODING_SIZE];
     match value {
         0..=0xFC => {
-            res.push(value as u8); // Cast ok because of match.
+            res[0] = value as u8; // Cast ok because of match.
         }
         0xFD..=0xFFFF => {
             let v = value as u16; // Cast ok because of match.
-            res.push(0xFD);
-            res.extend_from_slice(&v.to_le_bytes());
+            res[0] = 0xFD;
+            res[1..3].copy_from_slice(&v.to_le_bytes());
         }
-        0x10000..=0xFFFFFFFF => {
+        0x10000..=0xFFFF_FFFF => {
             let v = value as u32; // Cast ok because of match.
-            res.push(0xFE);
-            res.extend_from_slice(&v.to_le_bytes());
+            res[0] = 0xFE;
+            res[1..5].copy_from_slice(&v.to_le_bytes());
         }
         _ => {
-            res.push(0xFF);
-            res.extend_from_slice(&value.to_le_bytes());
+            res[0] = 0xFF;
+            res[1..].copy_from_slice(&value.to_le_bytes());
         }
     }
-    res
+    CompactSizeSlice(res, encoded_size(value))
+}
+
+/// A type to hold the encoded value of a `CompactSize` integer value.
+pub struct CompactSizeSlice([u8; MAX_ENCODING_SIZE], usize);
+
+impl CompactSizeSlice {
+    /// Convert the encoded size value into a byte slice.
+    pub fn as_slice(&self) -> &[u8] {
+        &self.0[..self.1]
+    }
+}
+
+impl core::ops::Deref for CompactSizeSlice {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target { self.as_slice() }
 }
 
 /// Gets the compact size encoded value from `slice` and moves slice past the encoding.
@@ -88,16 +113,12 @@ pub fn encode(value: impl ToU64) -> ArrayVec<u8, MAX_ENCODING_SIZE> {
 /// * Panics in release mode if the `slice` does not contain a valid minimal compact size encoding.
 /// * Panics in debug mode if the encoding is not minimal (referred to as "non-canonical" in Core).
 pub fn decode_unchecked(slice: &mut &[u8]) -> u64 {
-    if slice.is_empty() {
-        panic!("tried to decode an empty slice");
-    }
+    assert!(!slice.is_empty(), "tried to decode an empty slice");
 
     match slice[0] {
         0xFF => {
             const SIZE: usize = 9;
-            if slice.len() < SIZE {
-                panic!("slice too short, expected at least 9 bytes");
-            };
+            assert!(slice.len() >= SIZE, "slice too short, expected at least 9 bytes");
 
             let mut bytes = [0_u8; SIZE - 1];
             bytes.copy_from_slice(&slice[1..SIZE]);
@@ -109,9 +130,7 @@ pub fn decode_unchecked(slice: &mut &[u8]) -> u64 {
         }
         0xFE => {
             const SIZE: usize = 5;
-            if slice.len() < SIZE {
-                panic!("slice too short, expected at least 5 bytes");
-            };
+            assert!(slice.len() >= SIZE, "slice too short, expected at least 5 bytes");
 
             let mut bytes = [0_u8; SIZE - 1];
             bytes.copy_from_slice(&slice[1..SIZE]);
@@ -123,9 +142,7 @@ pub fn decode_unchecked(slice: &mut &[u8]) -> u64 {
         }
         0xFD => {
             const SIZE: usize = 3;
-            if slice.len() < SIZE {
-                panic!("slice too short, expected at least 3 bytes");
-            };
+            assert!(slice.len() >= SIZE, "slice too short, expected at least 3 bytes");
 
             let mut bytes = [0_u8; SIZE - 1];
             bytes.copy_from_slice(&slice[1..SIZE]);
@@ -150,7 +167,7 @@ mod tests {
     fn encoded_value_1_byte() {
         // Check lower bound, upper bound (and implicitly endian-ness).
         for v in [0x00, 0x01, 0x02, 0xFA, 0xFB, 0xFC] {
-            let v = v as u32;
+            let v = v as usize;
             assert_eq!(encoded_size(v), 1);
             // Should be encoded as the value as a u8.
             let want = [v as u8];
@@ -177,7 +194,7 @@ mod tests {
             $(
                 #[test]
                 fn $test_name() {
-                    let value = $value as u64; // Because default integer type is i32.
+                    let value = $value as usize; // Because default integer type is i32.
                     let got = encode(value);
                     assert_eq!(got.as_slice().len(), $size); // sanity check
                     assert_eq!(got.as_slice(), &$want);
@@ -195,6 +212,11 @@ mod tests {
         encoded_value_5_byte_lower_bound, 5, 0x0001_0000, [0xFE, 0x00, 0x00, 0x01, 0x00];
         encoded_value_5_byte_endianness, 5, 0x0123_4567, [0xFE, 0x67, 0x45, 0x23, 0x01];
         encoded_value_5_byte_upper_bound, 5, 0xFFFF_FFFF, [0xFE, 0xFF, 0xFF, 0xFF, 0xFF];
+    }
+
+    // Only test on platforms with a usize that is 64 bits
+    #[cfg(target_pointer_width = "64")]
+    check_encode! {
         // 9 byte encoding.
         encoded_value_9_byte_lower_bound, 9, 0x0000_0001_0000_0000, [0xFF, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00];
         encoded_value_9_byte_endianness, 9, 0x0123_4567_89AB_CDEF, [0xFF, 0xEF, 0xCD, 0xAB, 0x89, 0x67, 0x45, 0x23, 0x01];
@@ -239,14 +261,14 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "tried to decode an empty slice")]
     fn decode_from_empty_slice_panics() {
         let mut slice = [].as_slice();
         let _ = decode_unchecked(&mut slice);
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "slice too short, expected at least 5 bytes")]
     // Non-minimal is referred to as non-canonical in Core (`bitcoin/src/serialize.h`).
     fn decode_non_minimal_panics() {
         let mut slice = [0xFE, 0xCD, 0xAB].as_slice();

--- a/consensus_encoding/src/encode/encoders.rs
+++ b/consensus_encoding/src/encode/encoders.rs
@@ -12,9 +12,9 @@
 //!
 
 use internals::array_vec::ArrayVec;
-use internals::compact_size;
 
 use super::{Encodable, Encoder};
+use crate::compact_size;
 
 /// The maximum length of a compact size encoding.
 const SIZE: usize = 9;
@@ -227,14 +227,11 @@ pub struct CompactSizeEncoder {
 impl CompactSizeEncoder {
     /// Constructs a new `CompactSizeEncoder`.
     ///
-    /// Encodings are defined only for the range of u64. On systems where usize is
-    /// larger than u64, it will be possible to call this method with out-of-range
-    /// values. In such cases we will ignore the passed value and encode [`u64::MAX`].
-    /// But even on such exotic systems, we expect users to pass the length of an
-    /// in-memory object, meaning that such large values are impossible to obtain.
+    /// Encodings are defined only for the range of u64. Outside of this range, the
+    /// passed value is ignored, and [`u64::MAX`] encoded instead. See
+    /// [`compact_size::encode`] for more information.
     pub fn new(value: usize) -> Self {
-        let enc_value = value.try_into().unwrap_or(u64::MAX);
-        Self { buf: Some(compact_size::encode(enc_value)) }
+        Self { buf: Some(ArrayVec::from_slice(compact_size::encode(value).as_slice())) }
     }
 }
 

--- a/consensus_encoding/src/lib.rs
+++ b/consensus_encoding/src/lib.rs
@@ -17,6 +17,7 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+pub mod compact_size;
 mod decode;
 mod encode;
 

--- a/internals/src/lib.rs
+++ b/internals/src/lib.rs
@@ -42,7 +42,6 @@ pub mod _export {
 
 pub mod array;
 pub mod array_vec;
-pub mod compact_size;
 pub mod const_tools;
 pub mod error;
 pub mod macros;

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -21,12 +21,10 @@ use encoding::{ArrayEncoder, BytesEncoder, Encodable, Encoder2, UnexpectedEofErr
 #[cfg(feature = "alloc")]
 use encoding::{
     CompactSizeEncoder, Decodable, Decoder, Decoder2, Decoder3, Encoder, Encoder3, Encoder6,
-    SliceEncoder, VecDecoder, VecDecoderError,
+    SliceEncoder, VecDecoder, VecDecoderError, compact_size,
 };
 #[cfg(feature = "alloc")]
 use hashes::sha256d;
-#[cfg(feature = "alloc")]
-use internals::compact_size;
 use internals::array::ArrayExt as _;
 use internals::write_err;
 #[cfg(feature = "serde")]

--- a/primitives/src/witness.rs
+++ b/primitives/src/witness.rs
@@ -14,13 +14,13 @@ use arbitrary::{Arbitrary, Unstructured};
 use encoding::Decoder4;
 use encoding::{
     self, BytesEncoder, CompactSizeDecoder, CompactSizeDecoderError, CompactSizeEncoder, Decoder,
-    Encodable, Encoder, Encoder2, LengthPrefixExceedsMaxError,
+    Encodable, Encoder, Encoder2, LengthPrefixExceedsMaxError, compact_size,
 };
 #[cfg(feature = "hex")]
 use hex::DecodeVariableLengthBytesError;
 use internals::slice::SliceExt;
 use internals::wrap_debug::WrapDebug;
-use internals::{compact_size, write_err};
+use internals::write_err;
 
 use crate::prelude::{Box, Vec};
 #[cfg(doc)]


### PR DESCRIPTION
The compact_size module in internals provides various utilities for encoding and decoding numbers to/from their compact size encoding. With the advent of the consensus_encoding crate, this logic now better fits in the new crate.

Move the internals::compact_size module to the consensus_encoding crate, and fix linter errors caused by the more pedantic rules in consensus_encoding.

Closes #4831 