### PR TITLE
Fix decoder and encoder re-exports in `bitcoin`

### DIFF
--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -25,15 +25,22 @@ use crate::{internal_macros, BlockTime, Target, Weight, Work};
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
 pub use primitives::block::{
-    Block, Checked, Unchecked, Validation, Version, BlockHash, Header,
-    WitnessCommitment, compute_merkle_root, compute_witness_root,
+    Block, BlockDecoder, BlockEncoder, BlockHash, BlockHashDecoder, BlockHashEncoder,
+    Checked, Unchecked, Validation, Version, VersionDecoder, VersionEncoder, Header,
+    HeaderDecoder, HeaderEncoder, WitnessCommitment, compute_merkle_root, compute_witness_root,
 };
 #[doc(no_inline)]
-pub use primitives::block::{InvalidBlockError, ParseBlockError, ParseHeaderError};
+pub use primitives::block::{
+    BlockDecoderError, BlockHashDecoderError, HeaderDecoderError, InvalidBlockError,
+    ParseBlockError, ParseHeaderError, VersionDecoderError,
+};
 #[doc(inline)]
-pub use units::block::{BlockHeight, BlockHeightInterval, BlockMtp, BlockMtpInterval};
+pub use units::block::{
+    BlockHeight, BlockHeightDecoder, BlockHeightEncoder, BlockHeightInterval, BlockMtp,
+    BlockMtpInterval,
+};
 #[doc(no_inline)]
-pub use units::block::TooBigForRelativeHeightError;
+pub use units::block::{BlockHeightDecoderError, TooBigForRelativeHeightError};
 
 #[deprecated(since = "TBD", note = "use `BlockHeightInterval` instead")]
 #[doc(hidden)]

--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -81,10 +81,13 @@ pub use self::{
 #[doc(inline)]
 pub use primitives::script::{
     RedeemScript, RedeemScriptBuf, RedeemScriptSizeError, RedeemScriptTag, Script, ScriptBuf,
-    ScriptHash, ScriptHashableTag, ScriptPubKey, ScriptPubKeyBuf, ScriptPubKeyTag, ScriptSig,
-    ScriptSigBuf, ScriptSigTag, Tag, TapScript, TapScriptBuf, TapScriptTag, WScriptHash,
-    WitnessScript, WitnessScriptBuf, WitnessScriptSizeError, WitnessScriptTag,
+    ScriptBufDecoder, ScriptEncoder, ScriptHash, ScriptHashableTag, ScriptPubKey,
+    ScriptPubKeyBuf, ScriptPubKeyTag, ScriptSig, ScriptSigBuf, ScriptSigTag, Tag, TapScript,
+    TapScriptBuf, TapScriptTag, WScriptHash, WitnessScript, WitnessScriptBuf,
+    WitnessScriptSizeError, WitnessScriptTag,
 };
+#[doc(no_inline)]
+pub use primitives::script::ScriptBufDecoderError;
 
 pub(crate) use self::borrowed::ScriptExtPriv;
 pub(crate) use self::owned::ScriptBufExtPriv;

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -33,10 +33,17 @@ use crate::{internal_macros, Amount, FeeRate, Sequence, SignedAmount};
 
 #[rustfmt::skip]            // Keep public re-exports separate.
 #[doc(no_inline)]
-pub use primitives::transaction::{ParseTransactionError, ParseOutPointError};
+pub use primitives::transaction::{
+    BlockHashDecoderError, OutPointDecoderError, ParseTransactionError, ParseOutPointError,
+    TransactionDecoderError, TxInDecoderError, TxOutDecoderError,
+    VersionDecoderError,
+};
 #[doc(inline)]
 pub use primitives::transaction::{
-    Ntxid, OutPoint, Transaction, TxIn, TxOut, Txid, Version, Wtxid,
+    BlockHashDecoder, Ntxid, OutPoint, OutPointDecoder, OutPointEncoder, Transaction,
+    TransactionDecoder, TransactionEncoder, TxIn, TxInDecoder, TxInEncoder,
+    TxOut, TxOutDecoder, TxOutEncoder, Txid, Version,
+    VersionDecoder, VersionEncoder, WitnessesEncoder, Wtxid,
 };
 
 impl Encodable for Txid {

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -17,9 +17,9 @@ type BorrowedControlBlock<'a> = ControlBlock<&'a TaprootMerkleBranch, &'a Serial
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
-pub use primitives::witness::{Iter, Witness};
+pub use primitives::witness::{Iter, Witness, WitnessDecoder, WitnessEncoder};
 #[doc(no_inline)]
-pub use primitives::witness::UnexpectedEofError;
+pub use primitives::witness::{UnexpectedEofError, WitnessDecoderError};
 
 impl Decodable for Witness {
     fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, Error> {

--- a/contrib/generate-bitcoin-re-export-test.sh
+++ b/contrib/generate-bitcoin-re-export-test.sh
@@ -95,15 +95,14 @@ EOF
         # Extract pub mod
         elif [[ "$line" =~ ^pub\ mod\ (bitcoin_primitives::[^[:space:]]+)$ ]]; then
             path="${BASH_REMATCH[1]}"
+        # Extract pub use (re-exports)
+        elif [[ "$line" =~ ^pub\ use\ (bitcoin_primitives::[^[:space:]]+)$ ]]; then
+            path="${BASH_REMATCH[1]}"
         fi
 
         if [[ -n "$path" ]]; then
             # Remove generic type parameters (e.g., <T>)
             path="${path%%<*}"
-
-            if [[ "$path" == *Encoder* ]] || [[ $path == *Decoder* ]]; then
-                continue
-            fi
 
             # Convert bitcoin_primitives:: to bitcoin::
             local bitcoin_path="${path//bitcoin_primitives::/bitcoin::}"

--- a/contrib/generate-primitives-re-export-test.sh
+++ b/contrib/generate-primitives-re-export-test.sh
@@ -99,6 +99,9 @@ EOF
         # Extract pub mod
         elif [[ "$line" =~ ^pub\ mod\ (bitcoin_units::[^[:space:]]+)$ ]]; then
             path="${BASH_REMATCH[1]}"
+        # Extract pub use (re-exports)
+        elif [[ "$line" =~ ^pub\ use\ (bitcoin_primitives::[^[:space:]]+)$ ]]; then
+            path="${BASH_REMATCH[1]}"
         fi
 
         if [[ -n "$path" ]]; then


### PR DESCRIPTION
The bitcoin crate should always be a superset of primitives, and primitives a superset of units. Due to a filter check in generate-bitcoin-re-export-test.sh, encoder and decoder types and their associated errors are not being caught missing from bitcoin.

Remove the encoder/decoder type filter from generate-bitcoin-re-export-test.sh and correctly re-export all required types.

Closes #5689 