### PR TITLE
Remove rustdocs from pub extern crate re-exports

### DIFF
--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -62,35 +62,15 @@ extern crate std;
 #[cfg(feature = "arbitrary")]
 pub extern crate arbitrary;
 
-/// Encodes and decodes base64 as bytes or utf8.
 #[cfg(feature = "base64")]
 pub extern crate base64;
-
-/// Bitcoin base58 encoding and decoding.
 pub extern crate base58;
-
-/// Re-export the `bech32` crate.
 pub extern crate bech32;
-
-/// Re-export the `consensus-encoding` crate.
 pub extern crate encoding;
-
-/// Rust implementation of cryptographic hash function algorithms.
 pub extern crate hashes;
-
-/// Re-export the `hex-conservative` crate.
 pub extern crate hex_stable as hex;
-
-/// Re-export the `bitcoin-io` crate.
 pub extern crate io;
-
-/// Re-export the `primitives` crate.
 pub extern crate primitives;
-
-/// Re-export the `rust-secp256k1` crate.
-///
-/// Rust wrapper library for Pieter Wuille's libsecp256k1. Implements ECDSA and BIP-0340 signatures
-/// for the SECG elliptic curve group secp256k1 and related utilities.
 pub extern crate secp256k1;
 
 #[cfg(feature = "serde")]

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -72,17 +72,14 @@ extern crate core;
 #[cfg(feature = "std")]
 extern crate std;
 
-/// A generic serialization/deserialization framework.
 #[cfg(feature = "serde")]
 pub extern crate serde;
 
 #[cfg(all(test, feature = "serde"))]
 extern crate serde_test;
 
-/// Re-export the `consensus-encoding` crate.
 pub extern crate encoding;
 
-/// Re-export the `hex-conservative` crate.
 #[cfg(feature = "hex")]
 pub extern crate hex_stable as hex;
 #[cfg(feature = "hex")]

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -32,7 +32,6 @@ pub extern crate serde;
 #[cfg(feature = "arbitrary")]
 pub extern crate arbitrary;
 
-/// Re-export of the `encoding` crate.
 pub extern crate encoding;
 
 #[cfg(feature = "hex")]

--- a/units/src/lib.rs
+++ b/units/src/lib.rs
@@ -34,7 +34,6 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
-/// Re-export of the `encoding` crate.
 #[cfg(feature = "encoding")]
 pub extern crate encoding;
 


### PR DESCRIPTION
The docs are not rendered and are inconsistently applied across the repo.

Remove all docs from pub extern crate re-exports.

Closes #5847