### PR TITLE
Add note about Target maximum values

### DIFF
--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -135,6 +135,10 @@ impl Sub for Work {
 /// block to be accepted by the network. The lower the target, the more difficult it is to generate
 /// a block. (See also [`Work`].)
 ///
+/// [`Target`] does not limit its value to the maximum attainable value for any network when it
+/// is constructed. If you need to enforce that invariant, you should compare the constructed value
+/// against the required network's `MAX_ATTAINABLE_*` target constant.
+///
 /// ref: <https://en.bitcoin.it/wiki/Target>
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]


### PR DESCRIPTION
The Target type does not (and feasibly cannot) enforce a limit on the maximum value in its constructors. As such, we should document this behaviour in case it's unclear for users who expect typical behaviour.

Add note to Target struct about the lack of a maximum value invariant.

Closes #1828