### PR TITLE
BIP0152:Avoid unnecessary `Vec` clones in tests

### DIFF
--- a/p2p/src/bip152.rs
+++ b/p2p/src/bip152.rs
@@ -1110,8 +1110,7 @@ mod test {
                 // test that we return Err() if deserialization fails (and don't panic)
                 let mut raw: Vec<u8> = [0u8; 32].to_vec();
                 raw.extend(errorcase);
-                let get_block_txn = deserialize::<BlockTransactionsRequest>(&raw).unwrap();
-                assert!(get_block_txn.indices().is_err());
+                assert!(deserialize::<BlockTransactionsRequest>(&raw).is_err());
             }
         }
     }


### PR DESCRIPTION
In [bip152.rs](https://github.com/rust-bitcoin/rust-bitcoin/blob/master/p2p/src/bip152.rs), the deserialize function only requires a reference 
to the byte slice. Using .clone() on the raw Vec<u8> creates an 
unnecessary heap allocation and copies the entire buffer.

Removing these clones improves test performance and follows Rust 
best practices for memory efficiency.
History:
- old commit was removed
- using git cherry-pick that commit was picked and force-push with active rust-bitcoin/master branch
Fixes: #5799