### PR TITLE
Release tracking PR: The whole stack up to `bitcoin 0.34.0-beta`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -80,7 +80,7 @@ version = "0.0.0"
 
 [[package]]
 name = "bitcoin-consensus-encoding"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bitcoin-internals",
  "hex-conservative 0.3.2",

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-io"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bitcoin-consensus-encoding",
  "bitcoin-internals",

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -174,7 +174,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-units"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-primitives"
-version = "0.102.0"
+version = "0.103.0"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "arbitrary",
  "bitcoin-consensus-encoding",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -79,7 +79,7 @@ version = "0.0.0"
 
 [[package]]
 name = "bitcoin-consensus-encoding"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bitcoin-internals",
  "hex-conservative 0.3.2",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-primitives"
-version = "0.102.0"
+version = "0.103.0"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "arbitrary",
  "bitcoin-consensus-encoding",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-units"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-io"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bitcoin-consensus-encoding",
  "bitcoin-internals",

--- a/base58/Cargo.toml
+++ b/base58/Cargo.toml
@@ -18,7 +18,7 @@ std = ["alloc", "hashes/std", "internals/std"]
 alloc = ["hashes/alloc", "internals/alloc"]
 
 [dependencies]
-hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false }
+hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.21.0", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
 
 [dev-dependencies]

