### PR TITLE
Release tracking PR: `base58ck v0.3.0`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -16,7 +16,7 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "base58ck"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bitcoin-internals",
  "bitcoin_hashes",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -16,7 +16,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "base58ck"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bitcoin-internals",
  "bitcoin_hashes",

--- a/base58/CHANGELOG.md
+++ b/base58/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.0 - 2025-12-15
+
+- Bump MSRV from 1.63.0 to 1.74.0 for all crates in the repo [#4926](https://github.com/rust-bitcoin/rust-bitcoin/pull/4926)
+
 # 0.2.0 - 2024-12-10
 
 - Bump MSRV to `1.63` [#3100](https://github.com/rust-bitcoin/rust-bitcoin/pull/3100)

--- a/base58/Cargo.toml
+++ b/base58/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base58ck"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"
@@ -18,8 +18,8 @@ std = ["alloc", "hashes/std", "internals/std"]
 alloc = ["hashes/alloc", "internals/alloc"]
 
 [dependencies]
-hashes = { package = "bitcoin_hashes", path = "../hashes", default-features = false }
-internals = { package = "bitcoin-internals", path = "../internals" }
+hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.18.0", default-features = false }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.4.2" }
 
 [dev-dependencies]
 hex_lit = "0.1.1"

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -25,7 +25,7 @@ secp-recovery = ["secp256k1/recovery"]
 arbitrary = ["dep:arbitrary", "units/arbitrary", "primitives/arbitrary"]
 
 [dependencies]
-base58 = { package = "base58ck", path = "../base58", version = "0.2.0", default-features = false, features = ["alloc"] }
+base58 = { package = "base58ck", path = "../base58", version = "0.3.0", default-features = false, features = ["alloc"] }
 bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.18.0", default-features = false, features = ["alloc", "hex"] }
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "=1.0.0-rc.2", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
In preparation for release bump the version, add a changelog, and update the lock files.

Note there have been no public changes to this crate other than bumping the MSRV.

Ran: `cargo publish --dry-run -p base58ck`