### PR TITLE
Use usize for CompactSizeEncoder::new

### DIFF
--- a/api/consensus_encoding/all-features.txt
+++ b/api/consensus_encoding/all-features.txt
@@ -326,7 +326,7 @@ pub fn bitcoin_consensus_encoding::CompactSizeDecoderError::eq(&self, other: &bi
 pub fn bitcoin_consensus_encoding::CompactSizeDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_consensus_encoding::CompactSizeEncoder::advance(&mut self) -> bool
 pub fn bitcoin_consensus_encoding::CompactSizeEncoder::current_chunk(&self) -> &[u8]
-pub fn bitcoin_consensus_encoding::CompactSizeEncoder::new(value: impl bitcoin_internals::ToU64) -> Self
+pub fn bitcoin_consensus_encoding::CompactSizeEncoder::new(value: usize) -> Self
 pub fn bitcoin_consensus_encoding::Decodable::decoder() -> Self::Decoder
 pub fn bitcoin_consensus_encoding::Decoder2<A, B>::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_consensus_encoding::Decoder2<A, B>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bool, Self::Error>

--- a/api/consensus_encoding/alloc-only.txt
+++ b/api/consensus_encoding/alloc-only.txt
@@ -303,7 +303,7 @@ pub fn bitcoin_consensus_encoding::CompactSizeDecoderError::eq(&self, other: &bi
 pub fn bitcoin_consensus_encoding::CompactSizeDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_consensus_encoding::CompactSizeEncoder::advance(&mut self) -> bool
 pub fn bitcoin_consensus_encoding::CompactSizeEncoder::current_chunk(&self) -> &[u8]
-pub fn bitcoin_consensus_encoding::CompactSizeEncoder::new(value: impl bitcoin_internals::ToU64) -> Self
+pub fn bitcoin_consensus_encoding::CompactSizeEncoder::new(value: usize) -> Self
 pub fn bitcoin_consensus_encoding::Decodable::decoder() -> Self::Decoder
 pub fn bitcoin_consensus_encoding::Decoder2<A, B>::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_consensus_encoding::Decoder2<A, B>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bool, Self::Error>

--- a/api/consensus_encoding/no-features.txt
+++ b/api/consensus_encoding/no-features.txt
@@ -237,7 +237,7 @@ pub fn bitcoin_consensus_encoding::CompactSizeDecoderError::eq(&self, other: &bi
 pub fn bitcoin_consensus_encoding::CompactSizeDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_consensus_encoding::CompactSizeEncoder::advance(&mut self) -> bool
 pub fn bitcoin_consensus_encoding::CompactSizeEncoder::current_chunk(&self) -> &[u8]
-pub fn bitcoin_consensus_encoding::CompactSizeEncoder::new(value: impl bitcoin_internals::ToU64) -> Self
+pub fn bitcoin_consensus_encoding::CompactSizeEncoder::new(value: usize) -> Self
 pub fn bitcoin_consensus_encoding::Decodable::decoder() -> Self::Decoder
 pub fn bitcoin_consensus_encoding::Decoder2<A, B>::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_consensus_encoding::Decoder2<A, B>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bool, Self::Error>

--- a/consensus_encoding/tests/encode.rs
+++ b/consensus_encoding/tests/encode.rs
@@ -153,19 +153,19 @@ fn encode_slice_encoder_mixed_empty_and_data() {
 #[test]
 fn encode_compact_size_boundary_values() {
     // Test CompactSizeEncoder with boundary values.
-    let mut encoder = CompactSizeEncoder::new(252u32);
+    let mut encoder = CompactSizeEncoder::new(252usize);
     assert_eq!(encoder.current_chunk(), &[252]);
     assert!(!encoder.advance());
 
-    let mut encoder = CompactSizeEncoder::new(253u32);
+    let mut encoder = CompactSizeEncoder::new(253usize);
     assert_eq!(encoder.current_chunk(), &[0xFD, 253, 0]);
     assert!(!encoder.advance());
 
-    let mut encoder = CompactSizeEncoder::new(0x10000u32);
+    let mut encoder = CompactSizeEncoder::new(0x10000usize);
     assert_eq!(encoder.current_chunk(), &[0xFE, 0, 0, 1, 0]);
     assert!(!encoder.advance());
 
-    let mut encoder = CompactSizeEncoder::new(0u32);
+    let mut encoder = CompactSizeEncoder::new(0usize);
     assert_eq!(encoder.current_chunk(), &[0]);
     assert!(!encoder.advance());
 }

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -330,11 +330,11 @@ impl Encodable for Transaction {
     fn encoder(&self) -> Self::Encoder<'_> {
         let version = self.version.encoder();
         let inputs = Encoder2::new(
-            CompactSizeEncoder::new(self.inputs.len() as u64),
+            CompactSizeEncoder::new(self.inputs.len()),
             SliceEncoder::without_length_prefix(self.inputs.as_ref()),
         );
         let outputs = Encoder2::new(
-            CompactSizeEncoder::new(self.outputs.len() as u64),
+            CompactSizeEncoder::new(self.outputs.len()),
             SliceEncoder::without_length_prefix(self.outputs.as_ref()),
         );
         let lock_time = self.lock_time.encoder();


### PR DESCRIPTION
The current CompactSizeEncoder::new() constructor uses an impl ToU64 for its first parameter. The ToU64 trait is part of internals, and thus isn't permitted to be part of the public API of consensus_encoding.

Change the ToU64 parameter type to usize, encoding values outside of the u64 range (such as on 128 bit system) as u64::MAX.

Closes #5343