### PR TITLE
docs(crates): add consensus_encoding and crypto to current crates

### DIFF
--- a/docs/crates.md
+++ b/docs/crates.md
@@ -12,6 +12,8 @@ entry in [roadmap.md] and likely also a file of their own.
 - `base58`: Bitcoin base58 encoding and decoding (for pre-segwit addresses).
 - `bitcoin`: The `rust-bitcoin` crate.
 - `chacha20_poly1305`: ChaCha20 stream cipher with the Poly1305 MAC.
+- `consensus_encoding`: Consensus encoding and decoding.
+- `crypto`: Cryptography support for the rust-bitcoin ecosystem.
 - `hashes`: Rust Bitcoin hashes library.
 - `internals`: Used internally by crates in this repo.
 - `io`: Rust Bitcoin I/O library (to support `no_std`).


### PR DESCRIPTION
Hi, i've added `consensus_encoding` and `crypto` crates to relevant documentation, I noticed that these were absent in docs, so I thought maybe it's gonna be a bit useful to add