### PR TITLE
psbt: Add unit test case for key byte size handling

### DIFF
--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -1401,6 +1401,14 @@ mod tests {
     }
 
     #[test]
+    fn psbt_insufficient_byte_size() {
+        // construct a key where the key byte size (0x02) is less than even the type value length (in this case, 3)
+        let key_data = hex!("02fd07ffababababab");
+        let got = super::raw::Key::decode(&mut key_data.as_slice()).unwrap_err();
+        assert!(matches!(got, Error::InvalidKey(_)));
+    }
+
+    #[test]
     fn psbt_high_fee_checks() {
         let psbt = psbt_with_amounts(Amount::MAX.to_sat(), 1000);
 


### PR DESCRIPTION
Recently, a change ws introduced in psbt to fix key parsing when the key has a total byte size value that is so small as to fail to cover the type compact size. In this case, a panic/underflow could occur. This has been fixed, but a test case should be included to prevent regressions.

Introduce unit test to verify that small key bytes throw errors instead of panicing due to underflow.