### PR TITLE
Upgrade to potential `hex` RC release 

### DIFF
--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["tests", "contrib"]
 # If you change features or optional dependencies in any way please update the "# Cargo features" section in lib.rs as well.
 [features]
 default = [ "std", "secp-recovery" ]
-std = ["base58/std", "bech32/std", "encoding/std", "hashes/std", "hex-stable/std", "hex-unstable/std", "internals/std", "io/std", "network/std", "primitives/std", "secp256k1/std", "units/std", "base64?/std", "bitcoinconsensus?/std"]
+std = ["base58/std", "bech32/std", "encoding/std", "hashes/std", "hex/std", "internals/std", "io/std", "network/std", "primitives/std", "secp256k1/std", "units/std", "base64?/std", "bitcoinconsensus?/std"]
 rand = ["secp256k1/rand"]
 serde = ["base64", "dep:serde", "hashes/serde", "internals/serde", "network/serde", "primitives/serde", "secp256k1/serde", "units/serde"]
 secp-global-context = ["secp256k1/global-context"]
@@ -29,8 +29,7 @@ base58 = { package = "base58ck", path = "../base58", version = "0.4.0", default-
 bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false, features = ["alloc", "hex"] }
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.1.0", default-features = false, features = ["alloc"] }
-hex-stable = { package = "hex-conservative", version = "1.0.0", default-features = false, features = ["alloc"] }
-hex-unstable = { package = "hex-conservative", version = "0.3.2", default-features = false, features = ["alloc"] }
+hex = { package = "hex-conservative", version = "1.1.0", git = "https://github.com/tcharding/hex-conservative", branch = "push-zymmlwoymnqz", default-features = false, features = ["alloc"] }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0", features = ["alloc", "hex"] }
 io = { package = "bitcoin-io", path = "../io", version = "0.5.0", default-features = false, features = ["alloc", "hashes"] }
 network = { package = "bitcoin-network-kind", path = "../network", version = "0.1.0", default-features = false, features = ["alloc"]}

--- a/bitcoin/examples/sighash.rs
+++ b/bitcoin/examples/sighash.rs
@@ -3,7 +3,7 @@ use bitcoin::{
     consensus, ecdsa, sighash, Amount, CompressedPublicKey, ScriptPubKey, ScriptPubKeyBuf,
     Transaction, WitnessScript,
 };
-use hex_unstable::hex;
+use hex::hex;
 
 //These are real blockchain transactions examples of computing sighash for:
 // - P2WPKH

