### PR TITLE
hashes: Add links in rustdocs

### DIFF
--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -32,7 +32,7 @@
 //! ```
 //!
 //!
-//! Hashing content using [`std::io::Write`] on a `HashEngine`:
+//! Hashing content using [`std::io::Write`] on a [`HashEngine`]:
 //!
 //! ```
 //! # #[cfg(feature = "std")] {
@@ -178,7 +178,7 @@ pub trait HashEngine: Clone {
     /// The `Hash` type returned when finalizing this engine.
     type Hash: Hash;
 
-    /// The byte array that is used internally in `finalize`.
+    /// The byte array that is used internally in [`HashEngine::finalize`].
     type Bytes: Copy + IsByteArray;
 
     /// Length of the hash, in bytes.

--- a/hashes/src/macros.rs
+++ b/hashes/src/macros.rs
@@ -9,7 +9,7 @@
 
 /// Macro used to define a tag.
 ///
-/// Defines new struct and implements `Tag` for it.
+/// Defines new struct and implements [`Tag`](crate::sha256t::Tag) for it.
 ///
 /// The syntax is:
 ///

--- a/hashes/src/sha256/mod.rs
+++ b/hashes/src/sha256/mod.rs
@@ -261,7 +261,7 @@ impl convert::AsRef<[u8]> for Midstate {
     fn as_ref(&self) -> &[u8] { &self.bytes }
 }
 
-/// `Midstate` invariant violated (not a multiple of 64).
+/// [`Midstate`] invariant violated (not a multiple of 64).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MidstateError {
     /// The invalid number of bytes hashed.


### PR DESCRIPTION
[C-LINK](https://rust-lang.github.io/api-guidelines/documentation.html#c-link) states that "Prose contains hyperlinks to relevant things".
 
Add missing links to the rustdocs in hashes.

Docs change only.

Related issue #3633