### PR TITLE
Fix script::Builder::push_verify() following a push_int()

### DIFF
--- a/bitcoin/src/blockdata/script/builder.rs
+++ b/bitcoin/src/blockdata/script/builder.rs
@@ -43,7 +43,11 @@ impl<T> Builder<T> {
     /// # Errors
     ///
     /// Only errors if `data == i32::MIN` (CScriptNum cannot have value -2^31).
-    pub fn push_int(mut self, n: i32) -> Result<Self, Error> { self.0.push_int(n).map(|_| self) }
+    pub fn push_int(mut self, n: i32) -> Result<Self, Error> {
+        self.0.push_int(n)?;
+        self.1 = None;
+        Ok(self)
+    }
 
     /// Adds instructions to push an unchecked integer onto the stack.
     ///
@@ -62,6 +66,7 @@ impl<T> Builder<T> {
     /// Does not check whether `n` is in the range of [-2^31 +1...2^31 -1].
     pub fn push_int_unchecked(mut self, n: i64) -> Self {
         self.0.push_int_unchecked(n);
+        self.1 = None;
         self
     }
 
@@ -70,6 +75,7 @@ impl<T> Builder<T> {
     /// This uses the explicit encoding regardless of the availability of dedicated opcodes.
     pub(in crate::blockdata) fn push_int_non_minimal(mut self, data: i64) -> Self {
         self.0.push_int_non_minimal(data);
+        self.1 = None;
         self
     }
 

--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -352,6 +352,10 @@ fn script_builder_verify() {
     assert_eq!(trick_slice.to_hex_string_no_length_prefix(), "01ae69");
     let trick_slice2 = Builder::from(vec![0x01, 0xae]).push_verify().into_script();
     assert_eq!(trick_slice2.to_hex_string_no_length_prefix(), "01ae69");
+
+    let pushint_then_verify =
+        Builder::new().push_opcode(OP_EQUAL).push_int(5).unwrap().push_verify().into_script();
+    assert_eq!(pushint_then_verify.to_hex_string_no_length_prefix(), "875569");
 }
 
 #[test]


### PR DESCRIPTION
For example, prior to this fix, attempting to `push_verify()` on `OP_EQUAL OP_5` would pop the `OP_5` and replace it with the verify opcode, resulting in `OP_EQUAL OP_EQUALVERIFY` (instead of `OP_EQUAL OP_5 OP_VERIFY`).