### PR TITLE
Fix code comment so formatter doesn't munge it

### DIFF
--- a/primitives/src/script/tests.rs
+++ b/primitives/src/script/tests.rs
@@ -498,9 +498,10 @@ fn hex() {
     let b = ScriptBuf::from_hex_no_length_prefix(raw).unwrap();
     assert_eq!(a, b);
 
-    // Sanity check - negative case.
-    assert!(ScriptBuf::from_hex_prefixed(raw).is_err()); // Nice API, this misuse fails.
-                                                         // But this just puts the length prefix in the script, ouch.
+    // Sanity check - negative case. Nice API, this misuse fails.
+    assert!(ScriptBuf::from_hex_prefixed(raw).is_err()); //
+
+    // Sanity check - negative case. But this just puts the length prefix in the script, ouch.
     assert!(ScriptBuf::from_hex_no_length_prefix(consensus).is_ok());
 
     let script = ScriptBuf::from_hex_prefixed(consensus).unwrap();


### PR DESCRIPTION
Make the code comment more ugly than it is but less than the formatter will make it.