### PR TITLE
docs: fix mismatch between docs and code

### DIFF
--- a/bitcoin/embedded/README.md
+++ b/bitcoin/embedded/README.md
@@ -16,8 +16,7 @@ source ./scripts/env.sh && cargo +nightly run --target thumbv7m-none-eabi
 Output should be something like:
 
 ```text
-heap size 524288
-secp buf size 66240
+heap size 262144
 Seed WIF: L1HKVVLHXiUhecWnwFYF6L3shkf1E12HUmuZTESvBXUdx3yqVP1D
 Address: bc1qpx9t9pzzl4qsydmhyt6ctrxxjd4ep549np9993
 ```


### PR DESCRIPTION
in bitcoin/embedded/src/main.rs

```rust
const HEAP_SIZE: usize = 1024 * 256; // 256 KB
```

but in Readme it was heap size 524288.
