### PR TITLE
units: Use lazy && operator

### DIFF
--- a/units/src/sequence.rs
+++ b/units/src/sequence.rs
@@ -114,13 +114,13 @@ impl Sequence {
     /// Returns `true` if the sequence number encodes a block based relative lock-time.
     #[inline]
     pub fn is_height_locked(self) -> bool {
-        self.is_relative_lock_time() & (self.0 & Self::LOCK_TYPE_MASK == 0)
+        self.is_relative_lock_time() && (self.0 & Self::LOCK_TYPE_MASK == 0)
     }
 
     /// Returns `true` if the sequence number encodes a time interval based relative lock-time.
     #[inline]
     pub fn is_time_locked(self) -> bool {
-        self.is_relative_lock_time() & (self.0 & Self::LOCK_TYPE_MASK > 0)
+        self.is_relative_lock_time() && (self.0 & Self::LOCK_TYPE_MASK > 0)
     }
 
     /// Constructs a new `Sequence` from a prefixed hex string.


### PR DESCRIPTION
> Why is this bad?
> The bitwise operators do not support short-circuiting, so it may
> hinder code performance. Additionally, boolean logic “masked” as
> bitwise logic is not caught by lints like unnecessary_fold 

ref: https://rust-lang.github.io/rust-clippy/master/index.html#needless_bitwise_bool

As suggested, use `&&`.

No logic change.