### PR TITLE
Add kani verification proofs for ArrayVec, Amount,  FeeRate, and Weight

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,10 +1,12 @@
 additional_cargo_args = ["--all-features"]
 examine_globs = ["consensus_encoding/src/**/*.rs", "units/src/**/*.rs", "primitives/src/**/*.rs"]
 exclude_globs = [
-    "units/src/amount/verification.rs" # kani tests
+    "units/src/amount/verification.rs", # kani tests
+    "units/src/fee_rate/verification.rs", # kani tests
 ]
 exclude_re = [
     "impl Arbitrary",
+    "units/.* verification::check_weight_", # kani proofs
     "impl Debug",
     "impl fmt::Debug",
     ".*Error",

--- a/units/src/amount/verification.rs
+++ b/units/src/amount/verification.rs
@@ -58,3 +58,93 @@ fn s_amount_homomorphic() {
     assert_eq!(ssat(n1) + ssat(n2), ssat(n1 + n2).into());
     assert_eq!(ssat(n1) - ssat(n2), ssat(n1 - n2).into());
 }
+
+/// Verify that `checked_add` returns `None` exactly when sum > MAX_MONEY,
+/// and `Some(sum)` otherwise.
+#[kani::proof]
+fn check_amount_checked_add_boundary() {
+    let a_sat = kani::any::<u64>();
+    let b_sat = kani::any::<u64>();
+
+    kani::assume(Amount::from_sat(a_sat).is_ok());
+    kani::assume(Amount::from_sat(b_sat).is_ok());
+
+    let a = Amount::from_sat(a_sat).unwrap();
+    let b = Amount::from_sat(b_sat).unwrap();
+
+    let result = a.checked_add(b);
+    // Both inputs are <= MAX_MONEY so u64 addition cannot overflow.
+    let sum = a_sat + b_sat;
+    if sum <= Amount::MAX.to_sat() {
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().to_sat(), sum);
+    } else {
+        assert!(result.is_none());
+    }
+}
+
+/// Verify that `checked_sub` returns `None` exactly when a < b, and
+/// `Some(a - b)` otherwise.
+#[kani::proof]
+fn check_amount_checked_sub_boundary() {
+    let a_sat = kani::any::<u64>();
+    let b_sat = kani::any::<u64>();
+
+    kani::assume(Amount::from_sat(a_sat).is_ok());
+    kani::assume(Amount::from_sat(b_sat).is_ok());
+
+    let a = Amount::from_sat(a_sat).unwrap();
+    let b = Amount::from_sat(b_sat).unwrap();
+
+    let result = a.checked_sub(b);
+    if a_sat >= b_sat {
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().to_sat(), a_sat - b_sat);
+    } else {
+        assert!(result.is_none());
+    }
+}
+
+/// Verify `to_signed` then `to_unsigned` is a lossless roundtrip.
+#[kani::proof]
+fn check_amount_to_signed_roundtrip() {
+    let sat = kani::any::<u64>();
+    kani::assume(Amount::from_sat(sat).is_ok());
+
+    let amount = Amount::from_sat(sat).unwrap();
+    let signed = amount.to_signed();
+    let back = signed.to_unsigned();
+
+    assert!(back.is_ok());
+    assert_eq!(back.unwrap(), amount);
+}
+
+/// Verify `signed_sub` never panics for any two valid amounts.
+#[kani::proof]
+fn check_amount_signed_sub_no_panic() {
+    let a_sat = kani::any::<u64>();
+    let b_sat = kani::any::<u64>();
+
+    kani::assume(Amount::from_sat(a_sat).is_ok());
+    kani::assume(Amount::from_sat(b_sat).is_ok());
+
+    let a = Amount::from_sat(a_sat).unwrap();
+    let b = Amount::from_sat(b_sat).unwrap();
+
+    // signed_sub is documented to never overflow; verify it doesn't panic.
+    let result = a.signed_sub(b);
+    assert_eq!(result.to_sat(), a_sat as i64 - b_sat as i64);
+}
+
+/// Verify `SignedAmount::unsigned_abs` never panics and returns
+/// the correct magnitude.
+#[kani::proof]
+fn check_signed_amount_unsigned_abs() {
+    let sat = kani::any::<i64>();
+    kani::assume(SignedAmount::from_sat(sat).is_ok());
+
+    let amount = SignedAmount::from_sat(sat).unwrap();
+    let abs_val = amount.unsigned_abs();
+
+    assert_eq!(abs_val.to_sat(), sat.unsigned_abs());
+}

