### PR TITLE
units: Scrub encoder/decoder code

### DIFF
--- a/api/units/all-features.txt
+++ b/api/units/all-features.txt
@@ -76,6 +76,7 @@ impl core::clone::Clone for bitcoin_units::BlockTime
 impl core::clone::Clone for bitcoin_units::FeeRate
 impl core::clone::Clone for bitcoin_units::SignedAmount
 impl core::clone::Clone for bitcoin_units::Weight
+impl core::clone::Clone for bitcoin_units::amount::AmountDecoder
 impl core::clone::Clone for bitcoin_units::amount::Denomination
 impl core::clone::Clone for bitcoin_units::amount::Display
 impl core::clone::Clone for bitcoin_units::amount::error::AmountDecoderError
@@ -92,6 +93,7 @@ impl core::clone::Clone for bitcoin_units::amount::error::PossiblyConfusingDenom
 impl core::clone::Clone for bitcoin_units::amount::error::TooPreciseError
 impl core::clone::Clone for bitcoin_units::amount::error::UnknownDenominationError
 impl core::clone::Clone for bitcoin_units::block::BlockHeight
+impl core::clone::Clone for bitcoin_units::block::BlockHeightDecoder
 impl core::clone::Clone for bitcoin_units::block::BlockHeightDecoderError
 impl core::clone::Clone for bitcoin_units::block::BlockHeightInterval
 impl core::clone::Clone for bitcoin_units::block::BlockMtp
@@ -100,6 +102,7 @@ impl core::clone::Clone for bitcoin_units::block::TooBigForRelativeHeightError
 impl core::clone::Clone for bitcoin_units::fee_rate::serde::OverflowError
 impl core::clone::Clone for bitcoin_units::locktime::absolute::Height
 impl core::clone::Clone for bitcoin_units::locktime::absolute::LockTime
+impl core::clone::Clone for bitcoin_units::locktime::absolute::LockTimeDecoder
 impl core::clone::Clone for bitcoin_units::locktime::absolute::MedianTimePast
 impl core::clone::Clone for bitcoin_units::locktime::absolute::error::ConversionError
 impl core::clone::Clone for bitcoin_units::locktime::absolute::error::IncompatibleHeightError
@@ -121,11 +124,14 @@ impl core::clone::Clone for bitcoin_units::parse_int::ParseIntError
 impl core::clone::Clone for bitcoin_units::parse_int::PrefixedHexError
 impl core::clone::Clone for bitcoin_units::parse_int::UnprefixedHexError
 impl core::clone::Clone for bitcoin_units::pow::CompactTarget
+impl core::clone::Clone for bitcoin_units::pow::CompactTargetDecoder
 impl core::clone::Clone for bitcoin_units::pow::CompactTargetDecoderError
 impl core::clone::Clone for bitcoin_units::result::MathOp
 impl core::clone::Clone for bitcoin_units::result::NumOpError
 impl core::clone::Clone for bitcoin_units::sequence::Sequence
+impl core::clone::Clone for bitcoin_units::sequence::SequenceDecoder
 impl core::clone::Clone for bitcoin_units::sequence::SequenceDecoderError
+impl core::clone::Clone for bitcoin_units::time::BlockTimeDecoder
 impl core::clone::Clone for bitcoin_units::time::BlockTimeDecoderError
 impl core::cmp::Eq for bitcoin_units::Amount
 impl core::cmp::Eq for bitcoin_units::BlockTime
@@ -445,6 +451,7 @@ impl core::fmt::Debug for bitcoin_units::BlockTime
 impl core::fmt::Debug for bitcoin_units::FeeRate
 impl core::fmt::Debug for bitcoin_units::SignedAmount
 impl core::fmt::Debug for bitcoin_units::Weight
+impl core::fmt::Debug for bitcoin_units::amount::AmountDecoder
 impl core::fmt::Debug for bitcoin_units::amount::Denomination
 impl core::fmt::Debug for bitcoin_units::amount::Display
 impl core::fmt::Debug for bitcoin_units::amount::error::AmountDecoderError
@@ -461,6 +468,7 @@ impl core::fmt::Debug for bitcoin_units::amount::error::PossiblyConfusingDenomin
 impl core::fmt::Debug for bitcoin_units::amount::error::TooPreciseError
 impl core::fmt::Debug for bitcoin_units::amount::error::UnknownDenominationError
 impl core::fmt::Debug for bitcoin_units::block::BlockHeight
+impl core::fmt::Debug for bitcoin_units::block::BlockHeightDecoder
 impl core::fmt::Debug for bitcoin_units::block::BlockHeightDecoderError
 impl core::fmt::Debug for bitcoin_units::block::BlockHeightInterval
 impl core::fmt::Debug for bitcoin_units::block::BlockMtp
@@ -469,6 +477,7 @@ impl core::fmt::Debug for bitcoin_units::block::TooBigForRelativeHeightError
 impl core::fmt::Debug for bitcoin_units::fee_rate::serde::OverflowError
 impl core::fmt::Debug for bitcoin_units::locktime::absolute::Height
 impl core::fmt::Debug for bitcoin_units::locktime::absolute::LockTime
+impl core::fmt::Debug for bitcoin_units::locktime::absolute::LockTimeDecoder
 impl core::fmt::Debug for bitcoin_units::locktime::absolute::MedianTimePast
 impl core::fmt::Debug for bitcoin_units::locktime::absolute::error::ConversionError
 impl core::fmt::Debug for bitcoin_units::locktime::absolute::error::IncompatibleHeightError
@@ -490,11 +499,14 @@ impl core::fmt::Debug for bitcoin_units::parse_int::ParseIntError
 impl core::fmt::Debug for bitcoin_units::parse_int::PrefixedHexError
 impl core::fmt::Debug for bitcoin_units::parse_int::UnprefixedHexError
 impl core::fmt::Debug for bitcoin_units::pow::CompactTarget
+impl core::fmt::Debug for bitcoin_units::pow::CompactTargetDecoder
 impl core::fmt::Debug for bitcoin_units::pow::CompactTargetDecoderError
 impl core::fmt::Debug for bitcoin_units::result::MathOp
 impl core::fmt::Debug for bitcoin_units::result::NumOpError
 impl core::fmt::Debug for bitcoin_units::sequence::Sequence
