### PR TITLE
Adjust error re-export doc inlining

### DIFF
--- a/bitcoin/src/blockdata/script/push_bytes.rs
+++ b/bitcoin/src/blockdata/script/push_bytes.rs
@@ -471,7 +471,7 @@ impl PushBytesErrorReport for core::convert::Infallible {
     fn input_len(&self) -> usize { match *self {} }
 }
 
-#[doc(inline)]
+#[doc(no_inline)]
 pub use error::PushBytesError;
 
 #[cfg(any(target_pointer_width = "16", target_pointer_width = "32"))]

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -32,8 +32,10 @@ use crate::witness::Witness;
 use crate::{internal_macros, Amount, FeeRate, Sequence, SignedAmount};
 
 #[rustfmt::skip]            // Keep public re-exports separate.
+#[doc(no_inline)]
+pub use primitives::transaction::{ParseTransactionError, ParseOutPointError};
 #[doc(inline)]
-pub use primitives::transaction::{OutPoint, ParseTransactionError, ParseOutPointError, Transaction, Ntxid, Txid, Wtxid, Version, TxIn, TxOut};
+pub use primitives::transaction::{OutPoint, Transaction, Ntxid, Txid, Wtxid, Version, TxIn, TxOut};
 
 impl Encodable for Txid {
     fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -49,7 +49,9 @@ use crate::{absolute, Amount, ScriptPubKeyBuf, ScriptSigBuf, Sequence, Weight, W
 
 #[rustfmt::skip]            // Keep public re-exports separate.
 #[doc(inline)]
-pub use crate::hash_types::{Ntxid, Txid, Wtxid, BlockHashDecoder, BlockHashDecoderError, TxMerkleNodeDecoder, TxMerkleNodeDecoderError};
+pub use crate::hash_types::{Ntxid, Txid, Wtxid, BlockHashDecoder, TxMerkleNodeDecoder, TxMerkleNodeDecoderError};
+#[doc(no_inline)]
+pub use crate::hash_types::BlockHashDecoderError;
 
 /// Bitcoin transaction.
 ///


### PR DESCRIPTION
Error re-exports in bitcoin and primitives should use #[doc(no_inline)] to ensure that pure re-export types are rendered as re-exports and not defined types of the module in docs.

Use #[doc(no_inline)] for BlockHashDecoderError in primitives and PushBytesError, ParseTransactionError, and ParseOutPointError in bitcoin.

Contributes to #5304