### PR TITLE
Release tracking PR: `internals v0.4.2`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-internals"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "bincode",
  "hex-conservative 0.3.0",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -99,7 +99,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-internals"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "bincode",
  "hex-conservative 0.3.0",

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -29,7 +29,7 @@ base58 = { package = "base58ck", path = "../base58", version = "0.2.0", default-
 bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.18.0", default-features = false, features = ["alloc", "hex"] }
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false, features = ["alloc"] }
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.4.1", features = ["alloc", "hex"] }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.4.2", features = ["alloc", "hex"] }
 io = { package = "bitcoin-io", path = "../io", version = "0.3.0", default-features = false, features = ["alloc", "hashes"] }
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "1.0.0-rc.0", default-features = false, features = ["alloc", "hex"] }
 secp256k1 = { version = "0.32.0-beta.2", default-features = false, features = ["alloc"] }

--- a/internals/CHANGELOG.md
+++ b/internals/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.2 - 2025-12-08
+
+- Move `impl_array_newtype` to internals [#5334](https://github.com/rust-bitcoin/rust-bitcoin/pull/5334)
+
 # 0.4.1 - 2024-10-18
 
 - Bump MSRV to Rust 1.74.0 [#4926](https://github.com/rust-bitcoin/rust-bitcoin/pull/4926)

--- a/internals/Cargo.toml
+++ b/internals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-internals"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>", "The Rust Bitcoin developers"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"


### PR DESCRIPTION
In preparation for releasing `bitcoin 0.33.0-rc.0` we need do a point release of `internals` because we move a macro out of `bitcoin` and over to `internals`. No other crate uses the macro so far so we only update the `bitcoin` dependency on `internals` leaving the other crates as they are.
 
Bump the version, add a changelog, update the lockfiles.

Successfully ran: `cargo publish --dry-run  -p bitcoin-internals`
