### PR TITLE
internals: Add api files

### DIFF
--- a/api/internals/all-features.txt
+++ b/api/internals/all-features.txt
@@ -1,0 +1,230 @@
+impl bitcoin_internals::ToU64 for u16
+impl bitcoin_internals::ToU64 for u32
+impl bitcoin_internals::ToU64 for u64
+impl bitcoin_internals::ToU64 for u8
+impl bitcoin_internals::ToU64 for usize
+impl bitcoin_internals::error::input_string::InputString
+impl bitcoin_internals::serde::IntoDeError for core::convert::Infallible
+impl bitcoin_internals::serde::IntoDeError for core::num::error::ParseIntError
+impl core::clone::Clone for bitcoin_internals::error::input_string::InputString
+impl core::clone::Clone for bitcoin_internals::script::PushDataLenLen
+impl core::cmp::Eq for bitcoin_internals::error::input_string::InputString
+impl core::cmp::Eq for bitcoin_internals::script::PushDataLenLen
+impl core::cmp::Ord for bitcoin_internals::error::input_string::InputString
+impl core::cmp::Ord for bitcoin_internals::script::PushDataLenLen
+impl core::cmp::PartialEq for bitcoin_internals::error::input_string::InputString
+impl core::cmp::PartialEq for bitcoin_internals::script::PushDataLenLen
+impl core::cmp::PartialOrd for bitcoin_internals::error::input_string::InputString
+impl core::cmp::PartialOrd for bitcoin_internals::script::PushDataLenLen
+impl core::convert::From<&str> for bitcoin_internals::error::input_string::InputString
+impl core::convert::From<alloc::borrow::Cow<'_, str>> for bitcoin_internals::error::input_string::InputString
+impl core::convert::From<alloc::boxed::Box<str>> for bitcoin_internals::error::input_string::InputString
+impl core::convert::From<alloc::string::String> for bitcoin_internals::error::input_string::InputString
+impl core::fmt::Debug for bitcoin_internals::error::input_string::InputString
+impl core::fmt::Debug for bitcoin_internals::script::EarlyEndOfScriptError
+impl core::fmt::Debug for bitcoin_internals::script::PushDataLenLen
+impl core::hash::Hash for bitcoin_internals::error::input_string::InputString
+impl core::hash::Hash for bitcoin_internals::script::PushDataLenLen
+impl core::marker::Copy for bitcoin_internals::script::PushDataLenLen
+impl core::marker::Freeze for bitcoin_internals::error::input_string::InputString
+impl core::marker::Freeze for bitcoin_internals::script::EarlyEndOfScriptError
+impl core::marker::Freeze for bitcoin_internals::script::PushDataLenLen
+impl core::marker::Send for bitcoin_internals::error::input_string::InputString
+impl core::marker::Send for bitcoin_internals::script::EarlyEndOfScriptError
+impl core::marker::Send for bitcoin_internals::script::PushDataLenLen
+impl core::marker::StructuralPartialEq for bitcoin_internals::error::input_string::InputString
+impl core::marker::StructuralPartialEq for bitcoin_internals::script::PushDataLenLen
+impl core::marker::Sync for bitcoin_internals::error::input_string::InputString
+impl core::marker::Sync for bitcoin_internals::script::EarlyEndOfScriptError
+impl core::marker::Sync for bitcoin_internals::script::PushDataLenLen
+impl core::marker::Unpin for bitcoin_internals::error::input_string::InputString
+impl core::marker::Unpin for bitcoin_internals::script::EarlyEndOfScriptError
+impl core::marker::Unpin for bitcoin_internals::script::PushDataLenLen
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_internals::error::input_string::InputString
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_internals::script::EarlyEndOfScriptError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_internals::script::PushDataLenLen
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_internals::error::input_string::InputString
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_internals::script::EarlyEndOfScriptError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_internals::script::PushDataLenLen
+impl serde::ser::Serialize for bitcoin_internals::serde::SerializeBytesAsHex<'_>
+impl<'a, T> core::marker::Freeze for bitcoin_internals::error::input_string::CannotParse<'a, T> where T: ?core::marker::Sized
+impl<'a, T> core::marker::Send for bitcoin_internals::error::input_string::CannotParse<'a, T> where T: core::marker::Sync + ?core::marker::Sized
+impl<'a, T> core::marker::Sync for bitcoin_internals::error::input_string::CannotParse<'a, T> where T: core::marker::Sync + ?core::marker::Sized
+impl<'a, T> core::marker::Unpin for bitcoin_internals::error::input_string::CannotParse<'a, T> where T: ?core::marker::Sized
+impl<'a, T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_internals::error::input_string::CannotParse<'a, T> where T: core::panic::unwind_safe::RefUnwindSafe + ?core::marker::Sized
+impl<'a, T> core::panic::unwind_safe::UnwindSafe for bitcoin_internals::error::input_string::CannotParse<'a, T> where T: core::panic::unwind_safe::RefUnwindSafe + ?core::marker::Sized
+impl<'a> core::marker::Freeze for bitcoin_internals::serde::SerializeBytesAsHex<'a>
+impl<'a> core::marker::Send for bitcoin_internals::serde::SerializeBytesAsHex<'a>
+impl<'a> core::marker::Sync for bitcoin_internals::serde::SerializeBytesAsHex<'a>
+impl<'a> core::marker::Unpin for bitcoin_internals::serde::SerializeBytesAsHex<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for bitcoin_internals::serde::SerializeBytesAsHex<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for bitcoin_internals::serde::SerializeBytesAsHex<'a>
+impl<F: core::ops::function::Fn(&mut core::fmt::Formatter<'_>) -> core::fmt::Result> core::fmt::Debug for bitcoin_internals::wrap_debug::WrapDebug<F>
+impl<F> core::marker::Freeze for bitcoin_internals::wrap_debug::WrapDebug<F> where F: core::marker::Freeze
+impl<F> core::marker::Send for bitcoin_internals::wrap_debug::WrapDebug<F> where F: core::marker::Send
+impl<F> core::marker::Sync for bitcoin_internals::wrap_debug::WrapDebug<F> where F: core::marker::Sync
+impl<F> core::marker::Unpin for bitcoin_internals::wrap_debug::WrapDebug<F> where F: core::marker::Unpin
+impl<F> core::panic::unwind_safe::RefUnwindSafe for bitcoin_internals::wrap_debug::WrapDebug<F> where F: core::panic::unwind_safe::RefUnwindSafe
+impl<F> core::panic::unwind_safe::UnwindSafe for bitcoin_internals::wrap_debug::WrapDebug<F> where F: core::panic::unwind_safe::UnwindSafe
+impl<T, const CAP: usize> core::marker::Freeze for bitcoin_internals::array_vec::ArrayVec<T, CAP> where T: core::marker::Freeze
+impl<T, const CAP: usize> core::marker::Send for bitcoin_internals::array_vec::ArrayVec<T, CAP> where T: core::marker::Send
+impl<T, const CAP: usize> core::marker::Sync for bitcoin_internals::array_vec::ArrayVec<T, CAP> where T: core::marker::Sync
+impl<T, const CAP: usize> core::marker::Unpin for bitcoin_internals::array_vec::ArrayVec<T, CAP> where T: core::marker::Unpin
+impl<T, const CAP: usize> core::panic::unwind_safe::RefUnwindSafe for bitcoin_internals::array_vec::ArrayVec<T, CAP> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T, const CAP: usize> core::panic::unwind_safe::UnwindSafe for bitcoin_internals::array_vec::ArrayVec<T, CAP> where T: core::panic::unwind_safe::UnwindSafe
+impl<T: core::fmt::Display + ?core::marker::Sized> core::fmt::Display for bitcoin_internals::error::input_string::CannotParse<'_, T>
+impl<T: core::marker::Copy + core::cmp::Eq, const CAP: usize> core::cmp::Eq for bitcoin_internals::array_vec::ArrayVec<T, CAP>
+impl<T: core::marker::Copy + core::cmp::Ord, const CAP: usize> core::cmp::Ord for bitcoin_internals::array_vec::ArrayVec<T, CAP>
+impl<T: core::marker::Copy + core::cmp::PartialEq, const CAP1: usize, const CAP2: usize> core::cmp::PartialEq<bitcoin_internals::array_vec::ArrayVec<T, CAP2>> for bitcoin_internals::array_vec::ArrayVec<T, CAP1>
+impl<T: core::marker::Copy + core::cmp::PartialEq, const CAP: usize, const LEN: usize> core::cmp::PartialEq<[T; LEN]> for bitcoin_internals::array_vec::ArrayVec<T, CAP>
+impl<T: core::marker::Copy + core::cmp::PartialEq, const CAP: usize, const LEN: usize> core::cmp::PartialEq<bitcoin_internals::array_vec::ArrayVec<T, CAP>> for [T; LEN]
+impl<T: core::marker::Copy + core::cmp::PartialEq, const CAP: usize> core::cmp::PartialEq<[T]> for bitcoin_internals::array_vec::ArrayVec<T, CAP>
+impl<T: core::marker::Copy + core::cmp::PartialEq, const CAP: usize> core::cmp::PartialEq<bitcoin_internals::array_vec::ArrayVec<T, CAP>> for [T]
+impl<T: core::marker::Copy + core::cmp::PartialOrd, const CAP1: usize, const CAP2: usize> core::cmp::PartialOrd<bitcoin_internals::array_vec::ArrayVec<T, CAP2>> for bitcoin_internals::array_vec::ArrayVec<T, CAP1>
+impl<T: core::marker::Copy + core::fmt::Debug, const CAP: usize> core::fmt::Debug for bitcoin_internals::array_vec::ArrayVec<T, CAP>
+impl<T: core::marker::Copy + core::hash::Hash, const CAP: usize> core::hash::Hash for bitcoin_internals::array_vec::ArrayVec<T, CAP>
+impl<T: core::marker::Copy + core::marker::Copy, const CAP: usize> core::marker::Copy for bitcoin_internals::array_vec::ArrayVec<T, CAP>
+impl<T: core::marker::Copy, const CAP: usize> bitcoin_internals::array_vec::ArrayVec<T, CAP>
+impl<T: core::marker::Copy, const CAP: usize> core::clone::Clone for bitcoin_internals::array_vec::ArrayVec<T, CAP>
+impl<T: core::marker::Copy, const CAP: usize> core::default::Default for bitcoin_internals::array_vec::ArrayVec<T, CAP>
+impl<T: core::marker::Copy, const CAP: usize> core::ops::deref::Deref for bitcoin_internals::array_vec::ArrayVec<T, CAP>
+impl<T: core::marker::Copy, const CAP: usize> core::ops::deref::DerefMut for bitcoin_internals::array_vec::ArrayVec<T, CAP>
+impl<T> bitcoin_internals::slice::SliceExt for [T]
+impl<const N: usize, T> bitcoin_internals::array::ArrayExt for [T; N]
+pub bitcoin_internals::script::PushDataLenLen::Four = 4
+pub bitcoin_internals::script::PushDataLenLen::One = 1
+pub bitcoin_internals::script::PushDataLenLen::Two = 2
+pub const bitcoin_internals::compact_size::MAX_ENCODABLE_VALUE: u64
+pub const bitcoin_internals::compact_size::MAX_ENCODING_SIZE: usize
+pub const fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::as_slice(&self) -> &[T]
+pub const fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::from_slice(slice: &[T]) -> Self
+pub const fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::new() -> Self
+pub const fn bitcoin_internals::compact_size::encoded_size_const(value: u64) -> usize
+pub const fn bitcoin_internals::const_casts::i16_to_i64(value: i16) -> i64
+pub const fn bitcoin_internals::const_casts::u16_to_u32(value: u16) -> u32
+pub const fn bitcoin_internals::const_casts::u16_to_u64(value: u16) -> u64
+pub const fn bitcoin_internals::const_casts::u32_to_u64(value: u32) -> u64
+pub enum bitcoin_internals::script::PushDataLenLen
+pub extern crate bitcoin_internals::bincode
+pub extern crate bitcoin_internals::serde_json
+pub fn [T; LEN]::eq(&self, other: &bitcoin_internals::array_vec::ArrayVec<T, CAP>) -> bool
+pub fn [T; N]::split_array<const LEFT: usize, const RIGHT: usize>(&self) -> (&[Self::Item; LEFT], &[Self::Item; RIGHT])
+pub fn [T; N]::sub_array<const OFFSET: usize, const LEN: usize>(&self) -> &[Self::Item; LEN]
+pub fn [T]::bitcoin_as_chunks<const N: usize>(&self) -> (&[[Self::Item; N]], &[Self::Item])
+pub fn [T]::bitcoin_as_chunks_mut<const N: usize>(&mut self) -> (&mut [[Self::Item; N]], &mut [Self::Item])
+pub fn [T]::eq(&self, other: &bitcoin_internals::array_vec::ArrayVec<T, CAP>) -> bool
+pub fn [T]::get_array<const ARRAY_LEN: usize>(&self, offset: usize) -> core::option::Option<&[Self::Item; ARRAY_LEN]>
+pub fn [T]::split_first_chunk<const ARRAY_LEN: usize>(&self) -> core::option::Option<(&[Self::Item; ARRAY_LEN], &[Self::Item])>
+pub fn [T]::split_last_chunk<const ARRAY_LEN: usize>(&self) -> core::option::Option<(&[Self::Item], &[Self::Item; ARRAY_LEN])>
+pub fn bitcoin_internals::ToU64::to_u64(self) -> u64
+pub fn bitcoin_internals::array::ArrayExt::first(&self) -> &Self::Item
+pub fn bitcoin_internals::array::ArrayExt::get_static<const INDEX: usize>(&self) -> &Self::Item
+pub fn bitcoin_internals::array::ArrayExt::split_array<const LEFT: usize, const RIGHT: usize>(&self) -> (&[Self::Item; LEFT], &[Self::Item; RIGHT])
+pub fn bitcoin_internals::array::ArrayExt::split_first<const RIGHT: usize>(&self) -> (&Self::Item, &[Self::Item; RIGHT])
+pub fn bitcoin_internals::array::ArrayExt::split_last<const LEFT: usize>(&self) -> (&Self::Item, &[Self::Item; LEFT])
+pub fn bitcoin_internals::array::ArrayExt::sub_array<const OFFSET: usize, const LEN: usize>(&self) -> &[Self::Item; LEN]
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP1>::eq(&self, other: &bitcoin_internals::array_vec::ArrayVec<T, CAP2>) -> bool
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP1>::partial_cmp(&self, other: &bitcoin_internals::array_vec::ArrayVec<T, CAP2>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::as_mut_slice(&mut self) -> &mut [T]
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::clone(&self) -> Self
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::cmp(&self, other: &Self) -> core::cmp::Ordering
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::default() -> Self
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::deref(&self) -> &Self::Target
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::deref_mut(&mut self) -> &mut Self::Target
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::eq(&self, other: &[T; LEN]) -> bool
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::eq(&self, other: &[T]) -> bool
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::extend_from_slice(&mut self, slice: &[T])
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::hash<H: core::hash::Hasher>(&self, state: &mut H)
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::pop(&mut self) -> core::option::Option<T>
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::push(&mut self, element: T)
+pub fn bitcoin_internals::compact_size::decode_unchecked(slice: &mut &[u8]) -> u64
+pub fn bitcoin_internals::compact_size::encode(value: impl bitcoin_internals::ToU64) -> bitcoin_internals::array_vec::ArrayVec<u8, MAX_ENCODING_SIZE>
+pub fn bitcoin_internals::compact_size::encoded_size(value: impl bitcoin_internals::ToU64) -> usize
+pub fn bitcoin_internals::error::input_string::CannotParse<'_, T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_internals::error::input_string::InputString::clone(&self) -> bitcoin_internals::error::input_string::InputString
+pub fn bitcoin_internals::error::input_string::InputString::cmp(&self, other: &bitcoin_internals::error::input_string::InputString) -> core::cmp::Ordering
+pub fn bitcoin_internals::error::input_string::InputString::display_cannot_parse<'a, T>(&'a self, what: &'a T) -> bitcoin_internals::error::input_string::CannotParse<'a, T> where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_internals::error::input_string::InputString::eq(&self, other: &bitcoin_internals::error::input_string::InputString) -> bool
+pub fn bitcoin_internals::error::input_string::InputString::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_internals::error::input_string::InputString::from(input: &str) -> Self
+pub fn bitcoin_internals::error::input_string::InputString::from(input: alloc::borrow::Cow<'_, str>) -> Self
+pub fn bitcoin_internals::error::input_string::InputString::from(input: alloc::boxed::Box<str>) -> Self
+pub fn bitcoin_internals::error::input_string::InputString::from(input: alloc::string::String) -> Self
+pub fn bitcoin_internals::error::input_string::InputString::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_internals::error::input_string::InputString::partial_cmp(&self, other: &bitcoin_internals::error::input_string::InputString) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_internals::error::input_string::InputString::unknown_variant<T>(&self, what: &T, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_internals::script::EarlyEndOfScriptError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_internals::script::PushDataLenLen::clone(&self) -> bitcoin_internals::script::PushDataLenLen
+pub fn bitcoin_internals::script::PushDataLenLen::cmp(&self, other: &bitcoin_internals::script::PushDataLenLen) -> core::cmp::Ordering
+pub fn bitcoin_internals::script::PushDataLenLen::eq(&self, other: &bitcoin_internals::script::PushDataLenLen) -> bool
+pub fn bitcoin_internals::script::PushDataLenLen::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_internals::script::PushDataLenLen::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_internals::script::PushDataLenLen::partial_cmp(&self, other: &bitcoin_internals::script::PushDataLenLen) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_internals::script::read_push_data_len(data: &mut core::slice::iter::Iter<'_, u8>, size: bitcoin_internals::script::PushDataLenLen) -> core::result::Result<usize, bitcoin_internals::script::EarlyEndOfScriptError>
+pub fn bitcoin_internals::serde::IntoDeError::into_de_error<E: serde::de::Error>(self, expected: core::option::Option<&dyn serde::de::Expected>) -> E
+pub fn bitcoin_internals::serde::IntoDeError::try_into_de_error<E>(self, expected: core::option::Option<&dyn serde::de::Expected>) -> core::result::Result<E, Self> where E: serde::de::Error
+pub fn bitcoin_internals::serde::SerializeBytesAsHex<'_>::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+pub fn bitcoin_internals::slice::SliceExt::bitcoin_as_chunks<const N: usize>(&self) -> (&[[Self::Item; N]], &[Self::Item])
+pub fn bitcoin_internals::slice::SliceExt::bitcoin_as_chunks_mut<const N: usize>(&mut self) -> (&mut [[Self::Item; N]], &mut [Self::Item])
+pub fn bitcoin_internals::slice::SliceExt::get_array<const ARRAY_LEN: usize>(&self, offset: usize) -> core::option::Option<&[Self::Item; ARRAY_LEN]>
+pub fn bitcoin_internals::slice::SliceExt::split_first_chunk<const ARRAY_LEN: usize>(&self) -> core::option::Option<(&[Self::Item; ARRAY_LEN], &[Self::Item])>
+pub fn bitcoin_internals::slice::SliceExt::split_last_chunk<const ARRAY_LEN: usize>(&self) -> core::option::Option<(&[Self::Item], &[Self::Item; ARRAY_LEN])>
+pub fn bitcoin_internals::wrap_debug::WrapDebug<F>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn core::convert::Infallible::into_de_error<E: serde::de::Error>(self, _expected: core::option::Option<&dyn serde::de::Expected>) -> E
+pub fn core::num::error::ParseIntError::into_de_error<E: serde::de::Error>(self, expected: core::option::Option<&dyn serde::de::Expected>) -> E
+pub fn core::num::error::ParseIntError::try_into_de_error<E>(self, expected: core::option::Option<&dyn serde::de::Expected>) -> core::result::Result<E, Self> where E: serde::de::Error
+pub fn u16::to_u64(self) -> u64
+pub fn u32::to_u64(self) -> u64
+pub fn u64::to_u64(self) -> u64
+pub fn u8::to_u64(self) -> u64
+pub fn usize::to_u64(self) -> u64
+pub macro bitcoin_internals::concat_bytes_to_arr!
+pub macro bitcoin_internals::cond_const!
+pub macro bitcoin_internals::const_assert!
+pub macro bitcoin_internals::const_tools::concat_bytes_to_arr!
+pub macro bitcoin_internals::const_tools::cond_const!
+pub macro bitcoin_internals::const_tools::copy_byte_array_from_slice!
+pub macro bitcoin_internals::copy_byte_array_from_slice!
+pub macro bitcoin_internals::impl_array_newtype!
+pub macro bitcoin_internals::impl_parse!
+pub macro bitcoin_internals::impl_parse_and_serde!
+pub macro bitcoin_internals::impl_to_hex_from_lower_hex!
+pub macro bitcoin_internals::parse_error_type!
+pub macro bitcoin_internals::rust_version!
+pub macro bitcoin_internals::serde_round_trip!
+pub macro bitcoin_internals::serde_string_deserialize_impl!
+pub macro bitcoin_internals::serde_string_impl!
+pub macro bitcoin_internals::serde_string_serialize_impl!
+pub macro bitcoin_internals::serde_struct_human_string_impl!
+pub macro bitcoin_internals::transparent_newtype!
+pub macro bitcoin_internals::write_err!
+pub mod bitcoin_internals
+pub mod bitcoin_internals::array
+pub mod bitcoin_internals::array_vec
+pub mod bitcoin_internals::compact_size
+pub mod bitcoin_internals::const_casts
+pub mod bitcoin_internals::const_tools
+pub mod bitcoin_internals::error
+pub mod bitcoin_internals::error::input_string
+pub mod bitcoin_internals::macros
+pub mod bitcoin_internals::script
+pub mod bitcoin_internals::serde
+pub mod bitcoin_internals::slice
+pub mod bitcoin_internals::wrap_debug
+pub struct bitcoin_internals::array_vec::ArrayVec<T: core::marker::Copy, const CAP: usize>
+pub struct bitcoin_internals::error::InputString(_)
+pub struct bitcoin_internals::error::input_string::CannotParse<'a, T: core::fmt::Display + ?core::marker::Sized>
+pub struct bitcoin_internals::error::input_string::InputString(_)
+pub struct bitcoin_internals::script::EarlyEndOfScriptError
+pub struct bitcoin_internals::serde::SerializeBytesAsHex<'a>(pub &'a [u8])
+pub struct bitcoin_internals::wrap_debug::WrapDebug<F: core::ops::function::Fn(&mut core::fmt::Formatter<'_>) -> core::fmt::Result>(pub F)
+pub trait bitcoin_internals::ToU64
+pub trait bitcoin_internals::array::ArrayExt
+pub trait bitcoin_internals::serde::IntoDeError: core::marker::Sized
+pub trait bitcoin_internals::slice::SliceExt
+pub type [T; N]::Item = T
+pub type [T]::Item = T
+pub type bitcoin_internals::array::ArrayExt::Item
+pub type bitcoin_internals::array_vec::ArrayVec<T, CAP>::Target = [T]
+pub type bitcoin_internals::slice::SliceExt::Item

--- a/api/internals/alloc-only.txt
+++ b/api/internals/alloc-only.txt
@@ -1,0 +1,205 @@
+impl bitcoin_internals::ToU64 for u16
+impl bitcoin_internals::ToU64 for u32
+impl bitcoin_internals::ToU64 for u64
+impl bitcoin_internals::ToU64 for u8
+impl bitcoin_internals::ToU64 for usize
+impl bitcoin_internals::error::input_string::InputString
+impl core::clone::Clone for bitcoin_internals::error::input_string::InputString
+impl core::clone::Clone for bitcoin_internals::script::PushDataLenLen
+impl core::cmp::Eq for bitcoin_internals::error::input_string::InputString
+impl core::cmp::Eq for bitcoin_internals::script::PushDataLenLen
+impl core::cmp::Ord for bitcoin_internals::error::input_string::InputString
+impl core::cmp::Ord for bitcoin_internals::script::PushDataLenLen
+impl core::cmp::PartialEq for bitcoin_internals::error::input_string::InputString
+impl core::cmp::PartialEq for bitcoin_internals::script::PushDataLenLen
+impl core::cmp::PartialOrd for bitcoin_internals::error::input_string::InputString
+impl core::cmp::PartialOrd for bitcoin_internals::script::PushDataLenLen
+impl core::convert::From<&str> for bitcoin_internals::error::input_string::InputString
+impl core::convert::From<alloc::borrow::Cow<'_, str>> for bitcoin_internals::error::input_string::InputString
+impl core::convert::From<alloc::boxed::Box<str>> for bitcoin_internals::error::input_string::InputString
+impl core::convert::From<alloc::string::String> for bitcoin_internals::error::input_string::InputString
+impl core::fmt::Debug for bitcoin_internals::error::input_string::InputString
+impl core::fmt::Debug for bitcoin_internals::script::EarlyEndOfScriptError
+impl core::fmt::Debug for bitcoin_internals::script::PushDataLenLen
+impl core::hash::Hash for bitcoin_internals::error::input_string::InputString
+impl core::hash::Hash for bitcoin_internals::script::PushDataLenLen
+impl core::marker::Copy for bitcoin_internals::script::PushDataLenLen
+impl core::marker::Freeze for bitcoin_internals::error::input_string::InputString
+impl core::marker::Freeze for bitcoin_internals::script::EarlyEndOfScriptError
+impl core::marker::Freeze for bitcoin_internals::script::PushDataLenLen
+impl core::marker::Send for bitcoin_internals::error::input_string::InputString
+impl core::marker::Send for bitcoin_internals::script::EarlyEndOfScriptError
+impl core::marker::Send for bitcoin_internals::script::PushDataLenLen
+impl core::marker::StructuralPartialEq for bitcoin_internals::error::input_string::InputString
+impl core::marker::StructuralPartialEq for bitcoin_internals::script::PushDataLenLen
+impl core::marker::Sync for bitcoin_internals::error::input_string::InputString
+impl core::marker::Sync for bitcoin_internals::script::EarlyEndOfScriptError
+impl core::marker::Sync for bitcoin_internals::script::PushDataLenLen
+impl core::marker::Unpin for bitcoin_internals::error::input_string::InputString
+impl core::marker::Unpin for bitcoin_internals::script::EarlyEndOfScriptError
+impl core::marker::Unpin for bitcoin_internals::script::PushDataLenLen
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_internals::error::input_string::InputString
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_internals::script::EarlyEndOfScriptError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_internals::script::PushDataLenLen
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_internals::error::input_string::InputString
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_internals::script::EarlyEndOfScriptError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_internals::script::PushDataLenLen
+impl<'a, T> core::marker::Freeze for bitcoin_internals::error::input_string::CannotParse<'a, T> where T: ?core::marker::Sized
+impl<'a, T> core::marker::Send for bitcoin_internals::error::input_string::CannotParse<'a, T> where T: core::marker::Sync + ?core::marker::Sized
+impl<'a, T> core::marker::Sync for bitcoin_internals::error::input_string::CannotParse<'a, T> where T: core::marker::Sync + ?core::marker::Sized
+impl<'a, T> core::marker::Unpin for bitcoin_internals::error::input_string::CannotParse<'a, T> where T: ?core::marker::Sized
+impl<'a, T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_internals::error::input_string::CannotParse<'a, T> where T: core::panic::unwind_safe::RefUnwindSafe + ?core::marker::Sized
+impl<'a, T> core::panic::unwind_safe::UnwindSafe for bitcoin_internals::error::input_string::CannotParse<'a, T> where T: core::panic::unwind_safe::RefUnwindSafe + ?core::marker::Sized
+impl<F: core::ops::function::Fn(&mut core::fmt::Formatter<'_>) -> core::fmt::Result> core::fmt::Debug for bitcoin_internals::wrap_debug::WrapDebug<F>
+impl<F> core::marker::Freeze for bitcoin_internals::wrap_debug::WrapDebug<F> where F: core::marker::Freeze
+impl<F> core::marker::Send for bitcoin_internals::wrap_debug::WrapDebug<F> where F: core::marker::Send
+impl<F> core::marker::Sync for bitcoin_internals::wrap_debug::WrapDebug<F> where F: core::marker::Sync
+impl<F> core::marker::Unpin for bitcoin_internals::wrap_debug::WrapDebug<F> where F: core::marker::Unpin
+impl<F> core::panic::unwind_safe::RefUnwindSafe for bitcoin_internals::wrap_debug::WrapDebug<F> where F: core::panic::unwind_safe::RefUnwindSafe
+impl<F> core::panic::unwind_safe::UnwindSafe for bitcoin_internals::wrap_debug::WrapDebug<F> where F: core::panic::unwind_safe::UnwindSafe
+impl<T, const CAP: usize> core::marker::Freeze for bitcoin_internals::array_vec::ArrayVec<T, CAP> where T: core::marker::Freeze
+impl<T, const CAP: usize> core::marker::Send for bitcoin_internals::array_vec::ArrayVec<T, CAP> where T: core::marker::Send
+impl<T, const CAP: usize> core::marker::Sync for bitcoin_internals::array_vec::ArrayVec<T, CAP> where T: core::marker::Sync
+impl<T, const CAP: usize> core::marker::Unpin for bitcoin_internals::array_vec::ArrayVec<T, CAP> where T: core::marker::Unpin
+impl<T, const CAP: usize> core::panic::unwind_safe::RefUnwindSafe for bitcoin_internals::array_vec::ArrayVec<T, CAP> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T, const CAP: usize> core::panic::unwind_safe::UnwindSafe for bitcoin_internals::array_vec::ArrayVec<T, CAP> where T: core::panic::unwind_safe::UnwindSafe
+impl<T: core::fmt::Display + ?core::marker::Sized> core::fmt::Display for bitcoin_internals::error::input_string::CannotParse<'_, T>
+impl<T: core::marker::Copy + core::cmp::Eq, const CAP: usize> core::cmp::Eq for bitcoin_internals::array_vec::ArrayVec<T, CAP>
+impl<T: core::marker::Copy + core::cmp::Ord, const CAP: usize> core::cmp::Ord for bitcoin_internals::array_vec::ArrayVec<T, CAP>
+impl<T: core::marker::Copy + core::cmp::PartialEq, const CAP1: usize, const CAP2: usize> core::cmp::PartialEq<bitcoin_internals::array_vec::ArrayVec<T, CAP2>> for bitcoin_internals::array_vec::ArrayVec<T, CAP1>
+impl<T: core::marker::Copy + core::cmp::PartialEq, const CAP: usize, const LEN: usize> core::cmp::PartialEq<[T; LEN]> for bitcoin_internals::array_vec::ArrayVec<T, CAP>
+impl<T: core::marker::Copy + core::cmp::PartialEq, const CAP: usize, const LEN: usize> core::cmp::PartialEq<bitcoin_internals::array_vec::ArrayVec<T, CAP>> for [T; LEN]
+impl<T: core::marker::Copy + core::cmp::PartialEq, const CAP: usize> core::cmp::PartialEq<[T]> for bitcoin_internals::array_vec::ArrayVec<T, CAP>
+impl<T: core::marker::Copy + core::cmp::PartialEq, const CAP: usize> core::cmp::PartialEq<bitcoin_internals::array_vec::ArrayVec<T, CAP>> for [T]
+impl<T: core::marker::Copy + core::cmp::PartialOrd, const CAP1: usize, const CAP2: usize> core::cmp::PartialOrd<bitcoin_internals::array_vec::ArrayVec<T, CAP2>> for bitcoin_internals::array_vec::ArrayVec<T, CAP1>
+impl<T: core::marker::Copy + core::fmt::Debug, const CAP: usize> core::fmt::Debug for bitcoin_internals::array_vec::ArrayVec<T, CAP>
+impl<T: core::marker::Copy + core::hash::Hash, const CAP: usize> core::hash::Hash for bitcoin_internals::array_vec::ArrayVec<T, CAP>
+impl<T: core::marker::Copy + core::marker::Copy, const CAP: usize> core::marker::Copy for bitcoin_internals::array_vec::ArrayVec<T, CAP>
+impl<T: core::marker::Copy, const CAP: usize> bitcoin_internals::array_vec::ArrayVec<T, CAP>
+impl<T: core::marker::Copy, const CAP: usize> core::clone::Clone for bitcoin_internals::array_vec::ArrayVec<T, CAP>
+impl<T: core::marker::Copy, const CAP: usize> core::default::Default for bitcoin_internals::array_vec::ArrayVec<T, CAP>
+impl<T: core::marker::Copy, const CAP: usize> core::ops::deref::Deref for bitcoin_internals::array_vec::ArrayVec<T, CAP>
+impl<T: core::marker::Copy, const CAP: usize> core::ops::deref::DerefMut for bitcoin_internals::array_vec::ArrayVec<T, CAP>
+impl<T> bitcoin_internals::slice::SliceExt for [T]
+impl<const N: usize, T> bitcoin_internals::array::ArrayExt for [T; N]
+pub bitcoin_internals::script::PushDataLenLen::Four = 4
+pub bitcoin_internals::script::PushDataLenLen::One = 1
+pub bitcoin_internals::script::PushDataLenLen::Two = 2
+pub const bitcoin_internals::compact_size::MAX_ENCODABLE_VALUE: u64
+pub const bitcoin_internals::compact_size::MAX_ENCODING_SIZE: usize
+pub const fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::as_slice(&self) -> &[T]
+pub const fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::from_slice(slice: &[T]) -> Self
+pub const fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::new() -> Self
+pub const fn bitcoin_internals::compact_size::encoded_size_const(value: u64) -> usize
+pub const fn bitcoin_internals::const_casts::i16_to_i64(value: i16) -> i64
+pub const fn bitcoin_internals::const_casts::u16_to_u32(value: u16) -> u32
+pub const fn bitcoin_internals::const_casts::u16_to_u64(value: u16) -> u64
+pub const fn bitcoin_internals::const_casts::u32_to_u64(value: u32) -> u64
+pub enum bitcoin_internals::script::PushDataLenLen
+pub fn [T; LEN]::eq(&self, other: &bitcoin_internals::array_vec::ArrayVec<T, CAP>) -> bool
+pub fn [T; N]::split_array<const LEFT: usize, const RIGHT: usize>(&self) -> (&[Self::Item; LEFT], &[Self::Item; RIGHT])
+pub fn [T; N]::sub_array<const OFFSET: usize, const LEN: usize>(&self) -> &[Self::Item; LEN]
+pub fn [T]::bitcoin_as_chunks<const N: usize>(&self) -> (&[[Self::Item; N]], &[Self::Item])
+pub fn [T]::bitcoin_as_chunks_mut<const N: usize>(&mut self) -> (&mut [[Self::Item; N]], &mut [Self::Item])
+pub fn [T]::eq(&self, other: &bitcoin_internals::array_vec::ArrayVec<T, CAP>) -> bool
+pub fn [T]::get_array<const ARRAY_LEN: usize>(&self, offset: usize) -> core::option::Option<&[Self::Item; ARRAY_LEN]>
+pub fn [T]::split_first_chunk<const ARRAY_LEN: usize>(&self) -> core::option::Option<(&[Self::Item; ARRAY_LEN], &[Self::Item])>
+pub fn [T]::split_last_chunk<const ARRAY_LEN: usize>(&self) -> core::option::Option<(&[Self::Item], &[Self::Item; ARRAY_LEN])>
+pub fn bitcoin_internals::ToU64::to_u64(self) -> u64
+pub fn bitcoin_internals::array::ArrayExt::first(&self) -> &Self::Item
+pub fn bitcoin_internals::array::ArrayExt::get_static<const INDEX: usize>(&self) -> &Self::Item
+pub fn bitcoin_internals::array::ArrayExt::split_array<const LEFT: usize, const RIGHT: usize>(&self) -> (&[Self::Item; LEFT], &[Self::Item; RIGHT])
+pub fn bitcoin_internals::array::ArrayExt::split_first<const RIGHT: usize>(&self) -> (&Self::Item, &[Self::Item; RIGHT])
+pub fn bitcoin_internals::array::ArrayExt::split_last<const LEFT: usize>(&self) -> (&Self::Item, &[Self::Item; LEFT])
+pub fn bitcoin_internals::array::ArrayExt::sub_array<const OFFSET: usize, const LEN: usize>(&self) -> &[Self::Item; LEN]
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP1>::eq(&self, other: &bitcoin_internals::array_vec::ArrayVec<T, CAP2>) -> bool
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP1>::partial_cmp(&self, other: &bitcoin_internals::array_vec::ArrayVec<T, CAP2>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::as_mut_slice(&mut self) -> &mut [T]
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::clone(&self) -> Self
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::cmp(&self, other: &Self) -> core::cmp::Ordering
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::default() -> Self
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::deref(&self) -> &Self::Target
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::deref_mut(&mut self) -> &mut Self::Target
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::eq(&self, other: &[T; LEN]) -> bool
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::eq(&self, other: &[T]) -> bool
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::extend_from_slice(&mut self, slice: &[T])
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::hash<H: core::hash::Hasher>(&self, state: &mut H)
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::pop(&mut self) -> core::option::Option<T>
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::push(&mut self, element: T)
+pub fn bitcoin_internals::compact_size::decode_unchecked(slice: &mut &[u8]) -> u64
+pub fn bitcoin_internals::compact_size::encode(value: impl bitcoin_internals::ToU64) -> bitcoin_internals::array_vec::ArrayVec<u8, MAX_ENCODING_SIZE>
+pub fn bitcoin_internals::compact_size::encoded_size(value: impl bitcoin_internals::ToU64) -> usize
+pub fn bitcoin_internals::error::input_string::CannotParse<'_, T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_internals::error::input_string::InputString::clone(&self) -> bitcoin_internals::error::input_string::InputString
+pub fn bitcoin_internals::error::input_string::InputString::cmp(&self, other: &bitcoin_internals::error::input_string::InputString) -> core::cmp::Ordering
+pub fn bitcoin_internals::error::input_string::InputString::display_cannot_parse<'a, T>(&'a self, what: &'a T) -> bitcoin_internals::error::input_string::CannotParse<'a, T> where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_internals::error::input_string::InputString::eq(&self, other: &bitcoin_internals::error::input_string::InputString) -> bool
+pub fn bitcoin_internals::error::input_string::InputString::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_internals::error::input_string::InputString::from(input: &str) -> Self
+pub fn bitcoin_internals::error::input_string::InputString::from(input: alloc::borrow::Cow<'_, str>) -> Self
+pub fn bitcoin_internals::error::input_string::InputString::from(input: alloc::boxed::Box<str>) -> Self
+pub fn bitcoin_internals::error::input_string::InputString::from(input: alloc::string::String) -> Self
+pub fn bitcoin_internals::error::input_string::InputString::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_internals::error::input_string::InputString::partial_cmp(&self, other: &bitcoin_internals::error::input_string::InputString) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_internals::error::input_string::InputString::unknown_variant<T>(&self, what: &T, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_internals::script::EarlyEndOfScriptError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_internals::script::PushDataLenLen::clone(&self) -> bitcoin_internals::script::PushDataLenLen
+pub fn bitcoin_internals::script::PushDataLenLen::cmp(&self, other: &bitcoin_internals::script::PushDataLenLen) -> core::cmp::Ordering
+pub fn bitcoin_internals::script::PushDataLenLen::eq(&self, other: &bitcoin_internals::script::PushDataLenLen) -> bool
+pub fn bitcoin_internals::script::PushDataLenLen::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_internals::script::PushDataLenLen::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_internals::script::PushDataLenLen::partial_cmp(&self, other: &bitcoin_internals::script::PushDataLenLen) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_internals::script::read_push_data_len(data: &mut core::slice::iter::Iter<'_, u8>, size: bitcoin_internals::script::PushDataLenLen) -> core::result::Result<usize, bitcoin_internals::script::EarlyEndOfScriptError>
+pub fn bitcoin_internals::slice::SliceExt::bitcoin_as_chunks<const N: usize>(&self) -> (&[[Self::Item; N]], &[Self::Item])
+pub fn bitcoin_internals::slice::SliceExt::bitcoin_as_chunks_mut<const N: usize>(&mut self) -> (&mut [[Self::Item; N]], &mut [Self::Item])
+pub fn bitcoin_internals::slice::SliceExt::get_array<const ARRAY_LEN: usize>(&self, offset: usize) -> core::option::Option<&[Self::Item; ARRAY_LEN]>
+pub fn bitcoin_internals::slice::SliceExt::split_first_chunk<const ARRAY_LEN: usize>(&self) -> core::option::Option<(&[Self::Item; ARRAY_LEN], &[Self::Item])>
+pub fn bitcoin_internals::slice::SliceExt::split_last_chunk<const ARRAY_LEN: usize>(&self) -> core::option::Option<(&[Self::Item], &[Self::Item; ARRAY_LEN])>
+pub fn bitcoin_internals::wrap_debug::WrapDebug<F>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn u16::to_u64(self) -> u64
+pub fn u32::to_u64(self) -> u64
+pub fn u64::to_u64(self) -> u64
+pub fn u8::to_u64(self) -> u64
+pub fn usize::to_u64(self) -> u64
+pub macro bitcoin_internals::concat_bytes_to_arr!
+pub macro bitcoin_internals::cond_const!
+pub macro bitcoin_internals::const_assert!
+pub macro bitcoin_internals::const_tools::concat_bytes_to_arr!
+pub macro bitcoin_internals::const_tools::cond_const!
+pub macro bitcoin_internals::const_tools::copy_byte_array_from_slice!
+pub macro bitcoin_internals::copy_byte_array_from_slice!
+pub macro bitcoin_internals::impl_array_newtype!
+pub macro bitcoin_internals::impl_parse!
+pub macro bitcoin_internals::impl_parse_and_serde!
+pub macro bitcoin_internals::impl_to_hex_from_lower_hex!
+pub macro bitcoin_internals::parse_error_type!
+pub macro bitcoin_internals::rust_version!
+pub macro bitcoin_internals::transparent_newtype!
+pub macro bitcoin_internals::write_err!
+pub mod bitcoin_internals
+pub mod bitcoin_internals::array
+pub mod bitcoin_internals::array_vec
+pub mod bitcoin_internals::compact_size
+pub mod bitcoin_internals::const_casts
+pub mod bitcoin_internals::const_tools
+pub mod bitcoin_internals::error
+pub mod bitcoin_internals::error::input_string
+pub mod bitcoin_internals::macros
+pub mod bitcoin_internals::script
+pub mod bitcoin_internals::slice
+pub mod bitcoin_internals::wrap_debug
+pub struct bitcoin_internals::array_vec::ArrayVec<T: core::marker::Copy, const CAP: usize>
+pub struct bitcoin_internals::error::InputString(_)
+pub struct bitcoin_internals::error::input_string::CannotParse<'a, T: core::fmt::Display + ?core::marker::Sized>
+pub struct bitcoin_internals::error::input_string::InputString(_)
+pub struct bitcoin_internals::script::EarlyEndOfScriptError
+pub struct bitcoin_internals::wrap_debug::WrapDebug<F: core::ops::function::Fn(&mut core::fmt::Formatter<'_>) -> core::fmt::Result>(pub F)
+pub trait bitcoin_internals::ToU64
+pub trait bitcoin_internals::array::ArrayExt
+pub trait bitcoin_internals::slice::SliceExt
+pub type [T; N]::Item = T
+pub type [T]::Item = T
+pub type bitcoin_internals::array::ArrayExt::Item
+pub type bitcoin_internals::array_vec::ArrayVec<T, CAP>::Target = [T]
+pub type bitcoin_internals::slice::SliceExt::Item

--- a/api/internals/no-features.txt
+++ b/api/internals/no-features.txt
@@ -1,0 +1,199 @@
+impl bitcoin_internals::ToU64 for u16
+impl bitcoin_internals::ToU64 for u32
+impl bitcoin_internals::ToU64 for u64
+impl bitcoin_internals::ToU64 for u8
+impl bitcoin_internals::ToU64 for usize
+impl bitcoin_internals::error::input_string::InputString
+impl core::clone::Clone for bitcoin_internals::error::input_string::InputString
+impl core::clone::Clone for bitcoin_internals::script::PushDataLenLen
+impl core::cmp::Eq for bitcoin_internals::error::input_string::InputString
+impl core::cmp::Eq for bitcoin_internals::script::PushDataLenLen
+impl core::cmp::Ord for bitcoin_internals::error::input_string::InputString
+impl core::cmp::Ord for bitcoin_internals::script::PushDataLenLen
+impl core::cmp::PartialEq for bitcoin_internals::error::input_string::InputString
+impl core::cmp::PartialEq for bitcoin_internals::script::PushDataLenLen
+impl core::cmp::PartialOrd for bitcoin_internals::error::input_string::InputString
+impl core::cmp::PartialOrd for bitcoin_internals::script::PushDataLenLen
+impl core::convert::From<&str> for bitcoin_internals::error::input_string::InputString
+impl core::fmt::Debug for bitcoin_internals::error::input_string::InputString
+impl core::fmt::Debug for bitcoin_internals::script::EarlyEndOfScriptError
+impl core::fmt::Debug for bitcoin_internals::script::PushDataLenLen
+impl core::hash::Hash for bitcoin_internals::error::input_string::InputString
+impl core::hash::Hash for bitcoin_internals::script::PushDataLenLen
+impl core::marker::Copy for bitcoin_internals::script::PushDataLenLen
+impl core::marker::Freeze for bitcoin_internals::error::input_string::InputString
+impl core::marker::Freeze for bitcoin_internals::script::EarlyEndOfScriptError
+impl core::marker::Freeze for bitcoin_internals::script::PushDataLenLen
+impl core::marker::Send for bitcoin_internals::error::input_string::InputString
+impl core::marker::Send for bitcoin_internals::script::EarlyEndOfScriptError
+impl core::marker::Send for bitcoin_internals::script::PushDataLenLen
+impl core::marker::StructuralPartialEq for bitcoin_internals::error::input_string::InputString
+impl core::marker::StructuralPartialEq for bitcoin_internals::script::PushDataLenLen
+impl core::marker::Sync for bitcoin_internals::error::input_string::InputString
+impl core::marker::Sync for bitcoin_internals::script::EarlyEndOfScriptError
+impl core::marker::Sync for bitcoin_internals::script::PushDataLenLen
+impl core::marker::Unpin for bitcoin_internals::error::input_string::InputString
+impl core::marker::Unpin for bitcoin_internals::script::EarlyEndOfScriptError
+impl core::marker::Unpin for bitcoin_internals::script::PushDataLenLen
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_internals::error::input_string::InputString
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_internals::script::EarlyEndOfScriptError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_internals::script::PushDataLenLen
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_internals::error::input_string::InputString
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_internals::script::EarlyEndOfScriptError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_internals::script::PushDataLenLen
+impl<'a, T> core::marker::Freeze for bitcoin_internals::error::input_string::CannotParse<'a, T> where T: ?core::marker::Sized
+impl<'a, T> core::marker::Send for bitcoin_internals::error::input_string::CannotParse<'a, T> where T: core::marker::Sync + ?core::marker::Sized
+impl<'a, T> core::marker::Sync for bitcoin_internals::error::input_string::CannotParse<'a, T> where T: core::marker::Sync + ?core::marker::Sized
+impl<'a, T> core::marker::Unpin for bitcoin_internals::error::input_string::CannotParse<'a, T> where T: ?core::marker::Sized
+impl<'a, T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_internals::error::input_string::CannotParse<'a, T> where T: core::panic::unwind_safe::RefUnwindSafe + ?core::marker::Sized
+impl<'a, T> core::panic::unwind_safe::UnwindSafe for bitcoin_internals::error::input_string::CannotParse<'a, T> where T: core::panic::unwind_safe::RefUnwindSafe + ?core::marker::Sized
+impl<F: core::ops::function::Fn(&mut core::fmt::Formatter<'_>) -> core::fmt::Result> core::fmt::Debug for bitcoin_internals::wrap_debug::WrapDebug<F>
+impl<F> core::marker::Freeze for bitcoin_internals::wrap_debug::WrapDebug<F> where F: core::marker::Freeze
+impl<F> core::marker::Send for bitcoin_internals::wrap_debug::WrapDebug<F> where F: core::marker::Send
+impl<F> core::marker::Sync for bitcoin_internals::wrap_debug::WrapDebug<F> where F: core::marker::Sync
+impl<F> core::marker::Unpin for bitcoin_internals::wrap_debug::WrapDebug<F> where F: core::marker::Unpin
+impl<F> core::panic::unwind_safe::RefUnwindSafe for bitcoin_internals::wrap_debug::WrapDebug<F> where F: core::panic::unwind_safe::RefUnwindSafe
+impl<F> core::panic::unwind_safe::UnwindSafe for bitcoin_internals::wrap_debug::WrapDebug<F> where F: core::panic::unwind_safe::UnwindSafe
+impl<T, const CAP: usize> core::marker::Freeze for bitcoin_internals::array_vec::ArrayVec<T, CAP> where T: core::marker::Freeze
+impl<T, const CAP: usize> core::marker::Send for bitcoin_internals::array_vec::ArrayVec<T, CAP> where T: core::marker::Send
+impl<T, const CAP: usize> core::marker::Sync for bitcoin_internals::array_vec::ArrayVec<T, CAP> where T: core::marker::Sync
+impl<T, const CAP: usize> core::marker::Unpin for bitcoin_internals::array_vec::ArrayVec<T, CAP> where T: core::marker::Unpin
+impl<T, const CAP: usize> core::panic::unwind_safe::RefUnwindSafe for bitcoin_internals::array_vec::ArrayVec<T, CAP> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T, const CAP: usize> core::panic::unwind_safe::UnwindSafe for bitcoin_internals::array_vec::ArrayVec<T, CAP> where T: core::panic::unwind_safe::UnwindSafe
+impl<T: core::fmt::Display + ?core::marker::Sized> core::fmt::Display for bitcoin_internals::error::input_string::CannotParse<'_, T>
+impl<T: core::marker::Copy + core::cmp::Eq, const CAP: usize> core::cmp::Eq for bitcoin_internals::array_vec::ArrayVec<T, CAP>
+impl<T: core::marker::Copy + core::cmp::Ord, const CAP: usize> core::cmp::Ord for bitcoin_internals::array_vec::ArrayVec<T, CAP>
+impl<T: core::marker::Copy + core::cmp::PartialEq, const CAP1: usize, const CAP2: usize> core::cmp::PartialEq<bitcoin_internals::array_vec::ArrayVec<T, CAP2>> for bitcoin_internals::array_vec::ArrayVec<T, CAP1>
+impl<T: core::marker::Copy + core::cmp::PartialEq, const CAP: usize, const LEN: usize> core::cmp::PartialEq<[T; LEN]> for bitcoin_internals::array_vec::ArrayVec<T, CAP>
+impl<T: core::marker::Copy + core::cmp::PartialEq, const CAP: usize, const LEN: usize> core::cmp::PartialEq<bitcoin_internals::array_vec::ArrayVec<T, CAP>> for [T; LEN]
+impl<T: core::marker::Copy + core::cmp::PartialEq, const CAP: usize> core::cmp::PartialEq<[T]> for bitcoin_internals::array_vec::ArrayVec<T, CAP>
+impl<T: core::marker::Copy + core::cmp::PartialEq, const CAP: usize> core::cmp::PartialEq<bitcoin_internals::array_vec::ArrayVec<T, CAP>> for [T]
+impl<T: core::marker::Copy + core::cmp::PartialOrd, const CAP1: usize, const CAP2: usize> core::cmp::PartialOrd<bitcoin_internals::array_vec::ArrayVec<T, CAP2>> for bitcoin_internals::array_vec::ArrayVec<T, CAP1>
+impl<T: core::marker::Copy + core::fmt::Debug, const CAP: usize> core::fmt::Debug for bitcoin_internals::array_vec::ArrayVec<T, CAP>
+impl<T: core::marker::Copy + core::hash::Hash, const CAP: usize> core::hash::Hash for bitcoin_internals::array_vec::ArrayVec<T, CAP>
+impl<T: core::marker::Copy + core::marker::Copy, const CAP: usize> core::marker::Copy for bitcoin_internals::array_vec::ArrayVec<T, CAP>
+impl<T: core::marker::Copy, const CAP: usize> bitcoin_internals::array_vec::ArrayVec<T, CAP>
+impl<T: core::marker::Copy, const CAP: usize> core::clone::Clone for bitcoin_internals::array_vec::ArrayVec<T, CAP>
+impl<T: core::marker::Copy, const CAP: usize> core::default::Default for bitcoin_internals::array_vec::ArrayVec<T, CAP>
+impl<T: core::marker::Copy, const CAP: usize> core::ops::deref::Deref for bitcoin_internals::array_vec::ArrayVec<T, CAP>
+impl<T: core::marker::Copy, const CAP: usize> core::ops::deref::DerefMut for bitcoin_internals::array_vec::ArrayVec<T, CAP>
+impl<T> bitcoin_internals::slice::SliceExt for [T]
+impl<const N: usize, T> bitcoin_internals::array::ArrayExt for [T; N]
+pub bitcoin_internals::script::PushDataLenLen::Four = 4
+pub bitcoin_internals::script::PushDataLenLen::One = 1
+pub bitcoin_internals::script::PushDataLenLen::Two = 2
+pub const bitcoin_internals::compact_size::MAX_ENCODABLE_VALUE: u64
+pub const bitcoin_internals::compact_size::MAX_ENCODING_SIZE: usize
+pub const fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::as_slice(&self) -> &[T]
+pub const fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::from_slice(slice: &[T]) -> Self
+pub const fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::new() -> Self
+pub const fn bitcoin_internals::compact_size::encoded_size_const(value: u64) -> usize
+pub const fn bitcoin_internals::const_casts::i16_to_i64(value: i16) -> i64
+pub const fn bitcoin_internals::const_casts::u16_to_u32(value: u16) -> u32
+pub const fn bitcoin_internals::const_casts::u16_to_u64(value: u16) -> u64
+pub const fn bitcoin_internals::const_casts::u32_to_u64(value: u32) -> u64
+pub enum bitcoin_internals::script::PushDataLenLen
+pub fn [T; LEN]::eq(&self, other: &bitcoin_internals::array_vec::ArrayVec<T, CAP>) -> bool
+pub fn [T; N]::split_array<const LEFT: usize, const RIGHT: usize>(&self) -> (&[Self::Item; LEFT], &[Self::Item; RIGHT])
+pub fn [T; N]::sub_array<const OFFSET: usize, const LEN: usize>(&self) -> &[Self::Item; LEN]
+pub fn [T]::bitcoin_as_chunks<const N: usize>(&self) -> (&[[Self::Item; N]], &[Self::Item])
+pub fn [T]::bitcoin_as_chunks_mut<const N: usize>(&mut self) -> (&mut [[Self::Item; N]], &mut [Self::Item])
+pub fn [T]::eq(&self, other: &bitcoin_internals::array_vec::ArrayVec<T, CAP>) -> bool
+pub fn [T]::get_array<const ARRAY_LEN: usize>(&self, offset: usize) -> core::option::Option<&[Self::Item; ARRAY_LEN]>
+pub fn [T]::split_first_chunk<const ARRAY_LEN: usize>(&self) -> core::option::Option<(&[Self::Item; ARRAY_LEN], &[Self::Item])>
+pub fn [T]::split_last_chunk<const ARRAY_LEN: usize>(&self) -> core::option::Option<(&[Self::Item], &[Self::Item; ARRAY_LEN])>
+pub fn bitcoin_internals::ToU64::to_u64(self) -> u64
+pub fn bitcoin_internals::array::ArrayExt::first(&self) -> &Self::Item
+pub fn bitcoin_internals::array::ArrayExt::get_static<const INDEX: usize>(&self) -> &Self::Item
+pub fn bitcoin_internals::array::ArrayExt::split_array<const LEFT: usize, const RIGHT: usize>(&self) -> (&[Self::Item; LEFT], &[Self::Item; RIGHT])
+pub fn bitcoin_internals::array::ArrayExt::split_first<const RIGHT: usize>(&self) -> (&Self::Item, &[Self::Item; RIGHT])
+pub fn bitcoin_internals::array::ArrayExt::split_last<const LEFT: usize>(&self) -> (&Self::Item, &[Self::Item; LEFT])
+pub fn bitcoin_internals::array::ArrayExt::sub_array<const OFFSET: usize, const LEN: usize>(&self) -> &[Self::Item; LEN]
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP1>::eq(&self, other: &bitcoin_internals::array_vec::ArrayVec<T, CAP2>) -> bool
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP1>::partial_cmp(&self, other: &bitcoin_internals::array_vec::ArrayVec<T, CAP2>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::as_mut_slice(&mut self) -> &mut [T]
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::clone(&self) -> Self
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::cmp(&self, other: &Self) -> core::cmp::Ordering
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::default() -> Self
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::deref(&self) -> &Self::Target
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::deref_mut(&mut self) -> &mut Self::Target
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::eq(&self, other: &[T; LEN]) -> bool
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::eq(&self, other: &[T]) -> bool
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::extend_from_slice(&mut self, slice: &[T])
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::hash<H: core::hash::Hasher>(&self, state: &mut H)
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::pop(&mut self) -> core::option::Option<T>
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::push(&mut self, element: T)
+pub fn bitcoin_internals::compact_size::decode_unchecked(slice: &mut &[u8]) -> u64
+pub fn bitcoin_internals::compact_size::encode(value: impl bitcoin_internals::ToU64) -> bitcoin_internals::array_vec::ArrayVec<u8, MAX_ENCODING_SIZE>
+pub fn bitcoin_internals::compact_size::encoded_size(value: impl bitcoin_internals::ToU64) -> usize
+pub fn bitcoin_internals::error::input_string::CannotParse<'_, T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_internals::error::input_string::InputString::clone(&self) -> bitcoin_internals::error::input_string::InputString
+pub fn bitcoin_internals::error::input_string::InputString::cmp(&self, other: &bitcoin_internals::error::input_string::InputString) -> core::cmp::Ordering
+pub fn bitcoin_internals::error::input_string::InputString::display_cannot_parse<'a, T>(&'a self, what: &'a T) -> bitcoin_internals::error::input_string::CannotParse<'a, T> where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_internals::error::input_string::InputString::eq(&self, other: &bitcoin_internals::error::input_string::InputString) -> bool
+pub fn bitcoin_internals::error::input_string::InputString::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_internals::error::input_string::InputString::from(input: &str) -> Self
+pub fn bitcoin_internals::error::input_string::InputString::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_internals::error::input_string::InputString::partial_cmp(&self, other: &bitcoin_internals::error::input_string::InputString) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_internals::error::input_string::InputString::unknown_variant<T>(&self, what: &T, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_internals::script::EarlyEndOfScriptError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_internals::script::PushDataLenLen::clone(&self) -> bitcoin_internals::script::PushDataLenLen
+pub fn bitcoin_internals::script::PushDataLenLen::cmp(&self, other: &bitcoin_internals::script::PushDataLenLen) -> core::cmp::Ordering
+pub fn bitcoin_internals::script::PushDataLenLen::eq(&self, other: &bitcoin_internals::script::PushDataLenLen) -> bool
+pub fn bitcoin_internals::script::PushDataLenLen::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_internals::script::PushDataLenLen::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_internals::script::PushDataLenLen::partial_cmp(&self, other: &bitcoin_internals::script::PushDataLenLen) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_internals::script::read_push_data_len(data: &mut core::slice::iter::Iter<'_, u8>, size: bitcoin_internals::script::PushDataLenLen) -> core::result::Result<usize, bitcoin_internals::script::EarlyEndOfScriptError>
+pub fn bitcoin_internals::slice::SliceExt::bitcoin_as_chunks<const N: usize>(&self) -> (&[[Self::Item; N]], &[Self::Item])
+pub fn bitcoin_internals::slice::SliceExt::bitcoin_as_chunks_mut<const N: usize>(&mut self) -> (&mut [[Self::Item; N]], &mut [Self::Item])
+pub fn bitcoin_internals::slice::SliceExt::get_array<const ARRAY_LEN: usize>(&self, offset: usize) -> core::option::Option<&[Self::Item; ARRAY_LEN]>
+pub fn bitcoin_internals::slice::SliceExt::split_first_chunk<const ARRAY_LEN: usize>(&self) -> core::option::Option<(&[Self::Item; ARRAY_LEN], &[Self::Item])>
+pub fn bitcoin_internals::slice::SliceExt::split_last_chunk<const ARRAY_LEN: usize>(&self) -> core::option::Option<(&[Self::Item], &[Self::Item; ARRAY_LEN])>
+pub fn bitcoin_internals::wrap_debug::WrapDebug<F>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn u16::to_u64(self) -> u64
+pub fn u32::to_u64(self) -> u64
+pub fn u64::to_u64(self) -> u64
+pub fn u8::to_u64(self) -> u64
+pub fn usize::to_u64(self) -> u64
+pub macro bitcoin_internals::concat_bytes_to_arr!
+pub macro bitcoin_internals::cond_const!
+pub macro bitcoin_internals::const_assert!
+pub macro bitcoin_internals::const_tools::concat_bytes_to_arr!
+pub macro bitcoin_internals::const_tools::cond_const!
+pub macro bitcoin_internals::const_tools::copy_byte_array_from_slice!
+pub macro bitcoin_internals::copy_byte_array_from_slice!
+pub macro bitcoin_internals::impl_array_newtype!
+pub macro bitcoin_internals::impl_parse!
+pub macro bitcoin_internals::impl_parse_and_serde!
+pub macro bitcoin_internals::impl_to_hex_from_lower_hex!
+pub macro bitcoin_internals::parse_error_type!
+pub macro bitcoin_internals::rust_version!
+pub macro bitcoin_internals::transparent_newtype!
+pub macro bitcoin_internals::write_err!
+pub mod bitcoin_internals
+pub mod bitcoin_internals::array
+pub mod bitcoin_internals::array_vec
+pub mod bitcoin_internals::compact_size
+pub mod bitcoin_internals::const_casts
+pub mod bitcoin_internals::const_tools
+pub mod bitcoin_internals::error
+pub mod bitcoin_internals::error::input_string
+pub mod bitcoin_internals::macros
+pub mod bitcoin_internals::script
+pub mod bitcoin_internals::slice
+pub mod bitcoin_internals::wrap_debug
+pub struct bitcoin_internals::array_vec::ArrayVec<T: core::marker::Copy, const CAP: usize>
+pub struct bitcoin_internals::error::InputString(_)
+pub struct bitcoin_internals::error::input_string::CannotParse<'a, T: core::fmt::Display + ?core::marker::Sized>
+pub struct bitcoin_internals::error::input_string::InputString(_)
+pub struct bitcoin_internals::script::EarlyEndOfScriptError
+pub struct bitcoin_internals::wrap_debug::WrapDebug<F: core::ops::function::Fn(&mut core::fmt::Formatter<'_>) -> core::fmt::Result>(pub F)
+pub trait bitcoin_internals::ToU64
+pub trait bitcoin_internals::array::ArrayExt
+pub trait bitcoin_internals::slice::SliceExt
+pub type [T; N]::Item = T
+pub type [T]::Item = T
+pub type bitcoin_internals::array::ArrayExt::Item
+pub type bitcoin_internals::array_vec::ArrayVec<T, CAP>::Target = [T]
+pub type bitcoin_internals::slice::SliceExt::Item

--- a/contrib/check-for-api-changes.sh
+++ b/contrib/check-for-api-changes.sh
@@ -36,6 +36,9 @@ main() {
     generate_api_files "units"
     generate_api_files "primitives"
 
+    # Check crates under the stabilising crates
+    generate_api_files "internals"
+
     [ -f "Cargo.lock.tmp" ] && mv Cargo.lock.tmp Cargo.lock
 
     check_for_changes


### PR DESCRIPTION
Currently only stable crates have API files. Since some features may cross crate boundaries, and involve breaking changes to the API of crates under the stable crates, it's important to track the API of these crates also.

Add internals to check-api just function and add initial API files.

Contributes to #5404