### PR TITLE
consensus: Add CompactSize range check to deserialization

### DIFF
--- a/bitcoin/src/consensus/error.rs
+++ b/bitcoin/src/consensus/error.rs
@@ -157,6 +157,8 @@ pub enum ParseError {
     },
     /// CompactSize was encoded in a non-minimal way.
     NonMinimalCompactSize,
+    /// CompactSize value exceeds the maximum allowed size.
+    OversizedCompactSize,
     /// Parsing error.
     ParseFailed(&'static str),
     /// Unsupported SegWit flag.
@@ -181,6 +183,7 @@ impl fmt::Display for ParseError {
                 e[0], e[1], e[2], e[3], a[0], a[1], a[2], a[3],
             ),
             Self::NonMinimalCompactSize => write!(f, "non-minimal compact size"),
+            Self::OversizedCompactSize => write!(f, "value exceeds the maximum allowed compact size"),
             Self::ParseFailed(ref s) => write!(f, "parse failed: {}", s),
             Self::UnsupportedSegwitFlag(ref swflag) =>
                 write!(f, "unsupported SegWit version: {}", swflag),
@@ -198,6 +201,7 @@ impl std::error::Error for ParseError {
             | Self::OversizedVectorAllocation { .. }
             | Self::InvalidChecksum { .. }
             | Self::NonMinimalCompactSize
+            | Self::OversizedCompactSize
             | Self::ParseFailed(_)
             | Self::UnsupportedSegwitFlag(_) => None,
         }

--- a/bitcoin/src/consensus/serde.rs
+++ b/bitcoin/src/consensus/serde.rs
@@ -375,6 +375,8 @@ fn consensus_error_into_serde<E: serde::de::Error>(error: ParseError) -> E {
         ),
         ParseError::NonMinimalCompactSize =>
             E::custom(format_args!("compact size was not encoded minimally")),
+        ParseError::OversizedCompactSize =>
+            E::custom(format_args!("compact size value exceeds the maximum allowed size")),
         ParseError::ParseFailed(msg) => E::custom(msg),
         ParseError::UnsupportedSegwitFlag(flag) =>
             E::invalid_value(Unexpected::Unsigned(flag.into()), &"segwit version 1 flag"),

--- a/p2p/src/bip152.rs
+++ b/p2p/src/bip152.rs
@@ -754,8 +754,7 @@ mod test {
                 // test that we return Err() if deserialization fails (and don't panic)
                 let mut raw: Vec<u8> = [0u8; 32].to_vec();
                 raw.extend(errorcase);
-                let get_block_txn = deserialize::<BlockTransactionsRequest>(&raw.clone()).unwrap();
-                assert!(get_block_txn.indices().is_err());
+                assert!(deserialize::<BlockTransactionsRequest>(&raw).is_err());
             }
         }
     }


### PR DESCRIPTION
Reject `CompactSize` values exceeding `MAX_COMPACT_SIZE` (0x02000000) during deserialization, matching Bitcoin Core's serialize.h limit.

Extract read_compact_size logic into a private free function to allow tests to bypass the range check when validating non-minimal encoding.

Add test for the new `OversizedCompactSize` error at the boundary.

Update bip152 error test to expect failure at deserialization rather than at index computation, since the range check now triggers earlier.

Found by differential fuzzing using bitcoinfuzz.