### PR TITLE
Convert bip32_derivation fields to CompressedPublicKey

### DIFF
--- a/bitcoin/examples/ecdsa-psbt-simple.rs
+++ b/bitcoin/examples/ecdsa-psbt-simple.rs
@@ -186,7 +186,7 @@ fn main() {
     for (idx, pk) in pk_inputs.iter().enumerate() {
         let mut map = BTreeMap::new();
         let fingerprint = MASTER_FINGERPRINT.parse::<Fingerprint>().expect("valid fingerprint");
-        map.insert(pk.to_inner(), (fingerprint, derivation_paths[idx].clone()));
+        map.insert(*pk, (fingerprint, derivation_paths[idx].clone()));
         bip32_derivations.push(map);
     }
     psbt.inputs = vec![

--- a/bitcoin/examples/ecdsa-psbt.rs
+++ b/bitcoin/examples/ecdsa-psbt.rs
@@ -206,7 +206,7 @@ impl WatchOnly {
         let fingerprint = self.master_fingerprint;
         let path = input_derivation_path()?;
         let mut map = BTreeMap::new();
-        map.insert(pk.to_inner(), (fingerprint, path));
+        map.insert(pk, (fingerprint, path));
         input.bip32_derivation = map;
 
         let ty = "SIGHASH_ALL".parse::<PsbtSighashType>()?;

--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -13,7 +13,7 @@ use internals::slice::SliceExt;
 use super::map::{Input, Map, Output, PsbtSighashType};
 use crate::bip32::{ChildNumber, Fingerprint, KeySource};
 use crate::consensus::encode::{self, deserialize_partial, serialize, Decodable, Encodable};
-use crate::crypto::key::{PublicKey, XOnlyPublicKey};
+use crate::crypto::key::{CompressedPublicKey, PublicKey, XOnlyPublicKey};
 use crate::crypto::{ecdsa, taproot};
 use crate::io::Write;
 use crate::prelude::{DisplayHex, String, Vec};
@@ -178,6 +178,16 @@ impl Serialize for PublicKey {
 impl Deserialize for PublicKey {
     fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
         Self::from_slice(bytes).map_err(Error::InvalidPublicKey)
+    }
+}
+
+impl Serialize for CompressedPublicKey {
+    fn serialize(&self) -> Vec<u8> { self.to_bytes().to_vec() }
+}
+
+impl Deserialize for CompressedPublicKey {
+    fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
+        Self::from_slice(bytes).map_err(Error::InvalidSecp256k1PublicKey)
     }
 }
 

--- a/bitcoin/tests/bip_174.rs
+++ b/bitcoin/tests/bip_174.rs
@@ -10,8 +10,8 @@ use bitcoin::opcodes::all::OP_0;
 use bitcoin::psbt::{Psbt, PsbtSighashType};
 use bitcoin::script::{PushBytes, ScriptBuf, ScriptBufExt as _};
 use bitcoin::{
-    absolute, script, transaction, NetworkKind, OutPoint, PrivateKey, PublicKey, ScriptPubKeyBuf,
-    ScriptSigBuf, Sequence, Transaction, TxIn, TxOut, Witness,
+    absolute, script, transaction, CompressedPublicKey, NetworkKind, OutPoint, PrivateKey,
+    PublicKey, ScriptPubKeyBuf, ScriptSigBuf, Sequence, Transaction, TxIn, TxOut, Witness,
 };
 use hex_unstable::FromHex;
 
@@ -269,16 +269,16 @@ fn bip32_derivation(
     fingerprint: Fingerprint,
     pk_path: &[(&str, &str)],
     indices: Vec<usize>,
-) -> BTreeMap<secp256k1::PublicKey, KeySource> {
+) -> BTreeMap<CompressedPublicKey, KeySource> {
     let mut tree = BTreeMap::new();
     for i in indices {
         let pk = pk_path[i].0;
         let path = pk_path[i].1;
 
-        let pk = pk.parse::<PublicKey>().unwrap();
+        let pk = pk.parse::<CompressedPublicKey>().unwrap();
         let path = path.into_derivation_path().unwrap();
 
-        tree.insert(pk.to_inner(), (fingerprint, path));
+        tree.insert(pk, (fingerprint, path));
     }
     tree
 }

--- a/bitcoin/tests/serde.rs
+++ b/bitcoin/tests/serde.rs
@@ -31,9 +31,9 @@ use bitcoin::sighash::{EcdsaSighashType, TapSighashType};
 use bitcoin::taproot::{self, ControlBlock, LeafVersion, TapTree, TaprootBuilder};
 use bitcoin::witness::Witness;
 use bitcoin::{
-    ecdsa, transaction, Address, Amount, NetworkKind, OutPoint, PrivateKey, PublicKey,
-    ScriptPubKeyBuf, ScriptSigBuf, Sequence, TapScriptBuf, Target, Transaction, TxIn, TxOut, Txid,
-    Work,
+    ecdsa, transaction, Address, Amount, CompressedPublicKey, NetworkKind, OutPoint,
+    PrivateKey, PublicKey, ScriptPubKeyBuf, ScriptSigBuf, Sequence, TapScriptBuf, Target,
+    Transaction, TxIn, TxOut, Txid, Work,
 };
 use hex_unstable::FromHex;
 
@@ -227,7 +227,7 @@ fn serde_regression_psbt() {
             .into_iter()
             .collect();
     let key_source = ("deadbeef".parse().unwrap(), "0'/1".parse().unwrap());
-    let keypaths: BTreeMap<secp256k1::PublicKey, KeySource> = vec![(
+    let keypaths: BTreeMap<CompressedPublicKey, KeySource> = vec![(
         "0339880dc92394b7355e3d0439fa283c31de7590812ea011c4245c0674a685e883".parse().unwrap(),
         key_source.clone(),
     )]


### PR DESCRIPTION
The bip32_derivation fields on Input and Output currently take BTreeMaps from secp256k1::PublicKey to KeySource. Since it is trivial to construct a bitcoin CompressedPublicKey from a secp256k1 PublicKey, and since places where this field is constructed converts from the bitcoin type anyway, this field should instead use bitcoin's CompressedPublicKey as the key for the map. This also provides greater semantic meaning to the type, rather than using the secp256k1 type as an unstated compressed key.

This change also allows for many needless copies from dereferencing as_inner fields to be removed.

Convert bip32_derivation fields on Input and Output to take bitcoin CompressedPublicKey instead of secp256k1, and change all relevant tests/examples.