### PR TITLE
docs: Favour Constructs over Creates

### DIFF
--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -417,7 +417,7 @@ impl Keypair {
         Self::from(secp256k1::Keypair::new(rng))
     }
 
-    /// Creates a [`Keypair`] directly from a secp256k1 secret key.
+    /// Constructs a [`Keypair`] directly from a secp256k1 secret key.
     #[inline]
     pub fn from_secret_key(sk: &secp256k1::SecretKey) -> Self {
         Self::from(secp256k1::Keypair::from_secret_key(sk))

--- a/p2p/src/message_network.rs
+++ b/p2p/src/message_network.rs
@@ -264,7 +264,7 @@ pub struct UserAgentVersion {
 }
 
 impl UserAgentVersion {
-    /// Creates a user agent client version associated with a name.
+    /// Constructs a user agent client version associated with a name.
     pub const fn new(software_version: ClientSoftwareVersion) -> Self {
         Self { version: software_version, comments: None }
     }


### PR DESCRIPTION
We decided a while back to favour `/// Constructs ...` but some `/// Creates ...` have snuck in again.