### PR TITLE
ci: add fix-locks recipe to justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -62,6 +62,10 @@ check-api:
 @query-api crate command:
  {{justfile_directory()}}/contrib/api.sh $1 $2
 
+# Update the lockfiles and check the API is correct.
+[group('scripts')]
+fix-locks: update-lock-files check-api
+
 # Update the recent and minimal lock files.
 [group('scripts')]
 update-lock-files:


### PR DESCRIPTION
Add fix-locks recipe to automate update-lock-files followed by check-api.

This ensures a consistent state before submission, preventing common CI failures caused by out-of-sync lockfiles or stale API definitions.

Verified locally with just fix-locks.