### PR TITLE
hashes: C-GOOD-ERR add missing API test cases

### DIFF
--- a/hashes/tests/api.rs
+++ b/hashes/tests/api.rs
@@ -212,6 +212,22 @@ fn api_all_non_error_types_have_non_empty_debug() {
     check_debug!(t; a);
 }
 
+// Public error `Debug` representation is never empty (C-DEBUG-NONEMPTY).
+#[test]
+fn api_all_public_error_types_have_non_empty_debug() {
+    // HKDF is capped at 255 output blocks, so one byte past that limit must error.
+    let mut okm = vec![0_u8; 255 * 32 + 1];
+    let err = Hkdf::<sha256::HashEngine>::new(&[], &[]).expand(&[], &mut okm).unwrap_err();
+    let debug = format!("{:?}", err);
+    assert!(!debug.is_empty());
+
+    let mut engine = sha256::HashEngine::new();
+    engine.input(&[0xab]);
+    let err = engine.midstate().unwrap_err();
+    let debug = format!("{:?}", err);
+    assert!(!debug.is_empty());
+}
+
 #[test]
 fn all_types_implement_send_sync() {
     fn assert_send<T: Send>() {}


### PR DESCRIPTION
[C-GOOD-ERR](https://rust-lang.github.io/api-guidelines/interoperability.html#c-good-err) and [C-DEBUG](https://rust-lang.github.io/api-guidelines/debuggability.html#c-debug) are satisfied except for missing coverage in the API regression tests.

Add the missing tests.

Related issue #3633