### PR TITLE
remove From<UnexpectedEof> impls for decoder errors

### DIFF
--- a/api/primitives/all-features.txt
+++ b/api/primitives/all-features.txt
@@ -316,10 +316,6 @@ impl core::convert::From<&bitcoin_primitives::transaction::Transaction> for bitc
 impl core::convert::From<alloc::vec::Vec<&[u8]>> for bitcoin_primitives::witness::Witness
 impl core::convert::From<alloc::vec::Vec<alloc::vec::Vec<u8>>> for bitcoin_primitives::witness::Witness
 impl core::convert::From<bitcoin_consensus_encoding::decode::decoders::ByteVecDecoderError> for bitcoin_primitives::script::ScriptBufDecoderError
-impl core::convert::From<bitcoin_consensus_encoding::decode::decoders::UnexpectedEofError> for bitcoin_primitives::block::BlockHashDecoderError
-impl core::convert::From<bitcoin_consensus_encoding::decode::decoders::UnexpectedEofError> for bitcoin_primitives::block::VersionDecoderError
-impl core::convert::From<bitcoin_consensus_encoding::decode::decoders::UnexpectedEofError> for bitcoin_primitives::pow::CompactTargetDecoderError
-impl core::convert::From<bitcoin_consensus_encoding::decode::decoders::UnexpectedEofError> for bitcoin_primitives::transaction::TxMerkleNodeDecoderError
 impl core::convert::From<bitcoin_consensus_encoding::decode::decoders::VecDecoderError<bitcoin_primitives::transaction::TxInDecoderError>> for bitcoin_primitives::transaction::TransactionDecoderError
 impl core::convert::From<bitcoin_consensus_encoding::decode::decoders::VecDecoderError<bitcoin_primitives::transaction::TxOutDecoderError>> for bitcoin_primitives::transaction::TransactionDecoderError
 impl core::convert::From<bitcoin_primitives::block::Block> for bitcoin_primitives::BlockHash
@@ -1498,7 +1494,6 @@ pub fn bitcoin_primitives::block::BlockHashDecoder::read_limit(&self) -> usize
 pub fn bitcoin_primitives::block::BlockHashDecoderError::clone(&self) -> bitcoin_primitives::block::BlockHashDecoderError
 pub fn bitcoin_primitives::block::BlockHashDecoderError::eq(&self, other: &bitcoin_primitives::block::BlockHashDecoderError) -> bool
 pub fn bitcoin_primitives::block::BlockHashDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_primitives::block::BlockHashDecoderError::from(e: bitcoin_consensus_encoding::decode::decoders::UnexpectedEofError) -> Self
 pub fn bitcoin_primitives::block::BlockHashDecoderError::from(never: core::convert::Infallible) -> Self
 pub fn bitcoin_primitives::block::BlockHashDecoderError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 pub fn bitcoin_primitives::block::BlockHashEncoder::advance(&mut self) -> bool
@@ -1564,7 +1559,6 @@ pub fn bitcoin_primitives::block::VersionDecoder::read_limit(&self) -> usize
 pub fn bitcoin_primitives::block::VersionDecoderError::clone(&self) -> bitcoin_primitives::block::VersionDecoderError
 pub fn bitcoin_primitives::block::VersionDecoderError::eq(&self, other: &bitcoin_primitives::block::VersionDecoderError) -> bool
 pub fn bitcoin_primitives::block::VersionDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_primitives::block::VersionDecoderError::from(e: bitcoin_consensus_encoding::decode::decoders::UnexpectedEofError) -> Self
 pub fn bitcoin_primitives::block::VersionDecoderError::from(never: core::convert::Infallible) -> Self
 pub fn bitcoin_primitives::block::VersionDecoderError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 pub fn bitcoin_primitives::block::VersionEncoder::advance(&mut self) -> bool
