### PR TITLE
Split taproot types into new taproot-primitives crate

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -187,6 +187,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin-taproot-primitives"
+version = "0.1.0"
+
+[[package]]
 name = "bitcoin-units"
 version = "0.3.0"
 dependencies = [

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -60,6 +60,7 @@ dependencies = [
  "bitcoin-io",
  "bitcoin-network-kind",
  "bitcoin-primitives",
+ "bitcoin-taproot-primitives",
  "bitcoin-units",
  "bitcoin_hashes",
  "bitcoinconsensus",
@@ -189,6 +190,14 @@ dependencies = [
 [[package]]
 name = "bitcoin-taproot-primitives"
 version = "0.1.0"
+dependencies = [
+ "arbitrary",
+ "bitcoin-crypto",
+ "bitcoin-internals",
+ "bitcoin_hashes",
+ "secp256k1",
+ "serde",
+]
 
 [[package]]
 name = "bitcoin-units"

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -186,6 +186,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin-taproot-primitives"
+version = "0.1.0"
+
+[[package]]
 name = "bitcoin-units"
 version = "0.3.0"
 dependencies = [

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -59,6 +59,7 @@ dependencies = [
  "bitcoin-io",
  "bitcoin-network-kind",
  "bitcoin-primitives",
+ "bitcoin-taproot-primitives",
  "bitcoin-units",
  "bitcoin_hashes",
  "bitcoinconsensus",
@@ -188,6 +189,14 @@ dependencies = [
 [[package]]
 name = "bitcoin-taproot-primitives"
 version = "0.1.0"
+dependencies = [
+ "arbitrary",
+ "bitcoin-crypto",
+ "bitcoin-internals",
+ "bitcoin_hashes",
+ "secp256k1",
+ "serde",
+]
 
 [[package]]
 name = "bitcoin-units"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["addresses", "base58", "bip158", "bitcoin", "chacha20_poly1305", "consensus_encoding", "crypto", "fuzz", "hashes", "internals", "io", "key_expression", "network", "p2p", "primitives", "units"]
+members = ["addresses", "base58", "bip158", "bitcoin", "chacha20_poly1305", "consensus_encoding", "crypto", "fuzz", "hashes", "internals", "io", "key_expression", "network", "p2p", "primitives", "taproot-primitives", "units"]
 exclude = ["benches"]
 resolver = "2"
 

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -17,13 +17,13 @@ exclude = ["tests", "contrib"]
 # If you change features or optional dependencies in any way please update the "# Cargo features" section in lib.rs as well.
 [features]
 default = [ "std", "secp-recovery" ]
-std = ["base58/std", "bech32/std", "crypto/std", "encoding/std", "hashes/std", "hex-stable/std", "hex-unstable/std", "internals/std", "io/std", "network/std", "primitives/std", "secp256k1/std", "units/std", "base64?/std", "bitcoinconsensus?/std"]
+std = ["base58/std", "bech32/std", "crypto/std", "encoding/std", "hashes/std", "hex-stable/std", "hex-unstable/std", "internals/std", "io/std", "network/std", "primitives/std", "secp256k1/std", "taproot-primitives/std", "units/std", "base64?/std", "bitcoinconsensus?/std"]
 rand = ["secp256k1/rand", "crypto/rand"]
-serde = ["base64", "crypto/serde", "dep:serde", "hashes/serde", "internals/serde", "network/serde", "primitives/serde", "secp256k1/serde", "units/serde"]
+serde = ["base64", "crypto/serde", "dep:serde", "hashes/serde", "internals/serde", "network/serde", "primitives/serde", "secp256k1/serde", "taproot-primitives/serde", "units/serde"]
 secp-global-context = ["secp256k1/global-context"]
 secp-lowmemory = ["secp256k1/lowmemory"]
 secp-recovery = ["secp256k1/recovery"]
-arbitrary = ["crypto/arbitrary", "dep:arbitrary", "units/arbitrary", "primitives/arbitrary", "hashes/arbitrary", "secp256k1/arbitrary", "network/arbitrary"]
+arbitrary = ["crypto/arbitrary", "dep:arbitrary", "units/arbitrary", "primitives/arbitrary", "hashes/arbitrary", "secp256k1/arbitrary", "taproot-primitives/arbitrary", "network/arbitrary"]
 
 [dependencies]
 base58 = { package = "base58ck", path = "../base58", version = "0.4.0", default-features = false, features = ["alloc"] }
@@ -38,6 +38,7 @@ io = { package = "bitcoin-io", path = "../io", version = "0.5.0", default-featur
 network = { package = "bitcoin-network-kind", path = "../network", version = "0.1.0", default-features = false, features = ["alloc"]}
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.102.0", default-features = false, features = ["alloc", "hex"] }
 secp256k1 = { version = "0.32.0-beta.2", default-features = false, features = ["alloc"] }
+taproot-primitives = { package = "bitcoin-taproot-primitives", path = "../taproot-primitives", version = "0.1.0", default-features = false, features = ["alloc"] }
 units = { package = "bitcoin-units", path = "../units", version = "0.3.0", default-features = false, features = ["alloc"] }
 
 arbitrary = { version = "1.4.1", optional = true }

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -18,7 +18,7 @@ use crate::opcodes::{self, Opcode};
 use crate::policy::{DUST_RELAY_TX_FEE, MAX_OP_RETURN_RELAY};
 use crate::prelude::{sink, String, ToString};
 use crate::script::{self, ScriptPubKeyBufExt as _};
-use crate::taproot::{LeafVersion, TapLeafHash, TapNodeHash};
+use crate::taproot::{LeafVersion, TapLeafHash, TapLeafHashExt as _, TapNodeHash};
 use crate::witness_program::P2A_PROGRAM;
 use crate::{internal_macros, Amount, FeeRate, ScriptPubKeyBuf, WitnessScriptBuf};
 

--- a/bitcoin/src/taproot/mod.rs
+++ b/bitcoin/src/taproot/mod.rs
@@ -7,18 +7,17 @@
 pub mod merkle_branch;
 
 use core::cmp::{Ordering, Reverse};
+#[cfg(feature = "serde")]
 use core::fmt;
 use core::iter::FusedIterator;
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
-use hashes::{hash_newtype, sha256t, sha256t_tag, HashEngine};
+use hashes::{sha256t, HashEngine};
 use internals::array::ArrayExt;
-use internals::impl_to_hex_from_lower_hex;
 #[allow(unused)] // MSRV polyfill
 use internals::slice::SliceExt;
 use io::Write;
-use secp256k1::Scalar;
 
 use crate::consensus::Encodable;
 use crate::crypto::key::{
@@ -35,6 +34,13 @@ pub use crate::crypto::taproot::{SerializedSignature, Signature};
 pub use merkle_branch::TaprootMerkleBranch;
 #[doc(inline)]
 pub use merkle_branch::TaprootMerkleBranchBuf;
+#[doc(inline)]
+pub use taproot_primitives::{
+    FutureLeafVersion, LeafVersion, TapBranchTag, TapLeafHash, TapLeafTag, TapNodeHash,
+    TapTweakHash, TapTweakTag, TAPROOT_ANNEX_PREFIX, TAPROOT_CONTROL_BASE_SIZE,
+    TAPROOT_CONTROL_MAX_NODE_COUNT, TAPROOT_CONTROL_MAX_SIZE, TAPROOT_CONTROL_NODE_SIZE,
+    TAPROOT_LEAF_MASK, TAPROOT_LEAF_TAPSCRIPT,
+};
 
 #[doc(no_inline)]
 pub use self::error::{
@@ -48,84 +54,6 @@ use crate::psbt::serialize::Deserialize;
 pub use crate::XOnlyPublicKey;
 
 type ControlBlockArrayVec = internals::array_vec::ArrayVec<u8, TAPROOT_CONTROL_MAX_SIZE>;
-
-// Taproot test vectors from BIP-0341 state the hashes without any reversing
-sha256t_tag! {
-    pub struct TapLeafTag = hash_str("TapLeaf");
-}
-
-hash_newtype! {
-    /// Taproot-tagged hash with tag \"TapLeaf\".
-    ///
-    /// This is used for computing tapscript script spend hash.
-    pub struct TapLeafHash(sha256t::Hash<TapLeafTag>);
-}
-
-hashes::impl_hex_for_newtype!(TapLeafHash);
-#[cfg(feature = "serde")]
-hashes::impl_serde_for_newtype!(TapLeafHash);
-
-sha256t_tag! {
-    pub struct TapBranchTag = hash_str("TapBranch");
-}
-
-hash_newtype! {
-    /// Tagged hash used in Taproot trees.
-    ///
-    /// See BIP-0340 for tagging rules.
-    #[repr(transparent)]
-    pub struct TapNodeHash(sha256t::Hash<TapBranchTag>);
-}
-
-hashes::impl_hex_for_newtype!(TapNodeHash);
-#[cfg(feature = "serde")]
-hashes::impl_serde_for_newtype!(TapNodeHash);
-
-sha256t_tag! {
-    pub struct TapTweakTag = hash_str("TapTweak");
-}
-
-hash_newtype! {
-    /// Taproot-tagged hash with tag \"TapTweak\".
-    ///
-    /// This hash type is used while computing the tweaked public key.
-    pub struct TapTweakHash(sha256t::Hash<TapTweakTag>);
-}
-
-hashes::impl_hex_for_newtype!(TapTweakHash);
-#[cfg(feature = "serde")]
-hashes::impl_serde_for_newtype!(TapTweakHash);
-
-impl From<TapLeafHash> for TapNodeHash {
-    fn from(leaf: TapLeafHash) -> Self { Self::from_byte_array(leaf.to_byte_array()) }
-}
-
-impl TapTweakHash {
-    /// Constructs a new BIP-0341 [`TapTweakHash`] from key and Merkle root. Produces `H_taptweak(P||R)` where
-    /// `P` is the internal key and `R` is the Merkle root.
-    pub fn from_key_and_merkle_root<K: Into<UntweakedPublicKey>>(
-        internal_key: K,
-        merkle_root: Option<TapNodeHash>,
-    ) -> Self {
-        let internal_key = internal_key.into();
-        let mut eng = sha256t::Hash::<TapTweakTag>::engine();
-        // always hash the key
-        eng.input(&internal_key.serialize().0);
-        if let Some(h) = merkle_root {
-            eng.input(h.as_ref());
-        } else {
-            // nothing to hash
-        }
-        let inner = sha256t::Hash::<TapTweakTag>::from_engine(eng);
-        Self::from_byte_array(inner.to_byte_array())
-    }
-
-    /// Converts a `TapTweakHash` into a `Scalar` ready for use with key tweaking API.
-    pub fn to_scalar(self) -> Scalar {
-        // This is statistically extremely unlikely to panic.
-        Scalar::from_be_bytes(self.to_byte_array()).expect("hash value greater than curve order")
-    }
-}
 
 impl From<LeafNode> for TapNodeHash {
     fn from(leaf: LeafNode) -> Self { leaf.node_hash() }
@@ -191,28 +119,6 @@ fn combine_node_hashes(a: TapNodeHash, b: TapNodeHash) -> (TapNodeHash, bool) {
     let inner = sha256t::Hash::<TapBranchTag>::from_engine(eng);
     (TapNodeHash::from_byte_array(inner.to_byte_array()), a < b)
 }
-
-/// Maximum depth of a Taproot tree script spend path.
-// https://github.com/bitcoin/bitcoin/blob/e826b22da252e0599c61d21c98ff89f366b3120f/src/script/interpreter.h#L229
-pub const TAPROOT_CONTROL_MAX_NODE_COUNT: usize = 128;
-/// Size of a Taproot control node.
-// https://github.com/bitcoin/bitcoin/blob/e826b22da252e0599c61d21c98ff89f366b3120f/src/script/interpreter.h#L228
-pub const TAPROOT_CONTROL_NODE_SIZE: usize = 32;
-/// Tapleaf mask for getting the leaf version from first byte of control block.
-// https://github.com/bitcoin/bitcoin/blob/e826b22da252e0599c61d21c98ff89f366b3120f/src/script/interpreter.h#L225
-pub const TAPROOT_LEAF_MASK: u8 = 0xfe;
-/// Tapscript leaf version.
-// https://github.com/bitcoin/bitcoin/blob/e826b22da252e0599c61d21c98ff89f366b3120f/src/script/interpreter.h#L226
-pub const TAPROOT_LEAF_TAPSCRIPT: u8 = 0xc0;
-/// Taproot annex prefix.
-pub const TAPROOT_ANNEX_PREFIX: u8 = 0x50;
-/// Tapscript control base size.
-// https://github.com/bitcoin/bitcoin/blob/e826b22da252e0599c61d21c98ff89f366b3120f/src/script/interpreter.h#L227
-pub const TAPROOT_CONTROL_BASE_SIZE: usize = 33;
-/// Tapscript control max size.
-// https://github.com/bitcoin/bitcoin/blob/e826b22da252e0599c61d21c98ff89f366b3120f/src/script/interpreter.h#L230
-pub const TAPROOT_CONTROL_MAX_SIZE: usize =
-    TAPROOT_CONTROL_BASE_SIZE + TAPROOT_CONTROL_NODE_SIZE * TAPROOT_CONTROL_MAX_NODE_COUNT;
 
 /// The leaf script with its version.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
@@ -1223,154 +1129,6 @@ impl<Branch: AsRef<TaprootMerkleBranch> + ?Sized> ControlBlock<Branch> {
     }
 }
 
-/// Inner type representing future (non-tapscript) leaf versions. See [`LeafVersion::Future`].
-///
-/// NB: NO PUBLIC CONSTRUCTOR!
-/// The only way to construct this is by converting `u8` to [`LeafVersion`] and then extracting it.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub struct FutureLeafVersion(u8);
-
-impl FutureLeafVersion {
-    #[track_caller]
-    pub(self) fn from_consensus(version: u8) -> Result<Self, InvalidTaprootLeafVersionError> {
-        match version {
-            TAPROOT_LEAF_TAPSCRIPT => unreachable!(
-                "FutureLeafVersion::from_consensus should never be called for 0xC0 value"
-            ),
-            TAPROOT_ANNEX_PREFIX => Err(InvalidTaprootLeafVersionError(TAPROOT_ANNEX_PREFIX)),
-            odd if odd & 0xFE != odd => Err(InvalidTaprootLeafVersionError(odd)),
-            even => Ok(Self(even)),
-        }
-    }
-
-    /// Returns the consensus representation of this [`FutureLeafVersion`].
-    #[inline]
-    pub fn to_consensus(self) -> u8 { self.0 }
-}
-
-impl fmt::Display for FutureLeafVersion {
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { fmt::Display::fmt(&self.0, f) }
-}
-
-impl fmt::LowerHex for FutureLeafVersion {
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { fmt::LowerHex::fmt(&self.0, f) }
-}
-impl_to_hex_from_lower_hex!(FutureLeafVersion, |_| 2);
-
-impl fmt::UpperHex for FutureLeafVersion {
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { fmt::UpperHex::fmt(&self.0, f) }
-}
-
-/// The leaf version for tapleafs.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum LeafVersion {
-    /// BIP-0342 tapscript.
-    TapScript,
-
-    /// Future leaf version.
-    Future(FutureLeafVersion),
-}
-
-impl LeafVersion {
-    /// Constructs a new [`LeafVersion`] from consensus byte representation.
-    ///
-    /// # Errors
-    ///
-    /// - If the last bit of the `version` is odd.
-    /// - If the `version` is 0x50 ([`TAPROOT_ANNEX_PREFIX`]).
-    pub fn from_consensus(version: u8) -> Result<Self, InvalidTaprootLeafVersionError> {
-        match version {
-            TAPROOT_LEAF_TAPSCRIPT => Ok(Self::TapScript),
-            TAPROOT_ANNEX_PREFIX => Err(InvalidTaprootLeafVersionError(TAPROOT_ANNEX_PREFIX)),
-            future => FutureLeafVersion::from_consensus(future).map(LeafVersion::Future),
-        }
-    }
-
-    /// Returns the consensus representation of this [`LeafVersion`].
-    pub fn to_consensus(self) -> u8 {
-        match self {
-            Self::TapScript => TAPROOT_LEAF_TAPSCRIPT,
-            Self::Future(version) => version.to_consensus(),
-        }
-    }
-}
-
-impl fmt::Display for LeafVersion {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match (self, f.alternate()) {
-            (Self::TapScript, true) => f.write_str("tapscript"),
-            (Self::TapScript, false) => fmt::Display::fmt(&TAPROOT_LEAF_TAPSCRIPT, f),
-            (Self::Future(version), true) => write!(f, "future_script_{:#02x}", version.0),
-            (Self::Future(version), false) => fmt::Display::fmt(version, f),
-        }
-    }
-}
-
-impl fmt::LowerHex for LeafVersion {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::LowerHex::fmt(&self.to_consensus(), f)
-    }
-}
-impl_to_hex_from_lower_hex!(LeafVersion, |_| 2);
-
-impl fmt::UpperHex for LeafVersion {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::UpperHex::fmt(&self.to_consensus(), f)
-    }
-}
-
-/// Serializes [`LeafVersion`] as a `u8` using consensus encoding.
-#[cfg(feature = "serde")]
-impl serde::Serialize for LeafVersion {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_u8(self.to_consensus())
-    }
-}
-
-/// Deserializes [`LeafVersion`] as a `u8` using consensus encoding.
-#[cfg(feature = "serde")]
-impl<'de> serde::Deserialize<'de> for LeafVersion {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        struct U8Visitor;
-        impl serde::de::Visitor<'_> for U8Visitor {
-            type Value = LeafVersion;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("a valid consensus-encoded Taproot leaf version")
-            }
-
-            fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                let value = u8::try_from(value).map_err(|_| {
-                    E::invalid_value(
-                        serde::de::Unexpected::Unsigned(value),
-                        &"consensus-encoded leaf version as u8",
-                    )
-                })?;
-                LeafVersion::from_consensus(value).map_err(|_| {
-                    E::invalid_value(
-                        ::serde::de::Unexpected::Unsigned(value as u64),
-                        &"consensus-encoded leaf version as u8",
-                    )
-                })
-            }
-        }
-
-        deserializer.deserialize_u8(U8Visitor)
-    }
-}
-
 /// Error types for taproot.
 pub mod error {
     use core::convert::Infallible;
@@ -1387,6 +1145,8 @@ pub mod error {
     #[rustfmt::skip]
     #[doc(inline)]
     pub use crate::crypto::taproot::SigFromSliceError;
+    #[doc(no_inline)]
+    pub use taproot_primitives::InvalidTaprootLeafVersionError;
 
     /// Error happening when [`TapTree`] is constructed from a [`TaprootBuilder`]
     /// having hidden branches or not being finalized.
@@ -1654,30 +1414,6 @@ pub mod error {
         fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
     }
 
-    /// The last bit of tapleaf version must be zero.
-    #[derive(Debug, Clone, PartialEq, Eq)]
-    pub struct InvalidTaprootLeafVersionError(pub(super) u8);
-
-    impl InvalidTaprootLeafVersionError {
-        /// Accessor for the invalid leaf version.
-        pub fn invalid_leaf_version(&self) -> u8 { self.0 }
-    }
-
-    impl From<Infallible> for InvalidTaprootLeafVersionError {
-        fn from(never: Infallible) -> Self { match never {} }
-    }
-
-    impl fmt::Display for InvalidTaprootLeafVersionError {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            write!(f, "leaf version({}) must have the least significant bit 0", self.0)
-        }
-    }
-
-    #[cfg(feature = "std")]
-    impl std::error::Error for InvalidTaprootLeafVersionError {
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
-    }
-
     /// Invalid control block size.
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct InvalidControlBlockSizeError(pub(super) usize);
@@ -1704,40 +1440,6 @@ pub mod error {
     #[cfg(feature = "std")]
     impl std::error::Error for InvalidControlBlockSizeError {
         fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
-    }
-}
-
-#[cfg(feature = "arbitrary")]
-impl<'a> Arbitrary<'a> for TapLeafHash {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        Ok(Self::from_byte_array(u.arbitrary()?))
-    }
-}
-
-#[cfg(feature = "arbitrary")]
-impl<'a> Arbitrary<'a> for TapNodeHash {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        Ok(Self::from_byte_array(u.arbitrary()?))
-    }
-}
-
-#[cfg(feature = "arbitrary")]
-impl<'a> Arbitrary<'a> for FutureLeafVersion {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        match u8::arbitrary(u)? {
-            TAPROOT_LEAF_TAPSCRIPT => Err(arbitrary::Error::IncorrectFormat),
-            version => Self::from_consensus(version).map_err(|_| arbitrary::Error::IncorrectFormat),
-        }
-    }
-}
-
-#[cfg(feature = "arbitrary")]
-impl<'a> Arbitrary<'a> for LeafVersion {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        match bool::arbitrary(u)? {
-            true => Ok(Self::TapScript),
-            false => Ok(Self::Future(u.arbitrary()?)),
-        }
     }
 }
 

