### PR TITLE
CI: Use correct MSRV toolchain

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -88,7 +88,7 @@ jobs:
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.63.0"
+          toolchain: "1.56.1"
       - name: "Set dependencies"
         run: cp Cargo-${{ matrix.dep }}.lock Cargo.lock
       - name: "Run test script"


### PR DESCRIPTION
In commit 2a40a35587 (PR #3418) I copied the `rust.yml` file from `master` and in doing so used the wrong MSRV toolchain.

Use the correct MSRV toolchain for this branch. This means that since October 2024 we have not been testing in CI with the advertised MSRV toolchain.

Fix: #5350