### PR TITLE
Simple move of `bip152` to `p2p`

### DIFF
--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -116,7 +116,6 @@ pub mod ext {
 }
 #[macro_use]
 pub mod address;
-pub mod bip152;
 pub mod bip158;
 pub mod bip32;
 pub mod blockdata;

--- a/fuzz/fuzz_targets/bitcoin/deserialize_prefilled_transaction.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_prefilled_transaction.rs
@@ -2,7 +2,7 @@ use honggfuzz::fuzz;
 
 fn do_test(data: &[u8]) {
     // We already fuzz Transactions in `./deserialize_transaction.rs`.
-    let tx_result: Result<bitcoin::bip152::PrefilledTransaction, _> =
+    let tx_result: Result<p2p::bip152::PrefilledTransaction, _> =
         bitcoin::consensus::encode::deserialize(data);
 
     match tx_result {

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -19,6 +19,7 @@ mod network_ext;
 
 #[cfg(feature = "std")]
 pub mod address;
+pub mod bip152;
 #[cfg(feature = "std")]
 pub mod message;
 pub mod message_blockdata;

--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -956,7 +956,6 @@ mod test {
     use alloc::vec;
     use std::net::Ipv4Addr;
 
-    use bitcoin::bip152::BlockTransactionsRequest;
     use bitcoin::bip158::{FilterHash, FilterHeader};
     use bitcoin::block::{Block, BlockHash};
     use bitcoin::consensus::encode::{deserialize, deserialize_partial, serialize};
@@ -966,6 +965,7 @@ mod test {
 
     use super::*;
     use crate::address::AddrV2;
+    use crate::bip152::BlockTransactionsRequest;
     use crate::message_blockdata::{GetBlocksMessage, GetHeadersMessage, Inventory};
     use crate::message_bloom::{BloomFlags, FilterAdd, FilterLoad};
     use crate::message_compact_blocks::{GetBlockTxn, SendCmpct};

--- a/p2p/src/message_compact_blocks.rs
+++ b/p2p/src/message_compact_blocks.rs
@@ -5,8 +5,8 @@
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
-use bitcoin::bip152;
 
+use crate::bip152;
 use crate::consensus::impl_consensus_encoding;
 
 /// sendcmpct message


### PR DESCRIPTION
Replaces #5333 and #5365 by manually implementing `hex` traits for the `ShortId` type. `FromStr` is omitted as I can't think of a logical use of that method in this context. To make any sense of a string short ID one needs the nonce and siphash keys.