### PR TITLE
hashes: Add api files

### DIFF
--- a/api/hashes/all-features.txt
+++ b/api/hashes/all-features.txt
@@ -1,0 +1,1162 @@
+#[repr(transparent)] pub struct bitcoin_hashes::Hash160(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Hmac<T: bitcoin_hashes::Hash>(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Ripemd160(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha1(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha256(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha256d(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha384(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha3_256(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha512(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha512_256(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Siphash24(_)
+#[repr(transparent)] pub struct bitcoin_hashes::hash160::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::hmac::Hmac<T: bitcoin_hashes::Hash>(_)
+#[repr(transparent)] pub struct bitcoin_hashes::ripemd160::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha1::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256d::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256t::Hash<T>(_, _)
+#[repr(transparent)] pub struct bitcoin_hashes::sha384::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha3_256::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha512::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha512_256::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::siphash24::Hash(_)
+impl bitcoin_hashes::Hash for bitcoin_hashes::hash160::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::ripemd160::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha1::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha256::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha256d::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha384::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha3_256::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha512::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha512_256::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::siphash24::Hash
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::hash160::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::ripemd160::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha1::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha256::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha256d::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha384::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha3_256::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512_256::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::siphash24::HashEngine
+impl bitcoin_hashes::hash160::Hash
+impl bitcoin_hashes::hash160::HashEngine
+impl bitcoin_hashes::ripemd160::Hash
+impl bitcoin_hashes::ripemd160::HashEngine
+impl bitcoin_hashes::sha1::Hash
+impl bitcoin_hashes::sha1::HashEngine
+impl bitcoin_hashes::sha256::Hash
+impl bitcoin_hashes::sha256::HashEngine
+impl bitcoin_hashes::sha256::Midstate
+impl bitcoin_hashes::sha256d::Hash
+impl bitcoin_hashes::sha256d::HashEngine
+impl bitcoin_hashes::sha384::Hash
+impl bitcoin_hashes::sha384::HashEngine
+impl bitcoin_hashes::sha3_256::Hash
+impl bitcoin_hashes::sha3_256::HashEngine
+impl bitcoin_hashes::sha512::Hash
+impl bitcoin_hashes::sha512::HashEngine
+impl bitcoin_hashes::sha512_256::Hash
+impl bitcoin_hashes::sha512_256::HashEngine
+impl bitcoin_hashes::siphash24::Hash
+impl bitcoin_hashes::siphash24::HashEngine
+impl core::borrow::Borrow<[u8; 20]> for bitcoin_hashes::hash160::Hash
+impl core::borrow::Borrow<[u8; 20]> for bitcoin_hashes::ripemd160::Hash
+impl core::borrow::Borrow<[u8; 20]> for bitcoin_hashes::sha1::Hash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_hashes::sha256::Hash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_hashes::sha256d::Hash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_hashes::sha3_256::Hash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_hashes::sha512_256::Hash
+impl core::borrow::Borrow<[u8; 48]> for bitcoin_hashes::sha384::Hash
+impl core::borrow::Borrow<[u8; 64]> for bitcoin_hashes::sha512::Hash
+impl core::borrow::Borrow<[u8; 8]> for bitcoin_hashes::siphash24::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::hash160::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::ripemd160::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha1::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256d::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha384::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha3_256::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha512::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha512_256::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::siphash24::Hash
+impl core::clone::Clone for bitcoin_hashes::hash160::Hash
+impl core::clone::Clone for bitcoin_hashes::hash160::HashEngine
+impl core::clone::Clone for bitcoin_hashes::hkdf::MaxLengthError
+impl core::clone::Clone for bitcoin_hashes::ripemd160::Hash
+impl core::clone::Clone for bitcoin_hashes::ripemd160::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha1::Hash
+impl core::clone::Clone for bitcoin_hashes::sha1::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha256::Hash
+impl core::clone::Clone for bitcoin_hashes::sha256::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha256::Midstate
+impl core::clone::Clone for bitcoin_hashes::sha256::MidstateError
+impl core::clone::Clone for bitcoin_hashes::sha256d::Hash
+impl core::clone::Clone for bitcoin_hashes::sha256d::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha384::Hash
+impl core::clone::Clone for bitcoin_hashes::sha384::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha3_256::Hash
+impl core::clone::Clone for bitcoin_hashes::sha3_256::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha512::Hash
+impl core::clone::Clone for bitcoin_hashes::sha512::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha512_256::Hash
+impl core::clone::Clone for bitcoin_hashes::sha512_256::HashEngine
+impl core::clone::Clone for bitcoin_hashes::siphash24::Hash
+impl core::clone::Clone for bitcoin_hashes::siphash24::HashEngine
+impl core::clone::Clone for bitcoin_hashes::siphash24::State
+impl core::cmp::Eq for bitcoin_hashes::hash160::Hash
+impl core::cmp::Eq for bitcoin_hashes::hkdf::MaxLengthError
+impl core::cmp::Eq for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha1::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha256::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha256::Midstate
+impl core::cmp::Eq for bitcoin_hashes::sha256::MidstateError
+impl core::cmp::Eq for bitcoin_hashes::sha256d::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha384::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha3_256::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha512::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::Eq for bitcoin_hashes::siphash24::Hash
+impl core::cmp::Ord for bitcoin_hashes::hash160::Hash
+impl core::cmp::Ord for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha1::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha256::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha256::Midstate
+impl core::cmp::Ord for bitcoin_hashes::sha256d::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha384::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha3_256::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha512::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::Ord for bitcoin_hashes::siphash24::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::hash160::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::hkdf::MaxLengthError
+impl core::cmp::PartialEq for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha1::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha256::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha256::Midstate
+impl core::cmp::PartialEq for bitcoin_hashes::sha256::MidstateError
+impl core::cmp::PartialEq for bitcoin_hashes::sha256d::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha384::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha3_256::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha512::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::siphash24::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::hash160::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha1::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha256::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha256::Midstate
+impl core::cmp::PartialOrd for bitcoin_hashes::sha256d::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha384::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha3_256::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha512::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::siphash24::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::hash160::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::ripemd160::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::sha1::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256d::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha3_256::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha512_256::Hash
+impl core::convert::AsRef<[u8; 48]> for bitcoin_hashes::sha384::Hash
+impl core::convert::AsRef<[u8; 64]> for bitcoin_hashes::sha512::Hash
+impl core::convert::AsRef<[u8; 8]> for bitcoin_hashes::siphash24::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::hash160::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::ripemd160::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha1::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256::Midstate
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256d::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha384::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha3_256::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha512::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha512_256::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::siphash24::Hash
+impl core::default::Default for bitcoin_hashes::hash160::HashEngine
+impl core::default::Default for bitcoin_hashes::ripemd160::HashEngine
+impl core::default::Default for bitcoin_hashes::sha1::HashEngine
+impl core::default::Default for bitcoin_hashes::sha256::HashEngine
+impl core::default::Default for bitcoin_hashes::sha256::Midstate
+impl core::default::Default for bitcoin_hashes::sha256d::HashEngine
+impl core::default::Default for bitcoin_hashes::sha384::HashEngine
+impl core::default::Default for bitcoin_hashes::sha3_256::HashEngine
+impl core::default::Default for bitcoin_hashes::sha512::HashEngine
+impl core::default::Default for bitcoin_hashes::sha512_256::HashEngine
+impl core::error::Error for bitcoin_hashes::hkdf::MaxLengthError
+impl core::error::Error for bitcoin_hashes::sha256::MidstateError
+impl core::fmt::Debug for bitcoin_hashes::hash160::Hash
+impl core::fmt::Debug for bitcoin_hashes::hash160::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::hkdf::MaxLengthError
+impl core::fmt::Debug for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::Debug for bitcoin_hashes::ripemd160::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::sha1::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha1::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::sha256::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha256::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::sha256::Midstate
+impl core::fmt::Debug for bitcoin_hashes::sha256::MidstateError
+impl core::fmt::Debug for bitcoin_hashes::sha256d::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha256d::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::sha384::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha384::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::sha3_256::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha3_256::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::sha512::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha512::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha512_256::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::siphash24::Hash
+impl core::fmt::Debug for bitcoin_hashes::siphash24::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::siphash24::State
+impl core::fmt::Display for bitcoin_hashes::hash160::Hash
+impl core::fmt::Display for bitcoin_hashes::hkdf::MaxLengthError
+impl core::fmt::Display for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::Display for bitcoin_hashes::sha1::Hash
+impl core::fmt::Display for bitcoin_hashes::sha256::Hash
+impl core::fmt::Display for bitcoin_hashes::sha256::MidstateError
+impl core::fmt::Display for bitcoin_hashes::sha256d::Hash
+impl core::fmt::Display for bitcoin_hashes::sha384::Hash
+impl core::fmt::Display for bitcoin_hashes::sha3_256::Hash
+impl core::fmt::Display for bitcoin_hashes::sha512::Hash
+impl core::fmt::Display for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::Display for bitcoin_hashes::siphash24::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::hash160::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha1::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha256::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha256d::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha384::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha3_256::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha512::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::LowerHex for bitcoin_hashes::siphash24::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::hash160::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha1::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha256::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha256d::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha384::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha3_256::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha512::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::UpperHex for bitcoin_hashes::siphash24::Hash
+impl core::hash::Hash for bitcoin_hashes::hash160::Hash
+impl core::hash::Hash for bitcoin_hashes::ripemd160::Hash
+impl core::hash::Hash for bitcoin_hashes::sha1::Hash
+impl core::hash::Hash for bitcoin_hashes::sha256::Hash
+impl core::hash::Hash for bitcoin_hashes::sha256::Midstate
+impl core::hash::Hash for bitcoin_hashes::sha256d::Hash
+impl core::hash::Hash for bitcoin_hashes::sha384::Hash
+impl core::hash::Hash for bitcoin_hashes::sha3_256::Hash
+impl core::hash::Hash for bitcoin_hashes::sha512::Hash
+impl core::hash::Hash for bitcoin_hashes::sha512_256::Hash
+impl core::hash::Hash for bitcoin_hashes::siphash24::Hash
+impl core::marker::Copy for bitcoin_hashes::hash160::Hash
+impl core::marker::Copy for bitcoin_hashes::hkdf::MaxLengthError
+impl core::marker::Copy for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Copy for bitcoin_hashes::sha1::Hash
+impl core::marker::Copy for bitcoin_hashes::sha256::Hash
+impl core::marker::Copy for bitcoin_hashes::sha256::Midstate
+impl core::marker::Copy for bitcoin_hashes::sha256d::Hash
+impl core::marker::Copy for bitcoin_hashes::sha384::Hash
+impl core::marker::Copy for bitcoin_hashes::sha3_256::Hash
+impl core::marker::Copy for bitcoin_hashes::sha512::Hash
+impl core::marker::Copy for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Copy for bitcoin_hashes::siphash24::Hash
+impl core::marker::Freeze for bitcoin_hashes::hash160::Hash
+impl core::marker::Freeze for bitcoin_hashes::hash160::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::hkdf::MaxLengthError
+impl core::marker::Freeze for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Freeze for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha1::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha256::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha256::Midstate
+impl core::marker::Freeze for bitcoin_hashes::sha256::MidstateError
+impl core::marker::Freeze for bitcoin_hashes::sha256d::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha256d::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha384::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha384::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha3_256::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha3_256::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha512::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::siphash24::Hash
+impl core::marker::Freeze for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::siphash24::State
+impl core::marker::Send for bitcoin_hashes::hash160::Hash
+impl core::marker::Send for bitcoin_hashes::hash160::HashEngine
+impl core::marker::Send for bitcoin_hashes::hkdf::MaxLengthError
+impl core::marker::Send for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Send for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha1::Hash
+impl core::marker::Send for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha256::Hash
+impl core::marker::Send for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha256::Midstate
+impl core::marker::Send for bitcoin_hashes::sha256::MidstateError
+impl core::marker::Send for bitcoin_hashes::sha256d::Hash
+impl core::marker::Send for bitcoin_hashes::sha256d::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha384::Hash
+impl core::marker::Send for bitcoin_hashes::sha384::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha3_256::Hash
+impl core::marker::Send for bitcoin_hashes::sha3_256::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha512::Hash
+impl core::marker::Send for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Send for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Send for bitcoin_hashes::siphash24::Hash
+impl core::marker::Send for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Send for bitcoin_hashes::siphash24::State
+impl core::marker::StructuralPartialEq for bitcoin_hashes::hash160::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::hkdf::MaxLengthError
+impl core::marker::StructuralPartialEq for bitcoin_hashes::ripemd160::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha1::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256::Midstate
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256::MidstateError
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256d::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha384::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha3_256::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha512::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha512_256::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::siphash24::Hash
+impl core::marker::Sync for bitcoin_hashes::hash160::Hash
+impl core::marker::Sync for bitcoin_hashes::hash160::HashEngine
+impl core::marker::Sync for bitcoin_hashes::hkdf::MaxLengthError
+impl core::marker::Sync for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Sync for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha1::Hash
+impl core::marker::Sync for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha256::Hash
+impl core::marker::Sync for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha256::Midstate
+impl core::marker::Sync for bitcoin_hashes::sha256::MidstateError
+impl core::marker::Sync for bitcoin_hashes::sha256d::Hash
+impl core::marker::Sync for bitcoin_hashes::sha256d::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha384::Hash
+impl core::marker::Sync for bitcoin_hashes::sha384::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha3_256::Hash
+impl core::marker::Sync for bitcoin_hashes::sha3_256::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha512::Hash
+impl core::marker::Sync for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Sync for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Sync for bitcoin_hashes::siphash24::Hash
+impl core::marker::Sync for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Sync for bitcoin_hashes::siphash24::State
+impl core::marker::Unpin for bitcoin_hashes::hash160::Hash
+impl core::marker::Unpin for bitcoin_hashes::hash160::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::hkdf::MaxLengthError
+impl core::marker::Unpin for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Unpin for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha1::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha256::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha256::Midstate
+impl core::marker::Unpin for bitcoin_hashes::sha256::MidstateError
+impl core::marker::Unpin for bitcoin_hashes::sha256d::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha256d::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha384::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha384::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha3_256::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha3_256::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha512::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::siphash24::Hash
+impl core::marker::Unpin for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::siphash24::State
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hash160::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hash160::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hkdf::MaxLengthError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::ripemd160::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::ripemd160::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha1::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha1::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::Midstate
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::MidstateError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256d::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256d::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha384::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha384::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha3_256::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha3_256::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512_256::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512_256::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::State
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hash160::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hash160::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hkdf::MaxLengthError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::ripemd160::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::ripemd160::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha1::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha1::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::Midstate
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::MidstateError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256d::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256d::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha384::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha384::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha3_256::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha3_256::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512_256::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512_256::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::State
+impl core::str::traits::FromStr for bitcoin_hashes::hash160::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::ripemd160::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha1::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha256::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha256d::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha384::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha3_256::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha512::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::sha512_256::Hash
+impl core::str::traits::FromStr for bitcoin_hashes::siphash24::Hash
+impl serde::ser::Serialize for bitcoin_hashes::hash160::Hash
+impl serde::ser::Serialize for bitcoin_hashes::ripemd160::Hash
+impl serde::ser::Serialize for bitcoin_hashes::sha1::Hash
+impl serde::ser::Serialize for bitcoin_hashes::sha256::Hash
+impl serde::ser::Serialize for bitcoin_hashes::sha256d::Hash
+impl serde::ser::Serialize for bitcoin_hashes::sha384::Hash
+impl serde::ser::Serialize for bitcoin_hashes::sha3_256::Hash
+impl serde::ser::Serialize for bitcoin_hashes::sha512::Hash
+impl serde::ser::Serialize for bitcoin_hashes::sha512_256::Hash
+impl serde::ser::Serialize for bitcoin_hashes::siphash24::Hash
+impl std::io::Write for bitcoin_hashes::hash160::HashEngine
+impl std::io::Write for bitcoin_hashes::ripemd160::HashEngine
+impl std::io::Write for bitcoin_hashes::sha1::HashEngine
+impl std::io::Write for bitcoin_hashes::sha256::HashEngine
+impl std::io::Write for bitcoin_hashes::sha256d::HashEngine
+impl std::io::Write for bitcoin_hashes::sha384::HashEngine
+impl std::io::Write for bitcoin_hashes::sha3_256::HashEngine
+impl std::io::Write for bitcoin_hashes::sha512::HashEngine
+impl std::io::Write for bitcoin_hashes::sha512_256::HashEngine
+impl std::io::Write for bitcoin_hashes::siphash24::HashEngine
+impl<'de, T: bitcoin_hashes::Hash + serde::de::Deserialize<'de>> serde::de::Deserialize<'de> for bitcoin_hashes::hmac::Hmac<T>
+impl<'de, T: bitcoin_hashes::sha256t::Tag> serde::de::Deserialize<'de> for bitcoin_hashes::sha256t::Hash<T>
+impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::hash160::Hash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::ripemd160::Hash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::sha1::Hash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::sha256::Hash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::sha256d::Hash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::sha384::Hash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::sha3_256::Hash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::sha512::Hash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::sha512_256::Hash
+impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::siphash24::Hash
+impl<T: bitcoin_hashes::Hash + core::fmt::Debug> core::fmt::Debug for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash + core::fmt::Display> core::fmt::Display for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash + core::fmt::LowerHex> core::fmt::LowerHex for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash + core::str::traits::FromStr> core::str::traits::FromStr for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash + serde::ser::Serialize> serde::ser::Serialize for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> bitcoin_hashes::Hash for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::cmp::Eq for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::cmp::PartialEq for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::convert::AsRef<[u8]> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::HashEngine> bitcoin_hashes::HashEngine for bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::HashEngine> bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::HashEngine> core::fmt::Debug for bitcoin_hashes::hkdf::Hkdf<T>
+impl<T: bitcoin_hashes::HashEngine> std::io::Write for bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::sha256t::Tag> bitcoin_hashes::Hash for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> bitcoin_hashes::HashEngine for bitcoin_hashes::sha256t::HashEngine<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::borrow::Borrow<[u8; 32]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::clone::Clone for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::clone::Clone for bitcoin_hashes::sha256t::HashEngine<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::Eq for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::Ord for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::PartialEq for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::PartialOrd for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::convert::AsRef<[u8]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::default::Default for bitcoin_hashes::sha256t::HashEngine<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::Debug for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::Display for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::LowerHex for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::UpperHex for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::hash::Hash for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::marker::Copy for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::str::traits::FromStr for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> serde::ser::Serialize for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> std::io::Write for bitcoin_hashes::sha256t::HashEngine<T>
+impl<T: core::clone::Clone + bitcoin_hashes::Hash> core::clone::Clone for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::clone::Clone + bitcoin_hashes::HashEngine> core::clone::Clone for bitcoin_hashes::hkdf::Hkdf<T> where <T as bitcoin_hashes::HashEngine>::Hash: core::clone::Clone
+impl<T: core::clone::Clone + bitcoin_hashes::HashEngine> core::clone::Clone for bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: core::cmp::Ord + bitcoin_hashes::Hash> core::cmp::Ord for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::cmp::PartialOrd + bitcoin_hashes::Hash> core::cmp::PartialOrd for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::fmt::Debug + bitcoin_hashes::HashEngine> core::fmt::Debug for bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: core::fmt::Debug> core::fmt::Debug for bitcoin_hashes::sha256t::HashEngine<T>
+impl<T: core::hash::Hash + bitcoin_hashes::Hash> core::hash::Hash for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::marker::Copy + bitcoin_hashes::Hash> core::marker::Copy for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::marker::Copy + bitcoin_hashes::HashEngine> core::marker::Copy for bitcoin_hashes::hkdf::Hkdf<T> where <T as bitcoin_hashes::HashEngine>::Hash: core::marker::Copy
+impl<T> bitcoin_hashes::hkdf::Hkdf<T> where T: core::default::Default + bitcoin_hashes::HashEngine
+impl<T> bitcoin_hashes::sha256t::Hash<T>
+impl<T> bitcoin_hashes::sha256t::Hash<T> where T: bitcoin_hashes::sha256t::Tag
+impl<T> core::marker::Freeze for bitcoin_hashes::hkdf::Hkdf<T> where <T as bitcoin_hashes::HashEngine>::Hash: core::marker::Freeze
+impl<T> core::marker::Freeze for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Freeze
+impl<T> core::marker::Freeze for bitcoin_hashes::hmac::HmacEngine<T> where T: core::marker::Freeze
+impl<T> core::marker::Freeze for bitcoin_hashes::sha256t::Hash<T>
+impl<T> core::marker::Freeze for bitcoin_hashes::sha256t::HashEngine<T>
+impl<T> core::marker::Send for bitcoin_hashes::hkdf::Hkdf<T> where <T as bitcoin_hashes::HashEngine>::Hash: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::hmac::HmacEngine<T> where T: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::sha256t::HashEngine<T> where T: core::marker::Send
+impl<T> core::marker::Sync for bitcoin_hashes::hkdf::Hkdf<T> where <T as bitcoin_hashes::HashEngine>::Hash: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::hmac::HmacEngine<T> where T: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::sha256t::HashEngine<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bitcoin_hashes::hkdf::Hkdf<T> where <T as bitcoin_hashes::HashEngine>::Hash: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::hmac::HmacEngine<T> where T: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::sha256t::HashEngine<T> where T: core::marker::Unpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hkdf::Hkdf<T> where <T as bitcoin_hashes::HashEngine>::Hash: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::Hmac<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::HmacEngine<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256t::Hash<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256t::HashEngine<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hkdf::Hkdf<T> where <T as bitcoin_hashes::HashEngine>::Hash: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::Hmac<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::HmacEngine<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256t::Hash<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256t::HashEngine<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<ValueT, const N: usize> core::default::Default for bitcoin_hashes::macros::serde_details::BytesVisitor<ValueT, N>
+impl<ValueT, const N: usize> core::marker::Freeze for bitcoin_hashes::macros::serde_details::BytesVisitor<ValueT, N>
+impl<ValueT, const N: usize> core::marker::Send for bitcoin_hashes::macros::serde_details::BytesVisitor<ValueT, N> where ValueT: core::marker::Send
+impl<ValueT, const N: usize> core::marker::Sync for bitcoin_hashes::macros::serde_details::BytesVisitor<ValueT, N> where ValueT: core::marker::Sync
+impl<ValueT, const N: usize> core::marker::Unpin for bitcoin_hashes::macros::serde_details::BytesVisitor<ValueT, N> where ValueT: core::marker::Unpin
+impl<ValueT, const N: usize> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::macros::serde_details::BytesVisitor<ValueT, N> where ValueT: core::panic::unwind_safe::RefUnwindSafe
+impl<ValueT, const N: usize> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::macros::serde_details::BytesVisitor<ValueT, N> where ValueT: core::panic::unwind_safe::UnwindSafe
+impl<ValueT, const N: usize> serde::de::Visitor<'_> for bitcoin_hashes::macros::serde_details::BytesVisitor<ValueT, N> where ValueT: bitcoin_hashes::Hash + bitcoin_hashes::Hash<Bytes = [u8; N]>
+impl<ValueT> core::default::Default for bitcoin_hashes::macros::serde_details::HexVisitor<ValueT>
+impl<ValueT> core::marker::Freeze for bitcoin_hashes::macros::serde_details::HexVisitor<ValueT>
+impl<ValueT> core::marker::Send for bitcoin_hashes::macros::serde_details::HexVisitor<ValueT> where ValueT: core::marker::Send
+impl<ValueT> core::marker::Sync for bitcoin_hashes::macros::serde_details::HexVisitor<ValueT> where ValueT: core::marker::Sync
+impl<ValueT> core::marker::Unpin for bitcoin_hashes::macros::serde_details::HexVisitor<ValueT> where ValueT: core::marker::Unpin
+impl<ValueT> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::macros::serde_details::HexVisitor<ValueT> where ValueT: core::panic::unwind_safe::RefUnwindSafe
+impl<ValueT> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::macros::serde_details::HexVisitor<ValueT> where ValueT: core::panic::unwind_safe::UnwindSafe
+impl<ValueT> serde::de::Visitor<'_> for bitcoin_hashes::macros::serde_details::HexVisitor<ValueT> where ValueT: core::str::traits::FromStr, <ValueT as core::str::traits::FromStr>::Err: core::fmt::Display
+impl<const N: usize> bitcoin_hashes::IsByteArray for [u8; N]
+pub const [u8; N]::LEN: usize
+pub const bitcoin_hashes::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::Hash::LEN: usize
+pub const bitcoin_hashes::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::HashEngine::LEN: usize
+pub const bitcoin_hashes::IsByteArray::LEN: usize
+pub const bitcoin_hashes::hash160::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::hash160::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::hmac::HmacEngine<T>::BLOCK_SIZE: usize
+pub const bitcoin_hashes::ripemd160::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::ripemd160::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha1::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha1::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha256::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha256::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha256d::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha256d::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha256t::Hash<T>::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha256t::HashEngine<T>::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha256t::Tag::MIDSTATE: bitcoin_hashes::sha256::Midstate
+pub const bitcoin_hashes::sha384::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha384::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha3_256::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha3_256::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha512::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha512::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha512_256::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha512_256::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::siphash24::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::siphash24::HashEngine::BLOCK_SIZE: usize
+pub const fn bitcoin_hashes::hash160::Hash::as_byte_array(&self) -> &[u8; 20]
+pub const fn bitcoin_hashes::hash160::Hash::from_byte_array(bytes: [u8; 20]) -> Self
+pub const fn bitcoin_hashes::hash160::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub const fn bitcoin_hashes::hash160::Hash::to_byte_array(self) -> [u8; 20]
+pub const fn bitcoin_hashes::hash160::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::ripemd160::Hash::as_byte_array(&self) -> &[u8; 20]
+pub const fn bitcoin_hashes::ripemd160::Hash::from_byte_array(bytes: [u8; 20]) -> Self
+pub const fn bitcoin_hashes::ripemd160::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub const fn bitcoin_hashes::ripemd160::Hash::to_byte_array(self) -> [u8; 20]
+pub const fn bitcoin_hashes::ripemd160::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha1::Hash::as_byte_array(&self) -> &[u8; 20]
+pub const fn bitcoin_hashes::sha1::Hash::from_byte_array(bytes: [u8; 20]) -> Self
+pub const fn bitcoin_hashes::sha1::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub const fn bitcoin_hashes::sha1::Hash::to_byte_array(self) -> [u8; 20]
+pub const fn bitcoin_hashes::sha1::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha256::Hash::as_byte_array(&self) -> &[u8; 32]
+pub const fn bitcoin_hashes::sha256::Hash::from_byte_array(bytes: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub const fn bitcoin_hashes::sha256::Hash::hash_unoptimized(bytes: &[u8]) -> Self
+pub const fn bitcoin_hashes::sha256::Hash::to_byte_array(self) -> [u8; 32]
+pub const fn bitcoin_hashes::sha256::HashEngine::can_extract_midstate(&self) -> bool
+pub const fn bitcoin_hashes::sha256::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha256::Midstate::as_parts(&self) -> (&[u8; 32], u64)
+pub const fn bitcoin_hashes::sha256::Midstate::hash_tag(tag: &[u8]) -> Self
+pub const fn bitcoin_hashes::sha256::Midstate::new(state: [u8; 32], bytes_hashed: u64) -> Self
+pub const fn bitcoin_hashes::sha256::Midstate::to_parts(self) -> ([u8; 32], u64)
+pub const fn bitcoin_hashes::sha256d::Hash::as_byte_array(&self) -> &[u8; 32]
+pub const fn bitcoin_hashes::sha256d::Hash::from_byte_array(bytes: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha256d::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub const fn bitcoin_hashes::sha256d::Hash::to_byte_array(self) -> [u8; 32]
+pub const fn bitcoin_hashes::sha256d::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha256t::Hash<T>::as_byte_array(&self) -> &[u8; 32]
+pub const fn bitcoin_hashes::sha256t::Hash<T>::from_byte_array(bytes: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub const fn bitcoin_hashes::sha256t::Hash<T>::to_byte_array(self) -> [u8; 32]
+pub const fn bitcoin_hashes::sha384::Hash::as_byte_array(&self) -> &[u8; 48]
+pub const fn bitcoin_hashes::sha384::Hash::from_byte_array(bytes: [u8; 48]) -> Self
+pub const fn bitcoin_hashes::sha384::Hash::from_bytes_ref(bytes: &[u8; 48]) -> &Self
+pub const fn bitcoin_hashes::sha384::Hash::to_byte_array(self) -> [u8; 48]
+pub const fn bitcoin_hashes::sha384::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha3_256::Hash::as_byte_array(&self) -> &[u8; 32]
+pub const fn bitcoin_hashes::sha3_256::Hash::from_byte_array(bytes: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha3_256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub const fn bitcoin_hashes::sha3_256::Hash::to_byte_array(self) -> [u8; 32]
+pub const fn bitcoin_hashes::sha3_256::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha512::Hash::as_byte_array(&self) -> &[u8; 64]
+pub const fn bitcoin_hashes::sha512::Hash::from_byte_array(bytes: [u8; 64]) -> Self
+pub const fn bitcoin_hashes::sha512::Hash::from_bytes_ref(bytes: &[u8; 64]) -> &Self
+pub const fn bitcoin_hashes::sha512::Hash::to_byte_array(self) -> [u8; 64]
+pub const fn bitcoin_hashes::sha512::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha512_256::Hash::as_byte_array(&self) -> &[u8; 32]
+pub const fn bitcoin_hashes::sha512_256::Hash::from_byte_array(bytes: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha512_256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub const fn bitcoin_hashes::sha512_256::Hash::to_byte_array(self) -> [u8; 32]
+pub const fn bitcoin_hashes::sha512_256::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::siphash24::Hash::as_byte_array(&self) -> &[u8; 8]
+pub const fn bitcoin_hashes::siphash24::Hash::from_byte_array(bytes: [u8; 8]) -> Self
+pub const fn bitcoin_hashes::siphash24::Hash::from_bytes_ref(bytes: &[u8; 8]) -> &Self
+pub const fn bitcoin_hashes::siphash24::Hash::to_byte_array(self) -> [u8; 8]
+pub const fn bitcoin_hashes::siphash24::HashEngine::with_keys(k0: u64, k1: u64) -> Self
+pub extern crate bitcoin_hashes::hex
+pub extern crate bitcoin_hashes::serde
+pub fn bitcoin_hashes::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::HashEngine::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::HashEngine::input(&mut self, data: &[u8])
+pub fn bitcoin_hashes::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::cmp::fixed_time_eq(a: &[u8], b: &[u8]) -> bool
+pub fn bitcoin_hashes::debug_hex(bytes: &[u8], f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::encode_to_engine<T, H>(object: &T, engine: H) -> H where T: bitcoin_consensus_encoding::encode::Encodable + ?core::marker::Sized, H: bitcoin_hashes::HashEngine
+pub fn bitcoin_hashes::hash160::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::hash160::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::hash160::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::hash160::Hash::borrow(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::hash160::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::hash160::Hash::clone(&self) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::hash160::Hash::cmp(&self, other: &bitcoin_hashes::hash160::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::hash160::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::hash160::Hash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::hash160::Hash::engine() -> bitcoin_hashes::hash160::HashEngine
+pub fn bitcoin_hashes::hash160::Hash::eq(&self, other: &bitcoin_hashes::hash160::Hash) -> bool
+pub fn bitcoin_hashes::hash160::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hash160::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::hash160::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::hash160::Hash::from_engine(e: bitcoin_hashes::hash160::HashEngine) -> Self
+pub fn bitcoin_hashes::hash160::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::hash160::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::hash160::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::hash160::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::hash160::Hash::partial_cmp(&self, other: &bitcoin_hashes::hash160::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::hash160::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::hash160::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::hash160::HashEngine::clone(&self) -> bitcoin_hashes::hash160::HashEngine
+pub fn bitcoin_hashes::hash160::HashEngine::default() -> Self
+pub fn bitcoin_hashes::hash160::HashEngine::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::hash160::HashEngine::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::hash160::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hash160::HashEngine::input(&mut self, data: &[u8])
+pub fn bitcoin_hashes::hash160::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::hash160::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::hash160::hash(data: &[u8]) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::hash160::hash_byte_chunks<B, I>(byte_slices: I) -> bitcoin_hashes::hash160::Hash where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::hkdf::Hkdf<T>::clone(&self) -> bitcoin_hashes::hkdf::Hkdf<T>
+pub fn bitcoin_hashes::hkdf::Hkdf<T>::expand(&self, info: &[u8], okm: &mut [u8]) -> core::result::Result<(), bitcoin_hashes::hkdf::MaxLengthError>
+pub fn bitcoin_hashes::hkdf::Hkdf<T>::expand_to_len(&self, info: &[u8], len: usize) -> core::result::Result<alloc::vec::Vec<u8>, bitcoin_hashes::hkdf::MaxLengthError>
+pub fn bitcoin_hashes::hkdf::Hkdf<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hkdf::Hkdf<T>::new(salt: &[u8], ikm: &[u8]) -> Self
+pub fn bitcoin_hashes::hkdf::MaxLengthError::clone(&self) -> bitcoin_hashes::hkdf::MaxLengthError
+pub fn bitcoin_hashes::hkdf::MaxLengthError::eq(&self, other: &bitcoin_hashes::hkdf::MaxLengthError) -> bool
+pub fn bitcoin_hashes::hkdf::MaxLengthError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hmac::Hmac<T>::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::hmac::Hmac<T>::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::clone(&self) -> bitcoin_hashes::hmac::Hmac<T>
+pub fn bitcoin_hashes::hmac::Hmac<T>::cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::cmp::Ordering
+pub fn bitcoin_hashes::hmac::Hmac<T>::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::hmac::Hmac<T>::eq(&self, other: &Self) -> bool
+pub fn bitcoin_hashes::hmac::Hmac<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_byte_array(bytes: <T as bitcoin_hashes::Hash>::Bytes) -> Self
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::hmac::Hmac<T>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::hmac::Hmac<T>::partial_cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::hmac::Hmac<T>::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::hmac::Hmac<T>::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::clone(&self) -> bitcoin_hashes::hmac::HmacEngine<T>
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::from_inner_engines(iengine: T, oengine: T) -> Self
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::input(&mut self, buf: &[u8])
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::new(key: &[u8]) -> Self where T: core::default::Default
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::macros::serde_details::BytesVisitor<ValueT, N>::default() -> Self
+pub fn bitcoin_hashes::macros::serde_details::BytesVisitor<ValueT, N>::expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::macros::serde_details::BytesVisitor<ValueT, N>::visit_bytes<E>(self, v: &[u8]) -> core::result::Result<Self::Value, E> where E: serde::de::Error
+pub fn bitcoin_hashes::macros::serde_details::HexVisitor<ValueT>::default() -> Self
+pub fn bitcoin_hashes::macros::serde_details::HexVisitor<ValueT>::expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::macros::serde_details::HexVisitor<ValueT>::visit_bytes<E>(self, v: &[u8]) -> core::result::Result<Self::Value, E> where E: serde::de::Error
+pub fn bitcoin_hashes::macros::serde_details::HexVisitor<ValueT>::visit_str<E>(self, v: &str) -> core::result::Result<Self::Value, E> where E: serde::de::Error
+pub fn bitcoin_hashes::ripemd160::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::ripemd160::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::ripemd160::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::ripemd160::Hash::borrow(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::ripemd160::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::ripemd160::Hash::clone(&self) -> bitcoin_hashes::ripemd160::Hash
+pub fn bitcoin_hashes::ripemd160::Hash::cmp(&self, other: &bitcoin_hashes::ripemd160::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::ripemd160::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::ripemd160::Hash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::ripemd160::Hash::engine() -> bitcoin_hashes::ripemd160::HashEngine
+pub fn bitcoin_hashes::ripemd160::Hash::eq(&self, other: &bitcoin_hashes::ripemd160::Hash) -> bool
+pub fn bitcoin_hashes::ripemd160::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::ripemd160::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::ripemd160::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::ripemd160::Hash::from_engine(e: bitcoin_hashes::ripemd160::HashEngine) -> Self
+pub fn bitcoin_hashes::ripemd160::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::ripemd160::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::ripemd160::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::ripemd160::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::ripemd160::Hash::partial_cmp(&self, other: &bitcoin_hashes::ripemd160::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::ripemd160::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::ripemd160::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::ripemd160::HashEngine::clone(&self) -> bitcoin_hashes::ripemd160::HashEngine
+pub fn bitcoin_hashes::ripemd160::HashEngine::default() -> Self
+pub fn bitcoin_hashes::ripemd160::HashEngine::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::ripemd160::HashEngine::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::ripemd160::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::ripemd160::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::ripemd160::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::ripemd160::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::ripemd160::hash(data: &[u8]) -> bitcoin_hashes::ripemd160::Hash
+pub fn bitcoin_hashes::ripemd160::hash_byte_chunks<B, I>(byte_slices: I) -> bitcoin_hashes::ripemd160::Hash where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha1::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha1::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::sha1::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha1::Hash::borrow(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::sha1::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha1::Hash::clone(&self) -> bitcoin_hashes::sha1::Hash
+pub fn bitcoin_hashes::sha1::Hash::cmp(&self, other: &bitcoin_hashes::sha1::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha1::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha1::Hash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::sha1::Hash::engine() -> bitcoin_hashes::sha1::HashEngine
+pub fn bitcoin_hashes::sha1::Hash::eq(&self, other: &bitcoin_hashes::sha1::Hash) -> bool
+pub fn bitcoin_hashes::sha1::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha1::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha1::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::sha1::Hash::from_engine(e: bitcoin_hashes::sha1::HashEngine) -> Self
+pub fn bitcoin_hashes::sha1::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha1::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha1::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha1::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha1::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha1::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha1::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::sha1::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha1::HashEngine::clone(&self) -> bitcoin_hashes::sha1::HashEngine
+pub fn bitcoin_hashes::sha1::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha1::HashEngine::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::sha1::HashEngine::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::sha1::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha1::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha1::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha1::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::sha1::hash(data: &[u8]) -> bitcoin_hashes::sha1::Hash
+pub fn bitcoin_hashes::sha1::hash_byte_chunks<B, I>(byte_slices: I) -> bitcoin_hashes::sha1::Hash where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha256::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Hash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Hash::clone(&self) -> bitcoin_hashes::sha256::Hash
+pub fn bitcoin_hashes::sha256::Hash::cmp(&self, other: &bitcoin_hashes::sha256::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha256::Hash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::sha256::Hash::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha256::Hash::eq(&self, other: &bitcoin_hashes::sha256::Hash) -> bool
+pub fn bitcoin_hashes::sha256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> Self
+pub fn bitcoin_hashes::sha256::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha256::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256::Hash::hash_again(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha256::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha256::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::sha256::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256::HashEngine::clone(&self) -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha256::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha256::HashEngine::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::sha256::HashEngine::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::sha256::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256::HashEngine::from_midstate(midstate: bitcoin_hashes::sha256::Midstate) -> Self
+pub fn bitcoin_hashes::sha256::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha256::HashEngine::midstate(&self) -> core::result::Result<bitcoin_hashes::sha256::Midstate, bitcoin_hashes::sha256::MidstateError>
+pub fn bitcoin_hashes::sha256::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha256::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::sha256::Midstate::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Midstate::clone(&self) -> bitcoin_hashes::sha256::Midstate
+pub fn bitcoin_hashes::sha256::Midstate::cmp(&self, other: &bitcoin_hashes::sha256::Midstate) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256::Midstate::default() -> bitcoin_hashes::sha256::Midstate
+pub fn bitcoin_hashes::sha256::Midstate::eq(&self, other: &bitcoin_hashes::sha256::Midstate) -> bool
+pub fn bitcoin_hashes::sha256::Midstate::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256::Midstate::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256::Midstate::partial_cmp(&self, other: &bitcoin_hashes::sha256::Midstate) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256::MidstateError::clone(&self) -> bitcoin_hashes::sha256::MidstateError
+pub fn bitcoin_hashes::sha256::MidstateError::eq(&self, other: &bitcoin_hashes::sha256::MidstateError) -> bool
+pub fn bitcoin_hashes::sha256::MidstateError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256::hash(data: &[u8]) -> bitcoin_hashes::sha256::Hash
+pub fn bitcoin_hashes::sha256::hash_byte_chunks<B, I>(byte_slices: I) -> bitcoin_hashes::sha256::Hash where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha256d::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256d::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256d::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256d::Hash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256d::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256d::Hash::clone(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::cmp(&self, other: &bitcoin_hashes::sha256d::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256d::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha256d::Hash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::sha256d::Hash::engine() -> bitcoin_hashes::sha256d::HashEngine
+pub fn bitcoin_hashes::sha256d::Hash::eq(&self, other: &bitcoin_hashes::sha256d::Hash) -> bool
+pub fn bitcoin_hashes::sha256d::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256d::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256d::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256d::Hash::from_engine(e: bitcoin_hashes::sha256d::HashEngine) -> Self
+pub fn bitcoin_hashes::sha256d::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256d::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha256d::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256d::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha256d::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha256d::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256d::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::sha256d::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256d::HashEngine::clone(&self) -> bitcoin_hashes::sha256d::HashEngine
+pub fn bitcoin_hashes::sha256d::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha256d::HashEngine::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::sha256d::HashEngine::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::sha256d::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256d::HashEngine::input(&mut self, data: &[u8])
+pub fn bitcoin_hashes::sha256d::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha256d::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::sha256d::hash(data: &[u8]) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::hash_byte_chunks<B, I>(byte_slices: I) -> bitcoin_hashes::sha256d::Hash where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256t::Hash<T>::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256t::Hash<T>::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256t::Hash<T>::clone(&self) -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::cmp(&self, other: &Self) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256t::Hash<T>::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha256t::Hash<T>, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::sha256t::Hash<T>::engine() -> bitcoin_hashes::sha256t::HashEngine<T>
+pub fn bitcoin_hashes::sha256t::Hash<T>::eq(&self, other: &Self) -> bool
+pub fn bitcoin_hashes::sha256t::Hash<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_engine(e: bitcoin_hashes::sha256t::HashEngine<T>) -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha256t::Hash<T>::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::hash<H: core::hash::Hasher>(&self, h: &mut H)
+pub fn bitcoin_hashes::sha256t::Hash<T>::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha256t::Hash<T>::partial_cmp(&self, other: &Self) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256t::Hash<T>::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::sha256t::Hash<T>::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256t::HashEngine<T>::clone(&self) -> Self
+pub fn bitcoin_hashes::sha256t::HashEngine<T>::default() -> Self
+pub fn bitcoin_hashes::sha256t::HashEngine<T>::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::sha256t::HashEngine<T>::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::sha256t::HashEngine<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256t::HashEngine<T>::input(&mut self, data: &[u8])
+pub fn bitcoin_hashes::sha256t::HashEngine<T>::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha256t::HashEngine<T>::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::sha256t::hash<T>(data: &[u8]) -> bitcoin_hashes::sha256t::Hash<T> where T: bitcoin_hashes::sha256t::Tag
+pub fn bitcoin_hashes::sha256t::hash_byte_chunks<B, I, T>(byte_slices: I) -> bitcoin_hashes::sha256t::Hash<T> where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>, T: bitcoin_hashes::sha256t::Tag
+pub fn bitcoin_hashes::sha384::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha384::Hash::as_ref(&self) -> &[u8; 48]
+pub fn bitcoin_hashes::sha384::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha384::Hash::borrow(&self) -> &[u8; 48]
+pub fn bitcoin_hashes::sha384::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha384::Hash::clone(&self) -> bitcoin_hashes::sha384::Hash
+pub fn bitcoin_hashes::sha384::Hash::cmp(&self, other: &bitcoin_hashes::sha384::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha384::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha384::Hash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::sha384::Hash::engine() -> bitcoin_hashes::sha384::HashEngine
+pub fn bitcoin_hashes::sha384::Hash::eq(&self, other: &bitcoin_hashes::sha384::Hash) -> bool
+pub fn bitcoin_hashes::sha384::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha384::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha384::Hash::from_bytes_mut(bytes: &mut [u8; 48]) -> &mut Self
+pub fn bitcoin_hashes::sha384::Hash::from_engine(e: bitcoin_hashes::sha384::HashEngine) -> Self
+pub fn bitcoin_hashes::sha384::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha384::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha384::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha384::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha384::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha384::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha384::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::sha384::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha384::HashEngine::clone(&self) -> bitcoin_hashes::sha384::HashEngine
+pub fn bitcoin_hashes::sha384::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha384::HashEngine::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::sha384::HashEngine::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::sha384::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha384::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha384::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha384::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::sha384::hash(data: &[u8]) -> bitcoin_hashes::sha384::Hash
+pub fn bitcoin_hashes::sha384::hash_byte_chunks<B, I>(byte_slices: I) -> bitcoin_hashes::sha384::Hash where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha3_256::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha3_256::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha3_256::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha3_256::Hash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha3_256::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha3_256::Hash::clone(&self) -> bitcoin_hashes::sha3_256::Hash
+pub fn bitcoin_hashes::sha3_256::Hash::cmp(&self, other: &bitcoin_hashes::sha3_256::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha3_256::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha3_256::Hash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::sha3_256::Hash::engine() -> bitcoin_hashes::sha3_256::HashEngine
+pub fn bitcoin_hashes::sha3_256::Hash::eq(&self, other: &bitcoin_hashes::sha3_256::Hash) -> bool
+pub fn bitcoin_hashes::sha3_256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha3_256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha3_256::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha3_256::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha3_256::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha3_256::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha3_256::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha3_256::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha3_256::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha3_256::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::sha3_256::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha3_256::HashEngine::clone(&self) -> bitcoin_hashes::sha3_256::HashEngine
+pub fn bitcoin_hashes::sha3_256::HashEngine::default() -> bitcoin_hashes::sha3_256::HashEngine
+pub fn bitcoin_hashes::sha3_256::HashEngine::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::sha3_256::HashEngine::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::sha3_256::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha3_256::HashEngine::input(&mut self, data: &[u8])
+pub fn bitcoin_hashes::sha3_256::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha3_256::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::sha3_256::hash(data: &[u8]) -> bitcoin_hashes::sha3_256::Hash
+pub fn bitcoin_hashes::sha3_256::hash_byte_chunks<B, I>(byte_slices: I) -> bitcoin_hashes::sha3_256::Hash where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha512::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha512::Hash::as_ref(&self) -> &[u8; 64]
+pub fn bitcoin_hashes::sha512::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512::Hash::borrow(&self) -> &[u8; 64]
+pub fn bitcoin_hashes::sha512::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512::Hash::clone(&self) -> bitcoin_hashes::sha512::Hash
+pub fn bitcoin_hashes::sha512::Hash::cmp(&self, other: &bitcoin_hashes::sha512::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha512::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha512::Hash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::sha512::Hash::engine() -> bitcoin_hashes::sha512::HashEngine
+pub fn bitcoin_hashes::sha512::Hash::eq(&self, other: &bitcoin_hashes::sha512::Hash) -> bool
+pub fn bitcoin_hashes::sha512::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha512::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha512::Hash::from_bytes_mut(bytes: &mut [u8; 64]) -> &mut Self
+pub fn bitcoin_hashes::sha512::Hash::from_engine(e: bitcoin_hashes::sha512::HashEngine) -> Self
+pub fn bitcoin_hashes::sha512::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha512::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha512::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha512::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha512::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha512::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha512::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::sha512::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha512::HashEngine::clone(&self) -> bitcoin_hashes::sha512::HashEngine
+pub fn bitcoin_hashes::sha512::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha512::HashEngine::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::sha512::HashEngine::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::sha512::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha512::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha512::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha512::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::sha512::hash(data: &[u8]) -> bitcoin_hashes::sha512::Hash
+pub fn bitcoin_hashes::sha512::hash_byte_chunks<B, I>(byte_slices: I) -> bitcoin_hashes::sha512::Hash where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha512_256::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha512_256::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha512_256::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512_256::Hash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha512_256::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512_256::Hash::clone(&self) -> bitcoin_hashes::sha512_256::Hash
+pub fn bitcoin_hashes::sha512_256::Hash::cmp(&self, other: &bitcoin_hashes::sha512_256::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha512_256::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha512_256::Hash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::sha512_256::Hash::engine() -> bitcoin_hashes::sha512_256::HashEngine
+pub fn bitcoin_hashes::sha512_256::Hash::eq(&self, other: &bitcoin_hashes::sha512_256::Hash) -> bool
+pub fn bitcoin_hashes::sha512_256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha512_256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha512_256::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha512_256::Hash::from_engine(e: bitcoin_hashes::sha512_256::HashEngine) -> Self
+pub fn bitcoin_hashes::sha512_256::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::sha512_256::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha512_256::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha512_256::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha512_256::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha512_256::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha512_256::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::sha512_256::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha512_256::HashEngine::clone(&self) -> bitcoin_hashes::sha512_256::HashEngine
+pub fn bitcoin_hashes::sha512_256::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha512_256::HashEngine::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::sha512_256::HashEngine::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::sha512_256::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha512_256::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha512_256::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha512_256::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::sha512_256::hash(data: &[u8]) -> bitcoin_hashes::sha512_256::Hash
+pub fn bitcoin_hashes::sha512_256::hash_byte_chunks<B, I>(byte_slices: I) -> bitcoin_hashes::sha512_256::Hash where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::siphash24::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::siphash24::Hash::as_ref(&self) -> &[u8; 8]
+pub fn bitcoin_hashes::siphash24::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::siphash24::Hash::borrow(&self) -> &[u8; 8]
+pub fn bitcoin_hashes::siphash24::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::siphash24::Hash::clone(&self) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::cmp(&self, other: &bitcoin_hashes::siphash24::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::siphash24::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::siphash24::Hash, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::siphash24::Hash::engine(k0: u64, k1: u64) -> bitcoin_hashes::siphash24::HashEngine
+pub fn bitcoin_hashes::siphash24::Hash::eq(&self, other: &bitcoin_hashes::siphash24::Hash) -> bool
+pub fn bitcoin_hashes::siphash24::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::siphash24::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::siphash24::Hash::from_bytes_mut(bytes: &mut [u8; 8]) -> &mut Self
+pub fn bitcoin_hashes::siphash24::Hash::from_engine(e: bitcoin_hashes::siphash24::HashEngine) -> Self
+pub fn bitcoin_hashes::siphash24::Hash::from_engine_to_u64(e: bitcoin_hashes::siphash24::HashEngine) -> u64
+pub fn bitcoin_hashes::siphash24::Hash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::siphash24::Hash::from_u64(hash: u64) -> Self
+pub fn bitcoin_hashes::siphash24::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::siphash24::Hash::hash_to_u64_with_keys(k0: u64, k1: u64, data: &[u8]) -> u64
+pub fn bitcoin_hashes::siphash24::Hash::hash_with_keys(k0: u64, k1: u64, data: &[u8]) -> Self
+pub fn bitcoin_hashes::siphash24::Hash::partial_cmp(&self, other: &bitcoin_hashes::siphash24::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::siphash24::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::siphash24::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::siphash24::Hash::to_u64(self) -> u64
+pub fn bitcoin_hashes::siphash24::HashEngine::clone(&self) -> bitcoin_hashes::siphash24::HashEngine
+pub fn bitcoin_hashes::siphash24::HashEngine::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::siphash24::HashEngine::flush(&mut self) -> std::io::error::Result<()>
+pub fn bitcoin_hashes::siphash24::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::siphash24::HashEngine::input(&mut self, msg: &[u8])
+pub fn bitcoin_hashes::siphash24::HashEngine::keys(&self) -> (u64, u64)
+pub fn bitcoin_hashes::siphash24::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::siphash24::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize>
+pub fn bitcoin_hashes::siphash24::State::clone(&self) -> bitcoin_hashes::siphash24::State
+pub fn bitcoin_hashes::siphash24::State::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub macro bitcoin_hashes::hash_newtype!
+pub macro bitcoin_hashes::impl_debug_only_for_newtype!
+pub macro bitcoin_hashes::impl_hex_for_newtype!
+pub macro bitcoin_hashes::impl_serde_for_newtype!
+pub macro bitcoin_hashes::sha256t_tag!
+pub mod bitcoin_hashes
+pub mod bitcoin_hashes::cmp
+pub mod bitcoin_hashes::hash160
+pub mod bitcoin_hashes::hkdf
+pub mod bitcoin_hashes::hmac
+pub mod bitcoin_hashes::macros
+pub mod bitcoin_hashes::macros::serde_details
+pub mod bitcoin_hashes::ripemd160
+pub mod bitcoin_hashes::sha1
+pub mod bitcoin_hashes::sha256
+pub mod bitcoin_hashes::sha256d
+pub mod bitcoin_hashes::sha256t
+pub mod bitcoin_hashes::sha384
+pub mod bitcoin_hashes::sha3_256
+pub mod bitcoin_hashes::sha512
+pub mod bitcoin_hashes::sha512_256
+pub mod bitcoin_hashes::siphash24
+pub struct bitcoin_hashes::Hkdf<T: bitcoin_hashes::HashEngine>
+pub struct bitcoin_hashes::HmacEngine<T: bitcoin_hashes::HashEngine>
+pub struct bitcoin_hashes::hash160::HashEngine(_)
+pub struct bitcoin_hashes::hkdf::Hkdf<T: bitcoin_hashes::HashEngine>
+pub struct bitcoin_hashes::hkdf::MaxLengthError
+pub struct bitcoin_hashes::hmac::HmacEngine<T: bitcoin_hashes::HashEngine>
+pub struct bitcoin_hashes::macros::serde_details::BytesVisitor<ValueT, const N: usize>(_)
+pub struct bitcoin_hashes::macros::serde_details::HexVisitor<ValueT>(_)
+pub struct bitcoin_hashes::ripemd160::HashEngine
+pub struct bitcoin_hashes::sha1::HashEngine
+pub struct bitcoin_hashes::sha256::HashEngine
+pub struct bitcoin_hashes::sha256::Midstate
+pub struct bitcoin_hashes::sha256::MidstateError
+pub struct bitcoin_hashes::sha256d::HashEngine(_)
+pub struct bitcoin_hashes::sha256t::HashEngine<T>(_, _)
+pub struct bitcoin_hashes::sha384::HashEngine(_)
+pub struct bitcoin_hashes::sha3_256::HashEngine
+pub struct bitcoin_hashes::sha512::HashEngine
+pub struct bitcoin_hashes::sha512_256::HashEngine(_)
+pub struct bitcoin_hashes::siphash24::HashEngine
+pub struct bitcoin_hashes::siphash24::State
+pub trait bitcoin_hashes::Hash: core::marker::Copy + core::clone::Clone + core::cmp::PartialEq + core::cmp::Eq + core::cmp::PartialOrd + core::cmp::Ord + core::hash::Hash + core::convert::AsRef<[u8]>
+pub trait bitcoin_hashes::HashEngine: core::clone::Clone
+pub trait bitcoin_hashes::IsByteArray: core::convert::AsRef<[u8]> + bitcoin_hashes::sealed::IsByteArray
+pub trait bitcoin_hashes::sha256t::Tag
+pub type bitcoin_hashes::Hash::Bytes: core::marker::Copy + bitcoin_hashes::IsByteArray
+pub type bitcoin_hashes::HashEngine::Bytes: core::marker::Copy + bitcoin_hashes::IsByteArray
+pub type bitcoin_hashes::HashEngine::Hash: bitcoin_hashes::Hash
+pub type bitcoin_hashes::HkdfSha256 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha256::Hash>
+pub type bitcoin_hashes::HkdfSha512 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha512::Hash>
+pub type bitcoin_hashes::HmacSha256 = bitcoin_hashes::hmac::Hmac<bitcoin_hashes::sha256::Hash>
+pub type bitcoin_hashes::HmacSha512 = bitcoin_hashes::hmac::Hmac<bitcoin_hashes::sha512::Hash>
+pub type bitcoin_hashes::Sha256t<T> = bitcoin_hashes::sha256t::Hash<T>
+pub type bitcoin_hashes::hash160::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::hash160::Hash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_hashes::hash160::HashEngine::Bytes = [u8; 20]
+pub type bitcoin_hashes::hash160::HashEngine::Hash = bitcoin_hashes::hash160::Hash
+pub type bitcoin_hashes::hmac::Hmac<T>::Bytes = <T as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_hashes::hmac::Hmac<T>::Err = <T as core::str::traits::FromStr>::Err
+pub type bitcoin_hashes::hmac::HmacEngine<T>::Bytes = <T as bitcoin_hashes::HashEngine>::Bytes
+pub type bitcoin_hashes::hmac::HmacEngine<T>::Hash = bitcoin_hashes::hmac::Hmac<<T as bitcoin_hashes::HashEngine>::Hash>
+pub type bitcoin_hashes::macros::serde_details::BytesVisitor<ValueT, N>::Value = ValueT
+pub type bitcoin_hashes::macros::serde_details::HexVisitor<ValueT>::Value = ValueT
+pub type bitcoin_hashes::ripemd160::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::ripemd160::Hash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_hashes::ripemd160::HashEngine::Bytes = [u8; 20]
+pub type bitcoin_hashes::ripemd160::HashEngine::Hash = bitcoin_hashes::ripemd160::Hash
+pub type bitcoin_hashes::sha1::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::sha1::Hash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_hashes::sha1::HashEngine::Bytes = [u8; 20]
+pub type bitcoin_hashes::sha1::HashEngine::Hash = bitcoin_hashes::sha1::Hash
+pub type bitcoin_hashes::sha256::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256::Hash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_hashes::sha256::HashEngine::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256::HashEngine::Hash = bitcoin_hashes::sha256::Hash
+pub type bitcoin_hashes::sha256d::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256d::Hash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_hashes::sha256d::HashEngine::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256d::HashEngine::Hash = bitcoin_hashes::sha256d::Hash
+pub type bitcoin_hashes::sha256t::Hash<T>::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256t::Hash<T>::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_hashes::sha256t::HashEngine<T>::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256t::HashEngine<T>::Hash = bitcoin_hashes::sha256t::Hash<T>
+pub type bitcoin_hashes::sha384::Hash::Bytes = [u8; 48]
+pub type bitcoin_hashes::sha384::Hash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_hashes::sha384::HashEngine::Bytes = [u8; 48]
+pub type bitcoin_hashes::sha384::HashEngine::Hash = bitcoin_hashes::sha384::Hash
+pub type bitcoin_hashes::sha3_256::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha3_256::Hash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_hashes::sha3_256::HashEngine::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha3_256::HashEngine::Hash = bitcoin_hashes::sha3_256::Hash
+pub type bitcoin_hashes::sha512::Hash::Bytes = [u8; 64]
+pub type bitcoin_hashes::sha512::Hash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_hashes::sha512::HashEngine::Bytes = [u8; 64]
+pub type bitcoin_hashes::sha512::HashEngine::Hash = bitcoin_hashes::sha512::Hash
+pub type bitcoin_hashes::sha512_256::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha512_256::Hash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_hashes::sha512_256::HashEngine::Bytes = [u8; 64]
+pub type bitcoin_hashes::sha512_256::HashEngine::Hash = bitcoin_hashes::sha512_256::Hash
+pub type bitcoin_hashes::siphash24::Hash::Bytes = [u8; 8]
+pub type bitcoin_hashes::siphash24::Hash::Err = hex_conservative::error::HexToArrayError
+pub type bitcoin_hashes::siphash24::HashEngine::Bytes = [u8; 8]
+pub type bitcoin_hashes::siphash24::HashEngine::Hash = bitcoin_hashes::siphash24::Hash

--- a/api/hashes/alloc-only.txt
+++ b/api/hashes/alloc-only.txt
@@ -1,0 +1,978 @@
+#[repr(transparent)] pub struct bitcoin_hashes::Hash160(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Hmac<T: bitcoin_hashes::Hash>(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Ripemd160(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha1(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha256(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha256d(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha384(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha3_256(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha512(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha512_256(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Siphash24(_)
+#[repr(transparent)] pub struct bitcoin_hashes::hash160::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::hmac::Hmac<T: bitcoin_hashes::Hash>(_)
+#[repr(transparent)] pub struct bitcoin_hashes::ripemd160::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha1::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256d::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256t::Hash<T>(_, _)
+#[repr(transparent)] pub struct bitcoin_hashes::sha384::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha3_256::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha512::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha512_256::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::siphash24::Hash(_)
+impl bitcoin_hashes::Hash for bitcoin_hashes::hash160::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::ripemd160::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha1::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha256::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha256d::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha384::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha3_256::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha512::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha512_256::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::siphash24::Hash
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::hash160::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::ripemd160::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha1::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha256::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha256d::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha384::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha3_256::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512_256::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::siphash24::HashEngine
+impl bitcoin_hashes::hash160::Hash
+impl bitcoin_hashes::hash160::HashEngine
+impl bitcoin_hashes::ripemd160::Hash
+impl bitcoin_hashes::ripemd160::HashEngine
+impl bitcoin_hashes::sha1::Hash
+impl bitcoin_hashes::sha1::HashEngine
+impl bitcoin_hashes::sha256::Hash
+impl bitcoin_hashes::sha256::HashEngine
+impl bitcoin_hashes::sha256::Midstate
+impl bitcoin_hashes::sha256d::Hash
+impl bitcoin_hashes::sha256d::HashEngine
+impl bitcoin_hashes::sha384::Hash
+impl bitcoin_hashes::sha384::HashEngine
+impl bitcoin_hashes::sha3_256::Hash
+impl bitcoin_hashes::sha3_256::HashEngine
+impl bitcoin_hashes::sha512::Hash
+impl bitcoin_hashes::sha512::HashEngine
+impl bitcoin_hashes::sha512_256::Hash
+impl bitcoin_hashes::sha512_256::HashEngine
+impl bitcoin_hashes::siphash24::Hash
+impl bitcoin_hashes::siphash24::HashEngine
+impl core::borrow::Borrow<[u8; 20]> for bitcoin_hashes::hash160::Hash
+impl core::borrow::Borrow<[u8; 20]> for bitcoin_hashes::ripemd160::Hash
+impl core::borrow::Borrow<[u8; 20]> for bitcoin_hashes::sha1::Hash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_hashes::sha256::Hash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_hashes::sha256d::Hash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_hashes::sha3_256::Hash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_hashes::sha512_256::Hash
+impl core::borrow::Borrow<[u8; 48]> for bitcoin_hashes::sha384::Hash
+impl core::borrow::Borrow<[u8; 64]> for bitcoin_hashes::sha512::Hash
+impl core::borrow::Borrow<[u8; 8]> for bitcoin_hashes::siphash24::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::hash160::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::ripemd160::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha1::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256d::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha384::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha3_256::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha512::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha512_256::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::siphash24::Hash
+impl core::clone::Clone for bitcoin_hashes::hash160::Hash
+impl core::clone::Clone for bitcoin_hashes::hash160::HashEngine
+impl core::clone::Clone for bitcoin_hashes::hkdf::MaxLengthError
+impl core::clone::Clone for bitcoin_hashes::ripemd160::Hash
+impl core::clone::Clone for bitcoin_hashes::ripemd160::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha1::Hash
+impl core::clone::Clone for bitcoin_hashes::sha1::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha256::Hash
+impl core::clone::Clone for bitcoin_hashes::sha256::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha256::Midstate
+impl core::clone::Clone for bitcoin_hashes::sha256::MidstateError
+impl core::clone::Clone for bitcoin_hashes::sha256d::Hash
+impl core::clone::Clone for bitcoin_hashes::sha256d::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha384::Hash
+impl core::clone::Clone for bitcoin_hashes::sha384::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha3_256::Hash
+impl core::clone::Clone for bitcoin_hashes::sha3_256::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha512::Hash
+impl core::clone::Clone for bitcoin_hashes::sha512::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha512_256::Hash
+impl core::clone::Clone for bitcoin_hashes::sha512_256::HashEngine
+impl core::clone::Clone for bitcoin_hashes::siphash24::Hash
+impl core::clone::Clone for bitcoin_hashes::siphash24::HashEngine
+impl core::clone::Clone for bitcoin_hashes::siphash24::State
+impl core::cmp::Eq for bitcoin_hashes::hash160::Hash
+impl core::cmp::Eq for bitcoin_hashes::hkdf::MaxLengthError
+impl core::cmp::Eq for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha1::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha256::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha256::Midstate
+impl core::cmp::Eq for bitcoin_hashes::sha256::MidstateError
+impl core::cmp::Eq for bitcoin_hashes::sha256d::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha384::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha3_256::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha512::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::Eq for bitcoin_hashes::siphash24::Hash
+impl core::cmp::Ord for bitcoin_hashes::hash160::Hash
+impl core::cmp::Ord for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha1::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha256::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha256::Midstate
+impl core::cmp::Ord for bitcoin_hashes::sha256d::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha384::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha3_256::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha512::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::Ord for bitcoin_hashes::siphash24::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::hash160::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::hkdf::MaxLengthError
+impl core::cmp::PartialEq for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha1::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha256::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha256::Midstate
+impl core::cmp::PartialEq for bitcoin_hashes::sha256::MidstateError
+impl core::cmp::PartialEq for bitcoin_hashes::sha256d::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha384::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha3_256::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha512::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::siphash24::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::hash160::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha1::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha256::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha256::Midstate
+impl core::cmp::PartialOrd for bitcoin_hashes::sha256d::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha384::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha3_256::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha512::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::siphash24::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::hash160::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::ripemd160::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::sha1::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256d::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha3_256::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha512_256::Hash
+impl core::convert::AsRef<[u8; 48]> for bitcoin_hashes::sha384::Hash
+impl core::convert::AsRef<[u8; 64]> for bitcoin_hashes::sha512::Hash
+impl core::convert::AsRef<[u8; 8]> for bitcoin_hashes::siphash24::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::hash160::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::ripemd160::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha1::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256::Midstate
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256d::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha384::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha3_256::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha512::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha512_256::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::siphash24::Hash
+impl core::default::Default for bitcoin_hashes::hash160::HashEngine
+impl core::default::Default for bitcoin_hashes::ripemd160::HashEngine
+impl core::default::Default for bitcoin_hashes::sha1::HashEngine
+impl core::default::Default for bitcoin_hashes::sha256::HashEngine
+impl core::default::Default for bitcoin_hashes::sha256::Midstate
+impl core::default::Default for bitcoin_hashes::sha256d::HashEngine
+impl core::default::Default for bitcoin_hashes::sha384::HashEngine
+impl core::default::Default for bitcoin_hashes::sha3_256::HashEngine
+impl core::default::Default for bitcoin_hashes::sha512::HashEngine
+impl core::default::Default for bitcoin_hashes::sha512_256::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::hash160::Hash
+impl core::fmt::Debug for bitcoin_hashes::hash160::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::hkdf::MaxLengthError
+impl core::fmt::Debug for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::Debug for bitcoin_hashes::ripemd160::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::sha1::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha1::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::sha256::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha256::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::sha256::Midstate
+impl core::fmt::Debug for bitcoin_hashes::sha256::MidstateError
+impl core::fmt::Debug for bitcoin_hashes::sha256d::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha256d::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::sha384::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha384::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::sha3_256::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha3_256::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::sha512::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha512::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha512_256::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::siphash24::Hash
+impl core::fmt::Debug for bitcoin_hashes::siphash24::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::siphash24::State
+impl core::fmt::Display for bitcoin_hashes::hkdf::MaxLengthError
+impl core::fmt::Display for bitcoin_hashes::sha256::MidstateError
+impl core::hash::Hash for bitcoin_hashes::hash160::Hash
+impl core::hash::Hash for bitcoin_hashes::ripemd160::Hash
+impl core::hash::Hash for bitcoin_hashes::sha1::Hash
+impl core::hash::Hash for bitcoin_hashes::sha256::Hash
+impl core::hash::Hash for bitcoin_hashes::sha256::Midstate
+impl core::hash::Hash for bitcoin_hashes::sha256d::Hash
+impl core::hash::Hash for bitcoin_hashes::sha384::Hash
+impl core::hash::Hash for bitcoin_hashes::sha3_256::Hash
+impl core::hash::Hash for bitcoin_hashes::sha512::Hash
+impl core::hash::Hash for bitcoin_hashes::sha512_256::Hash
+impl core::hash::Hash for bitcoin_hashes::siphash24::Hash
+impl core::marker::Copy for bitcoin_hashes::hash160::Hash
+impl core::marker::Copy for bitcoin_hashes::hkdf::MaxLengthError
+impl core::marker::Copy for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Copy for bitcoin_hashes::sha1::Hash
+impl core::marker::Copy for bitcoin_hashes::sha256::Hash
+impl core::marker::Copy for bitcoin_hashes::sha256::Midstate
+impl core::marker::Copy for bitcoin_hashes::sha256d::Hash
+impl core::marker::Copy for bitcoin_hashes::sha384::Hash
+impl core::marker::Copy for bitcoin_hashes::sha3_256::Hash
+impl core::marker::Copy for bitcoin_hashes::sha512::Hash
+impl core::marker::Copy for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Copy for bitcoin_hashes::siphash24::Hash
+impl core::marker::Freeze for bitcoin_hashes::hash160::Hash
+impl core::marker::Freeze for bitcoin_hashes::hash160::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::hkdf::MaxLengthError
+impl core::marker::Freeze for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Freeze for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha1::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha256::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha256::Midstate
+impl core::marker::Freeze for bitcoin_hashes::sha256::MidstateError
+impl core::marker::Freeze for bitcoin_hashes::sha256d::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha256d::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha384::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha384::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha3_256::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha3_256::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha512::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::siphash24::Hash
+impl core::marker::Freeze for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::siphash24::State
+impl core::marker::Send for bitcoin_hashes::hash160::Hash
+impl core::marker::Send for bitcoin_hashes::hash160::HashEngine
+impl core::marker::Send for bitcoin_hashes::hkdf::MaxLengthError
+impl core::marker::Send for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Send for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha1::Hash
+impl core::marker::Send for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha256::Hash
+impl core::marker::Send for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha256::Midstate
+impl core::marker::Send for bitcoin_hashes::sha256::MidstateError
+impl core::marker::Send for bitcoin_hashes::sha256d::Hash
+impl core::marker::Send for bitcoin_hashes::sha256d::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha384::Hash
+impl core::marker::Send for bitcoin_hashes::sha384::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha3_256::Hash
+impl core::marker::Send for bitcoin_hashes::sha3_256::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha512::Hash
+impl core::marker::Send for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Send for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Send for bitcoin_hashes::siphash24::Hash
+impl core::marker::Send for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Send for bitcoin_hashes::siphash24::State
+impl core::marker::StructuralPartialEq for bitcoin_hashes::hash160::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::hkdf::MaxLengthError
+impl core::marker::StructuralPartialEq for bitcoin_hashes::ripemd160::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha1::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256::Midstate
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256::MidstateError
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256d::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha384::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha3_256::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha512::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha512_256::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::siphash24::Hash
+impl core::marker::Sync for bitcoin_hashes::hash160::Hash
+impl core::marker::Sync for bitcoin_hashes::hash160::HashEngine
+impl core::marker::Sync for bitcoin_hashes::hkdf::MaxLengthError
+impl core::marker::Sync for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Sync for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha1::Hash
+impl core::marker::Sync for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha256::Hash
+impl core::marker::Sync for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha256::Midstate
+impl core::marker::Sync for bitcoin_hashes::sha256::MidstateError
+impl core::marker::Sync for bitcoin_hashes::sha256d::Hash
+impl core::marker::Sync for bitcoin_hashes::sha256d::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha384::Hash
+impl core::marker::Sync for bitcoin_hashes::sha384::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha3_256::Hash
+impl core::marker::Sync for bitcoin_hashes::sha3_256::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha512::Hash
+impl core::marker::Sync for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Sync for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Sync for bitcoin_hashes::siphash24::Hash
+impl core::marker::Sync for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Sync for bitcoin_hashes::siphash24::State
+impl core::marker::Unpin for bitcoin_hashes::hash160::Hash
+impl core::marker::Unpin for bitcoin_hashes::hash160::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::hkdf::MaxLengthError
+impl core::marker::Unpin for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Unpin for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha1::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha256::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha256::Midstate
+impl core::marker::Unpin for bitcoin_hashes::sha256::MidstateError
+impl core::marker::Unpin for bitcoin_hashes::sha256d::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha256d::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha384::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha384::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha3_256::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha3_256::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha512::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::siphash24::Hash
+impl core::marker::Unpin for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::siphash24::State
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hash160::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hash160::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hkdf::MaxLengthError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::ripemd160::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::ripemd160::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha1::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha1::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::Midstate
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::MidstateError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256d::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256d::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha384::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha384::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha3_256::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha3_256::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512_256::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512_256::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::State
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hash160::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hash160::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hkdf::MaxLengthError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::ripemd160::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::ripemd160::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha1::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha1::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::Midstate
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::MidstateError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256d::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256d::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha384::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha384::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha3_256::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha3_256::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512_256::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512_256::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::State
+impl<T: bitcoin_hashes::Hash + core::fmt::Debug> core::fmt::Debug for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash + core::fmt::Display> core::fmt::Display for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash + core::fmt::LowerHex> core::fmt::LowerHex for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash + core::str::traits::FromStr> core::str::traits::FromStr for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> bitcoin_hashes::Hash for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::cmp::Eq for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::cmp::PartialEq for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::convert::AsRef<[u8]> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::HashEngine> bitcoin_hashes::HashEngine for bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::HashEngine> bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::HashEngine> core::fmt::Debug for bitcoin_hashes::hkdf::Hkdf<T>
+impl<T: bitcoin_hashes::sha256t::Tag> bitcoin_hashes::Hash for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> bitcoin_hashes::HashEngine for bitcoin_hashes::sha256t::HashEngine<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::borrow::Borrow<[u8; 32]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::clone::Clone for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::clone::Clone for bitcoin_hashes::sha256t::HashEngine<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::Eq for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::Ord for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::PartialEq for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::PartialOrd for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::convert::AsRef<[u8]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::default::Default for bitcoin_hashes::sha256t::HashEngine<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::Debug for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::hash::Hash for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::marker::Copy for bitcoin_hashes::sha256t::Hash<T>
+impl<T: core::clone::Clone + bitcoin_hashes::Hash> core::clone::Clone for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::clone::Clone + bitcoin_hashes::HashEngine> core::clone::Clone for bitcoin_hashes::hkdf::Hkdf<T> where <T as bitcoin_hashes::HashEngine>::Hash: core::clone::Clone
+impl<T: core::clone::Clone + bitcoin_hashes::HashEngine> core::clone::Clone for bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: core::cmp::Ord + bitcoin_hashes::Hash> core::cmp::Ord for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::cmp::PartialOrd + bitcoin_hashes::Hash> core::cmp::PartialOrd for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::fmt::Debug + bitcoin_hashes::HashEngine> core::fmt::Debug for bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: core::fmt::Debug> core::fmt::Debug for bitcoin_hashes::sha256t::HashEngine<T>
+impl<T: core::hash::Hash + bitcoin_hashes::Hash> core::hash::Hash for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::marker::Copy + bitcoin_hashes::Hash> core::marker::Copy for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::marker::Copy + bitcoin_hashes::HashEngine> core::marker::Copy for bitcoin_hashes::hkdf::Hkdf<T> where <T as bitcoin_hashes::HashEngine>::Hash: core::marker::Copy
+impl<T> bitcoin_hashes::hkdf::Hkdf<T> where T: core::default::Default + bitcoin_hashes::HashEngine
+impl<T> bitcoin_hashes::sha256t::Hash<T>
+impl<T> bitcoin_hashes::sha256t::Hash<T> where T: bitcoin_hashes::sha256t::Tag
+impl<T> core::marker::Freeze for bitcoin_hashes::hkdf::Hkdf<T> where <T as bitcoin_hashes::HashEngine>::Hash: core::marker::Freeze
+impl<T> core::marker::Freeze for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Freeze
+impl<T> core::marker::Freeze for bitcoin_hashes::hmac::HmacEngine<T> where T: core::marker::Freeze
+impl<T> core::marker::Freeze for bitcoin_hashes::sha256t::Hash<T>
+impl<T> core::marker::Freeze for bitcoin_hashes::sha256t::HashEngine<T>
+impl<T> core::marker::Send for bitcoin_hashes::hkdf::Hkdf<T> where <T as bitcoin_hashes::HashEngine>::Hash: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::hmac::HmacEngine<T> where T: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::sha256t::HashEngine<T> where T: core::marker::Send
+impl<T> core::marker::Sync for bitcoin_hashes::hkdf::Hkdf<T> where <T as bitcoin_hashes::HashEngine>::Hash: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::hmac::HmacEngine<T> where T: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::sha256t::HashEngine<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bitcoin_hashes::hkdf::Hkdf<T> where <T as bitcoin_hashes::HashEngine>::Hash: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::hmac::HmacEngine<T> where T: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::sha256t::HashEngine<T> where T: core::marker::Unpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hkdf::Hkdf<T> where <T as bitcoin_hashes::HashEngine>::Hash: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::Hmac<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::HmacEngine<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256t::Hash<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256t::HashEngine<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hkdf::Hkdf<T> where <T as bitcoin_hashes::HashEngine>::Hash: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::Hmac<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::HmacEngine<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256t::Hash<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256t::HashEngine<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<const N: usize> bitcoin_hashes::IsByteArray for [u8; N]
+pub const [u8; N]::LEN: usize
+pub const bitcoin_hashes::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::Hash::LEN: usize
+pub const bitcoin_hashes::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::HashEngine::LEN: usize
+pub const bitcoin_hashes::IsByteArray::LEN: usize
+pub const bitcoin_hashes::hash160::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::hash160::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::hmac::HmacEngine<T>::BLOCK_SIZE: usize
+pub const bitcoin_hashes::ripemd160::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::ripemd160::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha1::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha1::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha256::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha256::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha256d::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha256d::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha256t::Hash<T>::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha256t::HashEngine<T>::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha256t::Tag::MIDSTATE: bitcoin_hashes::sha256::Midstate
+pub const bitcoin_hashes::sha384::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha384::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha3_256::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha3_256::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha512::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha512::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha512_256::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha512_256::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::siphash24::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::siphash24::HashEngine::BLOCK_SIZE: usize
+pub const fn bitcoin_hashes::hash160::Hash::as_byte_array(&self) -> &[u8; 20]
+pub const fn bitcoin_hashes::hash160::Hash::from_byte_array(bytes: [u8; 20]) -> Self
+pub const fn bitcoin_hashes::hash160::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub const fn bitcoin_hashes::hash160::Hash::to_byte_array(self) -> [u8; 20]
+pub const fn bitcoin_hashes::hash160::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::ripemd160::Hash::as_byte_array(&self) -> &[u8; 20]
+pub const fn bitcoin_hashes::ripemd160::Hash::from_byte_array(bytes: [u8; 20]) -> Self
+pub const fn bitcoin_hashes::ripemd160::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub const fn bitcoin_hashes::ripemd160::Hash::to_byte_array(self) -> [u8; 20]
+pub const fn bitcoin_hashes::ripemd160::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha1::Hash::as_byte_array(&self) -> &[u8; 20]
+pub const fn bitcoin_hashes::sha1::Hash::from_byte_array(bytes: [u8; 20]) -> Self
+pub const fn bitcoin_hashes::sha1::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub const fn bitcoin_hashes::sha1::Hash::to_byte_array(self) -> [u8; 20]
+pub const fn bitcoin_hashes::sha1::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha256::Hash::as_byte_array(&self) -> &[u8; 32]
+pub const fn bitcoin_hashes::sha256::Hash::from_byte_array(bytes: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub const fn bitcoin_hashes::sha256::Hash::hash_unoptimized(bytes: &[u8]) -> Self
+pub const fn bitcoin_hashes::sha256::Hash::to_byte_array(self) -> [u8; 32]
+pub const fn bitcoin_hashes::sha256::HashEngine::can_extract_midstate(&self) -> bool
+pub const fn bitcoin_hashes::sha256::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha256::Midstate::as_parts(&self) -> (&[u8; 32], u64)
+pub const fn bitcoin_hashes::sha256::Midstate::hash_tag(tag: &[u8]) -> Self
+pub const fn bitcoin_hashes::sha256::Midstate::new(state: [u8; 32], bytes_hashed: u64) -> Self
+pub const fn bitcoin_hashes::sha256::Midstate::to_parts(self) -> ([u8; 32], u64)
+pub const fn bitcoin_hashes::sha256d::Hash::as_byte_array(&self) -> &[u8; 32]
+pub const fn bitcoin_hashes::sha256d::Hash::from_byte_array(bytes: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha256d::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub const fn bitcoin_hashes::sha256d::Hash::to_byte_array(self) -> [u8; 32]
+pub const fn bitcoin_hashes::sha256d::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha256t::Hash<T>::as_byte_array(&self) -> &[u8; 32]
+pub const fn bitcoin_hashes::sha256t::Hash<T>::from_byte_array(bytes: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub const fn bitcoin_hashes::sha256t::Hash<T>::to_byte_array(self) -> [u8; 32]
+pub const fn bitcoin_hashes::sha384::Hash::as_byte_array(&self) -> &[u8; 48]
+pub const fn bitcoin_hashes::sha384::Hash::from_byte_array(bytes: [u8; 48]) -> Self
+pub const fn bitcoin_hashes::sha384::Hash::from_bytes_ref(bytes: &[u8; 48]) -> &Self
+pub const fn bitcoin_hashes::sha384::Hash::to_byte_array(self) -> [u8; 48]
+pub const fn bitcoin_hashes::sha384::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha3_256::Hash::as_byte_array(&self) -> &[u8; 32]
+pub const fn bitcoin_hashes::sha3_256::Hash::from_byte_array(bytes: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha3_256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub const fn bitcoin_hashes::sha3_256::Hash::to_byte_array(self) -> [u8; 32]
+pub const fn bitcoin_hashes::sha3_256::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha512::Hash::as_byte_array(&self) -> &[u8; 64]
+pub const fn bitcoin_hashes::sha512::Hash::from_byte_array(bytes: [u8; 64]) -> Self
+pub const fn bitcoin_hashes::sha512::Hash::from_bytes_ref(bytes: &[u8; 64]) -> &Self
+pub const fn bitcoin_hashes::sha512::Hash::to_byte_array(self) -> [u8; 64]
+pub const fn bitcoin_hashes::sha512::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha512_256::Hash::as_byte_array(&self) -> &[u8; 32]
+pub const fn bitcoin_hashes::sha512_256::Hash::from_byte_array(bytes: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha512_256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub const fn bitcoin_hashes::sha512_256::Hash::to_byte_array(self) -> [u8; 32]
+pub const fn bitcoin_hashes::sha512_256::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::siphash24::Hash::as_byte_array(&self) -> &[u8; 8]
+pub const fn bitcoin_hashes::siphash24::Hash::from_byte_array(bytes: [u8; 8]) -> Self
+pub const fn bitcoin_hashes::siphash24::Hash::from_bytes_ref(bytes: &[u8; 8]) -> &Self
+pub const fn bitcoin_hashes::siphash24::Hash::to_byte_array(self) -> [u8; 8]
+pub const fn bitcoin_hashes::siphash24::HashEngine::with_keys(k0: u64, k1: u64) -> Self
+pub fn bitcoin_hashes::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::HashEngine::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::HashEngine::input(&mut self, data: &[u8])
+pub fn bitcoin_hashes::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::cmp::fixed_time_eq(a: &[u8], b: &[u8]) -> bool
+pub fn bitcoin_hashes::debug_hex(bytes: &[u8], f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::encode_to_engine<T, H>(object: &T, engine: H) -> H where T: bitcoin_consensus_encoding::encode::Encodable + ?core::marker::Sized, H: bitcoin_hashes::HashEngine
+pub fn bitcoin_hashes::hash160::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::hash160::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::hash160::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::hash160::Hash::borrow(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::hash160::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::hash160::Hash::clone(&self) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::hash160::Hash::cmp(&self, other: &bitcoin_hashes::hash160::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::hash160::Hash::engine() -> bitcoin_hashes::hash160::HashEngine
+pub fn bitcoin_hashes::hash160::Hash::eq(&self, other: &bitcoin_hashes::hash160::Hash) -> bool
+pub fn bitcoin_hashes::hash160::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hash160::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::hash160::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::hash160::Hash::from_engine(e: bitcoin_hashes::hash160::HashEngine) -> Self
+pub fn bitcoin_hashes::hash160::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::hash160::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::hash160::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::hash160::Hash::partial_cmp(&self, other: &bitcoin_hashes::hash160::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::hash160::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::hash160::HashEngine::clone(&self) -> bitcoin_hashes::hash160::HashEngine
+pub fn bitcoin_hashes::hash160::HashEngine::default() -> Self
+pub fn bitcoin_hashes::hash160::HashEngine::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::hash160::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hash160::HashEngine::input(&mut self, data: &[u8])
+pub fn bitcoin_hashes::hash160::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::hash160::hash(data: &[u8]) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::hash160::hash_byte_chunks<B, I>(byte_slices: I) -> bitcoin_hashes::hash160::Hash where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::hkdf::Hkdf<T>::clone(&self) -> bitcoin_hashes::hkdf::Hkdf<T>
+pub fn bitcoin_hashes::hkdf::Hkdf<T>::expand(&self, info: &[u8], okm: &mut [u8]) -> core::result::Result<(), bitcoin_hashes::hkdf::MaxLengthError>
+pub fn bitcoin_hashes::hkdf::Hkdf<T>::expand_to_len(&self, info: &[u8], len: usize) -> core::result::Result<alloc::vec::Vec<u8>, bitcoin_hashes::hkdf::MaxLengthError>
+pub fn bitcoin_hashes::hkdf::Hkdf<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hkdf::Hkdf<T>::new(salt: &[u8], ikm: &[u8]) -> Self
+pub fn bitcoin_hashes::hkdf::MaxLengthError::clone(&self) -> bitcoin_hashes::hkdf::MaxLengthError
+pub fn bitcoin_hashes::hkdf::MaxLengthError::eq(&self, other: &bitcoin_hashes::hkdf::MaxLengthError) -> bool
+pub fn bitcoin_hashes::hkdf::MaxLengthError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hmac::Hmac<T>::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::hmac::Hmac<T>::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::clone(&self) -> bitcoin_hashes::hmac::Hmac<T>
+pub fn bitcoin_hashes::hmac::Hmac<T>::cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::cmp::Ordering
+pub fn bitcoin_hashes::hmac::Hmac<T>::eq(&self, other: &Self) -> bool
+pub fn bitcoin_hashes::hmac::Hmac<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_byte_array(bytes: <T as bitcoin_hashes::Hash>::Bytes) -> Self
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::hmac::Hmac<T>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::hmac::Hmac<T>::partial_cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::hmac::Hmac<T>::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::clone(&self) -> bitcoin_hashes::hmac::HmacEngine<T>
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::from_inner_engines(iengine: T, oengine: T) -> Self
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::input(&mut self, buf: &[u8])
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::new(key: &[u8]) -> Self where T: core::default::Default
+pub fn bitcoin_hashes::ripemd160::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::ripemd160::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::ripemd160::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::ripemd160::Hash::borrow(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::ripemd160::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::ripemd160::Hash::clone(&self) -> bitcoin_hashes::ripemd160::Hash
+pub fn bitcoin_hashes::ripemd160::Hash::cmp(&self, other: &bitcoin_hashes::ripemd160::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::ripemd160::Hash::engine() -> bitcoin_hashes::ripemd160::HashEngine
+pub fn bitcoin_hashes::ripemd160::Hash::eq(&self, other: &bitcoin_hashes::ripemd160::Hash) -> bool
+pub fn bitcoin_hashes::ripemd160::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::ripemd160::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::ripemd160::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::ripemd160::Hash::from_engine(e: bitcoin_hashes::ripemd160::HashEngine) -> Self
+pub fn bitcoin_hashes::ripemd160::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::ripemd160::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::ripemd160::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::ripemd160::Hash::partial_cmp(&self, other: &bitcoin_hashes::ripemd160::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::ripemd160::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::ripemd160::HashEngine::clone(&self) -> bitcoin_hashes::ripemd160::HashEngine
+pub fn bitcoin_hashes::ripemd160::HashEngine::default() -> Self
+pub fn bitcoin_hashes::ripemd160::HashEngine::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::ripemd160::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::ripemd160::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::ripemd160::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::ripemd160::hash(data: &[u8]) -> bitcoin_hashes::ripemd160::Hash
+pub fn bitcoin_hashes::ripemd160::hash_byte_chunks<B, I>(byte_slices: I) -> bitcoin_hashes::ripemd160::Hash where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha1::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha1::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::sha1::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha1::Hash::borrow(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::sha1::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha1::Hash::clone(&self) -> bitcoin_hashes::sha1::Hash
+pub fn bitcoin_hashes::sha1::Hash::cmp(&self, other: &bitcoin_hashes::sha1::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha1::Hash::engine() -> bitcoin_hashes::sha1::HashEngine
+pub fn bitcoin_hashes::sha1::Hash::eq(&self, other: &bitcoin_hashes::sha1::Hash) -> bool
+pub fn bitcoin_hashes::sha1::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha1::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha1::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::sha1::Hash::from_engine(e: bitcoin_hashes::sha1::HashEngine) -> Self
+pub fn bitcoin_hashes::sha1::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha1::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha1::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha1::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha1::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha1::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha1::HashEngine::clone(&self) -> bitcoin_hashes::sha1::HashEngine
+pub fn bitcoin_hashes::sha1::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha1::HashEngine::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::sha1::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha1::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha1::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha1::hash(data: &[u8]) -> bitcoin_hashes::sha1::Hash
+pub fn bitcoin_hashes::sha1::hash_byte_chunks<B, I>(byte_slices: I) -> bitcoin_hashes::sha1::Hash where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha256::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Hash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Hash::clone(&self) -> bitcoin_hashes::sha256::Hash
+pub fn bitcoin_hashes::sha256::Hash::cmp(&self, other: &bitcoin_hashes::sha256::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256::Hash::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha256::Hash::eq(&self, other: &bitcoin_hashes::sha256::Hash) -> bool
+pub fn bitcoin_hashes::sha256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> Self
+pub fn bitcoin_hashes::sha256::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha256::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256::Hash::hash_again(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha256::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha256::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256::HashEngine::clone(&self) -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha256::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha256::HashEngine::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::sha256::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256::HashEngine::from_midstate(midstate: bitcoin_hashes::sha256::Midstate) -> Self
+pub fn bitcoin_hashes::sha256::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha256::HashEngine::midstate(&self) -> core::result::Result<bitcoin_hashes::sha256::Midstate, bitcoin_hashes::sha256::MidstateError>
+pub fn bitcoin_hashes::sha256::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha256::Midstate::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Midstate::clone(&self) -> bitcoin_hashes::sha256::Midstate
+pub fn bitcoin_hashes::sha256::Midstate::cmp(&self, other: &bitcoin_hashes::sha256::Midstate) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256::Midstate::default() -> bitcoin_hashes::sha256::Midstate
+pub fn bitcoin_hashes::sha256::Midstate::eq(&self, other: &bitcoin_hashes::sha256::Midstate) -> bool
+pub fn bitcoin_hashes::sha256::Midstate::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256::Midstate::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256::Midstate::partial_cmp(&self, other: &bitcoin_hashes::sha256::Midstate) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256::MidstateError::clone(&self) -> bitcoin_hashes::sha256::MidstateError
+pub fn bitcoin_hashes::sha256::MidstateError::eq(&self, other: &bitcoin_hashes::sha256::MidstateError) -> bool
+pub fn bitcoin_hashes::sha256::MidstateError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256::hash(data: &[u8]) -> bitcoin_hashes::sha256::Hash
+pub fn bitcoin_hashes::sha256::hash_byte_chunks<B, I>(byte_slices: I) -> bitcoin_hashes::sha256::Hash where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha256d::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256d::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256d::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256d::Hash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256d::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256d::Hash::clone(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::cmp(&self, other: &bitcoin_hashes::sha256d::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256d::Hash::engine() -> bitcoin_hashes::sha256d::HashEngine
+pub fn bitcoin_hashes::sha256d::Hash::eq(&self, other: &bitcoin_hashes::sha256d::Hash) -> bool
+pub fn bitcoin_hashes::sha256d::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256d::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256d::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256d::Hash::from_engine(e: bitcoin_hashes::sha256d::HashEngine) -> Self
+pub fn bitcoin_hashes::sha256d::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha256d::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256d::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha256d::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha256d::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256d::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256d::HashEngine::clone(&self) -> bitcoin_hashes::sha256d::HashEngine
+pub fn bitcoin_hashes::sha256d::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha256d::HashEngine::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::sha256d::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256d::HashEngine::input(&mut self, data: &[u8])
+pub fn bitcoin_hashes::sha256d::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha256d::hash(data: &[u8]) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::hash_byte_chunks<B, I>(byte_slices: I) -> bitcoin_hashes::sha256d::Hash where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256t::Hash<T>::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256t::Hash<T>::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256t::Hash<T>::clone(&self) -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::cmp(&self, other: &Self) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256t::Hash<T>::engine() -> bitcoin_hashes::sha256t::HashEngine<T>
+pub fn bitcoin_hashes::sha256t::Hash<T>::eq(&self, other: &Self) -> bool
+pub fn bitcoin_hashes::sha256t::Hash<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_engine(e: bitcoin_hashes::sha256t::HashEngine<T>) -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::hash<H: core::hash::Hasher>(&self, h: &mut H)
+pub fn bitcoin_hashes::sha256t::Hash<T>::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha256t::Hash<T>::partial_cmp(&self, other: &Self) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256t::Hash<T>::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256t::HashEngine<T>::clone(&self) -> Self
+pub fn bitcoin_hashes::sha256t::HashEngine<T>::default() -> Self
+pub fn bitcoin_hashes::sha256t::HashEngine<T>::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::sha256t::HashEngine<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256t::HashEngine<T>::input(&mut self, data: &[u8])
+pub fn bitcoin_hashes::sha256t::HashEngine<T>::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha256t::hash<T>(data: &[u8]) -> bitcoin_hashes::sha256t::Hash<T> where T: bitcoin_hashes::sha256t::Tag
+pub fn bitcoin_hashes::sha256t::hash_byte_chunks<B, I, T>(byte_slices: I) -> bitcoin_hashes::sha256t::Hash<T> where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>, T: bitcoin_hashes::sha256t::Tag
+pub fn bitcoin_hashes::sha384::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha384::Hash::as_ref(&self) -> &[u8; 48]
+pub fn bitcoin_hashes::sha384::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha384::Hash::borrow(&self) -> &[u8; 48]
+pub fn bitcoin_hashes::sha384::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha384::Hash::clone(&self) -> bitcoin_hashes::sha384::Hash
+pub fn bitcoin_hashes::sha384::Hash::cmp(&self, other: &bitcoin_hashes::sha384::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha384::Hash::engine() -> bitcoin_hashes::sha384::HashEngine
+pub fn bitcoin_hashes::sha384::Hash::eq(&self, other: &bitcoin_hashes::sha384::Hash) -> bool
+pub fn bitcoin_hashes::sha384::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha384::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha384::Hash::from_bytes_mut(bytes: &mut [u8; 48]) -> &mut Self
+pub fn bitcoin_hashes::sha384::Hash::from_engine(e: bitcoin_hashes::sha384::HashEngine) -> Self
+pub fn bitcoin_hashes::sha384::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha384::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha384::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha384::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha384::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha384::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha384::HashEngine::clone(&self) -> bitcoin_hashes::sha384::HashEngine
+pub fn bitcoin_hashes::sha384::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha384::HashEngine::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::sha384::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha384::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha384::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha384::hash(data: &[u8]) -> bitcoin_hashes::sha384::Hash
+pub fn bitcoin_hashes::sha384::hash_byte_chunks<B, I>(byte_slices: I) -> bitcoin_hashes::sha384::Hash where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha3_256::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha3_256::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha3_256::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha3_256::Hash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha3_256::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha3_256::Hash::clone(&self) -> bitcoin_hashes::sha3_256::Hash
+pub fn bitcoin_hashes::sha3_256::Hash::cmp(&self, other: &bitcoin_hashes::sha3_256::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha3_256::Hash::engine() -> bitcoin_hashes::sha3_256::HashEngine
+pub fn bitcoin_hashes::sha3_256::Hash::eq(&self, other: &bitcoin_hashes::sha3_256::Hash) -> bool
+pub fn bitcoin_hashes::sha3_256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha3_256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha3_256::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha3_256::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha3_256::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha3_256::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha3_256::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha3_256::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha3_256::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha3_256::HashEngine::clone(&self) -> bitcoin_hashes::sha3_256::HashEngine
+pub fn bitcoin_hashes::sha3_256::HashEngine::default() -> bitcoin_hashes::sha3_256::HashEngine
+pub fn bitcoin_hashes::sha3_256::HashEngine::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::sha3_256::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha3_256::HashEngine::input(&mut self, data: &[u8])
+pub fn bitcoin_hashes::sha3_256::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha3_256::hash(data: &[u8]) -> bitcoin_hashes::sha3_256::Hash
+pub fn bitcoin_hashes::sha3_256::hash_byte_chunks<B, I>(byte_slices: I) -> bitcoin_hashes::sha3_256::Hash where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha512::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha512::Hash::as_ref(&self) -> &[u8; 64]
+pub fn bitcoin_hashes::sha512::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512::Hash::borrow(&self) -> &[u8; 64]
+pub fn bitcoin_hashes::sha512::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512::Hash::clone(&self) -> bitcoin_hashes::sha512::Hash
+pub fn bitcoin_hashes::sha512::Hash::cmp(&self, other: &bitcoin_hashes::sha512::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha512::Hash::engine() -> bitcoin_hashes::sha512::HashEngine
+pub fn bitcoin_hashes::sha512::Hash::eq(&self, other: &bitcoin_hashes::sha512::Hash) -> bool
+pub fn bitcoin_hashes::sha512::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha512::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha512::Hash::from_bytes_mut(bytes: &mut [u8; 64]) -> &mut Self
+pub fn bitcoin_hashes::sha512::Hash::from_engine(e: bitcoin_hashes::sha512::HashEngine) -> Self
+pub fn bitcoin_hashes::sha512::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha512::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha512::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha512::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha512::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha512::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha512::HashEngine::clone(&self) -> bitcoin_hashes::sha512::HashEngine
+pub fn bitcoin_hashes::sha512::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha512::HashEngine::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::sha512::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha512::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha512::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha512::hash(data: &[u8]) -> bitcoin_hashes::sha512::Hash
+pub fn bitcoin_hashes::sha512::hash_byte_chunks<B, I>(byte_slices: I) -> bitcoin_hashes::sha512::Hash where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha512_256::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha512_256::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha512_256::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512_256::Hash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha512_256::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512_256::Hash::clone(&self) -> bitcoin_hashes::sha512_256::Hash
+pub fn bitcoin_hashes::sha512_256::Hash::cmp(&self, other: &bitcoin_hashes::sha512_256::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha512_256::Hash::engine() -> bitcoin_hashes::sha512_256::HashEngine
+pub fn bitcoin_hashes::sha512_256::Hash::eq(&self, other: &bitcoin_hashes::sha512_256::Hash) -> bool
+pub fn bitcoin_hashes::sha512_256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha512_256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha512_256::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha512_256::Hash::from_engine(e: bitcoin_hashes::sha512_256::HashEngine) -> Self
+pub fn bitcoin_hashes::sha512_256::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha512_256::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha512_256::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha512_256::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha512_256::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha512_256::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha512_256::HashEngine::clone(&self) -> bitcoin_hashes::sha512_256::HashEngine
+pub fn bitcoin_hashes::sha512_256::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha512_256::HashEngine::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::sha512_256::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha512_256::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha512_256::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha512_256::hash(data: &[u8]) -> bitcoin_hashes::sha512_256::Hash
+pub fn bitcoin_hashes::sha512_256::hash_byte_chunks<B, I>(byte_slices: I) -> bitcoin_hashes::sha512_256::Hash where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::siphash24::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::siphash24::Hash::as_ref(&self) -> &[u8; 8]
+pub fn bitcoin_hashes::siphash24::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::siphash24::Hash::borrow(&self) -> &[u8; 8]
+pub fn bitcoin_hashes::siphash24::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::siphash24::Hash::clone(&self) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::cmp(&self, other: &bitcoin_hashes::siphash24::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::siphash24::Hash::engine(k0: u64, k1: u64) -> bitcoin_hashes::siphash24::HashEngine
+pub fn bitcoin_hashes::siphash24::Hash::eq(&self, other: &bitcoin_hashes::siphash24::Hash) -> bool
+pub fn bitcoin_hashes::siphash24::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::siphash24::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::siphash24::Hash::from_bytes_mut(bytes: &mut [u8; 8]) -> &mut Self
+pub fn bitcoin_hashes::siphash24::Hash::from_engine(e: bitcoin_hashes::siphash24::HashEngine) -> Self
+pub fn bitcoin_hashes::siphash24::Hash::from_engine_to_u64(e: bitcoin_hashes::siphash24::HashEngine) -> u64
+pub fn bitcoin_hashes::siphash24::Hash::from_u64(hash: u64) -> Self
+pub fn bitcoin_hashes::siphash24::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::siphash24::Hash::hash_to_u64_with_keys(k0: u64, k1: u64, data: &[u8]) -> u64
+pub fn bitcoin_hashes::siphash24::Hash::hash_with_keys(k0: u64, k1: u64, data: &[u8]) -> Self
+pub fn bitcoin_hashes::siphash24::Hash::partial_cmp(&self, other: &bitcoin_hashes::siphash24::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::siphash24::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::siphash24::Hash::to_u64(self) -> u64
+pub fn bitcoin_hashes::siphash24::HashEngine::clone(&self) -> bitcoin_hashes::siphash24::HashEngine
+pub fn bitcoin_hashes::siphash24::HashEngine::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::siphash24::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::siphash24::HashEngine::input(&mut self, msg: &[u8])
+pub fn bitcoin_hashes::siphash24::HashEngine::keys(&self) -> (u64, u64)
+pub fn bitcoin_hashes::siphash24::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::siphash24::State::clone(&self) -> bitcoin_hashes::siphash24::State
+pub fn bitcoin_hashes::siphash24::State::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub macro bitcoin_hashes::hash_newtype!
+pub macro bitcoin_hashes::impl_debug_only_for_newtype!
+pub macro bitcoin_hashes::sha256t_tag!
+pub mod bitcoin_hashes
+pub mod bitcoin_hashes::cmp
+pub mod bitcoin_hashes::hash160
+pub mod bitcoin_hashes::hkdf
+pub mod bitcoin_hashes::hmac
+pub mod bitcoin_hashes::macros
+pub mod bitcoin_hashes::ripemd160
+pub mod bitcoin_hashes::sha1
+pub mod bitcoin_hashes::sha256
+pub mod bitcoin_hashes::sha256d
+pub mod bitcoin_hashes::sha256t
+pub mod bitcoin_hashes::sha384
+pub mod bitcoin_hashes::sha3_256
+pub mod bitcoin_hashes::sha512
+pub mod bitcoin_hashes::sha512_256
+pub mod bitcoin_hashes::siphash24
+pub struct bitcoin_hashes::Hkdf<T: bitcoin_hashes::HashEngine>
+pub struct bitcoin_hashes::HmacEngine<T: bitcoin_hashes::HashEngine>
+pub struct bitcoin_hashes::hash160::HashEngine(_)
+pub struct bitcoin_hashes::hkdf::Hkdf<T: bitcoin_hashes::HashEngine>
+pub struct bitcoin_hashes::hkdf::MaxLengthError
+pub struct bitcoin_hashes::hmac::HmacEngine<T: bitcoin_hashes::HashEngine>
+pub struct bitcoin_hashes::ripemd160::HashEngine
+pub struct bitcoin_hashes::sha1::HashEngine
+pub struct bitcoin_hashes::sha256::HashEngine
+pub struct bitcoin_hashes::sha256::Midstate
+pub struct bitcoin_hashes::sha256::MidstateError
+pub struct bitcoin_hashes::sha256d::HashEngine(_)
+pub struct bitcoin_hashes::sha256t::HashEngine<T>(_, _)
+pub struct bitcoin_hashes::sha384::HashEngine(_)
+pub struct bitcoin_hashes::sha3_256::HashEngine
+pub struct bitcoin_hashes::sha512::HashEngine
+pub struct bitcoin_hashes::sha512_256::HashEngine(_)
+pub struct bitcoin_hashes::siphash24::HashEngine
+pub struct bitcoin_hashes::siphash24::State
+pub trait bitcoin_hashes::Hash: core::marker::Copy + core::clone::Clone + core::cmp::PartialEq + core::cmp::Eq + core::cmp::PartialOrd + core::cmp::Ord + core::hash::Hash + core::convert::AsRef<[u8]>
+pub trait bitcoin_hashes::HashEngine: core::clone::Clone
+pub trait bitcoin_hashes::IsByteArray: core::convert::AsRef<[u8]> + bitcoin_hashes::sealed::IsByteArray
+pub trait bitcoin_hashes::sha256t::Tag
+pub type bitcoin_hashes::Hash::Bytes: core::marker::Copy + bitcoin_hashes::IsByteArray
+pub type bitcoin_hashes::HashEngine::Bytes: core::marker::Copy + bitcoin_hashes::IsByteArray
+pub type bitcoin_hashes::HashEngine::Hash: bitcoin_hashes::Hash
+pub type bitcoin_hashes::HkdfSha256 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha256::Hash>
+pub type bitcoin_hashes::HkdfSha512 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha512::Hash>
+pub type bitcoin_hashes::HmacSha256 = bitcoin_hashes::hmac::Hmac<bitcoin_hashes::sha256::Hash>
+pub type bitcoin_hashes::HmacSha512 = bitcoin_hashes::hmac::Hmac<bitcoin_hashes::sha512::Hash>
+pub type bitcoin_hashes::Sha256t<T> = bitcoin_hashes::sha256t::Hash<T>
+pub type bitcoin_hashes::hash160::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::hash160::HashEngine::Bytes = [u8; 20]
+pub type bitcoin_hashes::hash160::HashEngine::Hash = bitcoin_hashes::hash160::Hash
+pub type bitcoin_hashes::hmac::Hmac<T>::Bytes = <T as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_hashes::hmac::Hmac<T>::Err = <T as core::str::traits::FromStr>::Err
+pub type bitcoin_hashes::hmac::HmacEngine<T>::Bytes = <T as bitcoin_hashes::HashEngine>::Bytes
+pub type bitcoin_hashes::hmac::HmacEngine<T>::Hash = bitcoin_hashes::hmac::Hmac<<T as bitcoin_hashes::HashEngine>::Hash>
+pub type bitcoin_hashes::ripemd160::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::ripemd160::HashEngine::Bytes = [u8; 20]
+pub type bitcoin_hashes::ripemd160::HashEngine::Hash = bitcoin_hashes::ripemd160::Hash
+pub type bitcoin_hashes::sha1::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::sha1::HashEngine::Bytes = [u8; 20]
+pub type bitcoin_hashes::sha1::HashEngine::Hash = bitcoin_hashes::sha1::Hash
+pub type bitcoin_hashes::sha256::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256::HashEngine::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256::HashEngine::Hash = bitcoin_hashes::sha256::Hash
+pub type bitcoin_hashes::sha256d::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256d::HashEngine::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256d::HashEngine::Hash = bitcoin_hashes::sha256d::Hash
+pub type bitcoin_hashes::sha256t::Hash<T>::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256t::HashEngine<T>::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256t::HashEngine<T>::Hash = bitcoin_hashes::sha256t::Hash<T>
+pub type bitcoin_hashes::sha384::Hash::Bytes = [u8; 48]
+pub type bitcoin_hashes::sha384::HashEngine::Bytes = [u8; 48]
+pub type bitcoin_hashes::sha384::HashEngine::Hash = bitcoin_hashes::sha384::Hash
+pub type bitcoin_hashes::sha3_256::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha3_256::HashEngine::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha3_256::HashEngine::Hash = bitcoin_hashes::sha3_256::Hash
+pub type bitcoin_hashes::sha512::Hash::Bytes = [u8; 64]
+pub type bitcoin_hashes::sha512::HashEngine::Bytes = [u8; 64]
+pub type bitcoin_hashes::sha512::HashEngine::Hash = bitcoin_hashes::sha512::Hash
+pub type bitcoin_hashes::sha512_256::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha512_256::HashEngine::Bytes = [u8; 64]
+pub type bitcoin_hashes::sha512_256::HashEngine::Hash = bitcoin_hashes::sha512_256::Hash
+pub type bitcoin_hashes::siphash24::Hash::Bytes = [u8; 8]
+pub type bitcoin_hashes::siphash24::HashEngine::Bytes = [u8; 8]
+pub type bitcoin_hashes::siphash24::HashEngine::Hash = bitcoin_hashes::siphash24::Hash

--- a/api/hashes/no-features.txt
+++ b/api/hashes/no-features.txt
@@ -1,0 +1,977 @@
+#[repr(transparent)] pub struct bitcoin_hashes::Hash160(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Hmac<T: bitcoin_hashes::Hash>(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Ripemd160(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha1(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha256(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha256d(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha384(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha3_256(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha512(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Sha512_256(_)
+#[repr(transparent)] pub struct bitcoin_hashes::Siphash24(_)
+#[repr(transparent)] pub struct bitcoin_hashes::hash160::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::hmac::Hmac<T: bitcoin_hashes::Hash>(_)
+#[repr(transparent)] pub struct bitcoin_hashes::ripemd160::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha1::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256d::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha256t::Hash<T>(_, _)
+#[repr(transparent)] pub struct bitcoin_hashes::sha384::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha3_256::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha512::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::sha512_256::Hash(_)
+#[repr(transparent)] pub struct bitcoin_hashes::siphash24::Hash(_)
+impl bitcoin_hashes::Hash for bitcoin_hashes::hash160::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::ripemd160::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha1::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha256::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha256d::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha384::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha3_256::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha512::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::sha512_256::Hash
+impl bitcoin_hashes::Hash for bitcoin_hashes::siphash24::Hash
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::hash160::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::ripemd160::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha1::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha256::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha256d::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha384::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha3_256::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512_256::HashEngine
+impl bitcoin_hashes::HashEngine for bitcoin_hashes::siphash24::HashEngine
+impl bitcoin_hashes::hash160::Hash
+impl bitcoin_hashes::hash160::HashEngine
+impl bitcoin_hashes::ripemd160::Hash
+impl bitcoin_hashes::ripemd160::HashEngine
+impl bitcoin_hashes::sha1::Hash
+impl bitcoin_hashes::sha1::HashEngine
+impl bitcoin_hashes::sha256::Hash
+impl bitcoin_hashes::sha256::HashEngine
+impl bitcoin_hashes::sha256::Midstate
+impl bitcoin_hashes::sha256d::Hash
+impl bitcoin_hashes::sha256d::HashEngine
+impl bitcoin_hashes::sha384::Hash
+impl bitcoin_hashes::sha384::HashEngine
+impl bitcoin_hashes::sha3_256::Hash
+impl bitcoin_hashes::sha3_256::HashEngine
+impl bitcoin_hashes::sha512::Hash
+impl bitcoin_hashes::sha512::HashEngine
+impl bitcoin_hashes::sha512_256::Hash
+impl bitcoin_hashes::sha512_256::HashEngine
+impl bitcoin_hashes::siphash24::Hash
+impl bitcoin_hashes::siphash24::HashEngine
+impl core::borrow::Borrow<[u8; 20]> for bitcoin_hashes::hash160::Hash
+impl core::borrow::Borrow<[u8; 20]> for bitcoin_hashes::ripemd160::Hash
+impl core::borrow::Borrow<[u8; 20]> for bitcoin_hashes::sha1::Hash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_hashes::sha256::Hash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_hashes::sha256d::Hash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_hashes::sha3_256::Hash
+impl core::borrow::Borrow<[u8; 32]> for bitcoin_hashes::sha512_256::Hash
+impl core::borrow::Borrow<[u8; 48]> for bitcoin_hashes::sha384::Hash
+impl core::borrow::Borrow<[u8; 64]> for bitcoin_hashes::sha512::Hash
+impl core::borrow::Borrow<[u8; 8]> for bitcoin_hashes::siphash24::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::hash160::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::ripemd160::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha1::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256d::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha384::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha3_256::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha512::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha512_256::Hash
+impl core::borrow::Borrow<[u8]> for bitcoin_hashes::siphash24::Hash
+impl core::clone::Clone for bitcoin_hashes::hash160::Hash
+impl core::clone::Clone for bitcoin_hashes::hash160::HashEngine
+impl core::clone::Clone for bitcoin_hashes::hkdf::MaxLengthError
+impl core::clone::Clone for bitcoin_hashes::ripemd160::Hash
+impl core::clone::Clone for bitcoin_hashes::ripemd160::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha1::Hash
+impl core::clone::Clone for bitcoin_hashes::sha1::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha256::Hash
+impl core::clone::Clone for bitcoin_hashes::sha256::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha256::Midstate
+impl core::clone::Clone for bitcoin_hashes::sha256::MidstateError
+impl core::clone::Clone for bitcoin_hashes::sha256d::Hash
+impl core::clone::Clone for bitcoin_hashes::sha256d::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha384::Hash
+impl core::clone::Clone for bitcoin_hashes::sha384::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha3_256::Hash
+impl core::clone::Clone for bitcoin_hashes::sha3_256::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha512::Hash
+impl core::clone::Clone for bitcoin_hashes::sha512::HashEngine
+impl core::clone::Clone for bitcoin_hashes::sha512_256::Hash
+impl core::clone::Clone for bitcoin_hashes::sha512_256::HashEngine
+impl core::clone::Clone for bitcoin_hashes::siphash24::Hash
+impl core::clone::Clone for bitcoin_hashes::siphash24::HashEngine
+impl core::clone::Clone for bitcoin_hashes::siphash24::State
+impl core::cmp::Eq for bitcoin_hashes::hash160::Hash
+impl core::cmp::Eq for bitcoin_hashes::hkdf::MaxLengthError
+impl core::cmp::Eq for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha1::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha256::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha256::Midstate
+impl core::cmp::Eq for bitcoin_hashes::sha256::MidstateError
+impl core::cmp::Eq for bitcoin_hashes::sha256d::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha384::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha3_256::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha512::Hash
+impl core::cmp::Eq for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::Eq for bitcoin_hashes::siphash24::Hash
+impl core::cmp::Ord for bitcoin_hashes::hash160::Hash
+impl core::cmp::Ord for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha1::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha256::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha256::Midstate
+impl core::cmp::Ord for bitcoin_hashes::sha256d::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha384::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha3_256::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha512::Hash
+impl core::cmp::Ord for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::Ord for bitcoin_hashes::siphash24::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::hash160::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::hkdf::MaxLengthError
+impl core::cmp::PartialEq for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha1::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha256::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha256::Midstate
+impl core::cmp::PartialEq for bitcoin_hashes::sha256::MidstateError
+impl core::cmp::PartialEq for bitcoin_hashes::sha256d::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha384::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha3_256::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha512::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::PartialEq for bitcoin_hashes::siphash24::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::hash160::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::ripemd160::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha1::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha256::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha256::Midstate
+impl core::cmp::PartialOrd for bitcoin_hashes::sha256d::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha384::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha3_256::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha512::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::sha512_256::Hash
+impl core::cmp::PartialOrd for bitcoin_hashes::siphash24::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::hash160::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::ripemd160::Hash
+impl core::convert::AsRef<[u8; 20]> for bitcoin_hashes::sha1::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256d::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha3_256::Hash
+impl core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha512_256::Hash
+impl core::convert::AsRef<[u8; 48]> for bitcoin_hashes::sha384::Hash
+impl core::convert::AsRef<[u8; 64]> for bitcoin_hashes::sha512::Hash
+impl core::convert::AsRef<[u8; 8]> for bitcoin_hashes::siphash24::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::hash160::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::ripemd160::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha1::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256::Midstate
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha256d::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha384::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha3_256::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha512::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::sha512_256::Hash
+impl core::convert::AsRef<[u8]> for bitcoin_hashes::siphash24::Hash
+impl core::default::Default for bitcoin_hashes::hash160::HashEngine
+impl core::default::Default for bitcoin_hashes::ripemd160::HashEngine
+impl core::default::Default for bitcoin_hashes::sha1::HashEngine
+impl core::default::Default for bitcoin_hashes::sha256::HashEngine
+impl core::default::Default for bitcoin_hashes::sha256::Midstate
+impl core::default::Default for bitcoin_hashes::sha256d::HashEngine
+impl core::default::Default for bitcoin_hashes::sha384::HashEngine
+impl core::default::Default for bitcoin_hashes::sha3_256::HashEngine
+impl core::default::Default for bitcoin_hashes::sha512::HashEngine
+impl core::default::Default for bitcoin_hashes::sha512_256::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::hash160::Hash
+impl core::fmt::Debug for bitcoin_hashes::hash160::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::hkdf::MaxLengthError
+impl core::fmt::Debug for bitcoin_hashes::ripemd160::Hash
+impl core::fmt::Debug for bitcoin_hashes::ripemd160::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::sha1::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha1::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::sha256::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha256::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::sha256::Midstate
+impl core::fmt::Debug for bitcoin_hashes::sha256::MidstateError
+impl core::fmt::Debug for bitcoin_hashes::sha256d::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha256d::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::sha384::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha384::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::sha3_256::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha3_256::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::sha512::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha512::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::sha512_256::Hash
+impl core::fmt::Debug for bitcoin_hashes::sha512_256::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::siphash24::Hash
+impl core::fmt::Debug for bitcoin_hashes::siphash24::HashEngine
+impl core::fmt::Debug for bitcoin_hashes::siphash24::State
+impl core::fmt::Display for bitcoin_hashes::hkdf::MaxLengthError
+impl core::fmt::Display for bitcoin_hashes::sha256::MidstateError
+impl core::hash::Hash for bitcoin_hashes::hash160::Hash
+impl core::hash::Hash for bitcoin_hashes::ripemd160::Hash
+impl core::hash::Hash for bitcoin_hashes::sha1::Hash
+impl core::hash::Hash for bitcoin_hashes::sha256::Hash
+impl core::hash::Hash for bitcoin_hashes::sha256::Midstate
+impl core::hash::Hash for bitcoin_hashes::sha256d::Hash
+impl core::hash::Hash for bitcoin_hashes::sha384::Hash
+impl core::hash::Hash for bitcoin_hashes::sha3_256::Hash
+impl core::hash::Hash for bitcoin_hashes::sha512::Hash
+impl core::hash::Hash for bitcoin_hashes::sha512_256::Hash
+impl core::hash::Hash for bitcoin_hashes::siphash24::Hash
+impl core::marker::Copy for bitcoin_hashes::hash160::Hash
+impl core::marker::Copy for bitcoin_hashes::hkdf::MaxLengthError
+impl core::marker::Copy for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Copy for bitcoin_hashes::sha1::Hash
+impl core::marker::Copy for bitcoin_hashes::sha256::Hash
+impl core::marker::Copy for bitcoin_hashes::sha256::Midstate
+impl core::marker::Copy for bitcoin_hashes::sha256d::Hash
+impl core::marker::Copy for bitcoin_hashes::sha384::Hash
+impl core::marker::Copy for bitcoin_hashes::sha3_256::Hash
+impl core::marker::Copy for bitcoin_hashes::sha512::Hash
+impl core::marker::Copy for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Copy for bitcoin_hashes::siphash24::Hash
+impl core::marker::Freeze for bitcoin_hashes::hash160::Hash
+impl core::marker::Freeze for bitcoin_hashes::hash160::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::hkdf::MaxLengthError
+impl core::marker::Freeze for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Freeze for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha1::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha256::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha256::Midstate
+impl core::marker::Freeze for bitcoin_hashes::sha256::MidstateError
+impl core::marker::Freeze for bitcoin_hashes::sha256d::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha256d::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha384::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha384::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha3_256::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha3_256::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha512::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Freeze for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::siphash24::Hash
+impl core::marker::Freeze for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Freeze for bitcoin_hashes::siphash24::State
+impl core::marker::Send for bitcoin_hashes::hash160::Hash
+impl core::marker::Send for bitcoin_hashes::hash160::HashEngine
+impl core::marker::Send for bitcoin_hashes::hkdf::MaxLengthError
+impl core::marker::Send for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Send for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha1::Hash
+impl core::marker::Send for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha256::Hash
+impl core::marker::Send for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha256::Midstate
+impl core::marker::Send for bitcoin_hashes::sha256::MidstateError
+impl core::marker::Send for bitcoin_hashes::sha256d::Hash
+impl core::marker::Send for bitcoin_hashes::sha256d::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha384::Hash
+impl core::marker::Send for bitcoin_hashes::sha384::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha3_256::Hash
+impl core::marker::Send for bitcoin_hashes::sha3_256::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha512::Hash
+impl core::marker::Send for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Send for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Send for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Send for bitcoin_hashes::siphash24::Hash
+impl core::marker::Send for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Send for bitcoin_hashes::siphash24::State
+impl core::marker::StructuralPartialEq for bitcoin_hashes::hash160::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::hkdf::MaxLengthError
+impl core::marker::StructuralPartialEq for bitcoin_hashes::ripemd160::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha1::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256::Midstate
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256::MidstateError
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha256d::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha384::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha3_256::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha512::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::sha512_256::Hash
+impl core::marker::StructuralPartialEq for bitcoin_hashes::siphash24::Hash
+impl core::marker::Sync for bitcoin_hashes::hash160::Hash
+impl core::marker::Sync for bitcoin_hashes::hash160::HashEngine
+impl core::marker::Sync for bitcoin_hashes::hkdf::MaxLengthError
+impl core::marker::Sync for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Sync for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha1::Hash
+impl core::marker::Sync for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha256::Hash
+impl core::marker::Sync for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha256::Midstate
+impl core::marker::Sync for bitcoin_hashes::sha256::MidstateError
+impl core::marker::Sync for bitcoin_hashes::sha256d::Hash
+impl core::marker::Sync for bitcoin_hashes::sha256d::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha384::Hash
+impl core::marker::Sync for bitcoin_hashes::sha384::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha3_256::Hash
+impl core::marker::Sync for bitcoin_hashes::sha3_256::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha512::Hash
+impl core::marker::Sync for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Sync for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Sync for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Sync for bitcoin_hashes::siphash24::Hash
+impl core::marker::Sync for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Sync for bitcoin_hashes::siphash24::State
+impl core::marker::Unpin for bitcoin_hashes::hash160::Hash
+impl core::marker::Unpin for bitcoin_hashes::hash160::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::hkdf::MaxLengthError
+impl core::marker::Unpin for bitcoin_hashes::ripemd160::Hash
+impl core::marker::Unpin for bitcoin_hashes::ripemd160::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha1::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha1::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha256::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha256::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha256::Midstate
+impl core::marker::Unpin for bitcoin_hashes::sha256::MidstateError
+impl core::marker::Unpin for bitcoin_hashes::sha256d::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha256d::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha384::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha384::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha3_256::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha3_256::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha512::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha512::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::sha512_256::Hash
+impl core::marker::Unpin for bitcoin_hashes::sha512_256::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::siphash24::Hash
+impl core::marker::Unpin for bitcoin_hashes::siphash24::HashEngine
+impl core::marker::Unpin for bitcoin_hashes::siphash24::State
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hash160::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hash160::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hkdf::MaxLengthError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::ripemd160::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::ripemd160::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha1::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha1::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::Midstate
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256::MidstateError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256d::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256d::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha384::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha384::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha3_256::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha3_256::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512_256::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha512_256::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::Hash
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::HashEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::siphash24::State
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hash160::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hash160::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hkdf::MaxLengthError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::ripemd160::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::ripemd160::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha1::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha1::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::Midstate
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256::MidstateError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256d::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256d::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha384::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha384::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha3_256::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha3_256::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512_256::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha512_256::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::Hash
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::HashEngine
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::siphash24::State
+impl<T: bitcoin_hashes::Hash + core::fmt::Debug> core::fmt::Debug for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash + core::fmt::Display> core::fmt::Display for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash + core::fmt::LowerHex> core::fmt::LowerHex for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash + core::str::traits::FromStr> core::str::traits::FromStr for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> bitcoin_hashes::Hash for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::cmp::Eq for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::cmp::PartialEq for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::Hash> core::convert::AsRef<[u8]> for bitcoin_hashes::hmac::Hmac<T>
+impl<T: bitcoin_hashes::HashEngine> bitcoin_hashes::HashEngine for bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::HashEngine> bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: bitcoin_hashes::HashEngine> core::fmt::Debug for bitcoin_hashes::hkdf::Hkdf<T>
+impl<T: bitcoin_hashes::sha256t::Tag> bitcoin_hashes::Hash for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> bitcoin_hashes::HashEngine for bitcoin_hashes::sha256t::HashEngine<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::borrow::Borrow<[u8; 32]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::clone::Clone for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::clone::Clone for bitcoin_hashes::sha256t::HashEngine<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::Eq for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::Ord for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::PartialEq for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::cmp::PartialOrd for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::convert::AsRef<[u8; 32]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::convert::AsRef<[u8]> for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::default::Default for bitcoin_hashes::sha256t::HashEngine<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::fmt::Debug for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::hash::Hash for bitcoin_hashes::sha256t::Hash<T>
+impl<T: bitcoin_hashes::sha256t::Tag> core::marker::Copy for bitcoin_hashes::sha256t::Hash<T>
+impl<T: core::clone::Clone + bitcoin_hashes::Hash> core::clone::Clone for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::clone::Clone + bitcoin_hashes::HashEngine> core::clone::Clone for bitcoin_hashes::hkdf::Hkdf<T> where <T as bitcoin_hashes::HashEngine>::Hash: core::clone::Clone
+impl<T: core::clone::Clone + bitcoin_hashes::HashEngine> core::clone::Clone for bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: core::cmp::Ord + bitcoin_hashes::Hash> core::cmp::Ord for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::cmp::PartialOrd + bitcoin_hashes::Hash> core::cmp::PartialOrd for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::fmt::Debug + bitcoin_hashes::HashEngine> core::fmt::Debug for bitcoin_hashes::hmac::HmacEngine<T>
+impl<T: core::fmt::Debug> core::fmt::Debug for bitcoin_hashes::sha256t::HashEngine<T>
+impl<T: core::hash::Hash + bitcoin_hashes::Hash> core::hash::Hash for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::marker::Copy + bitcoin_hashes::Hash> core::marker::Copy for bitcoin_hashes::hmac::Hmac<T>
+impl<T: core::marker::Copy + bitcoin_hashes::HashEngine> core::marker::Copy for bitcoin_hashes::hkdf::Hkdf<T> where <T as bitcoin_hashes::HashEngine>::Hash: core::marker::Copy
+impl<T> bitcoin_hashes::hkdf::Hkdf<T> where T: core::default::Default + bitcoin_hashes::HashEngine
+impl<T> bitcoin_hashes::sha256t::Hash<T>
+impl<T> bitcoin_hashes::sha256t::Hash<T> where T: bitcoin_hashes::sha256t::Tag
+impl<T> core::marker::Freeze for bitcoin_hashes::hkdf::Hkdf<T> where <T as bitcoin_hashes::HashEngine>::Hash: core::marker::Freeze
+impl<T> core::marker::Freeze for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Freeze
+impl<T> core::marker::Freeze for bitcoin_hashes::hmac::HmacEngine<T> where T: core::marker::Freeze
+impl<T> core::marker::Freeze for bitcoin_hashes::sha256t::Hash<T>
+impl<T> core::marker::Freeze for bitcoin_hashes::sha256t::HashEngine<T>
+impl<T> core::marker::Send for bitcoin_hashes::hkdf::Hkdf<T> where <T as bitcoin_hashes::HashEngine>::Hash: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::hmac::HmacEngine<T> where T: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Send
+impl<T> core::marker::Send for bitcoin_hashes::sha256t::HashEngine<T> where T: core::marker::Send
+impl<T> core::marker::Sync for bitcoin_hashes::hkdf::Hkdf<T> where <T as bitcoin_hashes::HashEngine>::Hash: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::hmac::HmacEngine<T> where T: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Sync
+impl<T> core::marker::Sync for bitcoin_hashes::sha256t::HashEngine<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bitcoin_hashes::hkdf::Hkdf<T> where <T as bitcoin_hashes::HashEngine>::Hash: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::hmac::Hmac<T> where T: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::hmac::HmacEngine<T> where T: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Unpin
+impl<T> core::marker::Unpin for bitcoin_hashes::sha256t::HashEngine<T> where T: core::marker::Unpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hkdf::Hkdf<T> where <T as bitcoin_hashes::HashEngine>::Hash: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::Hmac<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::hmac::HmacEngine<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256t::Hash<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_hashes::sha256t::HashEngine<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hkdf::Hkdf<T> where <T as bitcoin_hashes::HashEngine>::Hash: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::Hmac<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::hmac::HmacEngine<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256t::Hash<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_hashes::sha256t::HashEngine<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<const N: usize> bitcoin_hashes::IsByteArray for [u8; N]
+pub const [u8; N]::LEN: usize
+pub const bitcoin_hashes::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::Hash::LEN: usize
+pub const bitcoin_hashes::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::HashEngine::LEN: usize
+pub const bitcoin_hashes::IsByteArray::LEN: usize
+pub const bitcoin_hashes::hash160::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::hash160::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::hmac::HmacEngine<T>::BLOCK_SIZE: usize
+pub const bitcoin_hashes::ripemd160::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::ripemd160::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha1::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha1::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha256::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha256::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha256d::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha256d::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha256t::Hash<T>::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha256t::HashEngine<T>::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha256t::Tag::MIDSTATE: bitcoin_hashes::sha256::Midstate
+pub const bitcoin_hashes::sha384::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha384::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha3_256::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha3_256::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha512::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha512::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::sha512_256::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::sha512_256::HashEngine::BLOCK_SIZE: usize
+pub const bitcoin_hashes::siphash24::Hash::DISPLAY_BACKWARD: bool
+pub const bitcoin_hashes::siphash24::HashEngine::BLOCK_SIZE: usize
+pub const fn bitcoin_hashes::hash160::Hash::as_byte_array(&self) -> &[u8; 20]
+pub const fn bitcoin_hashes::hash160::Hash::from_byte_array(bytes: [u8; 20]) -> Self
+pub const fn bitcoin_hashes::hash160::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub const fn bitcoin_hashes::hash160::Hash::to_byte_array(self) -> [u8; 20]
+pub const fn bitcoin_hashes::hash160::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::ripemd160::Hash::as_byte_array(&self) -> &[u8; 20]
+pub const fn bitcoin_hashes::ripemd160::Hash::from_byte_array(bytes: [u8; 20]) -> Self
+pub const fn bitcoin_hashes::ripemd160::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub const fn bitcoin_hashes::ripemd160::Hash::to_byte_array(self) -> [u8; 20]
+pub const fn bitcoin_hashes::ripemd160::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha1::Hash::as_byte_array(&self) -> &[u8; 20]
+pub const fn bitcoin_hashes::sha1::Hash::from_byte_array(bytes: [u8; 20]) -> Self
+pub const fn bitcoin_hashes::sha1::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub const fn bitcoin_hashes::sha1::Hash::to_byte_array(self) -> [u8; 20]
+pub const fn bitcoin_hashes::sha1::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha256::Hash::as_byte_array(&self) -> &[u8; 32]
+pub const fn bitcoin_hashes::sha256::Hash::from_byte_array(bytes: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub const fn bitcoin_hashes::sha256::Hash::hash_unoptimized(bytes: &[u8]) -> Self
+pub const fn bitcoin_hashes::sha256::Hash::to_byte_array(self) -> [u8; 32]
+pub const fn bitcoin_hashes::sha256::HashEngine::can_extract_midstate(&self) -> bool
+pub const fn bitcoin_hashes::sha256::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha256::Midstate::as_parts(&self) -> (&[u8; 32], u64)
+pub const fn bitcoin_hashes::sha256::Midstate::hash_tag(tag: &[u8]) -> Self
+pub const fn bitcoin_hashes::sha256::Midstate::new(state: [u8; 32], bytes_hashed: u64) -> Self
+pub const fn bitcoin_hashes::sha256::Midstate::to_parts(self) -> ([u8; 32], u64)
+pub const fn bitcoin_hashes::sha256d::Hash::as_byte_array(&self) -> &[u8; 32]
+pub const fn bitcoin_hashes::sha256d::Hash::from_byte_array(bytes: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha256d::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub const fn bitcoin_hashes::sha256d::Hash::to_byte_array(self) -> [u8; 32]
+pub const fn bitcoin_hashes::sha256d::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha256t::Hash<T>::as_byte_array(&self) -> &[u8; 32]
+pub const fn bitcoin_hashes::sha256t::Hash<T>::from_byte_array(bytes: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub const fn bitcoin_hashes::sha256t::Hash<T>::to_byte_array(self) -> [u8; 32]
+pub const fn bitcoin_hashes::sha384::Hash::as_byte_array(&self) -> &[u8; 48]
+pub const fn bitcoin_hashes::sha384::Hash::from_byte_array(bytes: [u8; 48]) -> Self
+pub const fn bitcoin_hashes::sha384::Hash::from_bytes_ref(bytes: &[u8; 48]) -> &Self
+pub const fn bitcoin_hashes::sha384::Hash::to_byte_array(self) -> [u8; 48]
+pub const fn bitcoin_hashes::sha384::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha3_256::Hash::as_byte_array(&self) -> &[u8; 32]
+pub const fn bitcoin_hashes::sha3_256::Hash::from_byte_array(bytes: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha3_256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub const fn bitcoin_hashes::sha3_256::Hash::to_byte_array(self) -> [u8; 32]
+pub const fn bitcoin_hashes::sha3_256::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha512::Hash::as_byte_array(&self) -> &[u8; 64]
+pub const fn bitcoin_hashes::sha512::Hash::from_byte_array(bytes: [u8; 64]) -> Self
+pub const fn bitcoin_hashes::sha512::Hash::from_bytes_ref(bytes: &[u8; 64]) -> &Self
+pub const fn bitcoin_hashes::sha512::Hash::to_byte_array(self) -> [u8; 64]
+pub const fn bitcoin_hashes::sha512::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::sha512_256::Hash::as_byte_array(&self) -> &[u8; 32]
+pub const fn bitcoin_hashes::sha512_256::Hash::from_byte_array(bytes: [u8; 32]) -> Self
+pub const fn bitcoin_hashes::sha512_256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub const fn bitcoin_hashes::sha512_256::Hash::to_byte_array(self) -> [u8; 32]
+pub const fn bitcoin_hashes::sha512_256::HashEngine::new() -> Self
+pub const fn bitcoin_hashes::siphash24::Hash::as_byte_array(&self) -> &[u8; 8]
+pub const fn bitcoin_hashes::siphash24::Hash::from_byte_array(bytes: [u8; 8]) -> Self
+pub const fn bitcoin_hashes::siphash24::Hash::from_bytes_ref(bytes: &[u8; 8]) -> &Self
+pub const fn bitcoin_hashes::siphash24::Hash::to_byte_array(self) -> [u8; 8]
+pub const fn bitcoin_hashes::siphash24::HashEngine::with_keys(k0: u64, k1: u64) -> Self
+pub fn bitcoin_hashes::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::HashEngine::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::HashEngine::input(&mut self, data: &[u8])
+pub fn bitcoin_hashes::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::cmp::fixed_time_eq(a: &[u8], b: &[u8]) -> bool
+pub fn bitcoin_hashes::debug_hex(bytes: &[u8], f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::encode_to_engine<T, H>(object: &T, engine: H) -> H where T: bitcoin_consensus_encoding::encode::Encodable + ?core::marker::Sized, H: bitcoin_hashes::HashEngine
+pub fn bitcoin_hashes::hash160::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::hash160::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::hash160::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::hash160::Hash::borrow(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::hash160::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::hash160::Hash::clone(&self) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::hash160::Hash::cmp(&self, other: &bitcoin_hashes::hash160::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::hash160::Hash::engine() -> bitcoin_hashes::hash160::HashEngine
+pub fn bitcoin_hashes::hash160::Hash::eq(&self, other: &bitcoin_hashes::hash160::Hash) -> bool
+pub fn bitcoin_hashes::hash160::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hash160::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::hash160::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::hash160::Hash::from_engine(e: bitcoin_hashes::hash160::HashEngine) -> Self
+pub fn bitcoin_hashes::hash160::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::hash160::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::hash160::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::hash160::Hash::partial_cmp(&self, other: &bitcoin_hashes::hash160::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::hash160::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::hash160::HashEngine::clone(&self) -> bitcoin_hashes::hash160::HashEngine
+pub fn bitcoin_hashes::hash160::HashEngine::default() -> Self
+pub fn bitcoin_hashes::hash160::HashEngine::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::hash160::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hash160::HashEngine::input(&mut self, data: &[u8])
+pub fn bitcoin_hashes::hash160::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::hash160::hash(data: &[u8]) -> bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::hash160::hash_byte_chunks<B, I>(byte_slices: I) -> bitcoin_hashes::hash160::Hash where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::hkdf::Hkdf<T>::clone(&self) -> bitcoin_hashes::hkdf::Hkdf<T>
+pub fn bitcoin_hashes::hkdf::Hkdf<T>::expand(&self, info: &[u8], okm: &mut [u8]) -> core::result::Result<(), bitcoin_hashes::hkdf::MaxLengthError>
+pub fn bitcoin_hashes::hkdf::Hkdf<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hkdf::Hkdf<T>::new(salt: &[u8], ikm: &[u8]) -> Self
+pub fn bitcoin_hashes::hkdf::MaxLengthError::clone(&self) -> bitcoin_hashes::hkdf::MaxLengthError
+pub fn bitcoin_hashes::hkdf::MaxLengthError::eq(&self, other: &bitcoin_hashes::hkdf::MaxLengthError) -> bool
+pub fn bitcoin_hashes::hkdf::MaxLengthError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hmac::Hmac<T>::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::hmac::Hmac<T>::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::hmac::Hmac<T>::clone(&self) -> bitcoin_hashes::hmac::Hmac<T>
+pub fn bitcoin_hashes::hmac::Hmac<T>::cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::cmp::Ordering
+pub fn bitcoin_hashes::hmac::Hmac<T>::eq(&self, other: &Self) -> bool
+pub fn bitcoin_hashes::hmac::Hmac<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_byte_array(bytes: <T as bitcoin_hashes::Hash>::Bytes) -> Self
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+pub fn bitcoin_hashes::hmac::Hmac<T>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::hmac::Hmac<T>::partial_cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::hmac::Hmac<T>::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::clone(&self) -> bitcoin_hashes::hmac::HmacEngine<T>
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::from_inner_engines(iengine: T, oengine: T) -> Self
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::input(&mut self, buf: &[u8])
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::hmac::HmacEngine<T>::new(key: &[u8]) -> Self where T: core::default::Default
+pub fn bitcoin_hashes::ripemd160::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::ripemd160::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::ripemd160::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::ripemd160::Hash::borrow(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::ripemd160::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::ripemd160::Hash::clone(&self) -> bitcoin_hashes::ripemd160::Hash
+pub fn bitcoin_hashes::ripemd160::Hash::cmp(&self, other: &bitcoin_hashes::ripemd160::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::ripemd160::Hash::engine() -> bitcoin_hashes::ripemd160::HashEngine
+pub fn bitcoin_hashes::ripemd160::Hash::eq(&self, other: &bitcoin_hashes::ripemd160::Hash) -> bool
+pub fn bitcoin_hashes::ripemd160::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::ripemd160::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::ripemd160::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::ripemd160::Hash::from_engine(e: bitcoin_hashes::ripemd160::HashEngine) -> Self
+pub fn bitcoin_hashes::ripemd160::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::ripemd160::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::ripemd160::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::ripemd160::Hash::partial_cmp(&self, other: &bitcoin_hashes::ripemd160::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::ripemd160::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::ripemd160::HashEngine::clone(&self) -> bitcoin_hashes::ripemd160::HashEngine
+pub fn bitcoin_hashes::ripemd160::HashEngine::default() -> Self
+pub fn bitcoin_hashes::ripemd160::HashEngine::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::ripemd160::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::ripemd160::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::ripemd160::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::ripemd160::hash(data: &[u8]) -> bitcoin_hashes::ripemd160::Hash
+pub fn bitcoin_hashes::ripemd160::hash_byte_chunks<B, I>(byte_slices: I) -> bitcoin_hashes::ripemd160::Hash where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha1::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha1::Hash::as_ref(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::sha1::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha1::Hash::borrow(&self) -> &[u8; 20]
+pub fn bitcoin_hashes::sha1::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha1::Hash::clone(&self) -> bitcoin_hashes::sha1::Hash
+pub fn bitcoin_hashes::sha1::Hash::cmp(&self, other: &bitcoin_hashes::sha1::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha1::Hash::engine() -> bitcoin_hashes::sha1::HashEngine
+pub fn bitcoin_hashes::sha1::Hash::eq(&self, other: &bitcoin_hashes::sha1::Hash) -> bool
+pub fn bitcoin_hashes::sha1::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha1::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha1::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
+pub fn bitcoin_hashes::sha1::Hash::from_engine(e: bitcoin_hashes::sha1::HashEngine) -> Self
+pub fn bitcoin_hashes::sha1::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha1::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha1::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha1::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha1::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha1::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha1::HashEngine::clone(&self) -> bitcoin_hashes::sha1::HashEngine
+pub fn bitcoin_hashes::sha1::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha1::HashEngine::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::sha1::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha1::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha1::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha1::hash(data: &[u8]) -> bitcoin_hashes::sha1::Hash
+pub fn bitcoin_hashes::sha1::hash_byte_chunks<B, I>(byte_slices: I) -> bitcoin_hashes::sha1::Hash where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha256::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Hash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Hash::clone(&self) -> bitcoin_hashes::sha256::Hash
+pub fn bitcoin_hashes::sha256::Hash::cmp(&self, other: &bitcoin_hashes::sha256::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256::Hash::engine() -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha256::Hash::eq(&self, other: &bitcoin_hashes::sha256::Hash) -> bool
+pub fn bitcoin_hashes::sha256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256::Hash::from_engine(e: bitcoin_hashes::sha256::HashEngine) -> Self
+pub fn bitcoin_hashes::sha256::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha256::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256::Hash::hash_again(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha256::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha256::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256::HashEngine::clone(&self) -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha256::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha256::HashEngine::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::sha256::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256::HashEngine::from_midstate(midstate: bitcoin_hashes::sha256::Midstate) -> Self
+pub fn bitcoin_hashes::sha256::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha256::HashEngine::midstate(&self) -> core::result::Result<bitcoin_hashes::sha256::Midstate, bitcoin_hashes::sha256::MidstateError>
+pub fn bitcoin_hashes::sha256::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha256::Midstate::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256::Midstate::clone(&self) -> bitcoin_hashes::sha256::Midstate
+pub fn bitcoin_hashes::sha256::Midstate::cmp(&self, other: &bitcoin_hashes::sha256::Midstate) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256::Midstate::default() -> bitcoin_hashes::sha256::Midstate
+pub fn bitcoin_hashes::sha256::Midstate::eq(&self, other: &bitcoin_hashes::sha256::Midstate) -> bool
+pub fn bitcoin_hashes::sha256::Midstate::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256::Midstate::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256::Midstate::partial_cmp(&self, other: &bitcoin_hashes::sha256::Midstate) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256::MidstateError::clone(&self) -> bitcoin_hashes::sha256::MidstateError
+pub fn bitcoin_hashes::sha256::MidstateError::eq(&self, other: &bitcoin_hashes::sha256::MidstateError) -> bool
+pub fn bitcoin_hashes::sha256::MidstateError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256::hash(data: &[u8]) -> bitcoin_hashes::sha256::Hash
+pub fn bitcoin_hashes::sha256::hash_byte_chunks<B, I>(byte_slices: I) -> bitcoin_hashes::sha256::Hash where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha256d::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256d::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256d::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256d::Hash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256d::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256d::Hash::clone(&self) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::cmp(&self, other: &bitcoin_hashes::sha256d::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256d::Hash::engine() -> bitcoin_hashes::sha256d::HashEngine
+pub fn bitcoin_hashes::sha256d::Hash::eq(&self, other: &bitcoin_hashes::sha256d::Hash) -> bool
+pub fn bitcoin_hashes::sha256d::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256d::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256d::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256d::Hash::from_engine(e: bitcoin_hashes::sha256d::HashEngine) -> Self
+pub fn bitcoin_hashes::sha256d::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha256d::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha256d::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha256d::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha256d::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256d::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256d::HashEngine::clone(&self) -> bitcoin_hashes::sha256d::HashEngine
+pub fn bitcoin_hashes::sha256d::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha256d::HashEngine::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::sha256d::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256d::HashEngine::input(&mut self, data: &[u8])
+pub fn bitcoin_hashes::sha256d::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha256d::hash(data: &[u8]) -> bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::hash_byte_chunks<B, I>(byte_slices: I) -> bitcoin_hashes::sha256d::Hash where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256t::Hash<T>::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256t::Hash<T>::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha256t::Hash<T>::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha256t::Hash<T>::clone(&self) -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::cmp(&self, other: &Self) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha256t::Hash<T>::engine() -> bitcoin_hashes::sha256t::HashEngine<T>
+pub fn bitcoin_hashes::sha256t::Hash<T>::eq(&self, other: &Self) -> bool
+pub fn bitcoin_hashes::sha256t::Hash<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_engine(e: bitcoin_hashes::sha256t::HashEngine<T>) -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::hash<H: core::hash::Hasher>(&self, h: &mut H)
+pub fn bitcoin_hashes::sha256t::Hash<T>::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha256t::Hash<T>::partial_cmp(&self, other: &Self) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha256t::Hash<T>::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha256t::HashEngine<T>::clone(&self) -> Self
+pub fn bitcoin_hashes::sha256t::HashEngine<T>::default() -> Self
+pub fn bitcoin_hashes::sha256t::HashEngine<T>::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::sha256t::HashEngine<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha256t::HashEngine<T>::input(&mut self, data: &[u8])
+pub fn bitcoin_hashes::sha256t::HashEngine<T>::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha256t::hash<T>(data: &[u8]) -> bitcoin_hashes::sha256t::Hash<T> where T: bitcoin_hashes::sha256t::Tag
+pub fn bitcoin_hashes::sha256t::hash_byte_chunks<B, I, T>(byte_slices: I) -> bitcoin_hashes::sha256t::Hash<T> where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>, T: bitcoin_hashes::sha256t::Tag
+pub fn bitcoin_hashes::sha384::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha384::Hash::as_ref(&self) -> &[u8; 48]
+pub fn bitcoin_hashes::sha384::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha384::Hash::borrow(&self) -> &[u8; 48]
+pub fn bitcoin_hashes::sha384::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha384::Hash::clone(&self) -> bitcoin_hashes::sha384::Hash
+pub fn bitcoin_hashes::sha384::Hash::cmp(&self, other: &bitcoin_hashes::sha384::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha384::Hash::engine() -> bitcoin_hashes::sha384::HashEngine
+pub fn bitcoin_hashes::sha384::Hash::eq(&self, other: &bitcoin_hashes::sha384::Hash) -> bool
+pub fn bitcoin_hashes::sha384::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha384::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha384::Hash::from_bytes_mut(bytes: &mut [u8; 48]) -> &mut Self
+pub fn bitcoin_hashes::sha384::Hash::from_engine(e: bitcoin_hashes::sha384::HashEngine) -> Self
+pub fn bitcoin_hashes::sha384::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha384::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha384::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha384::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha384::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha384::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha384::HashEngine::clone(&self) -> bitcoin_hashes::sha384::HashEngine
+pub fn bitcoin_hashes::sha384::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha384::HashEngine::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::sha384::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha384::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha384::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha384::hash(data: &[u8]) -> bitcoin_hashes::sha384::Hash
+pub fn bitcoin_hashes::sha384::hash_byte_chunks<B, I>(byte_slices: I) -> bitcoin_hashes::sha384::Hash where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha3_256::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha3_256::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha3_256::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha3_256::Hash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha3_256::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha3_256::Hash::clone(&self) -> bitcoin_hashes::sha3_256::Hash
+pub fn bitcoin_hashes::sha3_256::Hash::cmp(&self, other: &bitcoin_hashes::sha3_256::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha3_256::Hash::engine() -> bitcoin_hashes::sha3_256::HashEngine
+pub fn bitcoin_hashes::sha3_256::Hash::eq(&self, other: &bitcoin_hashes::sha3_256::Hash) -> bool
+pub fn bitcoin_hashes::sha3_256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha3_256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha3_256::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha3_256::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha3_256::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha3_256::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha3_256::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha3_256::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha3_256::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha3_256::HashEngine::clone(&self) -> bitcoin_hashes::sha3_256::HashEngine
+pub fn bitcoin_hashes::sha3_256::HashEngine::default() -> bitcoin_hashes::sha3_256::HashEngine
+pub fn bitcoin_hashes::sha3_256::HashEngine::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::sha3_256::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha3_256::HashEngine::input(&mut self, data: &[u8])
+pub fn bitcoin_hashes::sha3_256::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha3_256::hash(data: &[u8]) -> bitcoin_hashes::sha3_256::Hash
+pub fn bitcoin_hashes::sha3_256::hash_byte_chunks<B, I>(byte_slices: I) -> bitcoin_hashes::sha3_256::Hash where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha512::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha512::Hash::as_ref(&self) -> &[u8; 64]
+pub fn bitcoin_hashes::sha512::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512::Hash::borrow(&self) -> &[u8; 64]
+pub fn bitcoin_hashes::sha512::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512::Hash::clone(&self) -> bitcoin_hashes::sha512::Hash
+pub fn bitcoin_hashes::sha512::Hash::cmp(&self, other: &bitcoin_hashes::sha512::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha512::Hash::engine() -> bitcoin_hashes::sha512::HashEngine
+pub fn bitcoin_hashes::sha512::Hash::eq(&self, other: &bitcoin_hashes::sha512::Hash) -> bool
+pub fn bitcoin_hashes::sha512::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha512::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha512::Hash::from_bytes_mut(bytes: &mut [u8; 64]) -> &mut Self
+pub fn bitcoin_hashes::sha512::Hash::from_engine(e: bitcoin_hashes::sha512::HashEngine) -> Self
+pub fn bitcoin_hashes::sha512::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha512::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha512::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha512::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha512::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha512::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha512::HashEngine::clone(&self) -> bitcoin_hashes::sha512::HashEngine
+pub fn bitcoin_hashes::sha512::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha512::HashEngine::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::sha512::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha512::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha512::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha512::hash(data: &[u8]) -> bitcoin_hashes::sha512::Hash
+pub fn bitcoin_hashes::sha512::hash_byte_chunks<B, I>(byte_slices: I) -> bitcoin_hashes::sha512::Hash where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha512_256::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::sha512_256::Hash::as_ref(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha512_256::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512_256::Hash::borrow(&self) -> &[u8; 32]
+pub fn bitcoin_hashes::sha512_256::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::sha512_256::Hash::clone(&self) -> bitcoin_hashes::sha512_256::Hash
+pub fn bitcoin_hashes::sha512_256::Hash::cmp(&self, other: &bitcoin_hashes::sha512_256::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::sha512_256::Hash::engine() -> bitcoin_hashes::sha512_256::HashEngine
+pub fn bitcoin_hashes::sha512_256::Hash::eq(&self, other: &bitcoin_hashes::sha512_256::Hash) -> bool
+pub fn bitcoin_hashes::sha512_256::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha512_256::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::sha512_256::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
+pub fn bitcoin_hashes::sha512_256::Hash::from_engine(e: bitcoin_hashes::sha512_256::HashEngine) -> Self
+pub fn bitcoin_hashes::sha512_256::Hash::hash(data: &[u8]) -> Self
+pub fn bitcoin_hashes::sha512_256::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::sha512_256::Hash::hash_byte_chunks<B, I>(byte_slices: I) -> Self where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::sha512_256::Hash::partial_cmp(&self, other: &bitcoin_hashes::sha512_256::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::sha512_256::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::sha512_256::HashEngine::clone(&self) -> bitcoin_hashes::sha512_256::HashEngine
+pub fn bitcoin_hashes::sha512_256::HashEngine::default() -> Self
+pub fn bitcoin_hashes::sha512_256::HashEngine::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::sha512_256::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::sha512_256::HashEngine::input(&mut self, inp: &[u8])
+pub fn bitcoin_hashes::sha512_256::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::sha512_256::hash(data: &[u8]) -> bitcoin_hashes::sha512_256::Hash
+pub fn bitcoin_hashes::sha512_256::hash_byte_chunks<B, I>(byte_slices: I) -> bitcoin_hashes::sha512_256::Hash where B: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = B>
+pub fn bitcoin_hashes::siphash24::Hash::as_byte_array(&self) -> &Self::Bytes
+pub fn bitcoin_hashes::siphash24::Hash::as_ref(&self) -> &[u8; 8]
+pub fn bitcoin_hashes::siphash24::Hash::as_ref(&self) -> &[u8]
+pub fn bitcoin_hashes::siphash24::Hash::borrow(&self) -> &[u8; 8]
+pub fn bitcoin_hashes::siphash24::Hash::borrow(&self) -> &[u8]
+pub fn bitcoin_hashes::siphash24::Hash::clone(&self) -> bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::cmp(&self, other: &bitcoin_hashes::siphash24::Hash) -> core::cmp::Ordering
+pub fn bitcoin_hashes::siphash24::Hash::engine(k0: u64, k1: u64) -> bitcoin_hashes::siphash24::HashEngine
+pub fn bitcoin_hashes::siphash24::Hash::eq(&self, other: &bitcoin_hashes::siphash24::Hash) -> bool
+pub fn bitcoin_hashes::siphash24::Hash::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::siphash24::Hash::from_byte_array(bytes: Self::Bytes) -> Self
+pub fn bitcoin_hashes::siphash24::Hash::from_bytes_mut(bytes: &mut [u8; 8]) -> &mut Self
+pub fn bitcoin_hashes::siphash24::Hash::from_engine(e: bitcoin_hashes::siphash24::HashEngine) -> Self
+pub fn bitcoin_hashes::siphash24::Hash::from_engine_to_u64(e: bitcoin_hashes::siphash24::HashEngine) -> u64
+pub fn bitcoin_hashes::siphash24::Hash::from_u64(hash: u64) -> Self
+pub fn bitcoin_hashes::siphash24::Hash::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn bitcoin_hashes::siphash24::Hash::hash_to_u64_with_keys(k0: u64, k1: u64, data: &[u8]) -> u64
+pub fn bitcoin_hashes::siphash24::Hash::hash_with_keys(k0: u64, k1: u64, data: &[u8]) -> Self
+pub fn bitcoin_hashes::siphash24::Hash::partial_cmp(&self, other: &bitcoin_hashes::siphash24::Hash) -> core::option::Option<core::cmp::Ordering>
+pub fn bitcoin_hashes::siphash24::Hash::to_byte_array(self) -> Self::Bytes
+pub fn bitcoin_hashes::siphash24::Hash::to_u64(self) -> u64
+pub fn bitcoin_hashes::siphash24::HashEngine::clone(&self) -> bitcoin_hashes::siphash24::HashEngine
+pub fn bitcoin_hashes::siphash24::HashEngine::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::siphash24::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn bitcoin_hashes::siphash24::HashEngine::input(&mut self, msg: &[u8])
+pub fn bitcoin_hashes::siphash24::HashEngine::keys(&self) -> (u64, u64)
+pub fn bitcoin_hashes::siphash24::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::siphash24::State::clone(&self) -> bitcoin_hashes::siphash24::State
+pub fn bitcoin_hashes::siphash24::State::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub macro bitcoin_hashes::hash_newtype!
+pub macro bitcoin_hashes::impl_debug_only_for_newtype!
+pub macro bitcoin_hashes::sha256t_tag!
+pub mod bitcoin_hashes
+pub mod bitcoin_hashes::cmp
+pub mod bitcoin_hashes::hash160
+pub mod bitcoin_hashes::hkdf
+pub mod bitcoin_hashes::hmac
+pub mod bitcoin_hashes::macros
+pub mod bitcoin_hashes::ripemd160
+pub mod bitcoin_hashes::sha1
+pub mod bitcoin_hashes::sha256
+pub mod bitcoin_hashes::sha256d
+pub mod bitcoin_hashes::sha256t
+pub mod bitcoin_hashes::sha384
+pub mod bitcoin_hashes::sha3_256
+pub mod bitcoin_hashes::sha512
+pub mod bitcoin_hashes::sha512_256
+pub mod bitcoin_hashes::siphash24
+pub struct bitcoin_hashes::Hkdf<T: bitcoin_hashes::HashEngine>
+pub struct bitcoin_hashes::HmacEngine<T: bitcoin_hashes::HashEngine>
+pub struct bitcoin_hashes::hash160::HashEngine(_)
+pub struct bitcoin_hashes::hkdf::Hkdf<T: bitcoin_hashes::HashEngine>
+pub struct bitcoin_hashes::hkdf::MaxLengthError
+pub struct bitcoin_hashes::hmac::HmacEngine<T: bitcoin_hashes::HashEngine>
+pub struct bitcoin_hashes::ripemd160::HashEngine
+pub struct bitcoin_hashes::sha1::HashEngine
+pub struct bitcoin_hashes::sha256::HashEngine
+pub struct bitcoin_hashes::sha256::Midstate
+pub struct bitcoin_hashes::sha256::MidstateError
+pub struct bitcoin_hashes::sha256d::HashEngine(_)
+pub struct bitcoin_hashes::sha256t::HashEngine<T>(_, _)
+pub struct bitcoin_hashes::sha384::HashEngine(_)
+pub struct bitcoin_hashes::sha3_256::HashEngine
+pub struct bitcoin_hashes::sha512::HashEngine
+pub struct bitcoin_hashes::sha512_256::HashEngine(_)
+pub struct bitcoin_hashes::siphash24::HashEngine
+pub struct bitcoin_hashes::siphash24::State
+pub trait bitcoin_hashes::Hash: core::marker::Copy + core::clone::Clone + core::cmp::PartialEq + core::cmp::Eq + core::cmp::PartialOrd + core::cmp::Ord + core::hash::Hash + core::convert::AsRef<[u8]>
+pub trait bitcoin_hashes::HashEngine: core::clone::Clone
+pub trait bitcoin_hashes::IsByteArray: core::convert::AsRef<[u8]> + bitcoin_hashes::sealed::IsByteArray
+pub trait bitcoin_hashes::sha256t::Tag
+pub type bitcoin_hashes::Hash::Bytes: core::marker::Copy + bitcoin_hashes::IsByteArray
+pub type bitcoin_hashes::HashEngine::Bytes: core::marker::Copy + bitcoin_hashes::IsByteArray
+pub type bitcoin_hashes::HashEngine::Hash: bitcoin_hashes::Hash
+pub type bitcoin_hashes::HkdfSha256 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha256::Hash>
+pub type bitcoin_hashes::HkdfSha512 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha512::Hash>
+pub type bitcoin_hashes::HmacSha256 = bitcoin_hashes::hmac::Hmac<bitcoin_hashes::sha256::Hash>
+pub type bitcoin_hashes::HmacSha512 = bitcoin_hashes::hmac::Hmac<bitcoin_hashes::sha512::Hash>
+pub type bitcoin_hashes::Sha256t<T> = bitcoin_hashes::sha256t::Hash<T>
+pub type bitcoin_hashes::hash160::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::hash160::HashEngine::Bytes = [u8; 20]
+pub type bitcoin_hashes::hash160::HashEngine::Hash = bitcoin_hashes::hash160::Hash
+pub type bitcoin_hashes::hmac::Hmac<T>::Bytes = <T as bitcoin_hashes::Hash>::Bytes
+pub type bitcoin_hashes::hmac::Hmac<T>::Err = <T as core::str::traits::FromStr>::Err
+pub type bitcoin_hashes::hmac::HmacEngine<T>::Bytes = <T as bitcoin_hashes::HashEngine>::Bytes
+pub type bitcoin_hashes::hmac::HmacEngine<T>::Hash = bitcoin_hashes::hmac::Hmac<<T as bitcoin_hashes::HashEngine>::Hash>
+pub type bitcoin_hashes::ripemd160::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::ripemd160::HashEngine::Bytes = [u8; 20]
+pub type bitcoin_hashes::ripemd160::HashEngine::Hash = bitcoin_hashes::ripemd160::Hash
+pub type bitcoin_hashes::sha1::Hash::Bytes = [u8; 20]
+pub type bitcoin_hashes::sha1::HashEngine::Bytes = [u8; 20]
+pub type bitcoin_hashes::sha1::HashEngine::Hash = bitcoin_hashes::sha1::Hash
+pub type bitcoin_hashes::sha256::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256::HashEngine::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256::HashEngine::Hash = bitcoin_hashes::sha256::Hash
+pub type bitcoin_hashes::sha256d::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256d::HashEngine::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256d::HashEngine::Hash = bitcoin_hashes::sha256d::Hash
+pub type bitcoin_hashes::sha256t::Hash<T>::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256t::HashEngine<T>::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha256t::HashEngine<T>::Hash = bitcoin_hashes::sha256t::Hash<T>
+pub type bitcoin_hashes::sha384::Hash::Bytes = [u8; 48]
+pub type bitcoin_hashes::sha384::HashEngine::Bytes = [u8; 48]
+pub type bitcoin_hashes::sha384::HashEngine::Hash = bitcoin_hashes::sha384::Hash
+pub type bitcoin_hashes::sha3_256::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha3_256::HashEngine::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha3_256::HashEngine::Hash = bitcoin_hashes::sha3_256::Hash
+pub type bitcoin_hashes::sha512::Hash::Bytes = [u8; 64]
+pub type bitcoin_hashes::sha512::HashEngine::Bytes = [u8; 64]
+pub type bitcoin_hashes::sha512::HashEngine::Hash = bitcoin_hashes::sha512::Hash
+pub type bitcoin_hashes::sha512_256::Hash::Bytes = [u8; 32]
+pub type bitcoin_hashes::sha512_256::HashEngine::Bytes = [u8; 64]
+pub type bitcoin_hashes::sha512_256::HashEngine::Hash = bitcoin_hashes::sha512_256::Hash
+pub type bitcoin_hashes::siphash24::Hash::Bytes = [u8; 8]
+pub type bitcoin_hashes::siphash24::HashEngine::Bytes = [u8; 8]
+pub type bitcoin_hashes::siphash24::HashEngine::Hash = bitcoin_hashes::siphash24::Hash

--- a/contrib/check-for-api-changes.sh
+++ b/contrib/check-for-api-changes.sh
@@ -38,6 +38,7 @@ main() {
 
     # Check crates under the stabilising crates
     generate_api_files "internals"
+    generate_api_files "hashes"
 
     [ -f "Cargo.lock.tmp" ] && mv Cargo.lock.tmp Cargo.lock
 


### PR DESCRIPTION
Currently only stable crates have API files. Since some features may cross crate boundaries, and involve breaking changes to the API of crates under the stable crates, it's important to track the API of these crates also.

Add hashes to check-api just script and add initial API files.

Closes #5404 