### PR TITLE
Manual nightly rustfmt (2026-01-04)

### DIFF
--- a/bitcoin/src/consensus/encode.rs
+++ b/bitcoin/src/consensus/encode.rs
@@ -351,7 +351,10 @@ impl_int_encodable!(i32, read_i32, emit_i32);
 impl_int_encodable!(i64, read_i64, emit_i64);
 
 /// Returns 1 for 0..=0xFC, 3 for 0xFD..=(2^16-1), 5 for 0x10000..=(2^32-1), and 9 otherwise.
-#[deprecated(since = "0.33.0", note = "use `consensus_encoding::CompactSizeEncoder::encoded_size` instead")]
+#[deprecated(
+    since = "0.33.0",
+    note = "use `consensus_encoding::CompactSizeEncoder::encoded_size` instead"
+)]
 #[inline]
 pub const fn varint_size_u64(v: u64) -> usize {
     const LIMIT: u64 = if core::mem::size_of::<usize>() <= 8 {
@@ -368,7 +371,10 @@ pub const fn varint_size_u64(v: u64) -> usize {
 }
 
 /// Returns 1 for 0..=0xFC, 3 for 0xFD..=(2^16-1), 5 for 0x10000..=(2^32-1), and 9 otherwise.
-#[deprecated(since = "0.33.0", note = "use `consensus_encoding::CompactSizeEncoder::encoded_size` instead")]
+#[deprecated(
+    since = "0.33.0",
+    note = "use `consensus_encoding::CompactSizeEncoder::encoded_size` instead"
+)]
 #[inline]
 pub fn varint_size(v: impl ToU64) -> usize {
     encoding::CompactSizeEncoder::encoded_size(v.to_u64().try_into().unwrap_or(usize::MAX))

--- a/consensus_encoding/src/decode/decoders.rs
+++ b/consensus_encoding/src/decode/decoders.rs
@@ -107,10 +107,10 @@ impl Decoder for ByteVecDecoder {
 
     fn end(self) -> Result<Self::Output, Self::Error> {
         use {ByteVecDecoderError as E, ByteVecDecoderErrorInner as Inner};
-        
-        if let Some(ref prefix_decoder) = self.prefix_decoder {  
+
+        if let Some(ref prefix_decoder) = self.prefix_decoder {
             return Err(E(Inner::UnexpectedEof(UnexpectedEofError {
-                missing: prefix_decoder.read_limit(), 
+                missing: prefix_decoder.read_limit(),
             })));
         }
 
@@ -1221,7 +1221,7 @@ mod tests {
         let data = [];
         let _ = decoder.push_bytes(&mut data.as_slice());
         let err = decoder.end().unwrap_err();
-        
+
         if let ByteVecDecoderErrorInner::UnexpectedEof(e) = err.0 {
             assert_eq!(e.missing, 1);
         } else {
@@ -1251,7 +1251,7 @@ mod tests {
         let data = [0xFE];
         let _ = decoder.push_bytes(&mut data.as_slice());
         let err = decoder.end().unwrap_err();
-        
+
         if let ByteVecDecoderErrorInner::UnexpectedEof(e) = err.0 {
             assert_eq!(e.missing, 4);
         } else {
@@ -1266,7 +1266,7 @@ mod tests {
         let data = [0xFF];
         let _ = decoder.push_bytes(&mut data.as_slice());
         let err = decoder.end().unwrap_err();
-        
+
         if let ByteVecDecoderErrorInner::UnexpectedEof(e) = err.0 {
             assert_eq!(e.missing, 8);
         } else {

--- a/consensus_encoding/src/encode/encoders.rs
+++ b/consensus_encoding/src/encode/encoders.rs
@@ -11,9 +11,9 @@
 //! For implementing these newtypes, we provide the [`encoder_newtype`] macro.
 //!
 
-use super::{Encodable, Encoder};
-
 use internals::array_vec::ArrayVec;
+
+use super::{Encodable, Encoder};
 
 /// The maximum length of a compact size encoding.
 const SIZE: usize = 9;
@@ -231,9 +231,7 @@ impl CompactSizeEncoder {
     /// values. In such cases we will ignore the passed value and encode [`u64::MAX`].
     /// But even on such exotic systems, we expect users to pass the length of an
     /// in-memory object, meaning that such large values are impossible to obtain.
-    pub fn new(value: usize) -> Self {
-        Self { buf: Some(Self::encode(value)) }
-    }
+    pub fn new(value: usize) -> Self { Self { buf: Some(Self::encode(value)) } }
 
     /// Returns the number of bytes used to encode this `CompactSize` value.
     ///

--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -523,12 +523,16 @@ impl fmt::Display for Header {
 
 #[cfg(all(feature = "hex", feature = "alloc"))]
 impl fmt::LowerHex for Header {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(&crate::hex_codec::HexPrimitive(self), f) }
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::LowerHex::fmt(&crate::hex_codec::HexPrimitive(self), f)
+    }
 }
 
 #[cfg(all(feature = "hex", feature = "alloc"))]
 impl fmt::UpperHex for Header {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::UpperHex::fmt(&crate::hex_codec::HexPrimitive(self), f) }
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::UpperHex::fmt(&crate::hex_codec::HexPrimitive(self), f)
+    }
 }
 
 impl fmt::Debug for Header {
@@ -578,7 +582,9 @@ impl fmt::Display for ParseHeaderError {
 
 #[cfg(all(feature = "hex", feature = "alloc", feature = "std"))]
 impl std::error::Error for ParseHeaderError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { std::error::Error::source(&self.0) }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        std::error::Error::source(&self.0)
+    }
 }
 
 encoding::encoder_newtype! {
@@ -1221,10 +1227,8 @@ mod tests {
         assert_eq!(want, format!("{}", header));
 
         // And these should yield uppercase hex
-        let upper_encoded = want
-            .chars()
-            .map(|chr| chr.to_ascii_uppercase())
-            .collect::<alloc::string::String>();
+        let upper_encoded =
+            want.chars().map(|chr| chr.to_ascii_uppercase()).collect::<alloc::string::String>();
         assert_eq!(upper_encoded, format!("{:X}", header));
     }
 
@@ -1273,20 +1277,18 @@ mod tests {
         };
 
         let block: u32 = 741_521;
-        let transactions = vec![
-            Transaction {
-                version: crate::transaction::Version::ONE,
-                lock_time: units::absolute::LockTime::from_height(block).unwrap(),
-                inputs: vec![crate::transaction::TxIn {
-                    previous_output: crate::transaction::OutPoint::COINBASE_PREVOUT,
-                    // Coinbase scriptSig must be 2-100 bytes
-                    script_sig: crate::script::ScriptSigBuf::from_bytes(vec![0x51, 0x51]),
-                    sequence: crate::sequence::Sequence::MAX,
-                    witness: crate::witness::Witness::new(),
-                }],
-                outputs: Vec::new(),
-            },
-        ];
+        let transactions = vec![Transaction {
+            version: crate::transaction::Version::ONE,
+            lock_time: units::absolute::LockTime::from_height(block).unwrap(),
+            inputs: vec![crate::transaction::TxIn {
+                previous_output: crate::transaction::OutPoint::COINBASE_PREVOUT,
+                // Coinbase scriptSig must be 2-100 bytes
+                script_sig: crate::script::ScriptSigBuf::from_bytes(vec![0x51, 0x51]),
+                sequence: crate::sequence::Sequence::MAX,
+                witness: crate::witness::Witness::new(),
+            }],
+            outputs: Vec::new(),
+        }];
         let original_block = Block::new_unchecked(header, transactions);
 
         // Encode + decode the block

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -117,7 +117,7 @@ pub(crate) fn compact_size_encode(value: usize) -> ArrayVec<u8, 9> {
 }
 
 #[cfg(all(feature = "hex", feature = "alloc"))]
-use core::{fmt, convert};
+use core::{convert, fmt};
 
 #[cfg(all(feature = "hex", feature = "alloc"))]
 use encoding::{Decodable, Decoder};
@@ -142,7 +142,8 @@ impl<T: Decodable> fmt::Debug for ParsePrimitiveError<T> {
             Self::OddLengthString(ref e) => write_err!(f, "odd length string"; e),
             Self::InvalidChar(ref e) => write_err!(f, "invalid character"; e),
             // Decoder error types don't have Debug, so we only provide this generic error
-            Self::Decode(_) => write!(f, "failure decoding hex string into {}", core::any::type_name::<T>()),
+            Self::Decode(_) =>
+                write!(f, "failure decoding hex string into {}", core::any::type_name::<T>()),
         }
     }
 }
@@ -182,18 +183,19 @@ impl<T: Decodable> std::error::Error for ParsePrimitiveError<T> {
 
 #[cfg(all(feature = "hex", feature = "alloc"))]
 pub(crate) mod hex_codec {
-    use super::{fmt, Decodable, ParsePrimitiveError};
-
     use encoding::{Encodable, EncodableByteIter};
     use hex_unstable::{BytesToHexIter, Case};
 
+    use super::{fmt, Decodable, ParsePrimitiveError};
+
     /// Writes an Encodable object to the given formatter in the requested case.
     #[inline]
-    fn hex_write_with_case<T: Encodable + Decodable>(obj: &HexPrimitive<T>, f: &mut fmt::Formatter, case: Case) -> fmt::Result {
-        let iter = BytesToHexIter::new(
-            encoding::EncodableByteIter::new(obj.0),
-            case
-        );
+    fn hex_write_with_case<T: Encodable + Decodable>(
+        obj: &HexPrimitive<T>,
+        f: &mut fmt::Formatter,
+        case: Case,
+    ) -> fmt::Result {
+        let iter = BytesToHexIter::new(encoding::EncodableByteIter::new(obj.0), case);
         let collection = iter.collect::<alloc::string::String>();
         f.pad(&collection)
     }
@@ -209,9 +211,7 @@ pub(crate) mod hex_codec {
         type Item = u8;
         type IntoIter = EncodableByteIter<'a, T>;
 
-        fn into_iter(self) -> Self::IntoIter {
-            EncodableByteIter::new(self.0)
-        }
+        fn into_iter(self) -> Self::IntoIter { EncodableByteIter::new(self.0) }
     }
 
     impl<T: Encodable + Decodable> HexPrimitive<'_, T> {
@@ -245,11 +245,15 @@ pub(crate) mod hex_codec {
 
     impl<T: Encodable + Decodable> fmt::LowerHex for HexPrimitive<'_, T> {
         #[inline]
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { hex_write_with_case(self, f, Case::Lower) }
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            hex_write_with_case(self, f, Case::Lower)
+        }
     }
 
     impl<T: Encodable + Decodable> fmt::UpperHex for HexPrimitive<'_, T> {
         #[inline]
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { hex_write_with_case(self, f, Case::Upper) }
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            hex_write_with_case(self, f, Case::Upper)
+        }
     }
 }

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -375,22 +375,30 @@ impl Encodable for Transaction {
 impl core::str::FromStr for Transaction {
     type Err = ParseTransactionError;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> { crate::hex_codec::HexPrimitive::from_str(s).map_err(ParseTransactionError) }
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        crate::hex_codec::HexPrimitive::from_str(s).map_err(ParseTransactionError)
+    }
 }
 
 #[cfg(all(feature = "hex", feature = "alloc"))]
 impl fmt::Display for Transaction {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(&crate::hex_codec::HexPrimitive(self), f) }
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&crate::hex_codec::HexPrimitive(self), f)
+    }
 }
 
 #[cfg(all(feature = "hex", feature = "alloc"))]
 impl fmt::LowerHex for Transaction {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(&crate::hex_codec::HexPrimitive(self), f) }
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::LowerHex::fmt(&crate::hex_codec::HexPrimitive(self), f)
+    }
 }
 
 #[cfg(all(feature = "hex", feature = "alloc"))]
 impl fmt::UpperHex for Transaction {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::UpperHex::fmt(&crate::hex_codec::HexPrimitive(self), f) }
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::UpperHex::fmt(&crate::hex_codec::HexPrimitive(self), f)
+    }
 }
 
 /// An error that occurs during parsing of a [`Transaction`] from a hex string.
