### PR TITLE
Introduce wrapper type for secp256k1::Keypair

### DIFF
--- a/bitcoin/examples/sign-tx-taproot.rs
+++ b/bitcoin/examples/sign-tx-taproot.rs
@@ -19,7 +19,7 @@ const CHANGE_AMOUNT: Amount = Amount::from_sat_u32(14_999_000); // 1000 sat fee.
 fn main() {
     // Get a keypair we control. In a real application these would come from a stored secret.
     let keypair = senders_keys();
-    let (internal_key, _parity) = keypair.x_only_public_key();
+    let (internal_key, _parity) = keypair.to_x_only_public_key();
 
     // Get an unspent output that is locked to the key above that we control.
     // In a real application these would come from the chain.
@@ -67,7 +67,7 @@ fn main() {
 
     // Sign the sighash using the secp256k1 library (exported by rust-bitcoin).
     let tweaked: TweakedKeypair = keypair.tap_tweak(None);
-    let signature = secp256k1::schnorr::sign(&sighash.to_byte_array(), tweaked.as_keypair());
+    let signature = secp256k1::schnorr::sign(&sighash.to_byte_array(), &tweaked.as_keypair().to_inner());
 
     // Update the witness stack.
     let signature = bitcoin::taproot::Signature { signature, sighash_type };

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -743,8 +743,7 @@ impl Xpriv {
     /// Constructs a new BIP-0340 keypair for Schnorr signatures and Taproot use matching the internal
     /// secret key representation.
     pub fn to_keypair(self) -> Keypair {
-        Keypair::from_seckey_byte_array(self.private_key.to_secret_bytes())
-            .expect("BIP-0032 internal private key representation is broken")
+        Keypair::from_secret_key(&self.private_key)
     }
 
     /// Derives an extended private key from a path.

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -178,7 +178,7 @@ pub use crate::{
     address::{Address, AddressType, KnownHrp},
     bip32::XKeyIdentifier,
     crypto::ecdsa,
-    crypto::key::{self, CompressedPublicKey, PrivateKey, PublicKey, XOnlyPublicKey},
+    crypto::key::{self, CompressedPublicKey, Keypair, PrivateKey, PublicKey, XOnlyPublicKey},
     crypto::sighash::{self, LegacySighash, SegwitV0Sighash, TapSighash, TapSighashTag},
     merkle_tree::MerkleBlock,
     network::params::{self, Params},

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -19,12 +19,12 @@ use core::{cmp, fmt};
 use std::collections::{HashMap, HashSet};
 
 use internals::write_err;
-use secp256k1::{Keypair, Message};
+use secp256k1::Message;
 
 use crate::bip32::{self, KeySource, Xpriv, Xpub};
 use crate::crypto::key::{PrivateKey, PublicKey};
 use crate::crypto::{ecdsa, taproot};
-use crate::key::{TapTweak, XOnlyPublicKey};
+use crate::key::{TapTweak, XOnlyPublicKey, Keypair};
 use crate::prelude::{btree_map, BTreeMap, BTreeSet, Borrow, Box, Vec};
 use crate::script::{ScriptExt as _, ScriptPubKeyExt as _};
 use crate::sighash::{self, EcdsaSighashType, Prevouts, SighashCache};
@@ -432,10 +432,10 @@ impl Psbt {
                         .to_keypair();
 
                     #[cfg(all(feature = "rand", feature = "std"))]
-                    let signature = secp256k1::schnorr::sign(&sighash.to_byte_array(), &key_pair);
+                    let signature = secp256k1::schnorr::sign(&sighash.to_byte_array(), &key_pair.to_inner());
                     #[cfg(not(all(feature = "rand", feature = "std")))]
                     let signature =
-                        secp256k1::schnorr::sign_no_aux_rand(&sighash.to_byte_array(), &key_pair);
+                        secp256k1::schnorr::sign_no_aux_rand(&sighash.to_byte_array(), &key_pair.to_inner());
 
                     let signature = taproot::Signature { signature, sighash_type };
                     input.tap_key_sig = Some(signature);
@@ -461,11 +461,11 @@ impl Psbt {
 
                         #[cfg(all(feature = "rand", feature = "std"))]
                         let signature =
-                            secp256k1::schnorr::sign(&sighash.to_byte_array(), &key_pair);
+                            secp256k1::schnorr::sign(&sighash.to_byte_array(), &key_pair.to_inner());
                         #[cfg(not(all(feature = "rand", feature = "std")))]
                         let signature = secp256k1::schnorr::sign_no_aux_rand(
                             &sighash.to_byte_array(),
-                            &key_pair,
+                            &key_pair.to_inner(),
                         );
 
                         let signature = taproot::Signature { signature, sighash_type };


### PR DESCRIPTION
In order to solve the issue of imprecise types for from_str in XOnlyPublicKey, a wrapper type was implemented, alongside a corresponding narrow error type. This solution provided a cleaner interface for such keys, in place of directly working with secp256k1::XOnlyPublicKey types.

Add a wrapper type for secp256k1::Keypair to tighten the error type for from_str and add_xonly_tweak on Keypair.

Closes #4407