### PR TITLE
Scrub `BlockHash` encoding code

### DIFF
--- a/primitives/src/hash_types/block_hash.rs
+++ b/primitives/src/hash_types/block_hash.rs
@@ -37,6 +37,7 @@ encoding::encoder_newtype_exact! {
 
 impl encoding::Encodable for BlockHash {
     type Encoder<'e> = BlockHashEncoder<'e>;
+    #[inline]
     fn encoder(&self) -> Self::Encoder<'_> {
         BlockHashEncoder::new(encoding::ArrayRefEncoder::without_length_prefix(self.as_byte_array()))
     }
@@ -44,6 +45,7 @@ impl encoding::Encodable for BlockHash {
 
 impl encoding::Decodable for BlockHash {
     type Decoder = BlockHashDecoder;
+    #[inline]
     fn decoder() -> Self::Decoder { BlockHashDecoder(encoding::ArrayDecoder::<32>::new()) }
 }
 
@@ -52,10 +54,12 @@ pub struct BlockHashDecoder(encoding::ArrayDecoder<32>);
 
 impl BlockHashDecoder {
     /// Constructs a new [`BlockHash`] decoder.
+    #[inline]
     pub const fn new() -> Self { Self(encoding::ArrayDecoder::new()) }
 }
 
 impl Default for BlockHashDecoder {
+    #[inline]
     fn default() -> Self { Self::new() }
 }
 


### PR DESCRIPTION
In an effort to iron out a template for #5582 scrub clean the `BlockHash` code. Everything in this PR is up for discussion, bike shed like its your job.

To review I suggest opening `primitives/src/hash_types/block_hash.rs` and reviewing everything below 

    `include!("./generic.rs");`. 

Please review carefully because this PR introduces coding style policy.

### Open question

- Are we happy with the use of `encoding::` pre-fix on the `consensus_encoding` types e.g, `encoding::ArrayEncoder` (Question excludes traits. I claim in this PR that one level of path is better for traits.)
