### PR TITLE
Move `TxIdentifier` into `bip152`

### DIFF
--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -76,12 +76,6 @@ internal_macros::define_extension_trait! {
     }
 }
 
-/// Trait that abstracts over a transaction identifier i.e., `Txid` and `Wtxid`.
-pub trait TxIdentifier: sealed::Sealed + AsRef<[u8]> {}
-
-impl TxIdentifier for Txid {}
-impl TxIdentifier for Wtxid {}
-
 // Duplicated in `primitives`.
 /// The marker MUST be a 1-byte zero value: 0x00. (BIP-0141)
 const SEGWIT_MARKER: u8 = 0x00;

--- a/p2p/src/bip152.rs
+++ b/p2p/src/bip152.rs
@@ -13,7 +13,6 @@ use std::error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
 use bitcoin::consensus::encode::{self, Decodable, Encodable, ReadExt, WriteExt};
-use bitcoin::transaction::TxIdentifier;
 use bitcoin::{block, Block, BlockChecked, BlockHash, Transaction};
 use hashes::{sha256, siphash24};
 use internals::array::ArrayExt as _;
@@ -92,6 +91,18 @@ impl Decodable for PrefilledTransaction {
         let tx = Transaction::consensus_decode(r)?;
         Ok(Self { idx, tx })
     }
+}
+
+/// Trait that abstracts over a transaction identifier i.e., `Txid` and `Wtxid`.
+pub trait TxIdentifier: sealed::Sealed + AsRef<[u8]> {}
+
+impl TxIdentifier for bitcoin::Txid {}
+impl TxIdentifier for bitcoin::Wtxid {}
+
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for bitcoin::Txid {}
+    impl Sealed for bitcoin::Wtxid {}
 }
 
 /// Short transaction IDs are used to represent a transaction without sending a full 256-bit hash.


### PR DESCRIPTION
Further crate de-coupling from `bitcoin`.

~This generalizes the API for something `TxIdentifier` implements without having to duplicate type. If/when `TxIdentifier` is public in primitives, we can replace it again.~

Move the trait from `bitcoin/blockdata`, where it was only being used via `p2p`.