### PR TITLE
units: add `too_many_lines` clippy whitelist to `parse_signed_to_satoshi`

### DIFF
--- a/units/src/amount/mod.rs
+++ b/units/src/amount/mod.rs
@@ -209,6 +209,7 @@ const INPUT_STRING_LEN_LIMIT: usize = 50;
 /// [`bool`] indicator for a negative amount.
 ///
 /// The `bool` is only needed to distinguish -0 from 0.
+#[allow(clippy::too_many_lines)]
 fn parse_signed_to_satoshi(
     mut s: &str,
     denom: Denomination,


### PR DESCRIPTION
After the format bot runs, this function (which is currently just below the max line threshold) tips over, meaning that our format PRs are not passing CI.

Possibly this function should be split up, but I don't think so. It's split up into a few logical sections which are isolated from each other but which wouldn't benefit from the even-further-separation that would happen if we added extra functions.

Anyway we can debate that in a separate issue if people want. For now we need the format job to pass CI, since it's a 700+ line diff already and growing every week.