### PR TITLE
primitives: Improve test coverage of ParsePrimitiveError

### DIFF
--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -257,3 +257,55 @@ pub(crate) mod hex_codec {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "alloc")]
+    use alloc::{format, string::ToString};
+
+    #[cfg(feature = "alloc")]
+    use super::*;
+
+    #[test]
+    #[cfg(all(feature = "alloc", feature = "hex"))]
+    fn parse_primitive_error_display() {
+        let odd: ParsePrimitiveError<block::Header> =
+            hex_codec::HexPrimitive::from_str("0").unwrap_err();
+        let invalid: ParsePrimitiveError<block::Header> =
+            hex_codec::HexPrimitive::from_str("zz").unwrap_err();
+        let decode: ParsePrimitiveError<block::Header> =
+            hex_codec::HexPrimitive::from_str("00").unwrap_err();
+
+        assert!(!odd.to_string().is_empty());
+        assert!(!invalid.to_string().is_empty());
+        assert!(!decode.to_string().is_empty());
+    }
+
+    #[test]
+    #[cfg(all(feature = "hex", feature = "std"))]
+    fn parse_primitive_error_source() {
+        use std::error::Error as _;
+
+        let odd: ParsePrimitiveError<block::Header> =
+            hex_codec::HexPrimitive::from_str("0").unwrap_err();
+        let invalid: ParsePrimitiveError<block::Header> =
+            hex_codec::HexPrimitive::from_str("zz").unwrap_err();
+        let decode: ParsePrimitiveError<block::Header> =
+            hex_codec::HexPrimitive::from_str("00").unwrap_err();
+
+        assert!(odd.source().is_some());
+        assert!(invalid.source().is_some());
+        assert!(decode.source().is_none());
+    }
+
+    #[test]
+    #[cfg(all(feature = "alloc", feature = "hex"))]
+    fn hex_primitive_iter_and_debug() {
+        let header: block::Header =
+            encoding::decode_from_slice(&[0u8; block::Header::SIZE]).expect("valid header");
+        let hex = hex_codec::HexPrimitive(&header);
+
+        assert_eq!((&hex).into_iter().next(), Some(0u8));
+        assert!(!format!("{hex:?}").is_empty());
+    }
+}


### PR DESCRIPTION
Add tests for Display and Error implementations of ParsePrimitiveError to increase the test coverage of lib.rs to 100%.