--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -1025,7 +1025,7 @@ fn segwit_redeem_hash(pubkey_hash: PubkeyHash) -> hash160::Hash {
 mod tests {
     use alloc::string::ToString;
 
-    use hex_unstable::hex;
+    use hex::hex;
 
     use super::*;
     use crate::network::Network::{Bitcoin, Testnet};

--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -536,7 +536,7 @@ mod test {
     #[cfg(feature = "std")]
     use std::collections::HashMap;
 
-    use hex_unstable::hex;
+    use hex::hex;
     #[cfg(feature = "std")]
     use serde_json::Value;
 

--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -1157,7 +1157,7 @@ impl<'a> Arbitrary<'a> for Xpub {
 mod tests {
     use alloc::string::ToString;
 
-    use hex_unstable::hex;
+    use hex::hex;
     #[cfg(feature = "serde")]
     use internals::serde_round_trip;
 

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -393,7 +393,7 @@ impl std::error::Error for ValidationError {
 mod tests {
     use alloc::string::ToString;
 
-    use hex_unstable::hex;
+    use hex::hex;
     use internals::ToU64 as _;
     use primitives::Wtxid;
 

--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -286,7 +286,7 @@ impl ChainHash {
 mod test {
     use alloc::string::ToString;
 
-    use hex_unstable::hex;
+    use hex::hex;
 
     use super::*;
     use crate::consensus::encode::serialize;

--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -4,7 +4,7 @@
 use alloc::borrow::ToOwned;
 use alloc::string::ToString;
 
-use hex_unstable::hex;
+use hex::hex;
 
 use super::*;
 use crate::consensus::encode::{deserialize, serialize};

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -1282,7 +1282,7 @@ impl<'a> Arbitrary<'a> for InputWeightPrediction {
 mod tests {
     use alloc::string::ToString;
 
-    use hex_unstable::hex;
+    use hex::hex;
 
     use super::*;
     use crate::consensus::encode::{deserialize, serialize};

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -239,7 +239,7 @@ mod sealed {
 mod test {
     use alloc::vec::Vec;
 
-    use hex_unstable::{hex, DisplayHex};
+    use hex::{hex, DisplayHex as _};
 
     use super::*;
     use crate::consensus::{deserialize, encode, serialize};

--- a/bitcoin/src/consensus/encode.rs
+++ b/bitcoin/src/consensus/encode.rs
@@ -19,7 +19,7 @@ use core::{cmp, mem, slice};
 
 use encoding::{CompactSizeEncoder, Encoder};
 use hashes::{sha256, sha256d, Hash};
-use hex_unstable::DisplayHex as _;
+use hex::DisplayHex as _;
 use internals::ToU64;
 use io::{BufRead, Cursor, Read, Write};
 
@@ -59,7 +59,7 @@ pub fn deserialize<T: Decodable>(data: &[u8]) -> Result<T, DeserializeError> {
 /// Deserializes any decodable type from a hex string, will error if said deserialization
 /// doesn't consume the entire vector.
 pub fn deserialize_hex<T: Decodable>(hex: &str) -> Result<T, FromHexError> {
-    let iter = hex_unstable::HexSliceToBytesIter::new(hex)?;
+    let iter = hex::HexSliceToBytesIter::new(hex)?;
     let reader = IterReader::new(iter);
     Ok(reader.decode().map_err(FromHexError::Decode)?)
 }

--- a/bitcoin/src/consensus/error.rs
+++ b/bitcoin/src/consensus/error.rs
@@ -5,7 +5,7 @@
 use core::convert::Infallible;
 use core::fmt;
 
-use hex_unstable::error::{InvalidCharError, OddLengthStringError};
+use hex::error::{InvalidCharError, OddLengthStringError};
 use internals::write_err;
 
 #[cfg(doc)]

--- a/bitcoin/src/consensus/serde.rs
+++ b/bitcoin/src/consensus/serde.rs
@@ -38,7 +38,7 @@ pub mod hex {
     use core::fmt;
     use core::marker::PhantomData;
 
-    use hex_unstable::buf_encoder::BufEncoder;
+    use hex::buf_encoder::BufEncoder;
 
     /// Marker for upper/lower case type-level flags ("type-level enum").
     ///
@@ -54,15 +54,15 @@ pub mod hex {
     mod sealed {
         pub trait Case {
             /// Internal detail, don't depend on it!!!
-            const INTERNAL_CASE: hex_unstable::Case;
+            const INTERNAL_CASE: hex::Case;
         }
 
         impl Case for super::Lower {
-            const INTERNAL_CASE: hex_unstable::Case = hex_unstable::Case::Lower;
+            const INTERNAL_CASE: hex::Case = hex::Case::Lower;
         }
 
         impl Case for super::Upper {
-            const INTERNAL_CASE: hex_unstable::Case = hex_unstable::Case::Upper;
+            const INTERNAL_CASE: hex::Case = hex::Case::Upper;
         }
     }
 
@@ -101,18 +101,18 @@ pub mod hex {
 
     /// Error returned when a hex string decoder can't be created.
     #[derive(Debug, Clone, PartialEq, Eq)]
-    pub struct DecodeInitError(hex_unstable::OddLengthStringError);
+    pub struct DecodeInitError(hex::OddLengthStringError);
 
     /// Error returned when a hex string contains invalid characters.
     #[derive(Debug, Clone, PartialEq, Eq)]
-    pub struct DecodeError(hex_unstable::InvalidCharError);
+    pub struct DecodeError(hex::InvalidCharError);
 
     /// Hex decoder state.
-    pub struct Decoder<'a>(hex_unstable::HexSliceToBytesIter<'a>);
+    pub struct Decoder<'a>(hex::HexSliceToBytesIter<'a>);
 
     impl<'a> Decoder<'a> {
         fn new(s: &'a str) -> Result<Self, DecodeInitError> {
-            match hex_unstable::HexToBytesIter::new(s) {
+            match hex::HexToBytesIter::new(s) {
                 Ok(iter) => Ok(Decoder(iter)),
                 Err(error) => Err(DecodeInitError(error)),
             }

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -1540,7 +1540,7 @@ mod tests {
     use alloc::vec::Vec;
 
     use hashes::HashEngine;
-    use hex_unstable::hex;
+    use hex::hex;
 
     use super::*;
     use crate::consensus::deserialize;
@@ -1868,7 +1868,7 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn bip_341_sighash_tests() {
-        use hex_unstable::DisplayHex;
+        use hex::DisplayHex as _;
 
         fn sighash_deser_numeric<'de, D>(deserializer: D) -> Result<TapSighashType, D::Error>
         where

--- a/bitcoin/src/crypto/taproot.rs
+++ b/bitcoin/src/crypto/taproot.rs
@@ -97,9 +97,9 @@ impl fmt::Display for Signature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.sighash_type == TapSighashType::Default {
             // default sighash type, don't add extra sighash byte
-            hex_unstable::fmt_hex_exact!(f, 64, self.serialize(), hex_unstable::Case::Lower)
+            hex::fmt_hex_exact!(f, 64, self.serialize(), hex::Case::Lower)
         } else {
-            hex_unstable::fmt_hex_exact!(f, 65, self.serialize(), hex_unstable::Case::Lower)
+            hex::fmt_hex_exact!(f, 65, self.serialize(), hex::Case::Lower)
         }
     }
 }
@@ -177,7 +177,7 @@ impl fmt::Debug for SerializedSignature {
 
 impl fmt::Display for SerializedSignature {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        hex_unstable::fmt_hex_exact!(f, MAX_LEN, self, hex_unstable::Case::Lower)
+        hex::fmt_hex_exact!(f, MAX_LEN, self, hex::Case::Lower)
     }
 }
 

--- a/bitcoin/src/internal_macros.rs
+++ b/bitcoin/src/internal_macros.rs
@@ -62,14 +62,14 @@ macro_rules! impl_array_newtype_stringify {
 
         impl core::fmt::LowerHex for $t {
             fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-                use hex_unstable::{display, Case};
+                use hex::{display, Case};
                 display::fmt_hex_exact!(f, $len, &self.0, Case::Lower)
             }
         }
 
         impl core::fmt::UpperHex for $t {
             fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-                use hex_unstable::{display, Case};
+                use hex::{display, Case};
                 display::fmt_hex_exact!(f, $len, &self.0, Case::Upper)
             }
         }

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -68,7 +68,7 @@ pub extern crate base64;
 pub extern crate bech32;
 pub extern crate encoding;
 pub extern crate hashes;
-pub extern crate hex_stable as hex;
+pub extern crate hex;
 pub extern crate io;
 pub extern crate primitives;
 pub extern crate secp256k1;
@@ -214,7 +214,7 @@ mod prelude {
 
     pub use crate::io::sink;
 
-    pub use hex_unstable::DisplayHex;
+    pub use hex::DisplayHex;
 }
 
 pub mod amount {

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -1115,13 +1115,13 @@ macro_rules! impl_hex {
     ($hex:path, $case:expr) => {
         impl $hex for U256 {
             fn fmt(&self, f: &mut fmt::Formatter) -> core::fmt::Result {
-                hex_unstable::fmt_hex_exact!(f, 32, &self.to_be_bytes(), $case)
+                hex::fmt_hex_exact!(f, 32, &self.to_be_bytes(), $case)
             }
         }
     };
 }
-impl_hex!(fmt::LowerHex, hex_unstable::Case::Lower);
-impl_hex!(fmt::UpperHex, hex_unstable::Case::Upper);
+impl_hex!(fmt::LowerHex, hex::Case::Lower);
+impl_hex!(fmt::UpperHex, hex::Case::Upper);
 
 #[cfg(feature = "serde")]
 impl crate::serde::Serialize for U256 {

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -1300,7 +1300,7 @@ mod tests {
     use core::str::FromStr;
 
     use hashes::{hash160, ripemd160, sha256};
-    use hex_unstable::hex;
+    use hex::hex;
     #[cfg(all(feature = "rand", feature = "std"))]
     use {
         crate::bip32::Fingerprint, crate::locktime, crate::script::ScriptPubKeyBufExt as _,

--- a/bitcoin/src/taproot/mod.rs
+++ b/bitcoin/src/taproot/mod.rs
@@ -1732,7 +1732,7 @@ mod test {
     use alloc::string::ToString;
 
     use hashes::sha256;
-    use hex_unstable::DisplayHex;
+    use hex::DisplayHex as _;
 
     use super::*;
     use crate::sighash::TapSighashTag;

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -15,10 +15,9 @@ exclude = ["tests", "contrib"]
 
 [features]
 default = ["std"]
-std = ["alloc", "hex-stable/std", "hex-unstable/std"]
-alloc = ["hex-stable/alloc", "hex-unstable/alloc"]
+std = ["alloc", "hex?/std"]
+alloc = ["hex?/alloc"]
 serde = ["dep:serde", "hex"]
-hex = ["dep:hex-stable", "dep:hex-unstable"]
 # Smaller (but slower) implementation of sha256, sha512 and ripemd160
 small-hash = []
 
@@ -27,12 +26,9 @@ internals = { package = "bitcoin-internals", path = "../internals", version = "0
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.1.0", default-features = false }
 
 arbitrary = { version = "1.4.1", optional = true}
+hex = { package = "hex-conservative", version = "1.1.0", git = "https://github.com/tcharding/hex-conservative", branch = "push-zymmlwoymnqz", default-features = false, optional = true }
 serde = { version = "1.0.195", default-features = false, optional = true }
 cpufeatures = { version = "0.2", optional = true }
-
-# Both optional hex dependencies are behind the `hex` feature.
-hex-stable = { package = "hex-conservative", version = "1.0.0", default-features = false, optional = true }
-hex-unstable = { package = "hex-conservative", version = "0.3.2", default-features = false, optional = true }
 
 [dev-dependencies]
 serde_test = "1.0.19"

--- a/hashes/src/hkdf/mod.rs
+++ b/hashes/src/hkdf/mod.rs
@@ -154,7 +154,7 @@ impl<T: HashEngine> fmt::Debug for Hkdf<T> {
 #[cfg(feature = "alloc")]
 #[cfg(feature = "hex")]
 mod tests {
-    use hex_unstable::DisplayHex;
+    use hex::DisplayHex;
 
     use super::*;
     use crate::{hex, sha256};

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -81,9 +81,7 @@ extern crate serde_test;
 pub extern crate encoding;
 
 #[cfg(feature = "hex")]
-pub extern crate hex_stable as hex;
-#[cfg(feature = "hex")]
-pub extern crate hex_unstable;
+pub extern crate hex;
 
 #[doc(hidden)]
 pub mod _export {

--- a/hashes/src/macros.rs
+++ b/hashes/src/macros.rs
@@ -279,21 +279,21 @@ macro_rules! impl_hex_string_traits {
                 fn fmt(&self, f: &mut $crate::_export::_core::fmt::Formatter) -> $crate::_export::_core::fmt::Result {
                     if $reverse {
                         let bytes = $crate::_export::_core::borrow::Borrow::<[u8]>::borrow(self).iter().rev();
-                        $crate::hex_unstable::fmt_hex_exact!(f, ($len), bytes, $case)
+                        $crate::hex::fmt_hex_exact!(f, ($len), bytes, $case)
                     } else {
                         let bytes = $crate::_export::_core::borrow::Borrow::<[u8]>::borrow(self).iter();
-                        $crate::hex_unstable::fmt_hex_exact!(f, ($len), bytes, $case)
+                        $crate::hex::fmt_hex_exact!(f, ($len), bytes, $case)
                     }
                 }
             }
         }
 
         impl<$($gen: $gent),*> $crate::_export::_core::fmt::LowerHex for $ty<$($gen),*> {
-            impl_case_hex!($crate::hex_unstable::Case::Lower);
+            impl_case_hex!($crate::hex::Case::Lower);
         }
 
         impl<$($gen: $gent),*> $crate::_export::_core::fmt::UpperHex for $ty<$($gen),*> {
-            impl_case_hex!($crate::hex_unstable::Case::Upper);
+            impl_case_hex!($crate::hex::Case::Upper);
         }
 
         impl<$($gen: $gent),*> $crate::_export::_core::fmt::Display for $ty<$($gen),*> {

--- a/internals/Cargo.toml
+++ b/internals/Cargo.toml
@@ -21,7 +21,7 @@ alloc = ["hex?/alloc"]
 test-serde = ["serde", "dep:serde_json", "dep:bincode"]
 
 [dependencies]
-hex = { package = "hex-conservative", version = "0.3.2", default-features = false, optional = true }
+hex = { package = "hex-conservative", version = "1.1.0", git = "https://github.com/tcharding/hex-conservative", branch = "push-zymmlwoymnqz", default-features = false, optional = true }
 serde = { version = "1.0.195", default-features = false, optional = true }
 
 # Behind the test-serde feature.

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -14,11 +14,11 @@ exclude = ["tests", "contrib"]
 
 [features]
 default = ["std", "hex"]
-std = ["alloc", "hashes/std", "hex-stable?/std", "hex-unstable?/std", "internals/std", "units/std"]
-alloc = ["hashes/alloc", "hex-stable?/alloc", "hex-unstable?/alloc", "internals/alloc", "units/alloc"]
+std = ["alloc", "hashes/std", "hex?/std", "internals/std", "units/std"]
+alloc = ["hashes/alloc", "hex?/alloc", "internals/alloc", "units/alloc"]
 serde = ["dep:serde", "hashes/serde", "internals/serde", "units/serde", "alloc", "hex"]
 arbitrary = ["dep:arbitrary", "units/arbitrary"]
-hex = ["dep:hex-stable", "dep:hex-unstable", "hashes/hex", "internals/hex"]
+hex = ["dep:hex", "hashes/hex", "internals/hex"]
 
 [dependencies]
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.1.0", default-features = false }
@@ -27,10 +27,8 @@ internals = { package = "bitcoin-internals", path = "../internals", version = "0
 units = { package = "bitcoin-units", path = "../units", version = "0.3.0", default-features = false, features = [ "encoding" ] }
 
 arbitrary = { version = "1.4.1", optional = true }
+hex = { package = "hex-conservative", version = "1.1.0", git = "https://github.com/tcharding/hex-conservative", branch = "push-zymmlwoymnqz", default-features = false, optional = true }
 serde = { version = "1.0.195", default-features = false, features = ["derive", "alloc"], optional = true }
-# Both optional hex dependencies are behind the `hex` feature.
-hex-stable = { package = "hex-conservative", version = "1.0.0", default-features = false, optional = true }
-hex-unstable = { package = "hex-conservative", version = "0.3.2", default-features = false, optional = true }
 
 [dev-dependencies]
 serde_json = "1.0.68"

--- a/primitives/src/hex_codec.rs
+++ b/primitives/src/hex_codec.rs
@@ -13,7 +13,7 @@ use core::fmt;
 use core::fmt::Write as _;
 
 use encoding::{Decodable, Decoder, Encodable, EncodableByteIter};
-use hex_unstable::{BytesToHexIter, Case};
+use hex::{BytesToHexIter, Case};
 use internals::write_err;
 
 /// Hex encoding wrapper type for `Encodable` + `Decodable` types.
@@ -42,7 +42,7 @@ impl<T: Decodable> HexPrimitive<'_, T> {
     /// * `OddLength` or `InvalidChar` if decode the hex string to bytes fails.
     /// * `Decode` if consensus decoding the hex-decoded bytes fails.
     pub(crate) fn from_str(s: &str) -> Result<T, ParsePrimitiveError<T>> {
-        let iter = hex_unstable::HexToBytesIter::new(s)?;
+        let iter = hex::HexToBytesIter::new(s)?;
 
         let mut decoder = T::decoder();
         let mut buffer = [0u8; 4096]; // 4MB is bigger than most decodables, reducing push_bytes calls.
@@ -108,8 +108,8 @@ impl<T: Encodable> HexPrimitive<'_, T> {
         // Alt characters
         if f.alternate() {
             f.write_str(match case {
-                hex_unstable::Case::Lower => "0x",
-                hex_unstable::Case::Upper => "0X",
+                hex::Case::Lower => "0x",
+                hex::Case::Upper => "0X",
             })?;
         }
 
@@ -151,9 +151,9 @@ impl<T: Encodable> fmt::UpperHex for HexPrimitive<'_, T> {
 /// An error type for errors that can occur during parsing of a `Decodable` type from hex.
 pub(crate) enum ParsePrimitiveError<T: Decodable> {
     /// Tried to decode an odd length string
-    OddLengthString(hex_unstable::OddLengthStringError),
+    OddLengthString(hex::OddLengthStringError),
     /// Encountered an invalid hex character
-    InvalidChar(hex_unstable::InvalidCharError),
+    InvalidChar(hex::InvalidCharError),
     /// A decode error from `consensus_encoding`
     Decode(encoding::DecodeError<<T::Decoder as encoding::Decoder>::Error>),
 }
@@ -177,12 +177,12 @@ impl<T: Decodable> fmt::Display for ParsePrimitiveError<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { fmt::Debug::fmt(&self, f) }
 }
 
-impl<T: Decodable> From<hex_unstable::OddLengthStringError> for ParsePrimitiveError<T> {
-    fn from(err: hex_unstable::OddLengthStringError) -> Self { Self::OddLengthString(err) }
+impl<T: Decodable> From<hex::OddLengthStringError> for ParsePrimitiveError<T> {
+    fn from(err: hex::OddLengthStringError) -> Self { Self::OddLengthString(err) }
 }
 
-impl<T: Decodable> From<hex_unstable::InvalidCharError> for ParsePrimitiveError<T> {
-    fn from(err: hex_unstable::InvalidCharError) -> Self { Self::InvalidChar(err) }
+impl<T: Decodable> From<hex::InvalidCharError> for ParsePrimitiveError<T> {
+    fn from(err: hex::InvalidCharError) -> Self { Self::InvalidChar(err) }
 }
 
 #[cfg(feature = "std")]

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -35,7 +35,7 @@ pub extern crate arbitrary;
 pub extern crate encoding;
 
 #[cfg(feature = "hex")]
-pub extern crate hex_stable as hex;
+pub extern crate hex;
 
 #[doc(hidden)]
 pub mod _export {

--- a/primitives/src/script/borrowed.rs
+++ b/primitives/src/script/borrowed.rs
@@ -127,7 +127,7 @@ impl<T> Script<T> {
     /// `to_hex_string_no_length_prefix`.
     #[cfg(all(feature = "hex", feature = "alloc"))]
     pub fn to_hex_string_prefixed(&self) -> String {
-        use hex_unstable::{BytesToHexIter, Case};
+        use hex::{BytesToHexIter, Case};
 
         let iter = encoding::EncodableByteIter::new(self);
         BytesToHexIter::new(iter, Case::Lower).collect()
@@ -139,7 +139,7 @@ impl<T> Script<T> {
     /// prefix. See `to_hex_string_prefixed`.
     #[cfg(all(feature = "hex", feature = "alloc"))]
     pub fn to_hex_string_no_length_prefix(&self) -> String {
-        use hex_unstable::DisplayHex as _;
+        use hex::DisplayHex as _;
 
         self.as_bytes().to_lower_hex_string()
     }

--- a/primitives/src/script/mod.rs
+++ b/primitives/src/script/mod.rs
@@ -14,7 +14,7 @@ use core::fmt;
 use core::marker::PhantomData;
 
 #[cfg(feature = "hex")]
-use hex_unstable::DisplayHex;
+use hex::DisplayHex;
 use internals::script::{self, PushDataLenLen};
 
 use crate::prelude::rc::Rc;

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -1651,7 +1651,7 @@ mod tests {
 
     use encoding::Encoder as _;
     #[cfg(feature = "hex")]
-    use hex_unstable::hex;
+    use hex::hex;
 
     use super::*;
     #[cfg(all(feature = "alloc", feature = "hex"))]

--- a/primitives/src/witness.rs
+++ b/primitives/src/witness.rs
@@ -601,7 +601,7 @@ impl fmt::Debug for Witness {
                     #[cfg(feature = "hex")]
                     {
                         f.debug_list()
-                            .entries(self.iter().map(hex_unstable::DisplayHex::as_hex))
+                            .entries(self.iter().map(hex::DisplayHex::as_hex))
                             .finish()
                     }
                     #[cfg(not(feature = "hex"))]


### PR DESCRIPTION
In https://github.com/rust-bitcoin/hex-conservative/pull/210 I'm pushing for a RC release of `hex v1.1` (as `v0.4.0`). This branch verifies its usage and demos the changes.

CI will be all red, tested locally  with `cd bitcoin; cargo test --all-features; cargo test --no-default-features`.