### PR TITLE
units: add optional encoding dep to feature flag test matrix

### DIFF
--- a/units/rbmt.toml
+++ b/units/rbmt.toml
@@ -7,8 +7,8 @@ examples = []
 
 # Features to test with the conventional `std` feature enabled.
 # Tests each feature alone with std, all pairs, and all together.
-features_with_std = ["serde", "arbitrary"]
+features_with_std = ["serde", "arbitrary", "encoding"]
 
 # Features to test without the `std` feature.
 # Tests each feature alone, all pairs, and all together.
-features_without_std = ["alloc", "serde", "arbitrary"]
+features_without_std = ["alloc", "serde", "arbitrary", "encoding"]


### PR DESCRIPTION
Took a pass on `consensus_encoding`, `primitives` and `units` looking for untested feature flags after we spotted `hex` missing in https://github.com/rust-bitcoin/rust-bitcoin/pull/5703#discussion_r2825549000. Only gap I found is the optional `encoding` dep of `units`. I believe this should be flipped on for std and no-std tests given how the optional feature is used with the `std` flag.