### PR TITLE
primitives: reject transactions with invalid coinbase scriptSig length 

### DIFF
--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -1162,7 +1162,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // bad test; will be fixed in next commit
     #[cfg(feature = "alloc")]
     fn block_decode() {
         // Make a simple block, encode then decode. Verify equivalence.
@@ -1188,12 +1187,20 @@ mod tests {
         };
 
         let block: u32 = 741_521;
-        let transactions = vec![Transaction {
-            version: crate::transaction::Version::ONE,
-            lock_time: units::absolute::LockTime::from_height(block).unwrap(),
-            inputs: vec![crate::transaction::TxIn::EMPTY_COINBASE],
-            outputs: Vec::new(),
-        }];
+        let transactions = vec![
+            Transaction {
+                version: crate::transaction::Version::ONE,
+                lock_time: units::absolute::LockTime::from_height(block).unwrap(),
+                inputs: vec![crate::transaction::TxIn {
+                    previous_output: crate::transaction::OutPoint::COINBASE_PREVOUT,
+                    // Coinbase scriptSig must be 2-100 bytes
+                    script_sig: crate::script::ScriptSigBuf::from_bytes(vec![0x51, 0x51]),
+                    sequence: crate::sequence::Sequence::MAX,
+                    witness: crate::witness::Witness::new(),
+                }],
+                outputs: Vec::new(),
+            },
+        ];
         let original_block = Block::new_unchecked(header, transactions);
 
         // Encode + decode the block

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -780,6 +780,10 @@ pub struct TxIn {
 #[cfg(feature = "alloc")]
 impl TxIn {
     /// An empty transaction input with the previous output as for a coinbase transaction.
+    ///
+    /// This has a 0-byte scriptSig which is **invalid** per consensus rules
+    /// (coinbase scriptSig must be 2-100 bytes). This is kept for backwards compatibility
+    /// in PSBT workflows where the scriptSig is filled in later.
     pub const EMPTY_COINBASE: Self = Self {
         previous_output: OutPoint::COINBASE_PREVOUT,
         script_sig: ScriptSigBuf::new(),


### PR DESCRIPTION
Commit 1:
Coinbase input `scriptSig` must be between 2 and 100 bytes in length. This commit adds this validation rule to the transaction decoder.

Commit 2: 
According to `BIP34`, coinbase `scriptSig` must start with a push of the block height, which already supersedes the lower bound of 2 bytes.
However, we have a constant `EMPTY_COINBASE` that creates an invalid 0-byte scriptSig. For backward compatibility with PSBT, we keep this constand and only adds a comment explaining this behaviour.

Also update a test failing due to the new validation rule


Addresses part of #5383
