### PR TITLE
units: Correctly group deps

### DIFF
--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -18,9 +18,9 @@ std = ["alloc", "internals/std", "encoding?/std"]
 alloc = ["internals/alloc", "serde?/alloc", "encoding?/alloc"]
 
 [dependencies]
-encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "=1.0.0-rc.3", default-features = false, optional = true }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
 
+encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "=1.0.0-rc.3", default-features = false, optional = true }
 serde = { version = "1.0.195", default-features = false, features = ["derive"], optional = true }
 arbitrary = { version = "1.4.1", optional = true }
 


### PR DESCRIPTION
By convention optional dependencies are grouped separately to non-option ones.

Fix: #5516