### PR TITLE
Put feature gate below test attribute

### DIFF
--- a/consensus_encoding/src/decode/mod.rs
+++ b/consensus_encoding/src/decode/mod.rs
@@ -315,8 +315,8 @@ mod tests {
         assert_eq!(decoded.0, [1, 2, 3, 4]);
     }
 
-    #[cfg(feature = "std")]
     #[test]
+    #[cfg(feature = "std")]
     fn decode_from_read_extra_data() {
         let data = [1, 2, 3, 4, 5, 6];
         let mut cursor = Cursor::new(&data);
@@ -326,8 +326,8 @@ mod tests {
         assert_eq!(decoded.0, [1, 2, 3, 4]);
     }
 
-    #[cfg(feature = "std")]
     #[test]
+    #[cfg(feature = "std")]
     fn decode_from_read_success() {
         let data = [1, 2, 3, 4];
         let cursor = Cursor::new(&data);
@@ -337,8 +337,8 @@ mod tests {
         assert_eq!(decoded.0, [1, 2, 3, 4]);
     }
 
-    #[cfg(feature = "std")]
     #[test]
+    #[cfg(feature = "std")]
     fn decode_from_read_unexpected_eof() {
         let data = [1, 2, 3];
         let cursor = Cursor::new(&data);
@@ -346,8 +346,8 @@ mod tests {
         assert!(matches!(result, Err(ReadError::Decode(_))));
     }
 
-    #[cfg(feature = "std")]
     #[test]
+    #[cfg(feature = "std")]
     fn decode_from_read_trait_object() {
         let data = [1, 2, 3, 4];
         let mut cursor = Cursor::new(&data);
@@ -359,8 +359,8 @@ mod tests {
         assert_eq!(decoded.0, [1, 2, 3, 4]);
     }
 
-    #[cfg(feature = "std")]
     #[test]
+    #[cfg(feature = "std")]
     fn decode_from_read_by_reference() {
         let data = [1, 2, 3, 4];
         let mut cursor = Cursor::new(&data);
@@ -374,8 +374,8 @@ mod tests {
         let _ = cursor.read_to_end(&mut buf);
     }
 
-    #[cfg(feature = "std")]
     #[test]
+    #[cfg(feature = "std")]
     fn decode_from_read_unbuffered_success() {
         let data = [1, 2, 3, 4];
         let cursor = Cursor::new(&data);
@@ -385,8 +385,8 @@ mod tests {
         assert_eq!(decoded.0, [1, 2, 3, 4]);
     }
 
-    #[cfg(feature = "std")]
     #[test]
+    #[cfg(feature = "std")]
     fn decode_from_read_unbuffered_unexpected_eof() {
         let data = [1, 2, 3];
         let cursor = Cursor::new(&data);
@@ -394,8 +394,8 @@ mod tests {
         assert!(matches!(result, Err(ReadError::Decode(_))));
     }
 
-    #[cfg(feature = "std")]
     #[test]
+    #[cfg(feature = "std")]
     fn decode_from_read_unbuffered_empty() {
         let data = [];
         let cursor = Cursor::new(&data);
@@ -403,8 +403,8 @@ mod tests {
         assert!(matches!(result, Err(ReadError::Decode(_))));
     }
 
-    #[cfg(feature = "std")]
     #[test]
+    #[cfg(feature = "std")]
     fn decode_from_read_unbuffered_extra_data() {
         let data = [1, 2, 3, 4, 5, 6];
         let cursor = Cursor::new(&data);

--- a/consensus_encoding/tests/decode.rs
+++ b/consensus_encoding/tests/decode.rs
@@ -167,8 +167,8 @@ fn decode_compact_size_single_byte_read_limit() {
     assert_eq!(result, 66);
 }
 
-#[cfg(feature = "alloc")]
 #[test]
+#[cfg(feature = "alloc")]
 fn decode_cast_to_usize_boundary_conditions() {
     // Test the 4MB boundary and some edge cases.
     use bitcoin_consensus_encoding::cast_to_usize_if_valid;
@@ -179,8 +179,8 @@ fn decode_cast_to_usize_boundary_conditions() {
     assert_eq!(cast_to_usize_if_valid(0).unwrap(), 0);
 }
 
-#[cfg(feature = "alloc")]
 #[test]
+#[cfg(feature = "alloc")]
 fn decode_byte_vec_decoder_empty() {
     // Test decoding empty byte vector, with length prefix of 0.
     use bitcoin_consensus_encoding::{ByteVecDecoder, Decoder};
@@ -195,8 +195,8 @@ fn decode_byte_vec_decoder_empty() {
     assert!(result.is_empty());
 }
 
-#[cfg(feature = "alloc")]
 #[test]
+#[cfg(feature = "alloc")]
 fn decode_byte_vec_decoder_does_not_overconsume() {
     use bitcoin_consensus_encoding::ByteVecDecoder;
 

--- a/primitives/src/witness.rs
+++ b/primitives/src/witness.rs
@@ -1232,8 +1232,8 @@ mod test {
         assert!(witness4.is_empty());
     }
 
-    #[cfg(feature = "hex")]
     #[test]
+    #[cfg(feature = "hex")]
     fn test_from_hex() {
         let hex_strings = [
             "30440220703350f1c8be5b41b4cb03b3b680c4f3337f987514a6b08e16d5d9f81e9b5f72022018fb269ba5b82864c0e1edeaf788829eb332fe34a859cc1f99c4a02edfb5d0df01",
@@ -1311,8 +1311,8 @@ mod test {
         (witness, encoded)
     }
 
-    #[cfg(feature = "alloc")]
     #[test]
+    #[cfg(feature = "alloc")]
     fn decode_witness_one_single_call() {
         let (want, encoded) = witness_test_case();
 
@@ -1325,8 +1325,8 @@ mod test {
         assert_eq!(got, want);
     }
 
-    #[cfg(feature = "alloc")]
     #[test]
+    #[cfg(feature = "alloc")]
     #[allow(clippy::many_single_char_names)]
     fn decode_witness_many_calls() {
         let (want, encoded) = witness_test_case();
@@ -1354,8 +1354,8 @@ mod test {
         assert_eq!(got, want);
     }
 
-    #[cfg(feature = "alloc")]
     #[test]
+    #[cfg(feature = "alloc")]
     fn decode_max_length() {
         let mut encoded = Vec::new();
         encoded.extend_from_slice(compact_size::encode(1usize).as_slice());
@@ -1381,8 +1381,8 @@ mod test {
         ));
     }
 
-    #[cfg(feature = "alloc")]
     #[test]
+    #[cfg(feature = "alloc")]
     fn decode_empty_witness() {
         // Witness with 0 elements.
         let encoded = vec![0x00];
@@ -1396,8 +1396,8 @@ mod test {
         assert!(witness.is_empty());
     }
 
-    #[cfg(feature = "alloc")]
     #[test]
+    #[cfg(feature = "alloc")]
     fn decode_single_element() {
         // Witness with 1 element containing [0xAB, 0xCD].
         let encoded = vec![0x01, 0x02, 0xAB, 0xCD];
@@ -1411,8 +1411,8 @@ mod test {
         assert_eq!(&witness[0], &[0xABu8, 0xCD][..]);
     }
 
-    #[cfg(feature = "alloc")]
     #[test]
+    #[cfg(feature = "alloc")]
     fn decode_empty_element() {
         // Witness with 1 element that is empty (0 bytes).
         let encoded = vec![0x01, 0x00];
@@ -1426,8 +1426,8 @@ mod test {
         assert_eq!(&witness[0], &[] as &[u8]);
     }
 
-    #[cfg(feature = "alloc")]
     #[test]
+    #[cfg(feature = "alloc")]
     fn decode_multiple_empty_elements() {
         // Witness with 3 empty elements.
         let encoded = vec![0x03, 0x00, 0x00, 0x00];
@@ -1443,8 +1443,8 @@ mod test {
         assert_eq!(&witness[2], &[] as &[u8]);
     }
 
-    #[cfg(feature = "alloc")]
     #[test]
+    #[cfg(feature = "alloc")]
     fn decode_incomplete_witness_count() {
         // 3-byte compact size but only provide 2 bytes.
         let encoded = vec![0xFD, 0x03];
@@ -1457,8 +1457,8 @@ mod test {
         assert!(matches!(err, WitnessDecoderError(WitnessDecoderErrorInner::UnexpectedEof(_))));
     }
 
-    #[cfg(feature = "alloc")]
     #[test]
+    #[cfg(feature = "alloc")]
     fn decode_incomplete_element_length() {
         // Witness count = 1, but element length is incomplete.
         let encoded = vec![0x01, 0xFD, 0x05]; // Element length should be 3 bytes.
@@ -1471,8 +1471,8 @@ mod test {
         assert!(matches!(err, WitnessDecoderError(WitnessDecoderErrorInner::UnexpectedEof(_))));
     }
 
-    #[cfg(feature = "alloc")]
     #[test]
+    #[cfg(feature = "alloc")]
     fn decode_incomplete_element_data() {
         // Witness count = 1, element length = 5, but only 3 bytes of data provided.
         let encoded = vec![0x01, 0x05, 0xAA, 0xBB, 0xCC];
@@ -1485,8 +1485,8 @@ mod test {
         assert!(matches!(err, WitnessDecoderError(WitnessDecoderErrorInner::UnexpectedEof(_))));
     }
 
-    #[cfg(feature = "alloc")]
     #[test]
+    #[cfg(feature = "alloc")]
     fn decode_buffer_resizing() {
         // Create a witness with elements larger than initial 128-byte allocation.
         let large_element = vec![0xFF; 500];

--- a/units/src/amount/tests.rs
+++ b/units/src/amount/tests.rs
@@ -278,8 +278,8 @@ fn positive_sub() {
     assert!(ssat(10).positive_sub(ssat(11)).is_none());
 }
 
-#[cfg(feature = "alloc")]
 #[test]
+#[cfg(feature = "alloc")]
 fn amount_checked_div_by_weight_ceil() {
     let weight = Weight::from_kwu(1).unwrap();
     let fee_rate = sat(1).div_by_weight_ceil(weight).unwrap();
@@ -296,8 +296,8 @@ fn amount_checked_div_by_weight_ceil() {
     assert!(fee_rate.is_error());
 }
 
-#[cfg(feature = "alloc")]
 #[test]
+#[cfg(feature = "alloc")]
 fn amount_checked_div_by_weight_floor() {
     let weight = Weight::from_kwu(1).unwrap();
     let fee_rate = sat(1).div_by_weight_floor(weight).unwrap();
@@ -314,8 +314,8 @@ fn amount_checked_div_by_weight_floor() {
     assert!(fee_rate.is_error());
 }
 
-#[cfg(feature = "alloc")]
 #[test]
+#[cfg(feature = "alloc")]
 fn amount_checked_div_by_fee_rate() {
     let amount = sat(1000);
     let fee_rate = FeeRate::from_sat_per_kwu(2);
@@ -350,8 +350,8 @@ fn amount_checked_div_by_fee_rate() {
     assert_eq!(weight, Weight::from_wu(2_100_000_000_000_000_000));
 }
 
-#[cfg(feature = "alloc")]
 #[test]
+#[cfg(feature = "alloc")]
 fn floating_point() {
     use super::Denomination as D;
     let f = Amount::from_float_in;
@@ -477,8 +477,8 @@ fn to_string() {
 }
 
 // May help identify a problem sooner
-#[cfg(feature = "alloc")]
 #[test]
+#[cfg(feature = "alloc")]
 fn test_repeat_char() {
     let mut buf = String::new();
     repeat_char(&mut buf, '0', 0).unwrap();
@@ -742,8 +742,8 @@ fn from_str() {
     ok_scase("-0_._0_10_00 BTC", ssat(-1_000_000));
 }
 
-#[cfg(feature = "alloc")]
 #[test]
+#[cfg(feature = "alloc")]
 #[allow(clippy::inconsistent_digit_grouping)] // Group to show 100,000,000 sats per bitcoin.
 fn to_from_string_in() {
     use super::Denomination as D;
@@ -819,8 +819,8 @@ fn to_from_string_in() {
     );
 }
 
-#[cfg(feature = "alloc")]
 #[test]
+#[cfg(feature = "alloc")]
 fn to_string_with_denomination_from_str_roundtrip() {
     use super::{Denomination as D, ParseDenominationError};
 

--- a/units/tests/serde.rs
+++ b/units/tests/serde.rs
@@ -95,8 +95,8 @@ fn sat(sat: u64) -> Amount { Amount::from_sat(sat).unwrap() }
 #[track_caller]
 fn ssat(ssat: i64) -> SignedAmount { SignedAmount::from_sat(ssat).unwrap() }
 
-#[cfg(feature = "serde")]
 #[test]
+#[cfg(feature = "serde")]
 fn serde_as_sat() {
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
     struct T {
@@ -119,9 +119,9 @@ fn serde_as_sat() {
     );
 }
 
+#[test]
 #[cfg(feature = "serde")]
 #[cfg(feature = "alloc")]
-#[test]
 #[allow(clippy::inconsistent_digit_grouping)] // Group to show 100,000,000 sats per bitcoin.
 fn serde_as_btc() {
     use serde_json;
@@ -145,9 +145,9 @@ fn serde_as_btc() {
     assert_eq!(t, serde_json::from_value(value).unwrap());
 }
 
+#[test]
 #[cfg(feature = "serde")]
 #[cfg(feature = "alloc")]
-#[test]
 fn serde_as_str() {
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
     struct T {
@@ -170,9 +170,9 @@ fn serde_as_str() {
     );
 }
 
+#[test]
 #[cfg(feature = "serde")]
 #[cfg(feature = "alloc")]
-#[test]
 #[allow(clippy::inconsistent_digit_grouping)] // Group to show 100,000,000 sats per bitcoin.
 fn serde_as_btc_opt() {
     use serde_json;
@@ -209,9 +209,9 @@ fn serde_as_btc_opt() {
     assert_eq!(without, serde_json::from_value(value_without).unwrap());
 }
 
+#[test]
 #[cfg(feature = "serde")]
 #[cfg(feature = "alloc")]
-#[test]
 #[allow(clippy::inconsistent_digit_grouping)] // Group to show 100,000,000 sats per bitcoin.
 fn serde_as_sat_opt() {
     use serde_json;
@@ -248,9 +248,9 @@ fn serde_as_sat_opt() {
     assert_eq!(without, serde_json::from_value(value_without).unwrap());
 }
 
+#[test]
 #[cfg(feature = "serde")]
 #[cfg(feature = "alloc")]
-#[test]
 #[allow(clippy::inconsistent_digit_grouping)] // Group to show 100,000,000 sats per bitcoin.
 fn serde_as_str_opt() {
     use serde_json;


### PR DESCRIPTION
For the stabilising crates we would like test code to be treated as a first class citizen. In my book that means clean AF.

Audit all three crates and put the feature gate attributes below the `#[test]` attribute, based on two things:

- Uniformity (we could arbitrarily pick either)
- Puts the more important thing closer to the code (subjective)