### PR TITLE
Re-release without rc suffix

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -16,7 +16,7 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "base58ck"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bitcoin-internals",
  "bitcoin_hashes",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.33.0-beta.0"
+version = "0.33.0-beta"
 dependencies = [
  "arbitrary",
  "base58ck",
@@ -81,7 +81,7 @@ version = "0.0.0"
 
 [[package]]
 name = "bitcoin-consensus-encoding"
-version = "1.0.0-rc.3"
+version = "0.1.0"
 dependencies = [
  "bitcoin-internals",
  "hex-conservative 0.3.0",
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-io"
-version = "0.4.0-rc.0"
+version = "0.5.0"
 dependencies = [
  "bitcoin-consensus-encoding",
  "bitcoin-internals",
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-primitives"
-version = "1.0.0-rc.2"
+version = "0.102.0"
 dependencies = [
  "arbitrary",
  "bincode",
@@ -170,7 +170,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-units"
-version = "1.0.0-rc.4"
+version = "0.3.0"
 dependencies = [
  "arbitrary",
  "bincode",
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "bitcoin-consensus-encoding",
  "bitcoin-internals",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -16,7 +16,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "base58ck"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bitcoin-internals",
  "bitcoin_hashes",
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.33.0-beta.0"
+version = "0.33.0-beta"
 dependencies = [
  "arbitrary",
  "base58ck",
@@ -80,7 +80,7 @@ version = "0.0.0"
 
 [[package]]
 name = "bitcoin-consensus-encoding"
-version = "1.0.0-rc.3"
+version = "0.1.0"
 dependencies = [
  "bitcoin-internals",
  "hex-conservative 0.3.0",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-io"
-version = "0.4.0-rc.0"
+version = "0.5.0"
 dependencies = [
  "bitcoin-consensus-encoding",
  "bitcoin-internals",
@@ -152,7 +152,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-primitives"
-version = "1.0.0-rc.2"
+version = "0.102.0"
 dependencies = [
  "arbitrary",
  "bincode",
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-units"
-version = "1.0.0-rc.4"
+version = "0.3.0"
 dependencies = [
  "arbitrary",
  "bincode",
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "bitcoin-consensus-encoding",
  "bitcoin-internals",

--- a/base58/CHANGELOG.md
+++ b/base58/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.0 - 2025-01-08
+
+- Update to latest `hashes 0.20.0`
+
 # 0.3.0 - 2025-12-15
 
 - Bump MSRV from 1.63.0 to 1.74.0 for all crates in the repo [#4926](https://github.com/rust-bitcoin/rust-bitcoin/pull/4926)

--- a/base58/Cargo.toml
+++ b/base58/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base58ck"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"
@@ -18,7 +18,7 @@ std = ["alloc", "hashes/std", "internals/std"]
 alloc = ["hashes/alloc", "internals/alloc"]
 
 [dependencies]
-hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.19.0", default-features = false }
+hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
 
 [dev-dependencies]

--- a/bitcoin/CHANGELOG.md
+++ b/bitcoin/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.33.0-beta.0 - 2025-12-29
+# 0.33.0-beta - 2026-02-17
 
 This series of beta releases is meant for two things:
 
@@ -14,16 +14,19 @@ This series of beta releases is meant for two things:
 `cargo` can be surprising when there is a `-` in the version number
 (see discussion on [#5229](https://github.com/rust-bitcoin/rust-bitcoin/discussions/5229)).
 
-We do not currently intend on releasing `bitcoin 0.33.0` until the `1.0` releases above are done.
+We do not intend on ever releasing `0.33.0`. The next release will be
+`0.34.0-beta` (excluding possible `0.33.x-beta` point releases). We
+will remove the `-beta` suffix from release versions once `units`,
+`primitives`, and `consensus_encoding` `v1.0.0` are done.
 
 For changes to our dependencies included in this release see:
 
-- `bitcoin-primitives: 1.0.0-rc`: [changelog](https://github.com/rust-bitcoin/rust-bitcoin/blob/master/primitives/CHANGELOG.md)
-- `bitcoin-units 1.0.0-rc`: [changelog](https://github.com/rust-bitcoin/rust-bitcoin/blob/master/units/CHANGELOG.md)
-- `bitcoin-consensus-encoding 1.0.0-rc` [changelog](https://github.com/rust-bitcoin/rust-bitcoin/blob/master/consensus_encoding/CHANGELOG.md)
-- `bitcoin_hashes 0.19`: [changelog](https://github.com/rust-bitcoin/rust-bitcoin/blob/master/hashes/CHANGELOG.md)
-- `base58ck 0.3.0`: [changelog](https://github.com/rust-bitcoin/rust-bitcoin/blob/master/base58/CHANGELOG.md)
-- `bitcoin-io 0.2`: [changelog](https://github.com/rust-bitcoin/rust-bitcoin/blob/master/io/CHANGELOG.md)
+- `bitcoin-primitives: 0.102`: [changelog](https://github.com/rust-bitcoin/rust-bitcoin/blob/master/primitives/CHANGELOG.md)
+- `bitcoin-units 0.3`: [changelog](https://github.com/rust-bitcoin/rust-bitcoin/blob/master/units/CHANGELOG.md)
+- `bitcoin-consensus-encoding 0.1` [changelog](https://github.com/rust-bitcoin/rust-bitcoin/blob/master/consensus_encoding/CHANGELOG.md)
+- `bitcoin_hashes 0.20`: [changelog](https://github.com/rust-bitcoin/rust-bitcoin/blob/master/hashes/CHANGELOG.md)
+- `base58ck 0.4`: [changelog](https://github.com/rust-bitcoin/rust-bitcoin/blob/master/base58/CHANGELOG.md)
+- `bitcoin-io 0.5`: [changelog](https://github.com/rust-bitcoin/rust-bitcoin/blob/master/io/CHANGELOG.md)
 - `hex-conservative 1.0.0`: [changelog](https://github.com/rust-bitcoin/hex-conservative/blob/1.x/CHANGELOG.md)
 - `hex-conservative 0.3`: [changelog](https://github.com/rust-bitcoin/hex-conservative/blob/master/CHANGELOG.md)
 

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin"
-version = "0.33.0-beta.0"
+version = "0.33.0-beta"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"
@@ -25,18 +25,18 @@ secp-recovery = ["secp256k1/recovery"]
 arbitrary = ["dep:arbitrary", "units/arbitrary", "primitives/arbitrary"]
 
 [dependencies]
-base58 = { package = "base58ck", path = "../base58", version = "0.3.0", default-features = false, features = ["alloc"] }
+base58 = { package = "base58ck", path = "../base58", version = "0.4.0", default-features = false, features = ["alloc"] }
 bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
-hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.19.0", default-features = false, features = ["alloc", "hex"] }
-encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "=1.0.0-rc.3", default-features = false, features = ["alloc"] }
+hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false, features = ["alloc", "hex"] }
+encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.1.0", default-features = false, features = ["alloc"] }
 hex-stable = { package = "hex-conservative", version = "1.0.0", default-features = false, features = ["alloc"] }
 hex-unstable = { package = "hex-conservative", version = "0.3.0", default-features = false, features = ["alloc"] }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0", features = ["alloc", "hex"] }
-io = { package = "bitcoin-io", path = "../io", version = "=0.4.0-rc.0", default-features = false, features = ["alloc", "hashes"] }
+io = { package = "bitcoin-io", path = "../io", version = "0.5.0", default-features = false, features = ["alloc", "hashes"] }
 network = { package = "bitcoin-network-kind", path = "../network", version = "0.1.0", default-features = false, features = ["alloc"]}
-primitives = { package = "bitcoin-primitives", path = "../primitives", version = "=1.0.0-rc.2", default-features = false, features = ["alloc", "hex"] }
+primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.102.0", default-features = false, features = ["alloc", "hex"] }
 secp256k1 = { version = "0.32.0-beta.2", default-features = false, features = ["alloc"] }
-units = { package = "bitcoin-units", path = "../units", version = "=1.0.0-rc.4", default-features = false, features = ["alloc"] }
+units = { package = "bitcoin-units", path = "../units", version = "0.3.0", default-features = false, features = ["alloc"] }
 
 arbitrary = { version = "1.4.1", optional = true }
 base64 = { version = "0.22.0", optional = true, default-features = false, features = ["alloc"] }

--- a/consensus_encoding/CHANGELOG.md
+++ b/consensus_encoding/CHANGELOG.md
@@ -1,4 +1,17 @@
-# 1.0.0 - 2025-10-10
+# 0.1.0 - 2026-02-17
+
+It was found that the `1.0.0-rc.x` releases were troublesome because
+of how `cargo` resolves version numbers that include a suffix. For
+this reason we elected to go back to pre-1.0 version numbers.
+
+`v0.1.0` is a re-release of `v1.0.0-rc.3`
+
+- Add array ref encoder [#5572](https://github.com/rust-bitcoin/rust-bitcoin/pull/5572)
+- Introduce lifetimes to all public Encoders [#5556](https://github.com/rust-bitcoin/rust-bitcoin/pull/5556)
+- Add `flush_to_*` functions [#5534](https://github.com/rust-bitcoin/rust-bitcoin/pull/5534)
+- Add `ExactSizeEncoder` for known-length Encoders [#5445](https://github.com/rust-bitcoin/rust-bitcoin/pull/5445)
+
+# 1.0.0 Release Candidates - 2025-10-10
 
 This changelog is a rolling description of everything that will eventually end up in `v1.0`.
 

--- a/consensus_encoding/Cargo.toml
+++ b/consensus_encoding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-consensus-encoding"
-version = "1.0.0-rc.3"
+version = "0.1.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>", "Nick Johnson <nick@yonson.dev>", "Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"

--- a/consensus_encoding/README.md
+++ b/consensus_encoding/README.md
@@ -1,3 +1,13 @@
 # Bitcoin Consensus Encoding
 
 This crate provides traits that can be used to encode/decode objects in a consensus-consistent way.
+
+## `consensus_encoding 0.1.0`
+
+This is the start of the `v1.0.0` release candidate cycle. We will
+endeavour to not release breaking changes unless totally necessary and
+will honour semver rules as usual. From this release forward we will
+semver trick as possible in subsequent releases to assist downstream
+users testing these releases.
+
+Thanks for your patience and help.

--- a/hashes/CHANGELOG.md
+++ b/hashes/CHANGELOG.md
@@ -1,6 +1,20 @@
+# 0.20.0 - 2026-01-08
+
+It was found that the `1.0.0-rc.x` releases were troublesome because
+of how `cargo` resolves version numbers that include a suffix. For
+this reason we elected to go back to pre-1.0 version numbers.
+
+During this saga (and specifically in the `0.19.0` release) we started
+using `=1.0.0-rc.3` to specify the version number of
+`consensus_encoding`. To remove this and use the latest
+`consensus_encoding 0.1.0` requires a version bump of this crate.
+
+`v0.19.0` will be yanked.
+
 # 0.19.0 - 2025-12-05
 
 * Upgrade `internals` dependency (forces this release).
+* Pin version of `consensus_encoding` using `=` syntax.
 
 # 0.18.0 - 2025-11-27
 

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin_hashes"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin"
@@ -23,7 +23,7 @@ small-hash = []
 
 [dependencies]
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
-encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "=1.0.0-rc.3", default-features = false }
+encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.1.0", default-features = false }
 
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false, optional = true }
 serde = { version = "1.0.195", default-features = false, optional = true }

--- a/io/CHANGELOG.md
+++ b/io/CHANGELOG.md
@@ -1,4 +1,13 @@
-# 0.4.0 - 2025-12-29
+# 0.5.0 - 2026-01-08
+
+It was found that the `1.0.0-rc.x` releases were troublesome because
+of how `cargo` resolves version numbers that include a suffix. For
+this reason we elected to go back to pre-1.0 version numbers.
+
+`v0.5.0` is a re-release of `v0.4.0-rc.0`. The only change is to
+update the other `rust-bitcoin` repo dependencies.
+
+# 0.4.0-rc.0 - 2025-12-29
 
 * Upgrade dependencies: `bitcoin-internals`, `bitcoin-consensus-encoding`, and `bitcoin_hashes`.
 

--- a/io/Cargo.toml
+++ b/io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-io"
-version = "0.4.0-rc.0"
+version = "0.5.0"
 authors = ["Matt Corallo <birchneutea@mattcorallo.com>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin"
@@ -20,12 +20,12 @@ alloc = ["encoding/alloc", "hashes?/alloc", "internals/alloc"]
 
 [dependencies]
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
-encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "=1.0.0-rc.3", default-features = false }
+encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.1.0", default-features = false }
 
-hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.19.0", default-features = false, optional = true }
+hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false, optional = true }
 
 [dev-dependencies]
-hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.19.0", default-features = false, features = ["hex"] }
+hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false, features = ["hex"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -19,14 +19,14 @@ arbitrary = ["dep:arbitrary", "bitcoin/arbitrary"]
 
 [dependencies]
 bitcoin = { path = "../bitcoin/", default-features = false }
-encoding = { package = "bitcoin-consensus-encoding", version = "=1.0.0-rc.3", path = "../consensus_encoding", default-features = false }
-hashes = { package = "bitcoin_hashes", version = "0.19.0", path = "../hashes", default-features = false }
+encoding = { package = "bitcoin-consensus-encoding", version = "0.1.0", path = "../consensus_encoding", default-features = false }
+hashes = { package = "bitcoin_hashes", version = "0.20.0", path = "../hashes", default-features = false }
 network = { package = "bitcoin-network-kind", path = "../network", version = "0.1.0", default-features = false }
-primitives = { package = "bitcoin-primitives", path = "../primitives", version = "=1.0.0-rc.2", default-features = false }
+primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.102.0", default-features = false }
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", default-features = false }
-io = { package = "bitcoin-io", version = "=0.4.0-rc.0", path = "../io", default-features = false }
-units = { package = "bitcoin-units", path = "../units", version = "=1.0.0-rc.4", default-features = false }
+io = { package = "bitcoin-io", version = "0.5.0", path = "../io", default-features = false }
+units = { package = "bitcoin-units", path = "../units", version = "0.3.0", default-features = false }
 
 arbitrary = { version = "1.4.1", optional = true }
 

--- a/primitives/CHANGELOG.md
+++ b/primitives/CHANGELOG.md
@@ -1,9 +1,23 @@
-# TBD
-- Remove `From<UnexpectedEof>` for primitive decoder error types [#5606](https://github.com/rust-bitcoin/rust-bitcoin/pull/5606)
+# 0.102.0 - 2026-02-17
 
-# 1.0.0 - 2025-10-18
+It was found that the `1.0.0-rc.x` releases were troublesome because
+of how `cargo` resolves version numbers that include a suffix. For
+this reason we elected to go back to pre-1.0 version numbers but this
+release is still explicitly a 1.0 release candidate.
+
+- Remove `From<UnexpectedEof>` for primitive decoder error types [#5606](https://github.com/rust-bitcoin/rust-bitcoin/pull/5606)
+- Use `hashes` format implementations and fix reverse hashes [#5603](https://github.com/rust-bitcoin/rust-bitcoin/pull/5603)
+- Add fmt traits for simple wrapper types [#5597](https://github.com/rust-bitcoin/rust-bitcoin/pull/5597)
+- Use saturating add in `WitnessDecoder` [#5569](https://github.com/rust-bitcoin/rust-bitcoin/pull/5569)
+- Reject transactions with 0 outputs [#5470](https://github.com/rust-bitcoin/rust-bitcoin/pull/5470)
+- Prevent null prevout in non-coinbase transactions [#5450](https://github.com/rust-bitcoin/rust-bitcoin/pull/5450)
+- Reject txs with output sum > MAX_MONEY [#5443](https://github.com/rust-bitcoin/rust-bitcoin/pull/5443)
+- Reject transactions with invalid coinbase `scriptSig` length [#5430](https://github.com/rust-bitcoin/rust-bitcoin/pull/5430)
+
+# 1.0.0 Release Candidates - 2025-10-18
 
 This changelog is a rolling description of everything that will eventually end up in `v1.0`.
+EDIT: This changelog is for `1.0.0-rc.0` through `1.0.0-rc.2` and may well be missing stuff.
 
 There are a bunch of changes in this stable release, of note script
 tagging and the consensus encoding re-write.

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-primitives"
-version = "1.0.0-rc.2"
+version = "0.102.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>", "Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin"
@@ -21,10 +21,10 @@ arbitrary = ["dep:arbitrary", "units/arbitrary"]
 hex = ["dep:hex-stable", "dep:hex-unstable", "hashes/hex", "internals/hex"]
 
 [dependencies]
-encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "=1.0.0-rc.3", default-features = false }
-hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.19.0", default-features = false }
+encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.1.0", default-features = false }
+hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
-units = { package = "bitcoin-units", path = "../units", version = "=1.0.0-rc.4", default-features = false, features = [ "encoding" ] }
+units = { package = "bitcoin-units", path = "../units", version = "0.3.0", default-features = false, features = [ "encoding" ] }
 
 arbitrary = { version = "1.4.1", optional = true }
 hex-stable = { package = "hex-conservative", version = "1.0.0", default-features = false, optional = true }

--- a/primitives/README.md
+++ b/primitives/README.md
@@ -7,3 +7,13 @@ This crate provides primitive data types that are used throughout the
 
 Functions marked as unstable (e.g. `foo__unstable`) are not guaranteed to uphold semver compliance.
 They are primarily provided to support `rust-bitcoin`.
+
+## `bitcoin-primitives 0.102.0`
+
+This is the start of the 1.0.0 release candidate cycle. We will
+endeavour to not release breaking changes unless totally necessary and
+will honour semver rules as usual. From this release forward we will
+semver trick as possible in subsequent releases to assist downstream
+users testing these releases.
+
+Thanks for your patience and help.

--- a/units/CHANGELOG.md
+++ b/units/CHANGELOG.md
@@ -1,8 +1,17 @@
-# 1.0.0 - 2025-02-24
+# 0.3.0 - 2026-02-17
+
+It was found that the `1.0.0-rc.x` releases were troublesome because
+of how `cargo` resolves version numbers that include a suffix. For
+this reason we elected to go back to pre-1.0 version numbers.
+
+- Add next target calculation [#5544](https://github.com/rust-bitcoin/rust-bitcoin/pull/5544)
+
+# 1.0.0 Release Candidates - 2025-02-24
 
 BOOM! A long time in the making but here goes, our first 1.0 crate release.
 
 This changelog is a rolling description of everything that will eventually end up in `v1.0`.
+EDIT: This changelog is for `1.0.0-rc.0` through `1.0.0-rc.4` and may well be missing stuff.
 
 * Introduce limit to `Amount`
   * Prepare to enforce `MAX_MONEY` invariant [#4164](https://github.com/rust-bitcoin/rust-bitcoin/pull/4164)

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-units"
-version = "1.0.0-rc.4"
+version = "0.3.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>", "Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"
@@ -20,7 +20,7 @@ alloc = ["internals/alloc", "serde?/alloc", "encoding?/alloc"]
 [dependencies]
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
 
-encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "=1.0.0-rc.3", default-features = false, optional = true }
+encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.1.0", default-features = false, optional = true }
 serde = { version = "1.0.195", default-features = false, features = ["derive"], optional = true }
 arbitrary = { version = "1.4.1", optional = true }
 

--- a/units/README.md
+++ b/units/README.md
@@ -1,3 +1,13 @@
 # Bitcoin Units
 
 This crate provides basic Bitcoin numeric units such as `Amount`.
+
+## `bitcoin-units v0.3.0`
+
+This is the start of the `v1.0.0` release candidate cycle. We will
+endeavour to not release breaking changes unless totally necessary and
+will honour semver rules as usual. From this release forward we will
+semver trick as possible in subsequent releases to assist downstream
+users testing these releases.
+
+Thanks for your patience and help.


### PR DESCRIPTION
Turns out that the `-rc.0` suffix causes way more problems than it solves because of how `cargo` resolves the version numbers and what we intended on using the RC releases for.

In brief

- We wanted to be able to do breaking changes if required
- We wanted to signal that these releases were almost there (TM)
- We wanted to be able to do downstream testing including releasing downstream crates with the RC releases as part of their public API.

In hindsight we messed up and should have just kept iterating as normal until we were ready.

Re-release the whole stack without any rc suffix's. However keep `bitcoin 0.33.0-beta` because we want 0.32.0 to be the latest stable release and its important that it shows as such on docs.rs

Also, for pre-1.0 crates that had an rc release just jump to the next version i.e., `io 0.4.0-rc.0` goes to `io 0.5.0`. Just for good measure.


crate           |  latest stable  |  latest RC  | with this applied    |
----------------|---------------------|-----------------|---------------------------|
consensus_encoding | 0.0.0 | 1.0.0-rc.3 | 0.1.0
units  | 0.2.0 | 1.0.0-rc.4  | 0.3.0
primitives | 0.101.0 | 1.0.0-rc.2  | 0.102.0
hashes  | 0.19.0 |  - | 0.20.0
io | 0.3.0 | 0.4.0-rc.0 | 0.5.0
base58ck | 0.3.0 | - |  0.4.0



- bitcoin - 0.33.0-beta.0 to be yanked. Release as 0.33.0-beta
- hashes 0.19.0 to be yanked.
- p2p - updated deps, unrelased so no other changes. internals - not touched (currently 0.5.0)  
- chacha20_poly1305 - not touched

This PR fell out of a phone discussion between Andrew and myself where we discussed #5358.