### PR TITLE
Fix bug in `Psbt::spend_utxo` when missing output

### DIFF
--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -616,7 +616,7 @@ impl Psbt {
             witness_utxo
         } else if let Some(non_witness_utxo) = &input.non_witness_utxo {
             let vout = self.unsigned_tx.inputs[input_index].previous_output.vout;
-            &non_witness_utxo.outputs[vout as usize]
+            non_witness_utxo.outputs.get(vout as usize).ok_or(SignError::MissingSpendUtxo)?
         } else {
             return Err(SignError::MissingSpendUtxo);
         };
@@ -2551,6 +2551,52 @@ mod tests {
             psbt.internal_extract_tx_with_fee_rate_limit(FeeRate::MAX),
             Err(ExtractTxError::MissingInputAmount { tx: _ })
         ))
+    }
+    
+    #[test]
+    fn spending_psbt_with_missing_txout() {
+        let psbt = Psbt {
+            unsigned_tx: Transaction {
+                version: transaction::Version::TWO,
+                lock_time: absolute::LockTime::from_consensus(1257139),
+                inputs: vec![TxIn {
+                    previous_output: OutPoint {
+                        txid: "f61b1742ca13176464adb3cb66050c00787bb3a4eead37e985f2df1e37718126"
+                            .parse()
+                            .unwrap(),
+                        vout: 0,
+                    },
+                    script_sig: ScriptSigBuf::new(),
+                    sequence: Sequence::ENABLE_LOCKTIME_NO_RBF,
+                    witness: Witness::default(),
+                }],
+                outputs: vec![
+                    TxOut {
+                        amount: Amount::from_sat_u32(99_999_699),
+                        script_pubkey: ScriptPubKeyBuf::from_hex_no_length_prefix(
+                            "76a914d0c59903c5bac2868760e90fd521a4665aa7652088ac",
+                        )
+                        .unwrap(),
+                    },
+                ],
+            },
+            xpub: Default::default(),
+            version: 0,
+            proprietary: Default::default(),
+            unknown: Default::default(),
+            inputs: vec![Input {
+                non_witness_utxo: Some(Transaction {
+                    version: transaction::Version::TWO,
+                    lock_time: absolute::LockTime::ZERO,
+                    inputs: vec![],
+                    outputs: vec![], // No outputs here  
+                }),
+                ..Default::default()
+            }],
+            outputs: vec![Output::default()],
+        };
+
+        assert!(matches!(psbt.spend_utxo(0), Err(SignError::MissingSpendUtxo)))
     }
 
     #[test]


### PR DESCRIPTION
Something else found from fuzzing:

```
thread '<unnamed>' (8730670) panicked at bitcoin/src/psbt/mod.rs:625:38:
index out of bounds: the len is 0 but the index is 16765184
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
==1660== ERROR: libFuzzer: deadly signal
    #0 0x000104e693c4 in __sanitizer_print_stack_trace+0x28 (librustc-nightly_rt.asan.dylib:arm64+0x5d3c4)
    #1 0x000104439f6c in fuzzer::PrintStackTrace()+0x30 (bitcoin_arbitrary_psbt:arm64+0x100399f6c)
    #2 0x00010442e450 in fuzzer::Fuzzer::CrashCallback()+0x54 (bitcoin_arbitrary_psbt:arm64+0x10038e450)
    #3 0x00019914f740 in _sigtramp+0x34 (libsystem_platform.dylib:arm64+0x3740)
    #4 0x000199145884 in pthread_kill+0x124 (libsystem_pthread.dylib:arm64+0x6884)
    #5 0x00019904a84c in abort+0x78 (libsystem_c.dylib:arm64+0x7984c)
    #6 0x0001044b59f8 in _RNvNtNtNtCsk9AQ7OSayGk_3std3sys3pal4unix14abort_internal+0x8 (bitcoin_arbitrary_psbt:arm64+0x1004159f8)
    #7 0x0001044b5854 in _RNvNtCsk9AQ7OSayGk_3std7process5abort+0x8 (bitcoin_arbitrary_psbt:arm64+0x100415854)
    #8 0x0001044b0a30 in _RNCNvCsaBYAWE6hvc2_13libfuzzer_sys10initialize0B3_+0xb8 (bitcoin_arbitrary_psbt:arm64+0x100410a30)
    #9 0x0001044891bc in _RNvNtCsk9AQ7OSayGk_3std9panicking15panic_with_hook+0x264 (bitcoin_arbitrary_psbt:arm64+0x1003e91bc)
    #10 0x00010447d1f0 in _RNCNvNtCsk9AQ7OSayGk_3std9panicking13panic_handler0B5_+0x40 (bitcoin_arbitrary_psbt:arm64+0x1003dd1f0)
    #11 0x000104474b78 in _RINvNtNtCsk9AQ7OSayGk_3std3sys9backtrace26___rust_end_short_backtraceNCNvNtB6_9panicking13panic_handler0zEB6_+0x8 (bitcoin_arbitrary_psbt:arm64+0x1003d4b78)
    #12 0x00010447d800 in _RNvCseYE12Li5r0M_7___rustc17rust_begin_unwind+0x1c (bitcoin_arbitrary_psbt:arm64+0x1003dd800)
    #13 0x0001044b6150 in _RNvNtCsh0x4TIixgmZ_4core9panicking9panic_fmt+0x24 (bitcoin_arbitrary_psbt:arm64+0x100416150)
    #14 0x0001044b5f98 in _RNvNtCsh0x4TIixgmZ_4core9panicking18panic_bounds_check+0x34 (bitcoin_arbitrary_psbt:arm64+0x100415f98)
    #15 0x0001041bd2ac in _RNvMNtCs9rLNVcx1A2L_7bitcoin4psbtNtB2_4Psbt10spend_utxo+0x558 (bitcoin_arbitrary_psbt:arm64+0x10011d2ac)
    #16 0x0001040ebc3c in _RNvNvCshHXwvrCOqYg_22bitcoin_arbitrary_psbt1__19___libfuzzer_sys_run arbitrary_psbt.rs:41
    #17 0x0001040f73cc in rust_fuzzer_test_input lib.rs:276
    #18 0x00010442ca04 in _RINvNvNtCsk9AQ7OSayGk_3std9panicking12catch_unwind7do_callNCNvCsaBYAWE6hvc2_13libfuzzer_sys15test_input_wrap0lEBY_+0xc4 (bitcoin_arbitrary_psbt:arm64+0x10038ca04)
    #19 0x00010442d6cc in __rust_try+0x18 (bitcoin_arbitrary_psbt:arm64+0x10038d6cc)
    #20 0x00010442c304 in LLVMFuzzerTestOneInput+0x16c (bitcoin_arbitrary_psbt:arm64+0x10038c304)
    #21 0x00010442fd08 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long)+0x158 (bitcoin_arbitrary_psbt:arm64+0x10038fd08)
    #22 0x00010444b1c8 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long)+0xd8 (bitcoin_arbitrary_psbt:arm64+0x1003ab1c8)
    #23 0x00010444fe38 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long))+0x1b8c (bitcoin_arbitrary_psbt:arm64+0x1003afe38)
    #24 0x00010445c7f0 in main+0x24 (bitcoin_arbitrary_psbt:arm64+0x1003bc7f0)
    #25 0x000198d7dd50  (<unknown module>)

NOTE: libFuzzer has rudimentary signal handlers.
      Combine libFuzzer with AddressSanitizer or similar for better crash reports.
SUMMARY: libFuzzer: deadly signal
────────────────────────────────────────────────────────────────────────────────
```