### PR TITLE
Actually put the encoder trait impls first

### DIFF
--- a/primitives/src/hash_types/block_hash.rs
+++ b/primitives/src/hash_types/block_hash.rs
@@ -30,11 +30,6 @@ type Inner = sha256d::Hash;
 
 include!("./generic.rs");
 
-encoding::encoder_newtype_exact! {
-    /// The encoder for the [`BlockHash`] type.
-    pub struct BlockHashEncoder<'e>(encoding::ArrayRefEncoder<'e, 32>);
-}
-
 impl encoding::Encodable for BlockHash {
     type Encoder<'e> = BlockHashEncoder<'e>;
     #[inline]
@@ -49,6 +44,11 @@ impl encoding::Decodable for BlockHash {
     type Decoder = BlockHashDecoder;
     #[inline]
     fn decoder() -> Self::Decoder { BlockHashDecoder(encoding::ArrayDecoder::<32>::new()) }
+}
+
+encoding::encoder_newtype_exact! {
+    /// The encoder for the [`BlockHash`] type.
+    pub struct BlockHashEncoder<'e>(encoding::ArrayRefEncoder<'e, 32>);
 }
 
 /// The decoder for the [`BlockHash`] type.


### PR DESCRIPTION
In commit:

 84c51a8ea1c05b1ff1b8249793f9c1e0491aaee0 BlockHash: Move Encodable and Decodable trait impls

I wrote:

    Put the trait impls first. They are the most important thing in
    regards to the encoding/decoding logic, put them first and the
    supporting types and code next.
    
As correctly pointed out by Yancy this description does not correctly describe the state of the code after that patch was merged. The encoder newtype was put first but should be moved _below_ the trait impls.