### PR TITLE
Release tracking PR: `internals v0.4.2`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-internals"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "bincode",
  "hex-conservative 0.3.0",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-internals"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "bincode",
  "hex-conservative 0.3.0",

--- a/internals/CHANGELOG.md
+++ b/internals/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.4.2 - 2025-12-05
+
+- Remove `doc_auto_cfg`
+
+# 0.4.1 - 2024-10-18
+
+- Bump MSRV to Rust 1.74.0 [#4926](https://github.com/rust-bitcoin/rust-bitcoin/pull/4926)
+- Add `hex-conservative` dependency
+
 # 0.4.0 - 2024-09-18
 
 - Introduce `ToU64` trait [#2929](https://github.com/rust-bitcoin/rust-bitcoin/pull/2929)

--- a/internals/Cargo.toml
+++ b/internals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-internals"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>", "The Rust Bitcoin developers"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"

--- a/internals/src/lib.rs
+++ b/internals/src/lib.rs
@@ -6,8 +6,6 @@
 //! [rust-bitcoin](https://github.com/rust-bitcoin) ecosystem.
 
 #![no_std]
-// Experimental features we need.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // Coding conventions.
 #![warn(missing_docs)]
 #![warn(deprecated_in_future)]


### PR DESCRIPTION
Just fucking die already `doc_auto_cfg`.

Bump the version, add a changelog entry, and update the lock files.

Note 0.4.1 was released without a changelog so we add it here too.

Ran `cargo publish --dry-run  -p bitcoin-internals`

Close #5367