### PR TITLE
consensus_encoding: whitelist timeout mutants

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -64,4 +64,7 @@ exclude_re = [
     "consensus_encoding/.* decode_from_slice", # Mutations cause an infinite loop
     "consensus_encoding/.* decode_from_read", # Mutations cause an infinite loop
     "consensus_encoding/.* <impl Decoder for .*>::push_bytes", # Mutations cause an infinite loop
+    "consensus_encoding/.* <impl Encoder for .*>::advance", # Replacing the return with true causes an infinite loop.
+    "consensus_encoding/.* delete ! in flush_to_vec", # Causes an infinite loop.
+    "consensus_encoding/.* delete ! in flush_to_writer", # Causes an infinite loop.
 ]


### PR DESCRIPTION
The [weekly mutant job](https://github.com/rust-bitcoin/rust-bitcoin/actions/runs/22812355374/job/66171352292) is failing with three timeout mutants in consensus_encoding.

```
TIMEOUT  consensus_encoding/src/encode/mod.rs:183:12: delete ! in flush_to_vec in 0s build + 20s test
TIMEOUT  consensus_encoding/src/encode/mod.rs:227:12: delete ! in flush_to_writer in 0s build + 20s test
TIMEOUT  consensus_encoding/src/encode/encoders.rs:62:9: replace <impl Encoder for ArrayEncoder<N>>::advance -> bool with true in 0s build + 20s test
```

It looks like the weekly job creates a github issue only for *missed* mutants, but not timeouts. Which is maybe by design? But then the diff check on PRs fails for timeouts so these are surfacing when the relevant code gets touched.

Following the existing pattern to whitelist these timeouts since they are pretty difficult to squash (every use in tests needs to be checked or the test hangs an poisons the whole `cargo test` run).