@@ -1594,7 +1588,6 @@ pub fn bitcoin_primitives::pow::CompactTargetDecoder::read_limit(&self) -> usize
 pub fn bitcoin_primitives::pow::CompactTargetDecoderError::clone(&self) -> bitcoin_primitives::pow::CompactTargetDecoderError
 pub fn bitcoin_primitives::pow::CompactTargetDecoderError::eq(&self, other: &bitcoin_primitives::pow::CompactTargetDecoderError) -> bool
 pub fn bitcoin_primitives::pow::CompactTargetDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_primitives::pow::CompactTargetDecoderError::from(e: bitcoin_consensus_encoding::decode::decoders::UnexpectedEofError) -> Self
 pub fn bitcoin_primitives::pow::CompactTargetDecoderError::from(never: core::convert::Infallible) -> Self
 pub fn bitcoin_primitives::pow::CompactTargetDecoderError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 pub fn bitcoin_primitives::pow::CompactTargetEncoder::advance(&mut self) -> bool
@@ -1832,7 +1825,6 @@ pub fn bitcoin_primitives::transaction::TxMerkleNodeDecoder::read_limit(&self) -
 pub fn bitcoin_primitives::transaction::TxMerkleNodeDecoderError::clone(&self) -> bitcoin_primitives::transaction::TxMerkleNodeDecoderError
 pub fn bitcoin_primitives::transaction::TxMerkleNodeDecoderError::eq(&self, other: &bitcoin_primitives::transaction::TxMerkleNodeDecoderError) -> bool
 pub fn bitcoin_primitives::transaction::TxMerkleNodeDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_primitives::transaction::TxMerkleNodeDecoderError::from(e: bitcoin_consensus_encoding::decode::decoders::UnexpectedEofError) -> Self
 pub fn bitcoin_primitives::transaction::TxMerkleNodeDecoderError::from(never: core::convert::Infallible) -> Self
 pub fn bitcoin_primitives::transaction::TxMerkleNodeDecoderError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 pub fn bitcoin_primitives::transaction::TxOut::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>

--- a/api/primitives/alloc-only.txt
+++ b/api/primitives/alloc-only.txt
@@ -312,10 +312,6 @@ impl core::convert::From<&bitcoin_primitives::transaction::Transaction> for bitc
 impl core::convert::From<alloc::vec::Vec<&[u8]>> for bitcoin_primitives::witness::Witness
 impl core::convert::From<alloc::vec::Vec<alloc::vec::Vec<u8>>> for bitcoin_primitives::witness::Witness
 impl core::convert::From<bitcoin_consensus_encoding::decode::decoders::ByteVecDecoderError> for bitcoin_primitives::script::ScriptBufDecoderError
-impl core::convert::From<bitcoin_consensus_encoding::decode::decoders::UnexpectedEofError> for bitcoin_primitives::block::BlockHashDecoderError
-impl core::convert::From<bitcoin_consensus_encoding::decode::decoders::UnexpectedEofError> for bitcoin_primitives::block::VersionDecoderError
-impl core::convert::From<bitcoin_consensus_encoding::decode::decoders::UnexpectedEofError> for bitcoin_primitives::pow::CompactTargetDecoderError
-impl core::convert::From<bitcoin_consensus_encoding::decode::decoders::UnexpectedEofError> for bitcoin_primitives::transaction::TxMerkleNodeDecoderError
 impl core::convert::From<bitcoin_consensus_encoding::decode::decoders::VecDecoderError<bitcoin_primitives::transaction::TxInDecoderError>> for bitcoin_primitives::transaction::TransactionDecoderError
 impl core::convert::From<bitcoin_consensus_encoding::decode::decoders::VecDecoderError<bitcoin_primitives::transaction::TxOutDecoderError>> for bitcoin_primitives::transaction::TransactionDecoderError
 impl core::convert::From<bitcoin_primitives::block::Block> for bitcoin_primitives::BlockHash
@@ -1308,7 +1304,6 @@ pub fn bitcoin_primitives::block::BlockHashDecoder::read_limit(&self) -> usize
 pub fn bitcoin_primitives::block::BlockHashDecoderError::clone(&self) -> bitcoin_primitives::block::BlockHashDecoderError
 pub fn bitcoin_primitives::block::BlockHashDecoderError::eq(&self, other: &bitcoin_primitives::block::BlockHashDecoderError) -> bool
 pub fn bitcoin_primitives::block::BlockHashDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_primitives::block::BlockHashDecoderError::from(e: bitcoin_consensus_encoding::decode::decoders::UnexpectedEofError) -> Self
 pub fn bitcoin_primitives::block::BlockHashDecoderError::from(never: core::convert::Infallible) -> Self
 pub fn bitcoin_primitives::block::BlockHashEncoder::advance(&mut self) -> bool
 pub fn bitcoin_primitives::block::BlockHashEncoder::current_chunk(&self) -> &[u8]
