### PR TITLE
consensus_encoding: expose vis fragment on exposed macros

### DIFF
--- a/consensus_encoding/src/encode/mod.rs
+++ b/consensus_encoding/src/encode/mod.rs
@@ -49,14 +49,14 @@ pub trait Encoder {
 macro_rules! encoder_newtype{
     (
         $(#[$($struct_attr:tt)*])*
-        pub struct $name:ident<$lt:lifetime>($encoder:ty);
+        $vis:vis struct $name:ident<$lt:lifetime>($encoder:ty);
     ) => {
         $(#[$($struct_attr)*])*
-        pub struct $name<$lt>($encoder, core::marker::PhantomData<&$lt $encoder>);
+        $vis struct $name<$lt>($encoder, core::marker::PhantomData<&$lt $encoder>);
 
         impl<$lt> $name<$lt> {
             /// Construct a new instance of the newtype encoder
-            pub fn new(encoder: $encoder) -> $name<$lt> {
+            $vis fn new(encoder: $encoder) -> $name<$lt> {
                 $name(encoder, core::marker::PhantomData)
             }
         }
@@ -78,11 +78,11 @@ macro_rules! encoder_newtype{
 macro_rules! encoder_newtype_exact{
     (
         $(#[$($struct_attr:tt)*])*
-        pub struct $name:ident<$lt:lifetime>($encoder:ty);
+        $vis:vis struct $name:ident<$lt:lifetime>($encoder:ty);
     ) => {
         $crate::encoder_newtype! {
             $(#[$($struct_attr)*])*
-            pub struct $name<$lt>($encoder);
+            $vis struct $name<$lt>($encoder);
         }
 
         impl<$lt> $crate::ExactSizeEncoder for $name<$lt> {


### PR DESCRIPTION
Following the [C-MACRO-VIS](https://rust-lang.github.io/api-guidelines/macros.html#item-macros-support-visibility-specifiers-c-macro-vis) API convention, expose a vis fragment to allow the caller to choose the output's visibility. This change is backwards compatible with the existing callers in `units` and `primitives`.