### PR TITLE
p2p: Switch to network crate

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -141,6 +141,7 @@ dependencies = [
  "bitcoin-consensus-encoding",
  "bitcoin-internals",
  "bitcoin-io",
+ "bitcoin-network-kind",
  "bitcoin-primitives",
  "bitcoin-units",
  "bitcoin_hashes",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -140,6 +140,7 @@ dependencies = [
  "bitcoin-consensus-encoding",
  "bitcoin-internals",
  "bitcoin-io",
+ "bitcoin-network-kind",
  "bitcoin-primitives",
  "bitcoin-units",
  "bitcoin_hashes",

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -14,13 +14,14 @@ exclude = ["tests", "contrib"]
 
 [features]
 default = ["std"]
-std = ["encoding/std", "hashes/std", "hex/std", "internals/std", "io/std", "units/std", "bitcoin/std", "primitives/std"]
+std = ["encoding/std", "hashes/std", "network/std", "hex/std", "internals/std", "io/std", "units/std", "bitcoin/std", "primitives/std"]
 arbitrary = ["dep:arbitrary", "bitcoin/arbitrary"]
 
 [dependencies]
 bitcoin = { path = "../bitcoin/", default-features = false }
 encoding = { package = "bitcoin-consensus-encoding", version = "=1.0.0-rc.3", path = "../consensus_encoding", default-features = false }
 hashes = { package = "bitcoin_hashes", version = "0.19.0", path = "../hashes", default-features = false }
+network = { package = "bitcoin-network-kind", path = "../network", version = "0.1.0", default-features = false }
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "=1.0.0-rc.2", default-features = false }
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", default-features = false }

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -36,7 +36,7 @@ use core::{fmt, ops};
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
 use bitcoin::consensus::encode::{self, Decodable, Encodable};
-use bitcoin::network::{Network, TestnetVersion};
+use network::{Network, TestnetVersion};
 use hex::FromHex;
 use internals::impl_to_hex_from_lower_hex;
 use io::{BufRead, Write};

--- a/p2p/src/network_ext.rs
+++ b/p2p/src/network_ext.rs
@@ -4,7 +4,7 @@
 //! with getter methods for the default P2P port and default
 //! network [`Magic`] bytes.
 
-use bitcoin::{Network, TestnetVersion};
+use network::{Network, TestnetVersion};
 
 use crate::Magic;
 


### PR DESCRIPTION
First commit removes `from_params` constructor on `Magic` as `Params` is not in `bitcoin-network-kind` and `TryFrom` is already present for `Network` to `Magic`. Second commit updates the lock files and does the switch.