### PR TITLE
hashes: Test hmac incremental input

### DIFF
--- a/hashes/src/hmac/mod.rs
+++ b/hashes/src/hmac/mod.rs
@@ -276,6 +276,14 @@ mod tests {
             let hash = engine.finalize();
             assert_eq!(hash.as_ref(), test.output);
             assert_eq!(hash.to_byte_array(), test.output);
+
+            // Hash through engine, checking that we can input byte by byte
+            let mut engine = HmacEngine::<sha256::HashEngine>::new(test.key);
+            for ch in test.input {
+                engine.input(&[*ch]);
+            }
+            let hash = engine.finalize();
+            assert_eq!(hash.to_byte_array(), test.output);
         }
     }
 


### PR DESCRIPTION
Issue https://github.com/rust-bitcoin/rust-bitcoin/issues/5601 flagged sha3-256 did not test or handle incremental input correctly.

While correcting sha3-256 behavior in PR #5604, an audit of all hashing algorithms was undertaken to check they handle and test incremental input correctly.

All algorithms passed, except hmac which handled incremental input correctly but did not test it.

Extends the hmac hashing test suite with incremental input cases.