### PR TITLE
hashes: Add `cpufeatures` for no_std SIMD detection

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -186,6 +186,7 @@ version = "0.19.0"
 dependencies = [
  "bitcoin-consensus-encoding",
  "bitcoin-internals",
+ "cpufeatures",
  "hex-conservative 0.3.0",
  "serde",
  "serde_test",
@@ -229,6 +230,15 @@ name = "chacha20-poly1305"
 version = "0.1.2"
 dependencies = [
  "hex-conservative 0.3.0",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -185,6 +185,7 @@ version = "0.19.0"
 dependencies = [
  "bitcoin-consensus-encoding",
  "bitcoin-internals",
+ "cpufeatures",
  "hex-conservative 0.3.0",
  "serde",
  "serde_test",
@@ -225,6 +226,15 @@ name = "chacha20-poly1305"
 version = "0.1.2"
 dependencies = [
  "hex-conservative 0.3.0",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -27,6 +27,7 @@ encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encodi
 
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false, optional = true }
 serde = { version = "1.0.195", default-features = false, optional = true }
+cpufeatures = { version = "0.2", optional = true }
 
 [dev-dependencies]
 serde_test = "1.0.19"

--- a/hashes/src/sha256/crypto.rs
+++ b/hashes/src/sha256/crypto.rs
@@ -1,15 +1,32 @@
 // SPDX-License-Identifier: CC0-1.0
 
-#[cfg(all(feature = "std", target_arch = "aarch64"))]
-use core::arch::aarch64::*;
-#[cfg(all(feature = "std", target_arch = "x86"))]
+#[cfg(all(target_arch = "x86", any(feature = "std", feature = "cpufeatures")))]
 use core::arch::x86::*;
-#[cfg(all(feature = "std", target_arch = "x86_64"))]
+#[cfg(all(target_arch = "x86_64", any(feature = "std", feature = "cpufeatures")))]
 use core::arch::x86_64::*;
+#[cfg(all(target_arch = "aarch64", any(feature = "std", feature = "cpufeatures")))]
+use core::arch::aarch64::*;
 
 use internals::slice::SliceExt;
 
 use super::{HashEngine, Midstate, BLOCK_SIZE};
+
+#[cfg(all(feature = "cpufeatures", target_arch = "aarch64"))]
+// cpufeatures crate internally uses `u8::max_value()` which will be deprecated.
+// See: https://docs.rs/cpufeatures/0.2.17/src/cpufeatures/lib.rs.html#161
+#[allow(deprecated_in_future)]
+mod cpuid_sha256_aarch64 {
+    cpufeatures::new!(inner, "sha2");
+    pub fn get() -> bool { inner::get() }
+}
+#[cfg(all(feature = "cpufeatures", any(target_arch = "x86", target_arch = "x86_64")))]
+// cpufeatures crate internally uses `u8::max_value()` which will be deprecated.
+// See: https://docs.rs/cpufeatures/0.2.17/src/cpufeatures/lib.rs.html#161
+#[allow(deprecated_in_future)]
+mod cpuid_sha256_x86 {
+    cpufeatures::new!(inner, "sha", "sse2", "ssse3", "sse4.1");
+    pub fn get() -> bool { inner::get() }
+}
 
 #[allow(non_snake_case)]
 const fn Ch(x: u32, y: u32, z: u32) -> u32 { z ^ (x & (y ^ z)) }
@@ -262,9 +279,24 @@ impl HashEngine {
             }
         }
 
+        #[cfg(all(feature = "cpufeatures", any(target_arch = "x86", target_arch = "x86_64")))]
+        {
+            if cpuid_sha256_x86::get() {
+                return unsafe { self.process_block_simd_x86_intrinsics() };
+            }
+        }
+
+
         #[cfg(all(feature = "std", target_arch = "aarch64"))]
         {
             if std::arch::is_aarch64_feature_detected!("sha2") {
+                return unsafe { self.process_block_simd_arm_intrinsics() };
+            }
+        }
+
+        #[cfg(all(feature = "cpufeatures", target_arch = "aarch64"))]
+        {
+            if cpuid_sha256_aarch64::get() {
                 return unsafe { self.process_block_simd_arm_intrinsics() };
             }
         }
@@ -273,7 +305,7 @@ impl HashEngine {
         self.software_process_block()
     }
 
-    #[cfg(all(feature = "std", any(target_arch = "x86", target_arch = "x86_64")))]
+    #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), any(feature = "std", feature = "cpufeatures")))]
     #[target_feature(enable = "sha,sse2,ssse3,sse4.1")]
     unsafe fn process_block_simd_x86_intrinsics(&mut self) {
         // Code translated and based on from
@@ -532,7 +564,7 @@ impl HashEngine {
         _mm_storeu_si128(self.h.as_mut_ptr().add(4).cast::<__m128i>(), state1);
     }
 
-    #[cfg(all(feature = "std", target_arch = "aarch64"))]
+    #[cfg(all(target_arch = "aarch64", any(feature = "std", feature = "cpufeatures")))]
     #[target_feature(enable = "sha2")]
     unsafe fn process_block_simd_arm_intrinsics(&mut self) {
         // Code translated and based on from


### PR DESCRIPTION
Currently SIMD requires `std` because we use `is_x86_feature_detected!` and `is_aarch64_feature_detected!` macros for runtime CPU feature detection. This means `no_std` users cannot benefit from the performance boost provided by hardware SHA extensions.

This adds `cpufeatures` crate as an optional dependency. When enabled, it provides runtime CPU feature detection in `no_std` environments for both x86/x86_64 and aarch64.

Discussed in https://github.com/rust-bitcoin/rust-bitcoin/issues/5568#issuecomment-3816450830