### PR TITLE
fix(psbt): reuse leaf_hashes in bip32_sign_schnorr

### DIFF
--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -452,17 +452,17 @@ impl Psbt {
             }
 
             // script path spend
-            if let Some((leaf_hashes, _)) = input.tap_key_origins.get(&xonly) {
-                let leaf_hashes = leaf_hashes
+            {
+                let pending_leaf_hashes = leaf_hashes
                     .iter()
                     .filter(|lh| !input.tap_script_sigs.contains_key(&(xonly, **lh)))
-                    .cloned()
+                    .copied()
                     .collect::<Vec<_>>();
 
-                if !leaf_hashes.is_empty() {
+                if !pending_leaf_hashes.is_empty() {
                     let key_pair = Keypair::from_secret_key(&sk.inner);
 
-                    for lh in leaf_hashes {
+                    for lh in pending_leaf_hashes {
                         let (sighash, sighash_type) =
                             self.sighash_taproot(input_index, cache, Some(lh))?;
 


### PR DESCRIPTION
Inside the loop that already `has for (&xonly, (leaf_hashes, key_source)) in input.tap_key_origins.iter()`, the code does `if let Some((leaf_hashes, _)) = input.tap_key_origins.get(&xonly) { ... leaf_hashes.iter().filter(...).cloned().collect::<Vec<_>>() }`
Why it’s a problem:
Re-reads the same map entry and clones leaf hashes even though leaf_hashes are already available from the loop variable.

Now first build an owned list of pending leaf hashes from the existing reference, then insert script-path signatures as before