### PR TITLE
Release tracking PR: `bitcoin-units 0.4.0`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -174,7 +174,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-units"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -89,7 +89,7 @@ dependencies = [
  "bitcoin-network-kind",
  "bitcoin-primitives",
  "bitcoin-taproot-primitives",
- "bitcoin-units 0.3.0",
+ "bitcoin-units 0.4.0",
  "bitcoin_hashes 0.21.0",
  "bitcoinconsensus",
  "hex-conservative 1.1.0",
@@ -213,7 +213,7 @@ dependencies = [
  "bitcoin-internals 0.5.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
- "bitcoin-units 0.3.0",
+ "bitcoin-units 0.4.0",
  "bitcoin_hashes 0.21.0",
  "hex-conservative 1.1.0",
  "serde",
@@ -227,7 +227,7 @@ dependencies = [
  "bincode",
  "bitcoin-consensus-encoding",
  "bitcoin-internals 0.5.0",
- "bitcoin-units 0.3.0",
+ "bitcoin-units 0.4.0",
  "bitcoin_hashes 0.21.0",
  "hex-conservative 1.1.0",
  "serde",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-units"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -88,7 +88,7 @@ dependencies = [
  "bitcoin-network-kind",
  "bitcoin-primitives",
  "bitcoin-taproot-primitives",
- "bitcoin-units 0.3.0",
+ "bitcoin-units 0.4.0",
  "bitcoin_hashes 0.21.0",
  "bitcoinconsensus",
  "hex-conservative 1.1.0",
@@ -212,7 +212,7 @@ dependencies = [
  "bitcoin-internals 0.5.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
- "bitcoin-units 0.3.0",
+ "bitcoin-units 0.4.0",
  "bitcoin_hashes 0.21.0",
  "hex-conservative 1.1.0",
  "serde",
@@ -226,7 +226,7 @@ dependencies = [
  "bincode",
  "bitcoin-consensus-encoding",
  "bitcoin-internals 0.5.0",
- "bitcoin-units 0.3.0",
+ "bitcoin-units 0.4.0",
  "bitcoin_hashes 0.21.0",
  "hex-conservative 1.1.0",
  "serde",
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-units"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-units"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -37,7 +37,8 @@ io = { package = "bitcoin-io", path = "../io", version = "0.5.0", default-featur
 network = { package = "bitcoin-network-kind", path = "../network", version = "0.1.0", default-features = false, features = ["alloc"]}
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.102.0", default-features = false, features = ["alloc", "hex"] }
 secp256k1 = { version = "0.32.0-beta.2", default-features = false, features = ["alloc"] }
-units = { package = "bitcoin-units", path = "../units", version = "0.3.0", default-features = false, features = ["alloc"] }
+
+units = { package = "bitcoin-units", path = "../units", version = "0.4.0", default-features = false, features = ["alloc"] }
 
 arbitrary = { version = "1.4.1", optional = true }
 base64 = { version = "0.22.0", optional = true, default-features = false, features = ["alloc"] }

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -39,7 +39,7 @@ network = { package = "bitcoin-network-kind", path = "../network", version = "0.
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.102.0", default-features = false, features = ["alloc", "hex"] }
 secp256k1 = { version = "0.32.0-beta.2", default-features = false, features = ["alloc"] }
 taproot-primitives = { package = "bitcoin-taproot-primitives", path = "../taproot-primitives", version = "0.1.0", default-features = false, features = ["alloc", "hex"] }
-units = { package = "bitcoin-units", path = "../units", version = "0.3.0", default-features = false, features = ["alloc"] }
+units = { package = "bitcoin-units", path = "../units", version = "0.4.0", default-features = false, features = ["alloc"] }
 
 arbitrary = { version = "1.4.1", optional = true }
 base64 = { version = "0.22.0", optional = true, default-features = false, features = ["alloc"] }

--- a/internals/api/all-features.txt
+++ b/internals/api/all-features.txt
@@ -65,9 +65,11 @@ pub struct bitcoin_internals::array_vec::ArrayVec<T: core::marker::Copy, const C
 impl<T: core::marker::Copy, const CAP: usize> bitcoin_internals::array_vec::ArrayVec<T, CAP>
 pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::as_mut_slice(&mut self) -> &mut [T]
 pub const fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::as_slice(&self) -> &[T]
-pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::extend_from_slice(&mut self, slice: &[T])
 pub const fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::from_slice(slice: &[T]) -> Self
 pub const fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::new() -> Self
+pub unsafe fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::set_len(&mut self, new_len: usize)
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::spare_capacity_mut(&mut self) -> &mut [core::mem::maybe_uninit::MaybeUninit<T>]
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::extend_from_slice(&mut self, slice: &[T])
 pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::pop(&mut self) -> core::option::Option<T>
 pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::push(&mut self, element: T)
 pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::try_push(&mut self, element: T) -> core::result::Result<(), bitcoin_internals::array_vec::error::Error>

--- a/internals/api/alloc-only.txt
+++ b/internals/api/alloc-only.txt
@@ -61,9 +61,11 @@ pub struct bitcoin_internals::array_vec::ArrayVec<T: core::marker::Copy, const C
 impl<T: core::marker::Copy, const CAP: usize> bitcoin_internals::array_vec::ArrayVec<T, CAP>
 pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::as_mut_slice(&mut self) -> &mut [T]
 pub const fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::as_slice(&self) -> &[T]
-pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::extend_from_slice(&mut self, slice: &[T])
 pub const fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::from_slice(slice: &[T]) -> Self
 pub const fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::new() -> Self
+pub unsafe fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::set_len(&mut self, new_len: usize)
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::spare_capacity_mut(&mut self) -> &mut [core::mem::maybe_uninit::MaybeUninit<T>]
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::extend_from_slice(&mut self, slice: &[T])
 pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::pop(&mut self) -> core::option::Option<T>
 pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::push(&mut self, element: T)
 pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::try_push(&mut self, element: T) -> core::result::Result<(), bitcoin_internals::array_vec::error::Error>

--- a/internals/api/no-features.txt
+++ b/internals/api/no-features.txt
@@ -55,9 +55,11 @@ pub struct bitcoin_internals::array_vec::ArrayVec<T: core::marker::Copy, const C
 impl<T: core::marker::Copy, const CAP: usize> bitcoin_internals::array_vec::ArrayVec<T, CAP>
 pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::as_mut_slice(&mut self) -> &mut [T]
 pub const fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::as_slice(&self) -> &[T]
-pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::extend_from_slice(&mut self, slice: &[T])
 pub const fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::from_slice(slice: &[T]) -> Self
 pub const fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::new() -> Self
+pub unsafe fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::set_len(&mut self, new_len: usize)
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::spare_capacity_mut(&mut self) -> &mut [core::mem::maybe_uninit::MaybeUninit<T>]
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::extend_from_slice(&mut self, slice: &[T])
 pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::pop(&mut self) -> core::option::Option<T>
 pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::push(&mut self, element: T)
 pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::try_push(&mut self, element: T) -> core::result::Result<(), bitcoin_internals::array_vec::error::Error>

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -29,7 +29,7 @@ hex-stable = { package = "hex-conservative", version = "1.0.0", default-features
 hex-unstable = { package = "hex-conservative", version = "0.3.2", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", default-features = false }
 io = { package = "bitcoin-io", version = "0.5.0", path = "../io", default-features = false }
-units = { package = "bitcoin-units", path = "../units", version = "0.3.0", default-features = false }
+units = { package = "bitcoin-units", path = "../units", version = "0.4.0", default-features = false }
 
 arbitrary = { version = "1.4.1", optional = true }
 serde = { version = "1.0.195", default-features = false, features = ["derive", "alloc"], optional = true }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -26,7 +26,7 @@ network = { package = "bitcoin-network-kind", path = "../network", version = "0.
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.102.0", features = ["hex", "alloc"], default-features = false }
 hex = { package = "hex-conservative", version = "1.1.0", default-features = false, features = ["alloc"] }
 internals = { package = "bitcoin-internals", path = "../internals", default-features = false }
-units = { package = "bitcoin-units", path = "../units", version = "0.3.0", default-features = false }
+units = { package = "bitcoin-units", path = "../units", version = "0.4.0", default-features = false }
 
 arbitrary = { version = "1.4.1", optional = true }
 serde = { version = "1.0.195", default-features = false, features = ["derive", "alloc"], optional = true }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -25,7 +25,7 @@ hex = ["dep:hex-stable", "dep:hex-unstable", "hashes/hex", "internals/hex"]
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.2.0", default-features = false }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
-units = { package = "bitcoin-units", path = "../units", version = "0.3.0", default-features = false, features = [ "encoding" ] }
+units = { package = "bitcoin-units", path = "../units", version = "0.4.0", default-features = false, features = [ "encoding" ] }
 
 arbitrary = { version = "1.4.1", optional = true }
 serde = { version = "1.0.195", default-features = false, features = ["derive", "alloc"], optional = true }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -25,7 +25,7 @@ hex = ["dep:hex", "hashes/hex", "internals/hex"]
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0", default-features = false }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.21.0", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
-units = { package = "bitcoin-units", path = "../units", version = "0.3.0", default-features = false, features = [ "encoding" ] }
+units = { package = "bitcoin-units", path = "../units", version = "0.4.0", default-features = false, features = [ "encoding" ] }
 
 arbitrary = { version = "1.4.1", optional = true }
 hex = { package = "hex-conservative", version = "1.1.0", default-features = false, optional = true }

--- a/units/CHANGELOG.md
+++ b/units/CHANGELOG.md
@@ -1,3 +1,20 @@
+# 0.4.0 - 2026-04-18
+
+* Add format traits for `Target` and `Work` [#5626](https://github.com/rust-bitcoin/rust-bitcoin/pull/5626)
+* Move remaining `pow` types to units [#5608](https://github.com/rust-bitcoin/rust-bitcoin/pull/5608)
+* Extend `parse_int` and add hex string parsing to integer wrapper types [#5782](https://github.com/rust-bitcoin/rust-bitcoin/pull/5782)
+* Remove `From<SubError>` for error types [#5855](https://github.com/rust-bitcoin/rust-bitcoin/pull/5855)
+* Re-export `serde` and `arbitrary` when they appear in public API [#5862](https://github.com/rust-bitcoin/rust-bitcoin/pull/5862)
+* Unify `FromStr` impls for integer wrapper types [#5783](https://github.com/rust-bitcoin/rust-bitcoin/pull/5783)
+* Add `serde` support for `Vec<T>` [#5786](https://github.com/rust-bitcoin/rust-bitcoin/pull/5786)
+* Add next target calculation [#5544](https://github.com/rust-bitcoin/rust-bitcoin/pull/5544)
+* Move and improve `CompactTarget` [#5511](https://github.com/rust-bitcoin/rust-bitcoin/pull/5511)
+* Add `fmt` traits for simple wrapper types [#5510](https://github.com/rust-bitcoin/rust-bitcoin/pull/5510)
+* Upgrade to `consensus-encoding 0.2.0`
+
+Please note the breaking change in how we define encoders had the effect of breaking
+every type in the lib so there is no semver tricking done in this release - sorry.
+
 # 0.3.0 - 2026-02-17
 
 It was found that the `1.0.0-rc.x` releases were troublesome because

--- a/units/CHANGELOG.md
+++ b/units/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-27
+
+* Add format traits for `Target` and `Work` [#5626](https://github.com/rust-bitcoin/rust-bitcoin/pull/5626)
+* Move remaining `pow` types to units [#5608](https://github.com/rust-bitcoin/rust-bitcoin/pull/5608)
+* Extend `parse_int` and add hex string parsing to integer wrapper types [#5782](https://github.com/rust-bitcoin/rust-bitcoin/pull/5782)
+* Remove `From<SubError>` for error types [#5855](https://github.com/rust-bitcoin/rust-bitcoin/pull/5855)
+* Re-export `serde` and `arbitrary` when they appear in public API [#5862](https://github.com/rust-bitcoin/rust-bitcoin/pull/5862)
+* Unify `FromStr` impls for integer wrapper types [#5783](https://github.com/rust-bitcoin/rust-bitcoin/pull/5783)
+* Add `serde` support for `Vec<T>` [#5786](https://github.com/rust-bitcoin/rust-bitcoin/pull/5786)
+* Add next target calculation [#5544](https://github.com/rust-bitcoin/rust-bitcoin/pull/5544)
+* Move and improve `CompactTarget` [#5511](https://github.com/rust-bitcoin/rust-bitcoin/pull/5511)
+* Add `fmt` traits for simple wrapper types [#5510](https://github.com/rust-bitcoin/rust-bitcoin/pull/5510)
+* Upgrade to `consensus-encoding 1.0.0`
+
+Please note the breaking change in how we define encoders had the effect of breaking
+every type in the lib so there is no semver tricking done in this release - sorry.
+
 ## [0.3.0] - 2026-02-17
 
 It was found that the `1.0.0-rc.x` releases were troublesome because
@@ -123,5 +140,6 @@ The main types are:
 
 Empty crate to reserve the name on crates.io
 
-[Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-units-0.3.0...HEAD
+[Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-units-0.4.0...HEAD
+[0.4.0]: https://github.com/rust-bitcoin/rust-bitcoin/releases/tag/bitcoin-units-0.4.0
 [0.3.0]: https://github.com/rust-bitcoin/rust-bitcoin/releases/tag/bitcoin-units-0.3.0

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-units"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>", "Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"


### PR DESCRIPTION
In preparation for release add a changelog entry, bump the version, and update the lock files.

This RC is a big deal, we are hoping that this is the final (TM) RC release.  Please see [The intention is to let this sit quietly for six months](https://github.com/rust-bitcoin/rust-bitcoin/discussions/5941) then drop the `v1.0.0` where I ask permission to pull out of the six month wait and just drop the 1.0 when we think its ready i.e., in less than six months.