--- a/units/src/fee_rate/mod.rs
+++ b/units/src/fee_rate/mod.rs
@@ -447,3 +447,6 @@ mod tests {
         assert_eq!(got, 1_234_567);
     }
 }
+
+#[cfg(kani)]
+mod verification;

--- a/units/src/fee_rate/verification.rs
+++ b/units/src/fee_rate/verification.rs
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Verification tests for the `fee_rate` module.
+
+use super::*;
+
+/// Verify that `from_sat_per_kwu` roundtrips through `to_sat_per_kwu_floor`
+/// for all `u32` inputs: from_sat_per_kwu multiplies by 4_000,
+/// to_sat_per_kwu_floor divides by 4_000 — lossless for u32 inputs.
+#[kani::proof]
+fn check_fee_rate_kwu_roundtrip() {
+    let kwu_rate = kani::any::<u32>();
+    let fee_rate = FeeRate::from_sat_per_kwu(kwu_rate);
+    assert_eq!(fee_rate.to_sat_per_kwu_floor(), kwu_rate as u64);
+}
+
+/// Verify that `from_sat_per_kvb` roundtrips through `to_sat_per_kvb_floor`
+/// for all `u32` inputs: from_sat_per_kvb multiplies by 1_000,
+/// to_sat_per_kvb_floor divides by 1_000 — lossless for u32 inputs.
+#[kani::proof]
+fn check_fee_rate_kvb_roundtrip() {
+    let kvb_rate = kani::any::<u32>();
+    let fee_rate = FeeRate::from_sat_per_kvb(kvb_rate);
+    assert_eq!(fee_rate.to_sat_per_kvb_floor(), kvb_rate as u64);
+}
+
+/// Verify that `checked_add` returns `None` exactly when u64 addition
+/// overflows, and the correct value otherwise.
+#[kani::proof]
+fn check_fee_rate_checked_add() {
+    let a = kani::any::<u64>();
+    let b = kani::any::<u64>();
+
+    let fa = FeeRate::from_sat_per_mvb(a);
+    let fb = FeeRate::from_sat_per_mvb(b);
+    let result = fa.checked_add(fb);
+
+    match a.checked_add(b) {
+        Some(sum) => {
+            assert!(result.is_some());
+            assert_eq!(result.unwrap().to_sat_per_mvb(), sum);
+        }
+        None => assert!(result.is_none()),
+    }
+}
+
+/// Verify that `checked_sub` returns `None` exactly when a < b, and
+/// `Some(a - b)` otherwise.
+#[kani::proof]
+fn check_fee_rate_checked_sub() {
+    let a = kani::any::<u64>();
+    let b = kani::any::<u64>();
+
+    let fa = FeeRate::from_sat_per_mvb(a);
+    let fb = FeeRate::from_sat_per_mvb(b);
+    let result = fa.checked_sub(fb);
+
+    if a >= b {
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().to_sat_per_mvb(), a - b);
+    } else {
+        assert!(result.is_none());
+    }
+}


### PR DESCRIPTION
## Summary

Add  new kani proofs covering unsafe code in ArrayVec and checked arithmetic in Amount, FeeRate, and Weight.

### ArrayVec (3 proofs)
- `pop_returns_pushed_values`: verifies `assume_init()` only reads initialized memory
- `extend_from_slice_preserves_elements`: verifies the `&[T]` to `&[MaybeUninit<T>]` pointer cast
- `from_slice_initializes_correctly`: verifies `from_slice` + `as_slice` raw pointer roundtrip

### Amount (5 proofs)
- `checked_add_boundary`, `checked_sub_boundary`: full result comparison against raw arithmetic
- `to_signed_roundtrip`: Amount → SignedAmount → Amount lossless
- `signed_sub_no_panic`: verifies documented no-overflow guarantee
- `unsigned_abs`: verifies SignedAmount magnitude

### FeeRate (4 proofs)
- `kwu_roundtrip`, `kvb_roundtrip`: constructor/accessor roundtrips for all u32 inputs
- `checked_add`, `checked_sub`: full result comparison

### Weight (6 proofs)
- `from_vb_roundtrip`, `from_kwu_roundtrip`: constructor/accessor roundtrips
- `checked_add`, `checked_sub`: full result comparison
- `from_vb_overflow`, `from_kwu_overflow`: verifies None exactly
when multiplication overflows

## Note

- `check_weight_from_kwu_roundtrip` takes ~278s due to division by 1000 in the SAT solver; all others complete in <50s