### PR TITLE
Release tracking PR: `consensus_encoding v1.0.0-rc.2`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -74,7 +74,7 @@ version = "0.0.0"
 
 [[package]]
 name = "bitcoin-consensus-encoding"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "bitcoin-internals",
 ]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -73,7 +73,7 @@ version = "0.0.0"
 
 [[package]]
 name = "bitcoin-consensus-encoding"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "bitcoin-internals",
 ]

--- a/consensus_encoding/Cargo.toml
+++ b/consensus_encoding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-consensus-encoding"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>", "Nick Johnson <nick@yonson.dev>", "Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -23,7 +23,7 @@ small-hash = []
 
 [dependencies]
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.4.1" }
-encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0-rc.1", default-features = false }
+encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0-rc.2", default-features = false }
 
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false, optional = true }
 serde = { version = "1.0.195", default-features = false, optional = true }

--- a/io/Cargo.toml
+++ b/io/Cargo.toml
@@ -20,7 +20,7 @@ alloc = ["hashes?/alloc", "internals/alloc"]
 
 [dependencies]
 internals = { package = "bitcoin-internals", path = "../internals" }
-encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0-rc.1", default-features = false }
+encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0-rc.2", default-features = false }
 
 hashes = { package = "bitcoin_hashes", path = "../hashes", default-features = false, optional = true }
 

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -18,7 +18,7 @@ std = ["alloc", "internals/std", "encoding?/std"]
 alloc = ["internals/alloc", "serde?/alloc", "encoding?/alloc"]
 
 [dependencies]
-encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0-rc.1", default-features = false, optional = true }
+encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0-rc.2", default-features = false, optional = true }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.4.1" }
 
 serde = { version = "1.0.195", default-features = false, features = ["derive"], optional = true }


### PR DESCRIPTION
Do another RC release, no changelog additions required IMO.

Includes:

- Added `reserve` method
- Used `Self` instead of `Foo`
- Made a few constructors const
- Removed `hashes` dep

Bump the version, update to use this RC version in crates that depend on `encoding`, and update the lock files.