### PR TITLE
primitives: Fix feature gating in crate unit test

### DIFF
--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -259,10 +259,10 @@ pub(crate) mod hex_codec {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "alloc")]
+    #[cfg(all(feature = "alloc", feature = "hex"))]
     use alloc::{format, string::ToString};
 
-    #[cfg(feature = "alloc")]
+    #[cfg(all(feature = "alloc", feature = "hex"))]
     use super::*;
 
     #[test]


### PR DESCRIPTION
We don't lint all feature combinations. Fix the feature gating in the crate level unit test just for good measure.