### PR TITLE
docs(hashes): replace deprecated GeneralHash references

### DIFF
--- a/hashes/src/internal_macros.rs
+++ b/hashes/src/internal_macros.rs
@@ -15,7 +15,7 @@
 ///
 /// Restrictions on usage:
 ///
-/// * The hash type must implement the `GeneralHash` trait.
+/// * The `Hash` type in scope must provide `from_byte_array`, `to_byte_array`, and `as_byte_array` (e.g., via `hash_type_no_default!`).
 macro_rules! hash_trait_impls {
     ($bits:expr, $reverse:expr $(, $gen:ident: $gent:ident)*) => {
         $crate::impl_bytelike_traits!(Hash, { $bits / 8 } $(, $gen: $gent)*);
@@ -55,7 +55,7 @@ pub(crate) use hash_trait_impls;
 ///
 /// Restrictions on usage:
 ///
-/// * The hash type must implement the `GeneralHash` trait.
+/// * Requires a `HashEngine` type in this module implementing `Default` and `crate::HashEngine<Hash = Hash, Bytes = [u8; $bits / 8]>`.
 macro_rules! general_hash_type {
     ($bits:expr, $reverse:expr, $doc:literal) => {
         /// Hashes some bytes.

--- a/hashes/tests/api.rs
+++ b/hashes/tests/api.rs
@@ -201,7 +201,7 @@ fn api_all_non_error_types_have_non_empty_debug() {
     let t = Hashes::<Sha256>::new_sha256();
     check_debug!(t; a, c, d, e, f, g, h, i, j, k, l);
 
-    // This tests `Debug` on `Hkdf` but not for all `T: GeneralHash`.
+    // This tests `Debug` on `Hkdf` but not for all `HashEngine` types.
     let t = Hkdf::<sha256::HashEngine>::new(&[], &[]);
     let debug = format!("{:?}", t);
     assert!(!debug.is_empty());


### PR DESCRIPTION
The GeneralHash trait was removed (hashes/CHANGELOG.md #4085), but internal_macros.rs still referenced it in docs. Updated hash_trait_impls! and general_hash_type! documentation to reflect actual current requirements