### PR TITLE
consensus_encoding: Slightly improve docs on macros

### DIFF
--- a/consensus_encoding/src/encode/mod.rs
+++ b/consensus_encoding/src/encode/mod.rs
@@ -43,8 +43,10 @@ pub trait Encoder {
     fn advance(&mut self) -> bool;
 }
 
-/// Implements a newtype around an encoder which implements the
-/// [`Encoder`] trait by forwarding to the wrapped encoder.
+/// Implements a newtype around an encoder.
+///
+/// The new type will implement the [`Encoder`] trait by forwarding to the wrapped encoder. If your
+/// type has a known size consider using [`crate::encoder_newtype_exact`] instead.
 #[macro_export]
 macro_rules! encoder_newtype{
     (
@@ -71,8 +73,9 @@ macro_rules! encoder_newtype{
     }
 }
 
-/// Implements a newtype around an exact-size encoder which
-/// implements the [`Encoder`] and [`ExactSizeEncoder`] traits
+/// Implements a newtype around an exact-size encoder.
+///
+/// The new type will implement both the [`Encoder`] and [`ExactSizeEncoder`] traits
 /// by forwarding to the wrapped encoder.
 #[macro_export]
 macro_rules! encoder_newtype_exact{


### PR DESCRIPTION
In preparation for 1.0-ing this crate do some minor improvements to the encoder newtype macros.