### PR TITLE
Update stale semver check PR comment

### DIFF
--- a/.github/workflows/semver-checks-pr-label.yml
+++ b/.github/workflows/semver-checks-pr-label.yml
@@ -76,7 +76,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issue_number,
-              body: ':rotating_light: API BREAKING CHANGE DETECTED\n\nTo see the changes click details on "Check semver breaks / PR Semver - stable toolchain" job then expand "Run semver checker script" and scroll to the end of the section.'
+              body: ':rotating_light: API BREAKING CHANGE DETECTED\n\nTo see the changes click details on "Continuous integration / Check (api)" job then expand "Run api" and scroll to the end of the section.'
             });
 
             // add the label to the PR


### PR DESCRIPTION
The PR comment added by the semver check workflow when an API break is detected is stale.

Update the comment with the new CI check name.