### PR TITLE
hashes: C-SYNC-SEND add missing API test case

### DIFF
--- a/hashes/tests/api.rs
+++ b/hashes/tests/api.rs
@@ -220,6 +220,8 @@ fn all_types_implement_send_sync() {
     //  Types are `Send` and `Sync` where possible (C-SEND-SYNC).
     assert_send::<Hashes<Sha256>>();
     assert_sync::<Hashes<Sha256>>();
+    assert_send::<Hkdf<sha256::HashEngine>>();
+    assert_sync::<Hkdf<sha256::HashEngine>>();
     assert_send::<Engines>();
     assert_sync::<Engines>();
     assert_send::<OtherStructs>();


### PR DESCRIPTION
When looking into the rust API guidelines [C-SEND-SYNC](https://rust-lang.github.io/api-guidelines/interoperability.html#c-send-sync) it was noticed that the tests were not complete.

Add missing Hkdf to the sync/send tests.

Related issue #3633