### PR TITLE
units: Encapsulate locktime errors

### DIFF
--- a/units/api/all-features.txt
+++ b/units/api/all-features.txt
@@ -4597,7 +4597,7 @@ pub unsafe fn bitcoin_units::locktime::relative::error::IsSatisfiedByError::clon
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IsSatisfiedByError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByError::from(t: T) -> T
 pub enum bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
-pub bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError::Incompatible(bitcoin_units::locktime::relative::NumberOf512Seconds)
+pub bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError::Incompatible(bitcoin_units::locktime::relative::error::IncompatibleHeightError)
 pub bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError::Satisfaction(bitcoin_units::locktime::relative::error::InvalidHeightError)
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError::clone(&self) -> bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
@@ -4645,7 +4645,7 @@ pub unsafe fn bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError::from(t: T) -> T
 pub enum bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
-pub bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError::Incompatible(bitcoin_units::locktime::relative::NumberOfBlocks)
+pub bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError::Incompatible(bitcoin_units::locktime::relative::error::IncompatibleTimeError)
 pub bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError::Satisfaction(bitcoin_units::locktime::relative::error::InvalidTimeError)
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError::clone(&self) -> bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
@@ -4740,6 +4740,98 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::error:
 pub unsafe fn bitcoin_units::locktime::relative::error::DisabledLockTimeError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::DisabledLockTimeError
 pub fn bitcoin_units::locktime::relative::error::DisabledLockTimeError::from(t: T) -> T
