### PR TITLE
Add serde impls for FilterHash and FilterHeader

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -149,6 +149,7 @@ dependencies = [
  "bitcoin_hashes",
  "hex-conservative 0.3.0",
  "hex_lit",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -148,6 +148,7 @@ dependencies = [
  "bitcoin_hashes",
  "hex-conservative 0.3.0",
  "hex_lit",
+ "serde",
 ]
 
 [[package]]

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -16,6 +16,7 @@ exclude = ["tests", "contrib"]
 default = ["std"]
 std = ["encoding/std", "hashes/std", "network/std", "hex/std", "internals/std", "io/std", "units/std", "bitcoin/std", "primitives/std"]
 arbitrary = ["dep:arbitrary", "bitcoin/arbitrary"]
+serde = ["dep:serde", "hashes/serde"]
 
 [dependencies]
 bitcoin = { path = "../bitcoin/", default-features = false }
@@ -29,6 +30,7 @@ io = { package = "bitcoin-io", version = "0.5.0", path = "../io", default-featur
 units = { package = "bitcoin-units", path = "../units", version = "0.3.0", default-features = false }
 
 arbitrary = { version = "1.4.1", optional = true }
+serde = { version = "1.0.195", default-features = false, features = ["derive", "alloc"], optional = true }
 
 [dev-dependencies]
 hex_lit = "0.1.1"

--- a/p2p/rbmt.toml
+++ b/p2p/rbmt.toml
@@ -7,11 +7,11 @@ examples = []
 
 # Features to test with the conventional `std` feature enabled.
 # Tests each feature alone with std, all pairs, and all together.
-features_with_std = ["arbitrary"]
+features_with_std = ["arbitrary", "serde"]
 
 # Features to test without the `std` feature.
 # Tests each feature alone, all pairs, and all together.
-features_without_std = ["arbitrary"]
+features_without_std = ["arbitrary", "serde"]
 
 [lint]
 allowed_duplicates = [

--- a/p2p/src/message_filter.rs
+++ b/p2p/src/message_filter.rs
@@ -31,6 +31,8 @@ hashes::hash_newtype! {
 }
 
 hashes::impl_hex_for_newtype!(FilterHash, FilterHeader);
+#[cfg(feature = "serde")]
+hashes::impl_serde_for_newtype!(FilterHash, FilterHeader);
 
 impl FilterHash {
     /// Computes the filter header from a filter hash and previous filter header.


### PR DESCRIPTION
This PR adds serde impls for `FilterHash` and `FilterHeader` that were lost whenthese types were moved from bitcoin/src/bip158.rs` to `p2p` in #5387.

Closes #5691