--- a/bitcoin/CHANGELOG.md
+++ b/bitcoin/CHANGELOG.md
@@ -1,3 +1,23 @@
+# 0.34.0-beta - 2026-04-01
+
+- Reject 65 bytes signature with sighash 0x00 [#5718](https://github.com/rust-bitcoin/rust-bitcoin/pull/5718)
+- Preserve parity for `XOnlyPublicKey` [#5708](https://github.com/rust-bitcoin/rust-bitcoin/pull/5708)
+- Adjust `PublicKey::from_slice` and improve error documentation for key types [#5679](https://github.com/rust-bitcoin/rust-bitcoin/pull/5679)
+- Change `Params::pow_target_spacing` to `u32` [#5656](https://github.com/rust-bitcoin/rust-bitcoin/pull/5656)
+- Change `hex` re-export in bitcoin to stable `hex` [#5640](https://github.com/rust-bitcoin/rust-bitcoin/pull/5640)
+- Fix PSBT key deserialisation byte size [#5625](https://github.com/rust-bitcoin/rust-bitcoin/pull/5625)
+- Add bounds check for non-witness UTXO output index [#5617](https://github.com/rust-bitcoin/rust-bitcoin/pull/5617)
+- Encapsulate the PublicKey and PrivateKey types [#5614](https://github.com/rust-bitcoin/rust-bitcoin/pull/5614)
+- Add note about `Target` maximum values [#5609](https://github.com/rust-bitcoin/rust-bitcoin/pull/5609)
+- Add parity to `XOnlyPublicKey` and adjust API [#5593](https://github.com/rust-bitcoin/rust-bitcoin/pull/5593)
+- Depend on bitcoin-network-kind [#5528](https://github.com/rust-bitcoin/rust-bitcoin/pull/5528)
+- Add `FromStr` to `Target` and `Work` [#5539](https://github.com/rust-bitcoin/rust-bitcoin/pull/5539)
+- Fix `U256::overflowing_mul` [#5501](https://github.com/rust-bitcoin/rust-bitcoin/pull/5501)
+- Fix bug in `Psbt::spend_utxo` when missing output [#5500](https://github.com/rust-bitcoin/rust-bitcoin/pull/5500)
+- Fix unreachable error bug during iteration of funding utxos [#5492](https://github.com/rust-bitcoin/rust-bitcoin/pull/5492)
+
+New crate: https://crates.io/crates/bitcoin-network-kind
+
 # 0.33.0-beta - 2026-02-17
 
 This series of beta releases is meant for two things:

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -36,7 +36,8 @@ io = { package = "bitcoin-io", path = "../io", version = "0.6.0", default-featur
 network = { package = "bitcoin-network-kind", path = "../network", version = "0.1.0", default-features = false, features = ["alloc"]}
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.102.0", default-features = false, features = ["alloc", "hex"] }
 secp256k1 = { version = "0.32.0-beta.2", default-features = false, features = ["alloc"] }
-units = { package = "bitcoin-units", path = "../units", version = "0.3.0", default-features = false, features = ["alloc"] }
+
+units = { package = "bitcoin-units", path = "../units", version = "0.4.0", default-features = false, features = ["alloc"] }
 
 arbitrary = { version = "1.4.1", optional = true }
 base64 = { version = "0.22.0", optional = true, default-features = false, features = ["alloc"] }

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -32,7 +32,7 @@ encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encodi
 hex-stable = { package = "hex-conservative", version = "1.0.0", default-features = false, features = ["alloc"] }
 hex-unstable = { package = "hex-conservative", version = "0.3.2", default-features = false, features = ["alloc"] }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0", features = ["alloc", "hex"] }
-io = { package = "bitcoin-io", path = "../io", version = "0.5.0", default-features = false, features = ["alloc", "hashes"] }
+io = { package = "bitcoin-io", path = "../io", version = "0.6.0", default-features = false, features = ["alloc", "hashes"] }
 network = { package = "bitcoin-network-kind", path = "../network", version = "0.1.0", default-features = false, features = ["alloc"]}
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.102.0", default-features = false, features = ["alloc", "hex"] }
 secp256k1 = { version = "0.32.0-beta.2", default-features = false, features = ["alloc"] }

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -28,7 +28,7 @@ arbitrary = ["dep:arbitrary", "units/arbitrary", "primitives/arbitrary", "hashes
 base58 = { package = "base58ck", path = "../base58", version = "0.4.0", default-features = false, features = ["alloc"] }
 bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false, features = ["alloc", "hex"] }
-encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.1.0", default-features = false, features = ["alloc"] }
+encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.2.0", default-features = false, features = ["alloc"] }
 hex-stable = { package = "hex-conservative", version = "1.0.0", default-features = false, features = ["alloc"] }
 hex-unstable = { package = "hex-conservative", version = "0.3.2", default-features = false, features = ["alloc"] }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0", features = ["alloc", "hex"] }

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -34,7 +34,7 @@ hex-unstable = { package = "hex-conservative", version = "0.3.2", default-featur
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0", features = ["alloc", "hex"] }
 io = { package = "bitcoin-io", path = "../io", version = "0.6.0", default-features = false, features = ["alloc", "hashes"] }
 network = { package = "bitcoin-network-kind", path = "../network", version = "0.1.0", default-features = false, features = ["alloc"]}
-primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.102.0", default-features = false, features = ["alloc", "hex"] }
+primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.103.0", default-features = false, features = ["alloc", "hex"] }
 secp256k1 = { version = "0.32.0-beta.2", default-features = false, features = ["alloc"] }
 
 units = { package = "bitcoin-units", path = "../units", version = "0.4.0", default-features = false, features = ["alloc"] }

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -27,7 +27,7 @@ arbitrary = ["dep:arbitrary", "units/arbitrary", "primitives/arbitrary", "hashes
 [dependencies]
 base58 = { package = "base58ck", path = "../base58", version = "0.4.0", default-features = false, features = ["alloc"] }
 bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
-hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false, features = ["alloc", "hex"] }
+hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.21.0", default-features = false, features = ["alloc", "hex"] }
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.2.0", default-features = false, features = ["alloc"] }
 hex-stable = { package = "hex-conservative", version = "1.0.0", default-features = false, features = ["alloc"] }
 hex-unstable = { package = "hex-conservative", version = "0.3.2", default-features = false, features = ["alloc"] }

--- a/consensus_encoding/CHANGELOG.md
+++ b/consensus_encoding/CHANGELOG.md
@@ -1,3 +1,18 @@
+# 0.2.0 - 2026-04-01
+
+This release is breaking and causes our whole stack to have to be re-released ...
+
+- Match core's range check decoding compact sizes [#5897](https://github.com/rust-bitcoin/rust-bitcoin/pull/5897)
+- Add `u64` support to compact size [#5784](https://github.com/rust-bitcoin/rust-bitcoin/pull/5784)
+- Add common trait implementations [#5698](https://github.com/rust-bitcoin/rust-bitcoin/pull/5698)
+- Introduce `decode_from_slice_unbounded` [#5664](https://github.com/rust-bitcoin/rust-bitcoin/pull/5664)
+- Improve macro defined constructor [#5759](https://github.com/rust-bitcoin/rust-bitcoin/pull/5759)
+- Fill out the documentation [#5720](https://github.com/rust-bitcoin/rust-bitcoin/pull/5720)
+- Expose vis fragment on exposed macros [#5719](https://github.com/rust-bitcoin/rust-bitcoin/pull/5719)
+- Remove redundant trait bounds [#5716](https://github.com/rust-bitcoin/rust-bitcoin/pull/5716)
+- Add `track_caller` to panic-able sites [#5713](https://github.com/rust-bitcoin/rust-bitcoin/pull/5713)
+- Add macros to define `EncoderN` and `DecoderNError` [#5635](https://github.com/rust-bitcoin/rust-bitcoin/pull/5635)
+
 # 0.1.0 - 2026-02-17
 
 It was found that the `1.0.0-rc.x` releases were troublesome because

--- a/consensus_encoding/Cargo.toml
+++ b/consensus_encoding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-consensus-encoding"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>", "Nick Johnson <nick@yonson.dev>", "Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 homepage = "https://rust-bitcoin.org/"

--- a/hashes/CHANGELOG.md
+++ b/hashes/CHANGELOG.md
@@ -1,3 +1,19 @@
+# 0.21.0 - 2026-04-01
+
+Props to jrakibi, absolutely killing it this release.
+
+* Wipe secret data in HMAC and HKDF [#5706](https://github.com/rust-bitcoin/rust-bitcoin/pull/5706)
+* Simplify trait bounds [#5682](https://github.com/rust-bitcoin/rust-bitcoin/pull/5682)
+* Add NIST test vectors and chunk-combination tests [#5660](https://github.com/rust-bitcoin/rust-bitcoin/pull/5660)
+* Test `hmac` incremental input [#5624](https://github.com/rust-bitcoin/rust-bitcoin/pull/5624)
+* Fix incremental hashing for `sha3-256` [#5604](https://github.com/rust-bitcoin/rust-bitcoin/pull/5604)
+* Fix reverse hashes for no-hex debug [#5602](https://github.com/rust-bitcoin/rust-bitcoin/pull/5602)
+* Add `cpufeatures` for `no_std` SIMD detection [#5598](https://github.com/rust-bitcoin/rust-bitcoin/pull/5598)
+* Introduce `MuHash` wrapper type [#5594](https://github.com/rust-bitcoin/rust-bitcoin/pull/5594)
+* Include midstate and buffer in `MidstateError` [#5567](https://github.com/rust-bitcoin/rust-bitcoin/pull/5567)
+* Add SHA256 ARM hardware acceleration [#5493](https://github.com/rust-bitcoin/rust-bitcoin/pull/5493)
+* Upgrade to `consensus-encoding 0.2.0`
+
 # 0.20.0 - 2026-01-08
 
 It was found that the `1.0.0-rc.x` releases were troublesome because

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin_hashes"
-version = "0.20.0"
+version = "0.21.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin"

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -24,7 +24,7 @@ small-hash = []
 
 [dependencies]
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
-encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.1.0", default-features = false }
+encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.2.0", default-features = false }
 
 arbitrary = { version = "1.4.1", optional = true}
 serde = { version = "1.0.195", default-features = false, optional = true }

--- a/io/CHANGELOG.md
+++ b/io/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.6.0 - 2026-04-01
+
+* Replace gated `no_std` with blanket `no_std` [#5665](https://github.com/rust-bitcoin/rust-bitcoin/pull/5665)
+* Upgrade to `consensus-encoding 0.2.0`
+* Upgrade to `bitcoin_hashes 0.21.0`
+
 # 0.5.0 - 2026-01-08
 
 It was found that the `1.0.0-rc.x` releases were troublesome because

--- a/io/Cargo.toml
+++ b/io/Cargo.toml
@@ -20,7 +20,7 @@ alloc = ["encoding/alloc", "hashes?/alloc", "internals/alloc"]
 
 [dependencies]
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
-encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.1.0", default-features = false }
+encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.2.0", default-features = false }
 
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false, optional = true }
 

--- a/io/Cargo.toml
+++ b/io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-io"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Matt Corallo <birchneutea@mattcorallo.com>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin"

--- a/io/Cargo.toml
+++ b/io/Cargo.toml
@@ -22,10 +22,10 @@ alloc = ["encoding/alloc", "hashes?/alloc", "internals/alloc"]
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.2.0", default-features = false }
 
-hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false, optional = true }
+hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.21.0", default-features = false, optional = true }
 
 [dev-dependencies]
-hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false, features = ["hex"] }
+hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.21.0", default-features = false, features = ["hex"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -28,7 +28,7 @@ hex-stable = { package = "hex-conservative", version = "1.0.0", default-features
 hex-unstable = { package = "hex-conservative", version = "0.3.2", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", default-features = false }
 io = { package = "bitcoin-io", version = "0.6.0", path = "../io", default-features = false }
-units = { package = "bitcoin-units", path = "../units", version = "0.3.0", default-features = false }
+units = { package = "bitcoin-units", path = "../units", version = "0.4.0", default-features = false }
 
 arbitrary = { version = "1.4.1", optional = true }
 serde = { version = "1.0.195", default-features = false, features = ["derive", "alloc"], optional = true }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -27,7 +27,7 @@ primitives = { package = "bitcoin-primitives", path = "../primitives", version =
 hex-stable = { package = "hex-conservative", version = "1.0.0", default-features = false, features = ["alloc"] }
 hex-unstable = { package = "hex-conservative", version = "0.3.2", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", default-features = false }
-io = { package = "bitcoin-io", version = "0.5.0", path = "../io", default-features = false }
+io = { package = "bitcoin-io", version = "0.6.0", path = "../io", default-features = false }
 units = { package = "bitcoin-units", path = "../units", version = "0.3.0", default-features = false }
 
 arbitrary = { version = "1.4.1", optional = true }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -21,7 +21,7 @@ serde = ["dep:serde", "hashes/serde"]
 [dependencies]
 bitcoin = { path = "../bitcoin/", default-features = false }
 encoding = { package = "bitcoin-consensus-encoding", version = "0.2.0", path = "../consensus_encoding", default-features = false }
-hashes = { package = "bitcoin_hashes", version = "0.20.0", path = "../hashes", default-features = false }
+hashes = { package = "bitcoin_hashes", version = "0.21.0", path = "../hashes", default-features = false }
 network = { package = "bitcoin-network-kind", path = "../network", version = "0.1.0", default-features = false }
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.102.0", default-features = false }
 hex-stable = { package = "hex-conservative", version = "1.0.0", default-features = false, features = ["alloc"] }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -20,7 +20,7 @@ serde = ["dep:serde", "hashes/serde"]
 
 [dependencies]
 bitcoin = { path = "../bitcoin/", default-features = false }
-encoding = { package = "bitcoin-consensus-encoding", version = "0.1.0", path = "../consensus_encoding", default-features = false }
+encoding = { package = "bitcoin-consensus-encoding", version = "0.2.0", path = "../consensus_encoding", default-features = false }
 hashes = { package = "bitcoin_hashes", version = "0.20.0", path = "../hashes", default-features = false }
 network = { package = "bitcoin-network-kind", path = "../network", version = "0.1.0", default-features = false }
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.102.0", default-features = false }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -23,7 +23,7 @@ bitcoin = { path = "../bitcoin/", default-features = false }
 encoding = { package = "bitcoin-consensus-encoding", version = "0.2.0", path = "../consensus_encoding", default-features = false }
 hashes = { package = "bitcoin_hashes", version = "0.21.0", path = "../hashes", default-features = false }
 network = { package = "bitcoin-network-kind", path = "../network", version = "0.1.0", default-features = false }
-primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.102.0", default-features = false }
+primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.103.0", default-features = false }
 hex-stable = { package = "hex-conservative", version = "1.0.0", default-features = false, features = ["alloc"] }
 hex-unstable = { package = "hex-conservative", version = "0.3.2", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", default-features = false }

--- a/primitives/CHANGELOG.md
+++ b/primitives/CHANGELOG.md
@@ -1,3 +1,19 @@
+# 0.103.0 - 2026-04-01
+
+- Add `SignetBlockScript`/`Buf` for signet challenge scripts [#5871](https://github.com/rust-bitcoin/rust-bitcoin/pull/5871)
+- Implement `serde_as_consensus` and friends [#5704](https://github.com/rust-bitcoin/rust-bitcoin/pull/5704)
+- Move script hex parsing functions to `primitives` [#5657](https://github.com/rust-bitcoin/rust-bitcoin/pull/5657)
+- Remove `From<SubError>` for error types [#5855](https://github.com/rust-bitcoin/rust-bitcoin/pull/5855)
+- Do not re-export non-essential hash types [#5891](https://github.com/rust-bitcoin/rust-bitcoin/pull/5891)
+- Re-export `serde` and `arbitrary` when they appear in public API [#5862](https://github.com/rust-bitcoin/rust-bitcoin/pull/5862)
+- Implement stringly traits for `Block` using hex [#5703](https://github.com/rust-bitcoin/rust-bitcoin/pull/5703)
+- Move `TxMerkleNodeDecoder`/`Error` to `merkle_tree` module [#5724](https://github.com/rust-bitcoin/rust-bitcoin/pull/5724)
+- Remove excess allocations from `Witness::from_iter` [#5650](https://github.com/rust-bitcoin/rust-bitcoin/pull/5650)
+- Remove `BlockTime` decoder from root export [#5527](https://github.com/rust-bitcoin/rust-bitcoin/pull/5527)
+- Upgrade to `bitcoin-units 0.4.0`
+- Upgrade to `bitcoin_hashes 0.21.0`
+- Upgrade to `consensus-encoding 0.2.0`
+
 # 0.102.0 - 2026-02-17
 
 It was found that the `1.0.0-rc.x` releases were troublesome because

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -22,7 +22,7 @@ hex = ["dep:hex-stable", "dep:hex-unstable", "hashes/hex", "internals/hex"]
 
 [dependencies]
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.2.0", default-features = false }
-hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false }
+hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.21.0", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
 units = { package = "bitcoin-units", path = "../units", version = "0.3.0", default-features = false, features = [ "encoding" ] }
 

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-primitives"
-version = "0.102.0"
+version = "0.103.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>", "Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin"

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -21,7 +21,7 @@ arbitrary = ["dep:arbitrary", "units/arbitrary"]
 hex = ["dep:hex-stable", "dep:hex-unstable", "hashes/hex", "internals/hex"]
 
 [dependencies]
-encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.1.0", default-features = false }
+encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.2.0", default-features = false }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
 units = { package = "bitcoin-units", path = "../units", version = "0.3.0", default-features = false, features = [ "encoding" ] }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -24,7 +24,7 @@ hex = ["dep:hex-stable", "dep:hex-unstable", "hashes/hex", "internals/hex"]
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.2.0", default-features = false }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.21.0", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
-units = { package = "bitcoin-units", path = "../units", version = "0.3.0", default-features = false, features = [ "encoding" ] }
+units = { package = "bitcoin-units", path = "../units", version = "0.4.0", default-features = false, features = [ "encoding" ] }
 
 arbitrary = { version = "1.4.1", optional = true }
 serde = { version = "1.0.195", default-features = false, features = ["derive", "alloc"], optional = true }

--- a/units/CHANGELOG.md
+++ b/units/CHANGELOG.md
@@ -1,3 +1,18 @@
+# 0.4.0 - 2026-04-01
+
+- Extend `parse_int` and add hex string parsing to integer wrapper types [#5782](https://github.com/rust-bitcoin/rust-bitcoin/pull/5782)
+- Remove `From<SubError>` for error types [#5855](https://github.com/rust-bitcoin/rust-bitcoin/pull/5855)
+- Re-export `serde` and `arbitrary` when they appear in public API [#5862](https://github.com/rust-bitcoin/rust-bitcoin/pull/5862)
+- Unify `FromStr` impls for integer wrapper types [#5783](https://github.com/rust-bitcoin/rust-bitcoin/pull/5783)
+- Add `serde` support for `Vec<T>` [#5786](https://github.com/rust-bitcoin/rust-bitcoin/pull/5786)
+- Add next target calculation [#5544](https://github.com/rust-bitcoin/rust-bitcoin/pull/5544)
+- Move and improve `CompactTarget` [#5511](https://github.com/rust-bitcoin/rust-bitcoin/pull/5511)
+- Add `fmt` traits for simple wrapper types [#5510](https://github.com/rust-bitcoin/rust-bitcoin/pull/5510)
+- Upgrade to `consensus-encoding 0.2.0`
+
+Please note the breaking change in how we define encoders had the effect of breaking
+every type in the lib so there is no semver tricking done in this release - sorry.
+
 # 0.3.0 - 2026-02-17
 
 It was found that the `1.0.0-rc.x` releases were troublesome because

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-units"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>", "Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -20,7 +20,7 @@ alloc = ["internals/alloc", "serde?/alloc", "encoding?/alloc"]
 [dependencies]
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
 
-encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.1.0", default-features = false, optional = true }
+encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.2.0", default-features = false, optional = true }
 serde = { version = "1.0.195", default-features = false, features = ["derive"], optional = true }
 arbitrary = { version = "1.4.1", optional = true }
 


### PR DESCRIPTION
Done as a separate patch for each crate. CHANGELOG entries are current as of Wednesday April 1st (AEDT).

We are making some strong guarantees about these releases: https://github.com/rust-bitcoin/rust-bitcoin/discussions/5941

### Note on `consensus_encoding`

With all Nick's recent work `consensus_encoding` is very likely ready to 1.0 after this RC release. Implying that absolutely any open PR into that crate should be merged before we do this RC cycle.

### TODO

I think we want to wait for these but the six month window documented in link above is shrinking:

- https://github.com/rust-bitcoin/rust-bitcoin/pull/5981
- https://github.com/rust-bitcoin/hex-conservative/pull/210
- https://github.com/rust-bitcoin/rust-bitcoin/issues/5686

Merge these:

- https://github.com/rust-bitcoin/rust-bitcoin/pull/5934
- https://github.com/rust-bitcoin/rust-bitcoin/pull/5897
- https://github.com/rust-bitcoin/rust-bitcoin/pull/5608

Do prerelease checks for all crates _excluding_ `cargo publish --dry-run`.

Check API breaks:

https://github.com/rust-bitcoin/rust-bitcoin/pulls?q=is%3Aopen+is%3Apr+label%3A%22API+break%22

And maybe these:

- https://github.com/rust-bitcoin/rust-bitcoin/pull/5675
- https://github.com/rust-bitcoin/rust-bitcoin/pull/5612
- https://github.com/rust-bitcoin/rust-bitcoin/pull/5828


(None of these have changelogs, please do not delete merged PRs without me adding the respective changelog.)