### PR TITLE
Fix blockdata module re-export docs

### DIFF
--- a/bitcoin/src/blockdata/mod.rs
+++ b/bitcoin/src/blockdata/mod.rs
@@ -22,8 +22,10 @@ pub use self::{
 /// Implements `FeeRate` and associated features.
 pub mod fee_rate {
     #[cfg(feature = "serde")]
+    #[doc(inline)]
     pub use units::fee_rate::serde;
-    /// Re-export everything from the [`units::fee_rate`] module.
+    // Re-export everything from the [`units::fee_rate`] module.
+    #[doc(inline)]
     pub use units::fee_rate::FeeRate;
 }
 
@@ -39,7 +41,7 @@ pub mod locktime {
 
         pub use crate::consensus::encode::{self, Decodable, Encodable};
 
-        /// Re-export everything from the `units::locktime::absolute` module.
+        // Re-export everything from the `units::locktime::absolute` module.
         #[rustfmt::skip]        // Keep public re-exports separate.
         #[doc(inline)]
         pub use units::locktime::absolute::{error, Height, LockTime, MedianTimePast};
@@ -75,7 +77,7 @@ pub mod locktime {
         //! There are two types of lock time: lock-by-height and lock-by-time, distinguished by
         //! whether bit 22 of the `u32` consensus value is set.
 
-        /// Re-export everything from the `units::locktime::relative` module.
+        // Re-export everything from the `units::locktime::relative` module.
         #[doc(inline)]
         pub use units::locktime::relative::{error, LockTime, NumberOf512Seconds, NumberOfBlocks};
         #[doc(no_inline)]
@@ -96,6 +98,7 @@ pub mod locktime {
 
 /// Implements `Weight` and associated features.
 pub mod weight {
-    /// Re-export everything from the [`units::weight`] module.
+    // Re-export everything from the [`units::weight`] module.
+    #[doc(inline)]
     pub use units::weight::Weight;
 }


### PR DESCRIPTION
The module re-exports in bitcoin::blockdata currently have incorrect docs due to missing #[doc(inline)] and incorrect use of /// comments.

Introduce #[doc(inline)] where appropriate.
Replace incorrect uses of doc comments with standard comments.