### PR TITLE
hashes: use Rust-like syntax in hash type macros

### DIFF
--- a/hashes/src/hash160/mod.rs
+++ b/hashes/src/hash160/mod.rs
@@ -10,9 +10,10 @@
 use crate::{ripemd160, sha256};
 
 crate::internal_macros::general_hash_type! {
-    160,
-    false,
-    "Output of the Bitcoin HASH160 hash function. (RIPEMD160(SHA256))"
+    /// Output of the Bitcoin HASH160 hash function. (RIPEMD160(SHA256))
+    pub struct Hash([u8; 20]);
+
+    const DISPLAY_BACKWARD: bool = false;
 }
 
 impl Hash {

--- a/hashes/src/internal_macros.rs
+++ b/hashes/src/internal_macros.rs
@@ -47,17 +47,28 @@ pub(crate) use hash_trait_impls;
 /// The created type has a single field and will have all standard derives as well as an
 /// implementation of [`crate::Hash`].
 ///
-/// # Parameters
+/// # Syntax
 ///
-/// * `$bits` - the number of bits of the hash type
-/// * `$reverse` - `true` if the hash should be displayed backwards, `false` otherwise
-/// * `$doc` - the doc string to put on the type
+/// ```ignore
+/// // Requires a `HashEngine` type in scope.
+/// general_hash_type! {
+///     /// Documentation for the hash type.
+///     pub struct Hash([u8; 32]);
+///
+///     const DISPLAY_BACKWARD: bool = false;
+/// }
+/// ```
 ///
 /// Restrictions on usage:
 ///
-/// * Requires a `HashEngine` type in this module implementing `Default` and `crate::HashEngine<Hash = Hash, Bytes = [u8; $bits / 8]>`.
+/// * Requires a `HashEngine` type in this module implementing `Default` and `crate::HashEngine<Hash = Hash, Bytes = [u8; $len]>`.
 macro_rules! general_hash_type {
-    ($bits:expr, $reverse:expr, $doc:literal) => {
+    (
+        $(#[$type_attrs:meta])*
+        pub struct Hash([u8; $len:expr]);
+
+        const DISPLAY_BACKWARD: bool = $reverse:expr;
+    ) => {
         /// Hashes some bytes.
         pub fn hash(data: &[u8]) -> Hash {
             use crate::HashEngine as _;
@@ -82,7 +93,12 @@ macro_rules! general_hash_type {
             engine.finalize()
         }
 
-        $crate::internal_macros::hash_type_no_default!($bits, $reverse, $doc);
+        $crate::internal_macros::hash_type_no_default! {
+            $(#[$type_attrs])*
+            pub struct Hash([u8; $len]);
+
+            const DISPLAY_BACKWARD: bool = $reverse;
+        }
 
         impl Hash {
             /// Constructs a new engine.
@@ -113,11 +129,16 @@ macro_rules! general_hash_type {
 pub(crate) use general_hash_type;
 
 macro_rules! hash_type_no_default {
-    ($bits:expr, $reverse:expr, $doc:literal) => {
+    (
+        $(#[$type_attrs:meta])*
+        pub struct Hash([u8; $len:expr]);
+
+        const DISPLAY_BACKWARD: bool = $reverse:expr;
+    ) => {
         internals::transparent_newtype! {
-            #[doc = $doc]
+            $(#[$type_attrs])*
             #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-            pub struct Hash([u8; $bits / 8]);
+            pub struct Hash([u8; $len]);
 
             impl Hash {
                 /// Zero cost conversion between a fixed length byte array shared reference and
@@ -132,16 +153,17 @@ macro_rules! hash_type_no_default {
 
         impl Hash {
             /// Constructs a new hash from the underlying byte array.
-            pub const fn from_byte_array(bytes: [u8; $bits / 8]) -> Self { Hash(bytes) }
+            pub const fn from_byte_array(bytes: [u8; $len]) -> Self { Hash(bytes) }
 
             /// Returns the underlying byte array.
-            pub const fn to_byte_array(self) -> [u8; $bits / 8] { self.0 }
+            pub const fn to_byte_array(self) -> [u8; $len] { self.0 }
 
             /// Returns a reference to the underlying byte array.
-            pub const fn as_byte_array(&self) -> &[u8; $bits / 8] { &self.0 }
+            pub const fn as_byte_array(&self) -> &[u8; $len] { &self.0 }
         }
 
-        $crate::internal_macros::hash_trait_impls!($bits, $reverse);
+        // Parenthesize `$len` so additive expressions still map to the intended bit width.
+        $crate::internal_macros::hash_trait_impls!(($len) * 8, $reverse);
 
         $crate::internal_macros::impl_write!(
             HashEngine,

--- a/hashes/src/ripemd160/mod.rs
+++ b/hashes/src/ripemd160/mod.rs
@@ -12,9 +12,10 @@ mod tests;
 use crate::incomplete_block_len;
 
 crate::internal_macros::general_hash_type! {
-    160,
-    false,
-    "Output of the RIPEMD160 hash function."
+    /// Output of the RIPEMD160 hash function.
+    pub struct Hash([u8; 20]);
+
+    const DISPLAY_BACKWARD: bool = false;
 }
 
 impl Hash {

--- a/hashes/src/sha1/mod.rs
+++ b/hashes/src/sha1/mod.rs
@@ -12,9 +12,10 @@ mod tests;
 use crate::incomplete_block_len;
 
 crate::internal_macros::general_hash_type! {
-    160,
-    false,
-    "Output of the SHA1 hash function."
+    /// Output of the SHA1 hash function.
+    pub struct Hash([u8; 20]);
+
+    const DISPLAY_BACKWARD: bool = false;
 }
 
 impl Hash {

--- a/hashes/src/sha256/mod.rs
+++ b/hashes/src/sha256/mod.rs
@@ -17,9 +17,10 @@ use crate::{incomplete_block_len, sha256d};
 use crate::{sha256t, sha256t_tag};
 
 crate::internal_macros::general_hash_type! {
-    256,
-    false,
-    "Output of the SHA256 hash function."
+    /// Output of the SHA256 hash function.
+    pub struct Hash([u8; 32]);
+
+    const DISPLAY_BACKWARD: bool = false;
 }
 
 impl Hash {

--- a/hashes/src/sha256d/mod.rs
+++ b/hashes/src/sha256d/mod.rs
@@ -5,9 +5,10 @@
 use crate::sha256;
 
 crate::internal_macros::general_hash_type! {
-    256,
-    true,
-    "Output of the SHA256d hash function."
+    /// Output of the SHA256d hash function.
+    pub struct Hash([u8; 32]);
+
+    const DISPLAY_BACKWARD: bool = true;
 }
 
 impl Hash {

--- a/hashes/src/sha384/mod.rs
+++ b/hashes/src/sha384/mod.rs
@@ -5,9 +5,10 @@
 use crate::sha512;
 
 crate::internal_macros::general_hash_type! {
-    384,
-    false,
-    "Output of the SHA384 hash function."
+    /// Output of the SHA384 hash function.
+    pub struct Hash([u8; 48]);
+
+    const DISPLAY_BACKWARD: bool = false;
 }
 
 impl Hash {

--- a/hashes/src/sha3_256/mod.rs
+++ b/hashes/src/sha3_256/mod.rs
@@ -27,9 +27,10 @@
 use core::fmt;
 
 crate::internal_macros::general_hash_type! {
-    256,
-    false,
-    "Output of the SHA3-256 hash function."
+    /// Output of the SHA3-256 hash function.
+    pub struct Hash([u8; 32]);
+
+    const DISPLAY_BACKWARD: bool = false;
 }
 // The number of rows or columns.
 const B: usize = 5;

--- a/hashes/src/sha512/mod.rs
+++ b/hashes/src/sha512/mod.rs
@@ -13,9 +13,10 @@ mod tests;
 use crate::incomplete_block_len;
 
 crate::internal_macros::general_hash_type! {
-    512,
-    false,
-    "Output of the SHA512 hash function."
+    /// Output of the SHA512 hash function.
+    pub struct Hash([u8; 64]);
+
+    const DISPLAY_BACKWARD: bool = false;
 }
 
 impl Hash {

--- a/hashes/src/sha512_256/mod.rs
+++ b/hashes/src/sha512_256/mod.rs
@@ -9,9 +9,15 @@
 use crate::sha512;
 
 crate::internal_macros::general_hash_type! {
-    256,
-    false,
-    "Output of the SHA512/256 hash function.\n\nSHA512/256 is a hash function that uses the sha512 algorithm but it truncates the output to 256 bits. It has different initial constants than sha512 so it produces an entirely different hash compared to sha512. More information at <https://eprint.iacr.org/2010/548.pdf>."
+    /// Output of the SHA512/256 hash function.
+    ///
+    /// SHA512/256 is a hash function that uses the sha512 algorithm but it truncates the output to
+    /// 256 bits. It has different initial constants than sha512 so it produces an entirely
+    /// different hash compared to sha512. More information at
+    /// <https://eprint.iacr.org/2010/548.pdf>.
+    pub struct Hash([u8; 32]);
+
+    const DISPLAY_BACKWARD: bool = false;
 }
 
 impl Hash {

--- a/hashes/src/siphash24/mod.rs
+++ b/hashes/src/siphash24/mod.rs
@@ -9,9 +9,10 @@ use core::{cmp, mem};
 use crate::HashEngine as _;
 
 crate::internal_macros::hash_type_no_default! {
-    64,
-    false,
-    "Output of the SipHash24 hash function."
+    /// Output of the SipHash24 hash function.
+    pub struct Hash([u8; 8]);
+
+    const DISPLAY_BACKWARD: bool = false;
 }
 
 macro_rules! compress {


### PR DESCRIPTION
Change the internal hash type macros to accept declarations that look like normal Rust items at the call site. This makes the hash modules easier to read without exposing the implementation details that the macros are meant to hide.

Update the existing hash modules and siphash24 to the new syntax, refresh the macro documentation, and remove the old positional hash_type_no_default! form.

Assisted-by: github-copilot/gpt-5.4