### PR TITLE
Filter diff to include only rust files in diff cargo mutants CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -458,7 +458,7 @@ jobs:
       - name: "Fetch base branch for diff"
         run: git fetch origin master
       - name: "Retrieve relative diff"
-        run: git diff origin/master.. | tee git.diff
+        run: git diff origin/master.. -- '*.rs' | tee git.diff
       - uses: taiki-e/install-action@81ee1d48d9194cdcab880cbdc7d36e87d39874cb # v2.62.45
         with:
           tool: cargo-mutants


### PR DESCRIPTION
This is a workaround for a failure in the patch-rs dependency within cargo-mutants where it fails to properly parse the diff.  

This gets around it by filtering the diff to only include rust files. Even if this bug gets patched upstream I do not think that this workaround really needs to be removed.

Closes #5496 