### PR TITLE
p2p: optional fields in version message 

### DIFF
--- a/p2p/src/message_network.rs
+++ b/p2p/src/message_network.rs
@@ -969,6 +969,63 @@ mod tests {
         assert_eq!(encoding::encode_to_vec(&real_decode), from_sat);
     }
 
+    // Minimum-length (46 bytes) version payload: version + services + timestamp + addr_recv.
+    const MINIMAL_VERSION_PAYLOAD: [u8; 46] = hex!("721101000100000000000000e6e0845300000000010000000000000000000000000000000000ffff000000000000");
+
+    #[test]
+    #[should_panic(expected = "VersionMessageDecoderError")]
+    fn version_message_minimum_length_decode_from_slice() {
+        let msg: VersionMessage = encoding::decode_from_slice(&MINIMAL_VERSION_PAYLOAD).unwrap();
+        assert_eq!(msg.version.0, 70002);
+        assert_eq!(msg.services, ServiceFlags::NETWORK);
+        assert_eq!(msg.timestamp, 1_401_217_254);
+        // address decodes should be covered by Address tests
+
+        // fields from addr_from onwards are filled with Bitcoin Core defaults
+        assert_eq!(msg.sender, Address::useless());
+        assert_eq!(msg.nonce, 1);
+        assert_eq!(msg.user_agent, UserAgent::from_nonstandard(&""));
+        assert_eq!(msg.start_height, -1);
+        assert!(msg.relay);
+    }
+
+    #[test]
+    #[should_panic(expected = "MissingData")]
+    fn version_message_minimum_length_deserialize() {
+        let msg: VersionMessage = deserialize(&MINIMAL_VERSION_PAYLOAD).unwrap();
+        assert_eq!(msg.version.0, 70002);
+        assert_eq!(msg.services, ServiceFlags::NETWORK);
+        assert_eq!(msg.timestamp, 1_401_217_254);
+        // address decodes should be covered by Address tests
+
+        // fields from addr_from onwards are filled with Bitcoin Core defaults
+        assert_eq!(msg.sender, Address::useless());
+        assert_eq!(msg.nonce, 1);
+        assert_eq!(msg.user_agent, UserAgent::from_nonstandard(&""));
+        assert_eq!(msg.start_height, -1);
+        assert!(msg.relay);
+    }
+
+    #[test]
+    #[should_panic(expected = "V1NetworkMessageDecoderError(Payload)")]
+    fn version_message_minimum_length_via_v1_network_message() {
+        use crate::message::{NetworkMessage, V1NetworkMessage};
+
+        let frame: [u8; 70] = hex!("f9beb4d976657273696f6e00000000002e000000468a86c2721101000100000000000000e6e0845300000000010000000000000000000000000000000000ffff000000000000");
+        let msg: V1NetworkMessage = encoding::decode_from_slice(&frame).unwrap();
+
+        match msg.payload() {
+            NetworkMessage::Version(v) => {
+                assert_eq!(v.sender, Address::useless());
+                assert_eq!(v.nonce, 1);
+                assert_eq!(v.user_agent, UserAgent::from_nonstandard(&""));
+                assert_eq!(v.start_height, -1);
+                assert!(v.relay);
+            }
+            other => panic!("expected Version, got {:?}", other),
+        }
+    }
+
     #[test]
     fn reject_message_test() {
         let reject_tx_conflict = hex!("027478121474786e2d6d656d706f6f6c2d636f6e666c69637405df54d3860b3c41806a3546ab48279300affacf4b88591b229141dcf2f47004");

--- a/p2p/src/message_network.rs
+++ b/p2p/src/message_network.rs
@@ -253,18 +253,73 @@ pub struct VersionMessageDecoder {
     optional_buf: Vec<u8>,
 }
 
-impl_consensus_encoding!(
-    VersionMessage,
-    version,
-    services,
-    timestamp,
-    receiver,
-    sender,
-    nonce,
-    user_agent,
-    start_height,
-    relay
-);
+impl bitcoin::consensus::Encodable for VersionMessage {
+    #[inline]
+    fn consensus_encode<W: io::Write + ?Sized>(
+        &self,
+        w: &mut W,
+    ) -> core::result::Result<usize, io::Error> {
+        let mut len = 0;
+        len += self.version.consensus_encode(w)?;
+        len += self.services.consensus_encode(w)?;
+        len += self.timestamp.consensus_encode(w)?;
+        len += self.receiver.consensus_encode(w)?;
+        len += self.sender.consensus_encode(w)?;
+        len += self.nonce.consensus_encode(w)?;
+        len += self.user_agent.consensus_encode(w)?;
+        len += self.start_height.consensus_encode(w)?;
+        len += self.relay.consensus_encode(w)?;
+        Ok(len)
+    }
+}
+
+impl bitcoin::consensus::Decodable for VersionMessage {
+    #[inline]
+    fn consensus_decode_from_finite_reader<R: io::BufRead + ?Sized>(
+        r: &mut R,
+    ) -> core::result::Result<Self, bitcoin::consensus::encode::Error> {
+        let version = Decodable::consensus_decode_from_finite_reader(r)?;
+        let services = Decodable::consensus_decode_from_finite_reader(r)?;
+        let timestamp = Decodable::consensus_decode_from_finite_reader(r)?;
+        let receiver = Decodable::consensus_decode_from_finite_reader(r)?;
+
+        // Optional fields: initialize with Bitcoin Core defaults, overwrite if data available.
+        // Mirrors Bitcoin Core (net_processing.cpp).
+        let mut sender = Address::useless();
+        let mut nonce = 1u64;
+        let mut user_agent = UserAgent::from_nonstandard(&"");
+        let mut start_height = -1i32;
+        let mut relay = true;
+
+        if !r.fill_buf().map_or(true, <[u8]>::is_empty) {
+            sender = Decodable::consensus_decode_from_finite_reader(r)?;
+        }
+        if !r.fill_buf().map_or(true, <[u8]>::is_empty) {
+            nonce = Decodable::consensus_decode_from_finite_reader(r)?;
+        }
+        if !r.fill_buf().map_or(true, <[u8]>::is_empty) {
+            user_agent = Decodable::consensus_decode_from_finite_reader(r)?;
+        }
+        if !r.fill_buf().map_or(true, <[u8]>::is_empty) {
+            start_height = Decodable::consensus_decode_from_finite_reader(r)?;
+        }
+        if !r.fill_buf().map_or(true, <[u8]>::is_empty) {
+            relay = Decodable::consensus_decode_from_finite_reader(r)?;
+        }
+
+        Ok(Self {
+            version,
+            services,
+            timestamp,
+            receiver,
+            sender,
+            nonce,
+            user_agent,
+            start_height,
+            relay,
+        })
+    }
+}
 
 /// A bitcoin user agent defined by BIP-0014. The user agent is sent in the version message when a
 /// connection between two peers is established. It is intended to advertise client software in a
@@ -1026,7 +1081,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "MissingData")]
     fn version_message_minimum_length_deserialize() {
         let msg: VersionMessage = deserialize(&MINIMAL_VERSION_PAYLOAD).unwrap();
         assert_eq!(msg.version.0, 70002);
@@ -1043,7 +1097,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "V1NetworkMessageDecoderError(Payload)")]
     fn version_message_minimum_length_via_v1_network_message() {
         use crate::message::{NetworkMessage, V1NetworkMessage};
 

--- a/p2p/src/message_network.rs
+++ b/p2p/src/message_network.rs
@@ -145,21 +145,16 @@ impl encoding::Decodable for VersionMessage {
 
     #[inline]
     fn decoder() -> Self::Decoder {
-        VersionMessageDecoder(encoding::Decoder2::new(
-            encoding::Decoder3::new(
+        VersionMessageDecoder {
+            required: Decoder4::new(
                 crate::ProtocolVersion::decoder(),
                 crate::ServiceFlags::decoder(),
-                encoding::ArrayDecoder::<8>::new(),
-            ),
-            encoding::Decoder6::new(
+                ArrayDecoder::<8>::new(),
                 crate::address::Address::decoder(),
-                crate::address::Address::decoder(),
-                encoding::ArrayDecoder::<8>::new(),
-                UserAgent::decoder(),
-                encoding::ArrayDecoder::<4>::new(),
-                encoding::ArrayDecoder::<1>::new(),
             ),
-        ))
+            required_done: false,
+            optional_buf: Vec::new(),
+        }
     }
 }
 
@@ -167,17 +162,56 @@ impl encoding::Decoder for VersionMessageDecoder {
     type Output = VersionMessage;
     type Error = VersionMessageDecoderError;
 
-    #[inline]
     fn push_bytes(&mut self, bytes: &mut &[u8]) -> Result<bool, Self::Error> {
-        self.0.push_bytes(bytes).map_err(VersionMessageDecoderError)
+        if !self.required_done {
+            if self.required.push_bytes(bytes).map_err(VersionMessageDecoderError)? {
+                return Ok(true);
+            }
+            self.required_done = true;
+        }
+        self.optional_buf.extend_from_slice(core::mem::take(bytes));
+        Ok(false)
     }
 
-    #[inline]
     fn end(self) -> Result<Self::Output, Self::Error> {
-        let (
-            (version, services, timestamp),
-            (receiver, sender, nonce, user_agent, start_height, relay),
-        ) = self.0.end().map_err(VersionMessageDecoderError)?;
+        let (version, services, timestamp, receiver) =
+            self.required.end().map_err(VersionMessageDecoderError)?;
+
+        let mut remaining = self.optional_buf.as_slice();
+
+        // Optional fields: initialize with Bitcoin Core defaults, overwrite if data available.
+        // Mirrors Bitcoin Core (net_processing.cpp).
+        let mut sender = Address::useless();
+        let mut nonce = 1u64;
+        let mut user_agent = UserAgent::from_nonstandard(&"");
+        let mut start_height = -1i32;
+        let mut relay = true;
+
+        // addr_from + nonce are read together in Core.
+        if !remaining.is_empty() {
+            if let Ok(addr) = encoding::decode_from_slice_unbounded::<Address>(&mut remaining) {
+                sender = addr;
+            }
+            if remaining.len() >= 8 {
+                nonce = u64::from_le_bytes(remaining[..8].try_into().unwrap());
+                remaining = &remaining[8..];
+            }
+        }
+
+        if !remaining.is_empty() {
+            if let Ok(ua) = encoding::decode_from_slice_unbounded::<UserAgent>(&mut remaining) {
+                user_agent = ua;
+            }
+        }
+
+        if !remaining.is_empty() && remaining.len() >= 4 {
+            start_height = i32::from_le_bytes(remaining[..4].try_into().unwrap());
+            remaining = &remaining[4..];
+        }
+
+        if !remaining.is_empty() {
+            relay = remaining[0] != 0;
+        }
 
         Ok(VersionMessage {
             version,
@@ -185,36 +219,39 @@ impl encoding::Decoder for VersionMessageDecoder {
             timestamp: i64::from_le_bytes(timestamp),
             receiver,
             sender,
-            nonce: u64::from_le_bytes(nonce),
+            nonce,
             user_agent,
-            start_height: i32::from_le_bytes(start_height),
-            relay: relay[0] != 0,
+            start_height,
+            relay,
         })
     }
 
-    #[inline]
-    fn read_limit(&self) -> usize { self.0.read_limit() }
+    fn read_limit(&self) -> usize {
+        // sender(26) + nonce(8) + user_agent(1) + start_height(4) + relay(1)
+        const MIN_OPTIONAL_SIZE: usize = 40;
+
+        if self.required_done {
+            MIN_OPTIONAL_SIZE.saturating_sub(self.optional_buf.len())
+        } else {
+            self.required.read_limit() + MIN_OPTIONAL_SIZE
+        }
+    }
 }
 
-type VersionMessageInnerDecoder = encoding::Decoder2<
-    encoding::Decoder3<
-        crate::ProtocolVersionDecoder,
-        crate::ServiceFlagsDecoder,
-        encoding::ArrayDecoder<8>,
-    >,
-    encoding::Decoder6<
-        AddressDecoder,
-        AddressDecoder,
-        encoding::ArrayDecoder<8>,
-        UserAgentDecoder,
-        encoding::ArrayDecoder<4>,
-        encoding::ArrayDecoder<1>,
-    >,
+type RequiredFieldsDecoder = Decoder4<
+    crate::ProtocolVersionDecoder,
+    crate::ServiceFlagsDecoder,
+    ArrayDecoder<8>,
+    AddressDecoder,
 >;
 
 /// The Decoder for [`VersionMessage`].
 #[derive(Debug, Clone)]
-pub struct VersionMessageDecoder(VersionMessageInnerDecoder);
+pub struct VersionMessageDecoder {
+    required: RequiredFieldsDecoder,
+    required_done: bool,
+    optional_buf: Vec<u8>,
+}
 
 impl_consensus_encoding!(
     VersionMessage,
@@ -709,7 +746,7 @@ pub mod error {
     /// [`VersionMessage`]: super::VersionMessage
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct VersionMessageDecoderError(
-        pub(super) <super::VersionMessageInnerDecoder as encoding::Decoder>::Error,
+        pub(super) <super::RequiredFieldsDecoder as encoding::Decoder>::Error,
     );
 
     impl From<Infallible> for VersionMessageDecoderError {
@@ -973,7 +1010,6 @@ mod tests {
     const MINIMAL_VERSION_PAYLOAD: [u8; 46] = hex!("721101000100000000000000e6e0845300000000010000000000000000000000000000000000ffff000000000000");
 
     #[test]
-    #[should_panic(expected = "VersionMessageDecoderError")]
     fn version_message_minimum_length_decode_from_slice() {
         let msg: VersionMessage = encoding::decode_from_slice(&MINIMAL_VERSION_PAYLOAD).unwrap();
         assert_eq!(msg.version.0, 70002);


### PR DESCRIPTION
Fixes #5730

Attempting to decode a 46-byte `version` payload (the minimum Bitcoin Core considers valid) into a `VersionMessage` currently fails, because the decoders expect all fields to be present. Per Core, fields after `addr_recv` are optional and should be filled with defaults: `nonce=1`, `start_height=-1`, `relay=true`, `addr_from=zeros`, `user_agent=""`.

Decoder fix only - both of them (legacy and new). Field types on `VersionMessage` stay as plain values
(not `Option<T>`), per discussion in #5730.

`impl_consensus_encoding!` generates both `Encodable` and `Decodable` - replaced with hand-written impls to customize only the decoder.

Verified that Bitcoin Core accepts the 46-byte payload over TCP (no disconnect, got version and verack).