### PR TITLE
Run CI pushes on LTS 0.32.x branch

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,8 +2,7 @@
 on:   # yamllint disable-line rule:truthy
   push:
     branches:
-      - master
-      - 'test-ci/**'
+      - 0.32.x
   pull_request:
 
 name: Continuous integration


### PR DESCRIPTION
Hardening the CI for the LTS branch following the strategy in https://github.com/rust-bitcoin/rust-bitcoin/discussions/5647.