### PR TITLE
Downgrade the minimum version of cpufeatures

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -235,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
 ]


### PR DESCRIPTION
The update script does this and it is slightly confusing when it showings up in unrelated PRs.

Run `just ulf`.