### PR TITLE
Move `FilterHash`, `FilterHeader` to `p2p`

### DIFF
--- a/bitcoin/src/consensus/encode.rs
+++ b/bitcoin/src/consensus/encode.rs
@@ -684,7 +684,6 @@ mod tests {
     use core::mem::discriminant;
 
     use super::*;
-    use crate::bip158::FilterHash;
     use crate::block::BlockHash;
     use crate::merkle_tree::TxMerkleNode;
     use crate::prelude::{Cow, Vec};
@@ -1008,7 +1007,6 @@ mod tests {
 
         test_len_is_max_vec::<u8>();
         test_len_is_max_vec::<BlockHash>();
-        test_len_is_max_vec::<FilterHash>();
         test_len_is_max_vec::<TxMerkleNode>();
         test_len_is_max_vec::<Transaction>();
         test_len_is_max_vec::<TxOut>();

--- a/bitcoin/src/hash_types.rs
+++ b/bitcoin/src/hash_types.rs
@@ -5,8 +5,6 @@
 //! This module is deprecated. You can find hash types in their respective, hopefully obvious, modules.
 
 #[deprecated(since = "TBD", note = "use `crate::T` instead")]
-pub use crate::bip158::{FilterHash, FilterHeader};
-#[deprecated(since = "TBD", note = "use `crate::T` instead")]
 pub use crate::{BlockHash, TxMerkleNode, Txid, WitnessCommitment, WitnessMerkleNode, Wtxid};
 
 #[cfg(test)]
@@ -93,13 +91,5 @@ mod tests {
             "b472a266d0bd89c13706a4132ccfb16f7c3b9fcb",
         );
 
-        assert_eq!(
-            FilterHash::from_byte_array(DUMMY32).to_string(),
-            "56944c5d3f98413ef45cf54545538103cc9f298e0575820ad3591376e2e0f65d",
-        );
-        assert_eq!(
-            FilterHeader::from_byte_array(DUMMY32).to_string(),
-            "56944c5d3f98413ef45cf54545538103cc9f298e0575820ad3591376e2e0f65d",
-        );
     }
 }

--- a/bitcoin/src/internal_macros.rs
+++ b/bitcoin/src/internal_macros.rs
@@ -175,24 +175,6 @@ macro_rules! impl_array_newtype_stringify {
 pub(crate) use impl_array_newtype_stringify;
 
 #[rustfmt::skip]
-macro_rules! impl_hashencode {
-    ($hashtype:ident) => {
-        impl $crate::consensus::Encodable for $hashtype {
-            fn consensus_encode<W: $crate::io::Write + ?Sized>(&self, w: &mut W) -> core::result::Result<usize, $crate::io::Error> {
-                self.as_byte_array().consensus_encode(w)
-            }
-        }
-
-        impl $crate::consensus::Decodable for $hashtype {
-            fn consensus_decode<R: $crate::io::BufRead + ?Sized>(r: &mut R) -> core::result::Result<Self, $crate::consensus::encode::Error> {
-                Ok(Self::from_byte_array(<<$hashtype as $crate::hashes::Hash>::Bytes>::consensus_decode(r)?))
-            }
-        }
-    };
-}
-pub(crate) use impl_hashencode;
-
-#[rustfmt::skip]
 macro_rules! impl_asref_push_bytes {
     ($($hashtype:ident),*) => {
         $(

--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -1667,7 +1667,6 @@ mod test {
     use alloc::vec;
     use std::net::Ipv4Addr;
 
-    use bitcoin::bip158::{FilterHash, FilterHeader};
     use bitcoin::block::{Block, BlockHash};
     use bitcoin::consensus::encode::{deserialize, deserialize_partial, serialize};
     use bitcoin::transaction::{Transaction, Txid};
@@ -1681,7 +1680,7 @@ mod test {
     use crate::message_bloom::{BloomFlags, FilterAdd, FilterLoad};
     use crate::message_compact_blocks::{GetBlockTxn, SendCmpct};
     use crate::message_filter::{
-        CFCheckpt, CFHeaders, CFilter, GetCFCheckpt, GetCFHeaders, GetCFilters,
+        CFCheckpt, CFHeaders, CFilter, FilterHash, FilterHeader, GetCFCheckpt, GetCFHeaders, GetCFilters,
     };
     use crate::message_network::{Alert, Reject, RejectReason, VersionMessage};
     use crate::{ProtocolVersion, ServiceFlags};


### PR DESCRIPTION
These types are defined in [BIP-157](https://github.com/bitcoin/bips/blob/master/bip-0157.mediawiki#specification).

Defining these types within `p2p` is appropriate, as these are used for wire messages. By doing this move 1. no other crates would depend on `bip158` 2. we are adhering to the policy that a crate with a release that matches the BIP must implement only that BIP. As part of this move, a single test `assert` is removed, but this was testing a method that didn't make much sense in the first place. If a user wants to get a filter header, they should use the filter hash and previous filter header directly.

nyonson is there something I need to do for `(En/De)codable` or will we tackle that later?