--- a/bitcoin/src/taproot/mod.rs
+++ b/bitcoin/src/taproot/mod.rs
@@ -127,17 +127,6 @@ impl TapTweakHash {
     }
 }
 
-impl TapLeafHash {
-    /// Computes the leaf hash from components.
-    pub fn from_script(script: &TapScript, ver: LeafVersion) -> Self {
-        let mut eng = sha256t::Hash::<TapLeafTag>::engine();
-        ver.to_consensus().consensus_encode(&mut eng).expect("engines don't error");
-        script.consensus_encode(&mut eng).expect("engines don't error");
-        let inner = sha256t::Hash::<TapLeafTag>::from_engine(eng);
-        Self::from_byte_array(inner.to_byte_array())
-    }
-}
-
 impl From<LeafNode> for TapNodeHash {
     fn from(leaf: LeafNode) -> Self { leaf.node_hash() }
 }
@@ -146,21 +135,46 @@ impl From<&LeafNode> for TapNodeHash {
     fn from(leaf: &LeafNode) -> Self { leaf.node_hash() }
 }
 
-impl TapNodeHash {
-    /// Computes branch hash given two hashes of the nodes underneath it.
-    pub fn from_node_hashes(a: Self, b: Self) -> Self { combine_node_hashes(a, b).0 }
-
-    /// Assumes the given 32 byte array as hidden [`TapNodeHash`].
-    ///
-    /// Similar to [`TapLeafHash::from_byte_array`], but explicitly conveys that the
-    /// hash is constructed from a hidden node. This also has better ergonomics
-    /// because it does not require the caller to import the Hash trait.
-    pub fn assume_hidden(hash: [u8; 32]) -> Self { Self::from_byte_array(hash) }
-
-    /// Computes the [`TapNodeHash`] from a script and a leaf version.
-    pub fn from_script(script: &TapScript, ver: LeafVersion) -> Self {
-        Self::from(TapLeafHash::from_script(script, ver))
+crate::internal_macros::define_extension_trait! {
+    /// Extension functionality for the [`TapLeafHash`] type.
+    pub trait TapLeafHashExt impl for TapLeafHash {
+        /// Computes the leaf hash from components.
+        fn from_script(script: &TapScript, ver: LeafVersion) -> Self {
+            let mut eng = sha256t::Hash::<TapLeafTag>::engine();
+            ver.to_consensus().consensus_encode(&mut eng).expect("engines don't error");
+            script.consensus_encode(&mut eng).expect("engines don't error");
+            let inner = sha256t::Hash::<TapLeafTag>::from_engine(eng);
+            Self::from_byte_array(inner.to_byte_array())
+        }
     }
+}
+
+crate::internal_macros::define_extension_trait! {
+    /// Extension functionality for the [`TapNodeHash`] type.
+    pub trait TapNodeHashExt impl for TapNodeHash {
+        /// Computes branch hash given two hashes of the nodes underneath it.
+        fn from_node_hashes(a: Self, b: Self) -> Self {
+            combine_node_hashes(a, b).0
+        }
+
+        /// Assumes the given 32 byte array as hidden [`TapNodeHash`].
+        ///
+        /// Similar to [`TapLeafHash::from_byte_array`], but explicitly conveys that the
+        /// hash is constructed from a hidden node. This also has better ergonomics
+        /// because it does not require the caller to import the Hash trait.
+        fn assume_hidden(hash: [u8; 32]) -> Self { Self::from_byte_array(hash) }
+
+        /// Computes the [`TapNodeHash`] from a script and a leaf version.
+        fn from_script(script: &TapScript, ver: LeafVersion) -> Self {
+            Self::from(TapLeafHash::from_script(script, ver))
+        }
+    }
+}
+
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for super::TapLeafHash {}
+    impl Sealed for super::TapNodeHash {}
 }
 
 /// Computes branch hash given two hashes of the nodes underneath it and returns

--- a/taproot-primitives/CHANGELOG.md
+++ b/taproot-primitives/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.1.0 - Initial release
+
+- All the hash types and also the `LeafVersion` enum.

--- a/taproot-primitives/Cargo.toml
+++ b/taproot-primitives/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "bitcoin-taproot-primitives"
+version = "0.1.0"
+authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
+license = "CC0-1.0"
+repository = "https://github.com/rust-bitcoin/rust-bitcoin"
+description = "Taproot stuff destined for bitcoin-primitives"
+categories = ["cryptography::cryptocurrencies"]
+keywords = ["bitcoin", "types"]
+readme = "README.md"
+edition = "2021"
+rust-version = "1.74.0"
+exclude = ["tests", "contrib"]
+
+[features]
+default = ["std"]
+std = ["alloc"]
+alloc = []
+
+[dependencies]
+
+[dev-dependencies]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[lints]
+workspace = true

--- a/taproot-primitives/Cargo.toml
+++ b/taproot-primitives/Cargo.toml
@@ -14,10 +14,19 @@ exclude = ["tests", "contrib"]
 
 [features]
 default = ["std"]
-std = ["alloc"]
-alloc = []
+std = ["alloc", "crypto/std", "hashes/std", "internals/std", "serde?/std", "secp256k1/std"]
+alloc = ["crypto/alloc", "hashes/alloc", "internals/alloc", "secp256k1/alloc"]
+serde = ["dep:serde", "crypto/serde", "hashes/serde", "internals/serde", "secp256k1/serde"]
+arbitrary = ["crypto/arbitrary", "dep:arbitrary", "hashes/arbitrary", "secp256k1/arbitrary"]
 
 [dependencies]
+crypto = { package = "bitcoin-crypto", path = "../crypto", default-features = false }
+hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false, features = ["hex"] }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
+
+arbitrary = { version = "1.4.1", optional = true }
+secp256k1 = { version = "0.32.0-beta.2", default-features = false }
+serde = { version = "1.0.195", default-features = false, features = [ "derive" ], optional = true }
 
 [dev-dependencies]
 