+impl core::fmt::Debug for bitcoin_units::sequence::SequenceDecoder
 impl core::fmt::Debug for bitcoin_units::sequence::SequenceDecoderError
+impl core::fmt::Debug for bitcoin_units::time::BlockTimeDecoder
 impl core::fmt::Debug for bitcoin_units::time::BlockTimeDecoderError
 impl core::fmt::Display for bitcoin_units::Amount
 impl core::fmt::Display for bitcoin_units::BlockTime
@@ -1504,6 +1516,18 @@ impl<'e> bitcoin_consensus_encoding::encode::ExactSizeEncoder for bitcoin_units:
 impl<'e> bitcoin_consensus_encoding::encode::ExactSizeEncoder for bitcoin_units::pow::CompactTargetEncoder<'e>
 impl<'e> bitcoin_consensus_encoding::encode::ExactSizeEncoder for bitcoin_units::sequence::SequenceEncoder<'e>
 impl<'e> bitcoin_consensus_encoding::encode::ExactSizeEncoder for bitcoin_units::time::BlockTimeEncoder<'e>
+impl<'e> core::clone::Clone for bitcoin_units::amount::AmountEncoder<'e>
+impl<'e> core::clone::Clone for bitcoin_units::block::BlockHeightEncoder<'e>
+impl<'e> core::clone::Clone for bitcoin_units::locktime::absolute::LockTimeEncoder<'e>
+impl<'e> core::clone::Clone for bitcoin_units::pow::CompactTargetEncoder<'e>
+impl<'e> core::clone::Clone for bitcoin_units::sequence::SequenceEncoder<'e>
+impl<'e> core::clone::Clone for bitcoin_units::time::BlockTimeEncoder<'e>
+impl<'e> core::fmt::Debug for bitcoin_units::amount::AmountEncoder<'e>
+impl<'e> core::fmt::Debug for bitcoin_units::block::BlockHeightEncoder<'e>
+impl<'e> core::fmt::Debug for bitcoin_units::locktime::absolute::LockTimeEncoder<'e>
+impl<'e> core::fmt::Debug for bitcoin_units::pow::CompactTargetEncoder<'e>
+impl<'e> core::fmt::Debug for bitcoin_units::sequence::SequenceEncoder<'e>
+impl<'e> core::fmt::Debug for bitcoin_units::time::BlockTimeEncoder<'e>
 impl<'e> core::marker::Freeze for bitcoin_units::amount::AmountEncoder<'e>
 impl<'e> core::marker::Freeze for bitcoin_units::block::BlockHeightEncoder<'e>
 impl<'e> core::marker::Freeze for bitcoin_units::locktime::absolute::LockTimeEncoder<'e>
@@ -2151,12 +2175,16 @@ pub fn bitcoin_units::Weight::sum<I>(iter: I) -> Self where I: core::iter::trait
 pub fn bitcoin_units::Weight::try_from(s: &str) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_units::Weight::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_units::Weight::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::amount::AmountDecoder::clone(&self) -> bitcoin_units::amount::AmountDecoder
 pub fn bitcoin_units::amount::AmountDecoder::default() -> Self
 pub fn bitcoin_units::amount::AmountDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
+pub fn bitcoin_units::amount::AmountDecoder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_units::amount::AmountDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bool, Self::Error>
 pub fn bitcoin_units::amount::AmountDecoder::read_limit(&self) -> usize
 pub fn bitcoin_units::amount::AmountEncoder<'e>::advance(&mut self) -> bool
+pub fn bitcoin_units::amount::AmountEncoder<'e>::clone(&self) -> bitcoin_units::amount::AmountEncoder<'e>
 pub fn bitcoin_units::amount::AmountEncoder<'e>::current_chunk(&self) -> &[u8]
+pub fn bitcoin_units::amount::AmountEncoder<'e>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_units::amount::AmountEncoder<'e>::len(&self) -> usize
 pub fn bitcoin_units::amount::Denomination::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
 pub fn bitcoin_units::amount::Denomination::clone(&self) -> bitcoin_units::amount::Denomination
