### PR TITLE
docs: add missing errors documentation to primitives crate

### DIFF
--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -117,6 +117,14 @@ impl Block<Unchecked> {
     ///
     /// * The Merkle root of the header matches Merkle root of the transaction list.
     /// * The witness commitment in coinbase matches the transaction list.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// * The block has no transactions.
+    /// * The first transaction is not a coinbase transaction.
+    /// * The Merkle root of the header does not match the Merkle root of the transaction list.
+    /// * The witness commitment in the coinbase does not match the transaction list.
     pub fn validate(self) -> Result<Block<Checked>, InvalidBlockError> {
         if self.transactions.is_empty() {
             return Err(InvalidBlockError::NoTransactions);

--- a/primitives/src/hash_types/script_hash.rs
+++ b/primitives/src/hash_types/script_hash.rs
@@ -32,6 +32,10 @@ impl ScriptHash {
     /// > spend a P2SH output if the redemption script it refers to is >520 bytes in length.
     ///
     /// ref: [BIP-0016](https://github.com/bitcoin/bips/blob/master/bip-0016.mediawiki#user-content-520byte_limitation_on_serialized_script_size)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the script exceeds 520 bytes.
     #[inline]
     pub fn from_script<T>(redeem_script: &Script<T>) -> Result<Self, RedeemScriptSizeError>
     where

--- a/primitives/src/hash_types/witness_script_hash.rs
+++ b/primitives/src/hash_types/witness_script_hash.rs
@@ -30,6 +30,10 @@ impl WScriptHash {
     /// > witnessScript must match the 32-byte witness program.
     ///
     /// ref: [BIP-0141](https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the script exceeds 10,000 bytes.
     #[inline]
     pub fn from_script(witness_script: &WitnessScript) -> Result<Self, WitnessScriptSizeError> {
         if witness_script.len() > MAX_WITNESS_SCRIPT_SIZE {

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -18,7 +18,7 @@
 #![warn(deprecated_in_future)]
 #![doc(test(attr(warn(unused))))]
 // Package-specific lint overrides.
-#![allow(clippy::missing_errors_doc)] // TODO: Write errors section in docs.
+
 
 #[cfg(feature = "alloc")]
 extern crate alloc;


### PR DESCRIPTION
This PR addresses the `TODO` in [primitives/src/lib.rs](cci:7://file:///home/kaftandev/cont/primitives/src/lib.rs:0:0-0:0) by enabling the `clippy::missing_errors_doc` lint for the `bitcoin-primitives` crate.
It adds the missing `# Errors` section to the documentation of:

- `ScriptHash::from_script`
- `WScriptHash::from_script`
- `Block::validate`

These changes ensure better documentation coverage and help consumers understand potential error conditions.

## Checklist
- [x] All new code is covered by unit tests (docs only changes)
- [x] All changes compile and pass tests locally
- [x] Documentation updated