### PR TITLE
Clean up stale macro_use attribute

### DIFF
--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -107,7 +107,6 @@ pub mod ext {
     #[cfg(feature = "bitcoinconsensus")]
     pub use crate::consensus_validation::{ScriptPubKeyExt as _, TransactionExt as _};
 }
-#[macro_use]
 pub mod address;
 pub mod bip158;
 pub mod bip32;


### PR DESCRIPTION
The `#[macro_use]` attribute attached to `pub mod address` is out of place. Investigation shows that it's a leftover from an old `pub mod macros` that was removed in [`81bfc4f0271c47267307e7c83a45d6a5ec015ee8`](https://github.com/rust-bitcoin/rust-bitcoin/commit/81bfc4f0271c47267307e7c83a45d6a5ec015ee8). Given that the `address` module doesn't define any module-level macro's, the attribute can be safely cleaned up.