### PR TITLE
Re-export serde and arbitrary when they appear in public API

### DIFF
--- a/api/primitives/all-features.txt
+++ b/api/primitives/all-features.txt
@@ -1363,8 +1363,10 @@ pub enum bitcoin_primitives::script::ScriptPubKeyTag
 pub enum bitcoin_primitives::script::ScriptSigTag
 pub enum bitcoin_primitives::script::TapScriptTag
 pub enum bitcoin_primitives::script::WitnessScriptTag
+pub extern crate bitcoin_primitives::arbitrary
 pub extern crate bitcoin_primitives::encoding
 pub extern crate bitcoin_primitives::hex
+pub extern crate bitcoin_primitives::serde
 pub fn &'a bitcoin_primitives::script::Script<T>::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
 pub fn &'a bitcoin_primitives::witness::Witness::into_iter(self) -> Self::IntoIter
 pub fn &'de bitcoin_primitives::script::Script<T>::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>

--- a/api/units/all-features.txt
+++ b/api/units/all-features.txt
@@ -1810,7 +1810,9 @@ pub enum bitcoin_units::relative::error::IsSatisfiedByError
 pub enum bitcoin_units::relative::error::IsSatisfiedByHeightError
 pub enum bitcoin_units::relative::error::IsSatisfiedByTimeError
 pub enum bitcoin_units::result::NumOpResult<T>
+pub extern crate bitcoin_units::arbitrary
 pub extern crate bitcoin_units::encoding
+pub extern crate bitcoin_units::serde
 pub fn &bitcoin_units::Amount::add(self, rhs: &bitcoin_units::Amount) -> Self::Output
 pub fn &bitcoin_units::Amount::add(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>) -> Self::Output
 pub fn &bitcoin_units::Amount::add(self, rhs: bitcoin_units::Amount) -> Self::Output

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -59,6 +59,9 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+#[cfg(feature = "arbitrary")]
+pub extern crate arbitrary;
+
 /// Encodes and decodes base64 as bytes or utf8.
 #[cfg(feature = "base64")]
 pub extern crate base64;
@@ -92,7 +95,7 @@ pub extern crate secp256k1;
 
 #[cfg(feature = "serde")]
 #[macro_use]
-extern crate serde;
+pub extern crate serde;
 
 mod internal_macros;
 

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -16,7 +16,7 @@
 extern crate std;
 
 #[cfg(feature = "serde")]
-extern crate serde;
+pub extern crate serde;
 
 use core::fmt;
 use core::str::FromStr;

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -28,6 +28,12 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+#[cfg(feature = "serde")]
+pub extern crate serde;
+
+#[cfg(feature = "arbitrary")]
+pub extern crate arbitrary;
+
 pub extern crate hex_stable as hex;
 
 use alloc::borrow::ToOwned;

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -27,7 +27,10 @@ extern crate std;
 
 #[cfg(feature = "serde")]
 #[macro_use]
-extern crate serde;
+pub extern crate serde;
+
+#[cfg(feature = "arbitrary")]
+pub extern crate arbitrary;
 
 /// Re-export of the `encoding` crate.
 pub extern crate encoding;

--- a/units/src/lib.rs
+++ b/units/src/lib.rs
@@ -38,6 +38,12 @@ extern crate std;
 #[cfg(feature = "encoding")]
 pub extern crate encoding;
 
+#[cfg(feature = "serde")]
+pub extern crate serde;
+
+#[cfg(feature = "arbitrary")]
+pub extern crate arbitrary;
+
 #[doc(hidden)]
 pub mod _export {
     /// A re-export of `core::*`.


### PR DESCRIPTION
In various crates, we have types from external crates in the public APIs, such as serde's Serialize or arbitrary's Arbitrary. In order to simplify dependency handling, we should re-export these crates which have types appearing in the public API.

Add pub extern crate for serde and arbitrary in bitcoin, network, p2p, units and primitives as needed.

Closes #5822