### PR TITLE
Add Copy, Ord, and Hash traits to ChaCha20-Poly1305 structures

### DIFF
--- a/chacha20_poly1305/src/chacha20.rs
+++ b/chacha20_poly1305/src/chacha20.rs
@@ -14,7 +14,7 @@ const WORD_4: u32 = 0x6b206574;
 const CHACHA_BLOCKSIZE: usize = 64;
 
 /// A 256-bit secret key shared by the parties communicating.
-#[derive(Clone, Copy)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Key([u8; 32]);
 
 impl Key {
@@ -23,7 +23,7 @@ impl Key {
 }
 
 /// A 96-bit initialization vector (IV), or nonce.
-#[derive(Clone, Copy)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Nonce([u8; 12]);
 
 impl Nonce {
@@ -64,7 +64,7 @@ impl UpTo3<3> for () {}
 /// In the future, a "blacklist" for the alignment option might be useful to
 /// disable it on architectures which definitely do not support SIMD in order to avoid
 /// needless memory inefficiencies.
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 struct U32x4([u32; 4]);
 
 impl U32x4 {
@@ -143,7 +143,7 @@ impl BitXor for U32x4 {
 ///   4   5   6   7
 ///   8   9  10  11
 ///  12  13  14  15
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 struct State {
     matrix: [U32x4; 4],
 }
@@ -252,6 +252,7 @@ impl State {
 ///
 /// The 20-round IETF version uses a 96-bit nonce and 32-bit block counter. This is the
 /// variant used in the Bitcoin ecosystem, including BIP-0324.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChaCha20 {
     /// Secret key shared by the parties communicating.
     key: Key,

--- a/chacha20_poly1305/src/lib.rs
+++ b/chacha20_poly1305/src/lib.rs
@@ -58,6 +58,7 @@ impl std::error::Error for Error {
 }
 
 /// Encrypt and decrypt content along with an authentication tag.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChaCha20Poly1305 {
     key: Key,
     nonce: Nonce,

--- a/chacha20_poly1305/src/poly1305.rs
+++ b/chacha20_poly1305/src/poly1305.rs
@@ -13,6 +13,7 @@ const CARRY: u32 = 26;
 /// Poly1305 authenticator takes a 32-byte one-time key and a message and produces a 16-byte tag.
 ///
 /// 64-bit constant time multiplication and addition implementation.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Poly1305 {
     /// r part of the secret key.
     r: [u32; 5],


### PR DESCRIPTION
In `rust-lightning`, `ChaCha20-Poly1305` encryption is being refactored from the local `ChaCha20Poly1305RFC` to the `chacha20-poly1305` crate.

Previous local implementation had support for streaming in `ChaCha20Poly1305RFC` implementations, but the `chacha20-poly1305` doesn't have implementations that supports streaming, this leads to using the `ChaCha20` and `Poly1305` primitives.

To avoid computing `Poly1305` validation twice for input and additional authenticated data, it would be cool if `Poly1305` implements `Clone`, which saves computing the MAC twice.

[Downstream PR](https://github.com/lightningdevkit/rust-lightning/pull/4360#discussion_r2748145647) 