### PR TITLE
units: Replace manual ceil division with div_ceil

### DIFF
--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -466,11 +466,9 @@ impl Amount {
         // Mul by 1,000 because we use per/kwu.
         if let Some(sats) = self.to_sat().checked_mul(1_000) {
             // No need to use checked arithmetic because wu is non-zero.
-            if let Some(bump) = sats.checked_add(wu - 1) {
-                let fee_rate = bump / wu;
-                if let Ok(amount) = Self::from_sat(fee_rate) {
-                    return FeeRate::from_per_kwu(amount);
-                }
+            let fee_rate = sats.div_ceil(wu);
+            if let Ok(amount) = Self::from_sat(fee_rate) {
+                return FeeRate::from_per_kwu(amount);
             }
         }
         // Use `MathOp::Mul` because `Div` implies div by zero.
@@ -505,14 +503,7 @@ impl Amount {
 
         debug_assert!(Self::MAX.to_sat().checked_mul(1_000).is_some());
         let msats = self.to_sat() * 1_000;
-        match msats.checked_add(rate - 1) {
-            Some(bump) => {
-                let wu = bump / rate;
-                NumOpResult::Valid(Weight::from_wu(wu))
-            }
-            // Use `MathOp::Add` because `Div` implies div by zero.
-            None => R::Error(E::while_doing(MathOp::Add)),
-        }
+        NumOpResult::Valid(Weight::from_wu(msats.div_ceil(rate)))
     }
 }
 

--- a/units/src/fee_rate/mod.rs
+++ b/units/src/fee_rate/mod.rs
@@ -210,12 +210,9 @@ impl FeeRate {
     pub const fn mul_by_weight(self, weight: Weight) -> NumOpResult<Amount> {
         let wu = weight.to_wu();
         if let Some(fee_kwu) = self.to_sat_per_kwu_floor().checked_mul(wu) {
-            // Bump by 999 to do ceil division using kwu.
-            if let Some(bump) = fee_kwu.checked_add(999) {
-                let fee = bump / 1_000;
-                if let Ok(fee_amount) = Amount::from_sat(fee) {
-                    return NumOpResult::Valid(fee_amount);
-                }
+            let fee = fee_kwu.div_ceil(1_000);
+            if let Ok(fee_amount) = Amount::from_sat(fee) {
+                return NumOpResult::Valid(fee_amount);
             }
         }
         NumOpResult::Error(E::while_doing(MathOp::Mul))


### PR DESCRIPTION
Since the bump to MSRV 1.74, we now have access to div_ceil for ceiled division of integer types. There are various places in units that we manually implement ceiling division that can now be replaced by calls to div_ceil.

Convert div_by_weight_ceil, div_by_fee_rate_ceil and mul_by_weight to use div_ceil in place of manual ceiling division.

Contributes to #5330 