@@ -27,3 +36,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true
+
+[package.metadata.rbmt.lint]
+allowed_duplicates = [
+    "hex-conservative",
+]

--- a/taproot-primitives/README.md
+++ b/taproot-primitives/README.md
@@ -1,0 +1,8 @@
+# Taproot primitives
+
+This is stuff that will eventually end up in `primitives` but for
+which we are currently not 100% sure of the API.
+
+## Minimum Supported Rust Version (MSRV)
+
+This library should always compile with any combination of features on **Rust 1.74.0**.

--- a/taproot-primitives/src/lib.rs
+++ b/taproot-primitives/src/lib.rs
@@ -128,6 +128,7 @@ impl TapTweakHash {
     }
 
     /// Converts a `TapTweakHash` into a `Scalar` ready for use with key tweaking API.
+    #[allow(clippy::missing_panics_doc)]
     pub fn to_scalar(self) -> Scalar {
         // This is statistically extremely unlikely to panic.
         Scalar::from_be_bytes(self.to_byte_array()).expect("hash value greater than curve order")
@@ -230,7 +231,7 @@ impl<'de> serde::Deserialize<'de> for LeafVersion {
                 })?;
                 LeafVersion::from_consensus(value).map_err(|_| {
                     E::invalid_value(
-                        ::serde::de::Unexpected::Unsigned(value as u64),
+                        ::serde::de::Unexpected::Unsigned(u64::from(value)),
                         &"consensus-encoded leaf version as u8",
                     )
                 })

