### PR TITLE
units: Allow too_many_lines in test function

### DIFF
--- a/units/src/amount/error.rs
+++ b/units/src/amount/error.rs
@@ -505,6 +505,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "alloc")]
+    #[allow(clippy::too_many_lines)] // Test could be refactored ...
     fn error_display_is_non_empty() {
         // A helper macro to break out a ParseAmountErrorInner type and assert display down the chain.
         macro_rules! assert_amount_err {


### PR DESCRIPTION
Although the lint is likely correct just shoosh it for now because it is one line before the threshold until the formatter runs with this weeks nightly toolchain update.