@@ -1365,7 +1360,6 @@ pub fn bitcoin_primitives::block::VersionDecoder::read_limit(&self) -> usize
 pub fn bitcoin_primitives::block::VersionDecoderError::clone(&self) -> bitcoin_primitives::block::VersionDecoderError
 pub fn bitcoin_primitives::block::VersionDecoderError::eq(&self, other: &bitcoin_primitives::block::VersionDecoderError) -> bool
 pub fn bitcoin_primitives::block::VersionDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_primitives::block::VersionDecoderError::from(e: bitcoin_consensus_encoding::decode::decoders::UnexpectedEofError) -> Self
 pub fn bitcoin_primitives::block::VersionDecoderError::from(never: core::convert::Infallible) -> Self
 pub fn bitcoin_primitives::block::VersionEncoder::advance(&mut self) -> bool
 pub fn bitcoin_primitives::block::VersionEncoder::current_chunk(&self) -> &[u8]
@@ -1392,7 +1386,6 @@ pub fn bitcoin_primitives::pow::CompactTargetDecoder::read_limit(&self) -> usize
 pub fn bitcoin_primitives::pow::CompactTargetDecoderError::clone(&self) -> bitcoin_primitives::pow::CompactTargetDecoderError
 pub fn bitcoin_primitives::pow::CompactTargetDecoderError::eq(&self, other: &bitcoin_primitives::pow::CompactTargetDecoderError) -> bool
 pub fn bitcoin_primitives::pow::CompactTargetDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_primitives::pow::CompactTargetDecoderError::from(e: bitcoin_consensus_encoding::decode::decoders::UnexpectedEofError) -> Self
 pub fn bitcoin_primitives::pow::CompactTargetDecoderError::from(never: core::convert::Infallible) -> Self
 pub fn bitcoin_primitives::pow::CompactTargetEncoder::advance(&mut self) -> bool
 pub fn bitcoin_primitives::pow::CompactTargetEncoder::current_chunk(&self) -> &[u8]
@@ -1597,7 +1590,6 @@ pub fn bitcoin_primitives::transaction::TxMerkleNodeDecoder::read_limit(&self) -
 pub fn bitcoin_primitives::transaction::TxMerkleNodeDecoderError::clone(&self) -> bitcoin_primitives::transaction::TxMerkleNodeDecoderError
 pub fn bitcoin_primitives::transaction::TxMerkleNodeDecoderError::eq(&self, other: &bitcoin_primitives::transaction::TxMerkleNodeDecoderError) -> bool
 pub fn bitcoin_primitives::transaction::TxMerkleNodeDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_primitives::transaction::TxMerkleNodeDecoderError::from(e: bitcoin_consensus_encoding::decode::decoders::UnexpectedEofError) -> Self
 pub fn bitcoin_primitives::transaction::TxMerkleNodeDecoderError::from(never: core::convert::Infallible) -> Self
 pub fn bitcoin_primitives::transaction::TxOut::clone(&self) -> bitcoin_primitives::transaction::TxOut
 pub fn bitcoin_primitives::transaction::TxOut::cmp(&self, other: &bitcoin_primitives::transaction::TxOut) -> core::cmp::Ordering

--- a/api/primitives/no-features.txt
+++ b/api/primitives/no-features.txt
@@ -156,10 +156,6 @@ impl core::convert::AsRef<[u8]> for bitcoin_primitives::WitnessCommitment
 impl core::convert::AsRef<[u8]> for bitcoin_primitives::WitnessMerkleNode
 impl core::convert::AsRef<[u8]> for bitcoin_primitives::Wtxid
 impl core::convert::From<&bitcoin_primitives::block::Header> for bitcoin_primitives::BlockHash
