### PR TITLE
docs: fix copy-paste errors in comments

### DIFF
--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -32,7 +32,7 @@ const VERSION_BYTES_TESTNETS_PRIVATE: [u8; 4] = [0x04, 0x35, 0x83, 0x94];
 #[deprecated(since = "0.31.0", note = "use `Xpub` instead")]
 pub type ExtendedPubKey = Xpub;
 
-/// The old name for xpriv, extended public key.
+/// The old name for xpriv, extended private key.
 #[deprecated(since = "0.31.0", note = "use `Xpriv` instead")]
 pub type ExtendedPrivKey = Xpriv;
 

--- a/units/src/block.rs
+++ b/units/src/block.rs
@@ -350,7 +350,7 @@ impl From<absolute::MedianTimePast> for BlockMtp {
 impl TryFrom<BlockMtp> for absolute::MedianTimePast {
     type Error = absolute::ConversionError;
 
-    /// Converts a [`BlockHeight`] to a [`locktime::absolute::Height`].
+    /// Converts a [`BlockMtp`] to a [`locktime::absolute::MedianTimePast`].
     ///
     /// An absolute locktime MTP has a minimum value of [`absolute::LOCK_TIME_THRESHOLD`],
     /// while [`BlockMtp`] may take the full range of `u32`.


### PR DESCRIPTION
Found two places where doc comments were copied but not updated:

1. bip32.rs: ExtendedPrivKey was documented as "extended public key" instead of "extended private key"
2. block.rs: TryFrom<BlockMtp> comment mentioned BlockHeight/Height instead of BlockMtp/MedianTimePast
