### PR TITLE
units: Introduce coverage for Display on error types

### DIFF
--- a/units/src/result.rs
+++ b/units/src/result.rs
@@ -439,8 +439,13 @@ impl<'a> Arbitrary<'a> for MathOp {
 
 #[cfg(test)]
 mod tests {
-    use super::{MathOp, NumOpError, NumOpResult};
+    #[cfg(feature = "alloc")]
+    use alloc::string::ToString;
+    #[cfg(feature = "std")]
+    use std::error::Error;
+
     use crate::{Amount, FeeRate, Weight};
+    use crate::result::{MathOp, NumOpError, NumOpResult};
 
     #[test]
     fn mathop_predicates() {
@@ -604,5 +609,15 @@ mod tests {
             panic!("and_then should not evaluate for wrapped error values");
         });
         assert_eq!(res_err, res);
+    }
+
+    #[test]
+    #[cfg(feature = "alloc")]
+    fn error_display_is_non_empty() {
+        // NumOpError - math operation error
+        let e = (Amount::MAX + Amount::MAX).unwrap_err();
+        assert!(!e.to_string().is_empty());
+        #[cfg(feature = "std")]
+        assert!(e.source().is_none());
     }
 }

--- a/units/src/sequence.rs
+++ b/units/src/sequence.rs
@@ -383,9 +383,13 @@ impl<'a> Arbitrary<'a> for Sequence {
 mod tests {
     #[cfg(feature = "alloc")]
     use alloc::format;
+    #[cfg(all(feature = "encoding", feature = "alloc"))]
+    use alloc::string::ToString;
+    #[cfg(all(feature = "encoding", feature = "std"))]
+    use std::error::Error;
 
     #[cfg(feature = "encoding")]
-    use encoding::Decoder as _;
+    use encoding::{Decodable as _, Decoder as _};
     #[cfg(all(feature = "encoding", feature = "alloc"))]
     use encoding::UnexpectedEofError;
 
@@ -503,5 +507,20 @@ mod tests {
 
         let error = decoder.end().unwrap_err();
         assert!(matches!(error, SequenceDecoderError(UnexpectedEofError { .. })));
+    }
+
+    #[test]
+    #[cfg(feature = "alloc")]
+    fn decoder_error_display_is_non_empty() {
+        #[cfg(feature = "encoding")]
+        {
+            // SequenceDecoderError
+            let mut decoder = Sequence::decoder();
+            let _ = decoder.push_bytes(&mut [0u8; 3].as_slice());
+            let e = decoder.end().unwrap_err();
+            assert!(!e.to_string().is_empty());
+            #[cfg(feature = "std")]
+            assert!(e.source().is_some());
+        }
     }
 }

--- a/units/src/time.rs
+++ b/units/src/time.rs
@@ -177,6 +177,8 @@ impl<'a> Arbitrary<'a> for BlockTime {
 mod tests {
     #[cfg(feature = "alloc")]
     use alloc::string::ToString;
+    #[cfg(all(feature = "encoding", feature = "std"))]
+    use std::error::Error;
 
     #[cfg(feature = "encoding")]
     use encoding::Decoder as _;
@@ -229,8 +231,11 @@ mod tests {
         let bytes = [0xb0, 0x52, 0x39]; // 3 bytes is an EOF error
 
         let mut decoder = BlockTimeDecoder::default();
-        assert!(decoder.push_bytes(&mut bytes.as_slice()).unwrap());
+        let _ = decoder.push_bytes(&mut bytes.as_slice());
 
-        assert_ne!(decoder.end().unwrap_err().to_string(), "");
+        let e = decoder.end().unwrap_err();
+        assert!(!e.to_string().is_empty());
+        #[cfg(feature = "std")]
+        assert!(e.source().is_some());
     }
 }


### PR DESCRIPTION
The error types in units are largely untested by existing tests. Since it's important to ensure that error display some content, we should include assertions that error display messages are non-empty.

Introduce tests to cover Display impls for all error types in units