### PR TITLE
consensus_encoding: Error on byte-less end for `VecDecoder`

### DIFF
--- a/consensus_encoding/src/decode/decoders.rs
+++ b/consensus_encoding/src/decode/decoders.rs
@@ -265,6 +265,12 @@ impl<T: Decodable> Decoder for VecDecoder<T> {
     fn end(self) -> Result<Self::Output, Self::Error> {
         use VecDecoderErrorInner as E;
 
+        if let Some(ref prefix_decoder) = self.prefix_decoder {
+            return Err(VecDecoderError(E::UnexpectedEof(UnexpectedEofError {
+                missing: prefix_decoder.read_limit(),
+            })));
+        }
+
         if self.buffer.len() == self.length {
             Ok(self.buffer)
         } else {
@@ -1076,6 +1082,23 @@ mod tests {
         let want = Test(vec![]);
 
         assert_eq!(got, want);
+    }
+
+    #[test]
+    #[cfg(feature = "alloc")]
+    fn vec_decoder_empty_no_bytes() {
+        // Empty slice. Note the lack of any length prefix compact size.
+        let encoded = &[];
+
+        let mut slice = encoded.as_slice();
+        let mut decoder = Test::decoder();
+        // Should want more bytes since we've provided nothing
+        assert!(decoder.push_bytes(&mut slice).unwrap());
+
+        assert!(matches!(
+            decoder.end().unwrap_err(),
+            VecDecoderError(VecDecoderErrorInner::UnexpectedEof(_))
+        ));
     }
 
     #[test]


### PR DESCRIPTION
In the existing encoding, Vec<T> would error when attempting to decode an empty byte slice (i.e. one without a length prefix). In the new consensus_encoding crate, a VecDecoder successfully decodes a completely empty byte slice as 0 length Vec<T>. This difference in behaviour manifests in various decoders throughout the stack and thus results in differences in decoding behaviour.

Throw Eof error in VecDecoder::end() if no length prefix has been provided to the decoder.

Closes #5842