### PR TITLE
units: Fix re-exports and move pow error types to submodule

### DIFF
--- a/units/api/all-features.txt
+++ b/units/api/all-features.txt
@@ -5854,6 +5854,98 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::pow::error::CompactTargetD
 pub unsafe fn bitcoin_units::pow::error::CompactTargetDecoderError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_units::pow::error::CompactTargetDecoderError
 pub fn bitcoin_units::pow::error::CompactTargetDecoderError::from(t: T) -> T
+pub struct bitcoin_units::pow::error::ParseTargetError(_)
+impl core::clone::Clone for bitcoin_units::pow::error::ParseTargetError
+pub fn bitcoin_units::pow::error::ParseTargetError::clone(&self) -> bitcoin_units::pow::error::ParseTargetError
+impl core::cmp::Eq for bitcoin_units::pow::error::ParseTargetError
+impl core::cmp::PartialEq for bitcoin_units::pow::error::ParseTargetError
+pub fn bitcoin_units::pow::error::ParseTargetError::eq(&self, other: &bitcoin_units::pow::error::ParseTargetError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::pow::error::ParseTargetError
+pub fn bitcoin_units::pow::error::ParseTargetError::from(never: core::convert::Infallible) -> Self
+impl core::error::Error for bitcoin_units::pow::error::ParseTargetError
+pub fn bitcoin_units::pow::error::ParseTargetError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl core::fmt::Debug for bitcoin_units::pow::error::ParseTargetError
+pub fn bitcoin_units::pow::error::ParseTargetError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_units::pow::error::ParseTargetError
+pub fn bitcoin_units::pow::error::ParseTargetError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitcoin_units::pow::error::ParseTargetError
+impl core::marker::Freeze for bitcoin_units::pow::error::ParseTargetError
+impl core::marker::Send for bitcoin_units::pow::error::ParseTargetError
+impl core::marker::Sync for bitcoin_units::pow::error::ParseTargetError
+impl core::marker::Unpin for bitcoin_units::pow::error::ParseTargetError
+impl core::marker::UnsafeUnpin for bitcoin_units::pow::error::ParseTargetError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::pow::error::ParseTargetError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::pow::error::ParseTargetError
+impl<T, U> core::convert::Into<U> for bitcoin_units::pow::error::ParseTargetError where U: core::convert::From<T>
+pub fn bitcoin_units::pow::error::ParseTargetError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::pow::error::ParseTargetError where U: core::convert::Into<T>
+pub type bitcoin_units::pow::error::ParseTargetError::Error = core::convert::Infallible
+pub fn bitcoin_units::pow::error::ParseTargetError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::pow::error::ParseTargetError where U: core::convert::TryFrom<T>
+pub type bitcoin_units::pow::error::ParseTargetError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::pow::error::ParseTargetError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_units::pow::error::ParseTargetError where T: core::clone::Clone
+pub type bitcoin_units::pow::error::ParseTargetError::Owned = T
+pub fn bitcoin_units::pow::error::ParseTargetError::clone_into(&self, target: &mut T)
+pub fn bitcoin_units::pow::error::ParseTargetError::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin_units::pow::error::ParseTargetError where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseTargetError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin_units::pow::error::ParseTargetError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseTargetError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::pow::error::ParseTargetError where T: ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseTargetError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::pow::error::ParseTargetError where T: ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseTargetError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::pow::error::ParseTargetError where T: core::clone::Clone
+pub unsafe fn bitcoin_units::pow::error::ParseTargetError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::pow::error::ParseTargetError
+pub fn bitcoin_units::pow::error::ParseTargetError::from(t: T) -> T
+pub struct bitcoin_units::pow::error::ParseWorkError(_)
+impl core::clone::Clone for bitcoin_units::pow::error::ParseWorkError
+pub fn bitcoin_units::pow::error::ParseWorkError::clone(&self) -> bitcoin_units::pow::error::ParseWorkError
+impl core::cmp::Eq for bitcoin_units::pow::error::ParseWorkError
+impl core::cmp::PartialEq for bitcoin_units::pow::error::ParseWorkError
+pub fn bitcoin_units::pow::error::ParseWorkError::eq(&self, other: &bitcoin_units::pow::error::ParseWorkError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::pow::error::ParseWorkError
+pub fn bitcoin_units::pow::error::ParseWorkError::from(never: core::convert::Infallible) -> Self
+impl core::error::Error for bitcoin_units::pow::error::ParseWorkError
+pub fn bitcoin_units::pow::error::ParseWorkError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl core::fmt::Debug for bitcoin_units::pow::error::ParseWorkError
+pub fn bitcoin_units::pow::error::ParseWorkError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_units::pow::error::ParseWorkError
+pub fn bitcoin_units::pow::error::ParseWorkError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitcoin_units::pow::error::ParseWorkError
+impl core::marker::Freeze for bitcoin_units::pow::error::ParseWorkError
+impl core::marker::Send for bitcoin_units::pow::error::ParseWorkError
+impl core::marker::Sync for bitcoin_units::pow::error::ParseWorkError
+impl core::marker::Unpin for bitcoin_units::pow::error::ParseWorkError
+impl core::marker::UnsafeUnpin for bitcoin_units::pow::error::ParseWorkError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::pow::error::ParseWorkError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::pow::error::ParseWorkError
+impl<T, U> core::convert::Into<U> for bitcoin_units::pow::error::ParseWorkError where U: core::convert::From<T>
+pub fn bitcoin_units::pow::error::ParseWorkError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::pow::error::ParseWorkError where U: core::convert::Into<T>
+pub type bitcoin_units::pow::error::ParseWorkError::Error = core::convert::Infallible
+pub fn bitcoin_units::pow::error::ParseWorkError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::pow::error::ParseWorkError where U: core::convert::TryFrom<T>
+pub type bitcoin_units::pow::error::ParseWorkError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::pow::error::ParseWorkError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_units::pow::error::ParseWorkError where T: core::clone::Clone
+pub type bitcoin_units::pow::error::ParseWorkError::Owned = T
+pub fn bitcoin_units::pow::error::ParseWorkError::clone_into(&self, target: &mut T)
+pub fn bitcoin_units::pow::error::ParseWorkError::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin_units::pow::error::ParseWorkError where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseWorkError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin_units::pow::error::ParseWorkError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseWorkError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::pow::error::ParseWorkError where T: ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseWorkError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::pow::error::ParseWorkError where T: ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseWorkError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::pow::error::ParseWorkError where T: core::clone::Clone
+pub unsafe fn bitcoin_units::pow::error::ParseWorkError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::pow::error::ParseWorkError
+pub fn bitcoin_units::pow::error::ParseWorkError::from(t: T) -> T
 pub struct bitcoin_units::pow::CompactTarget(_)
 impl bitcoin_units::pow::CompactTarget
 pub fn bitcoin_units::pow::CompactTarget::from_consensus(bits: u32) -> Self
@@ -6074,97 +6166,97 @@ pub unsafe fn bitcoin_units::pow::CompactTargetEncoder<'e>::clone_to_uninit(&sel
 impl<T> core::convert::From<T> for bitcoin_units::pow::CompactTargetEncoder<'e>
 pub fn bitcoin_units::pow::CompactTargetEncoder<'e>::from(t: T) -> T
 pub struct bitcoin_units::pow::ParseTargetError(_)
-impl core::clone::Clone for bitcoin_units::pow::ParseTargetError
-pub fn bitcoin_units::pow::ParseTargetError::clone(&self) -> bitcoin_units::pow::ParseTargetError
-impl core::cmp::Eq for bitcoin_units::pow::ParseTargetError
-impl core::cmp::PartialEq for bitcoin_units::pow::ParseTargetError
-pub fn bitcoin_units::pow::ParseTargetError::eq(&self, other: &bitcoin_units::pow::ParseTargetError) -> bool
-impl core::convert::From<core::convert::Infallible> for bitcoin_units::pow::ParseTargetError
-pub fn bitcoin_units::pow::ParseTargetError::from(never: core::convert::Infallible) -> Self
-impl core::error::Error for bitcoin_units::pow::ParseTargetError
-pub fn bitcoin_units::pow::ParseTargetError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
-impl core::fmt::Debug for bitcoin_units::pow::ParseTargetError
-pub fn bitcoin_units::pow::ParseTargetError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::fmt::Display for bitcoin_units::pow::ParseTargetError
-pub fn bitcoin_units::pow::ParseTargetError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for bitcoin_units::pow::ParseTargetError
-impl core::marker::Freeze for bitcoin_units::pow::ParseTargetError
-impl core::marker::Send for bitcoin_units::pow::ParseTargetError
-impl core::marker::Sync for bitcoin_units::pow::ParseTargetError
-impl core::marker::Unpin for bitcoin_units::pow::ParseTargetError
-impl core::marker::UnsafeUnpin for bitcoin_units::pow::ParseTargetError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::pow::ParseTargetError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::pow::ParseTargetError
-impl<T, U> core::convert::Into<U> for bitcoin_units::pow::ParseTargetError where U: core::convert::From<T>
-pub fn bitcoin_units::pow::ParseTargetError::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for bitcoin_units::pow::ParseTargetError where U: core::convert::Into<T>
-pub type bitcoin_units::pow::ParseTargetError::Error = core::convert::Infallible
-pub fn bitcoin_units::pow::ParseTargetError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for bitcoin_units::pow::ParseTargetError where U: core::convert::TryFrom<T>
-pub type bitcoin_units::pow::ParseTargetError::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn bitcoin_units::pow::ParseTargetError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_units::pow::ParseTargetError where T: core::clone::Clone
-pub type bitcoin_units::pow::ParseTargetError::Owned = T
-pub fn bitcoin_units::pow::ParseTargetError::clone_into(&self, target: &mut T)
-pub fn bitcoin_units::pow::ParseTargetError::to_owned(&self) -> T
-impl<T> alloc::string::ToString for bitcoin_units::pow::ParseTargetError where T: core::fmt::Display + ?core::marker::Sized
-pub fn bitcoin_units::pow::ParseTargetError::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for bitcoin_units::pow::ParseTargetError where T: 'static + ?core::marker::Sized
-pub fn bitcoin_units::pow::ParseTargetError::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for bitcoin_units::pow::ParseTargetError where T: ?core::marker::Sized
-pub fn bitcoin_units::pow::ParseTargetError::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for bitcoin_units::pow::ParseTargetError where T: ?core::marker::Sized
-pub fn bitcoin_units::pow::ParseTargetError::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_units::pow::ParseTargetError where T: core::clone::Clone
-pub unsafe fn bitcoin_units::pow::ParseTargetError::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for bitcoin_units::pow::ParseTargetError
-pub fn bitcoin_units::pow::ParseTargetError::from(t: T) -> T
+impl core::clone::Clone for bitcoin_units::pow::error::ParseTargetError
+pub fn bitcoin_units::pow::error::ParseTargetError::clone(&self) -> bitcoin_units::pow::error::ParseTargetError
+impl core::cmp::Eq for bitcoin_units::pow::error::ParseTargetError
+impl core::cmp::PartialEq for bitcoin_units::pow::error::ParseTargetError
+pub fn bitcoin_units::pow::error::ParseTargetError::eq(&self, other: &bitcoin_units::pow::error::ParseTargetError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::pow::error::ParseTargetError
+pub fn bitcoin_units::pow::error::ParseTargetError::from(never: core::convert::Infallible) -> Self
+impl core::error::Error for bitcoin_units::pow::error::ParseTargetError
+pub fn bitcoin_units::pow::error::ParseTargetError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl core::fmt::Debug for bitcoin_units::pow::error::ParseTargetError
+pub fn bitcoin_units::pow::error::ParseTargetError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_units::pow::error::ParseTargetError
+pub fn bitcoin_units::pow::error::ParseTargetError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitcoin_units::pow::error::ParseTargetError
+impl core::marker::Freeze for bitcoin_units::pow::error::ParseTargetError
+impl core::marker::Send for bitcoin_units::pow::error::ParseTargetError
+impl core::marker::Sync for bitcoin_units::pow::error::ParseTargetError
+impl core::marker::Unpin for bitcoin_units::pow::error::ParseTargetError
+impl core::marker::UnsafeUnpin for bitcoin_units::pow::error::ParseTargetError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::pow::error::ParseTargetError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::pow::error::ParseTargetError
+impl<T, U> core::convert::Into<U> for bitcoin_units::pow::error::ParseTargetError where U: core::convert::From<T>
+pub fn bitcoin_units::pow::error::ParseTargetError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::pow::error::ParseTargetError where U: core::convert::Into<T>
+pub type bitcoin_units::pow::error::ParseTargetError::Error = core::convert::Infallible
+pub fn bitcoin_units::pow::error::ParseTargetError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::pow::error::ParseTargetError where U: core::convert::TryFrom<T>
+pub type bitcoin_units::pow::error::ParseTargetError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::pow::error::ParseTargetError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_units::pow::error::ParseTargetError where T: core::clone::Clone
+pub type bitcoin_units::pow::error::ParseTargetError::Owned = T
+pub fn bitcoin_units::pow::error::ParseTargetError::clone_into(&self, target: &mut T)
+pub fn bitcoin_units::pow::error::ParseTargetError::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin_units::pow::error::ParseTargetError where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseTargetError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin_units::pow::error::ParseTargetError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseTargetError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::pow::error::ParseTargetError where T: ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseTargetError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::pow::error::ParseTargetError where T: ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseTargetError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::pow::error::ParseTargetError where T: core::clone::Clone
+pub unsafe fn bitcoin_units::pow::error::ParseTargetError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::pow::error::ParseTargetError
+pub fn bitcoin_units::pow::error::ParseTargetError::from(t: T) -> T
 pub struct bitcoin_units::pow::ParseWorkError(_)
-impl core::clone::Clone for bitcoin_units::pow::ParseWorkError
-pub fn bitcoin_units::pow::ParseWorkError::clone(&self) -> bitcoin_units::pow::ParseWorkError
-impl core::cmp::Eq for bitcoin_units::pow::ParseWorkError
-impl core::cmp::PartialEq for bitcoin_units::pow::ParseWorkError
-pub fn bitcoin_units::pow::ParseWorkError::eq(&self, other: &bitcoin_units::pow::ParseWorkError) -> bool
-impl core::convert::From<core::convert::Infallible> for bitcoin_units::pow::ParseWorkError
-pub fn bitcoin_units::pow::ParseWorkError::from(never: core::convert::Infallible) -> Self
-impl core::error::Error for bitcoin_units::pow::ParseWorkError
-pub fn bitcoin_units::pow::ParseWorkError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
-impl core::fmt::Debug for bitcoin_units::pow::ParseWorkError
-pub fn bitcoin_units::pow::ParseWorkError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::fmt::Display for bitcoin_units::pow::ParseWorkError
-pub fn bitcoin_units::pow::ParseWorkError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for bitcoin_units::pow::ParseWorkError
-impl core::marker::Freeze for bitcoin_units::pow::ParseWorkError
-impl core::marker::Send for bitcoin_units::pow::ParseWorkError
-impl core::marker::Sync for bitcoin_units::pow::ParseWorkError
-impl core::marker::Unpin for bitcoin_units::pow::ParseWorkError
-impl core::marker::UnsafeUnpin for bitcoin_units::pow::ParseWorkError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::pow::ParseWorkError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::pow::ParseWorkError
-impl<T, U> core::convert::Into<U> for bitcoin_units::pow::ParseWorkError where U: core::convert::From<T>
-pub fn bitcoin_units::pow::ParseWorkError::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for bitcoin_units::pow::ParseWorkError where U: core::convert::Into<T>
-pub type bitcoin_units::pow::ParseWorkError::Error = core::convert::Infallible
-pub fn bitcoin_units::pow::ParseWorkError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for bitcoin_units::pow::ParseWorkError where U: core::convert::TryFrom<T>
-pub type bitcoin_units::pow::ParseWorkError::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn bitcoin_units::pow::ParseWorkError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_units::pow::ParseWorkError where T: core::clone::Clone
-pub type bitcoin_units::pow::ParseWorkError::Owned = T
-pub fn bitcoin_units::pow::ParseWorkError::clone_into(&self, target: &mut T)
-pub fn bitcoin_units::pow::ParseWorkError::to_owned(&self) -> T
-impl<T> alloc::string::ToString for bitcoin_units::pow::ParseWorkError where T: core::fmt::Display + ?core::marker::Sized
-pub fn bitcoin_units::pow::ParseWorkError::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for bitcoin_units::pow::ParseWorkError where T: 'static + ?core::marker::Sized
-pub fn bitcoin_units::pow::ParseWorkError::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for bitcoin_units::pow::ParseWorkError where T: ?core::marker::Sized
-pub fn bitcoin_units::pow::ParseWorkError::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for bitcoin_units::pow::ParseWorkError where T: ?core::marker::Sized
-pub fn bitcoin_units::pow::ParseWorkError::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_units::pow::ParseWorkError where T: core::clone::Clone
-pub unsafe fn bitcoin_units::pow::ParseWorkError::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for bitcoin_units::pow::ParseWorkError
-pub fn bitcoin_units::pow::ParseWorkError::from(t: T) -> T
+impl core::clone::Clone for bitcoin_units::pow::error::ParseWorkError
+pub fn bitcoin_units::pow::error::ParseWorkError::clone(&self) -> bitcoin_units::pow::error::ParseWorkError
+impl core::cmp::Eq for bitcoin_units::pow::error::ParseWorkError
+impl core::cmp::PartialEq for bitcoin_units::pow::error::ParseWorkError
+pub fn bitcoin_units::pow::error::ParseWorkError::eq(&self, other: &bitcoin_units::pow::error::ParseWorkError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::pow::error::ParseWorkError
+pub fn bitcoin_units::pow::error::ParseWorkError::from(never: core::convert::Infallible) -> Self
+impl core::error::Error for bitcoin_units::pow::error::ParseWorkError
+pub fn bitcoin_units::pow::error::ParseWorkError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl core::fmt::Debug for bitcoin_units::pow::error::ParseWorkError
+pub fn bitcoin_units::pow::error::ParseWorkError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_units::pow::error::ParseWorkError
+pub fn bitcoin_units::pow::error::ParseWorkError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitcoin_units::pow::error::ParseWorkError
+impl core::marker::Freeze for bitcoin_units::pow::error::ParseWorkError
+impl core::marker::Send for bitcoin_units::pow::error::ParseWorkError
+impl core::marker::Sync for bitcoin_units::pow::error::ParseWorkError
+impl core::marker::Unpin for bitcoin_units::pow::error::ParseWorkError
+impl core::marker::UnsafeUnpin for bitcoin_units::pow::error::ParseWorkError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::pow::error::ParseWorkError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::pow::error::ParseWorkError
+impl<T, U> core::convert::Into<U> for bitcoin_units::pow::error::ParseWorkError where U: core::convert::From<T>
+pub fn bitcoin_units::pow::error::ParseWorkError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::pow::error::ParseWorkError where U: core::convert::Into<T>
+pub type bitcoin_units::pow::error::ParseWorkError::Error = core::convert::Infallible
+pub fn bitcoin_units::pow::error::ParseWorkError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::pow::error::ParseWorkError where U: core::convert::TryFrom<T>
+pub type bitcoin_units::pow::error::ParseWorkError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::pow::error::ParseWorkError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_units::pow::error::ParseWorkError where T: core::clone::Clone
+pub type bitcoin_units::pow::error::ParseWorkError::Owned = T
+pub fn bitcoin_units::pow::error::ParseWorkError::clone_into(&self, target: &mut T)
+pub fn bitcoin_units::pow::error::ParseWorkError::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin_units::pow::error::ParseWorkError where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseWorkError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin_units::pow::error::ParseWorkError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseWorkError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::pow::error::ParseWorkError where T: ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseWorkError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::pow::error::ParseWorkError where T: ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseWorkError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::pow::error::ParseWorkError where T: core::clone::Clone
+pub unsafe fn bitcoin_units::pow::error::ParseWorkError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::pow::error::ParseWorkError
+pub fn bitcoin_units::pow::error::ParseWorkError::from(t: T) -> T
 pub struct bitcoin_units::pow::Target(_)
 impl bitcoin_units::pow::Target
 pub const bitcoin_units::pow::Target::MAX: Self
@@ -6207,7 +6299,7 @@ pub fn bitcoin_units::pow::Target::hash<__H: core::hash::Hasher>(&self, state: &
 impl core::marker::Copy for bitcoin_units::pow::Target
 impl core::marker::StructuralPartialEq for bitcoin_units::pow::Target
 impl core::str::traits::FromStr for bitcoin_units::pow::Target
-pub type bitcoin_units::pow::Target::Err = bitcoin_units::pow::ParseTargetError
+pub type bitcoin_units::pow::Target::Err = bitcoin_units::pow::error::ParseTargetError
 pub fn bitcoin_units::pow::Target::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 impl serde::ser::Serialize for bitcoin_units::pow::Target
 pub fn bitcoin_units::pow::Target::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
@@ -6283,7 +6375,7 @@ impl core::ops::arith::Sub for bitcoin_units::pow::Work
 pub type bitcoin_units::pow::Work::Output = bitcoin_units::pow::Work
 pub fn bitcoin_units::pow::Work::sub(self, rhs: Self) -> Self
 impl core::str::traits::FromStr for bitcoin_units::pow::Work
-pub type bitcoin_units::pow::Work::Err = bitcoin_units::pow::ParseWorkError
+pub type bitcoin_units::pow::Work::Err = bitcoin_units::pow::error::ParseWorkError
 pub fn bitcoin_units::pow::Work::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 impl serde::ser::Serialize for bitcoin_units::pow::Work
 pub fn bitcoin_units::pow::Work::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
@@ -10819,7 +10911,7 @@ pub fn bitcoin_units::pow::Target::hash<__H: core::hash::Hasher>(&self, state: &
 impl core::marker::Copy for bitcoin_units::pow::Target
 impl core::marker::StructuralPartialEq for bitcoin_units::pow::Target
 impl core::str::traits::FromStr for bitcoin_units::pow::Target
-pub type bitcoin_units::pow::Target::Err = bitcoin_units::pow::ParseTargetError
+pub type bitcoin_units::pow::Target::Err = bitcoin_units::pow::error::ParseTargetError
 pub fn bitcoin_units::pow::Target::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 impl serde::ser::Serialize for bitcoin_units::pow::Target
 pub fn bitcoin_units::pow::Target::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
@@ -11198,7 +11290,7 @@ impl core::ops::arith::Sub for bitcoin_units::pow::Work
 pub type bitcoin_units::pow::Work::Output = bitcoin_units::pow::Work
 pub fn bitcoin_units::pow::Work::sub(self, rhs: Self) -> Self
 impl core::str::traits::FromStr for bitcoin_units::pow::Work
-pub type bitcoin_units::pow::Work::Err = bitcoin_units::pow::ParseWorkError
+pub type bitcoin_units::pow::Work::Err = bitcoin_units::pow::error::ParseWorkError
 pub fn bitcoin_units::pow::Work::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 impl serde::ser::Serialize for bitcoin_units::pow::Work
 pub fn bitcoin_units::pow::Work::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer

--- a/units/api/alloc-only.txt
+++ b/units/api/alloc-only.txt
@@ -4794,6 +4794,94 @@ pub fn bitcoin_units::parse_int::int_from_str<T: bitcoin_units::parse_int::Integ
 pub fn bitcoin_units::parse_int::int_from_string<T: bitcoin_units::parse_int::Integer>(s: alloc::string::String) -> core::result::Result<T, bitcoin_units::parse_int::error::ParseIntError>
 pub mod bitcoin_units::pow
 pub mod bitcoin_units::pow::error
+pub struct bitcoin_units::pow::error::ParseTargetError(_)
+impl core::clone::Clone for bitcoin_units::pow::error::ParseTargetError
+pub fn bitcoin_units::pow::error::ParseTargetError::clone(&self) -> bitcoin_units::pow::error::ParseTargetError
+impl core::cmp::Eq for bitcoin_units::pow::error::ParseTargetError
+impl core::cmp::PartialEq for bitcoin_units::pow::error::ParseTargetError
+pub fn bitcoin_units::pow::error::ParseTargetError::eq(&self, other: &bitcoin_units::pow::error::ParseTargetError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::pow::error::ParseTargetError
+pub fn bitcoin_units::pow::error::ParseTargetError::from(never: core::convert::Infallible) -> Self
+impl core::fmt::Debug for bitcoin_units::pow::error::ParseTargetError
+pub fn bitcoin_units::pow::error::ParseTargetError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_units::pow::error::ParseTargetError
+pub fn bitcoin_units::pow::error::ParseTargetError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitcoin_units::pow::error::ParseTargetError
+impl core::marker::Freeze for bitcoin_units::pow::error::ParseTargetError
+impl core::marker::Send for bitcoin_units::pow::error::ParseTargetError
+impl core::marker::Sync for bitcoin_units::pow::error::ParseTargetError
+impl core::marker::Unpin for bitcoin_units::pow::error::ParseTargetError
+impl core::marker::UnsafeUnpin for bitcoin_units::pow::error::ParseTargetError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::pow::error::ParseTargetError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::pow::error::ParseTargetError
+impl<T, U> core::convert::Into<U> for bitcoin_units::pow::error::ParseTargetError where U: core::convert::From<T>
+pub fn bitcoin_units::pow::error::ParseTargetError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::pow::error::ParseTargetError where U: core::convert::Into<T>
+pub type bitcoin_units::pow::error::ParseTargetError::Error = core::convert::Infallible
+pub fn bitcoin_units::pow::error::ParseTargetError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::pow::error::ParseTargetError where U: core::convert::TryFrom<T>
+pub type bitcoin_units::pow::error::ParseTargetError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::pow::error::ParseTargetError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_units::pow::error::ParseTargetError where T: core::clone::Clone
+pub type bitcoin_units::pow::error::ParseTargetError::Owned = T
+pub fn bitcoin_units::pow::error::ParseTargetError::clone_into(&self, target: &mut T)
+pub fn bitcoin_units::pow::error::ParseTargetError::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin_units::pow::error::ParseTargetError where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseTargetError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin_units::pow::error::ParseTargetError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseTargetError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::pow::error::ParseTargetError where T: ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseTargetError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::pow::error::ParseTargetError where T: ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseTargetError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::pow::error::ParseTargetError where T: core::clone::Clone
+pub unsafe fn bitcoin_units::pow::error::ParseTargetError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::pow::error::ParseTargetError
+pub fn bitcoin_units::pow::error::ParseTargetError::from(t: T) -> T
+pub struct bitcoin_units::pow::error::ParseWorkError(_)
+impl core::clone::Clone for bitcoin_units::pow::error::ParseWorkError
+pub fn bitcoin_units::pow::error::ParseWorkError::clone(&self) -> bitcoin_units::pow::error::ParseWorkError
+impl core::cmp::Eq for bitcoin_units::pow::error::ParseWorkError
+impl core::cmp::PartialEq for bitcoin_units::pow::error::ParseWorkError
+pub fn bitcoin_units::pow::error::ParseWorkError::eq(&self, other: &bitcoin_units::pow::error::ParseWorkError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::pow::error::ParseWorkError
+pub fn bitcoin_units::pow::error::ParseWorkError::from(never: core::convert::Infallible) -> Self
+impl core::fmt::Debug for bitcoin_units::pow::error::ParseWorkError
+pub fn bitcoin_units::pow::error::ParseWorkError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_units::pow::error::ParseWorkError
+pub fn bitcoin_units::pow::error::ParseWorkError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitcoin_units::pow::error::ParseWorkError
+impl core::marker::Freeze for bitcoin_units::pow::error::ParseWorkError
+impl core::marker::Send for bitcoin_units::pow::error::ParseWorkError
+impl core::marker::Sync for bitcoin_units::pow::error::ParseWorkError
+impl core::marker::Unpin for bitcoin_units::pow::error::ParseWorkError
+impl core::marker::UnsafeUnpin for bitcoin_units::pow::error::ParseWorkError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::pow::error::ParseWorkError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::pow::error::ParseWorkError
+impl<T, U> core::convert::Into<U> for bitcoin_units::pow::error::ParseWorkError where U: core::convert::From<T>
+pub fn bitcoin_units::pow::error::ParseWorkError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::pow::error::ParseWorkError where U: core::convert::Into<T>
+pub type bitcoin_units::pow::error::ParseWorkError::Error = core::convert::Infallible
+pub fn bitcoin_units::pow::error::ParseWorkError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::pow::error::ParseWorkError where U: core::convert::TryFrom<T>
+pub type bitcoin_units::pow::error::ParseWorkError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::pow::error::ParseWorkError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_units::pow::error::ParseWorkError where T: core::clone::Clone
+pub type bitcoin_units::pow::error::ParseWorkError::Owned = T
+pub fn bitcoin_units::pow::error::ParseWorkError::clone_into(&self, target: &mut T)
+pub fn bitcoin_units::pow::error::ParseWorkError::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin_units::pow::error::ParseWorkError where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseWorkError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin_units::pow::error::ParseWorkError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseWorkError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::pow::error::ParseWorkError where T: ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseWorkError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::pow::error::ParseWorkError where T: ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseWorkError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::pow::error::ParseWorkError where T: core::clone::Clone
+pub unsafe fn bitcoin_units::pow::error::ParseWorkError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::pow::error::ParseWorkError
+pub fn bitcoin_units::pow::error::ParseWorkError::from(t: T) -> T
 pub struct bitcoin_units::pow::CompactTarget(_)
 impl bitcoin_units::pow::CompactTarget
 pub fn bitcoin_units::pow::CompactTarget::from_consensus(bits: u32) -> Self
@@ -4872,93 +4960,93 @@ pub unsafe fn bitcoin_units::pow::CompactTarget::clone_to_uninit(&self, dest: *m
 impl<T> core::convert::From<T> for bitcoin_units::pow::CompactTarget
 pub fn bitcoin_units::pow::CompactTarget::from(t: T) -> T
 pub struct bitcoin_units::pow::ParseTargetError(_)
-impl core::clone::Clone for bitcoin_units::pow::ParseTargetError
-pub fn bitcoin_units::pow::ParseTargetError::clone(&self) -> bitcoin_units::pow::ParseTargetError
-impl core::cmp::Eq for bitcoin_units::pow::ParseTargetError
-impl core::cmp::PartialEq for bitcoin_units::pow::ParseTargetError
-pub fn bitcoin_units::pow::ParseTargetError::eq(&self, other: &bitcoin_units::pow::ParseTargetError) -> bool
-impl core::convert::From<core::convert::Infallible> for bitcoin_units::pow::ParseTargetError
-pub fn bitcoin_units::pow::ParseTargetError::from(never: core::convert::Infallible) -> Self
-impl core::fmt::Debug for bitcoin_units::pow::ParseTargetError
-pub fn bitcoin_units::pow::ParseTargetError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::fmt::Display for bitcoin_units::pow::ParseTargetError
-pub fn bitcoin_units::pow::ParseTargetError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for bitcoin_units::pow::ParseTargetError
-impl core::marker::Freeze for bitcoin_units::pow::ParseTargetError
-impl core::marker::Send for bitcoin_units::pow::ParseTargetError
-impl core::marker::Sync for bitcoin_units::pow::ParseTargetError
-impl core::marker::Unpin for bitcoin_units::pow::ParseTargetError
-impl core::marker::UnsafeUnpin for bitcoin_units::pow::ParseTargetError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::pow::ParseTargetError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::pow::ParseTargetError
-impl<T, U> core::convert::Into<U> for bitcoin_units::pow::ParseTargetError where U: core::convert::From<T>
-pub fn bitcoin_units::pow::ParseTargetError::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for bitcoin_units::pow::ParseTargetError where U: core::convert::Into<T>
-pub type bitcoin_units::pow::ParseTargetError::Error = core::convert::Infallible
-pub fn bitcoin_units::pow::ParseTargetError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for bitcoin_units::pow::ParseTargetError where U: core::convert::TryFrom<T>
-pub type bitcoin_units::pow::ParseTargetError::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn bitcoin_units::pow::ParseTargetError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_units::pow::ParseTargetError where T: core::clone::Clone
-pub type bitcoin_units::pow::ParseTargetError::Owned = T
-pub fn bitcoin_units::pow::ParseTargetError::clone_into(&self, target: &mut T)
-pub fn bitcoin_units::pow::ParseTargetError::to_owned(&self) -> T
-impl<T> alloc::string::ToString for bitcoin_units::pow::ParseTargetError where T: core::fmt::Display + ?core::marker::Sized
-pub fn bitcoin_units::pow::ParseTargetError::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for bitcoin_units::pow::ParseTargetError where T: 'static + ?core::marker::Sized
-pub fn bitcoin_units::pow::ParseTargetError::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for bitcoin_units::pow::ParseTargetError where T: ?core::marker::Sized
-pub fn bitcoin_units::pow::ParseTargetError::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for bitcoin_units::pow::ParseTargetError where T: ?core::marker::Sized
-pub fn bitcoin_units::pow::ParseTargetError::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_units::pow::ParseTargetError where T: core::clone::Clone
-pub unsafe fn bitcoin_units::pow::ParseTargetError::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for bitcoin_units::pow::ParseTargetError
-pub fn bitcoin_units::pow::ParseTargetError::from(t: T) -> T
+impl core::clone::Clone for bitcoin_units::pow::error::ParseTargetError
+pub fn bitcoin_units::pow::error::ParseTargetError::clone(&self) -> bitcoin_units::pow::error::ParseTargetError
+impl core::cmp::Eq for bitcoin_units::pow::error::ParseTargetError
+impl core::cmp::PartialEq for bitcoin_units::pow::error::ParseTargetError
+pub fn bitcoin_units::pow::error::ParseTargetError::eq(&self, other: &bitcoin_units::pow::error::ParseTargetError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::pow::error::ParseTargetError
+pub fn bitcoin_units::pow::error::ParseTargetError::from(never: core::convert::Infallible) -> Self
+impl core::fmt::Debug for bitcoin_units::pow::error::ParseTargetError
+pub fn bitcoin_units::pow::error::ParseTargetError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_units::pow::error::ParseTargetError
+pub fn bitcoin_units::pow::error::ParseTargetError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitcoin_units::pow::error::ParseTargetError
+impl core::marker::Freeze for bitcoin_units::pow::error::ParseTargetError
+impl core::marker::Send for bitcoin_units::pow::error::ParseTargetError
+impl core::marker::Sync for bitcoin_units::pow::error::ParseTargetError
+impl core::marker::Unpin for bitcoin_units::pow::error::ParseTargetError
+impl core::marker::UnsafeUnpin for bitcoin_units::pow::error::ParseTargetError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::pow::error::ParseTargetError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::pow::error::ParseTargetError
+impl<T, U> core::convert::Into<U> for bitcoin_units::pow::error::ParseTargetError where U: core::convert::From<T>
+pub fn bitcoin_units::pow::error::ParseTargetError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::pow::error::ParseTargetError where U: core::convert::Into<T>
+pub type bitcoin_units::pow::error::ParseTargetError::Error = core::convert::Infallible
+pub fn bitcoin_units::pow::error::ParseTargetError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::pow::error::ParseTargetError where U: core::convert::TryFrom<T>
+pub type bitcoin_units::pow::error::ParseTargetError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::pow::error::ParseTargetError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_units::pow::error::ParseTargetError where T: core::clone::Clone
+pub type bitcoin_units::pow::error::ParseTargetError::Owned = T
+pub fn bitcoin_units::pow::error::ParseTargetError::clone_into(&self, target: &mut T)
+pub fn bitcoin_units::pow::error::ParseTargetError::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin_units::pow::error::ParseTargetError where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseTargetError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin_units::pow::error::ParseTargetError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseTargetError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::pow::error::ParseTargetError where T: ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseTargetError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::pow::error::ParseTargetError where T: ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseTargetError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::pow::error::ParseTargetError where T: core::clone::Clone
+pub unsafe fn bitcoin_units::pow::error::ParseTargetError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::pow::error::ParseTargetError
+pub fn bitcoin_units::pow::error::ParseTargetError::from(t: T) -> T
 pub struct bitcoin_units::pow::ParseWorkError(_)
-impl core::clone::Clone for bitcoin_units::pow::ParseWorkError
-pub fn bitcoin_units::pow::ParseWorkError::clone(&self) -> bitcoin_units::pow::ParseWorkError
-impl core::cmp::Eq for bitcoin_units::pow::ParseWorkError
-impl core::cmp::PartialEq for bitcoin_units::pow::ParseWorkError
-pub fn bitcoin_units::pow::ParseWorkError::eq(&self, other: &bitcoin_units::pow::ParseWorkError) -> bool
-impl core::convert::From<core::convert::Infallible> for bitcoin_units::pow::ParseWorkError
-pub fn bitcoin_units::pow::ParseWorkError::from(never: core::convert::Infallible) -> Self
-impl core::fmt::Debug for bitcoin_units::pow::ParseWorkError
-pub fn bitcoin_units::pow::ParseWorkError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::fmt::Display for bitcoin_units::pow::ParseWorkError
-pub fn bitcoin_units::pow::ParseWorkError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for bitcoin_units::pow::ParseWorkError
-impl core::marker::Freeze for bitcoin_units::pow::ParseWorkError
-impl core::marker::Send for bitcoin_units::pow::ParseWorkError
-impl core::marker::Sync for bitcoin_units::pow::ParseWorkError
-impl core::marker::Unpin for bitcoin_units::pow::ParseWorkError
-impl core::marker::UnsafeUnpin for bitcoin_units::pow::ParseWorkError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::pow::ParseWorkError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::pow::ParseWorkError
-impl<T, U> core::convert::Into<U> for bitcoin_units::pow::ParseWorkError where U: core::convert::From<T>
-pub fn bitcoin_units::pow::ParseWorkError::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for bitcoin_units::pow::ParseWorkError where U: core::convert::Into<T>
-pub type bitcoin_units::pow::ParseWorkError::Error = core::convert::Infallible
-pub fn bitcoin_units::pow::ParseWorkError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for bitcoin_units::pow::ParseWorkError where U: core::convert::TryFrom<T>
-pub type bitcoin_units::pow::ParseWorkError::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn bitcoin_units::pow::ParseWorkError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_units::pow::ParseWorkError where T: core::clone::Clone
-pub type bitcoin_units::pow::ParseWorkError::Owned = T
-pub fn bitcoin_units::pow::ParseWorkError::clone_into(&self, target: &mut T)
-pub fn bitcoin_units::pow::ParseWorkError::to_owned(&self) -> T
-impl<T> alloc::string::ToString for bitcoin_units::pow::ParseWorkError where T: core::fmt::Display + ?core::marker::Sized
-pub fn bitcoin_units::pow::ParseWorkError::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for bitcoin_units::pow::ParseWorkError where T: 'static + ?core::marker::Sized
-pub fn bitcoin_units::pow::ParseWorkError::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for bitcoin_units::pow::ParseWorkError where T: ?core::marker::Sized
-pub fn bitcoin_units::pow::ParseWorkError::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for bitcoin_units::pow::ParseWorkError where T: ?core::marker::Sized
-pub fn bitcoin_units::pow::ParseWorkError::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_units::pow::ParseWorkError where T: core::clone::Clone
-pub unsafe fn bitcoin_units::pow::ParseWorkError::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for bitcoin_units::pow::ParseWorkError
-pub fn bitcoin_units::pow::ParseWorkError::from(t: T) -> T
+impl core::clone::Clone for bitcoin_units::pow::error::ParseWorkError
+pub fn bitcoin_units::pow::error::ParseWorkError::clone(&self) -> bitcoin_units::pow::error::ParseWorkError
+impl core::cmp::Eq for bitcoin_units::pow::error::ParseWorkError
+impl core::cmp::PartialEq for bitcoin_units::pow::error::ParseWorkError
+pub fn bitcoin_units::pow::error::ParseWorkError::eq(&self, other: &bitcoin_units::pow::error::ParseWorkError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::pow::error::ParseWorkError
+pub fn bitcoin_units::pow::error::ParseWorkError::from(never: core::convert::Infallible) -> Self
+impl core::fmt::Debug for bitcoin_units::pow::error::ParseWorkError
+pub fn bitcoin_units::pow::error::ParseWorkError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_units::pow::error::ParseWorkError
+pub fn bitcoin_units::pow::error::ParseWorkError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitcoin_units::pow::error::ParseWorkError
+impl core::marker::Freeze for bitcoin_units::pow::error::ParseWorkError
+impl core::marker::Send for bitcoin_units::pow::error::ParseWorkError
+impl core::marker::Sync for bitcoin_units::pow::error::ParseWorkError
+impl core::marker::Unpin for bitcoin_units::pow::error::ParseWorkError
+impl core::marker::UnsafeUnpin for bitcoin_units::pow::error::ParseWorkError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::pow::error::ParseWorkError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::pow::error::ParseWorkError
+impl<T, U> core::convert::Into<U> for bitcoin_units::pow::error::ParseWorkError where U: core::convert::From<T>
+pub fn bitcoin_units::pow::error::ParseWorkError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::pow::error::ParseWorkError where U: core::convert::Into<T>
+pub type bitcoin_units::pow::error::ParseWorkError::Error = core::convert::Infallible
+pub fn bitcoin_units::pow::error::ParseWorkError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::pow::error::ParseWorkError where U: core::convert::TryFrom<T>
+pub type bitcoin_units::pow::error::ParseWorkError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::pow::error::ParseWorkError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_units::pow::error::ParseWorkError where T: core::clone::Clone
+pub type bitcoin_units::pow::error::ParseWorkError::Owned = T
+pub fn bitcoin_units::pow::error::ParseWorkError::clone_into(&self, target: &mut T)
+pub fn bitcoin_units::pow::error::ParseWorkError::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin_units::pow::error::ParseWorkError where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseWorkError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin_units::pow::error::ParseWorkError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseWorkError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::pow::error::ParseWorkError where T: ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseWorkError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::pow::error::ParseWorkError where T: ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseWorkError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::pow::error::ParseWorkError where T: core::clone::Clone
+pub unsafe fn bitcoin_units::pow::error::ParseWorkError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::pow::error::ParseWorkError
+pub fn bitcoin_units::pow::error::ParseWorkError::from(t: T) -> T
 pub struct bitcoin_units::pow::Target(_)
 impl bitcoin_units::pow::Target
 pub const bitcoin_units::pow::Target::MAX: Self
@@ -5001,7 +5089,7 @@ pub fn bitcoin_units::pow::Target::hash<__H: core::hash::Hasher>(&self, state: &
 impl core::marker::Copy for bitcoin_units::pow::Target
 impl core::marker::StructuralPartialEq for bitcoin_units::pow::Target
 impl core::str::traits::FromStr for bitcoin_units::pow::Target
-pub type bitcoin_units::pow::Target::Err = bitcoin_units::pow::ParseTargetError
+pub type bitcoin_units::pow::Target::Err = bitcoin_units::pow::error::ParseTargetError
 pub fn bitcoin_units::pow::Target::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 impl core::marker::Freeze for bitcoin_units::pow::Target
 impl core::marker::Send for bitcoin_units::pow::Target
@@ -5072,7 +5160,7 @@ impl core::ops::arith::Sub for bitcoin_units::pow::Work
 pub type bitcoin_units::pow::Work::Output = bitcoin_units::pow::Work
 pub fn bitcoin_units::pow::Work::sub(self, rhs: Self) -> Self
 impl core::str::traits::FromStr for bitcoin_units::pow::Work
-pub type bitcoin_units::pow::Work::Err = bitcoin_units::pow::ParseWorkError
+pub type bitcoin_units::pow::Work::Err = bitcoin_units::pow::error::ParseWorkError
 pub fn bitcoin_units::pow::Work::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 impl core::marker::Freeze for bitcoin_units::pow::Work
 impl core::marker::Send for bitcoin_units::pow::Work
@@ -9086,7 +9174,7 @@ pub fn bitcoin_units::pow::Target::hash<__H: core::hash::Hasher>(&self, state: &
 impl core::marker::Copy for bitcoin_units::pow::Target
 impl core::marker::StructuralPartialEq for bitcoin_units::pow::Target
 impl core::str::traits::FromStr for bitcoin_units::pow::Target
-pub type bitcoin_units::pow::Target::Err = bitcoin_units::pow::ParseTargetError
+pub type bitcoin_units::pow::Target::Err = bitcoin_units::pow::error::ParseTargetError
 pub fn bitcoin_units::pow::Target::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 impl core::marker::Freeze for bitcoin_units::pow::Target
 impl core::marker::Send for bitcoin_units::pow::Target
@@ -9453,7 +9541,7 @@ impl core::ops::arith::Sub for bitcoin_units::pow::Work
 pub type bitcoin_units::pow::Work::Output = bitcoin_units::pow::Work
 pub fn bitcoin_units::pow::Work::sub(self, rhs: Self) -> Self
 impl core::str::traits::FromStr for bitcoin_units::pow::Work
-pub type bitcoin_units::pow::Work::Err = bitcoin_units::pow::ParseWorkError
+pub type bitcoin_units::pow::Work::Err = bitcoin_units::pow::error::ParseWorkError
 pub fn bitcoin_units::pow::Work::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 impl core::marker::Freeze for bitcoin_units::pow::Work
 impl core::marker::Send for bitcoin_units::pow::Work

--- a/units/api/no-features.txt
+++ b/units/api/no-features.txt
@@ -4254,6 +4254,82 @@ pub fn bitcoin_units::parse_int::hex_u64_unprefixed(s: &str) -> core::result::Re
 pub fn bitcoin_units::parse_int::int_from_str<T: bitcoin_units::parse_int::Integer>(s: &str) -> core::result::Result<T, bitcoin_units::parse_int::error::ParseIntError>
 pub mod bitcoin_units::pow
 pub mod bitcoin_units::pow::error
+pub struct bitcoin_units::pow::error::ParseTargetError(_)
+impl core::clone::Clone for bitcoin_units::pow::error::ParseTargetError
+pub fn bitcoin_units::pow::error::ParseTargetError::clone(&self) -> bitcoin_units::pow::error::ParseTargetError
+impl core::cmp::Eq for bitcoin_units::pow::error::ParseTargetError
+impl core::cmp::PartialEq for bitcoin_units::pow::error::ParseTargetError
+pub fn bitcoin_units::pow::error::ParseTargetError::eq(&self, other: &bitcoin_units::pow::error::ParseTargetError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::pow::error::ParseTargetError
+pub fn bitcoin_units::pow::error::ParseTargetError::from(never: core::convert::Infallible) -> Self
+impl core::fmt::Debug for bitcoin_units::pow::error::ParseTargetError
+pub fn bitcoin_units::pow::error::ParseTargetError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_units::pow::error::ParseTargetError
+pub fn bitcoin_units::pow::error::ParseTargetError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitcoin_units::pow::error::ParseTargetError
+impl core::marker::Freeze for bitcoin_units::pow::error::ParseTargetError
+impl core::marker::Send for bitcoin_units::pow::error::ParseTargetError
+impl core::marker::Sync for bitcoin_units::pow::error::ParseTargetError
+impl core::marker::Unpin for bitcoin_units::pow::error::ParseTargetError
+impl core::marker::UnsafeUnpin for bitcoin_units::pow::error::ParseTargetError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::pow::error::ParseTargetError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::pow::error::ParseTargetError
+impl<T, U> core::convert::Into<U> for bitcoin_units::pow::error::ParseTargetError where U: core::convert::From<T>
+pub fn bitcoin_units::pow::error::ParseTargetError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::pow::error::ParseTargetError where U: core::convert::Into<T>
+pub type bitcoin_units::pow::error::ParseTargetError::Error = core::convert::Infallible
+pub fn bitcoin_units::pow::error::ParseTargetError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::pow::error::ParseTargetError where U: core::convert::TryFrom<T>
+pub type bitcoin_units::pow::error::ParseTargetError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::pow::error::ParseTargetError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for bitcoin_units::pow::error::ParseTargetError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseTargetError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::pow::error::ParseTargetError where T: ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseTargetError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::pow::error::ParseTargetError where T: ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseTargetError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::pow::error::ParseTargetError where T: core::clone::Clone
+pub unsafe fn bitcoin_units::pow::error::ParseTargetError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::pow::error::ParseTargetError
+pub fn bitcoin_units::pow::error::ParseTargetError::from(t: T) -> T
+pub struct bitcoin_units::pow::error::ParseWorkError(_)
+impl core::clone::Clone for bitcoin_units::pow::error::ParseWorkError
+pub fn bitcoin_units::pow::error::ParseWorkError::clone(&self) -> bitcoin_units::pow::error::ParseWorkError
+impl core::cmp::Eq for bitcoin_units::pow::error::ParseWorkError
+impl core::cmp::PartialEq for bitcoin_units::pow::error::ParseWorkError
+pub fn bitcoin_units::pow::error::ParseWorkError::eq(&self, other: &bitcoin_units::pow::error::ParseWorkError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::pow::error::ParseWorkError
+pub fn bitcoin_units::pow::error::ParseWorkError::from(never: core::convert::Infallible) -> Self
+impl core::fmt::Debug for bitcoin_units::pow::error::ParseWorkError
+pub fn bitcoin_units::pow::error::ParseWorkError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_units::pow::error::ParseWorkError
+pub fn bitcoin_units::pow::error::ParseWorkError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitcoin_units::pow::error::ParseWorkError
+impl core::marker::Freeze for bitcoin_units::pow::error::ParseWorkError
+impl core::marker::Send for bitcoin_units::pow::error::ParseWorkError
+impl core::marker::Sync for bitcoin_units::pow::error::ParseWorkError
+impl core::marker::Unpin for bitcoin_units::pow::error::ParseWorkError
+impl core::marker::UnsafeUnpin for bitcoin_units::pow::error::ParseWorkError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::pow::error::ParseWorkError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::pow::error::ParseWorkError
+impl<T, U> core::convert::Into<U> for bitcoin_units::pow::error::ParseWorkError where U: core::convert::From<T>
+pub fn bitcoin_units::pow::error::ParseWorkError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::pow::error::ParseWorkError where U: core::convert::Into<T>
+pub type bitcoin_units::pow::error::ParseWorkError::Error = core::convert::Infallible
+pub fn bitcoin_units::pow::error::ParseWorkError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::pow::error::ParseWorkError where U: core::convert::TryFrom<T>
+pub type bitcoin_units::pow::error::ParseWorkError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::pow::error::ParseWorkError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for bitcoin_units::pow::error::ParseWorkError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseWorkError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::pow::error::ParseWorkError where T: ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseWorkError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::pow::error::ParseWorkError where T: ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseWorkError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::pow::error::ParseWorkError where T: core::clone::Clone
+pub unsafe fn bitcoin_units::pow::error::ParseWorkError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::pow::error::ParseWorkError
+pub fn bitcoin_units::pow::error::ParseWorkError::from(t: T) -> T
 pub struct bitcoin_units::pow::CompactTarget(_)
 impl bitcoin_units::pow::CompactTarget
 pub fn bitcoin_units::pow::CompactTarget::from_consensus(bits: u32) -> Self
@@ -4319,81 +4395,81 @@ pub unsafe fn bitcoin_units::pow::CompactTarget::clone_to_uninit(&self, dest: *m
 impl<T> core::convert::From<T> for bitcoin_units::pow::CompactTarget
 pub fn bitcoin_units::pow::CompactTarget::from(t: T) -> T
 pub struct bitcoin_units::pow::ParseTargetError(_)
-impl core::clone::Clone for bitcoin_units::pow::ParseTargetError
-pub fn bitcoin_units::pow::ParseTargetError::clone(&self) -> bitcoin_units::pow::ParseTargetError
-impl core::cmp::Eq for bitcoin_units::pow::ParseTargetError
-impl core::cmp::PartialEq for bitcoin_units::pow::ParseTargetError
-pub fn bitcoin_units::pow::ParseTargetError::eq(&self, other: &bitcoin_units::pow::ParseTargetError) -> bool
-impl core::convert::From<core::convert::Infallible> for bitcoin_units::pow::ParseTargetError
-pub fn bitcoin_units::pow::ParseTargetError::from(never: core::convert::Infallible) -> Self
-impl core::fmt::Debug for bitcoin_units::pow::ParseTargetError
-pub fn bitcoin_units::pow::ParseTargetError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::fmt::Display for bitcoin_units::pow::ParseTargetError
-pub fn bitcoin_units::pow::ParseTargetError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for bitcoin_units::pow::ParseTargetError
-impl core::marker::Freeze for bitcoin_units::pow::ParseTargetError
-impl core::marker::Send for bitcoin_units::pow::ParseTargetError
-impl core::marker::Sync for bitcoin_units::pow::ParseTargetError
-impl core::marker::Unpin for bitcoin_units::pow::ParseTargetError
-impl core::marker::UnsafeUnpin for bitcoin_units::pow::ParseTargetError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::pow::ParseTargetError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::pow::ParseTargetError
-impl<T, U> core::convert::Into<U> for bitcoin_units::pow::ParseTargetError where U: core::convert::From<T>
-pub fn bitcoin_units::pow::ParseTargetError::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for bitcoin_units::pow::ParseTargetError where U: core::convert::Into<T>
-pub type bitcoin_units::pow::ParseTargetError::Error = core::convert::Infallible
-pub fn bitcoin_units::pow::ParseTargetError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for bitcoin_units::pow::ParseTargetError where U: core::convert::TryFrom<T>
-pub type bitcoin_units::pow::ParseTargetError::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn bitcoin_units::pow::ParseTargetError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for bitcoin_units::pow::ParseTargetError where T: 'static + ?core::marker::Sized
-pub fn bitcoin_units::pow::ParseTargetError::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for bitcoin_units::pow::ParseTargetError where T: ?core::marker::Sized
-pub fn bitcoin_units::pow::ParseTargetError::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for bitcoin_units::pow::ParseTargetError where T: ?core::marker::Sized
-pub fn bitcoin_units::pow::ParseTargetError::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_units::pow::ParseTargetError where T: core::clone::Clone
-pub unsafe fn bitcoin_units::pow::ParseTargetError::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for bitcoin_units::pow::ParseTargetError
-pub fn bitcoin_units::pow::ParseTargetError::from(t: T) -> T
+impl core::clone::Clone for bitcoin_units::pow::error::ParseTargetError
+pub fn bitcoin_units::pow::error::ParseTargetError::clone(&self) -> bitcoin_units::pow::error::ParseTargetError
+impl core::cmp::Eq for bitcoin_units::pow::error::ParseTargetError
+impl core::cmp::PartialEq for bitcoin_units::pow::error::ParseTargetError
+pub fn bitcoin_units::pow::error::ParseTargetError::eq(&self, other: &bitcoin_units::pow::error::ParseTargetError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::pow::error::ParseTargetError
+pub fn bitcoin_units::pow::error::ParseTargetError::from(never: core::convert::Infallible) -> Self
+impl core::fmt::Debug for bitcoin_units::pow::error::ParseTargetError
+pub fn bitcoin_units::pow::error::ParseTargetError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_units::pow::error::ParseTargetError
+pub fn bitcoin_units::pow::error::ParseTargetError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitcoin_units::pow::error::ParseTargetError
+impl core::marker::Freeze for bitcoin_units::pow::error::ParseTargetError
+impl core::marker::Send for bitcoin_units::pow::error::ParseTargetError
+impl core::marker::Sync for bitcoin_units::pow::error::ParseTargetError
+impl core::marker::Unpin for bitcoin_units::pow::error::ParseTargetError
+impl core::marker::UnsafeUnpin for bitcoin_units::pow::error::ParseTargetError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::pow::error::ParseTargetError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::pow::error::ParseTargetError
+impl<T, U> core::convert::Into<U> for bitcoin_units::pow::error::ParseTargetError where U: core::convert::From<T>
+pub fn bitcoin_units::pow::error::ParseTargetError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::pow::error::ParseTargetError where U: core::convert::Into<T>
+pub type bitcoin_units::pow::error::ParseTargetError::Error = core::convert::Infallible
+pub fn bitcoin_units::pow::error::ParseTargetError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::pow::error::ParseTargetError where U: core::convert::TryFrom<T>
+pub type bitcoin_units::pow::error::ParseTargetError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::pow::error::ParseTargetError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for bitcoin_units::pow::error::ParseTargetError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseTargetError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::pow::error::ParseTargetError where T: ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseTargetError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::pow::error::ParseTargetError where T: ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseTargetError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::pow::error::ParseTargetError where T: core::clone::Clone
+pub unsafe fn bitcoin_units::pow::error::ParseTargetError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::pow::error::ParseTargetError
+pub fn bitcoin_units::pow::error::ParseTargetError::from(t: T) -> T
 pub struct bitcoin_units::pow::ParseWorkError(_)
-impl core::clone::Clone for bitcoin_units::pow::ParseWorkError
-pub fn bitcoin_units::pow::ParseWorkError::clone(&self) -> bitcoin_units::pow::ParseWorkError
-impl core::cmp::Eq for bitcoin_units::pow::ParseWorkError
-impl core::cmp::PartialEq for bitcoin_units::pow::ParseWorkError
-pub fn bitcoin_units::pow::ParseWorkError::eq(&self, other: &bitcoin_units::pow::ParseWorkError) -> bool
-impl core::convert::From<core::convert::Infallible> for bitcoin_units::pow::ParseWorkError
-pub fn bitcoin_units::pow::ParseWorkError::from(never: core::convert::Infallible) -> Self
-impl core::fmt::Debug for bitcoin_units::pow::ParseWorkError
-pub fn bitcoin_units::pow::ParseWorkError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::fmt::Display for bitcoin_units::pow::ParseWorkError
-pub fn bitcoin_units::pow::ParseWorkError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::StructuralPartialEq for bitcoin_units::pow::ParseWorkError
-impl core::marker::Freeze for bitcoin_units::pow::ParseWorkError
-impl core::marker::Send for bitcoin_units::pow::ParseWorkError
-impl core::marker::Sync for bitcoin_units::pow::ParseWorkError
-impl core::marker::Unpin for bitcoin_units::pow::ParseWorkError
-impl core::marker::UnsafeUnpin for bitcoin_units::pow::ParseWorkError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::pow::ParseWorkError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::pow::ParseWorkError
-impl<T, U> core::convert::Into<U> for bitcoin_units::pow::ParseWorkError where U: core::convert::From<T>
-pub fn bitcoin_units::pow::ParseWorkError::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for bitcoin_units::pow::ParseWorkError where U: core::convert::Into<T>
-pub type bitcoin_units::pow::ParseWorkError::Error = core::convert::Infallible
-pub fn bitcoin_units::pow::ParseWorkError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for bitcoin_units::pow::ParseWorkError where U: core::convert::TryFrom<T>
-pub type bitcoin_units::pow::ParseWorkError::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn bitcoin_units::pow::ParseWorkError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for bitcoin_units::pow::ParseWorkError where T: 'static + ?core::marker::Sized
-pub fn bitcoin_units::pow::ParseWorkError::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for bitcoin_units::pow::ParseWorkError where T: ?core::marker::Sized
-pub fn bitcoin_units::pow::ParseWorkError::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for bitcoin_units::pow::ParseWorkError where T: ?core::marker::Sized
-pub fn bitcoin_units::pow::ParseWorkError::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_units::pow::ParseWorkError where T: core::clone::Clone
-pub unsafe fn bitcoin_units::pow::ParseWorkError::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for bitcoin_units::pow::ParseWorkError
-pub fn bitcoin_units::pow::ParseWorkError::from(t: T) -> T
+impl core::clone::Clone for bitcoin_units::pow::error::ParseWorkError
+pub fn bitcoin_units::pow::error::ParseWorkError::clone(&self) -> bitcoin_units::pow::error::ParseWorkError
+impl core::cmp::Eq for bitcoin_units::pow::error::ParseWorkError
+impl core::cmp::PartialEq for bitcoin_units::pow::error::ParseWorkError
+pub fn bitcoin_units::pow::error::ParseWorkError::eq(&self, other: &bitcoin_units::pow::error::ParseWorkError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::pow::error::ParseWorkError
+pub fn bitcoin_units::pow::error::ParseWorkError::from(never: core::convert::Infallible) -> Self
+impl core::fmt::Debug for bitcoin_units::pow::error::ParseWorkError
+pub fn bitcoin_units::pow::error::ParseWorkError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_units::pow::error::ParseWorkError
+pub fn bitcoin_units::pow::error::ParseWorkError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitcoin_units::pow::error::ParseWorkError
+impl core::marker::Freeze for bitcoin_units::pow::error::ParseWorkError
+impl core::marker::Send for bitcoin_units::pow::error::ParseWorkError
+impl core::marker::Sync for bitcoin_units::pow::error::ParseWorkError
+impl core::marker::Unpin for bitcoin_units::pow::error::ParseWorkError
+impl core::marker::UnsafeUnpin for bitcoin_units::pow::error::ParseWorkError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::pow::error::ParseWorkError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::pow::error::ParseWorkError
+impl<T, U> core::convert::Into<U> for bitcoin_units::pow::error::ParseWorkError where U: core::convert::From<T>
+pub fn bitcoin_units::pow::error::ParseWorkError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::pow::error::ParseWorkError where U: core::convert::Into<T>
+pub type bitcoin_units::pow::error::ParseWorkError::Error = core::convert::Infallible
+pub fn bitcoin_units::pow::error::ParseWorkError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::pow::error::ParseWorkError where U: core::convert::TryFrom<T>
+pub type bitcoin_units::pow::error::ParseWorkError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::pow::error::ParseWorkError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for bitcoin_units::pow::error::ParseWorkError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseWorkError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::pow::error::ParseWorkError where T: ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseWorkError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::pow::error::ParseWorkError where T: ?core::marker::Sized
+pub fn bitcoin_units::pow::error::ParseWorkError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::pow::error::ParseWorkError where T: core::clone::Clone
+pub unsafe fn bitcoin_units::pow::error::ParseWorkError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::pow::error::ParseWorkError
+pub fn bitcoin_units::pow::error::ParseWorkError::from(t: T) -> T
 pub struct bitcoin_units::pow::Target(_)
 impl bitcoin_units::pow::Target
 pub const bitcoin_units::pow::Target::MAX: Self
@@ -4436,7 +4512,7 @@ pub fn bitcoin_units::pow::Target::hash<__H: core::hash::Hasher>(&self, state: &
 impl core::marker::Copy for bitcoin_units::pow::Target
 impl core::marker::StructuralPartialEq for bitcoin_units::pow::Target
 impl core::str::traits::FromStr for bitcoin_units::pow::Target
-pub type bitcoin_units::pow::Target::Err = bitcoin_units::pow::ParseTargetError
+pub type bitcoin_units::pow::Target::Err = bitcoin_units::pow::error::ParseTargetError
 pub fn bitcoin_units::pow::Target::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 impl core::marker::Freeze for bitcoin_units::pow::Target
 impl core::marker::Send for bitcoin_units::pow::Target
@@ -4501,7 +4577,7 @@ impl core::ops::arith::Sub for bitcoin_units::pow::Work
 pub type bitcoin_units::pow::Work::Output = bitcoin_units::pow::Work
 pub fn bitcoin_units::pow::Work::sub(self, rhs: Self) -> Self
 impl core::str::traits::FromStr for bitcoin_units::pow::Work
-pub type bitcoin_units::pow::Work::Err = bitcoin_units::pow::ParseWorkError
+pub type bitcoin_units::pow::Work::Err = bitcoin_units::pow::error::ParseWorkError
 pub fn bitcoin_units::pow::Work::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 impl core::marker::Freeze for bitcoin_units::pow::Work
 impl core::marker::Send for bitcoin_units::pow::Work
@@ -8218,7 +8294,7 @@ pub fn bitcoin_units::pow::Target::hash<__H: core::hash::Hasher>(&self, state: &
 impl core::marker::Copy for bitcoin_units::pow::Target
 impl core::marker::StructuralPartialEq for bitcoin_units::pow::Target
 impl core::str::traits::FromStr for bitcoin_units::pow::Target
-pub type bitcoin_units::pow::Target::Err = bitcoin_units::pow::ParseTargetError
+pub type bitcoin_units::pow::Target::Err = bitcoin_units::pow::error::ParseTargetError
 pub fn bitcoin_units::pow::Target::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 impl core::marker::Freeze for bitcoin_units::pow::Target
 impl core::marker::Send for bitcoin_units::pow::Target
@@ -8567,7 +8643,7 @@ impl core::ops::arith::Sub for bitcoin_units::pow::Work
 pub type bitcoin_units::pow::Work::Output = bitcoin_units::pow::Work
 pub fn bitcoin_units::pow::Work::sub(self, rhs: Self) -> Self
 impl core::str::traits::FromStr for bitcoin_units::pow::Work
-pub type bitcoin_units::pow::Work::Err = bitcoin_units::pow::ParseWorkError
+pub type bitcoin_units::pow::Work::Err = bitcoin_units::pow::error::ParseWorkError
 pub fn bitcoin_units::pow::Work::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 impl core::marker::Freeze for bitcoin_units::pow::Work
 impl core::marker::Send for bitcoin_units::pow::Work

--- a/units/src/pow.rs
+++ b/units/src/pow.rs
@@ -12,6 +12,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::parse_int::{self, ParseIntError, PrefixedHexError, UnprefixedHexError};
 
+#[rustfmt::skip]                // Keep public re-exports separate.
+#[cfg(feature = "encoding")]
+#[doc(no_inline)]
+pub use self::error::CompactTargetDecoderError;
+
 /// Implement traits and methods shared by `Target` and `Work`.
 macro_rules! do_impl {
     ($ty:ident, $err_ty:ident) => {
@@ -247,11 +252,6 @@ impl Target {
     pub fn to_work(self) -> Work { Work(self.0.inverse()) }
 }
 do_impl!(Target, ParseTargetError);
-
-#[rustfmt::skip]                // Keep public re-exports separate.
-#[cfg(feature = "encoding")]
-#[doc(no_inline)]
-pub use self::error::CompactTargetDecoderError;
 
 /// Encoding of 256-bit target as 32-bit float.
 ///

--- a/units/src/pow.rs
+++ b/units/src/pow.rs
@@ -16,6 +16,8 @@ use crate::parse_int::{self, ParseIntError, PrefixedHexError, UnprefixedHexError
 #[cfg(feature = "encoding")]
 #[doc(no_inline)]
 pub use self::error::CompactTargetDecoderError;
+#[doc(no_inline)]
+pub use self::error::{ParseTargetError, ParseWorkError};
 
 /// Implement traits and methods shared by `Target` and `Work`.
 macro_rules! do_impl {
@@ -98,25 +100,6 @@ macro_rules! do_impl {
             fn from_str(s: &str) -> Result<Self, Self::Err> {
                 U256::from_str(s).map($ty).map_err($err_ty)
             }
-        }
-
-        #[doc = "Error returned when parsing a [`"]
-        #[doc = stringify!($ty)]
-        #[doc = "`] from a string."]
-        #[derive(Debug, Clone, PartialEq, Eq)]
-        pub struct $err_ty(ParseU256Error);
-
-        impl From<core::convert::Infallible> for $err_ty {
-            fn from(never: core::convert::Infallible) -> Self { match never {} }
-        }
-
-        impl fmt::Display for $err_ty {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { self.0.fmt(f) }
-        }
-
-        #[cfg(feature = "std")]
-        impl std::error::Error for $err_ty {
-            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
         }
     };
 }
@@ -373,13 +356,12 @@ impl encoding::Decodable for CompactTarget {
 
 /// Error types for proof-of-work related integer types.
 pub mod error {
-    #[cfg(feature = "encoding")]
     use core::convert::Infallible;
-    #[cfg(feature = "encoding")]
     use core::fmt;
 
-    #[cfg(feature = "encoding")]
     use internals::write_err;
+
+    use super::ParseU256Error;
 
     /// An error consensus decoding an `CompactTarget`.
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -401,6 +383,52 @@ pub mod error {
     #[cfg(feature = "std")]
     #[cfg(feature = "encoding")]
     impl std::error::Error for CompactTargetDecoderError {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
+    }
+
+    /// Error returned when parsing a [`Work`] from a string.
+    ///
+    /// [`Work`]: super::Work
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct ParseWorkError(pub(super) ParseU256Error);
+
+    impl From<Infallible> for ParseWorkError {
+        fn from(never: Infallible) -> Self { match never {} }
+    }
+
+    impl fmt::Display for ParseWorkError {
+        #[inline]
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write_err!(f, "work parse error"; self.0)
+        }
+    }
+
+    #[cfg(feature = "std")]
+    impl std::error::Error for ParseWorkError {
+        #[inline]
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
+    }
+
+    /// Error returned when parsing a [`Target`] from a string.
+    ///
+    /// [`Target`]: super::Target
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct ParseTargetError(pub(super) ParseU256Error);
+
+    impl From<Infallible> for ParseTargetError {
+        fn from(never: Infallible) -> Self { match never {} }
+    }
+
+    impl fmt::Display for ParseTargetError {
+        #[inline]
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write_err!(f, "target parse error"; self.0)
+        }
+    }
+
+    #[cfg(feature = "std")]
+    impl std::error::Error for ParseTargetError {
+        #[inline]
         fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
     }
 }


### PR DESCRIPTION
As part of the move for pow types into units, the error type definitions were left in the top level of the pow module. Following
existing patterns, they should be defined in the error submodule and re-exported with #[doc(no_inline)] from the module.

- Patch 1 moves the error re-export to the correct position in the file.
- Patch 2 moves ParseWorkError and ParseTargetError to the error submodule and re-exports.
- Patch 3 updates the API files.

Contributes to #3824 