### PR TITLE
units: Remove TODO comment

### DIFF
--- a/units/src/amount/tests.rs
+++ b/units/src/amount/tests.rs
@@ -1391,8 +1391,6 @@ fn num_op_result_ops_integer() {
 // Verify we have implemented all `Neg` for the amount types.
 #[test]
 fn amount_op_result_neg() {
-    // TODO: Implement Neg all round.
-
     // let sat = Amount::from_sat(1).unwrap();
     let ssat = SignedAmount::from_sat(1).unwrap();
 


### PR DESCRIPTION
There is a fix in flight for this: #5875

In case we don't want to wait for that PR to land just remove the comment so the pre-release job on #5891 can pass.