### PR TITLE
bitcoin: Stop using `FromHex`

### DIFF
--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -3,7 +3,6 @@
 #[cfg(doc)]
 use core::ops::Deref;
 
-use hex_unstable::FromHex as _;
 use internals::ToU64 as _;
 
 use super::{
@@ -156,7 +155,7 @@ internal_macros::define_extension_trait! {
 
         /// Constructs a new [`ScriptBuf`] from a hex string.
         #[deprecated(since = "TBD", note = "use `from_hex_no_length_prefix()` instead")]
-        fn from_hex(s: &str) -> Result<Self, hex_unstable::HexToBytesError>
+        fn from_hex(s: &str) -> Result<Self, hex::DecodeVariableLengthBytesError>
             where Self: Sized
         {
             Self::from_hex_no_length_prefix(s)


### PR DESCRIPTION
In the upcoming `hex v1.1.0` we remove the `FromHex` trait. In order to use that release we need to remove its usage here. The single usage was left in so as not to change the function signature on a deprecated signature, just go ahead and do that now. It is still better to keep the different signature because downstream will get the deprecation notice and _hopefully_ not too many folk are matching on the return type.