### PR TITLE
bitcoin: preserve parity for `XOnlyPublicKey`

### DIFF
--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -365,7 +365,10 @@ impl From<secp256k1::XOnlyPublicKey> for XOnlyPublicKey {
 }
 
 impl From<secp256k1::PublicKey> for XOnlyPublicKey {
-    fn from(pk: secp256k1::PublicKey) -> Self { Self::from_secp(pk) }
+    fn from(pk: secp256k1::PublicKey) -> Self {
+        let (xonly, parity) = pk.x_only_public_key();
+        Self::from_secp(xonly).with_parity(parity)
+    }
 }
 
 impl fmt::LowerHex for XOnlyPublicKey {
@@ -654,7 +657,10 @@ impl From<secp256k1::PublicKey> for PublicKey {
 }
 
 impl From<PublicKey> for XOnlyPublicKey {
-    fn from(pk: PublicKey) -> Self { Self::from_secp(pk.to_inner()) }
+    fn from(pk: PublicKey) -> Self {
+        let (xonly, parity) = pk.to_inner().x_only_public_key();
+        Self::from_secp(xonly).with_parity(parity)
+    }
 }
 
 /// An opaque return type for PublicKey::to_sort_key.


### PR DESCRIPTION
Both `From` impls for XOnlyPublicKey lose parity because they call `from_secp()`, which defaults to Parity::Even. 
we now preserve parity by extracting it from x_only_public_key() instead.

Discussed in https://github.com/rust-bitcoin/rust-bitcoin/pull/5593#discussion_r2810872671