@@ -409,7 +417,9 @@ impl fmt::Display for ParseTransactionError {
 
 #[cfg(all(feature = "hex", feature = "alloc", feature = "std"))]
 impl std::error::Error for ParseTransactionError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { std::error::Error::source(&self.0) }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        std::error::Error::source(&self.0)
+    }
 }
 
 /// The decoder for the [`Transaction`] type.
@@ -757,9 +767,12 @@ impl fmt::Display for TransactionDecoderError {
             E::NoWitnesses => write!(f, "non-empty Segwit transaction with no witnesses"),
             E::LockTime(ref e) => write_err!(f, "transaction decoder error"; e),
             E::EarlyEnd(s) => write!(f, "early end of transaction (still decoding {})", s),
-            E::NullPrevoutInNonCoinbase(index) => write!(f, "null prevout in non-coinbase transaction at input {}", index),
-            E::CoinbaseScriptSigTooSmall(len) => write!(f, "coinbase scriptSig too small: {} bytes (min 2)", len),
-            E::CoinbaseScriptSigTooLarge(len) => write!(f, "coinbase scriptSig too large: {} bytes (max 100)", len),
+            E::NullPrevoutInNonCoinbase(index) =>
+                write!(f, "null prevout in non-coinbase transaction at input {}", index),
+            E::CoinbaseScriptSigTooSmall(len) =>
+                write!(f, "coinbase scriptSig too small: {} bytes (min 2)", len),
+            E::CoinbaseScriptSigTooLarge(len) =>
+                write!(f, "coinbase scriptSig too large: {} bytes (max 100)", len),
         }
     }
 }
