### PR TITLE
p2p: Re-export hash types

### DIFF
--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -44,7 +44,10 @@ use network::{Network, TestnetVersion};
 
 #[rustfmt::skip]
 #[doc(inline)]
-pub use self::network_ext::NetworkExt;
+pub use self::{
+    message_filter::{FilterHash, FilterHeader},
+    network_ext::NetworkExt,
+};
 
 #[cfg(feature = "std")]
 #[rustfmt::skip]


### PR DESCRIPTION
In bitcoin 0.32.8, the FilterHash and FilterHeader hash types were exported from the top level of the crate. Following the split of p2p, these types now need to be accessed inside of the module in p2p. To match the previous interface (albeit in the new crate), these should be re-exported from the top level of the p2p crate.

Re-export FilterHash and FilterHeader from the top level of the p2p crate.

Closes #5638 