### PR TITLE
hashes: silence new `unused-assignments` clippy lint

### DIFF
--- a/hashes/src/sha256/crypto.rs
+++ b/hashes/src/sha256/crypto.rs
@@ -608,6 +608,7 @@ impl HashEngine {
         round!(d, e, f, g, h, a, b, c, 0xa4506ceb, w[13], w[11], w[6], w[14]);
         round!(c, d, e, f, g, h, a, b, 0xbef9a3f7, w[14], w[12], w[7], w[15]);
         round!(b, c, d, e, f, g, h, a, 0xc67178f2, w[15], w[13], w[8], w[0]);
+        let _ = w[15]; // silence "unnecessary assignment" lint in macro
 
         self.h[0] = self.h[0].wrapping_add(a);
         self.h[1] = self.h[1].wrapping_add(b);

--- a/hashes/src/sha512/crypto.rs
+++ b/hashes/src/sha512/crypto.rs
@@ -174,6 +174,7 @@ impl HashEngine {
         round!(d, e, f, g, h, a, b, c, 0x597f299cfc657e2a, w[13], w[11], w[6], w[14]);
         round!(c, d, e, f, g, h, a, b, 0x5fcb6fab3ad6faec, w[14], w[12], w[7], w[15]);
         round!(b, c, d, e, f, g, h, a, 0x6c44198c4a475817, w[15], w[13], w[8], w[0]);
+        let _ = w[15]; // silence "unnecessary assignment" lint in macro
 
         self.h[0] = self.h[0].wrapping_add(a);
         self.h[1] = self.h[1].wrapping_add(b);


### PR DESCRIPTION
In our `round!` macro invocation for the implementation for sha256 and sha512 we do an assignment of a variable `$w` which is fed into the next round. On the last round, this assignment is unused, which makes clippy unhappy on recent nightlies.

Fix this so we can update our nightly compiler.