### PR TITLE
Add v1 message header constructor

### DIFF
--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -243,6 +243,27 @@ pub struct V1MessageHeader {
     pub checksum: [u8; 4],
 }
 
+impl V1MessageHeader {
+    /// Constructs a new [`V1MessageHeader`] with computed 4 byte checksum.
+    ///
+    /// # Parameters
+    ///
+    /// * `magic` - the network magic bytes.
+    /// * `message` - the message described by header.
+    /// * `command` - the character string which defines the transmitted command.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the payload length exceeds `u32::MAX`.
+    pub fn new<T: encoding::Encode>(magic: Magic, message: &T, command: &'static str) -> Self {
+        let (bytes_hashed, checksum) = sha2_checksum(message);
+        let payload_len = u32::try_from(bytes_hashed).expect("network message use u32 as length");
+        let command = CommandString::try_from_static(command).unwrap();
+
+        Self { magic, command, length: payload_len, checksum }
+    }
+}
+
 impl encoding::Encode for V1MessageHeader {
     type Encoder<'e>
         = V1MessageHeaderEncoder<'e>
@@ -2783,6 +2804,22 @@ mod test {
     use crate::{ProtocolVersion, ServiceFlags};
 
     fn hash(array: [u8; 32]) -> sha256d::Hash { sha256d::Hash::from_byte_array(array) }
+
+    #[test]
+    fn v1_message_header() {
+        let magic = Magic::BITCOIN;
+        let payload = Pong(314);
+
+        let header = V1MessageHeader::new(magic, &payload, "pong");
+
+        let target_header = V1MessageHeader {
+            magic: Magic::BITCOIN,
+            command: CommandString::try_from_static("pong").unwrap(),
+            length: 8,
+            checksum: [198, 34, 189, 120],
+        };
+        assert_eq!(header, target_header);
+    }
 
     #[test]
     #[allow(clippy::too_many_lines)]


### PR DESCRIPTION
Adds a constructor to `V1MessageHeader` which also computes the 4 byte checksum as defined by protocol docs.  This constructor is used to compose a network header that can be transmitted over the network stream.

Any network message (payload) must be directly preceded in the network stream by a header.  In that way, the receiving client knows how many bytes to read, and what message to interpret.

A working code example might be a Pong response:
```
let encoder = bitcoin_p2p_messages::message::Pong(nonce);
let msg_header = V1MessageHeader::new(magic, &encoder, "pong");

// write the header to stream
encoding::encode_to_writer(&msg_header, &stream);

// write message to stream
encoding::encode_to_writer(&encoder, &stream);
```

Note that Currently, CommandString wraps a Cow<'static, str>, so the lifetime of `cmd` must match the static lifetime.  However, the protocol documents define this as a 12 byte field, so this can and should be changed at some point.

The fields defined in `V1MessageHeader` is the first four fields of a message structure.  An example given in the docs of message header is given as:

```
Message Header:
 F9 BE B4 D9                         - Main network magic bytes
 76 65 72 73 69 6F 6E 00 00 00 00 00 - "version" command
 64 00 00 00                         - Payload is 100 bytes long
 35 8d 49 32                         - payload checksum (byte order)