@@ -2368,7 +2381,10 @@ mod tests {
         decoder.push_bytes(&mut slice).unwrap();
         let err = decoder.end().expect_err("null prevout in non-coinbase tx should be rejected");
 
-        assert_eq!(err, TransactionDecoderError(TransactionDecoderErrorInner::NullPrevoutInNonCoinbase(0)));
+        assert_eq!(
+            err,
+            TransactionDecoderError(TransactionDecoderErrorInner::NullPrevoutInNonCoinbase(0))
+        );
     }
 
     #[test]
@@ -2384,7 +2400,10 @@ mod tests {
         decoder.push_bytes(&mut slice).unwrap();
         let err = decoder.end().expect_err("coinbase with 1-byte scriptSig should be rejected");
 
-        assert_eq!(err, TransactionDecoderError(TransactionDecoderErrorInner::CoinbaseScriptSigTooSmall(1)));
+        assert_eq!(
+            err,
+            TransactionDecoderError(TransactionDecoderErrorInner::CoinbaseScriptSigTooSmall(1))
+        );
     }
 
     #[test]
@@ -2400,7 +2419,10 @@ mod tests {
         decoder.push_bytes(&mut slice).unwrap();
         let err = decoder.end().expect_err("coinbase with 101-byte scriptSig should be rejected");
 
-        assert_eq!(err, TransactionDecoderError(TransactionDecoderErrorInner::CoinbaseScriptSigTooLarge(101)));
+        assert_eq!(
+            err,
+            TransactionDecoderError(TransactionDecoderErrorInner::CoinbaseScriptSigTooLarge(101))
+        );
     }
 
     #[test]

