### PR TITLE
p2p: Use `primitives` in `bip152` tests

### DIFF
--- a/p2p/src/bip152.rs
+++ b/p2p/src/bip152.rs
@@ -480,13 +480,13 @@ mod test {
     use alloc::vec;
 
     use bitcoin::consensus::encode::{deserialize, serialize};
-    use bitcoin::locktime::absolute;
     use bitcoin::merkle_tree::TxMerkleNode;
-    use bitcoin::{
+    use hex::FromHex;
+    use primitives::locktime::absolute;
+    use primitives::{
         transaction, Amount, BlockChecked, BlockTime, CompactTarget, OutPoint, ScriptPubKeyBuf,
         ScriptSigBuf, Sequence, TxIn, TxOut, Txid, Witness,
     };
-    use hex::FromHex;
 
     use super::*;
 


### PR DESCRIPTION
Small follow up to #5342 and a step in #5411