### PR TITLE
primitives: Remove BlockTime decoder from root export

### DIFF
--- a/api/primitives/all-features.txt
+++ b/api/primitives/all-features.txt
@@ -2124,8 +2124,6 @@ pub use bitcoin_primitives::BlockHeightInterval
 pub use bitcoin_primitives::BlockMtp
 pub use bitcoin_primitives::BlockMtpInterval
 pub use bitcoin_primitives::BlockTime
-pub use bitcoin_primitives::BlockTimeDecoder
-pub use bitcoin_primitives::BlockTimeDecoderError
 pub use bitcoin_primitives::FeeRate
 pub use bitcoin_primitives::NumOpResult
 pub use bitcoin_primitives::Sequence

--- a/api/primitives/alloc-only.txt
+++ b/api/primitives/alloc-only.txt
@@ -1863,8 +1863,6 @@ pub use bitcoin_primitives::BlockHeightInterval
 pub use bitcoin_primitives::BlockMtp
 pub use bitcoin_primitives::BlockMtpInterval
 pub use bitcoin_primitives::BlockTime
-pub use bitcoin_primitives::BlockTimeDecoder
-pub use bitcoin_primitives::BlockTimeDecoderError
 pub use bitcoin_primitives::FeeRate
 pub use bitcoin_primitives::NumOpResult
 pub use bitcoin_primitives::Sequence

--- a/api/primitives/no-features.txt
+++ b/api/primitives/no-features.txt
@@ -762,8 +762,6 @@ pub use bitcoin_primitives::BlockHeightInterval
 pub use bitcoin_primitives::BlockMtp
 pub use bitcoin_primitives::BlockMtpInterval
 pub use bitcoin_primitives::BlockTime
-pub use bitcoin_primitives::BlockTimeDecoder
-pub use bitcoin_primitives::BlockTimeDecoderError
 pub use bitcoin_primitives::FeeRate
 pub use bitcoin_primitives::NumOpResult
 pub use bitcoin_primitives::Sequence

--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -29,10 +29,12 @@ use crate::pow::{CompactTargetDecoder, CompactTargetDecoderError};
 #[cfg(feature = "alloc")]
 use crate::prelude::Vec;
 #[cfg(feature = "alloc")]
+use crate::time::{BlockTimeDecoder, BlockTimeDecoderError};
+#[cfg(feature = "alloc")]
 use crate::transaction::{TxMerkleNodeDecoder, TxMerkleNodeDecoderError};
 use crate::{BlockTime, CompactTarget, TxMerkleNode};
 #[cfg(feature = "alloc")]
-use crate::{BlockTimeDecoder, BlockTimeDecoderError, Transaction, WitnessMerkleNode};
+use crate::{Transaction, WitnessMerkleNode};
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -62,7 +62,7 @@ pub use units::{
     parse_int,
     result::{self, NumOpResult},
     sequence::{self, Sequence},
-    time::{self, BlockTime, BlockTimeDecoder, BlockTimeDecoderError},
+    time::{self, BlockTime},
     weight::{self, Weight},
 };
 

--- a/primitives/tests/api.rs
+++ b/primitives/tests/api.rs
@@ -213,8 +213,7 @@ fn api_can_use_units_modules_from_crate_root() {
 fn api_can_use_units_types_from_crate_root() {
     use bitcoin_primitives::{
         Amount, BlockHeight, BlockHeightInterval, BlockMtp, BlockMtpInterval, BlockTime,
-        BlockTimeDecoder, BlockTimeDecoderError, FeeRate, NumOpResult, Sequence, SignedAmount,
-        Weight,
+        FeeRate, NumOpResult, Sequence, SignedAmount, Weight,
     };
 }
 


### PR DESCRIPTION
Encoder/decoder types are not typically exported outside of the module they are defined in. The BlockTimeDecoder (and associated error) are.

Remove BlockTimeDecoder and BlockTimeDecoderError from root level re-export in primitives.

Closes #5522 