### PR TITLE
primitives: Unit test hex feature

### DIFF
--- a/primitives/rbmt.toml
+++ b/primitives/rbmt.toml
@@ -7,11 +7,11 @@ examples = []
 
 # Features to test with the conventional `std` feature enabled.
 # Tests each feature alone with std, all pairs, and all together.
-features_with_std = ["serde", "arbitrary"]
+features_with_std = ["serde", "arbitrary", "hex"]
 
 # Features to test without the `std` feature.
 # Tests each feature alone, all pairs, and all together.
-features_without_std = ["alloc", "serde", "arbitrary"]
+features_without_std = ["alloc", "serde", "arbitrary", "hex"]
 
 [lint]
 allowed_duplicates = [


### PR DESCRIPTION
When I added the `hex` feature (#5213) I forgot to tie it into CI.

Test the feature both with and without `std` enabled.
