### PR TITLE
crypto: Re-export types and extern crates

### DIFF
--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -32,5 +32,11 @@ pub mod key;
 #[cfg(feature = "alloc")]
 pub mod sighash;
 
+#[doc(inline)]
+#[cfg(feature = "alloc")]
+pub use self::{
+    key::{FullPublicKey, Keypair, PrivateKey, LegacyPublicKey, XOnlyPublicKey},
+};
+
 #[cfg(feature = "alloc")]
 include!("../include/newtype.rs"); // Explained in `REPO_DIR/docs/README.md`.

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -15,8 +15,15 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
-/// Re-export the `hex-conservative` crate.
 pub extern crate hex_stable as hex;
+
+pub extern crate base58;
+
+pub extern crate network;
+
+pub extern crate io;
+
+pub extern crate secp256k1;
 
 #[cfg(feature = "alloc")]
 pub mod ecdsa;


### PR DESCRIPTION
The crypto crate has types from various external crates in the public API. When this happens, those external crates should be accessible through re-export in the crate itself. Further, important types should be accessible from the crate root, similarly to how they are in bitcoin.

- Patch 1 externs all crates with types in the public API.
- Patch 2 re-exports the key types in the crate root.