### PR TITLE
consensus_encoding: add track_caller to panic-able sites

### DIFF
--- a/consensus_encoding/src/decode/mod.rs
+++ b/consensus_encoding/src/decode/mod.rs
@@ -40,6 +40,7 @@ pub trait Decoder: Sized {
     ///
     /// May panic if called after a previous call to [`Self::push_bytes`] errored.
     #[must_use = "must check result to avoid panics on subsequent calls"]
+    #[track_caller]
     fn push_bytes(&mut self, bytes: &mut &[u8]) -> Result<bool, Self::Error>;
 
     /// Complete the decoding process and return the final result.
@@ -57,6 +58,7 @@ pub trait Decoder: Sized {
     ///
     /// May panic if called after a previous call to [`Self::push_bytes`] errored.
     #[must_use = "must check result to avoid panics on subsequent calls"]
+    #[track_caller]
     fn end(self) -> Result<Self::Output, Self::Error>;
 
     /// Returns the maximum number of bytes this decoder can consume without over-reading.


### PR DESCRIPTION
The composite `Decoder*`'s panic if a caller calls push bytes again after receiving an error. This contract is already documented in the exposed docs for `push_bytes` and `end`, but adding `track_caller` will help the caller if they do break the contract. Adding to [the `Decoder` trait itself](https://rustc-dev-guide.rust-lang.org/backend/implicit-caller-location.html#traits) so that all `Decoder*`'s inherit it.

Part of #5518 