### PR TITLE
Backport hex-conservative upgrade to 0.32.x in order to fix minimal versions bug

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -164,9 +164,9 @@ checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
 
 [[package]]
 name = "hex-conservative"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1aa273bf451e37ed35ced41c71a5e2a4e29064afb104158f2514bcd71c2c986"
+checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
 dependencies = [
  "arrayvec",
 ]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -163,9 +163,9 @@ checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
 
 [[package]]
 name = "hex-conservative"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1aa273bf451e37ed35ced41c71a5e2a4e29064afb104158f2514bcd71c2c986"
+checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
 dependencies = [
  "arrayvec",
 ]

--- a/base58/Cargo.toml
+++ b/base58/Cargo.toml
@@ -25,7 +25,7 @@ hashes = { package = "bitcoin_hashes", version = "0.14.0", default-features = fa
 internals = { package = "bitcoin-internals", version = "0.3.0", features = ["alloc"] }
 
 [dev-dependencies]
-hex = { package = "hex-conservative", version = "0.2.0", default-features = false, features = ["alloc"] }
+hex = { package = "hex-conservative", version = "0.2.2", default-features = false, features = ["alloc"] }
 
 [lints.rust]
 unexpected_cfgs = { level = "deny", check-cfg = ['cfg(bench)', 'cfg(fuzzing)', 'cfg(kani)' ] }

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -31,7 +31,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 base58 = { package = "base58ck", version = "0.1.0", default-features = false }
 bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
 hashes = { package = "bitcoin_hashes", version = "0.14.0", default-features = false, features = ["alloc", "io"] }
-hex = { package = "hex-conservative", version = "0.2.0", default-features = false, features = ["alloc"] }
+hex = { package = "hex-conservative", version = "0.2.2", default-features = false, features = ["alloc"] }
 hex_lit = "0.1.1"
 internals = { package = "bitcoin-internals", version = "0.3.0", features = ["alloc"] }
 io = { package = "bitcoin-io", version = "0.1.1", default-features = false, features = ["alloc"] }

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -27,7 +27,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-hex = { package = "hex-conservative", version = "0.2.0", default-features = false }
+hex = { package = "hex-conservative", version = "0.2.2", default-features = false }
 
 bitcoin-io = { version = "0.1.1", default-features = false, optional = true }
 schemars = { version = "0.8.3", default-features = false, optional = true }


### PR DESCRIPTION
Backporting hex-conservative point version bump to the `0.32.x` branch to fix the minimal version issue iron'd out in https://github.com/rust-bitcoin/hex-conservative/pull/86.

Closes #5314 