### PR TITLE
p2p: add v1 header decoder

### DIFF
--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -255,6 +255,64 @@ pub struct V1MessageHeader {
     pub checksum: [u8; 4],
 }
 
+type V1MessageHeaderInnerDecoder = encoding::Decoder4<
+            encoding::ArrayDecoder<4>,
+            CommandStringDecoder,
+            encoding::ArrayDecoder<4>,
+            encoding::ArrayDecoder<4>,
+        >;
+
+/// The Decoder for `V1MessageHeader`
+pub struct V1MessageHeaderDecoder(V1MessageHeaderInnerDecoder);
+
+impl encoding::Decoder for V1MessageHeaderDecoder {
+    type Output = V1MessageHeader;
+    type Error = V1MessageHeaderDecoderError;
+
+    #[inline]
+    fn push_bytes(&mut self, bytes: &mut &[u8]) -> Result<bool, Self::Error> {
+        self.0.push_bytes(bytes).map_err(V1MessageHeaderDecoderError)
+    }
+
+    #[inline]
+    fn end(self) -> Result<Self::Output, Self::Error> {
+        let (magic, command, length, checksum) = self.0.end().map_err(V1MessageHeaderDecoderError)?;
+        Ok(
+            V1MessageHeader {
+                magic: Magic(magic),
+                command,
+                length: u32::from_le_bytes(length),
+                checksum
+            }
+        )
+    }
+
+    #[inline]
+    fn read_limit(&self) -> usize { self.0.read_limit() }
+}
+
+impl encoding::Decodable for V1MessageHeader {
+    type Decoder = V1MessageHeaderDecoder;
+    fn decoder() -> Self::Decoder {
+        V1MessageHeaderDecoder (encoding::Decoder4::new(
+            encoding::ArrayDecoder::<4>::new(),
+            CommandString::decoder(),
+            encoding::ArrayDecoder::<4>::new(),
+            encoding::ArrayDecoder::<4>::new()
+        ))
+    }
+}
+
+/// An error consensus decoding a [`V1MessageHeaderDecoderError`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct V1MessageHeaderDecoderError(<V1MessageHeaderInnerDecoder as encoding::Decoder>::Error);
+
+impl fmt::Display for V1MessageHeaderDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        internals::write_err!(f, "message header decoder error"; self.0)
+    }
+}
+
 impl_consensus_encoding!(V1MessageHeader, magic, command, length, checksum);
 
 /// A Network message using the v2 p2p protocol defined in BIP-0324.


### PR DESCRIPTION
Allow decoding a p2p network message header.  A fixed size limit is used in `read_limit()` of 24.  That is, the header is composed of fields:

* 4 bytes for the magic bytes
* 12 bytes for the command
* 4 bytes for the length
* 4 bytes for the checksum

The header can then be read using the consensus_encoding crate:

```
let V1MessageHeader {command, ..} =
    decode_from_read_unbuffered::<V1MessageHeader, _>(&mut r).unwrap()
```