### PR TITLE
Make Schnorr auxiliary randomness optional

### DIFF
--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -23,6 +23,7 @@ secp-global-context = ["secp256k1/global-context"]
 secp-lowmemory = ["secp256k1/lowmemory"]
 secp-recovery = ["secp256k1/recovery"]
 arbitrary = ["dep:arbitrary", "units/arbitrary", "primitives/arbitrary"]
+no-aux-rand = []
 
 [dependencies]
 base58 = { package = "base58ck", path = "../base58", version = "0.2.0", default-features = false, features = ["alloc"] }

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -20,6 +20,7 @@
 //! * `serde` (dependency) - implements `serde`-based serialization and deserialization.
 //! * `secp-lowmemory` - optimizations for low-memory devices.
 //! * `secp-recovery` - enables calculating public key from a signature and message.
+//! * `no-aux-rand` - disables auxiliary randomness for Schnorr signatures
 //! * `std` - the usual dependency on `std`.
 
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -431,9 +431,13 @@ impl Psbt {
                         .tap_tweak(input.tap_merkle_root)
                         .to_keypair();
 
-                    #[cfg(all(feature = "rand", feature = "std"))]
+                    #[cfg(all(feature = "rand", feature = "std", not(feature = "no-aux-rand")))]
                     let signature = secp256k1::schnorr::sign(&sighash.to_byte_array(), &key_pair);
-                    #[cfg(not(all(feature = "rand", feature = "std")))]
+                    #[cfg(not(all(
+                        feature = "rand",
+                        feature = "std",
+                        not(feature = "no-aux-rand")
+                    )))]
                     let signature =
                         secp256k1::schnorr::sign_no_aux_rand(&sighash.to_byte_array(), &key_pair);
 
@@ -459,10 +463,18 @@ impl Psbt {
                         let (sighash, sighash_type) =
                             self.sighash_taproot(input_index, cache, Some(lh))?;
 
-                        #[cfg(all(feature = "rand", feature = "std"))]
+                        #[cfg(all(
+                            feature = "rand",
+                            feature = "std",
+                            not(feature = "no-aux-rand")
+                        ))]
                         let signature =
                             secp256k1::schnorr::sign(&sighash.to_byte_array(), &key_pair);
-                        #[cfg(not(all(feature = "rand", feature = "std")))]
+                        #[cfg(not(all(
+                            feature = "rand",
+                            feature = "std",
+                            not(feature = "no-aux-rand")
+                        )))]
                         let signature = secp256k1::schnorr::sign_no_aux_rand(
                             &sighash.to_byte_array(),
                             &key_pair,


### PR DESCRIPTION
Add a new `no-aux-rand` feature that makes it possible to enable `rand` without also enabling auxiliary randomness for Schnorr PSBT signing.