### PR TITLE
hashes: remove hex unstable dependence

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -193,7 +193,6 @@ dependencies = [
  "bitcoin-consensus-encoding",
  "bitcoin-internals",
  "cpufeatures",
- "hex-conservative 0.3.2",
  "hex-conservative 1.0.0",
  "serde",
  "serde_test",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -192,7 +192,6 @@ dependencies = [
  "bitcoin-consensus-encoding",
  "bitcoin-internals",
  "cpufeatures",
- "hex-conservative 0.3.2",
  "hex-conservative 1.0.0",
  "serde",
  "serde_test",

--- a/api/hashes/all-features.txt
+++ b/api/hashes/all-features.txt
@@ -730,7 +730,6 @@ pub const fn bitcoin_hashes::siphash24::Hash::to_byte_array(self) -> [u8; 8]
 pub const fn bitcoin_hashes::siphash24::HashEngine::with_keys(k0: u64, k1: u64) -> Self
 pub extern crate bitcoin_hashes::encoding
 pub extern crate bitcoin_hashes::hex
-pub extern crate bitcoin_hashes::hex_unstable
 pub extern crate bitcoin_hashes::serde
 pub fn bitcoin_hashes::Hash::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin_hashes::Hash::from_byte_array(bytes: Self::Bytes) -> Self

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -15,10 +15,9 @@ exclude = ["tests", "contrib"]
 
 [features]
 default = ["std"]
-std = ["alloc", "hex-stable/std", "hex-unstable/std"]
-alloc = ["hex-stable/alloc", "hex-unstable/alloc"]
+std = ["alloc", "hex?/std"]
+alloc = ["hex?/alloc"]
 serde = ["dep:serde", "hex"]
-hex = ["dep:hex-stable", "dep:hex-unstable"]
 # Smaller (but slower) implementation of sha256, sha512 and ripemd160
 small-hash = []
 
@@ -29,10 +28,7 @@ encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encodi
 arbitrary = { version = "1.4.1", optional = true}
 serde = { version = "1.0.195", default-features = false, optional = true }
 cpufeatures = { version = "0.2", optional = true }
-
-# Both optional hex dependencies are behind the `hex` feature.
-hex-stable = { package = "hex-conservative", version = "1.0.0", default-features = false, optional = true }
-hex-unstable = { package = "hex-conservative", version = "0.3.2", default-features = false, optional = true }
+hex = { package = "hex-conservative", version = "1.0.0", default-features = false, optional = true }
 
 [dev-dependencies]
 serde_test = "1.0.19"

--- a/hashes/src/hkdf/mod.rs
+++ b/hashes/src/hkdf/mod.rs
@@ -154,8 +154,6 @@ impl<T: HashEngine> fmt::Debug for Hkdf<T> {
 #[cfg(feature = "alloc")]
 #[cfg(feature = "hex")]
 mod tests {
-    use hex_unstable::DisplayHex;
-
     use super::*;
     use crate::{hex, sha256};
 
@@ -169,10 +167,12 @@ mod tests {
         let mut okm = [0u8; 42];
         hkdf.expand(&info, &mut okm).unwrap();
 
-        assert_eq!(
-            okm.to_lower_hex_string(),
-            "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865"
-        );
+        let expected_okm = hex::decode_to_vec(
+            "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865",
+        )
+        .unwrap();
+
+        assert_eq!(okm.as_slice(), expected_okm.as_slice());
     }
 
     #[test]
@@ -191,10 +191,11 @@ mod tests {
         let mut okm = [0u8; 82];
         hkdf.expand(&info, &mut okm).unwrap();
 
-        assert_eq!(
-            okm.to_lower_hex_string(),
+        let expected_okm = hex::decode_to_vec(
             "b11e398dc80327a1c8e7f78c596a49344f012eda2d4efad8a050cc4c19afa97c59045a99cac7827271cb41c65e590e09da3275600c2f09b8367793a9aca3db71cc30c58179ec3e87c14c01d5c1f3434f1d87"
-        );
+        ).unwrap();
+
+        assert_eq!(okm.as_slice(), expected_okm.as_slice());
     }
 
     #[test]
@@ -220,7 +221,9 @@ mod tests {
         let mut okm = [0u8; 1];
         hkdf.expand(&info, &mut okm).unwrap();
 
-        assert_eq!(okm.to_lower_hex_string(), "3c");
+        let expected_okm = hex::decode_to_vec("3c").unwrap();
+
+        assert_eq!(okm.as_slice(), expected_okm.as_slice());
     }
 
     #[test]
@@ -232,10 +235,12 @@ mod tests {
         let hkdf = Hkdf::<sha256::HashEngine>::new(&salt, &ikm);
         let okm = hkdf.expand_to_len(&info, 42).unwrap();
 
-        assert_eq!(
-            okm.to_lower_hex_string(),
-            "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865"
-        );
+        let expected_okm = hex::decode_to_vec(
+            "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865",
+        )
+        .unwrap();
+
+        assert_eq!(okm.as_slice(), expected_okm.as_slice());
     }
 
     #[test]

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -81,9 +81,7 @@ extern crate serde_test;
 pub extern crate encoding;
 
 #[cfg(feature = "hex")]
-pub extern crate hex_stable as hex;
-#[cfg(feature = "hex")]
-pub extern crate hex_unstable;
+pub extern crate hex;
 
 #[doc(hidden)]
 pub mod _export {

--- a/hashes/src/macros.rs
+++ b/hashes/src/macros.rs
@@ -621,6 +621,13 @@ mod test {
 
     impl TestHash {
         fn all_zeros() -> Self { Self::from_byte_array([0; 32]) }
+
+        #[cfg(feature = "hex")]
+        fn hex_char_set() -> Self {
+            let mut bytes = [0u8; 32];
+            bytes[24..].copy_from_slice(&[0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef]);
+            Self::from_byte_array(bytes)
+        }
     }
 
     #[test]
@@ -667,8 +674,8 @@ mod test {
     fn display() {
         use alloc::format;
 
-        let want = "0000000000000000000000000000000000000000000000000000000000000000";
-        let got = format!("{}", TestHash::all_zeros());
+        let want = "efcdab8967452301000000000000000000000000000000000000000000000000";
+        let got = format!("{}", TestHash::hex_char_set());
         assert_eq!(got, want);
     }
 
@@ -678,8 +685,8 @@ mod test {
     fn display_alternate() {
         use alloc::format;
 
-        let want = "0x0000000000000000000000000000000000000000000000000000000000000000";
-        let got = format!("{:#}", TestHash::all_zeros());
+        let want = "0xefcdab8967452301000000000000000000000000000000000000000000000000";
+        let got = format!("{:#}", TestHash::hex_char_set());
         assert_eq!(got, want);
     }
 
@@ -689,8 +696,8 @@ mod test {
     fn lower_hex() {
         use alloc::format;
 
-        let want = "0000000000000000000000000000000000000000000000000000000000000000";
-        let got = format!("{:x}", TestHash::all_zeros());
+        let want = "efcdab8967452301000000000000000000000000000000000000000000000000";
+        let got = format!("{:x}", TestHash::hex_char_set());
         assert_eq!(got, want);
     }
 
@@ -700,8 +707,8 @@ mod test {
     fn lower_hex_alternate() {
         use alloc::format;
 
-        let want = "0x0000000000000000000000000000000000000000000000000000000000000000";
-        let got = format!("{:#x}", TestHash::all_zeros());
+        let want = "0xefcdab8967452301000000000000000000000000000000000000000000000000";
+        let got = format!("{:#x}", TestHash::hex_char_set());
         assert_eq!(got, want);
     }
 

--- a/hashes/src/macros.rs
+++ b/hashes/src/macros.rs
@@ -613,9 +613,14 @@ mod test {
     hash_newtype! {
         /// Test hash.
         struct TestHash(crate::sha256d::Hash);
+
+        /// Test hash with forced forward display.
+        #[hash_newtype(forward)]
+        struct ForwardTestHash(crate::sha256d::Hash);
     }
+
     #[cfg(feature = "hex")]
-    crate::impl_hex_for_newtype!(TestHash);
+    crate::impl_hex_for_newtype!(TestHash, ForwardTestHash);
     #[cfg(not(feature = "hex"))]
     crate::impl_debug_only_for_newtype!(TestHash);
 
@@ -623,6 +628,15 @@ mod test {
         fn all_zeros() -> Self { Self::from_byte_array([0; 32]) }
 
         #[cfg(feature = "hex")]
+        fn hex_char_set() -> Self {
+            let mut bytes = [0u8; 32];
+            bytes[24..].copy_from_slice(&[0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef]);
+            Self::from_byte_array(bytes)
+        }
+    }
+
+    #[cfg(feature = "hex")]
+    impl ForwardTestHash {
         fn hex_char_set() -> Self {
             let mut bytes = [0u8; 32];
             bytes[24..].copy_from_slice(&[0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef]);
@@ -704,11 +718,55 @@ mod test {
     #[test]
     #[cfg(feature = "alloc")]
     #[cfg(feature = "hex")]
+    fn upper_hex() {
+        use alloc::format;
+
+        let want = "EFCDAB8967452301000000000000000000000000000000000000000000000000";
+        let got = format!("{:X}", TestHash::hex_char_set());
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    #[cfg(feature = "alloc")]
+    #[cfg(feature = "hex")]
     fn lower_hex_alternate() {
         use alloc::format;
 
         let want = "0xefcdab8967452301000000000000000000000000000000000000000000000000";
         let got = format!("{:#x}", TestHash::hex_char_set());
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    #[cfg(feature = "alloc")]
+    #[cfg(feature = "hex")]
+    fn lower_hex_even_precision() {
+        use alloc::format;
+
+        let want = "efcd";
+        let got = format!("{:.4x}", TestHash::hex_char_set());
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    #[cfg(feature = "alloc")]
+    #[cfg(feature = "hex")]
+    fn lower_hex_odd_precision() {
+        use alloc::format;
+
+        let want = "efcda";
+        let got = format!("{:.5x}", TestHash::hex_char_set());
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    #[cfg(feature = "alloc")]
+    #[cfg(feature = "hex")]
+    fn lower_hex_forward() {
+        use alloc::format;
+
+        let want = "0000000000000000000000000000000000000000000000000123456789abcdef";
+        let got = format!("{:x}", ForwardTestHash::hex_char_set());
         assert_eq!(got, want);
     }
 


### PR DESCRIPTION
In order to stabilize `hashes` the dependence on the unstable version on `hex-conservative` has been removed by implementing hash formatting locally in the macro, instead of using unstable hex helpers.

- Replace hex unstable in hashes macro: Update the macro to perform the formatting locally so that the dependence on the unstable hex crate can be removed.
- Remove unstable hex dependence from hashes: Update the HKDF tests to compare raw slices and not rely on unstable hex. Remove the unstable hex dependency and reexport. Update the lock files. In Cargo.toml add `?` to hex in the alloc and std features so that enabling them does not enable hex when hex it is not explicitly enabled.
- Add hashes macro test vector: Add a test vector that has all the hex characters and use it in the tests to ensure that the hex formatting is correct.
- Add missing formatting tests: Adds tests of precision, upper hex and forward direction that were not covered by the existing tests.
- Update the api files.

Closes #5895