### PR TITLE
Release tracking PR: `consensus_encoding v0.2.0`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -80,7 +80,7 @@ version = "0.0.0"
 
 [[package]]
 name = "bitcoin-consensus-encoding"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bitcoin-internals",
  "hex-conservative 0.3.2",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -79,7 +79,7 @@ version = "0.0.0"
 
 [[package]]
 name = "bitcoin-consensus-encoding"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bitcoin-internals",
  "hex-conservative 0.3.2",

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -29,7 +29,7 @@ arbitrary = ["dep:arbitrary", "units/arbitrary", "primitives/arbitrary", "hashes
 base58 = { package = "base58ck", path = "../base58", version = "0.4.0", default-features = false, features = ["alloc"] }
 bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false, features = ["alloc", "hex"] }
-encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.1.0", default-features = false, features = ["alloc"] }
+encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.2.0", default-features = false, features = ["alloc"] }
 hex-stable = { package = "hex-conservative", version = "1.0.0", default-features = false, features = ["alloc"] }
 hex-unstable = { package = "hex-conservative", version = "0.3.2", default-features = false, features = ["alloc"] }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0", features = ["alloc", "hex"] }

--- a/consensus_encoding/CHANGELOG.md
+++ b/consensus_encoding/CHANGELOG.md
@@ -1,3 +1,18 @@
+# 0.2.0 - 2026-04-08
+
+This release is breaking and causes our whole stack to have to be re-released ...
+
+- Match core's range check decoding compact sizes [#5897](https://github.com/rust-bitcoin/rust-bitcoin/pull/5897)
+- Add `u64` support to compact size [#5784](https://github.com/rust-bitcoin/rust-bitcoin/pull/5784)
+- Add common trait implementations [#5698](https://github.com/rust-bitcoin/rust-bitcoin/pull/5698)
+- Introduce `decode_from_slice_unbounded` [#5664](https://github.com/rust-bitcoin/rust-bitcoin/pull/5664)
+- Improve macro defined constructor [#5759](https://github.com/rust-bitcoin/rust-bitcoin/pull/5759)
+- Fill out the documentation [#5720](https://github.com/rust-bitcoin/rust-bitcoin/pull/5720)
+- Expose vis fragment on exposed macros [#5719](https://github.com/rust-bitcoin/rust-bitcoin/pull/5719)
+- Remove redundant trait bounds [#5716](https://github.com/rust-bitcoin/rust-bitcoin/pull/5716)
+- Add `track_caller` to panic-able sites [#5713](https://github.com/rust-bitcoin/rust-bitcoin/pull/5713)
+- Add macros to define `EncoderN` and `DecoderNError` [#5635](https://github.com/rust-bitcoin/rust-bitcoin/pull/5635)
+
 # 0.1.0 - 2026-02-17
 
 It was found that the `1.0.0-rc.x` releases were troublesome because

--- a/consensus_encoding/Cargo.toml
+++ b/consensus_encoding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-consensus-encoding"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>", "Nick Johnson <nick@yonson.dev>", "Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 homepage = "https://rust-bitcoin.org/"

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -25,7 +25,7 @@ small-hash = []
 
 [dependencies]
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
-encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.1.0", default-features = false }
+encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.2.0", default-features = false }
 
 arbitrary = { version = "1.4.1", optional = true}
 serde = { version = "1.0.195", default-features = false, optional = true }

--- a/io/Cargo.toml
+++ b/io/Cargo.toml
@@ -21,7 +21,7 @@ alloc = ["encoding/alloc", "hashes?/alloc", "internals/alloc"]
 
 [dependencies]
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
-encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.1.0", default-features = false }
+encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.2.0", default-features = false }
 
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false, optional = true }
 

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -21,7 +21,7 @@ serde = ["dep:serde", "hashes/serde"]
 
 [dependencies]
 bitcoin = { path = "../bitcoin/", default-features = false }
-encoding = { package = "bitcoin-consensus-encoding", version = "0.1.0", path = "../consensus_encoding", default-features = false }
+encoding = { package = "bitcoin-consensus-encoding", version = "0.2.0", path = "../consensus_encoding", default-features = false }
 hashes = { package = "bitcoin_hashes", version = "0.20.0", path = "../hashes", default-features = false }
 network = { package = "bitcoin-network-kind", path = "../network", version = "0.1.0", default-features = false }
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.102.0", default-features = false }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -22,7 +22,7 @@ arbitrary = ["dep:arbitrary", "units/arbitrary"]
 hex = ["dep:hex-stable", "dep:hex-unstable", "hashes/hex", "internals/hex"]
 
 [dependencies]
-encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.1.0", default-features = false }
+encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.2.0", default-features = false }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
 units = { package = "bitcoin-units", path = "../units", version = "0.3.0", default-features = false, features = [ "encoding" ] }

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -21,7 +21,7 @@ alloc = ["internals/alloc", "serde?/alloc", "encoding?/alloc"]
 [dependencies]
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
 
-encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.1.0", default-features = false, optional = true }
+encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.2.0", default-features = false, optional = true }
 serde = { version = "1.0.195", default-features = false, features = ["derive"], optional = true }
 arbitrary = { version = "1.4.1", optional = true }
 


### PR DESCRIPTION
This release is a release candidate for `consensus_encoding v1.0.0`. And hopefully it is the last one. `v1.0.0` release imminent ...

In preparation for release add a changelog entry, bump the version, and update the lock files.