### PR TITLE
primitives: Update API files

### DIFF
--- a/api/primitives/no-features.txt
+++ b/api/primitives/no-features.txt
@@ -324,6 +324,8 @@ impl core::marker::UnsafeUnpin for bitcoin_primitives::Wtxid
 impl core::marker::UnsafeUnpin for bitcoin_primitives::block::BlockHashDecoder
 impl core::marker::UnsafeUnpin for bitcoin_primitives::block::BlockHashDecoderError
 impl core::marker::UnsafeUnpin for bitcoin_primitives::block::Header
+impl core::marker::UnsafeUnpin for bitcoin_primitives::block::HeaderDecoder
+impl core::marker::UnsafeUnpin for bitcoin_primitives::block::HeaderDecoderError
 impl core::marker::UnsafeUnpin for bitcoin_primitives::block::Version
 impl core::marker::UnsafeUnpin for bitcoin_primitives::block::VersionDecoder
 impl core::marker::UnsafeUnpin for bitcoin_primitives::block::VersionDecoderError


### PR DESCRIPTION
The API files for primitives are somehow behind on the tip of master, causing all CI to break for new PRs.

Update the api files using "just check-api"