### PR TITLE
Release tracking PR: `bitcoin-io v0.3.0`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-io"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bitcoin-consensus-encoding",
  "bitcoin-internals",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-io"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bitcoin-consensus-encoding",
  "bitcoin-internals",

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -30,7 +30,7 @@ bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.18.0", default-features = false, features = ["alloc", "hex"] }
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false, features = ["alloc"] }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.4.1", features = ["alloc", "hex"] }
-io = { package = "bitcoin-io", path = "../io", version = "0.2.0", default-features = false, features = ["alloc", "hashes"] }
+io = { package = "bitcoin-io", path = "../io", version = "0.3.0", default-features = false, features = ["alloc", "hashes"] }
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "1.0.0-rc.0", default-features = false, features = ["alloc", "hex"] }
 secp256k1 = { version = "0.32.0-beta.2", default-features = false, features = ["alloc"] }
 units = { package = "bitcoin-units", path = "../units", version = "1.0.0-rc.2", default-features = false, features = ["alloc"] }

--- a/io/CHANGELOG.md
+++ b/io/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 0.3.0 - 2025-12-01
+
+* Bump MSRV to Rust `1.74` [#4926](https://github.com/rust-bitcoin/rust-bitcoin/pull/)
+* Make traits dyn compatible [#5249](https://github.com/rust-bitcoin/rust-bitcoin/pull/5249)
+* Invert dependency between `io` and `hashes` [#3961](https://github.com/rust-bitcoin/rust-bitcoin/pull/3961)
+* Introduce `encode_to_writer` for `Write` trait [#5214](https://github.com/rust-bitcoin/rust-bitcoin/pull/5214)
+* Add consensus decoding functions [#5212](https://github.com/rust-bitcoin/rust-bitcoin/pull/5212)
+* Remove assertion in `Cursor` when reading past end [#5062](https://github.com/rust-bitcoin/rust-bitcoin/pull/5062)
+* Enable features in internals crate [#4890](https://github.com/rust-bitcoin/rust-bitcoin/pull/4890)
+* Make `io::Error` `Sync` [#3920](https://github.com/rust-bitcoin/rust-bitcoin/pull/3920)
+* Use `get_ref` / `get_mut` API [#3855](https://github.com/rust-bitcoin/rust-bitcoin/pull/3855)
+
 # 0.2.0 - 2024-09-18
 
 * Add blanket impl of io traits for `&mut T` [#3188](https://github.com/rust-bitcoin/rust-bitcoin/pull/3188)

--- a/io/Cargo.toml
+++ b/io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-io"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Matt Corallo <birchneutea@mattcorallo.com>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin"

--- a/io/src/bridge.rs
+++ b/io/src/bridge.rs
@@ -35,12 +35,12 @@ impl<T> FromStd<T> {
 
     /// Returns a reference to the wrapped value.
     #[inline]
-    #[deprecated(since = "TBD", note = "use `get_ref()` instead")]
+    #[deprecated(since = "0.3.0", note = "use `get_ref()` instead")]
     pub fn inner(&self) -> &T { &self.0 }
 
     /// Returns a mutable reference to the wrapped value.
     #[inline]
-    #[deprecated(since = "TBD", note = "use `get_mut()` instead")]
+    #[deprecated(since = "0.3.0", note = "use `get_mut()` instead")]
     pub fn inner_mut(&mut self) -> &mut T { &mut self.0 }
 }
 

--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -276,7 +276,7 @@ impl<T: AsRef<[u8]>> Cursor<T> {
     ///
     /// This is the whole wrapped buffer, including the bytes already read.
     #[inline]
-    #[deprecated(since = "TBD", note = "use `get_ref()` instead")]
+    #[deprecated(since = "0.3.0", note = "use `get_ref()` instead")]
     pub fn inner(&self) -> &T { &self.inner }
 }
 


### PR DESCRIPTION
In preparation for release bump the version, add a changelog entry, and update the lockfiles.
    
Set the since field in deprecation attribute from TBD to `0.3.0`.