--- a/taproot-primitives/src/lib.rs
+++ b/taproot-primitives/src/lib.rs
@@ -12,3 +12,336 @@
 #![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
 #![allow(clippy::manual_range_contains)] // More readable than clippy's format.
 #![allow(clippy::uninlined_format_args)] // Allow `format!("{}", x)` instead of enforcing `format!("{x}")`
+
+extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;
+
+#[rustfmt::skip] // Keep pub re-exports separate
+#[doc(no_inline)]
+pub use self::error::InvalidTaprootLeafVersionError;
+
+use core::fmt;
+
+#[cfg(feature = "arbitrary")]
+use arbitrary::{Arbitrary, Unstructured};
+#[cfg(feature = "alloc")]
+use crypto::key::UntweakedPublicKey;
+use hashes::{hash_newtype, sha256t, sha256t_tag};
+#[cfg(feature = "alloc")]
+use hashes::HashEngine;
+use secp256k1::Scalar;
+
+/// Maximum depth of a Taproot tree script spend path.
+// https://github.com/bitcoin/bitcoin/blob/e826b22da252e0599c61d21c98ff89f366b3120f/src/script/interpreter.h#L229
+pub const TAPROOT_CONTROL_MAX_NODE_COUNT: usize = 128;
+/// Size of a Taproot control node.
+// https://github.com/bitcoin/bitcoin/blob/e826b22da252e0599c61d21c98ff89f366b3120f/src/script/interpreter.h#L228
+pub const TAPROOT_CONTROL_NODE_SIZE: usize = 32;
+/// Tapleaf mask for getting the leaf version from first byte of control block.
+// https://github.com/bitcoin/bitcoin/blob/e826b22da252e0599c61d21c98ff89f366b3120f/src/script/interpreter.h#L225
+pub const TAPROOT_LEAF_MASK: u8 = 0xfe;
+/// Tapscript leaf version.
+// https://github.com/bitcoin/bitcoin/blob/e826b22da252e0599c61d21c98ff89f366b3120f/src/script/interpreter.h#L226
+pub const TAPROOT_LEAF_TAPSCRIPT: u8 = 0xc0;
+/// Taproot annex prefix.
+pub const TAPROOT_ANNEX_PREFIX: u8 = 0x50;
+/// Tapscript control base size.
+// https://github.com/bitcoin/bitcoin/blob/e826b22da252e0599c61d21c98ff89f366b3120f/src/script/interpreter.h#L227
+pub const TAPROOT_CONTROL_BASE_SIZE: usize = 33;
+/// Tapscript control max size.
+// https://github.com/bitcoin/bitcoin/blob/e826b22da252e0599c61d21c98ff89f366b3120f/src/script/interpreter.h#L230
+pub const TAPROOT_CONTROL_MAX_SIZE: usize =
+    TAPROOT_CONTROL_BASE_SIZE + TAPROOT_CONTROL_NODE_SIZE * TAPROOT_CONTROL_MAX_NODE_COUNT;
+
+// Taproot test vectors from BIP-0341 state the hashes without any reversing
+sha256t_tag! {
+    pub struct TapLeafTag = hash_str("TapLeaf");
+}
+
+hash_newtype! {
+    /// Taproot-tagged hash with tag \"TapLeaf\".
+    ///
+    /// This is used for computing tapscript script spend hash.
+    pub struct TapLeafHash(sha256t::Hash<TapLeafTag>);
+}
+
+hashes::impl_hex_for_newtype!(TapLeafHash);
+#[cfg(feature = "serde")]
+hashes::impl_serde_for_newtype!(TapLeafHash);
+
+sha256t_tag! {
+    pub struct TapBranchTag = hash_str("TapBranch");
+}
+
+hash_newtype! {
+    /// Tagged hash used in Taproot trees.
+    ///
+    /// See BIP-0340 for tagging rules.
+    #[repr(transparent)]
+    pub struct TapNodeHash(sha256t::Hash<TapBranchTag>);
+}
+
+hashes::impl_hex_for_newtype!(TapNodeHash);
+#[cfg(feature = "serde")]
+hashes::impl_serde_for_newtype!(TapNodeHash);
+
+sha256t_tag! {
+    pub struct TapTweakTag = hash_str("TapTweak");
+}
+
+hash_newtype! {
+    /// Taproot-tagged hash with tag \"TapTweak\".
+    ///
+    /// This hash type is used while computing the tweaked public key.
+    pub struct TapTweakHash(sha256t::Hash<TapTweakTag>);
+}
+
+hashes::impl_hex_for_newtype!(TapTweakHash);
+#[cfg(feature = "serde")]
+hashes::impl_serde_for_newtype!(TapTweakHash);
+
+impl From<TapLeafHash> for TapNodeHash {
+    fn from(leaf: TapLeafHash) -> Self { Self::from_byte_array(leaf.to_byte_array()) }
+}
+
+impl TapTweakHash {
+    /// Constructs a new BIP-0341 [`TapTweakHash`] from key and Merkle root. Produces `H_taptweak(P||R)` where
+    /// `P` is the internal key and `R` is the Merkle root.
+    #[cfg(feature = "alloc")]
+    pub fn from_key_and_merkle_root<K: Into<UntweakedPublicKey>>(
+        internal_key: K,
+        merkle_root: Option<TapNodeHash>,
+    ) -> Self {
+        let internal_key = internal_key.into();
+        let mut eng = sha256t::Hash::<TapTweakTag>::engine();
+        // always hash the key
+        eng.input(&internal_key.serialize().0);
+        if let Some(h) = merkle_root {
+            eng.input(h.as_ref());
+        } else {
+            // nothing to hash
+        }
+        let inner = sha256t::Hash::<TapTweakTag>::from_engine(eng);
+        Self::from_byte_array(inner.to_byte_array())
+    }
+
+    /// Converts a `TapTweakHash` into a `Scalar` ready for use with key tweaking API.
+    pub fn to_scalar(self) -> Scalar {
+        // This is statistically extremely unlikely to panic.
+        Scalar::from_be_bytes(self.to_byte_array()).expect("hash value greater than curve order")
+    }
+}
+
+/// The leaf version for tapleafs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum LeafVersion {
+    /// BIP-0342 tapscript.
+    TapScript,
+
+    /// Future leaf version.
+    Future(FutureLeafVersion),
+}
+
+impl LeafVersion {
+    /// Constructs a new [`LeafVersion`] from consensus byte representation.
+    ///
+    /// # Errors
+    ///
+    /// - If the last bit of the `version` is odd.
+    /// - If the `version` is 0x50 ([`TAPROOT_ANNEX_PREFIX`]).
+    pub fn from_consensus(version: u8) -> Result<Self, InvalidTaprootLeafVersionError> {
+        match version {
+            TAPROOT_LEAF_TAPSCRIPT => Ok(Self::TapScript),
+            TAPROOT_ANNEX_PREFIX => Err(InvalidTaprootLeafVersionError(TAPROOT_ANNEX_PREFIX)),
+            future => FutureLeafVersion::from_consensus(future).map(LeafVersion::Future),
+        }
+    }
+
+    /// Returns the consensus representation of this [`LeafVersion`].
+    pub fn to_consensus(self) -> u8 {
+        match self {
+            Self::TapScript => TAPROOT_LEAF_TAPSCRIPT,
+            Self::Future(version) => version.to_consensus(),
+        }
+    }
+}
+
+impl fmt::Display for LeafVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match (self, f.alternate()) {
+            (Self::TapScript, true) => f.write_str("tapscript"),
+            (Self::TapScript, false) => fmt::Display::fmt(&TAPROOT_LEAF_TAPSCRIPT, f),
+            (Self::Future(version), true) => write!(f, "future_script_{:#02x}", version.0),
+            (Self::Future(version), false) => fmt::Display::fmt(version, f),
+        }
+    }
+}
+
+impl fmt::LowerHex for LeafVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.to_consensus(), f)
+    }
+}
+internals::impl_to_hex_from_lower_hex!(LeafVersion, |_| 2);
+
+impl fmt::UpperHex for LeafVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::UpperHex::fmt(&self.to_consensus(), f)
+    }
+}
+
+/// Serializes [`LeafVersion`] as a `u8` using consensus encoding.
+#[cfg(feature = "serde")]
+impl serde::Serialize for LeafVersion {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_u8(self.to_consensus())
+    }
+}
+
+/// Deserializes [`LeafVersion`] as a `u8` using consensus encoding.
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for LeafVersion {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct U8Visitor;
+        impl serde::de::Visitor<'_> for U8Visitor {
+            type Value = LeafVersion;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a valid consensus-encoded Taproot leaf version")
+            }
+
+            fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                let value = u8::try_from(value).map_err(|_| {
+                    E::invalid_value(
+                        serde::de::Unexpected::Unsigned(value),
+                        &"consensus-encoded leaf version as u8",
+                    )
+                })?;
+                LeafVersion::from_consensus(value).map_err(|_| {
+                    E::invalid_value(
+                        ::serde::de::Unexpected::Unsigned(value as u64),
+                        &"consensus-encoded leaf version as u8",
+                    )
+                })
+            }
+        }
+
+        deserializer.deserialize_u8(U8Visitor)
+    }
+}
+
+/// Inner type representing future (non-tapscript) leaf versions. See [`LeafVersion::Future`].
+///
+/// NB: NO PUBLIC CONSTRUCTOR!
+/// The only way to construct this is by converting `u8` to [`LeafVersion`] and then extracting it.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct FutureLeafVersion(u8);
+
+impl FutureLeafVersion {
+    #[track_caller]
+    pub(self) fn from_consensus(version: u8) -> Result<Self, InvalidTaprootLeafVersionError> {
+        match version {
+            TAPROOT_LEAF_TAPSCRIPT => unreachable!(
+                "FutureLeafVersion::from_consensus should never be called for 0xC0 value"
+            ),
+            TAPROOT_ANNEX_PREFIX => Err(InvalidTaprootLeafVersionError(TAPROOT_ANNEX_PREFIX)),
+            odd if odd & 0xFE != odd => Err(InvalidTaprootLeafVersionError(odd)),
+            even => Ok(Self(even)),
+        }
+    }
+
+    /// Returns the consensus representation of this [`FutureLeafVersion`].
+    #[inline]
+    pub fn to_consensus(self) -> u8 { self.0 }
+}
+
+impl fmt::Display for FutureLeafVersion {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { fmt::Display::fmt(&self.0, f) }
+}
+
+impl fmt::LowerHex for FutureLeafVersion {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { fmt::LowerHex::fmt(&self.0, f) }
+}
+internals::impl_to_hex_from_lower_hex!(FutureLeafVersion, |_| 2);
+
+impl fmt::UpperHex for FutureLeafVersion {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { fmt::UpperHex::fmt(&self.0, f) }
+}
+
+/// Error types for taproot primitives
+pub mod error {
+    use core::convert::Infallible;
+    use core::fmt;
+
+    /// The last bit of tapleaf version must be zero.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct InvalidTaprootLeafVersionError(pub(super) u8);
+
+    impl InvalidTaprootLeafVersionError {
+        /// Accessor for the invalid leaf version.
+        pub fn invalid_leaf_version(&self) -> u8 { self.0 }
+    }
+
+    impl From<Infallible> for InvalidTaprootLeafVersionError {
+        fn from(never: Infallible) -> Self { match never {} }
+    }
+
+    impl fmt::Display for InvalidTaprootLeafVersionError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "leaf version({}) must have the least significant bit 0", self.0)
+        }
+    }
+
+    #[cfg(feature = "std")]
+    impl std::error::Error for InvalidTaprootLeafVersionError {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> Arbitrary<'a> for TapLeafHash {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Self::from_byte_array(u.arbitrary()?))
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> Arbitrary<'a> for TapNodeHash {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Self::from_byte_array(u.arbitrary()?))
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> Arbitrary<'a> for FutureLeafVersion {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        match u8::arbitrary(u)? {
+            TAPROOT_LEAF_TAPSCRIPT => Err(arbitrary::Error::IncorrectFormat),
+            version => Self::from_consensus(version).map_err(|_| arbitrary::Error::IncorrectFormat),
+        }
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> Arbitrary<'a> for LeafVersion {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        match bool::arbitrary(u)? {
+            true => Ok(Self::TapScript),
+            false => Ok(Self::Future(u.arbitrary()?)),
+        }
+    }
+}