--- a/primitives/src/witness.rs
+++ b/primitives/src/witness.rs
@@ -1093,15 +1093,15 @@ mod test {
     #[test]
     fn witness_size() {
         let mut witness = Witness::new();
-        let want = 1;           // Number of elements compact size encoded.
+        let want = 1; // Number of elements compact size encoded.
         assert_eq!(witness.size(), want);
 
         witness.push([1, 2, 3]);
-        let want = 5;           // 1 + 1 + 3
+        let want = 5; // 1 + 1 + 3
         assert_eq!(witness.size(), want);
 
         witness.push([4, 5]);
-        let want = 8;           // 5 + 1 + 2
+        let want = 8; // 5 + 1 + 2
         assert_eq!(witness.size(), want);
     }
 

--- a/units/src/block.rs
+++ b/units/src/block.rs
@@ -597,11 +597,10 @@ impl<'a> core::iter::Sum<&'a Self> for BlockMtpInterval {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     #[cfg(feature = "encoding")]
     use encoding::{Decodable as _, Decoder as _, UnexpectedEofError};
 
+    use super::*;
     use crate::relative::{NumberOf512Seconds, TimeOverflowError};
 
     #[test]
@@ -755,7 +754,6 @@ mod tests {
             TimeOverflowError { seconds: max_seconds + 1 }
         );
     }
-
 
     #[test]
     fn block_mtp_interval_to_relative_mtp_ceil() {

--- a/units/src/sequence.rs
+++ b/units/src/sequence.rs
@@ -392,12 +392,12 @@ mod tests {
     #[cfg(feature = "alloc")]
     use alloc::format;
 
-    use super::*;
-
-    #[cfg(feature = "encoding")]
-    use encoding::{Decodable as _, Decoder as _};
     #[cfg(all(feature = "encoding", feature = "alloc"))]
     use encoding::UnexpectedEofError;
+    #[cfg(feature = "encoding")]
+    use encoding::{Decodable as _, Decoder as _};
+
+    use super::*;
 
     const MAXIMUM_ENCODABLE_SECONDS: u32 = u16::MAX as u32 * 512;
 


### PR DESCRIPTION
Shorten the comment that gets incorrectly put on a new line by nightly rustfmt.
 
Run nightly 2026-01-04 rustfmt.