-impl core::convert::From<bitcoin_consensus_encoding::decode::decoders::UnexpectedEofError> for bitcoin_primitives::block::BlockHashDecoderError
-impl core::convert::From<bitcoin_consensus_encoding::decode::decoders::UnexpectedEofError> for bitcoin_primitives::block::VersionDecoderError
-impl core::convert::From<bitcoin_consensus_encoding::decode::decoders::UnexpectedEofError> for bitcoin_primitives::pow::CompactTargetDecoderError
-impl core::convert::From<bitcoin_consensus_encoding::decode::decoders::UnexpectedEofError> for bitcoin_primitives::transaction::TxMerkleNodeDecoderError
 impl core::convert::From<bitcoin_primitives::block::Header> for bitcoin_primitives::BlockHash
 impl core::convert::From<bitcoin_primitives::transaction::Version> for u32
 impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::block::BlockHashDecoderError
@@ -584,7 +580,6 @@ pub fn bitcoin_primitives::block::BlockHashDecoder::read_limit(&self) -> usize
 pub fn bitcoin_primitives::block::BlockHashDecoderError::clone(&self) -> bitcoin_primitives::block::BlockHashDecoderError
 pub fn bitcoin_primitives::block::BlockHashDecoderError::eq(&self, other: &bitcoin_primitives::block::BlockHashDecoderError) -> bool
 pub fn bitcoin_primitives::block::BlockHashDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_primitives::block::BlockHashDecoderError::from(e: bitcoin_consensus_encoding::decode::decoders::UnexpectedEofError) -> Self
 pub fn bitcoin_primitives::block::BlockHashDecoderError::from(never: core::convert::Infallible) -> Self
 pub fn bitcoin_primitives::block::BlockHashEncoder::advance(&mut self) -> bool
 pub fn bitcoin_primitives::block::BlockHashEncoder::current_chunk(&self) -> &[u8]
@@ -617,7 +612,6 @@ pub fn bitcoin_primitives::block::VersionDecoder::read_limit(&self) -> usize
 pub fn bitcoin_primitives::block::VersionDecoderError::clone(&self) -> bitcoin_primitives::block::VersionDecoderError
 pub fn bitcoin_primitives::block::VersionDecoderError::eq(&self, other: &bitcoin_primitives::block::VersionDecoderError) -> bool
 pub fn bitcoin_primitives::block::VersionDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_primitives::block::VersionDecoderError::from(e: bitcoin_consensus_encoding::decode::decoders::UnexpectedEofError) -> Self
 pub fn bitcoin_primitives::block::VersionDecoderError::from(never: core::convert::Infallible) -> Self
 pub fn bitcoin_primitives::block::VersionEncoder::advance(&mut self) -> bool
 pub fn bitcoin_primitives::block::VersionEncoder::current_chunk(&self) -> &[u8]
@@ -641,7 +635,6 @@ pub fn bitcoin_primitives::pow::CompactTargetDecoder::read_limit(&self) -> usize
 pub fn bitcoin_primitives::pow::CompactTargetDecoderError::clone(&self) -> bitcoin_primitives::pow::CompactTargetDecoderError
 pub fn bitcoin_primitives::pow::CompactTargetDecoderError::eq(&self, other: &bitcoin_primitives::pow::CompactTargetDecoderError) -> bool
 pub fn bitcoin_primitives::pow::CompactTargetDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_primitives::pow::CompactTargetDecoderError::from(e: bitcoin_consensus_encoding::decode::decoders::UnexpectedEofError) -> Self
 pub fn bitcoin_primitives::pow::CompactTargetDecoderError::from(never: core::convert::Infallible) -> Self
 pub fn bitcoin_primitives::pow::CompactTargetEncoder::advance(&mut self) -> bool
 pub fn bitcoin_primitives::pow::CompactTargetEncoder::current_chunk(&self) -> &[u8]
@@ -671,7 +664,6 @@ pub fn bitcoin_primitives::transaction::TxMerkleNodeDecoder::read_limit(&self) -
 pub fn bitcoin_primitives::transaction::TxMerkleNodeDecoderError::clone(&self) -> bitcoin_primitives::transaction::TxMerkleNodeDecoderError
 pub fn bitcoin_primitives::transaction::TxMerkleNodeDecoderError::eq(&self, other: &bitcoin_primitives::transaction::TxMerkleNodeDecoderError) -> bool
 pub fn bitcoin_primitives::transaction::TxMerkleNodeDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn bitcoin_primitives::transaction::TxMerkleNodeDecoderError::from(e: bitcoin_consensus_encoding::decode::decoders::UnexpectedEofError) -> Self
 pub fn bitcoin_primitives::transaction::TxMerkleNodeDecoderError::from(never: core::convert::Infallible) -> Self
 pub fn bitcoin_primitives::transaction::Version::clone(&self) -> bitcoin_primitives::transaction::Version
 pub fn bitcoin_primitives::transaction::Version::cmp(&self, other: &bitcoin_primitives::transaction::Version) -> core::cmp::Ordering