@@ -2273,8 +2301,10 @@ pub fn bitcoin_units::block::BlockHeight::sub(self, rhs: bitcoin_units::block::B
 pub fn bitcoin_units::block::BlockHeight::try_from(s: &str) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_units::block::BlockHeight::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_units::block::BlockHeight::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::block::BlockHeightDecoder::clone(&self) -> bitcoin_units::block::BlockHeightDecoder
 pub fn bitcoin_units::block::BlockHeightDecoder::default() -> Self
 pub fn bitcoin_units::block::BlockHeightDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
+pub fn bitcoin_units::block::BlockHeightDecoder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_units::block::BlockHeightDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bool, Self::Error>
 pub fn bitcoin_units::block::BlockHeightDecoder::read_limit(&self) -> usize
 pub fn bitcoin_units::block::BlockHeightDecoderError::clone(&self) -> bitcoin_units::block::BlockHeightDecoderError
@@ -2283,7 +2313,9 @@ pub fn bitcoin_units::block::BlockHeightDecoderError::fmt(&self, f: &mut core::f
 pub fn bitcoin_units::block::BlockHeightDecoderError::from(never: core::convert::Infallible) -> Self
 pub fn bitcoin_units::block::BlockHeightDecoderError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 pub fn bitcoin_units::block::BlockHeightEncoder<'e>::advance(&mut self) -> bool
+pub fn bitcoin_units::block::BlockHeightEncoder<'e>::clone(&self) -> bitcoin_units::block::BlockHeightEncoder<'e>
 pub fn bitcoin_units::block::BlockHeightEncoder<'e>::current_chunk(&self) -> &[u8]
+pub fn bitcoin_units::block::BlockHeightEncoder<'e>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_units::block::BlockHeightEncoder<'e>::len(&self) -> usize
 pub fn bitcoin_units::block::BlockHeightInterval::add(self, rhs: &bitcoin_units::block::BlockHeightInterval) -> Self::Output
 pub fn bitcoin_units::block::BlockHeightInterval::add(self, rhs: bitcoin_units::block::BlockHeightInterval) -> Self::Output
@@ -2437,12 +2469,16 @@ pub fn bitcoin_units::locktime::absolute::LockTime::to_consensus_u32(self) -> u3
 pub fn bitcoin_units::locktime::absolute::LockTime::try_from(s: &str) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_units::locktime::absolute::LockTime::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_units::locktime::absolute::LockTime::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::locktime::absolute::LockTimeDecoder::clone(&self) -> bitcoin_units::locktime::absolute::LockTimeDecoder
 pub fn bitcoin_units::locktime::absolute::LockTimeDecoder::default() -> Self
 pub fn bitcoin_units::locktime::absolute::LockTimeDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
+pub fn bitcoin_units::locktime::absolute::LockTimeDecoder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_units::locktime::absolute::LockTimeDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bool, Self::Error>
 pub fn bitcoin_units::locktime::absolute::LockTimeDecoder::read_limit(&self) -> usize
 pub fn bitcoin_units::locktime::absolute::LockTimeEncoder<'e>::advance(&mut self) -> bool
+pub fn bitcoin_units::locktime::absolute::LockTimeEncoder<'e>::clone(&self) -> bitcoin_units::locktime::absolute::LockTimeEncoder<'e>
 pub fn bitcoin_units::locktime::absolute::LockTimeEncoder<'e>::current_chunk(&self) -> &[u8]
+pub fn bitcoin_units::locktime::absolute::LockTimeEncoder<'e>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_units::locktime::absolute::LockTimeEncoder<'e>::len(&self) -> usize
 pub fn bitcoin_units::locktime::absolute::MedianTimePast::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
 pub fn bitcoin_units::locktime::absolute::MedianTimePast::clone(&self) -> bitcoin_units::locktime::absolute::MedianTimePast
@@ -2633,8 +2669,10 @@ pub fn bitcoin_units::pow::CompactTarget::to_hex(self) -> alloc::string::String
 pub fn bitcoin_units::pow::CompactTarget::try_from(s: &str) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_units::pow::CompactTarget::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_units::pow::CompactTarget::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::pow::CompactTargetDecoder::clone(&self) -> bitcoin_units::pow::CompactTargetDecoder
 pub fn bitcoin_units::pow::CompactTargetDecoder::default() -> Self
 pub fn bitcoin_units::pow::CompactTargetDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
+pub fn bitcoin_units::pow::CompactTargetDecoder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_units::pow::CompactTargetDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bool, Self::Error>
 pub fn bitcoin_units::pow::CompactTargetDecoder::read_limit(&self) -> usize
 pub fn bitcoin_units::pow::CompactTargetDecoderError::clone(&self) -> bitcoin_units::pow::CompactTargetDecoderError
@@ -2643,7 +2681,9 @@ pub fn bitcoin_units::pow::CompactTargetDecoderError::fmt(&self, f: &mut core::f
 pub fn bitcoin_units::pow::CompactTargetDecoderError::from(never: core::convert::Infallible) -> Self
 pub fn bitcoin_units::pow::CompactTargetDecoderError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 pub fn bitcoin_units::pow::CompactTargetEncoder<'e>::advance(&mut self) -> bool
+pub fn bitcoin_units::pow::CompactTargetEncoder<'e>::clone(&self) -> bitcoin_units::pow::CompactTargetEncoder<'e>
 pub fn bitcoin_units::pow::CompactTargetEncoder<'e>::current_chunk(&self) -> &[u8]
+pub fn bitcoin_units::pow::CompactTargetEncoder<'e>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_units::pow::CompactTargetEncoder<'e>::len(&self) -> usize
 pub fn bitcoin_units::result::MathOp::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
 pub fn bitcoin_units::result::MathOp::clone(&self) -> bitcoin_units::result::MathOp
@@ -2773,8 +2813,10 @@ pub fn bitcoin_units::sequence::Sequence::to_relative_lock_time(self) -> core::o
 pub fn bitcoin_units::sequence::Sequence::try_from(s: &str) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_units::sequence::Sequence::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error>
 pub fn bitcoin_units::sequence::Sequence::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error>
+pub fn bitcoin_units::sequence::SequenceDecoder::clone(&self) -> bitcoin_units::sequence::SequenceDecoder
 pub fn bitcoin_units::sequence::SequenceDecoder::default() -> Self
 pub fn bitcoin_units::sequence::SequenceDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
+pub fn bitcoin_units::sequence::SequenceDecoder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_units::sequence::SequenceDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bool, Self::Error>
 pub fn bitcoin_units::sequence::SequenceDecoder::read_limit(&self) -> usize
 pub fn bitcoin_units::sequence::SequenceDecoderError::clone(&self) -> bitcoin_units::sequence::SequenceDecoderError
@@ -2783,10 +2825,14 @@ pub fn bitcoin_units::sequence::SequenceDecoderError::fmt(&self, f: &mut core::f
 pub fn bitcoin_units::sequence::SequenceDecoderError::from(never: core::convert::Infallible) -> Self
 pub fn bitcoin_units::sequence::SequenceDecoderError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 pub fn bitcoin_units::sequence::SequenceEncoder<'e>::advance(&mut self) -> bool
+pub fn bitcoin_units::sequence::SequenceEncoder<'e>::clone(&self) -> bitcoin_units::sequence::SequenceEncoder<'e>
 pub fn bitcoin_units::sequence::SequenceEncoder<'e>::current_chunk(&self) -> &[u8]
+pub fn bitcoin_units::sequence::SequenceEncoder<'e>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_units::sequence::SequenceEncoder<'e>::len(&self) -> usize
+pub fn bitcoin_units::time::BlockTimeDecoder::clone(&self) -> bitcoin_units::time::BlockTimeDecoder
 pub fn bitcoin_units::time::BlockTimeDecoder::default() -> Self
 pub fn bitcoin_units::time::BlockTimeDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
+pub fn bitcoin_units::time::BlockTimeDecoder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_units::time::BlockTimeDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bool, Self::Error>
 pub fn bitcoin_units::time::BlockTimeDecoder::read_limit(&self) -> usize
 pub fn bitcoin_units::time::BlockTimeDecoderError::clone(&self) -> bitcoin_units::time::BlockTimeDecoderError
@@ -2795,7 +2841,9 @@ pub fn bitcoin_units::time::BlockTimeDecoderError::fmt(&self, f: &mut core::fmt:
 pub fn bitcoin_units::time::BlockTimeDecoderError::from(never: core::convert::Infallible) -> Self
 pub fn bitcoin_units::time::BlockTimeDecoderError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 pub fn bitcoin_units::time::BlockTimeEncoder<'e>::advance(&mut self) -> bool
+pub fn bitcoin_units::time::BlockTimeEncoder<'e>::clone(&self) -> bitcoin_units::time::BlockTimeEncoder<'e>
 pub fn bitcoin_units::time::BlockTimeEncoder<'e>::current_chunk(&self) -> &[u8]
+pub fn bitcoin_units::time::BlockTimeEncoder<'e>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn bitcoin_units::time::BlockTimeEncoder<'e>::len(&self) -> usize
 pub fn core::num::error::ParseIntError::from(value: bitcoin_units::parse_int::ParseIntError) -> Self
 pub fn i64::mul(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -825,7 +825,10 @@ impl CompressedPublicKey {
     /// # Errors
     ///
     /// See [`secp256k1::PublicKey::from_slice`].
-    #[deprecated(since = "TBD", note = "use `from_bytes` instead; if you only have a slice, use `<&[u8; 33]>::try_from` first")]
+    #[deprecated(
+        since = "TBD",
+        note = "use `from_bytes` instead; if you only have a slice, use `<&[u8; 33]>::try_from` first"
+    )]
     pub fn from_slice(data: &[u8]) -> Result<Self, secp256k1::Error> {
         let bytes_arr = data.try_into().map_err(|_| secp256k1::Error::InvalidPublicKey)?;
         Self::from_bytes(bytes_arr)

--- a/p2p/src/address.rs
+++ b/p2p/src/address.rs
@@ -15,7 +15,8 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV
 use arbitrary::{Arbitrary, Unstructured};
 use bitcoin::consensus::encode::{self, Decodable, Encodable, ReadExt, WriteExt};
 use encoding::{
-    ArrayDecoder, ArrayEncoder, ByteVecDecoder, BytesEncoder, CompactSizeEncoder, CompactSizeU64Decoder, Decoder2, Decoder4, Encoder2, Encoder4
+    ArrayDecoder, ArrayEncoder, ByteVecDecoder, BytesEncoder, CompactSizeEncoder,
+    CompactSizeU64Decoder, Decoder2, Decoder4, Encoder2, Encoder4,
 };
 use internals::array::ArrayExt;
 use internals::write_err;
@@ -858,18 +859,17 @@ impl encoding::Encodable for AddrV2Message {
     type Encoder<'e> = AddrV2MessageEncoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
-        AddrV2MessageEncoder::new(
-            Encoder4::new(
-                ArrayEncoder::without_length_prefix(self.time.to_le_bytes()),
-                CompactSizeEncoder::new_u64(self.services.to_u64()),
-                self.addr.encoder(),
-                ArrayEncoder::without_length_prefix(self.port.to_be_bytes())
-            )
-        )
+        AddrV2MessageEncoder::new(Encoder4::new(
+            ArrayEncoder::without_length_prefix(self.time.to_le_bytes()),
+            CompactSizeEncoder::new_u64(self.services.to_u64()),
+            self.addr.encoder(),
+            ArrayEncoder::without_length_prefix(self.port.to_be_bytes()),
+        ))
     }
 }
 
-type AddrV2MessageInnerDecoder = Decoder4<ArrayDecoder<4>, CompactSizeU64Decoder, AddrV2Decoder, ArrayDecoder<2>>;
+type AddrV2MessageInnerDecoder =
+    Decoder4<ArrayDecoder<4>, CompactSizeU64Decoder, AddrV2Decoder, ArrayDecoder<2>>;
 
 /// The decoder for an [`AddrV2Message`].
 pub struct AddrV2MessageDecoder(AddrV2MessageInnerDecoder);
@@ -904,8 +904,8 @@ impl encoding::Decodable for AddrV2Message {
             ArrayDecoder::new(),
             CompactSizeU64Decoder::new(),
             AddrV2::decoder(),
-            ArrayDecoder::new())
-        )
+            ArrayDecoder::new(),
+        ))
     }
 }
 

