### PR TITLE
primitives: Use `ArrayRefEncoder`

### DIFF
--- a/primitives/src/hash_types/transaction_merkle_node.rs
+++ b/primitives/src/hash_types/transaction_merkle_node.rs
@@ -52,14 +52,14 @@ impl TxMerkleNode {
 
 encoding::encoder_newtype_exact! {
     /// The encoder for the [`TxMerkleNode`] type.
-    pub struct TxMerkleNodeEncoder<'e>(encoding::ArrayEncoder<32>);
+    pub struct TxMerkleNodeEncoder<'e>(encoding::ArrayRefEncoder<'e, 32>);
 }
 
 impl encoding::Encodable for TxMerkleNode {
     type Encoder<'e> = TxMerkleNodeEncoder<'e>;
     fn encoder(&self) -> Self::Encoder<'_> {
-        TxMerkleNodeEncoder::new(encoding::ArrayEncoder::without_length_prefix(
-            self.to_byte_array(),
+        TxMerkleNodeEncoder::new(encoding::ArrayRefEncoder::without_length_prefix(
+            self.as_byte_array(),
         ))
     }
 }

--- a/primitives/src/hash_types/witness_merkle_node.rs
+++ b/primitives/src/hash_types/witness_merkle_node.rs
@@ -52,14 +52,14 @@ impl WitnessMerkleNode {
 
 encoding::encoder_newtype_exact! {
     /// The encoder for the [`WitnessMerkleNode`] type.
-    pub struct WitnessMerkleNodeEncoder<'e>(encoding::ArrayEncoder<32>);
+    pub struct WitnessMerkleNodeEncoder<'e>(encoding::ArrayRefEncoder<'e, 32>);
 }
 
 impl encoding::Encodable for WitnessMerkleNode {
     type Encoder<'e> = WitnessMerkleNodeEncoder<'e>;
     fn encoder(&self) -> Self::Encoder<'_> {
-        WitnessMerkleNodeEncoder::new(encoding::ArrayEncoder::without_length_prefix(
-            self.to_byte_array(),
+        WitnessMerkleNodeEncoder::new(encoding::ArrayRefEncoder::without_length_prefix(
+            self.as_byte_array(),
         ))
     }
 }


### PR DESCRIPTION
No need to copy the hash type when encoding the `TxMerkleNode` or the `WitnessMerkleNode`.

Use `ArrayRefEncoder` as we do for the other hash types. Props to claude for noticing this while chugging through some other changes for me. I did the changes manually though.