--- a/primitives/CHANGELOG.md
+++ b/primitives/CHANGELOG.md
@@ -1,3 +1,6 @@
+# TBD
+- Remove `From<UnexpectedEof>` for primitive decoder error types [#5606](https://github.com/rust-bitcoin/rust-bitcoin/pull/5606)
+
 # 1.0.0 - 2025-10-18
 
 This changelog is a rolling description of everything that will eventually end up in `v1.0`.

--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -837,12 +837,12 @@ impl encoding::Decoder for VersionDecoder {
 
     #[inline]
     fn push_bytes(&mut self, bytes: &mut &[u8]) -> Result<bool, Self::Error> {
-        Ok(self.0.push_bytes(bytes)?)
+        self.0.push_bytes(bytes).map_err(VersionDecoderError)
     }
 
     #[inline]
     fn end(self) -> Result<Self::Output, Self::Error> {
-        let n = i32::from_le_bytes(self.0.end()?);
+        let n = i32::from_le_bytes(self.0.end().map_err(VersionDecoderError)?);
         Ok(Version::from_consensus(n))
     }
 
@@ -861,10 +861,6 @@ pub struct VersionDecoderError(encoding::UnexpectedEofError);
 
 impl From<Infallible> for VersionDecoderError {
     fn from(never: Infallible) -> Self { match never {} }
-}
-
-impl From<encoding::UnexpectedEofError> for VersionDecoderError {
-    fn from(e: encoding::UnexpectedEofError) -> Self { Self(e) }
 }
 
 impl fmt::Display for VersionDecoderError {

--- a/primitives/src/hash_types/block_hash.rs
+++ b/primitives/src/hash_types/block_hash.rs
@@ -59,12 +59,12 @@ impl encoding::Decoder for BlockHashDecoder {
 
     #[inline]
     fn push_bytes(&mut self, bytes: &mut &[u8]) -> Result<bool, Self::Error> {
-        Ok(self.0.push_bytes(bytes)?)
+        self.0.push_bytes(bytes).map_err(BlockHashDecoderError)
     }
 
     #[inline]
     fn end(self) -> Result<Self::Output, Self::Error> {
-        let a = self.0.end()?;
+        let a = self.0.end().map_err(BlockHashDecoderError)?;
         Ok(BlockHash::from_byte_array(a))
     }
 
@@ -83,10 +83,6 @@ pub struct BlockHashDecoderError(encoding::UnexpectedEofError);
 
 impl From<Infallible> for BlockHashDecoderError {
     fn from(never: Infallible) -> Self { match never {} }
-}
-
-impl From<encoding::UnexpectedEofError> for BlockHashDecoderError {
-    fn from(e: encoding::UnexpectedEofError) -> Self { Self(e) }
 }
 
 impl fmt::Display for BlockHashDecoderError {

--- a/primitives/src/hash_types/transaction_merkle_node.rs
+++ b/primitives/src/hash_types/transaction_merkle_node.rs
@@ -78,12 +78,12 @@ impl encoding::Decoder for TxMerkleNodeDecoder {
 
     #[inline]
     fn push_bytes(&mut self, bytes: &mut &[u8]) -> Result<bool, Self::Error> {
-        Ok(self.0.push_bytes(bytes)?)
+        self.0.push_bytes(bytes).map_err(TxMerkleNodeDecoderError)
     }
 
     #[inline]
     fn end(self) -> Result<Self::Output, Self::Error> {
-        let a = self.0.end()?;
+        let a = self.0.end().map_err(TxMerkleNodeDecoderError)?;
         Ok(TxMerkleNode::from_byte_array(a))
     }
 
@@ -102,10 +102,6 @@ pub struct TxMerkleNodeDecoderError(encoding::UnexpectedEofError);
 
 impl From<Infallible> for TxMerkleNodeDecoderError {
     fn from(never: Infallible) -> Self { match never {} }
-}
-
-impl From<encoding::UnexpectedEofError> for TxMerkleNodeDecoderError {
-    fn from(e: encoding::UnexpectedEofError) -> Self { Self(e) }
 }
 
 impl fmt::Display for TxMerkleNodeDecoderError {

--- a/primitives/src/hash_types/witness_merkle_node.rs
+++ b/primitives/src/hash_types/witness_merkle_node.rs
@@ -80,12 +80,12 @@ impl encoding::Decoder for WitnessMerkleNodeDecoder {
 
     #[inline]
     fn push_bytes(&mut self, bytes: &mut &[u8]) -> Result<bool, Self::Error> {
-        Ok(self.0.push_bytes(bytes)?)
+        self.0.push_bytes(bytes).map_err(WitnessMerkleNodeDecoderError)
     }
 
     #[inline]
     fn end(self) -> Result<Self::Output, Self::Error> {
-        let a = self.0.end()?;
+        let a = self.0.end().map_err(WitnessMerkleNodeDecoderError)?;
         Ok(WitnessMerkleNode::from_byte_array(a))
     }
 
@@ -104,10 +104,6 @@ pub struct WitnessMerkleNodeDecoderError(encoding::UnexpectedEofError);
 
 impl From<Infallible> for WitnessMerkleNodeDecoderError {
     fn from(never: Infallible) -> Self { match never {} }
-}
-
-impl From<encoding::UnexpectedEofError> for WitnessMerkleNodeDecoderError {
-    fn from(e: encoding::UnexpectedEofError) -> Self { Self(e) }
 }
 
 impl fmt::Display for WitnessMerkleNodeDecoderError {

--- a/primitives/src/pow.rs
+++ b/primitives/src/pow.rs
@@ -83,12 +83,12 @@ impl encoding::Decoder for CompactTargetDecoder {
 
     #[inline]
     fn push_bytes(&mut self, bytes: &mut &[u8]) -> Result<bool, Self::Error> {
-        Ok(self.0.push_bytes(bytes)?)
+        self.0.push_bytes(bytes).map_err(CompactTargetDecoderError)
     }
 
     #[inline]
     fn end(self) -> Result<Self::Output, Self::Error> {
-        let n = u32::from_le_bytes(self.0.end()?);
+        let n = u32::from_le_bytes(self.0.end().map_err(CompactTargetDecoderError)?);
         Ok(CompactTarget::from_consensus(n))
     }
 
@@ -107,10 +107,6 @@ pub struct CompactTargetDecoderError(encoding::UnexpectedEofError);
 
 impl From<Infallible> for CompactTargetDecoderError {
     fn from(never: Infallible) -> Self { match never {} }
-}
-
-impl From<encoding::UnexpectedEofError> for CompactTargetDecoderError {
-    fn from(e: encoding::UnexpectedEofError) -> Self { Self(e) }
 }
 
 impl fmt::Display for CompactTargetDecoderError {


### PR DESCRIPTION
## Description

This PR removes the `From<UnexpectedEof>` implementations for several decoder error types in the `primitives` crate. These have been replaced with `.map_err()` calls.

### Context
> In general `From<Foo>` impls are risky because they put `Foo` into the public API which means we cannot modify it in a breaking way.
> 
> Specifically in this case the problem is that for an EOF coming from a composite decoder we may, at some future date, want to differentiate between the different sources but because of the `From` we cannot do so without breaking the API.
> 
> Perhaps we should use `map` and remove the `From` for all decoders codebase wide.
> 
> ref: [#5466 (comment)](https://github.com/rust-bitcoin/rust-bitcoin/pull/5466#issuecomment-3705675827)

## Changes

The following decoder error types no longer implement `From<UnexpectedEof>`:
| Error Type | Location |
| :--- | :--- |
| `VersionDecoderError` | `primitives/src/block.rs` |
| `BlockHashDecoderError` | `primitives/src/hash_types/block_hash.rs` |
| `TxMerkleNodeDecoderError` | `primitives/src/hash_types/transaction_merkle_node.rs` |
| `WitnessMerkleNodeDecoderError` | `primitives/src/hash_types/witness_merkle_node.rs` |
| `CompactTargetDecoderError` | `primitives/src/pow.rs` |

closes #5562