+pub struct bitcoin_units::locktime::relative::error::IncompatibleHeightError(_)
+impl core::clone::Clone for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::clone(&self) -> bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::cmp::Eq for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::eq(&self, other: &bitcoin_units::locktime::relative::error::IncompatibleHeightError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::from(never: core::convert::Infallible) -> Self
+impl core::error::Error for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl core::fmt::Debug for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Freeze for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Send for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Sync for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Unpin for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::UnsafeUnpin for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl<T, U> core::convert::Into<U> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where U: core::convert::From<T>
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where U: core::convert::Into<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleHeightError::Error = core::convert::Infallible
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where U: core::convert::TryFrom<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleHeightError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: core::clone::Clone
+pub type bitcoin_units::locktime::relative::error::IncompatibleHeightError::Owned = T
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::clone_into(&self, target: &mut T)
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: core::clone::Clone
+pub unsafe fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::from(t: T) -> T
+pub struct bitcoin_units::locktime::relative::error::IncompatibleTimeError(_)
+impl core::clone::Clone for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::clone(&self) -> bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::cmp::Eq for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::eq(&self, other: &bitcoin_units::locktime::relative::error::IncompatibleTimeError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::from(never: core::convert::Infallible) -> Self
+impl core::error::Error for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl core::fmt::Debug for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Freeze for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Send for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Sync for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Unpin for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::UnsafeUnpin for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl<T, U> core::convert::Into<U> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where U: core::convert::From<T>
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where U: core::convert::Into<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleTimeError::Error = core::convert::Infallible
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where U: core::convert::TryFrom<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleTimeError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: core::clone::Clone
+pub type bitcoin_units::locktime::relative::error::IncompatibleTimeError::Owned = T
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::clone_into(&self, target: &mut T)
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: core::clone::Clone
+pub unsafe fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::from(t: T) -> T
 pub struct bitcoin_units::locktime::relative::error::InvalidHeightError
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::InvalidHeightError
 pub fn bitcoin_units::locktime::relative::error::InvalidHeightError::clone(&self) -> bitcoin_units::locktime::relative::error::InvalidHeightError
@@ -4927,7 +5019,7 @@ pub unsafe fn bitcoin_units::locktime::relative::error::IsSatisfiedByError::clon
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IsSatisfiedByError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByError::from(t: T) -> T
 pub enum bitcoin_units::locktime::relative::IsSatisfiedByHeightError
-pub bitcoin_units::locktime::relative::IsSatisfiedByHeightError::Incompatible(bitcoin_units::locktime::relative::NumberOf512Seconds)
+pub bitcoin_units::locktime::relative::IsSatisfiedByHeightError::Incompatible(bitcoin_units::locktime::relative::error::IncompatibleHeightError)
 pub bitcoin_units::locktime::relative::IsSatisfiedByHeightError::Satisfaction(bitcoin_units::locktime::relative::error::InvalidHeightError)
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError::clone(&self) -> bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
@@ -4975,7 +5067,7 @@ pub unsafe fn bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError::from(t: T) -> T
 pub enum bitcoin_units::locktime::relative::IsSatisfiedByTimeError
-pub bitcoin_units::locktime::relative::IsSatisfiedByTimeError::Incompatible(bitcoin_units::locktime::relative::NumberOfBlocks)
+pub bitcoin_units::locktime::relative::IsSatisfiedByTimeError::Incompatible(bitcoin_units::locktime::relative::error::IncompatibleTimeError)
 pub bitcoin_units::locktime::relative::IsSatisfiedByTimeError::Satisfaction(bitcoin_units::locktime::relative::error::InvalidTimeError)
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError::clone(&self) -> bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
@@ -5152,6 +5244,98 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::error:
 pub unsafe fn bitcoin_units::locktime::relative::error::DisabledLockTimeError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::DisabledLockTimeError
 pub fn bitcoin_units::locktime::relative::error::DisabledLockTimeError::from(t: T) -> T
+pub struct bitcoin_units::locktime::relative::IncompatibleHeightError(_)
+impl core::clone::Clone for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::clone(&self) -> bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::cmp::Eq for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::eq(&self, other: &bitcoin_units::locktime::relative::error::IncompatibleHeightError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::from(never: core::convert::Infallible) -> Self
+impl core::error::Error for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl core::fmt::Debug for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Freeze for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Send for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Sync for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Unpin for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::UnsafeUnpin for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl<T, U> core::convert::Into<U> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where U: core::convert::From<T>
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where U: core::convert::Into<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleHeightError::Error = core::convert::Infallible
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where U: core::convert::TryFrom<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleHeightError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: core::clone::Clone
+pub type bitcoin_units::locktime::relative::error::IncompatibleHeightError::Owned = T
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::clone_into(&self, target: &mut T)
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: core::clone::Clone
+pub unsafe fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::from(t: T) -> T
+pub struct bitcoin_units::locktime::relative::IncompatibleTimeError(_)
+impl core::clone::Clone for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::clone(&self) -> bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::cmp::Eq for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::eq(&self, other: &bitcoin_units::locktime::relative::error::IncompatibleTimeError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::from(never: core::convert::Infallible) -> Self
+impl core::error::Error for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl core::fmt::Debug for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Freeze for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Send for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Sync for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Unpin for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::UnsafeUnpin for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl<T, U> core::convert::Into<U> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where U: core::convert::From<T>
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where U: core::convert::Into<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleTimeError::Error = core::convert::Infallible
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where U: core::convert::TryFrom<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleTimeError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: core::clone::Clone
+pub type bitcoin_units::locktime::relative::error::IncompatibleTimeError::Owned = T
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::clone_into(&self, target: &mut T)
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: core::clone::Clone
+pub unsafe fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::from(t: T) -> T
 pub struct bitcoin_units::locktime::relative::InvalidHeightError
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::InvalidHeightError
 pub fn bitcoin_units::locktime::relative::error::InvalidHeightError::clone(&self) -> bitcoin_units::locktime::relative::error::InvalidHeightError
@@ -6372,7 +6556,7 @@ pub unsafe fn bitcoin_units::locktime::relative::error::IsSatisfiedByError::clon
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IsSatisfiedByError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByError::from(t: T) -> T
 pub enum bitcoin_units::relative::error::IsSatisfiedByHeightError
-pub bitcoin_units::relative::error::IsSatisfiedByHeightError::Incompatible(bitcoin_units::locktime::relative::NumberOf512Seconds)
+pub bitcoin_units::relative::error::IsSatisfiedByHeightError::Incompatible(bitcoin_units::locktime::relative::error::IncompatibleHeightError)
 pub bitcoin_units::relative::error::IsSatisfiedByHeightError::Satisfaction(bitcoin_units::locktime::relative::error::InvalidHeightError)
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError::clone(&self) -> bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
@@ -6420,7 +6604,7 @@ pub unsafe fn bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError::from(t: T) -> T
 pub enum bitcoin_units::relative::error::IsSatisfiedByTimeError
-pub bitcoin_units::relative::error::IsSatisfiedByTimeError::Incompatible(bitcoin_units::locktime::relative::NumberOfBlocks)
+pub bitcoin_units::relative::error::IsSatisfiedByTimeError::Incompatible(bitcoin_units::locktime::relative::error::IncompatibleTimeError)
 pub bitcoin_units::relative::error::IsSatisfiedByTimeError::Satisfaction(bitcoin_units::locktime::relative::error::InvalidTimeError)
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError::clone(&self) -> bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
@@ -6515,6 +6699,98 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::error:
 pub unsafe fn bitcoin_units::locktime::relative::error::DisabledLockTimeError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::DisabledLockTimeError
 pub fn bitcoin_units::locktime::relative::error::DisabledLockTimeError::from(t: T) -> T
+pub struct bitcoin_units::relative::error::IncompatibleHeightError(_)
+impl core::clone::Clone for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::clone(&self) -> bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::cmp::Eq for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::eq(&self, other: &bitcoin_units::locktime::relative::error::IncompatibleHeightError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::from(never: core::convert::Infallible) -> Self
+impl core::error::Error for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl core::fmt::Debug for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Freeze for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Send for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Sync for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Unpin for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::UnsafeUnpin for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl<T, U> core::convert::Into<U> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where U: core::convert::From<T>
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where U: core::convert::Into<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleHeightError::Error = core::convert::Infallible
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where U: core::convert::TryFrom<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleHeightError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: core::clone::Clone
+pub type bitcoin_units::locktime::relative::error::IncompatibleHeightError::Owned = T
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::clone_into(&self, target: &mut T)
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: core::clone::Clone
+pub unsafe fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::from(t: T) -> T
+pub struct bitcoin_units::relative::error::IncompatibleTimeError(_)
+impl core::clone::Clone for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::clone(&self) -> bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::cmp::Eq for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::eq(&self, other: &bitcoin_units::locktime::relative::error::IncompatibleTimeError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::from(never: core::convert::Infallible) -> Self
+impl core::error::Error for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl core::fmt::Debug for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Freeze for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Send for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Sync for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Unpin for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::UnsafeUnpin for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl<T, U> core::convert::Into<U> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where U: core::convert::From<T>
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where U: core::convert::Into<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleTimeError::Error = core::convert::Infallible
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where U: core::convert::TryFrom<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleTimeError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: core::clone::Clone
+pub type bitcoin_units::locktime::relative::error::IncompatibleTimeError::Owned = T
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::clone_into(&self, target: &mut T)
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: core::clone::Clone
+pub unsafe fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::from(t: T) -> T
 pub struct bitcoin_units::relative::error::InvalidHeightError
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::InvalidHeightError
 pub fn bitcoin_units::locktime::relative::error::InvalidHeightError::clone(&self) -> bitcoin_units::locktime::relative::error::InvalidHeightError
@@ -6702,7 +6978,7 @@ pub unsafe fn bitcoin_units::locktime::relative::error::IsSatisfiedByError::clon
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IsSatisfiedByError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByError::from(t: T) -> T
 pub enum bitcoin_units::relative::IsSatisfiedByHeightError
-pub bitcoin_units::relative::IsSatisfiedByHeightError::Incompatible(bitcoin_units::locktime::relative::NumberOf512Seconds)
+pub bitcoin_units::relative::IsSatisfiedByHeightError::Incompatible(bitcoin_units::locktime::relative::error::IncompatibleHeightError)
 pub bitcoin_units::relative::IsSatisfiedByHeightError::Satisfaction(bitcoin_units::locktime::relative::error::InvalidHeightError)
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError::clone(&self) -> bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
@@ -6750,7 +7026,7 @@ pub unsafe fn bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError::from(t: T) -> T
 pub enum bitcoin_units::relative::IsSatisfiedByTimeError
-pub bitcoin_units::relative::IsSatisfiedByTimeError::Incompatible(bitcoin_units::locktime::relative::NumberOfBlocks)
+pub bitcoin_units::relative::IsSatisfiedByTimeError::Incompatible(bitcoin_units::locktime::relative::error::IncompatibleTimeError)
 pub bitcoin_units::relative::IsSatisfiedByTimeError::Satisfaction(bitcoin_units::locktime::relative::error::InvalidTimeError)
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError::clone(&self) -> bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
@@ -6927,6 +7203,98 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::error:
 pub unsafe fn bitcoin_units::locktime::relative::error::DisabledLockTimeError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::DisabledLockTimeError
 pub fn bitcoin_units::locktime::relative::error::DisabledLockTimeError::from(t: T) -> T
+pub struct bitcoin_units::relative::IncompatibleHeightError(_)
+impl core::clone::Clone for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::clone(&self) -> bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::cmp::Eq for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::eq(&self, other: &bitcoin_units::locktime::relative::error::IncompatibleHeightError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::from(never: core::convert::Infallible) -> Self
+impl core::error::Error for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl core::fmt::Debug for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Freeze for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Send for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Sync for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Unpin for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::UnsafeUnpin for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl<T, U> core::convert::Into<U> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where U: core::convert::From<T>
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where U: core::convert::Into<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleHeightError::Error = core::convert::Infallible
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where U: core::convert::TryFrom<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleHeightError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: core::clone::Clone
+pub type bitcoin_units::locktime::relative::error::IncompatibleHeightError::Owned = T
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::clone_into(&self, target: &mut T)
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: core::clone::Clone
+pub unsafe fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::from(t: T) -> T
+pub struct bitcoin_units::relative::IncompatibleTimeError(_)
+impl core::clone::Clone for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::clone(&self) -> bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::cmp::Eq for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::eq(&self, other: &bitcoin_units::locktime::relative::error::IncompatibleTimeError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::from(never: core::convert::Infallible) -> Self
+impl core::error::Error for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl core::fmt::Debug for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Freeze for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Send for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Sync for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Unpin for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::UnsafeUnpin for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl<T, U> core::convert::Into<U> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where U: core::convert::From<T>
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where U: core::convert::Into<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleTimeError::Error = core::convert::Infallible
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where U: core::convert::TryFrom<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleTimeError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: core::clone::Clone
+pub type bitcoin_units::locktime::relative::error::IncompatibleTimeError::Owned = T
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::clone_into(&self, target: &mut T)
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: core::clone::Clone
+pub unsafe fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::from(t: T) -> T
 pub struct bitcoin_units::relative::InvalidHeightError
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::InvalidHeightError
 pub fn bitcoin_units::locktime::relative::error::InvalidHeightError::clone(&self) -> bitcoin_units::locktime::relative::error::InvalidHeightError

--- a/units/api/alloc-only.txt
+++ b/units/api/alloc-only.txt
@@ -3632,7 +3632,7 @@ pub unsafe fn bitcoin_units::locktime::relative::error::IsSatisfiedByError::clon
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IsSatisfiedByError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByError::from(t: T) -> T
 pub enum bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
-pub bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError::Incompatible(bitcoin_units::locktime::relative::NumberOf512Seconds)
+pub bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError::Incompatible(bitcoin_units::locktime::relative::error::IncompatibleHeightError)
 pub bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError::Satisfaction(bitcoin_units::locktime::relative::error::InvalidHeightError)
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError::clone(&self) -> bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
@@ -3678,7 +3678,7 @@ pub unsafe fn bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError::from(t: T) -> T
 pub enum bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
-pub bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError::Incompatible(bitcoin_units::locktime::relative::NumberOfBlocks)
+pub bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError::Incompatible(bitcoin_units::locktime::relative::error::IncompatibleTimeError)
 pub bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError::Satisfaction(bitcoin_units::locktime::relative::error::InvalidTimeError)
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError::clone(&self) -> bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
@@ -3769,6 +3769,94 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::error:
 pub unsafe fn bitcoin_units::locktime::relative::error::DisabledLockTimeError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::DisabledLockTimeError
 pub fn bitcoin_units::locktime::relative::error::DisabledLockTimeError::from(t: T) -> T
+pub struct bitcoin_units::locktime::relative::error::IncompatibleHeightError(_)
+impl core::clone::Clone for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::clone(&self) -> bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::cmp::Eq for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::eq(&self, other: &bitcoin_units::locktime::relative::error::IncompatibleHeightError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::from(never: core::convert::Infallible) -> Self
+impl core::fmt::Debug for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Freeze for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Send for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Sync for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Unpin for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::UnsafeUnpin for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl<T, U> core::convert::Into<U> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where U: core::convert::From<T>
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where U: core::convert::Into<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleHeightError::Error = core::convert::Infallible
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where U: core::convert::TryFrom<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleHeightError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: core::clone::Clone
+pub type bitcoin_units::locktime::relative::error::IncompatibleHeightError::Owned = T
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::clone_into(&self, target: &mut T)
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: core::clone::Clone
+pub unsafe fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::from(t: T) -> T
+pub struct bitcoin_units::locktime::relative::error::IncompatibleTimeError(_)
+impl core::clone::Clone for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::clone(&self) -> bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::cmp::Eq for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::eq(&self, other: &bitcoin_units::locktime::relative::error::IncompatibleTimeError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::from(never: core::convert::Infallible) -> Self
+impl core::fmt::Debug for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Freeze for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Send for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Sync for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Unpin for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::UnsafeUnpin for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl<T, U> core::convert::Into<U> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where U: core::convert::From<T>
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where U: core::convert::Into<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleTimeError::Error = core::convert::Infallible
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where U: core::convert::TryFrom<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleTimeError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: core::clone::Clone
+pub type bitcoin_units::locktime::relative::error::IncompatibleTimeError::Owned = T
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::clone_into(&self, target: &mut T)
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: core::clone::Clone
+pub unsafe fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::from(t: T) -> T
 pub struct bitcoin_units::locktime::relative::error::InvalidHeightError
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::InvalidHeightError
 pub fn bitcoin_units::locktime::relative::error::InvalidHeightError::clone(&self) -> bitcoin_units::locktime::relative::error::InvalidHeightError
@@ -3948,7 +4036,7 @@ pub unsafe fn bitcoin_units::locktime::relative::error::IsSatisfiedByError::clon
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IsSatisfiedByError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByError::from(t: T) -> T
 pub enum bitcoin_units::locktime::relative::IsSatisfiedByHeightError
-pub bitcoin_units::locktime::relative::IsSatisfiedByHeightError::Incompatible(bitcoin_units::locktime::relative::NumberOf512Seconds)
+pub bitcoin_units::locktime::relative::IsSatisfiedByHeightError::Incompatible(bitcoin_units::locktime::relative::error::IncompatibleHeightError)
 pub bitcoin_units::locktime::relative::IsSatisfiedByHeightError::Satisfaction(bitcoin_units::locktime::relative::error::InvalidHeightError)
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError::clone(&self) -> bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
@@ -3994,7 +4082,7 @@ pub unsafe fn bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError::from(t: T) -> T
 pub enum bitcoin_units::locktime::relative::IsSatisfiedByTimeError
-pub bitcoin_units::locktime::relative::IsSatisfiedByTimeError::Incompatible(bitcoin_units::locktime::relative::NumberOfBlocks)
+pub bitcoin_units::locktime::relative::IsSatisfiedByTimeError::Incompatible(bitcoin_units::locktime::relative::error::IncompatibleTimeError)
 pub bitcoin_units::locktime::relative::IsSatisfiedByTimeError::Satisfaction(bitcoin_units::locktime::relative::error::InvalidTimeError)
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError::clone(&self) -> bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
@@ -4160,6 +4248,94 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::error:
 pub unsafe fn bitcoin_units::locktime::relative::error::DisabledLockTimeError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::DisabledLockTimeError
 pub fn bitcoin_units::locktime::relative::error::DisabledLockTimeError::from(t: T) -> T
+pub struct bitcoin_units::locktime::relative::IncompatibleHeightError(_)
+impl core::clone::Clone for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::clone(&self) -> bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::cmp::Eq for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::eq(&self, other: &bitcoin_units::locktime::relative::error::IncompatibleHeightError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::from(never: core::convert::Infallible) -> Self
+impl core::fmt::Debug for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Freeze for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Send for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Sync for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Unpin for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::UnsafeUnpin for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl<T, U> core::convert::Into<U> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where U: core::convert::From<T>
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where U: core::convert::Into<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleHeightError::Error = core::convert::Infallible
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where U: core::convert::TryFrom<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleHeightError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: core::clone::Clone
+pub type bitcoin_units::locktime::relative::error::IncompatibleHeightError::Owned = T
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::clone_into(&self, target: &mut T)
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: core::clone::Clone
+pub unsafe fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::from(t: T) -> T
+pub struct bitcoin_units::locktime::relative::IncompatibleTimeError(_)
+impl core::clone::Clone for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::clone(&self) -> bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::cmp::Eq for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::eq(&self, other: &bitcoin_units::locktime::relative::error::IncompatibleTimeError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::from(never: core::convert::Infallible) -> Self
+impl core::fmt::Debug for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Freeze for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Send for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Sync for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Unpin for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::UnsafeUnpin for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl<T, U> core::convert::Into<U> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where U: core::convert::From<T>
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where U: core::convert::Into<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleTimeError::Error = core::convert::Infallible
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where U: core::convert::TryFrom<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleTimeError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: core::clone::Clone
+pub type bitcoin_units::locktime::relative::error::IncompatibleTimeError::Owned = T
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::clone_into(&self, target: &mut T)
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: core::clone::Clone
+pub unsafe fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::from(t: T) -> T
 pub struct bitcoin_units::locktime::relative::InvalidHeightError
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::InvalidHeightError
 pub fn bitcoin_units::locktime::relative::error::InvalidHeightError::clone(&self) -> bitcoin_units::locktime::relative::error::InvalidHeightError
@@ -5154,7 +5330,7 @@ pub unsafe fn bitcoin_units::locktime::relative::error::IsSatisfiedByError::clon
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IsSatisfiedByError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByError::from(t: T) -> T
 pub enum bitcoin_units::relative::error::IsSatisfiedByHeightError
-pub bitcoin_units::relative::error::IsSatisfiedByHeightError::Incompatible(bitcoin_units::locktime::relative::NumberOf512Seconds)
+pub bitcoin_units::relative::error::IsSatisfiedByHeightError::Incompatible(bitcoin_units::locktime::relative::error::IncompatibleHeightError)
 pub bitcoin_units::relative::error::IsSatisfiedByHeightError::Satisfaction(bitcoin_units::locktime::relative::error::InvalidHeightError)
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError::clone(&self) -> bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
@@ -5200,7 +5376,7 @@ pub unsafe fn bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError::from(t: T) -> T
 pub enum bitcoin_units::relative::error::IsSatisfiedByTimeError
-pub bitcoin_units::relative::error::IsSatisfiedByTimeError::Incompatible(bitcoin_units::locktime::relative::NumberOfBlocks)
+pub bitcoin_units::relative::error::IsSatisfiedByTimeError::Incompatible(bitcoin_units::locktime::relative::error::IncompatibleTimeError)
 pub bitcoin_units::relative::error::IsSatisfiedByTimeError::Satisfaction(bitcoin_units::locktime::relative::error::InvalidTimeError)
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError::clone(&self) -> bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
@@ -5291,6 +5467,94 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::error:
 pub unsafe fn bitcoin_units::locktime::relative::error::DisabledLockTimeError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::DisabledLockTimeError
 pub fn bitcoin_units::locktime::relative::error::DisabledLockTimeError::from(t: T) -> T
+pub struct bitcoin_units::relative::error::IncompatibleHeightError(_)
+impl core::clone::Clone for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::clone(&self) -> bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::cmp::Eq for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::eq(&self, other: &bitcoin_units::locktime::relative::error::IncompatibleHeightError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::from(never: core::convert::Infallible) -> Self
+impl core::fmt::Debug for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Freeze for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Send for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Sync for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Unpin for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::UnsafeUnpin for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl<T, U> core::convert::Into<U> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where U: core::convert::From<T>
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where U: core::convert::Into<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleHeightError::Error = core::convert::Infallible
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where U: core::convert::TryFrom<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleHeightError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: core::clone::Clone
+pub type bitcoin_units::locktime::relative::error::IncompatibleHeightError::Owned = T
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::clone_into(&self, target: &mut T)
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: core::clone::Clone
+pub unsafe fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::from(t: T) -> T
+pub struct bitcoin_units::relative::error::IncompatibleTimeError(_)
+impl core::clone::Clone for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::clone(&self) -> bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::cmp::Eq for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::eq(&self, other: &bitcoin_units::locktime::relative::error::IncompatibleTimeError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::from(never: core::convert::Infallible) -> Self
+impl core::fmt::Debug for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Freeze for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Send for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Sync for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Unpin for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::UnsafeUnpin for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl<T, U> core::convert::Into<U> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where U: core::convert::From<T>
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where U: core::convert::Into<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleTimeError::Error = core::convert::Infallible
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where U: core::convert::TryFrom<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleTimeError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: core::clone::Clone
+pub type bitcoin_units::locktime::relative::error::IncompatibleTimeError::Owned = T
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::clone_into(&self, target: &mut T)
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: core::clone::Clone
+pub unsafe fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::from(t: T) -> T
 pub struct bitcoin_units::relative::error::InvalidHeightError
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::InvalidHeightError
 pub fn bitcoin_units::locktime::relative::error::InvalidHeightError::clone(&self) -> bitcoin_units::locktime::relative::error::InvalidHeightError
@@ -5470,7 +5734,7 @@ pub unsafe fn bitcoin_units::locktime::relative::error::IsSatisfiedByError::clon
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IsSatisfiedByError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByError::from(t: T) -> T
 pub enum bitcoin_units::relative::IsSatisfiedByHeightError
-pub bitcoin_units::relative::IsSatisfiedByHeightError::Incompatible(bitcoin_units::locktime::relative::NumberOf512Seconds)
+pub bitcoin_units::relative::IsSatisfiedByHeightError::Incompatible(bitcoin_units::locktime::relative::error::IncompatibleHeightError)
 pub bitcoin_units::relative::IsSatisfiedByHeightError::Satisfaction(bitcoin_units::locktime::relative::error::InvalidHeightError)
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError::clone(&self) -> bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
@@ -5516,7 +5780,7 @@ pub unsafe fn bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError::from(t: T) -> T
 pub enum bitcoin_units::relative::IsSatisfiedByTimeError
-pub bitcoin_units::relative::IsSatisfiedByTimeError::Incompatible(bitcoin_units::locktime::relative::NumberOfBlocks)
+pub bitcoin_units::relative::IsSatisfiedByTimeError::Incompatible(bitcoin_units::locktime::relative::error::IncompatibleTimeError)
 pub bitcoin_units::relative::IsSatisfiedByTimeError::Satisfaction(bitcoin_units::locktime::relative::error::InvalidTimeError)
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError::clone(&self) -> bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
@@ -5682,6 +5946,94 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::error:
 pub unsafe fn bitcoin_units::locktime::relative::error::DisabledLockTimeError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::DisabledLockTimeError
 pub fn bitcoin_units::locktime::relative::error::DisabledLockTimeError::from(t: T) -> T
+pub struct bitcoin_units::relative::IncompatibleHeightError(_)
+impl core::clone::Clone for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::clone(&self) -> bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::cmp::Eq for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::eq(&self, other: &bitcoin_units::locktime::relative::error::IncompatibleHeightError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::from(never: core::convert::Infallible) -> Self
+impl core::fmt::Debug for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Freeze for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Send for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Sync for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Unpin for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::UnsafeUnpin for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl<T, U> core::convert::Into<U> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where U: core::convert::From<T>
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where U: core::convert::Into<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleHeightError::Error = core::convert::Infallible
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where U: core::convert::TryFrom<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleHeightError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: core::clone::Clone
+pub type bitcoin_units::locktime::relative::error::IncompatibleHeightError::Owned = T
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::clone_into(&self, target: &mut T)
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: core::clone::Clone
+pub unsafe fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::from(t: T) -> T
+pub struct bitcoin_units::relative::IncompatibleTimeError(_)
+impl core::clone::Clone for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::clone(&self) -> bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::cmp::Eq for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::eq(&self, other: &bitcoin_units::locktime::relative::error::IncompatibleTimeError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::from(never: core::convert::Infallible) -> Self
+impl core::fmt::Debug for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Freeze for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Send for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Sync for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Unpin for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::UnsafeUnpin for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl<T, U> core::convert::Into<U> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where U: core::convert::From<T>
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where U: core::convert::Into<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleTimeError::Error = core::convert::Infallible
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where U: core::convert::TryFrom<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleTimeError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: core::clone::Clone
+pub type bitcoin_units::locktime::relative::error::IncompatibleTimeError::Owned = T
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::clone_into(&self, target: &mut T)
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: core::clone::Clone
+pub unsafe fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::from(t: T) -> T
 pub struct bitcoin_units::relative::InvalidHeightError
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::InvalidHeightError
 pub fn bitcoin_units::locktime::relative::error::InvalidHeightError::clone(&self) -> bitcoin_units::locktime::relative::error::InvalidHeightError

--- a/units/api/no-features.txt
+++ b/units/api/no-features.txt
@@ -3238,7 +3238,7 @@ pub unsafe fn bitcoin_units::locktime::relative::error::IsSatisfiedByError::clon
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IsSatisfiedByError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByError::from(t: T) -> T
 pub enum bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
-pub bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError::Incompatible(bitcoin_units::locktime::relative::NumberOf512Seconds)
+pub bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError::Incompatible(bitcoin_units::locktime::relative::error::IncompatibleHeightError)
 pub bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError::Satisfaction(bitcoin_units::locktime::relative::error::InvalidHeightError)
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError::clone(&self) -> bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
@@ -3278,7 +3278,7 @@ pub unsafe fn bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError::from(t: T) -> T
 pub enum bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
-pub bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError::Incompatible(bitcoin_units::locktime::relative::NumberOfBlocks)
+pub bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError::Incompatible(bitcoin_units::locktime::relative::error::IncompatibleTimeError)
 pub bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError::Satisfaction(bitcoin_units::locktime::relative::error::InvalidTimeError)
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError::clone(&self) -> bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
@@ -3357,6 +3357,82 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::error:
 pub unsafe fn bitcoin_units::locktime::relative::error::DisabledLockTimeError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::DisabledLockTimeError
 pub fn bitcoin_units::locktime::relative::error::DisabledLockTimeError::from(t: T) -> T
+pub struct bitcoin_units::locktime::relative::error::IncompatibleHeightError(_)
+impl core::clone::Clone for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::clone(&self) -> bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::cmp::Eq for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::eq(&self, other: &bitcoin_units::locktime::relative::error::IncompatibleHeightError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::from(never: core::convert::Infallible) -> Self
+impl core::fmt::Debug for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Freeze for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Send for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Sync for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Unpin for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::UnsafeUnpin for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl<T, U> core::convert::Into<U> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where U: core::convert::From<T>
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where U: core::convert::Into<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleHeightError::Error = core::convert::Infallible
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where U: core::convert::TryFrom<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleHeightError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: core::clone::Clone
+pub unsafe fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::from(t: T) -> T
+pub struct bitcoin_units::locktime::relative::error::IncompatibleTimeError(_)
+impl core::clone::Clone for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::clone(&self) -> bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::cmp::Eq for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::eq(&self, other: &bitcoin_units::locktime::relative::error::IncompatibleTimeError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::from(never: core::convert::Infallible) -> Self
+impl core::fmt::Debug for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Freeze for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Send for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Sync for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Unpin for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::UnsafeUnpin for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl<T, U> core::convert::Into<U> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where U: core::convert::From<T>
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where U: core::convert::Into<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleTimeError::Error = core::convert::Infallible
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where U: core::convert::TryFrom<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleTimeError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: core::clone::Clone
+pub unsafe fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::from(t: T) -> T
 pub struct bitcoin_units::locktime::relative::error::InvalidHeightError
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::InvalidHeightError
 pub fn bitcoin_units::locktime::relative::error::InvalidHeightError::clone(&self) -> bitcoin_units::locktime::relative::error::InvalidHeightError
@@ -3512,7 +3588,7 @@ pub unsafe fn bitcoin_units::locktime::relative::error::IsSatisfiedByError::clon
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IsSatisfiedByError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByError::from(t: T) -> T
 pub enum bitcoin_units::locktime::relative::IsSatisfiedByHeightError
-pub bitcoin_units::locktime::relative::IsSatisfiedByHeightError::Incompatible(bitcoin_units::locktime::relative::NumberOf512Seconds)
+pub bitcoin_units::locktime::relative::IsSatisfiedByHeightError::Incompatible(bitcoin_units::locktime::relative::error::IncompatibleHeightError)
 pub bitcoin_units::locktime::relative::IsSatisfiedByHeightError::Satisfaction(bitcoin_units::locktime::relative::error::InvalidHeightError)
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError::clone(&self) -> bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
@@ -3552,7 +3628,7 @@ pub unsafe fn bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError::from(t: T) -> T
 pub enum bitcoin_units::locktime::relative::IsSatisfiedByTimeError
-pub bitcoin_units::locktime::relative::IsSatisfiedByTimeError::Incompatible(bitcoin_units::locktime::relative::NumberOfBlocks)
+pub bitcoin_units::locktime::relative::IsSatisfiedByTimeError::Incompatible(bitcoin_units::locktime::relative::error::IncompatibleTimeError)
 pub bitcoin_units::locktime::relative::IsSatisfiedByTimeError::Satisfaction(bitcoin_units::locktime::relative::error::InvalidTimeError)
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError::clone(&self) -> bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
@@ -3700,6 +3776,82 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::error:
 pub unsafe fn bitcoin_units::locktime::relative::error::DisabledLockTimeError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::DisabledLockTimeError
 pub fn bitcoin_units::locktime::relative::error::DisabledLockTimeError::from(t: T) -> T
+pub struct bitcoin_units::locktime::relative::IncompatibleHeightError(_)
+impl core::clone::Clone for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::clone(&self) -> bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::cmp::Eq for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::eq(&self, other: &bitcoin_units::locktime::relative::error::IncompatibleHeightError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::from(never: core::convert::Infallible) -> Self
+impl core::fmt::Debug for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Freeze for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Send for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Sync for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Unpin for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::UnsafeUnpin for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl<T, U> core::convert::Into<U> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where U: core::convert::From<T>
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where U: core::convert::Into<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleHeightError::Error = core::convert::Infallible
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where U: core::convert::TryFrom<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleHeightError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: core::clone::Clone
+pub unsafe fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::from(t: T) -> T
+pub struct bitcoin_units::locktime::relative::IncompatibleTimeError(_)
+impl core::clone::Clone for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::clone(&self) -> bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::cmp::Eq for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::eq(&self, other: &bitcoin_units::locktime::relative::error::IncompatibleTimeError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::from(never: core::convert::Infallible) -> Self
+impl core::fmt::Debug for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Freeze for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Send for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Sync for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Unpin for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::UnsafeUnpin for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl<T, U> core::convert::Into<U> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where U: core::convert::From<T>
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where U: core::convert::Into<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleTimeError::Error = core::convert::Infallible
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where U: core::convert::TryFrom<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleTimeError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: core::clone::Clone
+pub unsafe fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::from(t: T) -> T
 pub struct bitcoin_units::locktime::relative::InvalidHeightError
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::InvalidHeightError
 pub fn bitcoin_units::locktime::relative::error::InvalidHeightError::clone(&self) -> bitcoin_units::locktime::relative::error::InvalidHeightError
@@ -4571,7 +4723,7 @@ pub unsafe fn bitcoin_units::locktime::relative::error::IsSatisfiedByError::clon
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IsSatisfiedByError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByError::from(t: T) -> T
 pub enum bitcoin_units::relative::error::IsSatisfiedByHeightError
-pub bitcoin_units::relative::error::IsSatisfiedByHeightError::Incompatible(bitcoin_units::locktime::relative::NumberOf512Seconds)
+pub bitcoin_units::relative::error::IsSatisfiedByHeightError::Incompatible(bitcoin_units::locktime::relative::error::IncompatibleHeightError)
 pub bitcoin_units::relative::error::IsSatisfiedByHeightError::Satisfaction(bitcoin_units::locktime::relative::error::InvalidHeightError)
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError::clone(&self) -> bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
@@ -4611,7 +4763,7 @@ pub unsafe fn bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError::from(t: T) -> T
 pub enum bitcoin_units::relative::error::IsSatisfiedByTimeError
-pub bitcoin_units::relative::error::IsSatisfiedByTimeError::Incompatible(bitcoin_units::locktime::relative::NumberOfBlocks)
+pub bitcoin_units::relative::error::IsSatisfiedByTimeError::Incompatible(bitcoin_units::locktime::relative::error::IncompatibleTimeError)
 pub bitcoin_units::relative::error::IsSatisfiedByTimeError::Satisfaction(bitcoin_units::locktime::relative::error::InvalidTimeError)
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError::clone(&self) -> bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
@@ -4690,6 +4842,82 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::error:
 pub unsafe fn bitcoin_units::locktime::relative::error::DisabledLockTimeError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::DisabledLockTimeError
 pub fn bitcoin_units::locktime::relative::error::DisabledLockTimeError::from(t: T) -> T
+pub struct bitcoin_units::relative::error::IncompatibleHeightError(_)
+impl core::clone::Clone for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::clone(&self) -> bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::cmp::Eq for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::eq(&self, other: &bitcoin_units::locktime::relative::error::IncompatibleHeightError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::from(never: core::convert::Infallible) -> Self
+impl core::fmt::Debug for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Freeze for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Send for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Sync for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Unpin for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::UnsafeUnpin for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl<T, U> core::convert::Into<U> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where U: core::convert::From<T>
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where U: core::convert::Into<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleHeightError::Error = core::convert::Infallible
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where U: core::convert::TryFrom<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleHeightError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: core::clone::Clone
+pub unsafe fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::from(t: T) -> T
+pub struct bitcoin_units::relative::error::IncompatibleTimeError(_)
+impl core::clone::Clone for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::clone(&self) -> bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::cmp::Eq for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::eq(&self, other: &bitcoin_units::locktime::relative::error::IncompatibleTimeError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::from(never: core::convert::Infallible) -> Self
+impl core::fmt::Debug for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Freeze for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Send for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Sync for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Unpin for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::UnsafeUnpin for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl<T, U> core::convert::Into<U> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where U: core::convert::From<T>
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where U: core::convert::Into<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleTimeError::Error = core::convert::Infallible
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where U: core::convert::TryFrom<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleTimeError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: core::clone::Clone
+pub unsafe fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::from(t: T) -> T
 pub struct bitcoin_units::relative::error::InvalidHeightError
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::InvalidHeightError
 pub fn bitcoin_units::locktime::relative::error::InvalidHeightError::clone(&self) -> bitcoin_units::locktime::relative::error::InvalidHeightError
@@ -4845,7 +5073,7 @@ pub unsafe fn bitcoin_units::locktime::relative::error::IsSatisfiedByError::clon
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IsSatisfiedByError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByError::from(t: T) -> T
 pub enum bitcoin_units::relative::IsSatisfiedByHeightError
-pub bitcoin_units::relative::IsSatisfiedByHeightError::Incompatible(bitcoin_units::locktime::relative::NumberOf512Seconds)
+pub bitcoin_units::relative::IsSatisfiedByHeightError::Incompatible(bitcoin_units::locktime::relative::error::IncompatibleHeightError)
 pub bitcoin_units::relative::IsSatisfiedByHeightError::Satisfaction(bitcoin_units::locktime::relative::error::InvalidHeightError)
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError::clone(&self) -> bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
@@ -4885,7 +5113,7 @@ pub unsafe fn bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError::from(t: T) -> T
 pub enum bitcoin_units::relative::IsSatisfiedByTimeError
-pub bitcoin_units::relative::IsSatisfiedByTimeError::Incompatible(bitcoin_units::locktime::relative::NumberOfBlocks)
+pub bitcoin_units::relative::IsSatisfiedByTimeError::Incompatible(bitcoin_units::locktime::relative::error::IncompatibleTimeError)
 pub bitcoin_units::relative::IsSatisfiedByTimeError::Satisfaction(bitcoin_units::locktime::relative::error::InvalidTimeError)
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
 pub fn bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError::clone(&self) -> bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError
@@ -5033,6 +5261,82 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::error:
 pub unsafe fn bitcoin_units::locktime::relative::error::DisabledLockTimeError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::DisabledLockTimeError
 pub fn bitcoin_units::locktime::relative::error::DisabledLockTimeError::from(t: T) -> T
+pub struct bitcoin_units::relative::IncompatibleHeightError(_)
+impl core::clone::Clone for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::clone(&self) -> bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::cmp::Eq for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::eq(&self, other: &bitcoin_units::locktime::relative::error::IncompatibleHeightError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::from(never: core::convert::Infallible) -> Self
+impl core::fmt::Debug for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Freeze for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Send for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Sync for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::Unpin for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::marker::UnsafeUnpin for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+impl<T, U> core::convert::Into<U> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where U: core::convert::From<T>
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where U: core::convert::Into<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleHeightError::Error = core::convert::Infallible
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where U: core::convert::TryFrom<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleHeightError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::error::IncompatibleHeightError where T: core::clone::Clone
+pub unsafe fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IncompatibleHeightError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleHeightError::from(t: T) -> T
+pub struct bitcoin_units::relative::IncompatibleTimeError(_)
+impl core::clone::Clone for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::clone(&self) -> bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::cmp::Eq for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::cmp::PartialEq for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::eq(&self, other: &bitcoin_units::locktime::relative::error::IncompatibleTimeError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::from(never: core::convert::Infallible) -> Self
+impl core::fmt::Debug for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Freeze for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Send for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Sync for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::Unpin for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::marker::UnsafeUnpin for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+impl<T, U> core::convert::Into<U> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where U: core::convert::From<T>
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where U: core::convert::Into<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleTimeError::Error = core::convert::Infallible
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where U: core::convert::TryFrom<T>
+pub type bitcoin_units::locktime::relative::error::IncompatibleTimeError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: ?core::marker::Sized
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::error::IncompatibleTimeError where T: core::clone::Clone
+pub unsafe fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::error::IncompatibleTimeError
+pub fn bitcoin_units::locktime::relative::error::IncompatibleTimeError::from(t: T) -> T
 pub struct bitcoin_units::relative::InvalidHeightError
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::InvalidHeightError
 pub fn bitcoin_units::locktime::relative::error::InvalidHeightError::clone(&self) -> bitcoin_units::locktime::relative::error::InvalidHeightError

--- a/units/src/locktime/relative/error.rs
+++ b/units/src/locktime/relative/error.rs
@@ -78,8 +78,7 @@ pub enum IsSatisfiedByHeightError {
     /// Satisfaction of the lock height value failed.
     Satisfaction(InvalidHeightError),
     /// Tried to satisfy a lock-by-height locktime using seconds.
-    // TODO: Hide inner value in a new struct error type.
-    Incompatible(NumberOf512Seconds),
+    Incompatible(IncompatibleHeightError),
 }
 
 impl From<Infallible> for IsSatisfiedByHeightError {
@@ -91,8 +90,7 @@ impl fmt::Display for IsSatisfiedByHeightError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Self::Satisfaction(ref e) => write_err!(f, "satisfaction"; e),
-            Self::Incompatible(time) =>
-                write!(f, "tried to satisfy a lock-by-height locktime using seconds {}", time),
+            Self::Incompatible(ref e) => write_err!(f, "incompatible"; e),
         }
     }
 }
@@ -103,9 +101,29 @@ impl std::error::Error for IsSatisfiedByHeightError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match *self {
             Self::Satisfaction(ref e) => Some(e),
-            Self::Incompatible(_) => None,
+            Self::Incompatible(ref e) => Some(e),
         }
     }
+}
+
+/// Error returned when `is_satisfied_by_height` fails with a block time.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IncompatibleHeightError(pub(crate) NumberOf512Seconds);
+
+impl From<Infallible> for IncompatibleHeightError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+impl fmt::Display for IncompatibleHeightError {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "tried to satisfy a lock-by-height locktime using seconds {}", self.0)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for IncompatibleHeightError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
 }
 
 /// Error returned when `is_satisfied_by_time` fails.
@@ -114,8 +132,7 @@ pub enum IsSatisfiedByTimeError {
     /// Satisfaction of the lock time value failed.
     Satisfaction(InvalidTimeError),
     /// Tried to satisfy a lock-by-time locktime using number of blocks.
-    // TODO: Hide inner value in a new struct error type.
-    Incompatible(NumberOfBlocks),
+    Incompatible(IncompatibleTimeError),
 }
 
 impl From<Infallible> for IsSatisfiedByTimeError {
@@ -127,8 +144,8 @@ impl fmt::Display for IsSatisfiedByTimeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Self::Satisfaction(ref e) => write_err!(f, "satisfaction"; e),
-            Self::Incompatible(blocks) =>
-                write!(f, "tried to satisfy a lock-by-time locktime using blocks {}", blocks),
+            Self::Incompatible(ref e) => write_err!(f, "incompatible"; e),
+
         }
     }
 }
@@ -139,9 +156,29 @@ impl std::error::Error for IsSatisfiedByTimeError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match *self {
             Self::Satisfaction(ref e) => Some(e),
-            Self::Incompatible(_) => None,
+            Self::Incompatible(ref e) => Some(e),
         }
     }
+}
+
+/// Error returned when `is_satisfied_by_time` fails with a block height.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IncompatibleTimeError(pub(crate) NumberOfBlocks);
+
+impl From<Infallible> for IncompatibleTimeError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+impl fmt::Display for IncompatibleTimeError {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "tried to satisfy a lock-by-time locktime using blocks {}", self.0)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for IncompatibleTimeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
 }
 
 /// Error returned when the input time in seconds was too large to be encoded to a 16 bit 512 second interval.
@@ -308,7 +345,7 @@ mod tests {
             .unwrap_err();
         assert!(!e.to_string().is_empty());
         #[cfg(feature = "std")]
-        assert!(e.source().is_none());
+        assert!(e.source().is_some());
         // Satisfaction type
         let e = height_lock
             .is_satisfied_by_height(BlockHeight::from_u32(5), BlockHeight::from_u32(10))
@@ -324,7 +361,7 @@ mod tests {
             .unwrap_err();
         assert!(!e.to_string().is_empty());
         #[cfg(feature = "std")]
-        assert!(e.source().is_none());
+        assert!(e.source().is_some());
         // Satisfaction type
         let e = time_lock
             .is_satisfied_by_time(BlockMtp::from_u32(5), BlockMtp::from_u32(10))

--- a/units/src/locktime/relative/mod.rs
+++ b/units/src/locktime/relative/mod.rs
@@ -22,8 +22,9 @@ use crate::{BlockHeight, BlockMtp, Sequence};
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(no_inline)]
 pub use self::error::{
-    DisabledLockTimeError, InvalidHeightError, InvalidTimeError, IsSatisfiedByError,
-    IsSatisfiedByHeightError, IsSatisfiedByTimeError, TimeOverflowError,
+    DisabledLockTimeError, IncompatibleHeightError, IncompatibleTimeError, InvalidHeightError,
+    InvalidTimeError, IsSatisfiedByError, IsSatisfiedByHeightError, IsSatisfiedByTimeError,
+    TimeOverflowError,
 };
 
 /// A relative lock time value, representing either a block height or time (512 second intervals).
@@ -236,7 +237,7 @@ impl LockTime {
             Self::Blocks(blocks) => blocks
                 .is_satisfied_by(chain_tip, utxo_mined_at)
                 .map_err(IsSatisfiedByHeightError::Satisfaction),
-            Self::Time(time) => Err(IsSatisfiedByHeightError::Incompatible(time)),
+            Self::Time(time) => Err(IsSatisfiedByHeightError::Incompatible(IncompatibleHeightError(time))),
         }
     }
 
@@ -258,7 +259,7 @@ impl LockTime {
             Self::Time(time) => time
                 .is_satisfied_by(chain_tip, utxo_mined_at)
                 .map_err(IsSatisfiedByTimeError::Satisfaction),
-            Self::Blocks(blocks) => Err(IsSatisfiedByTimeError::Incompatible(blocks)),
+            Self::Blocks(blocks) => Err(IsSatisfiedByTimeError::Incompatible(IncompatibleTimeError(blocks))),
         }
     }
 
@@ -838,7 +839,7 @@ mod tests {
         let err = lock_by_time.is_satisfied_by_height(chain_tip, mined_at).unwrap_err();
 
         let expected_time = NumberOf512Seconds::from_512_second_intervals(70);
-        assert_eq!(err, IsSatisfiedByHeightError::Incompatible(expected_time));
+        assert_eq!(err, IsSatisfiedByHeightError::Incompatible(IncompatibleHeightError(expected_time)));
         assert!(!format!("{}", err).is_empty());
     }
 
@@ -866,7 +867,7 @@ mod tests {
         let err = lock_by_height.is_satisfied_by_time(chain_tip, mined_at).unwrap_err();
 
         let expected_height = NumberOfBlocks::from(10);
-        assert_eq!(err, IsSatisfiedByTimeError::Incompatible(expected_height));
+        assert_eq!(err, IsSatisfiedByTimeError::Incompatible(IncompatibleTimeError(expected_height)));
         assert!(!format!("{}", err).is_empty());
     }
 


### PR DESCRIPTION
Remove two TODOs from the code by encapsulating a couple of errors. Note the pair height/time - the error is named after the enum it appears in not after the type it holds.