--- a/taproot-primitives/src/lib.rs
+++ b/taproot-primitives/src/lib.rs
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Taproot stuff destined for bitcoin-primitives.
+
+#![no_std]
+// Experimental features we need.
+#![doc(test(attr(warn(unused))))]
+// Coding conventions.
+#![warn(deprecated_in_future)]
+#![warn(missing_docs)]
+// Exclude lints we don't think are valuable.
+#![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
+#![allow(clippy::manual_range_contains)] // More readable than clippy's format.
+#![allow(clippy::uninlined_format_args)] // Allow `format!("{}", x)` instead of enforcing `format!("{x}")`


### PR DESCRIPTION
As part of the overarching goal of crate smashing, taproot primitives will need to be split from bitcoin to facilitate other logic separation. As mentioned here: https://github.com/rust-bitcoin/rust-bitcoin/issues/5673#issuecomment-3911396634, the temporary introduction of a taproot-primitives crate to house these primitives is suitable to help smooth this process.

 - Patch 1 creates an empty taproot-primitives crate.
 - Patch 2 splits TapNodeHash and TapLeafHash impls into extension traits in bitcoin.
 - Patch 3 moves the hash types and LeafVersion/FutureLeafVersion from bitcoin into taproot-primitives.
 - Patch 4 fixes lint issues arising from the move.