--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -536,7 +536,8 @@ impl encoding::Encodable for AddrV2Payload {
 
     fn encoder(&self) -> Self::Encoder<'_> {
         Encoder2::new(
-            CompactSizeEncoder::new(self.0.len()), SliceEncoder::without_length_prefix(&self.0)
+            CompactSizeEncoder::new(self.0.len()),
+            SliceEncoder::without_length_prefix(&self.0),
         )
     }
 }
@@ -557,7 +558,7 @@ impl encoding::Decoder for AddrV2PayloadDecoder {
 
     #[inline]
     fn end(self) -> Result<Self::Output, Self::Error> {
-       Ok(AddrV2Payload(self.0.end().map_err(AddrV2PayloadDecoderError)?))
+        Ok(AddrV2Payload(self.0.end().map_err(AddrV2PayloadDecoderError)?))
     }
 
     #[inline]
@@ -566,9 +567,7 @@ impl encoding::Decoder for AddrV2PayloadDecoder {
 
 impl encoding::Decodable for AddrV2Payload {
     type Decoder = AddrV2PayloadDecoder;
-    fn decoder() -> Self::Decoder {
-        AddrV2PayloadDecoder(VecDecoder::new())
-    }
+    fn decoder() -> Self::Decoder { AddrV2PayloadDecoder(VecDecoder::new()) }
 }
 
 /// An error decoding a [`AddrV2Payload`].

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -591,6 +591,7 @@ impl TryFrom<SignedAmount> for Amount {
 #[cfg(feature = "encoding")]
 encoding::encoder_newtype_exact! {
     /// The encoder for the [`Amount`] type.
+    #[derive(Debug, Clone)]
     pub struct AmountEncoder<'e>(encoding::ArrayEncoder<8>);
 }
 
@@ -606,6 +607,7 @@ impl encoding::Encodable for Amount {
 
 /// The decoder for the [`Amount`] type.
 #[cfg(feature = "encoding")]
+#[derive(Debug, Clone)]
 pub struct AmountDecoder(encoding::ArrayDecoder<8>);
 
 #[cfg(feature = "encoding")]

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -589,13 +589,6 @@ impl TryFrom<SignedAmount> for Amount {
 }
 
 #[cfg(feature = "encoding")]
-encoding::encoder_newtype_exact! {
-    /// The encoder for the [`Amount`] type.
-    #[derive(Debug, Clone)]
-    pub struct AmountEncoder<'e>(encoding::ArrayEncoder<8>);
-}
-
-#[cfg(feature = "encoding")]
 impl encoding::Encodable for Amount {
     type Encoder<'e> = AmountEncoder<'e>;
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -603,6 +596,19 @@ impl encoding::Encodable for Amount {
             self.to_sat().to_le_bytes(),
         ))
     }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decodable for Amount {
+    type Decoder = AmountDecoder;
+    fn decoder() -> Self::Decoder { AmountDecoder(encoding::ArrayDecoder::<8>::new()) }
+}
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// The encoder for the [`Amount`] type.
+    #[derive(Debug, Clone)]
+    pub struct AmountEncoder<'e>(encoding::ArrayEncoder<8>);
 }
 
 /// The decoder for the [`Amount`] type.
@@ -639,12 +645,6 @@ impl encoding::Decoder for AmountDecoder {
 
     #[inline]
     fn read_limit(&self) -> usize { self.0.read_limit() }
-}
-
-#[cfg(feature = "encoding")]
-impl encoding::Decodable for Amount {
-    type Decoder = AmountDecoder;
-    fn decoder() -> Self::Decoder { AmountDecoder(encoding::ArrayDecoder::<8>::new()) }
 }
 
 #[cfg(feature = "arbitrary")]

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -591,6 +591,8 @@ impl TryFrom<SignedAmount> for Amount {
 #[cfg(feature = "encoding")]
 impl encoding::Encodable for Amount {
     type Encoder<'e> = AmountEncoder<'e>;
+
+    #[inline]
     fn encoder(&self) -> Self::Encoder<'_> {
         AmountEncoder::new(encoding::ArrayEncoder::without_length_prefix(
             self.to_sat().to_le_bytes(),
@@ -601,6 +603,8 @@ impl encoding::Encodable for Amount {
 #[cfg(feature = "encoding")]
 impl encoding::Decodable for Amount {
     type Decoder = AmountDecoder;
+
+    #[inline]
     fn decoder() -> Self::Decoder { AmountDecoder(encoding::ArrayDecoder::<8>::new()) }
 }
 
@@ -619,11 +623,13 @@ pub struct AmountDecoder(encoding::ArrayDecoder<8>);
 #[cfg(feature = "encoding")]
 impl AmountDecoder {
     /// Constructs a new [`Amount`] decoder.
+    #[inline]
     pub const fn new() -> Self { Self(encoding::ArrayDecoder::new()) }
 }
 
 #[cfg(feature = "encoding")]
 impl Default for AmountDecoder {
+    #[inline]
     fn default() -> Self { Self::new() }
 }
 

--- a/units/src/block.rs
+++ b/units/src/block.rs
@@ -194,6 +194,7 @@ impl TryFrom<BlockHeight> for absolute::Height {
 #[cfg(feature = "encoding")]
 encoding::encoder_newtype_exact! {
     /// The encoder for the [`BlockHeight`] type.
+    #[derive(Debug, Clone)]
     pub struct BlockHeightEncoder<'e>(encoding::ArrayEncoder<4>);
 }
 
@@ -209,6 +210,7 @@ impl encoding::Encodable for BlockHeight {
 
 /// The decoder for the [`BlockHeight`] type.
 #[cfg(feature = "encoding")]
+#[derive(Debug, Clone)]
 pub struct BlockHeightDecoder(encoding::ArrayDecoder<4>);
 
 #[cfg(feature = "encoding")]

--- a/units/src/block.rs
+++ b/units/src/block.rs
@@ -192,13 +192,6 @@ impl TryFrom<BlockHeight> for absolute::Height {
 }
 
 #[cfg(feature = "encoding")]
-encoding::encoder_newtype_exact! {
-    /// The encoder for the [`BlockHeight`] type.
-    #[derive(Debug, Clone)]
-    pub struct BlockHeightEncoder<'e>(encoding::ArrayEncoder<4>);
-}
-
-#[cfg(feature = "encoding")]
 impl encoding::Encodable for BlockHeight {
     type Encoder<'e> = BlockHeightEncoder<'e>;
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -206,6 +199,19 @@ impl encoding::Encodable for BlockHeight {
             self.to_u32().to_le_bytes(),
         ))
     }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decodable for BlockHeight {
+    type Decoder = BlockHeightDecoder;
+    fn decoder() -> Self::Decoder { BlockHeightDecoder(encoding::ArrayDecoder::<4>::new()) }
+}
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// The encoder for the [`BlockHeight`] type.
+    #[derive(Debug, Clone)]
+    pub struct BlockHeightEncoder<'e>(encoding::ArrayEncoder<4>);
 }
 
 /// The decoder for the [`BlockHeight`] type.
@@ -242,12 +248,6 @@ impl encoding::Decoder for BlockHeightDecoder {
 
     #[inline]
     fn read_limit(&self) -> usize { self.0.read_limit() }
-}
-
-#[cfg(feature = "encoding")]
-impl encoding::Decodable for BlockHeight {
-    type Decoder = BlockHeightDecoder;
-    fn decoder() -> Self::Decoder { BlockHeightDecoder(encoding::ArrayDecoder::<4>::new()) }
 }
 
 /// An error consensus decoding an `BlockHeight`.

--- a/units/src/block.rs
+++ b/units/src/block.rs
@@ -194,6 +194,8 @@ impl TryFrom<BlockHeight> for absolute::Height {
 #[cfg(feature = "encoding")]
 impl encoding::Encodable for BlockHeight {
     type Encoder<'e> = BlockHeightEncoder<'e>;
+
+    #[inline]
     fn encoder(&self) -> Self::Encoder<'_> {
         BlockHeightEncoder::new(encoding::ArrayEncoder::without_length_prefix(
             self.to_u32().to_le_bytes(),
@@ -204,6 +206,8 @@ impl encoding::Encodable for BlockHeight {
 #[cfg(feature = "encoding")]
 impl encoding::Decodable for BlockHeight {
     type Decoder = BlockHeightDecoder;
+
+    #[inline]
     fn decoder() -> Self::Decoder { BlockHeightDecoder(encoding::ArrayDecoder::<4>::new()) }
 }
 
@@ -221,12 +225,14 @@ pub struct BlockHeightDecoder(encoding::ArrayDecoder<4>);
 
 #[cfg(feature = "encoding")]
 impl Default for BlockHeightDecoder {
+    #[inline]
     fn default() -> Self { Self::new() }
 }
 
 #[cfg(feature = "encoding")]
 impl BlockHeightDecoder {
     /// Constructs a new [`BlockHeight`] decoder.
+    #[inline]
     pub const fn new() -> Self { Self(encoding::ArrayDecoder::new()) }
 }
 

--- a/units/src/locktime/absolute/mod.rs
+++ b/units/src/locktime/absolute/mod.rs
@@ -400,6 +400,7 @@ parse_int::impl_parse_str_from_int_infallible!(LockTime, u32, from_consensus);
 #[cfg(feature = "encoding")]
 encoding::encoder_newtype_exact! {
     /// The encoder for the [`LockTime`] type.
+    #[derive(Debug, Clone)]
     pub struct LockTimeEncoder<'e>(encoding::ArrayEncoder<4>);
 }
 
@@ -415,6 +416,7 @@ impl encoding::Encodable for LockTime {
 
 /// The decoder for the [`LockTime`] type.
 #[cfg(feature = "encoding")]
+#[derive(Debug, Clone)]
 pub struct LockTimeDecoder(encoding::ArrayDecoder<4>);
 
 #[cfg(feature = "encoding")]

--- a/units/src/locktime/absolute/mod.rs
+++ b/units/src/locktime/absolute/mod.rs
@@ -400,6 +400,8 @@ parse_int::impl_parse_str_from_int_infallible!(LockTime, u32, from_consensus);
 #[cfg(feature = "encoding")]
 impl encoding::Encodable for LockTime {
     type Encoder<'e> = LockTimeEncoder<'e>;
+
+    #[inline]
     fn encoder(&self) -> Self::Encoder<'_> {
         LockTimeEncoder::new(encoding::ArrayEncoder::without_length_prefix(
             self.to_consensus_u32().to_le_bytes(),
@@ -410,6 +412,8 @@ impl encoding::Encodable for LockTime {
 #[cfg(feature = "encoding")]
 impl encoding::Decodable for LockTime {
     type Decoder = LockTimeDecoder;
+
+    #[inline]
     fn decoder() -> Self::Decoder { LockTimeDecoder(encoding::ArrayDecoder::<4>::new()) }
 }
 
@@ -428,11 +432,13 @@ pub struct LockTimeDecoder(encoding::ArrayDecoder<4>);
 #[cfg(feature = "encoding")]
 impl LockTimeDecoder {
     /// Constructs a new [`LockTime`] decoder.
+    #[inline]
     pub const fn new() -> Self { Self(encoding::ArrayDecoder::new()) }
 }
 
 #[cfg(feature = "encoding")]
 impl Default for LockTimeDecoder {
+    #[inline]
     fn default() -> Self { Self::new() }
 }
 

--- a/units/src/locktime/absolute/mod.rs
+++ b/units/src/locktime/absolute/mod.rs
@@ -398,13 +398,6 @@ impl LockTime {
 parse_int::impl_parse_str_from_int_infallible!(LockTime, u32, from_consensus);
 
 #[cfg(feature = "encoding")]
-encoding::encoder_newtype_exact! {
-    /// The encoder for the [`LockTime`] type.
-    #[derive(Debug, Clone)]
-    pub struct LockTimeEncoder<'e>(encoding::ArrayEncoder<4>);
-}
-
-#[cfg(feature = "encoding")]
 impl encoding::Encodable for LockTime {
     type Encoder<'e> = LockTimeEncoder<'e>;
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -412,6 +405,19 @@ impl encoding::Encodable for LockTime {
             self.to_consensus_u32().to_le_bytes(),
         ))
     }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decodable for LockTime {
+    type Decoder = LockTimeDecoder;
+    fn decoder() -> Self::Decoder { LockTimeDecoder(encoding::ArrayDecoder::<4>::new()) }
+}
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// The encoder for the [`LockTime`] type.
+    #[derive(Debug, Clone)]
+    pub struct LockTimeEncoder<'e>(encoding::ArrayEncoder<4>);
 }
 
 /// The decoder for the [`LockTime`] type.
@@ -448,12 +454,6 @@ impl encoding::Decoder for LockTimeDecoder {
 
     #[inline]
     fn read_limit(&self) -> usize { self.0.read_limit() }
-}
-
-#[cfg(feature = "encoding")]
-impl encoding::Decodable for LockTime {
-    type Decoder = LockTimeDecoder;
-    fn decoder() -> Self::Decoder { LockTimeDecoder(encoding::ArrayDecoder::<4>::new()) }
 }
 
 impl From<Height> for LockTime {

--- a/units/src/pow.rs
+++ b/units/src/pow.rs
@@ -87,13 +87,6 @@ impl fmt::Display for CompactTarget {
 parse_int::impl_parse_str_from_int_infallible!(CompactTarget, u32, from_consensus);
 
 #[cfg(feature = "encoding")]
-encoding::encoder_newtype_exact! {
-    /// The encoder for the [`CompactTarget`] type.
-    #[derive(Debug, Clone)]
-    pub struct CompactTargetEncoder<'e>(encoding::ArrayEncoder<4>);
-}
-
-#[cfg(feature = "encoding")]
 impl encoding::Encodable for CompactTarget {
     type Encoder<'e> = CompactTargetEncoder<'e>;
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -101,6 +94,19 @@ impl encoding::Encodable for CompactTarget {
             self.to_consensus().to_le_bytes(),
         ))
     }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decodable for CompactTarget {
+    type Decoder = CompactTargetDecoder;
+    fn decoder() -> Self::Decoder { CompactTargetDecoder(encoding::ArrayDecoder::<4>::new()) }
+}
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// The encoder for the [`CompactTarget`] type.
+    #[derive(Debug, Clone)]
+    pub struct CompactTargetEncoder<'e>(encoding::ArrayEncoder<4>);
 }
 
 /// The decoder for the [`CompactTarget`] type.
@@ -137,12 +143,6 @@ impl encoding::Decoder for CompactTargetDecoder {
 
     #[inline]
     fn read_limit(&self) -> usize { self.0.read_limit() }
-}
-
-#[cfg(feature = "encoding")]
-impl encoding::Decodable for CompactTarget {
-    type Decoder = CompactTargetDecoder;
-    fn decoder() -> Self::Decoder { CompactTargetDecoder(encoding::ArrayDecoder::<4>::new()) }
 }
 
 /// An error consensus decoding an `CompactTarget`.

--- a/units/src/pow.rs
+++ b/units/src/pow.rs
@@ -89,6 +89,7 @@ parse_int::impl_parse_str_from_int_infallible!(CompactTarget, u32, from_consensu
 #[cfg(feature = "encoding")]
 encoding::encoder_newtype_exact! {
     /// The encoder for the [`CompactTarget`] type.
+    #[derive(Debug, Clone)]
     pub struct CompactTargetEncoder<'e>(encoding::ArrayEncoder<4>);
 }
 
@@ -104,6 +105,7 @@ impl encoding::Encodable for CompactTarget {
 
 /// The decoder for the [`CompactTarget`] type.
 #[cfg(feature = "encoding")]
+#[derive(Debug, Clone)]
 pub struct CompactTargetDecoder(encoding::ArrayDecoder<4>);
 
 #[cfg(feature = "encoding")]

--- a/units/src/pow.rs
+++ b/units/src/pow.rs
@@ -89,6 +89,8 @@ parse_int::impl_parse_str_from_int_infallible!(CompactTarget, u32, from_consensu
 #[cfg(feature = "encoding")]
 impl encoding::Encodable for CompactTarget {
     type Encoder<'e> = CompactTargetEncoder<'e>;
+
+    #[inline]
     fn encoder(&self) -> Self::Encoder<'_> {
         CompactTargetEncoder::new(encoding::ArrayEncoder::without_length_prefix(
             self.to_consensus().to_le_bytes(),
@@ -99,6 +101,8 @@ impl encoding::Encodable for CompactTarget {
 #[cfg(feature = "encoding")]
 impl encoding::Decodable for CompactTarget {
     type Decoder = CompactTargetDecoder;
+
+    #[inline]
     fn decoder() -> Self::Decoder { CompactTargetDecoder(encoding::ArrayDecoder::<4>::new()) }
 }
 
@@ -117,11 +121,13 @@ pub struct CompactTargetDecoder(encoding::ArrayDecoder<4>);
 #[cfg(feature = "encoding")]
 impl CompactTargetDecoder {
     /// Constructs a new [`CompactTarget`] decoder.
+    #[inline]
     pub const fn new() -> Self { Self(encoding::ArrayDecoder::new()) }
 }
 
 #[cfg(feature = "encoding")]
 impl Default for CompactTargetDecoder {
+    #[inline]
     fn default() -> Self { Self::new() }
 }
 

--- a/units/src/sequence.rs
+++ b/units/src/sequence.rs
@@ -260,6 +260,8 @@ parse_int::impl_parse_str_from_int_infallible!(Sequence, u32, from_consensus);
 #[cfg(feature = "encoding")]
 impl encoding::Encodable for Sequence {
     type Encoder<'e> = SequenceEncoder<'e>;
+
+    #[inline]
     fn encoder(&self) -> Self::Encoder<'_> {
         SequenceEncoder::new(encoding::ArrayEncoder::without_length_prefix(
             self.to_consensus_u32().to_le_bytes(),
@@ -270,6 +272,8 @@ impl encoding::Encodable for Sequence {
 #[cfg(feature = "encoding")]
 impl encoding::Decodable for Sequence {
     type Decoder = SequenceDecoder;
+
+    #[inline]
     fn decoder() -> Self::Decoder { SequenceDecoder(encoding::ArrayDecoder::<4>::new()) }
 }
 
@@ -287,12 +291,14 @@ pub struct SequenceDecoder(encoding::ArrayDecoder<4>);
 
 #[cfg(feature = "encoding")]
 impl Default for SequenceDecoder {
+    #[inline]
     fn default() -> Self { Self::new() }
 }
 
 #[cfg(feature = "encoding")]
 impl SequenceDecoder {
     /// Constructs a new [`Sequence`] decoder.
+    #[inline]
     pub const fn new() -> Self { Self(encoding::ArrayDecoder::new()) }
 }
 

--- a/units/src/sequence.rs
+++ b/units/src/sequence.rs
@@ -258,13 +258,6 @@ impl fmt::Debug for Sequence {
 parse_int::impl_parse_str_from_int_infallible!(Sequence, u32, from_consensus);
 
 #[cfg(feature = "encoding")]
-encoding::encoder_newtype_exact! {
-    /// The encoder for the [`Sequence`] type.
-    #[derive(Debug, Clone)]
-    pub struct SequenceEncoder<'e>(encoding::ArrayEncoder<4>);
-}
-
-#[cfg(feature = "encoding")]
 impl encoding::Encodable for Sequence {
     type Encoder<'e> = SequenceEncoder<'e>;
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -272,6 +265,19 @@ impl encoding::Encodable for Sequence {
             self.to_consensus_u32().to_le_bytes(),
         ))
     }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decodable for Sequence {
+    type Decoder = SequenceDecoder;
+    fn decoder() -> Self::Decoder { SequenceDecoder(encoding::ArrayDecoder::<4>::new()) }
+}
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// The encoder for the [`Sequence`] type.
+    #[derive(Debug, Clone)]
+    pub struct SequenceEncoder<'e>(encoding::ArrayEncoder<4>);
 }
 
 /// The decoder for the [`Sequence`] type.
@@ -308,12 +314,6 @@ impl encoding::Decoder for SequenceDecoder {
 
     #[inline]
     fn read_limit(&self) -> usize { self.0.read_limit() }
-}
-
-#[cfg(feature = "encoding")]
-impl encoding::Decodable for Sequence {
-    type Decoder = SequenceDecoder;
-    fn decoder() -> Self::Decoder { SequenceDecoder(encoding::ArrayDecoder::<4>::new()) }
 }
 
 /// An error consensus decoding an `Sequence`.

--- a/units/src/sequence.rs
+++ b/units/src/sequence.rs
@@ -260,6 +260,7 @@ parse_int::impl_parse_str_from_int_infallible!(Sequence, u32, from_consensus);
 #[cfg(feature = "encoding")]
 encoding::encoder_newtype_exact! {
     /// The encoder for the [`Sequence`] type.
+    #[derive(Debug, Clone)]
     pub struct SequenceEncoder<'e>(encoding::ArrayEncoder<4>);
 }
 
@@ -275,6 +276,7 @@ impl encoding::Encodable for Sequence {
 
 /// The decoder for the [`Sequence`] type.
 #[cfg(feature = "encoding")]
+#[derive(Debug, Clone)]
 pub struct SequenceDecoder(encoding::ArrayDecoder<4>);
 
 #[cfg(feature = "encoding")]

--- a/units/src/time.rs
+++ b/units/src/time.rs
@@ -116,13 +116,6 @@ impl<'de> Deserialize<'de> for BlockTime {
 }
 
 #[cfg(feature = "encoding")]
-encoding::encoder_newtype_exact! {
-    /// The encoder for the [`BlockTime`] type.
-    #[derive(Debug, Clone)]
-    pub struct BlockTimeEncoder<'e>(encoding::ArrayEncoder<4>);
-}
-
-#[cfg(feature = "encoding")]
 impl encoding::Encodable for BlockTime {
     type Encoder<'e> = BlockTimeEncoder<'e>;
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -130,6 +123,19 @@ impl encoding::Encodable for BlockTime {
             self.to_u32().to_le_bytes(),
         ))
     }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decodable for BlockTime {
+    type Decoder = BlockTimeDecoder;
+    fn decoder() -> Self::Decoder { BlockTimeDecoder(encoding::ArrayDecoder::<4>::new()) }
+}
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// The encoder for the [`BlockTime`] type.
+    #[derive(Debug, Clone)]
+    pub struct BlockTimeEncoder<'e>(encoding::ArrayEncoder<4>);
 }
 
 /// The decoder for the [`BlockTime`] type.
@@ -166,12 +172,6 @@ impl encoding::Decoder for BlockTimeDecoder {
 
     #[inline]
     fn read_limit(&self) -> usize { self.0.read_limit() }
-}
-
-#[cfg(feature = "encoding")]
-impl encoding::Decodable for BlockTime {
-    type Decoder = BlockTimeDecoder;
-    fn decoder() -> Self::Decoder { BlockTimeDecoder(encoding::ArrayDecoder::<4>::new()) }
 }
 
 /// An error consensus decoding an `BlockTime`.

--- a/units/src/time.rs
+++ b/units/src/time.rs
@@ -118,6 +118,7 @@ impl<'de> Deserialize<'de> for BlockTime {
 #[cfg(feature = "encoding")]
 encoding::encoder_newtype_exact! {
     /// The encoder for the [`BlockTime`] type.
+    #[derive(Debug, Clone)]
     pub struct BlockTimeEncoder<'e>(encoding::ArrayEncoder<4>);
 }
 
@@ -133,6 +134,7 @@ impl encoding::Encodable for BlockTime {
 
 /// The decoder for the [`BlockTime`] type.
 #[cfg(feature = "encoding")]
+#[derive(Debug, Clone)]
 pub struct BlockTimeDecoder(encoding::ArrayDecoder<4>);
 
 #[cfg(feature = "encoding")]

--- a/units/src/time.rs
+++ b/units/src/time.rs
@@ -118,6 +118,8 @@ impl<'de> Deserialize<'de> for BlockTime {
 #[cfg(feature = "encoding")]
 impl encoding::Encodable for BlockTime {
     type Encoder<'e> = BlockTimeEncoder<'e>;
+
+    #[inline]
     fn encoder(&self) -> Self::Encoder<'_> {
         BlockTimeEncoder::new(encoding::ArrayEncoder::without_length_prefix(
             self.to_u32().to_le_bytes(),
@@ -128,6 +130,8 @@ impl encoding::Encodable for BlockTime {
 #[cfg(feature = "encoding")]
 impl encoding::Decodable for BlockTime {
     type Decoder = BlockTimeDecoder;
+
+    #[inline]
     fn decoder() -> Self::Decoder { BlockTimeDecoder(encoding::ArrayDecoder::<4>::new()) }
 }
 
@@ -145,12 +149,14 @@ pub struct BlockTimeDecoder(encoding::ArrayDecoder<4>);
 
 #[cfg(feature = "encoding")]
 impl Default for BlockTimeDecoder {
+    #[inline]
     fn default() -> Self { Self::new() }
 }
 
 #[cfg(feature = "encoding")]
 impl BlockTimeDecoder {
     /// Constructs a new [`BlockTime`] decoder.
+    #[inline]
     pub const fn new() -> Self { Self(encoding::ArrayDecoder::new()) }
 }
 


### PR DESCRIPTION
Draft because on top of #5901 

Scrub the encoder code in `untis` as per policy introduced in #5583. Internal change only and no logic change.