### PR TITLE
Fix justfile with cargo-rbmt

### DIFF
--- a/contrib/ensure-maintainer-tools.sh
+++ b/contrib/ensure-maintainer-tools.sh
@@ -5,27 +5,12 @@
 set -euo pipefail
 
 REPO_DIR=$(git rev-parse --show-toplevel)
-MAINTAINER_TOOLS_REF=$(cat "$REPO_DIR/maintainer-tools-version")
 
 cd "$REPO_DIR"
 
-if [ ! -d ".maintainer-tools" ]; then
-    echo "Fetching maintainer tools..."
-    git clone "https://github.com/rust-bitcoin/rust-bitcoin-maintainer-tools.git" ".maintainer-tools"
-    cd ".maintainer-tools"
-    git checkout "$MAINTAINER_TOOLS_REF"
-else
-    cd ".maintainer-tools"
-    CURRENT_REF=$(git rev-parse HEAD)
-    if [ "$CURRENT_REF" != "$MAINTAINER_TOOLS_REF" ]; then
-        echo "Updating maintainer tools to $MAINTAINER_TOOLS_REF"
-        git fetch
-        git checkout "$MAINTAINER_TOOLS_REF"
-    fi
-fi
-
-if ! command -v jq >/dev/null 2>&1; then
-    echo "Error: jq is required for maintainer tools but not found in PATH" >&2
-    echo "Please install jq or ensure it's available in your environment" >&2
+if ! command -v cargo-rbmt >/dev/null 2>&1; then
+    echo "Error: cargo-rmbt is required for maintainer tools but not found in PATH" >&2
+    echo "Please ensure it's available in your environment or install cargo-rbmt using:" >&2
+    echo "cargo +stable install --git https://github.com/rust-bitcoin/rust-bitcoin-maintainer-tools.git --rev \"$(cat "$REPO_DIR/rbmt-version")\" cargo-rbmt --locked" >&2
     exit 1
 fi

--- a/justfile
+++ b/justfile
@@ -12,12 +12,11 @@ _default:
 [group('ci')]
 @ci task toolchain="stable" lock="recent":
   {{justfile_directory()}}/contrib/ensure-maintainer-tools.sh
-  cp -f {{justfile_directory()}}/Cargo-{{lock}}.lock {{justfile_directory()}}/Cargo.lock
-  MAINTAINER_TOOLS_LOG_LEVEL=quiet rustup run {{toolchain}} {{justfile_directory()}}/.maintainer-tools/ci/run_task.sh {{task}}
+  RBMT_LOG_LEVEL=quiet cargo +{{toolchain}} rbmt {{task}} --lock-file {{lock}}
 
 # Test workspace with stable toolchain.
 [group('ci')]
-ci-stable: (ci "stable")
+ci-stable: (ci "test stable")
 
 # Lint workspace.
 [group('ci')]


### PR DESCRIPTION
The new cargo-rbmt tool supplants the prior maintainer tools. For contributors using the just ci commands (like just ci-stable), the move to cargo-rbmt broke their workflow.

Fix justfile and ensure-maintainer-tools.sh to work with new cargo-rbmt tools.