### PR TITLE
Create empty `bip158` crate

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -73,6 +73,10 @@ name = "bitcoin-addresses"
 version = "0.0.0"
 
 [[package]]
+name = "bitcoin-bip158"
+version = "0.0.0"
+
+[[package]]
 name = "bitcoin-consensus-encoding"
 version = "1.0.0-rc.2"
 dependencies = [

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -72,6 +72,10 @@ name = "bitcoin-addresses"
 version = "0.0.0"
 
 [[package]]
+name = "bitcoin-bip158"
+version = "0.0.0"
+
+[[package]]
 name = "bitcoin-consensus-encoding"
 version = "1.0.0-rc.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
 [workspace]
-members = ["addresses", "base58", "bitcoin", "chacha20_poly1305", "consensus_encoding", "crypto", "fuzz", "hashes", "internals", "io", "p2p", "primitives", "units"]
+members = ["addresses", "base58", "bip158", "bitcoin", "chacha20_poly1305", "consensus_encoding", "crypto", "fuzz", "hashes", "internals", "io", "p2p", "primitives", "units"]
 exclude = ["benches"]
 resolver = "2"

--- a/bip158/CHANGELOG.md
+++ b/bip158/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.1.0 - 2025-12-09
+
+* Initial release of the `github.com/rust-bitcoin/rust-bitcoin/bip158` crate as `bip158`.

--- a/bip158/Cargo.toml
+++ b/bip158/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "bitcoin-bip158"
+version = "0.0.0"
+authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
+license = "CC0-1.0"
+repository = "https://github.com/rust-bitcoin/rust-bitcoin"
+description = "Golomb-rice coded filters for set membership query."
+categories = ["cryptography::cryptocurrencies"]
+keywords = ["bitcoin", "peer-to-peer", "cryptography"]
+readme = "README.md"
+edition = "2021"
+rust-version = "1.74.0"
+exclude = ["tests", "contrib"]
+
+[dependencies]
+
+[dev-dependencies]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[lints.clippy]
+redundant_clone = "warn"
+use_self = "warn"

--- a/bip158/README.md
+++ b/bip158/README.md
@@ -1,0 +1,12 @@
+# BIP-158
+
+Implementation of [BIP-158](https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki) golomb coded block filters for private light client set membership query.
+
+## Minimum Supported Rust Version (MSRV)
+
+This library should always compile with any combination of features on **Rust 1.74.0**.
+
+## Licensing
+
+The code in this project is licensed under the [Creative Commons CC0 1.0 Universal license](LICENSE).
+We use the [SPDX license list](https://spdx.org/licenses/) and [SPDX IDs](https://spdx.dev/ids/).

--- a/bip158/contrib/extra_lints.sh
+++ b/bip158/contrib/extra_lints.sh
@@ -1,0 +1,4 @@
+# No shebang, this file should not be executed.
+# shellcheck disable=SC2148
+
+cargo clippy --all-targets --no-default-features --keep-going -- -D warnings

--- a/bip158/contrib/test_vars.sh
+++ b/bip158/contrib/test_vars.sh
@@ -1,0 +1,14 @@
+# No shebang, this file should not be executed.
+# shellcheck disable=SC2148
+#
+# disable verify unused vars, despite the fact that they are used when sourced
+# shellcheck disable=SC2034
+
+# Test all these features with "std" enabled.
+FEATURES_WITH_STD=""
+
+# Test all these features without "std" enabled.
+FEATURES_WITHOUT_STD=""
+
+# Run these examples.
+EXAMPLES=""

--- a/bip158/src/lib.rs
+++ b/bip158/src/lib.rs
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! # Rust Bitcoin BIP-158 implementation.
+
+// Experimental features we need.
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+// Coding conventions.
+#![warn(missing_docs)]
+#![warn(deprecated_in_future)]
+#![doc(test(attr(warn(unused))))]
+// Pedantic lints that we enforce.
+#![warn(clippy::return_self_not_must_use)]
+// Exclude lints we don't think are valuable.
+#![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
+#![allow(clippy::manual_range_contains)] // More readable than clippy's format.
+#![allow(clippy::uninlined_format_args)] // Allow `format!("{}", x)`instead of enforcing `format!("{x}")`


### PR DESCRIPTION
As part of discussion #5331, `bitcoin` and `p2p` should not depend on each other and should instead mutually depend on `primitives`, `hashes`, etc. BIP-158 is the last remaining dependency from `bitcoin` in `p2p`. It is not a peer-to-peer specification, but it is not an essential module of `bitcoin` either. IMO the best option for this module is to release it as a crate.

Blaming the module shows it hasn't changed architecturally in many years. A new crate would allow us to revisit some of the design choices. Particularly the heavy use of generics, dependency on `io` that could be replaced by `consensus_encoding`, and perhaps an opportunity to benchmark and improve performance.