### PR TITLE
Adjust XOnlyPublicKey from_secp constructor and to_public_key

### DIFF
--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -310,11 +310,9 @@ impl XOnlyPublicKey {
     ///
     /// The [`PublicKey`] is constructed using the parity in this x-only public key.
     #[inline]
-    // to_* functions are used for non-free conversions to owned types. Clippy complains
-    // since XOnlyPublicKey is Copy but we intentionally use &self to remove a copy and
-    // to_* to indicate the cost of the operation.
-    #[allow(clippy::wrong_self_convention)]
-    pub fn to_public_key(&self) -> PublicKey { self.as_inner().public_key(self.parity()).into() }
+    pub fn to_public_key(self) -> PublicKey {
+        self.as_inner().public_key(self.parity()).into()
+    }
 
     /// Verifies that a tweak produced by [`XOnlyPublicKey::add_tweak`] was computed correctly.
     ///


### PR DESCRIPTION
In the process of introducing parity to XOnlyPublicKey, various small issues crept into the API that were sub-optimal. Due to the size of #5593, they're addressed here instead.

 - Patch 1 adds a parity argument to the from_secp constructor, replacing various from_secp().with_parity() uses.
 - Patch 2 reverts XOnlyPublicKey::to_public_key to take self by value.