### PR TITLE
docs: fix incorrect comments in units crate

### DIFF
--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -397,7 +397,7 @@ impl Amount {
         match self.to_sat().checked_rem(rhs) {
             Some(res) => match Self::from_sat(res) {
                 Ok(amount) => Some(amount),
-                Err(_) => None, // Unreachable because of checked_div above.
+                Err(_) => None, // Unreachable because of checked_rem above.
             },
             None => None,
         }

--- a/units/src/locktime/relative/mod.rs
+++ b/units/src/locktime/relative/mod.rs
@@ -482,7 +482,7 @@ impl NumberOf512Seconds {
     /// The minimum relative block time (0), can be included in any block.
     pub const MIN: Self = Self::ZERO;
 
-    /// The maximum relative block time (33,554,432 seconds or approx 388 days).
+    /// The maximum relative block time (33,553,920 seconds or approx 388 days).
     pub const MAX: Self = Self(u16::MAX);
 
     /// Constructs a new [`NumberOf512Seconds`] using time intervals where each interval is


### PR DESCRIPTION


- amount/unsigned.rs: checked_rem function comment incorrectly referenced checked_div instead of checked_rem

- locktime/relative/mod.rs: MAX constant comment had wrong value 33,554,432 seconds (should be 33,553,920 = 65535 * 512)