### PR TITLE
Release tracking PR: `bitcoin_hashes 0.21.0`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -29,7 +29,7 @@ name = "base58ck"
 version = "0.4.0"
 dependencies = [
  "bitcoin-internals 0.5.0",
- "bitcoin_hashes 0.20.0",
+ "bitcoin_hashes 0.21.0",
  "hex-conservative 1.1.0",
 ]
 
@@ -90,7 +90,7 @@ dependencies = [
  "bitcoin-primitives",
  "bitcoin-taproot-primitives",
  "bitcoin-units 0.3.0",
- "bitcoin_hashes 0.20.0",
+ "bitcoin_hashes 0.21.0",
  "bitcoinconsensus",
  "hex-conservative 1.1.0",
  "secp256k1 0.32.0-beta.2",
@@ -124,7 +124,7 @@ dependencies = [
  "bitcoin-internals 0.5.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
- "bitcoin_hashes 0.20.0",
+ "bitcoin_hashes 0.21.0",
  "hex-conservative 1.1.0",
  "secp256k1 0.32.0-beta.2",
  "serde",
@@ -174,7 +174,7 @@ version = "0.5.0"
 dependencies = [
  "bitcoin-consensus-encoding",
  "bitcoin-internals 0.5.0",
- "bitcoin_hashes 0.20.0",
+ "bitcoin_hashes 0.21.0",
 ]
 
 [[package]]
@@ -186,7 +186,7 @@ dependencies = [
  "bitcoin-crypto",
  "bitcoin-internals 0.5.0",
  "bitcoin-network-kind",
- "bitcoin_hashes 0.20.0",
+ "bitcoin_hashes 0.21.0",
  "hex-conservative 1.1.0",
  "secp256k1 0.32.0-beta.2",
  "serde",
@@ -214,7 +214,7 @@ dependencies = [
  "bitcoin-network-kind",
  "bitcoin-primitives",
  "bitcoin-units 0.3.0",
- "bitcoin_hashes 0.20.0",
+ "bitcoin_hashes 0.21.0",
  "hex-conservative 1.1.0",
  "serde",
 ]
@@ -228,7 +228,7 @@ dependencies = [
  "bitcoin-consensus-encoding",
  "bitcoin-internals 0.5.0",
  "bitcoin-units 0.3.0",
- "bitcoin_hashes 0.20.0",
+ "bitcoin_hashes 0.21.0",
  "hex-conservative 1.1.0",
  "serde",
  "serde_json",
@@ -246,7 +246,7 @@ version = "0.1.0"
 dependencies = [
  "arbitrary",
  "bitcoin-internals 0.5.0",
- "bitcoin_hashes 0.20.0",
+ "bitcoin_hashes 0.21.0",
  "secp256k1 0.32.0-beta.2",
  "serde",
 ]
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "arbitrary",
  "bitcoin-consensus-encoding",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -29,7 +29,7 @@ name = "base58ck"
 version = "0.4.0"
 dependencies = [
  "bitcoin-internals 0.5.0",
- "bitcoin_hashes 0.20.0",
+ "bitcoin_hashes 0.21.0",
  "hex-conservative 1.1.0",
 ]
 
@@ -89,7 +89,7 @@ dependencies = [
  "bitcoin-primitives",
  "bitcoin-taproot-primitives",
  "bitcoin-units 0.3.0",
- "bitcoin_hashes 0.20.0",
+ "bitcoin_hashes 0.21.0",
  "bitcoinconsensus",
  "hex-conservative 1.1.0",
  "secp256k1 0.32.0-beta.2",
@@ -123,7 +123,7 @@ dependencies = [
  "bitcoin-internals 0.5.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
- "bitcoin_hashes 0.20.0",
+ "bitcoin_hashes 0.21.0",
  "hex-conservative 1.1.0",
  "secp256k1 0.32.0-beta.2",
  "serde",
@@ -173,7 +173,7 @@ version = "0.5.0"
 dependencies = [
  "bitcoin-consensus-encoding",
  "bitcoin-internals 0.5.0",
- "bitcoin_hashes 0.20.0",
+ "bitcoin_hashes 0.21.0",
 ]
 
 [[package]]
@@ -185,7 +185,7 @@ dependencies = [
  "bitcoin-crypto",
  "bitcoin-internals 0.5.0",
  "bitcoin-network-kind",
- "bitcoin_hashes 0.20.0",
+ "bitcoin_hashes 0.21.0",
  "hex-conservative 1.1.0",
  "secp256k1 0.32.0-beta.2",
  "serde",
@@ -213,7 +213,7 @@ dependencies = [
  "bitcoin-network-kind",
  "bitcoin-primitives",
  "bitcoin-units 0.3.0",
- "bitcoin_hashes 0.20.0",
+ "bitcoin_hashes 0.21.0",
  "hex-conservative 1.1.0",
  "serde",
 ]
@@ -227,7 +227,7 @@ dependencies = [
  "bitcoin-consensus-encoding",
  "bitcoin-internals 0.5.0",
  "bitcoin-units 0.3.0",
- "bitcoin_hashes 0.20.0",
+ "bitcoin_hashes 0.21.0",
  "hex-conservative 1.1.0",
  "serde",
  "serde_json",
@@ -239,7 +239,7 @@ version = "0.1.0"
 dependencies = [
  "arbitrary",
  "bitcoin-internals 0.5.0",
- "bitcoin_hashes 0.20.0",
+ "bitcoin_hashes 0.21.0",
  "secp256k1 0.32.0-beta.2",
  "serde",
 ]
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "arbitrary",
  "bitcoin-consensus-encoding",

--- a/base58/Cargo.toml
+++ b/base58/Cargo.toml
@@ -19,7 +19,7 @@ std = ["alloc", "hashes/std", "internals/std"]
 alloc = ["hashes/alloc", "internals/alloc"]
 
 [dependencies]
-hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false }
+hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.21.0", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
 
 [dev-dependencies]

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -29,7 +29,7 @@ arbitrary = ["crypto/arbitrary", "dep:arbitrary", "units/arbitrary", "primitives
 base58 = { package = "base58ck", path = "../base58", version = "0.4.0", default-features = false, features = ["alloc"] }
 bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
 crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.2.0", default-features = false, features = ["alloc"] }
-hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false, features = ["alloc", "hex"] }
+hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.21.0", default-features = false, features = ["alloc", "hex"] }
 key-expression = { package = "bitcoin-key-expression", path = "../key_expression", version = "0.0.0", default-features = false, features = ["alloc"] }
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0", default-features = false, features = ["alloc"] }
 hex = { package = "hex-conservative", version = "1.1.0", default-features = false, features = ["alloc"] }

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -23,7 +23,7 @@ arbitrary = ["dep:arbitrary", "secp256k1/arbitrary"]
 
 [dependencies]
 base58 = { package = "base58ck", path = "../base58", version = "0.4.0", default-features = false }
-hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false, features = ["hex"] }
+hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.21.0", default-features = false, features = ["hex"] }
 hex = { package = "hex-conservative", version = "1.1.0", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0", features = ["hex"] }
 network = { package = "bitcoin-network-kind", path = "../network", version = "0.1.0", default-features = false }

--- a/hashes/CHANGELOG.md
+++ b/hashes/CHANGELOG.md
@@ -1,3 +1,37 @@
+# 0.21.0 - 2026-05-12
+
+This is intended to be the last release prior to `bitcoin_hashes 1.0.0`.
+
+Props to jrakibi for all the SIMD work in this release.
+
+* Remove `Bytes` and `LEN` from `HashEngine` trait [#6205](https://github.com/rust-bitcoin/rust-bitcoin/pull/6205)
+* Wipe secret data in HMAC and HKDF [#5706](https://github.com/rust-bitcoin/rust-bitcoin/pull/5706)
+* Simplify trait bounds [#5682](https://github.com/rust-bitcoin/rust-bitcoin/pull/5682)
+* Add NIST test vectors and chunk-combination tests [#5660](https://github.com/rust-bitcoin/rust-bitcoin/pull/5660)
+* Test `hmac` incremental input [#5624](https://github.com/rust-bitcoin/rust-bitcoin/pull/5624)
+* Fix incremental hashing for `sha3-256` [#5604](https://github.com/rust-bitcoin/rust-bitcoin/pull/5604)
+* Fix reverse hashes for no-hex debug [#5602](https://github.com/rust-bitcoin/rust-bitcoin/pull/5602)
+* Add `cpufeatures` for `no_std` SIMD detection [#5598](https://github.com/rust-bitcoin/rust-bitcoin/pull/5598)
+* Introduce `MuHash` wrapper type [#5594](https://github.com/rust-bitcoin/rust-bitcoin/pull/5594)
+* Include midstate and buffer in `MidstateError` [#5567](https://github.com/rust-bitcoin/rust-bitcoin/pull/5567)
+* Add SHA256 midstate conversion to `Midstate` [#5874](https://github.com/rust-bitcoin/rust-bitcoin/pull/5874)
+* Add `drain_to_engine` function [#6065](https://github.com/rust-bitcoin/rust-bitcoin/pull/6065)
+* Upgrade to `consensus-encoding 1.0.0` (includes re-name of encoding traits [#6028](https://github.com/rust-bitcoin/rust-bitcoin/pull/6028))
+* Change engine parameter to be a mutable reference [#6063](https://github.com/rust-bitcoin/rust-bitcoin/pull/6063)
+* Move errors to error submodules [#5928](https://github.com/rust-bitcoin/rust-bitcoin/pull/5928)
+* Use Rust-like syntax in hash type macros [#5853](https://github.com/rust-bitcoin/rust-bitcoin/pull/5853)
+* Remove the unstable `hex-conservative` dependency [#6148](https://github.com/rust-bitcoin/rust-bitcoin/pull/6148)
+
+SIMD optimizaions: 
+
+* https://github.com/rust-bitcoin/rust-bitcoin/pull/6060
+* https://github.com/rust-bitcoin/rust-bitcoin/pull/6069
+* https://github.com/rust-bitcoin/rust-bitcoin/pull/5493
+* https://github.com/rust-bitcoin/rust-bitcoin/pull/5992
+* https://github.com/rust-bitcoin/rust-bitcoin/pull/5888
+* https://github.com/rust-bitcoin/rust-bitcoin/pull/6129
+* https://github.com/rust-bitcoin/rust-bitcoin/pull/6152
+
 # 0.20.0 - 2026-01-08
 
 It was found that the `1.0.0-rc.x` releases were troublesome because

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin_hashes"
-version = "0.20.0"
+version = "0.21.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin"

--- a/io/Cargo.toml
+++ b/io/Cargo.toml
@@ -23,10 +23,10 @@ alloc = ["encoding/alloc", "hashes?/alloc", "internals/alloc"]
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0", default-features = false }
 
-hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false, optional = true }
+hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.21.0", default-features = false, optional = true }
 
 [dev-dependencies]
-hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false, features = ["hex"] }
+hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.21.0", default-features = false, features = ["hex"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/key_expression/Cargo.toml
+++ b/key_expression/Cargo.toml
@@ -23,7 +23,7 @@ arbitrary = ["crypto/arbitrary", "dep:arbitrary", "hashes/arbitrary", "secp256k1
 [dependencies]
 base58 = { package = "base58ck", path = "../base58", version = "0.4.0", default-features = false }
 crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.2.0", default-features = false }
-hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false, features = ["hex"] }
+hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.21.0", default-features = false, features = ["hex"] }
 hex = { package = "hex-conservative", version = "1.1.0", default-features = false, features = ["alloc"] }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0", features = ["hex"] }
 network = { package = "bitcoin-network-kind", path = "../network", version = "0.1.0", default-features = false }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -21,7 +21,7 @@ serde = ["dep:serde", "hashes/serde"]
 
 [dependencies]
 encoding = { package = "bitcoin-consensus-encoding", version = "1.0.0", path = "../consensus_encoding", features = ["alloc"], default-features = false }
-hashes = { package = "bitcoin_hashes", version = "0.20.0", path = "../hashes", default-features = false }
+hashes = { package = "bitcoin_hashes", version = "0.21.0", path = "../hashes", default-features = false }
 network = { package = "bitcoin-network-kind", path = "../network", version = "0.1.0", default-features = false }
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.102.0", features = ["hex", "alloc"], default-features = false }
 hex = { package = "hex-conservative", version = "1.1.0", default-features = false, features = ["alloc"] }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -23,7 +23,7 @@ hex = ["dep:hex", "hashes/hex", "internals/hex"]
 
 [dependencies]
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0", default-features = false }
-hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false }
+hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.21.0", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
 units = { package = "bitcoin-units", path = "../units", version = "0.3.0", default-features = false, features = [ "encoding" ] }
 

--- a/taproot-primitives/Cargo.toml
+++ b/taproot-primitives/Cargo.toml
@@ -21,7 +21,7 @@ arbitrary = ["dep:arbitrary", "secp256k1/arbitrary"]
 hex = ["hashes/hex"]
 
 [dependencies]
-hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false }
+hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.21.0", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
 
 arbitrary = { version = "1.4.1", optional = true }


### PR DESCRIPTION
In preparation for release add a changelog entry, bump the version, and update the lock files.

One last release before we do `1.0.0` ...
