### PR TITLE
Create an empty `key-expression` crate

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -125,6 +125,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin-key-expression"
+version = "0.0.0"
+
+[[package]]
 name = "bitcoin-network-kind"
 version = "0.1.0"
 dependencies = [

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -124,6 +124,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin-key-expression"
+version = "0.0.0"
+
+[[package]]
 name = "bitcoin-network-kind"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["addresses", "base58", "bip158", "bitcoin", "chacha20_poly1305", "consensus_encoding", "crypto", "fuzz", "hashes", "internals", "io", "network", "p2p", "primitives", "units"]
+members = ["addresses", "base58", "bip158", "bitcoin", "chacha20_poly1305", "consensus_encoding", "crypto", "fuzz", "hashes", "internals", "io", "key_expression", "network", "p2p", "primitives", "units"]
 exclude = ["benches"]
 resolver = "2"
 

--- a/key_expression/CHANGELOG.md
+++ b/key_expression/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.0.0 - Initial dummy release
+
+- Empty crate to reserve the name on crates.io

--- a/key_expression/Cargo.toml
+++ b/key_expression/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "bitcoin-key-expression"
+version = "0.0.0"
+authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
+license = "CC0-1.0"
+repository = "https://github.com/rust-bitcoin/rust-bitcoin"
+description = "Bitcoin key expression and deterministic derivation"
+categories = ["cryptography::cryptocurrencies"]
+keywords = ["bitcoin", "peer-to-peer", "cryptography"]
+readme = "README.md"
+edition = "2021"
+rust-version = "1.74.0"
+exclude = ["tests", "contrib"]
+
+[features]
+default = ["std"]
+std = ["alloc"]
+alloc = []
+
+[dependencies]
+
+[dev-dependencies]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[lints]
+workspace = true

--- a/key_expression/README.md
+++ b/key_expression/README.md
@@ -1,0 +1,4 @@
+# Key expressions and deterministic derivation
+
+This library provides types and functionality for key expressions and deterministic key
+derivation.

--- a/key_expression/rbmt.toml
+++ b/key_expression/rbmt.toml
@@ -1,0 +1,14 @@
+# Configuration for rbmt (Rust Bitcoin Maintainer Tools)
+
+[test]
+# Examples to run with specific features enabled.
+# Format: "example_name:feature1 feature2"
+examples = []
+
+# Features to test with the conventional `std` feature enabled.
+# Tests each feature alone with std, all pairs, and all together.
+features_with_std = []
+
+# Features to test without the `std` feature.
+# Tests each feature alone, all pairs, and all together.
+features_without_std = ["alloc"]

--- a/key_expression/src/lib.rs
+++ b/key_expression/src/lib.rs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Bitcoin key expression and deterministic derivation
+//!
+//! This library provides types and functionality for key expressions and deterministic key
+//! derivation.
+
+// NB: This crate is empty if `alloc` is not enabled.
+#![cfg(feature = "alloc")]
+#![no_std]
+// Experimental features we need.
+#![doc(test(attr(warn(unused))))]
+// Coding conventions.
+#![warn(deprecated_in_future)]
+#![warn(missing_docs)]
+
+extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;


### PR DESCRIPTION
In preparation for crate smashing the bip32 module and associated functionality, create an empty crate.