### PR TITLE
hashes: use consistent round numbering in comments

### DIFF
--- a/hashes/src/sha256/crypto/arm_sha2.rs
+++ b/hashes/src/sha256/crypto/arm_sha2.rs
@@ -72,7 +72,7 @@ pub(super) unsafe fn process_block(state: &mut [u32; 8], block: &[u8]) {
 
     tmp0 = vaddq_u32(msg0, vld1q_u32(K.as_ptr().add(0x00)));
 
-    // Rounds 0-3
+    // Rounds 1-4
     msg0 = vsha256su0q_u32(msg0, msg1);
     tmp2 = state0;
     tmp1 = vaddq_u32(msg1, vld1q_u32(K.as_ptr().add(0x04)));
@@ -80,7 +80,7 @@ pub(super) unsafe fn process_block(state: &mut [u32; 8], block: &[u8]) {
     state1 = vsha256h2q_u32(state1, tmp2, tmp0);
     msg0 = vsha256su1q_u32(msg0, msg2, msg3);
 
-    // Rounds 4-7
+    // Rounds 5-8
     msg1 = vsha256su0q_u32(msg1, msg2);
     tmp2 = state0;
     tmp0 = vaddq_u32(msg2, vld1q_u32(K.as_ptr().add(0x08)));
@@ -88,7 +88,7 @@ pub(super) unsafe fn process_block(state: &mut [u32; 8], block: &[u8]) {
     state1 = vsha256h2q_u32(state1, tmp2, tmp1);
     msg1 = vsha256su1q_u32(msg1, msg3, msg0);
 
-    // Rounds 8-11
+    // Rounds 9-12
     msg2 = vsha256su0q_u32(msg2, msg3);
     tmp2 = state0;
     tmp1 = vaddq_u32(msg3, vld1q_u32(K.as_ptr().add(0x0c)));
@@ -96,7 +96,7 @@ pub(super) unsafe fn process_block(state: &mut [u32; 8], block: &[u8]) {
     state1 = vsha256h2q_u32(state1, tmp2, tmp0);
     msg2 = vsha256su1q_u32(msg2, msg0, msg1);
 
-    // Rounds 12-15
+    // Rounds 13-16
     msg3 = vsha256su0q_u32(msg3, msg0);
     tmp2 = state0;
     tmp0 = vaddq_u32(msg0, vld1q_u32(K.as_ptr().add(0x10)));
@@ -104,7 +104,7 @@ pub(super) unsafe fn process_block(state: &mut [u32; 8], block: &[u8]) {
     state1 = vsha256h2q_u32(state1, tmp2, tmp1);
     msg3 = vsha256su1q_u32(msg3, msg1, msg2);
 
-    // Rounds 16-19
+    // Rounds 17-20
     msg0 = vsha256su0q_u32(msg0, msg1);
     tmp2 = state0;
     tmp1 = vaddq_u32(msg1, vld1q_u32(K.as_ptr().add(0x14)));
@@ -112,7 +112,7 @@ pub(super) unsafe fn process_block(state: &mut [u32; 8], block: &[u8]) {
     state1 = vsha256h2q_u32(state1, tmp2, tmp0);
     msg0 = vsha256su1q_u32(msg0, msg2, msg3);
 
-    // Rounds 20-23
+    // Rounds 21-24
     msg1 = vsha256su0q_u32(msg1, msg2);
     tmp2 = state0;
     tmp0 = vaddq_u32(msg2, vld1q_u32(K.as_ptr().add(0x18)));
@@ -120,7 +120,7 @@ pub(super) unsafe fn process_block(state: &mut [u32; 8], block: &[u8]) {
     state1 = vsha256h2q_u32(state1, tmp2, tmp1);
     msg1 = vsha256su1q_u32(msg1, msg3, msg0);
 
-    // Rounds 24-27
+    // Rounds 25-28
     msg2 = vsha256su0q_u32(msg2, msg3);
     tmp2 = state0;
     tmp1 = vaddq_u32(msg3, vld1q_u32(K.as_ptr().add(0x1c)));
@@ -128,7 +128,7 @@ pub(super) unsafe fn process_block(state: &mut [u32; 8], block: &[u8]) {
     state1 = vsha256h2q_u32(state1, tmp2, tmp0);
     msg2 = vsha256su1q_u32(msg2, msg0, msg1);
 
-    // Rounds 28-31
+    // Rounds 29-32
     msg3 = vsha256su0q_u32(msg3, msg0);
     tmp2 = state0;
     tmp0 = vaddq_u32(msg0, vld1q_u32(K.as_ptr().add(0x20)));
@@ -136,7 +136,7 @@ pub(super) unsafe fn process_block(state: &mut [u32; 8], block: &[u8]) {
     state1 = vsha256h2q_u32(state1, tmp2, tmp1);
     msg3 = vsha256su1q_u32(msg3, msg1, msg2);
 
-    // Rounds 32-35
+    // Rounds 33-36
     msg0 = vsha256su0q_u32(msg0, msg1);
     tmp2 = state0;
     tmp1 = vaddq_u32(msg1, vld1q_u32(K.as_ptr().add(0x24)));
@@ -144,7 +144,7 @@ pub(super) unsafe fn process_block(state: &mut [u32; 8], block: &[u8]) {
     state1 = vsha256h2q_u32(state1, tmp2, tmp0);
     msg0 = vsha256su1q_u32(msg0, msg2, msg3);
 
-    // Rounds 36-39
+    // Rounds 37-40
     msg1 = vsha256su0q_u32(msg1, msg2);
     tmp2 = state0;
     tmp0 = vaddq_u32(msg2, vld1q_u32(K.as_ptr().add(0x28)));
@@ -152,7 +152,7 @@ pub(super) unsafe fn process_block(state: &mut [u32; 8], block: &[u8]) {
     state1 = vsha256h2q_u32(state1, tmp2, tmp1);
     msg1 = vsha256su1q_u32(msg1, msg3, msg0);
 
-    // Rounds 40-43
+    // Rounds 41-44
     msg2 = vsha256su0q_u32(msg2, msg3);
     tmp2 = state0;
     tmp1 = vaddq_u32(msg3, vld1q_u32(K.as_ptr().add(0x2c)));
@@ -160,7 +160,7 @@ pub(super) unsafe fn process_block(state: &mut [u32; 8], block: &[u8]) {
     state1 = vsha256h2q_u32(state1, tmp2, tmp0);
     msg2 = vsha256su1q_u32(msg2, msg0, msg1);
 
-    // Rounds 44-47
+    // Rounds 45-48
     msg3 = vsha256su0q_u32(msg3, msg0);
     tmp2 = state0;
     tmp0 = vaddq_u32(msg0, vld1q_u32(K.as_ptr().add(0x30)));
@@ -168,25 +168,25 @@ pub(super) unsafe fn process_block(state: &mut [u32; 8], block: &[u8]) {
     state1 = vsha256h2q_u32(state1, tmp2, tmp1);
     msg3 = vsha256su1q_u32(msg3, msg1, msg2);
 
-    // Rounds 48-51
+    // Rounds 49-52
     tmp2 = state0;
     tmp1 = vaddq_u32(msg1, vld1q_u32(K.as_ptr().add(0x34)));
     state0 = vsha256hq_u32(state0, state1, tmp0);
     state1 = vsha256h2q_u32(state1, tmp2, tmp0);
 
-    // Rounds 52-55
+    // Rounds 53-56
     tmp2 = state0;
     tmp0 = vaddq_u32(msg2, vld1q_u32(K.as_ptr().add(0x38)));
     state0 = vsha256hq_u32(state0, state1, tmp1);
     state1 = vsha256h2q_u32(state1, tmp2, tmp1);
 
-    // Rounds 56-59
+    // Rounds 57-60
     tmp2 = state0;
     tmp1 = vaddq_u32(msg3, vld1q_u32(K.as_ptr().add(0x3c)));
     state0 = vsha256hq_u32(state0, state1, tmp0);
     state1 = vsha256h2q_u32(state1, tmp2, tmp0);
 
-    // Rounds 60-63
+    // Rounds 61-64
     tmp2 = state0;
     state0 = vsha256hq_u32(state0, state1, tmp1);
     state1 = vsha256h2q_u32(state1, tmp2, tmp1);

--- a/hashes/src/sha256/crypto/x86_shani.rs
+++ b/hashes/src/sha256/crypto/x86_shani.rs
@@ -59,7 +59,7 @@ pub(super) unsafe fn process_block(state: &mut [u32; 8], block: &[u8]) {
         abef_save = state0;
         cdgh_save = state1;
 
-        // Rounds 0-3
+        // Rounds 1-4
         msg = _mm_loadu_si128(block.as_ptr().add(block_offset).cast::<__m128i>());
         msg0 = _mm_shuffle_epi8(msg, MASK);
         msg = _mm_add_epi32(
@@ -70,7 +70,7 @@ pub(super) unsafe fn process_block(state: &mut [u32; 8], block: &[u8]) {
         msg = _mm_shuffle_epi32(msg, 0x0E);
         state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
 
-        // Rounds 4-7
+        // Rounds 5-8
         msg1 = _mm_loadu_si128(block.as_ptr().add(block_offset + 16).cast::<__m128i>());
         msg1 = _mm_shuffle_epi8(msg1, MASK);
         msg = _mm_add_epi32(
@@ -82,7 +82,7 @@ pub(super) unsafe fn process_block(state: &mut [u32; 8], block: &[u8]) {
         state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
         msg0 = _mm_sha256msg1_epu32(msg0, msg1);
 
-        // Rounds 8-11
+        // Rounds 9-12
         msg2 = _mm_loadu_si128(block.as_ptr().add(block_offset + 32).cast::<__m128i>());
         msg2 = _mm_shuffle_epi8(msg2, MASK);
         msg = _mm_add_epi32(
@@ -94,7 +94,7 @@ pub(super) unsafe fn process_block(state: &mut [u32; 8], block: &[u8]) {
         state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
         msg1 = _mm_sha256msg1_epu32(msg1, msg2);
 
-        // Rounds 12-15
+        // Rounds 13-16
         msg3 = _mm_loadu_si128(block.as_ptr().add(block_offset + 48).cast::<__m128i>());
         msg3 = _mm_shuffle_epi8(msg3, MASK);
         msg = _mm_add_epi32(
@@ -109,7 +109,7 @@ pub(super) unsafe fn process_block(state: &mut [u32; 8], block: &[u8]) {
         state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
         msg2 = _mm_sha256msg1_epu32(msg2, msg3);
 
-        // Rounds 16-19
+        // Rounds 17-20
         msg = _mm_add_epi32(
             msg0,
             _mm_set_epi64x(0x240CA1CC0FC19DC6u64 as i64, 0xEFBE4786E49B69C1u64 as i64),
@@ -122,7 +122,7 @@ pub(super) unsafe fn process_block(state: &mut [u32; 8], block: &[u8]) {
         state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
         msg3 = _mm_sha256msg1_epu32(msg3, msg0);
 
-        // Rounds 20-23
+        // Rounds 21-24
         msg = _mm_add_epi32(
             msg1,
             _mm_set_epi64x(0x76F988DA5CB0A9DCu64 as i64, 0x4A7484AA2DE92C6Fu64 as i64),
@@ -135,7 +135,7 @@ pub(super) unsafe fn process_block(state: &mut [u32; 8], block: &[u8]) {
         state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
         msg0 = _mm_sha256msg1_epu32(msg0, msg1);
 
-        // Rounds 24-27
+        // Rounds 25-28
         msg = _mm_add_epi32(
             msg2,
             _mm_set_epi64x(0xBF597FC7B00327C8u64 as i64, 0xA831C66D983E5152u64 as i64),
@@ -148,7 +148,7 @@ pub(super) unsafe fn process_block(state: &mut [u32; 8], block: &[u8]) {
         state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
         msg1 = _mm_sha256msg1_epu32(msg1, msg2);
 
-        // Rounds 28-31
+        // Rounds 29-32
         msg = _mm_add_epi32(
             msg3,
             _mm_set_epi64x(0x1429296706CA6351u64 as i64, 0xD5A79147C6E00BF3u64 as i64),
@@ -161,7 +161,7 @@ pub(super) unsafe fn process_block(state: &mut [u32; 8], block: &[u8]) {
         state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
         msg2 = _mm_sha256msg1_epu32(msg2, msg3);
 
-        // Rounds 32-35
+        // Rounds 33-36
         msg = _mm_add_epi32(
             msg0,
             _mm_set_epi64x(0x53380D134D2C6DFCu64 as i64, 0x2E1B213827B70A85u64 as i64),
@@ -174,7 +174,7 @@ pub(super) unsafe fn process_block(state: &mut [u32; 8], block: &[u8]) {
         state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
         msg3 = _mm_sha256msg1_epu32(msg3, msg0);
 
-        // Rounds 36-39
+        // Rounds 37-40
         msg = _mm_add_epi32(
             msg1,
             _mm_set_epi64x(0x92722C8581C2C92Eu64 as i64, 0x766A0ABB650A7354u64 as i64),
@@ -187,7 +187,7 @@ pub(super) unsafe fn process_block(state: &mut [u32; 8], block: &[u8]) {
         state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
         msg0 = _mm_sha256msg1_epu32(msg0, msg1);
 
-        // Rounds 40-43
+        // Rounds 41-44
         msg = _mm_add_epi32(
             msg2,
             _mm_set_epi64x(0xC76C51A3C24B8B70u64 as i64, 0xA81A664BA2BFE8A1u64 as i64),
@@ -200,7 +200,7 @@ pub(super) unsafe fn process_block(state: &mut [u32; 8], block: &[u8]) {
         state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
         msg1 = _mm_sha256msg1_epu32(msg1, msg2);
 
-        // Rounds 44-47
+        // Rounds 45-48
         msg = _mm_add_epi32(
             msg3,
             _mm_set_epi64x(0x106AA070F40E3585u64 as i64, 0xD6990624D192E819u64 as i64),
@@ -213,7 +213,7 @@ pub(super) unsafe fn process_block(state: &mut [u32; 8], block: &[u8]) {
         state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
         msg2 = _mm_sha256msg1_epu32(msg2, msg3);
 
-        // Rounds 48-51
+        // Rounds 49-52
         msg = _mm_add_epi32(
             msg0,
             _mm_set_epi64x(0x34B0BCB52748774Cu64 as i64, 0x1E376C0819A4C116u64 as i64),
@@ -226,7 +226,7 @@ pub(super) unsafe fn process_block(state: &mut [u32; 8], block: &[u8]) {
         state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
         msg3 = _mm_sha256msg1_epu32(msg3, msg0);
 
-        // Rounds 52-55
+        // Rounds 53-56
         msg = _mm_add_epi32(
             msg1,
             _mm_set_epi64x(0x682E6FF35B9CCA4Fu64 as i64, 0x4ED8AA4A391C0CB3u64 as i64),
@@ -238,7 +238,7 @@ pub(super) unsafe fn process_block(state: &mut [u32; 8], block: &[u8]) {
         msg = _mm_shuffle_epi32(msg, 0x0E);
         state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
 
-        // Rounds 56-59
+        // Rounds 57-60
         msg = _mm_add_epi32(
             msg2,
             _mm_set_epi64x(0x8CC7020884C87814u64 as i64, 0x78A5636F748F82EEu64 as i64),
@@ -250,7 +250,7 @@ pub(super) unsafe fn process_block(state: &mut [u32; 8], block: &[u8]) {
         msg = _mm_shuffle_epi32(msg, 0x0E);
         state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
 
-        // Rounds 60-63
+        // Rounds 61-64
         msg = _mm_add_epi32(
             msg3,
             _mm_set_epi64x(0xC67178F2BEF9A3F7u64 as i64, 0xA4506CEB90BEFFFAu64 as i64),


### PR DESCRIPTION
1-way ARM and x86 SHA-NI functions used `Rounds 0-3` while the 2-way ARM function used `Rounds 1-4` in the comments.

Use 1-64 numbering consistently everywhere.

This is just a comment change, no code change.
