### PR TITLE
internals, hashes, primivties: clean up optional deps

### DIFF
--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -30,7 +30,7 @@ arbitrary = { version = "1.4.1", optional = true}
 serde = { version = "1.0.195", default-features = false, optional = true }
 cpufeatures = { version = "0.2", optional = true }
 
-# You likely don't want to enable these directly, use hex instead.
+# Both optional hex dependencies are behind the `hex` feature.
 hex-stable = { package = "hex-conservative", version = "1.0.0", default-features = false, optional = true }
 hex-unstable = { package = "hex-conservative", version = "0.3.2", default-features = false, optional = true }
 

--- a/internals/Cargo.toml
+++ b/internals/Cargo.toml
@@ -18,13 +18,13 @@ default = []
 std = ["alloc", "hex?/std"]
 alloc = ["hex?/alloc"]
 
-test-serde = ["serde", "serde_json", "bincode"]
+test-serde = ["serde", "dep:serde_json", "dep:bincode"]
 
 [dependencies]
 hex = { package = "hex-conservative", version = "0.3.2", default-features = false, optional = true }
 serde = { version = "1.0.195", default-features = false, optional = true }
 
-# Don't enable these directly, use `test-serde` feature instead.
+# Behind the test-serde feature.
 serde_json = { version = "1.0.68", optional = true }
 bincode = { version = "1.3.1", optional = true }
 

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -28,7 +28,7 @@ units = { package = "bitcoin-units", path = "../units", version = "0.3.0", defau
 
 arbitrary = { version = "1.4.1", optional = true }
 serde = { version = "1.0.195", default-features = false, features = ["derive", "alloc"], optional = true }
-# You probably don't want to use these directly, consider using the `hex` feature.
+# Both optional hex dependencies are behind the `hex` feature.
 hex-stable = { package = "hex-conservative", version = "1.0.0", default-features = false, optional = true }
 hex-unstable = { package = "hex-conservative", version = "0.3.2", default-features = false, optional = true }
 


### PR DESCRIPTION
If you use the `dep:OPTIONAL_DEP` syntax in a package's feature, then the implicit feature flag for the optional dependency is disabled. No need to tell end users to avoid it.

These manifest comments were confusing me. I verified with `cargo metadata --format-version 1 --no-deps` and took a look at the output for the `primitives` package.

```json
      "features": {
        "alloc": [
          "hashes/alloc",
          "hex-stable?/alloc",
          "hex-unstable?/alloc",
          "internals/alloc",
          "units/alloc"
        ],
        "arbitrary": [
          "dep:arbitrary",
          "units/arbitrary"
        ],
        "default": [
          "std",
          "hex"
        ],
        "hex": [
          "dep:hex-stable",
          "dep:hex-unstable",
          "hashes/hex",
          "internals/hex"
        ],
        "serde": [
          "dep:serde",
          "hashes/serde",
          "internals/serde",
          "units/serde",
          "alloc",
          "hex"
        ],
        "std": [
          "alloc",
          "hashes/std",
          "hex-stable?/std",
          "hex-unstable?/std",
          "internals/std",
          "units/std"
        ]
      },
```

You can also see in the [docs](https://docs.rs/crate/bitcoin-primitives/0.102.0/features) there are no feature flags for `hex-stable` and `hex-unstable` exposed.