### PR TITLE
ci: pin zizmor version to avoid random breaks

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -10,7 +10,7 @@ permissions: {}
 
 jobs:
   zizmor:
-    name: zizmor latest via PyPI
+    name: zizmor via PyPI
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -22,4 +22,4 @@ jobs:
         uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41 # v5
 
       - name: Run zizmor 🌈
-        run: uvx zizmor .
+        run: uvx zizmor@1.22.0 .


### PR DESCRIPTION
Been seeing new lints showing up on random branches for zizmor. I think we should just pin its version.

closes #5833 