### PR TITLE
Use roundtrip instead of rinsed

### DIFF
--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -1578,17 +1578,17 @@ mod tests {
         // Serialize with an unchecked address.
         let foo_unchecked = Foo { address: unchecked };
         let ser = serde_json::to_string(&foo_unchecked).expect("failed to serialize");
-        let rinsed: Foo<NetworkUnchecked> =
+        let roundtrip: Foo<NetworkUnchecked> =
             serde_json::from_str(&ser).expect("failed to deserialize");
-        assert_eq!(rinsed, foo_unchecked);
+        assert_eq!(roundtrip, foo_unchecked);
 
         // Serialize with a checked address.
         let foo_checked = Foo { address: unchecked.assume_checked() };
         let ser = serde_json::to_string(&foo_checked).expect("failed to serialize");
-        let rinsed: Foo<NetworkUnchecked> =
+        let roundtrip: Foo<NetworkUnchecked> =
             serde_json::from_str(&ser).expect("failed to deserialize");
-        assert_eq!(&rinsed.address, foo_checked.address.as_unchecked());
-        assert_eq!(rinsed, foo_unchecked);
+        assert_eq!(&roundtrip.address, foo_checked.address.as_unchecked());
+        assert_eq!(roundtrip, foo_unchecked);
     }
 
     #[test]

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -379,8 +379,8 @@ mod test {
         let got_ser = encode::serialize(&got_witness);
         assert_eq!(got_ser, want_ser);
 
-        let rinsed: Witness = encode::deserialize(&got_ser).unwrap();
-        assert_eq!(rinsed, want_witness)
+        let roundtrip: Witness = encode::deserialize(&got_ser).unwrap();
+        assert_eq!(roundtrip, want_witness)
     }
 
     #[test]

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -307,7 +307,7 @@ mod tests {
 
         let orig = DUMMY;
         let hex = format!("{}", orig);
-        let rinsed = hex.parse::<TestNewtype>().expect("failed to parse hex");
-        assert_eq!(rinsed, orig)
+        let roundtrip = hex.parse::<TestNewtype>().expect("failed to parse hex");
+        assert_eq!(roundtrip, orig)
     }
 }

--- a/hashes/src/sha256/tests.rs
+++ b/hashes/src/sha256/tests.rs
@@ -77,8 +77,8 @@ fn fmt_roundtrips() {
 
     let hash = sha256::Hash::hash(b"some arbitrary bytes");
     let hex = format!("{}", hash);
-    let rinsed = hex.parse::<sha256::Hash>().expect("failed to parse hex");
-    assert_eq!(rinsed, hash)
+    let roundtrip = hex.parse::<sha256::Hash>().expect("failed to parse hex");
+    assert_eq!(roundtrip, hash)
 }
 
 #[test]

--- a/hashes/src/sha256d/mod.rs
+++ b/hashes/src/sha256d/mod.rs
@@ -112,8 +112,8 @@ mod tests {
 
         let hash = sha256d::Hash::hash(b"some arbitrary bytes");
         let hex = format!("{}", hash);
-        let rinsed = hex.parse::<sha256d::Hash>().expect("failed to parse hex");
-        assert_eq!(rinsed, hash)
+        let roundtrip = hex.parse::<sha256d::Hash>().expect("failed to parse hex");
+        assert_eq!(roundtrip, hash)
     }
 
     #[test]

--- a/primitives/src/witness.rs
+++ b/primitives/src/witness.rs
@@ -1178,8 +1178,8 @@ mod test {
     fn serde_bincode_roundtrips() {
         let original = arbitrary_witness();
         let ser = bincode::serialize(&original).unwrap();
-        let rinsed: Witness = bincode::deserialize(&ser).unwrap();
-        assert_eq!(rinsed, original);
+        let roundtrip: Witness = bincode::deserialize(&ser).unwrap();
+        assert_eq!(roundtrip, original);
     }
 
     #[test]
@@ -1187,8 +1187,8 @@ mod test {
     fn serde_human_roundtrips() {
         let original = arbitrary_witness();
         let ser = serde_json::to_string(&original).unwrap();
-        let rinsed: Witness = serde_json::from_str(&ser).unwrap();
-        assert_eq!(rinsed, original);
+        let roundtrip: Witness = serde_json::from_str(&ser).unwrap();
+        assert_eq!(roundtrip, original);
     }
 
     #[test]

--- a/units/src/amount/serde.rs
+++ b/units/src/amount/serde.rs
@@ -370,8 +370,8 @@ mod tests {
         let want = "{\"amount\":100000000,\"signed_amount\":100000000}";
         assert_eq!(json, want);
 
-        let rinsed: HasAmount = serde_json::from_str(&json).expect("failed to deser");
-        assert_eq!(rinsed, orig);
+        let roundtrip: HasAmount = serde_json::from_str(&json).expect("failed to deser");
+        assert_eq!(roundtrip, orig);
     }
 
     #[test]
@@ -391,8 +391,8 @@ mod tests {
         let want = "{\"amount\":1.0,\"signed_amount\":1.0}";
         assert_eq!(json, want);
 
-        let rinsed: HasAmount = serde_json::from_str(&json).expect("failed to deser");
-        assert_eq!(rinsed, orig);
+        let roundtrip: HasAmount = serde_json::from_str(&json).expect("failed to deser");
+        assert_eq!(roundtrip, orig);
     }
 
     #[test]
@@ -412,7 +412,7 @@ mod tests {
         let want = "{\"amount\":\"1\",\"signed_amount\":\"1\"}";
         assert_eq!(json, want);
 
-        let rinsed: HasAmount = serde_json::from_str(&json).expect("failed to deser");
-        assert_eq!(rinsed, orig);
+        let roundtrip: HasAmount = serde_json::from_str(&json).expect("failed to deser");
+        assert_eq!(roundtrip, orig);
     }
 }


### PR DESCRIPTION
I never was really happy with the local variable `rinsed` but never came up with a better one. In #5386 Mitch introduced `roundtrip` instead, I like that better - use it everywhere.