### PR TITLE
Fix `to_secret_key` docs on `Keypair`

### DIFF
--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -424,7 +424,7 @@ impl Keypair {
         Self::from(secp256k1::Keypair::from_secret_key(sk))
     }
 
-    /// Returns the [`PrivateKey`] for this [`Keypair`].
+    /// Returns the [`secp256k1::SecretKey`] for this [`Keypair`].
     ///
     /// This is equivalent to using [`secp256k1::SecretKey::from_keypair`] on the inner value.
     #[inline]


### PR DESCRIPTION
The to_secret_key function docs state that it returns a PrivateKey type, but the function actually returns a secp256k1::SecretKey.

Fix to_secret_key docs on Keypair to correctly reference secp256k1::SecretKey return type.