### PR TITLE
hashes: use to_le_bytes() in KeccakState

### DIFF
--- a/hashes/src/sha3_256/mod.rs
+++ b/hashes/src/sha3_256/mod.rs
@@ -85,7 +85,7 @@ impl fmt::Debug for KeccakState {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for y in 0..B {
             for x in 0..B {
-                writeln!(f, "[{},{}]: {:016x}", x, y, self.lane(x, y).to_le())?;
+                writeln!(f, "[{},{}]: {:02x?}", x, y, self.lane(x, y).to_le_bytes())?;
             }
         }
         Ok(())


### PR DESCRIPTION
Since #627 we moved away from using `to_le()` because it behaves differently depending on the target architecture (it's a no-op on LE systems but swaps bytes on BE systems)

use `to_le_bytes()` instead since it's architecture-independent