### PR TITLE
p2p: add V1MessageHeader encoding traits

### DIFF
--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -285,6 +285,36 @@ pub struct V1MessageHeader {
     pub checksum: [u8; 4],
 }
 
+impl encoding::Encodable for V1MessageHeader {
+    type Encoder<'e>
+        = V1MessageHeaderEncoder<'e>
+    where
+        Self: 'e;
+
+    #[inline]
+    fn encoder(&self) -> Self::Encoder<'_> {
+        let enc = encoding::Encoder4::new(
+            self.magic.encoder(),
+            self.command.encoder(),
+            encoding::ArrayEncoder::without_length_prefix(self.length.to_le_bytes()),
+            encoding::ArrayEncoder::without_length_prefix(self.checksum),
+        );
+
+        V1MessageHeaderEncoder::new(enc)
+    }
+}
+
+encoding::encoder_newtype! {
+    /// The encoder for the [`V1MessageHeader`] type.
+    pub struct V1MessageHeaderEncoder<'e>(
+        encoding::Encoder4<
+            crate::MagicEncoder<'e>,
+            CommandStringEncoder,
+            encoding::ArrayEncoder<4>,
+            encoding::ArrayEncoder<4>
+    >);
+}
+
 type V1MessageHeaderInnerDecoder = encoding::Decoder4<
     encoding::ArrayDecoder<4>,
     CommandStringDecoder,


### PR DESCRIPTION
`V1MessageHeader` has traits for decoding a message header, however the traits to encode a header are missing.