### PR TITLE
hashes: Remove uneeded wildcard import

### DIFF
--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -275,7 +275,6 @@ pub fn debug_hex(bytes: &[u8], f: &mut fmt::Formatter) -> fmt::Result {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::sha256d;
 
     hash_newtype! {


### PR DESCRIPTION
We don't need this atm, found by clippy while updating nightly toolchain.