### PR TITLE
impl TryFrom<&str> for AddressType

### DIFF
--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -121,6 +121,13 @@ impl FromStr for AddressType {
         }
     }
 }
+impl TryFrom<&str> for AddressType {
+    type Error = UnknownAddressTypeError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        core::str::FromStr::from_str(s)
+    }
+}
 
 mod sealed {
     pub trait NetworkValidation {}


### PR DESCRIPTION
Resolves: #1802

This PR implements `TryFrom<&str>` for `AddressType`, as requested in issue #1802.

Currently, `AddressType` implements `FromStr` but lacks the corresponding `TryFrom` implementation. This addition brings consistency to the API and allows parsing address types from string slices without needing to allocate a `String` first.

Verified with `cargo check -p bitcoin`.