### PR TITLE
doc: Make crate headers uniform

### DIFF
--- a/addresses/src/lib.rs
+++ b/addresses/src/lib.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! Bitcoin Addresses
+//! # Bitcoin Addresses
 //!
 //! Bitcoin addresses do not appear on chain; rather, they are conventions used by Bitcoin (wallet)
 //! software to communicate where coins should be sent and are based on the output type e.g., P2WPKH.

--- a/base58/src/lib.rs
+++ b/base58/src/lib.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! Bitcoin base58 encoding and decoding.
+//! # Bitcoin Base58 Encoding and Decoding
 //!
 //! This crate can be used in a no-std environment but requires an allocator.
 

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! Rust Bitcoin Library
+//! # Rust Bitcoin Library
 //!
 //! This is a library that supports the Bitcoin network protocol and associated primitives. It is
 //! designed for Rust programs built to work with the Bitcoin network.

--- a/chacha20_poly1305/src/lib.rs
+++ b/chacha20_poly1305/src/lib.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! `ChaCha20` - `Poly1305`
+//! # `ChaCha20` - `Poly1305`
 //!
 //! Combine the `ChaCha20` stream cipher with the `Poly1305` message authentication code
 //! to form an authenticated encryption with additional data (AEAD) algorithm.

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! Cryptography support for the rust-bitcoin ecosystem.
+//! # Rust Bitcoin Cryptography
 
 // NB: This crate is empty if `alloc` is not enabled.
 #![cfg(feature = "alloc")]

--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! Rust Bitcoin I/O Library
+//! # Rust Bitcoin I/O Library
 //!
 //! The [`std::io`] module is not exposed in `no-std` Rust so building `no-std` applications which
 //! require reading and writing objects via standard traits is not generally possible. Thus, this

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! Bitcoin network.
+//! # Bitcoin network
 //!
 //! The term "network" is overloaded, here [`Network`] refers to the specific
 //! Bitcoin network we are operating on e.g., signet, regtest. The terms


### PR DESCRIPTION
I incorrectly churned this in #4667 which was pointed out in #5720 but only fixed in the stabalizing crates. Now its been done in `hashes` and again confused me so just do the whole repo already.