### PR TITLE
key: Rename PrivateKey::public_key to to_public_key

### DIFF
--- a/bitcoin/embedded/src/main.rs
+++ b/bitcoin/embedded/src/main.rs
@@ -33,7 +33,7 @@ fn main() -> ! {
     hprintln!("Seed WIF: {}", wk.to_wif()).unwrap();
 
     // Derive address
-    let pubkey = wk.private_key.public_key().try_into().unwrap();
+    let pubkey = wk.private_key.to_public_key().try_into().unwrap();
     let address = Address::p2wpkh(pubkey, Network::Bitcoin);
     hprintln!("Address: {}", address).unwrap();
 

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -661,7 +661,7 @@ impl PublicKey {
     }
 
     /// Computes the public key as supposed to be used with this secret.
-    pub fn from_private_key(sk: PrivateKey) -> Self { sk.public_key() }
+    pub fn from_private_key(sk: PrivateKey) -> Self { sk.to_public_key() }
 
     /// Extracts the public key from a Keypair
     pub fn from_keypair(pair: &Keypair) -> Self {
@@ -827,7 +827,7 @@ impl CompressedPublicKey {
     ///
     /// Errors if the private key is not compressed.
     pub fn from_private_key(sk: PrivateKey) -> Result<Self, UncompressedPublicKeyError> {
-        sk.public_key().try_into()
+        sk.to_public_key().try_into()
     }
 
     /// Checks that `sig` is a valid ECDSA signature for `msg` using this public key.
@@ -910,7 +910,7 @@ impl PrivateKey {
     }
 
     /// Constructs a new public key from this private key.
-    pub fn public_key(&self) -> PublicKey {
+    pub fn to_public_key(&self) -> PublicKey {
         match self.compressed() {
             true => PublicKey::from_secp(secp256k1::PublicKey::from_secret_key(self.as_inner())),
             false => PublicKey::from_secp_uncompressed(secp256k1::PublicKey::from_secret_key(
@@ -918,6 +918,10 @@ impl PrivateKey {
             )),
         }
     }
+
+    /// Constructs a new public key from this private key.
+    #[deprecated(since = "TBD", note = "use `to_public_key` instead")]
+    pub fn public_key(&self) -> PublicKey { self.to_public_key() }
 
     /// Serializes the private key to bytes.
     #[deprecated(since = "TBD", note = "use to_secret_vec instead")]
@@ -1780,7 +1784,7 @@ mod tests {
         assert!(sk.private_key.compressed());
         assert_eq!(&sk.to_wif(), "cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy");
 
-        let pk = Address::p2pkh(sk.private_key.public_key(), sk.network_kind);
+        let pk = Address::p2pkh(sk.private_key.to_public_key(), sk.network_kind);
         assert_eq!(&pk.to_string(), "mqwpxxvfv3QbM8PU8uBx2jaNt9btQqvQNx");
 
         // test string conversion
@@ -1795,7 +1799,7 @@ mod tests {
         assert!(!sk.private_key.compressed());
         assert_eq!(&sk.to_wif(), "5JYkZjmN7PVMjJUfJWfRFwtuXTGB439XV6faajeHPAM9Z2PT2R3");
 
-        let mut pk = sk.private_key.public_key();
+        let mut pk = sk.private_key.to_public_key();
         assert!(!pk.compressed());
         assert_eq!(&pk.to_string(), "042e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af191923a2964c177f5b5923ae500fca49e99492d534aa3759d6b25a8bc971b133");
         assert_eq!(pk, "042e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af191923a2964c177f5b5923ae500fca49e99492d534aa3759d6b25a8bc971b133"

--- a/bitcoin/src/psbt/mod.rs
+++ b/bitcoin/src/psbt/mod.rs
@@ -375,7 +375,7 @@ impl Psbt {
                 sighash_type: sighash_ty,
             };
 
-            let pk = sk.public_key();
+            let pk = sk.to_public_key();
 
             input.partial_sigs.insert(pk, sig);
             used.push(pk);
@@ -463,7 +463,7 @@ impl Psbt {
                         input.tap_script_sigs.insert((xonly, lh), signature);
                     }
 
-                    used.push(sk.public_key().into());
+                    used.push(sk.to_public_key().into());
                 }
             }
         }
@@ -906,7 +906,7 @@ impl GetKey for $map<XOnlyPublicKey, PrivateKey> {
                 let (xonly, parity) = pk.to_inner().x_only_public_key();
 
                 if let Some(mut priv_key) = self.get(&XOnlyPublicKey::from(xonly)).cloned() {
-                    let computed_pk = priv_key.public_key();
+                    let computed_pk = priv_key.to_public_key();
                     let (_, computed_parity) = computed_pk.to_inner().x_only_public_key();
 
                     if computed_parity != parity {
@@ -2388,7 +2388,7 @@ mod tests {
 
         if parity == secp256k1::Parity::Even {
             priv_key = priv_key.negate();
-            pk = priv_key.public_key();
+            pk = priv_key.to_public_key();
         }
 
         pubkey_map.insert(pk, priv_key);
@@ -2397,7 +2397,7 @@ mod tests {
 
         let retrieved_key = req_result.unwrap();
 
-        let retrieved_pub_key = retrieved_key.public_key();
+        let retrieved_pub_key = retrieved_key.to_public_key();
         let (retrieved_xonly, retrieved_parity) = retrieved_pub_key.to_inner().x_only_public_key();
 
         assert_eq!(xonly, retrieved_xonly);


### PR DESCRIPTION
The public_key function on PrivateKey converts the key into a matching PublicKey. Since this function is not a getter but a conversion function, it should use the {to_,as_,into_} naming scheme. In this case, to_public_key matches the naming used for the equivalent function on the Keypair type.

Rename PrivateKey::public_key function to to_public_key, deprecating the old function name.