### PR TITLE
primitives: reject transactions with 0 outputs

### DIFF
--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -1284,7 +1284,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // bad test; will be fixed in next commit
     #[cfg(feature = "alloc")]
     fn block_decode() {
         // Make a simple block, encode then decode. Verify equivalence.
@@ -1320,7 +1319,10 @@ mod tests {
                 sequence: crate::sequence::Sequence::MAX,
                 witness: crate::witness::Witness::new(),
             }],
-            outputs: Vec::new(),
+            outputs: vec![crate::transaction::TxOut {
+                amount: units::Amount::ONE_SAT,
+                script_pubkey: crate::script::ScriptPubKeyBuf::new(),
+            }],
         }];
         let original_block = Block::new_unchecked(header, transactions);
 

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -2397,16 +2397,15 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // bad test; will be fixed in next commit
     #[cfg(feature = "alloc")]
     fn decode_zero_inputs() {
-        // Test empty transaction with no inputs or outputs.
+        // Test transaction with no inputs (but with one output to satisfy validation).
         let block: u32 = 741_521;
         let original_tx = Transaction {
             version: Version::ONE,
             lock_time: absolute::LockTime::from_height(block).expect("valid height"),
             inputs: vec![],
-            outputs: vec![],
+            outputs: vec![TxOut { amount: Amount::ONE_SAT, script_pubkey: ScriptPubKeyBuf::new() }],
         };
 
         let encoded = encoding::encode_to_vec(&original_tx);


### PR DESCRIPTION
Transactions must have at least one output.
This is another syntactic check that doesn't depend on any context, and the last one on this list https://github.com/rust-bitcoin/rust-bitcoin/issues/5383#issuecomment-3646014920. 

Patch1: We add validation to reject transactions with empty outputs during decoding.

Patch 2: Two existing tests that created txs with no outputs are ignored in patch 1 and fixed here.

Closes https://github.com/rust-bitcoin/rust-bitcoin/issues/5383