### PR TITLE
examples: Use NetworkKind in call to PrivateKey::from_sec

### DIFF
--- a/bitcoin/examples/create-p2wpkh-address.rs
+++ b/bitcoin/examples/create-p2wpkh-address.rs
@@ -1,5 +1,5 @@
 use bitcoin::secp256k1::rand;
-use bitcoin::{Address, CompressedPublicKey, Network, PrivateKey};
+use bitcoin::{Address, CompressedPublicKey, Network, NetworkKind, PrivateKey};
 
 /// Generate a P2WPKH (pay-to-witness-public-key-hash) address and print it
 /// along with the associated private key needed to transact.
@@ -8,7 +8,8 @@ fn main() {
     let (secret_key, public_key) = secp256k1::generate_keypair(&mut rand::rng());
 
     // Create a Bitcoin private key to be used on the Bitcoin mainnet.
-    let private_key = PrivateKey::from_secp(secret_key, Network::Bitcoin);
+    // Equivalent to `PrivateKey::from_secp(secret_key, Network::Bitcoin)`.
+    let private_key = PrivateKey::from_secp(secret_key, NetworkKind::Main);
 
     // Create a compressed Bitcoin public key from the secp256k1 public key.
     let public_key = CompressedPublicKey::from_secp(public_key);


### PR DESCRIPTION
Guide users to the `NetworkKind` by calling `PrivateKey::from_secp` with it. Done because I was confused the other day why private key needed the network and I've been hacking on this library for 5 years now ...

Close #5810