### PR TITLE
p2p: Implement `encoding` traits for `FilterAdd`

### DIFF
--- a/p2p/src/message_bloom.rs
+++ b/p2p/src/message_bloom.rs
@@ -5,10 +5,14 @@
 //! This module describes BIP-0037 Connection Bloom filtering network messages.
 
 use alloc::vec::Vec;
+use core::convert::Infallible;
+use core::fmt;
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
 use bitcoin::consensus::{encode, Decodable, Encodable, ReadExt};
+use encoding::{ByteVecDecoder, BytesEncoder, CompactSizeEncoder, Encoder2};
+use internals::write_err;
 use io::{BufRead, Write};
 
 use crate::consensus::impl_consensus_encoding;
@@ -66,6 +70,75 @@ impl Decodable for BloomFlags {
 pub struct FilterAdd {
     /// The data element to add to the current filter.
     pub data: Vec<u8>,
+}
+
+encoding::encoder_newtype! {
+    /// The encoder of the [`FilterAdd`] message.
+    pub struct FilterAddEncoder<'e>(Encoder2<CompactSizeEncoder, BytesEncoder<'e>>);
+}
+
+impl encoding::Encodable for FilterAdd {
+    type Encoder<'e> = FilterAddEncoder<'e>;
+
+    fn encoder(&self) -> Self::Encoder<'_> {
+        FilterAddEncoder(
+            Encoder2::new(
+                CompactSizeEncoder::new(self.data.len()),
+                BytesEncoder::without_length_prefix(&self.data)
+            )
+        )
+    }
+}
+
+type FilterAddInnerDecoder = ByteVecDecoder;
+
+/// The decoder for the [`FilterAdd`] message.
+pub struct FilterAddDecoder(FilterAddInnerDecoder);
+
+impl encoding::Decoder for FilterAddDecoder {
+    type Output = FilterAdd;
+    type Error = FilterAddDecoderError;
+
+    #[inline]
+    fn push_bytes(&mut self, bytes: &mut &[u8]) -> Result<bool, Self::Error> {
+        self.0.push_bytes(bytes).map_err(FilterAddDecoderError)
+    }
+
+    #[inline]
+    fn end(self) -> Result<Self::Output, Self::Error> {
+        let data = self.0.end().map_err(FilterAddDecoderError)?;
+        Ok(FilterAdd { data })
+    }
+
+    #[inline]
+    fn read_limit(&self) -> usize { self.0.read_limit() }
+}
+
+impl encoding::Decodable for FilterAdd {
+    type Decoder = FilterAddDecoder;
+
+    fn decoder() -> Self::Decoder {
+        FilterAddDecoder(FilterAddInnerDecoder::new())
+    }
+}
+
+/// An error decoding a [`FilterAdd`] message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FilterAddDecoderError(<FilterAddInnerDecoder as encoding::Decoder>::Error);
+
+impl From<Infallible> for FilterAddDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+impl fmt::Display for FilterAddDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_err!(f, "filteradd error"; self)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for FilterAddDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
 }
 
 impl_consensus_encoding!(FilterAdd, data);


### PR DESCRIPTION
Trying my hand at a pure byte vector en/decoder. I will hold off on pushing more until there is a review cycle on the other types.