### PR TITLE
test(pow): verify MAX_ATTAINABLE_REGTEST value

### DIFF
--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -2015,6 +2015,27 @@ mod tests {
     }
 
     #[test]
+    fn target_max_attainable_hex() {
+        // Also check explicit hex representations for regression testing.
+        assert_eq!(
+            format!("{:x}", Target::MAX_ATTAINABLE_MAINNET),
+            "00000000ffff0000000000000000000000000000000000000000000000000000"
+        );
+        assert_eq!(
+            format!("{:x}", Target::MAX_ATTAINABLE_TESTNET),
+            "00000000ffff0000000000000000000000000000000000000000000000000000"
+        );
+        assert_eq!(
+            format!("{:x}", Target::MAX_ATTAINABLE_REGTEST),
+            "7fffff0000000000000000000000000000000000000000000000000000000000"
+        );
+        assert_eq!(
+            format!("{:x}", Target::MAX_ATTAINABLE_SIGNET),
+            "00000377ae000000000000000000000000000000000000000000000000000000"
+        );
+    }
+
+    #[test]
     fn target_difficulty_float() {
         let params = Params::new(crate::Network::Bitcoin);
 


### PR DESCRIPTION
Add test_max_attainable_regtest to verify the constant against its expected hex representation.

Target::MAX_ATTAINABLE_REGTEST involves complex bitshifts and currently lacks a direct assertion. cargo-mutants identified a surviving mutant where << was replaced by >>. This test kills the mutant and ensures the constant remains stable.