### PR TITLE
psbt: Handle underflow on small key byte length

### DIFF
--- a/bitcoin/src/psbt/raw.rs
+++ b/bitcoin/src/psbt/raw.rs
@@ -87,7 +87,15 @@ impl Key {
             0x10000..=0xFFFF_FFFF => 5,
             _ => 9,
         };
-        let key_byte_size = byte_size - type_size;
+
+        // This may cause an underflow/panic if the byte count is insufficient to even capture
+        // the key type CompactSize value. So we use a checked_sub here.
+        let key_byte_size = match byte_size.checked_sub(type_size) {
+            Some(val) => val,
+            None => {
+                return Err(Error::InvalidKey(Self { type_value, key_data: vec![] }));
+            }
+        };
 
         if key_byte_size > MAX_VEC_SIZE {
             return Err(encode::Error::Parse(encode::ParseError::OversizedVectorAllocation {


### PR DESCRIPTION
In PSBT keys, a change was recently introduced to allow for multi-byte key type values. In this change, the key data length was changed to calculate based on the total key length, subtracting the byte count of the key type compact size value. For malformed PSBT inputs where the total key length is insufficient to cover the type value compact size, this causes an underflow in the subtraction, panicing on debug and potentially causing incorrect behaviour for release.

Instead, this calculation should use a checked_sub, erroring gracefully when this underflow would otherwise occur.

Change key data length calculation to use checked_sub and return an InvalidKey error when the total key length value is invalid to parse the key type correctly.