### PR TITLE
primitives: Remove arrayvec dependency

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -141,7 +141,6 @@ name = "bitcoin-primitives"
 version = "1.0.0-rc.1"
 dependencies = [
  "arbitrary",
- "arrayvec",
  "bincode",
  "bitcoin-consensus-encoding",
  "bitcoin-internals",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -140,7 +140,6 @@ name = "bitcoin-primitives"
 version = "1.0.0-rc.1"
 dependencies = [
  "arbitrary",
- "arrayvec",
  "bincode",
  "bitcoin-consensus-encoding",
  "bitcoin-internals",

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["tests", "contrib"]
 
 [features]
 default = ["std", "hex"]
-std = ["alloc", "hashes/std", "hex-stable?/std", "hex-unstable?/std", "internals/std", "units/std", "arrayvec/std"]
+std = ["alloc", "hashes/std", "hex-stable?/std", "hex-unstable?/std", "internals/std", "units/std"]
 alloc = ["hashes/alloc", "hex-stable?/alloc", "hex-unstable?/alloc", "internals/alloc", "units/alloc"]
 serde = ["dep:serde", "hashes/serde", "internals/serde", "units/serde", "alloc", "hex"]
 arbitrary = ["dep:arbitrary", "units/arbitrary"]
@@ -25,7 +25,6 @@ encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encodi
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.18.0", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.4.1" }
 units = { package = "bitcoin-units", path = "../units", version = "=1.0.0-rc.3", default-features = false, features = [ "encoding" ] }
-arrayvec = { version = "0.7.2", default-features = false }
 
 arbitrary = { version = "1.4.1", optional = true }
 hex-stable = { package = "hex-conservative", version = "1.0.0", default-features = false, optional = true }

--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -15,6 +15,8 @@ use core::marker::PhantomData;
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
 use encoding::Encodable;
+#[cfg(feature = "hex")]
+use encoding::EncodableByteIter;
 #[cfg(feature = "alloc")]
 use encoding::{CompactSizeEncoder, Decodable, Decoder, Decoder2, Decoder6, Encoder2, SliceEncoder, VecDecoder};
 use hashes::{sha256d, HashEngine as _};
@@ -491,23 +493,11 @@ impl Header {
 
 #[cfg(feature = "hex")]
 impl fmt::Display for Header {
+    #[allow(clippy::use_self)]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use fmt::Write as _;
-        use hex_unstable::DisplayHex as _;
+        use hex_unstable::{fmt_hex_exact, Case};
 
-        let mut buf = arrayvec::ArrayString::<160>::new();
-        write!(
-            &mut buf,
-            "{}{}{}{}{}{}",
-            self.version.to_consensus().to_le_bytes().as_hex(),
-            self.prev_blockhash.as_byte_array().as_hex(),
-            self.merkle_root.as_byte_array().as_hex(),
-            self.time.to_u32().to_le_bytes().as_hex(),
-            self.bits.to_consensus().to_le_bytes().as_hex(),
-            self.nonce.to_le_bytes().as_hex(),
-        )
-        .expect("total length of written objects is 160 characters");
-        fmt::Display::fmt(&buf, f)
+        fmt_hex_exact!(f, Header::SIZE, HeaderIter(EncodableByteIter::new(self)), Case::Lower)
     }
 }
 
@@ -524,6 +514,23 @@ impl fmt::Debug for Header {
             .finish()
     }
 }
+
+/// A wrapper around [`encoding::EncodableByteIter`]
+///
+/// This wrapper implements `ExactSizeIterator` for use with `fmt_hex_exact!`.
+#[cfg(feature = "hex")]
+struct HeaderIter<'a>(EncodableByteIter<'a, Header>);
+
+#[cfg(feature = "hex")]
+impl Iterator for HeaderIter<'_> {
+    type Item = u8;
+
+    fn next(&mut self) -> Option<Self::Item> { self.0.next() }
+
+    fn size_hint(&self) -> (usize, Option<usize>) { (Header::SIZE, Some(Header::SIZE)) }
+}
+#[cfg(feature = "hex")]
+impl ExactSizeIterator for HeaderIter<'_> {}
 
 encoding::encoder_newtype! {
     /// The encoder for the [`Header`] type.


### PR DESCRIPTION
The primitives crate only uses the arrayvec crate to provide Display trait for Header. In order to minimise the use of external dependencies, it should be removed.

Convert Header Display impl to use fmt_hex_exact and remove the arrayvec dependency from primitives.