### PR TITLE
io: Add version number to all dependencies

### DIFF
--- a/io/Cargo.toml
+++ b/io/Cargo.toml
@@ -19,13 +19,13 @@ std = ["alloc", "encoding/std", "hashes?/std", "internals/std"]
 alloc = ["encoding/alloc", "hashes?/alloc", "internals/alloc"]
 
 [dependencies]
-internals = { package = "bitcoin-internals", path = "../internals" }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.4.1" }
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0-rc.2", default-features = false }
 
-hashes = { package = "bitcoin_hashes", path = "../hashes", default-features = false, optional = true }
+hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.18.0", default-features = false, optional = true }
 
 [dev-dependencies]
-hashes = { package = "bitcoin_hashes", path = "../hashes", default-features = false, features = ["hex"] }
+hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.18.0", default-features = false, features = ["hex"] }
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Explicit version numbers are required to publish - face palm.

Fixes the recent attempted release of `io v0.3.0`.

`cargo publish -p bitcoin-io --dry-run` runs successfully with this applied.