### PR TITLE
hashes: Add 2-way SHA-NI implementation for double-sha256 for 64-byte inputs

### DIFF
--- a/hashes/src/sha256/crypto/mod.rs
+++ b/hashes/src/sha256/crypto/mod.rs
@@ -339,7 +339,37 @@ impl HashEngine {
 
         // TODO: 8-way AVX2
         // TODO: 4-way SSE4.1
-        // TODO: 2-way x86 SHA-NI
+
+        // 2-way x86 SHA-NI
+        #[cfg(feature = "std")]
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        {
+            if std::is_x86_feature_detected!("sse4.1")
+                && std::is_x86_feature_detected!("sha")
+                && std::is_x86_feature_detected!("sse2")
+                && std::is_x86_feature_detected!("ssse3")
+            {
+                while count - i >= 2 {
+                    let out = <&mut [[u8; 32]; 2]>::try_from(&mut outputs[i..i + 2]).unwrap();
+                    let inp = <&[[u8; 64]; 2]>::try_from(&inputs[i..i + 2]).unwrap();
+                    unsafe { x86_shani::sha256d_64_2way(out, inp) };
+                    i += 2;
+                }
+            }
+        }
+
+        #[cfg(feature = "cpufeatures")]
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        {
+            if cpuid_sha256_x86::get() {
+                while count - i >= 2 {
+                    let out = <&mut [[u8; 32]; 2]>::try_from(&mut outputs[i..i + 2]).unwrap();
+                    let inp = <&[[u8; 64]; 2]>::try_from(&inputs[i..i + 2]).unwrap();
+                    unsafe { x86_shani::sha256d_64_2way(out, inp) };
+                    i += 2;
+                }
+            }
+        }
 
         // 2-way ARM SHA2
         #[cfg(feature = "std")]

--- a/hashes/src/sha256/crypto/x86_shani.rs
+++ b/hashes/src/sha256/crypto/x86_shani.rs
@@ -276,9 +276,9 @@ pub(super) unsafe fn process_block(state: &mut [u32; 8], block: &[u8]) {
     _mm_storeu_si128(state.as_mut_ptr().add(4).cast::<__m128i>(), state1);
 }
 
-/// Computes `SHA256d` of a single 64-byte input using x86 SHA-NI.
+/// computes `SHA256d` of two 64-byte inputs in parallel using ARM SHA2 intrinsics.
 #[target_feature(enable = "sha,sse2,ssse3,sse4.1")]
-unsafe fn sha256d_64_x86(output: &mut [u8; 32], input: &[u8; 64]) {
+pub(super) unsafe fn sha256d_64_2way(output: &mut [[u8; 32]; 2], input: &[[u8; 64]; 2]) {
     // SHA256 round constants
     #[rustfmt::skip]
     const K: [u32; 64] = [
@@ -345,451 +345,765 @@ unsafe fn sha256d_64_x86(output: &mut [u8; 32], input: &[u8; 64]) {
     let init0: __m128i = _mm_set_epi64x(0x6a09e667bb67ae85u64 as i64, 0x510e527f9b05688cu64 as i64);
     let init1: __m128i = _mm_set_epi64x(0x3c6ef372a54ff53au64 as i64, 0x1f83d9ab5be0cd19u64 as i64);
 
-    let (mut state0, mut state1);
-    let (abef_save, cdgh_save);
-    let (mut msg, mut tmp);
-    let (mut msg0, mut msg1, mut msg2, mut msg3);
+    let (mut state0_a, mut state0_b, mut state1_a, mut state1_b);
+    let (abef_save_a, abef_save_b, cdgh_save_a, cdgh_save_b);
+    let (mut msg_a, mut msg_b, mut tmp_a, mut tmp_b);
+    let (mut msg0_a, mut msg0_b, mut msg1_a, mut msg1_b);
+    let (mut msg2_a, mut msg2_b, mut msg3_a, mut msg3_b);
 
     // ------------------ Transform 1 -------------------
 
     // Load state
-    state0 = init0;
-    state1 = init1;
+    state0_a = init0;
+    state0_b = init0;
+    state1_a = init1;
+    state1_b = init1;
 
     // Rounds 0-3
-    msg = _mm_loadu_si128(input.as_ptr().add(0).cast::<__m128i>());
-    msg0 = _mm_shuffle_epi8(msg, MASK);
-    msg = _mm_add_epi32(msg0, _mm_loadu_si128(K.as_ptr().add(0).cast::<__m128i>()));
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    let k = _mm_loadu_si128(K.as_ptr().add(0).cast::<__m128i>());
+    msg_a = _mm_loadu_si128(input[0].as_ptr().add(0).cast::<__m128i>());
+    msg_b = _mm_loadu_si128(input[1].as_ptr().add(0).cast::<__m128i>());
+    msg0_a = _mm_shuffle_epi8(msg_a, MASK);
+    msg0_b = _mm_shuffle_epi8(msg_b, MASK);
+    msg_a = _mm_add_epi32(msg0_a, k);
+    msg_b = _mm_add_epi32(msg0_b, k);
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_b);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    msg_b = _mm_shuffle_epi32(msg_b, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_b);
 
     // Rounds 4-7
-    msg = _mm_loadu_si128(input.as_ptr().add(16).cast::<__m128i>());
-    msg1 = _mm_shuffle_epi8(msg, MASK);
-    msg = _mm_add_epi32(msg1, _mm_loadu_si128(K.as_ptr().add(4).cast::<__m128i>()));
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
-    msg0 = _mm_sha256msg1_epu32(msg0, msg1);
+    let k = _mm_loadu_si128(K.as_ptr().add(4).cast::<__m128i>());
+    msg_a = _mm_loadu_si128(input[0].as_ptr().add(16).cast::<__m128i>());
+    msg_b = _mm_loadu_si128(input[1].as_ptr().add(16).cast::<__m128i>());
+    msg1_a = _mm_shuffle_epi8(msg_a, MASK);
+    msg1_b = _mm_shuffle_epi8(msg_b, MASK);
+    msg_a = _mm_add_epi32(msg1_a, k);
+    msg_b = _mm_add_epi32(msg1_b, k);
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_b);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    msg_b = _mm_shuffle_epi32(msg_b, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_b);
+    msg0_a = _mm_sha256msg1_epu32(msg0_a, msg1_a);
+    msg0_b = _mm_sha256msg1_epu32(msg0_b, msg1_b);
 
     // Rounds 8-11
-    msg = _mm_loadu_si128(input.as_ptr().add(32).cast::<__m128i>());
-    msg2 = _mm_shuffle_epi8(msg, MASK);
-    msg = _mm_add_epi32(msg2, _mm_loadu_si128(K.as_ptr().add(8).cast::<__m128i>()));
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
-    msg1 = _mm_sha256msg1_epu32(msg1, msg2);
+    let k = _mm_loadu_si128(K.as_ptr().add(8).cast::<__m128i>());
+    msg_a = _mm_loadu_si128(input[0].as_ptr().add(32).cast::<__m128i>());
+    msg_b = _mm_loadu_si128(input[1].as_ptr().add(32).cast::<__m128i>());
+    msg2_a = _mm_shuffle_epi8(msg_a, MASK);
+    msg2_b = _mm_shuffle_epi8(msg_b, MASK);
+    msg_a = _mm_add_epi32(msg2_a, k);
+    msg_b = _mm_add_epi32(msg2_b, k);
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_b);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    msg_b = _mm_shuffle_epi32(msg_b, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_b);
+    msg1_a = _mm_sha256msg1_epu32(msg1_a, msg2_a);
+    msg1_b = _mm_sha256msg1_epu32(msg1_b, msg2_b);
 
     // Rounds 12-15
-    msg = _mm_loadu_si128(input.as_ptr().add(48).cast::<__m128i>());
-    msg3 = _mm_shuffle_epi8(msg, MASK);
-    msg = _mm_add_epi32(msg3, _mm_loadu_si128(K.as_ptr().add(12).cast::<__m128i>()));
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    tmp = _mm_alignr_epi8(msg3, msg2, 4);
-    msg0 = _mm_add_epi32(msg0, tmp);
-    msg0 = _mm_sha256msg2_epu32(msg0, msg3);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
-    msg2 = _mm_sha256msg1_epu32(msg2, msg3);
+    let k = _mm_loadu_si128(K.as_ptr().add(12).cast::<__m128i>());
+    msg_a = _mm_loadu_si128(input[0].as_ptr().add(48).cast::<__m128i>());
+    msg_b = _mm_loadu_si128(input[1].as_ptr().add(48).cast::<__m128i>());
+    msg3_a = _mm_shuffle_epi8(msg_a, MASK);
+    msg3_b = _mm_shuffle_epi8(msg_b, MASK);
+    msg_a = _mm_add_epi32(msg3_a, k);
+    msg_b = _mm_add_epi32(msg3_b, k);
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_b);
+    tmp_a = _mm_alignr_epi8(msg3_a, msg2_a, 4);
+    tmp_b = _mm_alignr_epi8(msg3_b, msg2_b, 4);
+    msg0_a = _mm_add_epi32(msg0_a, tmp_a);
+    msg0_b = _mm_add_epi32(msg0_b, tmp_b);
+    msg0_a = _mm_sha256msg2_epu32(msg0_a, msg3_a);
+    msg0_b = _mm_sha256msg2_epu32(msg0_b, msg3_b);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    msg_b = _mm_shuffle_epi32(msg_b, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_b);
+    msg2_a = _mm_sha256msg1_epu32(msg2_a, msg3_a);
+    msg2_b = _mm_sha256msg1_epu32(msg2_b, msg3_b);
 
     // Rounds 16-19
-    msg = _mm_add_epi32(msg0, _mm_loadu_si128(K.as_ptr().add(16).cast::<__m128i>()));
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    tmp = _mm_alignr_epi8(msg0, msg3, 4);
-    msg1 = _mm_add_epi32(msg1, tmp);
-    msg1 = _mm_sha256msg2_epu32(msg1, msg0);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
-    msg3 = _mm_sha256msg1_epu32(msg3, msg0);
+    let k = _mm_loadu_si128(K.as_ptr().add(16).cast::<__m128i>());
+    msg_a = _mm_add_epi32(msg0_a, k);
+    msg_b = _mm_add_epi32(msg0_b, k);
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_b);
+    tmp_a = _mm_alignr_epi8(msg0_a, msg3_a, 4);
+    tmp_b = _mm_alignr_epi8(msg0_b, msg3_b, 4);
+    msg1_a = _mm_add_epi32(msg1_a, tmp_a);
+    msg1_b = _mm_add_epi32(msg1_b, tmp_b);
+    msg1_a = _mm_sha256msg2_epu32(msg1_a, msg0_a);
+    msg1_b = _mm_sha256msg2_epu32(msg1_b, msg0_b);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    msg_b = _mm_shuffle_epi32(msg_b, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_b);
+    msg3_a = _mm_sha256msg1_epu32(msg3_a, msg0_a);
+    msg3_b = _mm_sha256msg1_epu32(msg3_b, msg0_b);
 
     // Rounds 20-23
-    msg = _mm_add_epi32(msg1, _mm_loadu_si128(K.as_ptr().add(20).cast::<__m128i>()));
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    tmp = _mm_alignr_epi8(msg1, msg0, 4);
-    msg2 = _mm_add_epi32(msg2, tmp);
-    msg2 = _mm_sha256msg2_epu32(msg2, msg1);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
-    msg0 = _mm_sha256msg1_epu32(msg0, msg1);
+    let k = _mm_loadu_si128(K.as_ptr().add(20).cast::<__m128i>());
+    msg_a = _mm_add_epi32(msg1_a, k);
+    msg_b = _mm_add_epi32(msg1_b, k);
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_b);
+    tmp_a = _mm_alignr_epi8(msg1_a, msg0_a, 4);
+    tmp_b = _mm_alignr_epi8(msg1_b, msg0_b, 4);
+    msg2_a = _mm_add_epi32(msg2_a, tmp_a);
+    msg2_b = _mm_add_epi32(msg2_b, tmp_b);
+    msg2_a = _mm_sha256msg2_epu32(msg2_a, msg1_a);
+    msg2_b = _mm_sha256msg2_epu32(msg2_b, msg1_b);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    msg_b = _mm_shuffle_epi32(msg_b, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_b);
+    msg0_a = _mm_sha256msg1_epu32(msg0_a, msg1_a);
+    msg0_b = _mm_sha256msg1_epu32(msg0_b, msg1_b);
 
     // Rounds 24-27
-    msg = _mm_add_epi32(msg2, _mm_loadu_si128(K.as_ptr().add(24).cast::<__m128i>()));
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    tmp = _mm_alignr_epi8(msg2, msg1, 4);
-    msg3 = _mm_add_epi32(msg3, tmp);
-    msg3 = _mm_sha256msg2_epu32(msg3, msg2);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
-    msg1 = _mm_sha256msg1_epu32(msg1, msg2);
+    let k = _mm_loadu_si128(K.as_ptr().add(24).cast::<__m128i>());
+    msg_a = _mm_add_epi32(msg2_a, k);
+    msg_b = _mm_add_epi32(msg2_b, k);
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_b);
+    tmp_a = _mm_alignr_epi8(msg2_a, msg1_a, 4);
+    tmp_b = _mm_alignr_epi8(msg2_b, msg1_b, 4);
+    msg3_a = _mm_add_epi32(msg3_a, tmp_a);
+    msg3_b = _mm_add_epi32(msg3_b, tmp_b);
+    msg3_a = _mm_sha256msg2_epu32(msg3_a, msg2_a);
+    msg3_b = _mm_sha256msg2_epu32(msg3_b, msg2_b);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    msg_b = _mm_shuffle_epi32(msg_b, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_b);
+    msg1_a = _mm_sha256msg1_epu32(msg1_a, msg2_a);
+    msg1_b = _mm_sha256msg1_epu32(msg1_b, msg2_b);
 
     // Rounds 28-31
-    msg = _mm_add_epi32(msg3, _mm_loadu_si128(K.as_ptr().add(28).cast::<__m128i>()));
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    tmp = _mm_alignr_epi8(msg3, msg2, 4);
-    msg0 = _mm_add_epi32(msg0, tmp);
-    msg0 = _mm_sha256msg2_epu32(msg0, msg3);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
-    msg2 = _mm_sha256msg1_epu32(msg2, msg3);
+    let k = _mm_loadu_si128(K.as_ptr().add(28).cast::<__m128i>());
+    msg_a = _mm_add_epi32(msg3_a, k);
+    msg_b = _mm_add_epi32(msg3_b, k);
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_b);
+    tmp_a = _mm_alignr_epi8(msg3_a, msg2_a, 4);
+    tmp_b = _mm_alignr_epi8(msg3_b, msg2_b, 4);
+    msg0_a = _mm_add_epi32(msg0_a, tmp_a);
+    msg0_b = _mm_add_epi32(msg0_b, tmp_b);
+    msg0_a = _mm_sha256msg2_epu32(msg0_a, msg3_a);
+    msg0_b = _mm_sha256msg2_epu32(msg0_b, msg3_b);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    msg_b = _mm_shuffle_epi32(msg_b, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_b);
+    msg2_a = _mm_sha256msg1_epu32(msg2_a, msg3_a);
+    msg2_b = _mm_sha256msg1_epu32(msg2_b, msg3_b);
 
     // Rounds 32-35
-    msg = _mm_add_epi32(msg0, _mm_loadu_si128(K.as_ptr().add(32).cast::<__m128i>()));
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    tmp = _mm_alignr_epi8(msg0, msg3, 4);
-    msg1 = _mm_add_epi32(msg1, tmp);
-    msg1 = _mm_sha256msg2_epu32(msg1, msg0);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
-    msg3 = _mm_sha256msg1_epu32(msg3, msg0);
+    let k = _mm_loadu_si128(K.as_ptr().add(32).cast::<__m128i>());
+    msg_a = _mm_add_epi32(msg0_a, k);
+    msg_b = _mm_add_epi32(msg0_b, k);
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_b);
+    tmp_a = _mm_alignr_epi8(msg0_a, msg3_a, 4);
+    tmp_b = _mm_alignr_epi8(msg0_b, msg3_b, 4);
+    msg1_a = _mm_add_epi32(msg1_a, tmp_a);
+    msg1_b = _mm_add_epi32(msg1_b, tmp_b);
+    msg1_a = _mm_sha256msg2_epu32(msg1_a, msg0_a);
+    msg1_b = _mm_sha256msg2_epu32(msg1_b, msg0_b);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    msg_b = _mm_shuffle_epi32(msg_b, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_b);
+    msg3_a = _mm_sha256msg1_epu32(msg3_a, msg0_a);
+    msg3_b = _mm_sha256msg1_epu32(msg3_b, msg0_b);
 
     // Rounds 36-39
-    msg = _mm_add_epi32(msg1, _mm_loadu_si128(K.as_ptr().add(36).cast::<__m128i>()));
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    tmp = _mm_alignr_epi8(msg1, msg0, 4);
-    msg2 = _mm_add_epi32(msg2, tmp);
-    msg2 = _mm_sha256msg2_epu32(msg2, msg1);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
-    msg0 = _mm_sha256msg1_epu32(msg0, msg1);
+    let k = _mm_loadu_si128(K.as_ptr().add(36).cast::<__m128i>());
+    msg_a = _mm_add_epi32(msg1_a, k);
+    msg_b = _mm_add_epi32(msg1_b, k);
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_b);
+    tmp_a = _mm_alignr_epi8(msg1_a, msg0_a, 4);
+    tmp_b = _mm_alignr_epi8(msg1_b, msg0_b, 4);
+    msg2_a = _mm_add_epi32(msg2_a, tmp_a);
+    msg2_b = _mm_add_epi32(msg2_b, tmp_b);
+    msg2_a = _mm_sha256msg2_epu32(msg2_a, msg1_a);
+    msg2_b = _mm_sha256msg2_epu32(msg2_b, msg1_b);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    msg_b = _mm_shuffle_epi32(msg_b, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_b);
+    msg0_a = _mm_sha256msg1_epu32(msg0_a, msg1_a);
+    msg0_b = _mm_sha256msg1_epu32(msg0_b, msg1_b);
 
     // Rounds 40-43
-    msg = _mm_add_epi32(msg2, _mm_loadu_si128(K.as_ptr().add(40).cast::<__m128i>()));
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    tmp = _mm_alignr_epi8(msg2, msg1, 4);
-    msg3 = _mm_add_epi32(msg3, tmp);
-    msg3 = _mm_sha256msg2_epu32(msg3, msg2);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
-    msg1 = _mm_sha256msg1_epu32(msg1, msg2);
+    let k = _mm_loadu_si128(K.as_ptr().add(40).cast::<__m128i>());
+    msg_a = _mm_add_epi32(msg2_a, k);
+    msg_b = _mm_add_epi32(msg2_b, k);
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_b);
+    tmp_a = _mm_alignr_epi8(msg2_a, msg1_a, 4);
+    tmp_b = _mm_alignr_epi8(msg2_b, msg1_b, 4);
+    msg3_a = _mm_add_epi32(msg3_a, tmp_a);
+    msg3_b = _mm_add_epi32(msg3_b, tmp_b);
+    msg3_a = _mm_sha256msg2_epu32(msg3_a, msg2_a);
+    msg3_b = _mm_sha256msg2_epu32(msg3_b, msg2_b);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    msg_b = _mm_shuffle_epi32(msg_b, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_b);
+    msg1_a = _mm_sha256msg1_epu32(msg1_a, msg2_a);
+    msg1_b = _mm_sha256msg1_epu32(msg1_b, msg2_b);
 
     // Rounds 44-47
-    msg = _mm_add_epi32(msg3, _mm_loadu_si128(K.as_ptr().add(44).cast::<__m128i>()));
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    tmp = _mm_alignr_epi8(msg3, msg2, 4);
-    msg0 = _mm_add_epi32(msg0, tmp);
-    msg0 = _mm_sha256msg2_epu32(msg0, msg3);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
-    msg2 = _mm_sha256msg1_epu32(msg2, msg3);
+    let k = _mm_loadu_si128(K.as_ptr().add(44).cast::<__m128i>());
+    msg_a = _mm_add_epi32(msg3_a, k);
+    msg_b = _mm_add_epi32(msg3_b, k);
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_b);
+    tmp_a = _mm_alignr_epi8(msg3_a, msg2_a, 4);
+    tmp_b = _mm_alignr_epi8(msg3_b, msg2_b, 4);
+    msg0_a = _mm_add_epi32(msg0_a, tmp_a);
+    msg0_b = _mm_add_epi32(msg0_b, tmp_b);
+    msg0_a = _mm_sha256msg2_epu32(msg0_a, msg3_a);
+    msg0_b = _mm_sha256msg2_epu32(msg0_b, msg3_b);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    msg_b = _mm_shuffle_epi32(msg_b, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_b);
+    msg2_a = _mm_sha256msg1_epu32(msg2_a, msg3_a);
+    msg2_b = _mm_sha256msg1_epu32(msg2_b, msg3_b);
 
     // Rounds 48-51
-    msg = _mm_add_epi32(msg0, _mm_loadu_si128(K.as_ptr().add(48).cast::<__m128i>()));
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    tmp = _mm_alignr_epi8(msg0, msg3, 4);
-    msg1 = _mm_add_epi32(msg1, tmp);
-    msg1 = _mm_sha256msg2_epu32(msg1, msg0);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
-    msg3 = _mm_sha256msg1_epu32(msg3, msg0);
+    let k = _mm_loadu_si128(K.as_ptr().add(48).cast::<__m128i>());
+    msg_a = _mm_add_epi32(msg0_a, k);
+    msg_b = _mm_add_epi32(msg0_b, k);
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_b);
+    tmp_a = _mm_alignr_epi8(msg0_a, msg3_a, 4);
+    tmp_b = _mm_alignr_epi8(msg0_b, msg3_b, 4);
+    msg1_a = _mm_add_epi32(msg1_a, tmp_a);
+    msg1_b = _mm_add_epi32(msg1_b, tmp_b);
+    msg1_a = _mm_sha256msg2_epu32(msg1_a, msg0_a);
+    msg1_b = _mm_sha256msg2_epu32(msg1_b, msg0_b);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    msg_b = _mm_shuffle_epi32(msg_b, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_b);
+    msg3_a = _mm_sha256msg1_epu32(msg3_a, msg0_a);
+    msg3_b = _mm_sha256msg1_epu32(msg3_b, msg0_b);
 
     // Rounds 52-55
-    msg = _mm_add_epi32(msg1, _mm_loadu_si128(K.as_ptr().add(52).cast::<__m128i>()));
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    tmp = _mm_alignr_epi8(msg1, msg0, 4);
-    msg2 = _mm_add_epi32(msg2, tmp);
-    msg2 = _mm_sha256msg2_epu32(msg2, msg1);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    let k = _mm_loadu_si128(K.as_ptr().add(52).cast::<__m128i>());
+    msg_a = _mm_add_epi32(msg1_a, k);
+    msg_b = _mm_add_epi32(msg1_b, k);
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_b);
+    tmp_a = _mm_alignr_epi8(msg1_a, msg0_a, 4);
+    tmp_b = _mm_alignr_epi8(msg1_b, msg0_b, 4);
+    msg2_a = _mm_add_epi32(msg2_a, tmp_a);
+    msg2_b = _mm_add_epi32(msg2_b, tmp_b);
+    msg2_a = _mm_sha256msg2_epu32(msg2_a, msg1_a);
+    msg2_b = _mm_sha256msg2_epu32(msg2_b, msg1_b);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    msg_b = _mm_shuffle_epi32(msg_b, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_b);
 
     // Rounds 56-59
-    msg = _mm_add_epi32(msg2, _mm_loadu_si128(K.as_ptr().add(56).cast::<__m128i>()));
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    tmp = _mm_alignr_epi8(msg2, msg1, 4);
-    msg3 = _mm_add_epi32(msg3, tmp);
-    msg3 = _mm_sha256msg2_epu32(msg3, msg2);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    let k = _mm_loadu_si128(K.as_ptr().add(56).cast::<__m128i>());
+    msg_a = _mm_add_epi32(msg2_a, k);
+    msg_b = _mm_add_epi32(msg2_b, k);
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_b);
+    tmp_a = _mm_alignr_epi8(msg2_a, msg1_a, 4);
+    tmp_b = _mm_alignr_epi8(msg2_b, msg1_b, 4);
+    msg3_a = _mm_add_epi32(msg3_a, tmp_a);
+    msg3_b = _mm_add_epi32(msg3_b, tmp_b);
+    msg3_a = _mm_sha256msg2_epu32(msg3_a, msg2_a);
+    msg3_b = _mm_sha256msg2_epu32(msg3_b, msg2_b);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    msg_b = _mm_shuffle_epi32(msg_b, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_b);
 
     // Rounds 60-63
-    msg = _mm_add_epi32(msg3, _mm_loadu_si128(K.as_ptr().add(60).cast::<__m128i>()));
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    let k = _mm_loadu_si128(K.as_ptr().add(60).cast::<__m128i>());
+    msg_a = _mm_add_epi32(msg3_a, k);
+    msg_b = _mm_add_epi32(msg3_b, k);
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_b);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    msg_b = _mm_shuffle_epi32(msg_b, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_b);
 
     // Transform 1: Update state
-    state0 = _mm_add_epi32(state0, init0);
-    state1 = _mm_add_epi32(state1, init1);
+    state0_a = _mm_add_epi32(state0_a, init0);
+    state0_b = _mm_add_epi32(state0_b, init0);
+    state1_a = _mm_add_epi32(state1_a, init1);
+    state1_b = _mm_add_epi32(state1_b, init1);
 
     // ------------------ Transform 2 -------------------
 
     // Save state
-    abef_save = state0;
-    cdgh_save = state1;
+    abef_save_a = state0_a;
+    abef_save_b = state0_b;
+    cdgh_save_a = state1_a;
+    cdgh_save_b = state1_b;
 
     // Rounds 0-3
-    msg = _mm_loadu_si128(MIDS.as_ptr().add(0).cast::<__m128i>());
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg_a = _mm_loadu_si128(MIDS.as_ptr().add(0).cast::<__m128i>());
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_a);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_a);
 
     // Rounds 4-7
-    msg = _mm_loadu_si128(MIDS.as_ptr().add(4).cast::<__m128i>());
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg_a = _mm_loadu_si128(MIDS.as_ptr().add(4).cast::<__m128i>());
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_a);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_a);
 
     // Rounds 8-11
-    msg = _mm_loadu_si128(MIDS.as_ptr().add(8).cast::<__m128i>());
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg_a = _mm_loadu_si128(MIDS.as_ptr().add(8).cast::<__m128i>());
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_a);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_a);
 
     // Rounds 12-15
-    msg = _mm_loadu_si128(MIDS.as_ptr().add(12).cast::<__m128i>());
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg_a = _mm_loadu_si128(MIDS.as_ptr().add(12).cast::<__m128i>());
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_a);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_a);
 
     // Rounds 16-19
-    msg = _mm_loadu_si128(MIDS.as_ptr().add(16).cast::<__m128i>());
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg_a = _mm_loadu_si128(MIDS.as_ptr().add(16).cast::<__m128i>());
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_a);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_a);
 
     // Rounds 20-23
-    msg = _mm_loadu_si128(MIDS.as_ptr().add(20).cast::<__m128i>());
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg_a = _mm_loadu_si128(MIDS.as_ptr().add(20).cast::<__m128i>());
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_a);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_a);
 
     // Rounds 24-27
-    msg = _mm_loadu_si128(MIDS.as_ptr().add(24).cast::<__m128i>());
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg_a = _mm_loadu_si128(MIDS.as_ptr().add(24).cast::<__m128i>());
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_a);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_a);
 
     // Rounds 28-31
-    msg = _mm_loadu_si128(MIDS.as_ptr().add(28).cast::<__m128i>());
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg_a = _mm_loadu_si128(MIDS.as_ptr().add(28).cast::<__m128i>());
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_a);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_a);
 
     // Rounds 32-35
-    msg = _mm_loadu_si128(MIDS.as_ptr().add(32).cast::<__m128i>());
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg_a = _mm_loadu_si128(MIDS.as_ptr().add(32).cast::<__m128i>());
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_a);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_a);
 
     // Rounds 36-39
-    msg = _mm_loadu_si128(MIDS.as_ptr().add(36).cast::<__m128i>());
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg_a = _mm_loadu_si128(MIDS.as_ptr().add(36).cast::<__m128i>());
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_a);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_a);
 
     // Rounds 40-43
-    msg = _mm_loadu_si128(MIDS.as_ptr().add(40).cast::<__m128i>());
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg_a = _mm_loadu_si128(MIDS.as_ptr().add(40).cast::<__m128i>());
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_a);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_a);
 
     // Rounds 44-47
-    msg = _mm_loadu_si128(MIDS.as_ptr().add(44).cast::<__m128i>());
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg_a = _mm_loadu_si128(MIDS.as_ptr().add(44).cast::<__m128i>());
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_a);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_a);
 
     // Rounds 48-51
-    msg = _mm_loadu_si128(MIDS.as_ptr().add(48).cast::<__m128i>());
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg_a = _mm_loadu_si128(MIDS.as_ptr().add(48).cast::<__m128i>());
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_a);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_a);
 
     // Rounds 52-55
-    msg = _mm_loadu_si128(MIDS.as_ptr().add(52).cast::<__m128i>());
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg_a = _mm_loadu_si128(MIDS.as_ptr().add(52).cast::<__m128i>());
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_a);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_a);
 
     // Rounds 56-59
-    msg = _mm_loadu_si128(MIDS.as_ptr().add(56).cast::<__m128i>());
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg_a = _mm_loadu_si128(MIDS.as_ptr().add(56).cast::<__m128i>());
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_a);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_a);
 
     // Rounds 60-63
-    msg = _mm_loadu_si128(MIDS.as_ptr().add(60).cast::<__m128i>());
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg_a = _mm_loadu_si128(MIDS.as_ptr().add(60).cast::<__m128i>());
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_a);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_a);
 
     // Transform 2: Update state
-    state0 = _mm_add_epi32(state0, abef_save);
-    state1 = _mm_add_epi32(state1, cdgh_save);
+    state0_a = _mm_add_epi32(state0_a, abef_save_a);
+    state0_b = _mm_add_epi32(state0_b, abef_save_b);
+    state1_a = _mm_add_epi32(state1_a, cdgh_save_a);
+    state1_b = _mm_add_epi32(state1_b, cdgh_save_b);
 
     // Unshuffle to extract hash
-    tmp = _mm_shuffle_epi32(state0, 0x1B);
-    state1 = _mm_shuffle_epi32(state1, 0xB1);
-    msg0 = _mm_blend_epi16(tmp, state1, 0xF0);
-    msg1 = _mm_alignr_epi8(state1, tmp, 8);
+    tmp_a = _mm_shuffle_epi32(state0_a, 0x1B);
+    tmp_b = _mm_shuffle_epi32(state0_b, 0x1B);
+    state1_a = _mm_shuffle_epi32(state1_a, 0xB1);
+    state1_b = _mm_shuffle_epi32(state1_b, 0xB1);
+    msg0_a = _mm_blend_epi16(tmp_a, state1_a, 0xF0);
+    msg0_b = _mm_blend_epi16(tmp_b, state1_b, 0xF0);
+    msg1_a = _mm_alignr_epi8(state1_a, tmp_a, 8);
+    msg1_b = _mm_alignr_epi8(state1_b, tmp_b, 8);
 
     // ------------------ Transform 3 -------------------
 
     // Load state
-    state0 = init0;
-    state1 = init1;
+    state0_a = init0;
+    state0_b = init0;
+    state1_a = init1;
+    state1_b = init1;
 
     // Rounds 0-3
-    msg = _mm_add_epi32(msg0, _mm_loadu_si128(K.as_ptr().add(0).cast::<__m128i>()));
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    let k = _mm_loadu_si128(K.as_ptr().add(0).cast::<__m128i>());
+    msg_a = _mm_add_epi32(msg0_a, k);
+    msg_b = _mm_add_epi32(msg0_b, k);
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_b);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    msg_b = _mm_shuffle_epi32(msg_b, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_b);
 
     // Rounds 4-7
-    msg = _mm_add_epi32(msg1, _mm_loadu_si128(K.as_ptr().add(4).cast::<__m128i>()));
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
-    msg0 = _mm_sha256msg1_epu32(msg0, msg1);
+    let k = _mm_loadu_si128(K.as_ptr().add(4).cast::<__m128i>());
+    msg_a = _mm_add_epi32(msg1_a, k);
+    msg_b = _mm_add_epi32(msg1_b, k);
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_b);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    msg_b = _mm_shuffle_epi32(msg_b, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_b);
+    msg0_a = _mm_sha256msg1_epu32(msg0_a, msg1_a);
+    msg0_b = _mm_sha256msg1_epu32(msg0_b, msg1_b);
 
     // Rounds 8-11
-    msg2 = _mm_loadu_si128(FINS.as_ptr().add(4).cast::<__m128i>());
-    msg = _mm_loadu_si128(FINS.as_ptr().add(0).cast::<__m128i>());
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
-    msg1 = _mm_sha256msg1_epu32(msg1, msg2);
+    msg2_a = _mm_loadu_si128(FINS.as_ptr().add(4).cast::<__m128i>());
+    msg2_b = msg2_a;
+    msg_a = _mm_loadu_si128(FINS.as_ptr().add(0).cast::<__m128i>());
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_a);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_a);
+    msg1_a = _mm_sha256msg1_epu32(msg1_a, msg2_a);
+    msg1_b = _mm_sha256msg1_epu32(msg1_b, msg2_b);
 
     // Rounds 12-15
-    msg3 = _mm_loadu_si128(FINAL.as_ptr().add(4).cast::<__m128i>());
-    msg = _mm_loadu_si128(FINS.as_ptr().add(8).cast::<__m128i>());
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    tmp = _mm_alignr_epi8(msg3, msg2, 4);
-    msg0 = _mm_add_epi32(msg0, tmp);
-    msg0 = _mm_sha256msg2_epu32(msg0, msg3);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
-    msg2 = _mm_sha256msg1_epu32(msg2, msg3);
+    msg3_a = _mm_loadu_si128(FINAL.as_ptr().add(4).cast::<__m128i>());
+    msg3_b = msg3_a;
+    msg_a = _mm_loadu_si128(FINS.as_ptr().add(8).cast::<__m128i>());
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_a);
+    tmp_a = _mm_alignr_epi8(msg3_a, msg2_a, 4);
+    tmp_b = _mm_alignr_epi8(msg3_b, msg2_b, 4);
+    msg0_a = _mm_add_epi32(msg0_a, tmp_a);
+    msg0_b = _mm_add_epi32(msg0_b, tmp_b);
+    msg0_a = _mm_sha256msg2_epu32(msg0_a, msg3_a);
+    msg0_b = _mm_sha256msg2_epu32(msg0_b, msg3_b);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_a);
+    msg2_a = _mm_sha256msg1_epu32(msg2_a, msg3_a);
+    msg2_b = _mm_sha256msg1_epu32(msg2_b, msg3_b);
 
     // Rounds 16-19
-    msg = _mm_add_epi32(msg0, _mm_loadu_si128(K.as_ptr().add(16).cast::<__m128i>()));
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    tmp = _mm_alignr_epi8(msg0, msg3, 4);
-    msg1 = _mm_add_epi32(msg1, tmp);
-    msg1 = _mm_sha256msg2_epu32(msg1, msg0);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
-    msg3 = _mm_sha256msg1_epu32(msg3, msg0);
+    let k = _mm_loadu_si128(K.as_ptr().add(16).cast::<__m128i>());
+    msg_a = _mm_add_epi32(msg0_a, k);
+    msg_b = _mm_add_epi32(msg0_b, k);
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_b);
+    tmp_a = _mm_alignr_epi8(msg0_a, msg3_a, 4);
+    tmp_b = _mm_alignr_epi8(msg0_b, msg3_b, 4);
+    msg1_a = _mm_add_epi32(msg1_a, tmp_a);
+    msg1_b = _mm_add_epi32(msg1_b, tmp_b);
+    msg1_a = _mm_sha256msg2_epu32(msg1_a, msg0_a);
+    msg1_b = _mm_sha256msg2_epu32(msg1_b, msg0_b);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    msg_b = _mm_shuffle_epi32(msg_b, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_b);
+    msg3_a = _mm_sha256msg1_epu32(msg3_a, msg0_a);
+    msg3_b = _mm_sha256msg1_epu32(msg3_b, msg0_b);
 
     // Rounds 20-23
-    msg = _mm_add_epi32(msg1, _mm_loadu_si128(K.as_ptr().add(20).cast::<__m128i>()));
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    tmp = _mm_alignr_epi8(msg1, msg0, 4);
-    msg2 = _mm_add_epi32(msg2, tmp);
-    msg2 = _mm_sha256msg2_epu32(msg2, msg1);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
-    msg0 = _mm_sha256msg1_epu32(msg0, msg1);
+    let k = _mm_loadu_si128(K.as_ptr().add(20).cast::<__m128i>());
+    msg_a = _mm_add_epi32(msg1_a, k);
+    msg_b = _mm_add_epi32(msg1_b, k);
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_b);
+    tmp_a = _mm_alignr_epi8(msg1_a, msg0_a, 4);
+    tmp_b = _mm_alignr_epi8(msg1_b, msg0_b, 4);
+    msg2_a = _mm_add_epi32(msg2_a, tmp_a);
+    msg2_b = _mm_add_epi32(msg2_b, tmp_b);
+    msg2_a = _mm_sha256msg2_epu32(msg2_a, msg1_a);
+    msg2_b = _mm_sha256msg2_epu32(msg2_b, msg1_b);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    msg_b = _mm_shuffle_epi32(msg_b, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_b);
+    msg0_a = _mm_sha256msg1_epu32(msg0_a, msg1_a);
+    msg0_b = _mm_sha256msg1_epu32(msg0_b, msg1_b);
 
     // Rounds 24-27
-    msg = _mm_add_epi32(msg2, _mm_loadu_si128(K.as_ptr().add(24).cast::<__m128i>()));
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    tmp = _mm_alignr_epi8(msg2, msg1, 4);
-    msg3 = _mm_add_epi32(msg3, tmp);
-    msg3 = _mm_sha256msg2_epu32(msg3, msg2);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
-    msg1 = _mm_sha256msg1_epu32(msg1, msg2);
+    let k = _mm_loadu_si128(K.as_ptr().add(24).cast::<__m128i>());
+    msg_a = _mm_add_epi32(msg2_a, k);
+    msg_b = _mm_add_epi32(msg2_b, k);
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_b);
+    tmp_a = _mm_alignr_epi8(msg2_a, msg1_a, 4);
+    tmp_b = _mm_alignr_epi8(msg2_b, msg1_b, 4);
+    msg3_a = _mm_add_epi32(msg3_a, tmp_a);
+    msg3_b = _mm_add_epi32(msg3_b, tmp_b);
+    msg3_a = _mm_sha256msg2_epu32(msg3_a, msg2_a);
+    msg3_b = _mm_sha256msg2_epu32(msg3_b, msg2_b);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    msg_b = _mm_shuffle_epi32(msg_b, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_b);
+    msg1_a = _mm_sha256msg1_epu32(msg1_a, msg2_a);
+    msg1_b = _mm_sha256msg1_epu32(msg1_b, msg2_b);
 
     // Rounds 28-31
-    msg = _mm_add_epi32(msg3, _mm_loadu_si128(K.as_ptr().add(28).cast::<__m128i>()));
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    tmp = _mm_alignr_epi8(msg3, msg2, 4);
-    msg0 = _mm_add_epi32(msg0, tmp);
-    msg0 = _mm_sha256msg2_epu32(msg0, msg3);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
-    msg2 = _mm_sha256msg1_epu32(msg2, msg3);
+    let k = _mm_loadu_si128(K.as_ptr().add(28).cast::<__m128i>());
+    msg_a = _mm_add_epi32(msg3_a, k);
+    msg_b = _mm_add_epi32(msg3_b, k);
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_b);
+    tmp_a = _mm_alignr_epi8(msg3_a, msg2_a, 4);
+    tmp_b = _mm_alignr_epi8(msg3_b, msg2_b, 4);
+    msg0_a = _mm_add_epi32(msg0_a, tmp_a);
+    msg0_b = _mm_add_epi32(msg0_b, tmp_b);
+    msg0_a = _mm_sha256msg2_epu32(msg0_a, msg3_a);
+    msg0_b = _mm_sha256msg2_epu32(msg0_b, msg3_b);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    msg_b = _mm_shuffle_epi32(msg_b, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_b);
+    msg2_a = _mm_sha256msg1_epu32(msg2_a, msg3_a);
+    msg2_b = _mm_sha256msg1_epu32(msg2_b, msg3_b);
 
     // Rounds 32-35
-    msg = _mm_add_epi32(msg0, _mm_loadu_si128(K.as_ptr().add(32).cast::<__m128i>()));
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    tmp = _mm_alignr_epi8(msg0, msg3, 4);
-    msg1 = _mm_add_epi32(msg1, tmp);
-    msg1 = _mm_sha256msg2_epu32(msg1, msg0);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
-    msg3 = _mm_sha256msg1_epu32(msg3, msg0);
+    let k = _mm_loadu_si128(K.as_ptr().add(32).cast::<__m128i>());
+    msg_a = _mm_add_epi32(msg0_a, k);
+    msg_b = _mm_add_epi32(msg0_b, k);
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_b);
+    tmp_a = _mm_alignr_epi8(msg0_a, msg3_a, 4);
+    tmp_b = _mm_alignr_epi8(msg0_b, msg3_b, 4);
+    msg1_a = _mm_add_epi32(msg1_a, tmp_a);
+    msg1_b = _mm_add_epi32(msg1_b, tmp_b);
+    msg1_a = _mm_sha256msg2_epu32(msg1_a, msg0_a);
+    msg1_b = _mm_sha256msg2_epu32(msg1_b, msg0_b);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    msg_b = _mm_shuffle_epi32(msg_b, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_b);
+    msg3_a = _mm_sha256msg1_epu32(msg3_a, msg0_a);
+    msg3_b = _mm_sha256msg1_epu32(msg3_b, msg0_b);
 
     // Rounds 36-39
-    msg = _mm_add_epi32(msg1, _mm_loadu_si128(K.as_ptr().add(36).cast::<__m128i>()));
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    tmp = _mm_alignr_epi8(msg1, msg0, 4);
-    msg2 = _mm_add_epi32(msg2, tmp);
-    msg2 = _mm_sha256msg2_epu32(msg2, msg1);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
-    msg0 = _mm_sha256msg1_epu32(msg0, msg1);
+    let k = _mm_loadu_si128(K.as_ptr().add(36).cast::<__m128i>());
+    msg_a = _mm_add_epi32(msg1_a, k);
+    msg_b = _mm_add_epi32(msg1_b, k);
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_b);
+    tmp_a = _mm_alignr_epi8(msg1_a, msg0_a, 4);
+    tmp_b = _mm_alignr_epi8(msg1_b, msg0_b, 4);
+    msg2_a = _mm_add_epi32(msg2_a, tmp_a);
+    msg2_b = _mm_add_epi32(msg2_b, tmp_b);
+    msg2_a = _mm_sha256msg2_epu32(msg2_a, msg1_a);
+    msg2_b = _mm_sha256msg2_epu32(msg2_b, msg1_b);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    msg_b = _mm_shuffle_epi32(msg_b, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_b);
+    msg0_a = _mm_sha256msg1_epu32(msg0_a, msg1_a);
+    msg0_b = _mm_sha256msg1_epu32(msg0_b, msg1_b);
 
     // Rounds 40-43
-    msg = _mm_add_epi32(msg2, _mm_loadu_si128(K.as_ptr().add(40).cast::<__m128i>()));
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    tmp = _mm_alignr_epi8(msg2, msg1, 4);
-    msg3 = _mm_add_epi32(msg3, tmp);
-    msg3 = _mm_sha256msg2_epu32(msg3, msg2);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
-    msg1 = _mm_sha256msg1_epu32(msg1, msg2);
+    let k = _mm_loadu_si128(K.as_ptr().add(40).cast::<__m128i>());
+    msg_a = _mm_add_epi32(msg2_a, k);
+    msg_b = _mm_add_epi32(msg2_b, k);
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_b);
+    tmp_a = _mm_alignr_epi8(msg2_a, msg1_a, 4);
+    tmp_b = _mm_alignr_epi8(msg2_b, msg1_b, 4);
+    msg3_a = _mm_add_epi32(msg3_a, tmp_a);
+    msg3_b = _mm_add_epi32(msg3_b, tmp_b);
+    msg3_a = _mm_sha256msg2_epu32(msg3_a, msg2_a);
+    msg3_b = _mm_sha256msg2_epu32(msg3_b, msg2_b);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    msg_b = _mm_shuffle_epi32(msg_b, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_b);
+    msg1_a = _mm_sha256msg1_epu32(msg1_a, msg2_a);
+    msg1_b = _mm_sha256msg1_epu32(msg1_b, msg2_b);
 
     // Rounds 44-47
-    msg = _mm_add_epi32(msg3, _mm_loadu_si128(K.as_ptr().add(44).cast::<__m128i>()));
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    tmp = _mm_alignr_epi8(msg3, msg2, 4);
-    msg0 = _mm_add_epi32(msg0, tmp);
-    msg0 = _mm_sha256msg2_epu32(msg0, msg3);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
-    msg2 = _mm_sha256msg1_epu32(msg2, msg3);
+    let k = _mm_loadu_si128(K.as_ptr().add(44).cast::<__m128i>());
+    msg_a = _mm_add_epi32(msg3_a, k);
+    msg_b = _mm_add_epi32(msg3_b, k);
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_b);
+    tmp_a = _mm_alignr_epi8(msg3_a, msg2_a, 4);
+    tmp_b = _mm_alignr_epi8(msg3_b, msg2_b, 4);
+    msg0_a = _mm_add_epi32(msg0_a, tmp_a);
+    msg0_b = _mm_add_epi32(msg0_b, tmp_b);
+    msg0_a = _mm_sha256msg2_epu32(msg0_a, msg3_a);
+    msg0_b = _mm_sha256msg2_epu32(msg0_b, msg3_b);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    msg_b = _mm_shuffle_epi32(msg_b, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_b);
+    msg2_a = _mm_sha256msg1_epu32(msg2_a, msg3_a);
+    msg2_b = _mm_sha256msg1_epu32(msg2_b, msg3_b);
 
     // Rounds 48-51
-    msg = _mm_add_epi32(msg0, _mm_loadu_si128(K.as_ptr().add(48).cast::<__m128i>()));
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    tmp = _mm_alignr_epi8(msg0, msg3, 4);
-    msg1 = _mm_add_epi32(msg1, tmp);
-    msg1 = _mm_sha256msg2_epu32(msg1, msg0);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
-    msg3 = _mm_sha256msg1_epu32(msg3, msg0);
+    let k = _mm_loadu_si128(K.as_ptr().add(48).cast::<__m128i>());
+    msg_a = _mm_add_epi32(msg0_a, k);
+    msg_b = _mm_add_epi32(msg0_b, k);
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_b);
+    tmp_a = _mm_alignr_epi8(msg0_a, msg3_a, 4);
+    tmp_b = _mm_alignr_epi8(msg0_b, msg3_b, 4);
+    msg1_a = _mm_add_epi32(msg1_a, tmp_a);
+    msg1_b = _mm_add_epi32(msg1_b, tmp_b);
+    msg1_a = _mm_sha256msg2_epu32(msg1_a, msg0_a);
+    msg1_b = _mm_sha256msg2_epu32(msg1_b, msg0_b);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    msg_b = _mm_shuffle_epi32(msg_b, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_b);
+    msg3_a = _mm_sha256msg1_epu32(msg3_a, msg0_a);
+    msg3_b = _mm_sha256msg1_epu32(msg3_b, msg0_b);
 
     // Rounds 52-55
-    msg = _mm_add_epi32(msg1, _mm_loadu_si128(K.as_ptr().add(52).cast::<__m128i>()));
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    tmp = _mm_alignr_epi8(msg1, msg0, 4);
-    msg2 = _mm_add_epi32(msg2, tmp);
-    msg2 = _mm_sha256msg2_epu32(msg2, msg1);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    let k = _mm_loadu_si128(K.as_ptr().add(52).cast::<__m128i>());
+    msg_a = _mm_add_epi32(msg1_a, k);
+    msg_b = _mm_add_epi32(msg1_b, k);
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_b);
+    tmp_a = _mm_alignr_epi8(msg1_a, msg0_a, 4);
+    tmp_b = _mm_alignr_epi8(msg1_b, msg0_b, 4);
+    msg2_a = _mm_add_epi32(msg2_a, tmp_a);
+    msg2_b = _mm_add_epi32(msg2_b, tmp_b);
+    msg2_a = _mm_sha256msg2_epu32(msg2_a, msg1_a);
+    msg2_b = _mm_sha256msg2_epu32(msg2_b, msg1_b);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    msg_b = _mm_shuffle_epi32(msg_b, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_b);
 
     // Rounds 56-59
-    msg = _mm_add_epi32(msg2, _mm_loadu_si128(K.as_ptr().add(56).cast::<__m128i>()));
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    tmp = _mm_alignr_epi8(msg2, msg1, 4);
-    msg3 = _mm_add_epi32(msg3, tmp);
-    msg3 = _mm_sha256msg2_epu32(msg3, msg2);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    let k = _mm_loadu_si128(K.as_ptr().add(56).cast::<__m128i>());
+    msg_a = _mm_add_epi32(msg2_a, k);
+    msg_b = _mm_add_epi32(msg2_b, k);
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_b);
+    tmp_a = _mm_alignr_epi8(msg2_a, msg1_a, 4);
+    tmp_b = _mm_alignr_epi8(msg2_b, msg1_b, 4);
+    msg3_a = _mm_add_epi32(msg3_a, tmp_a);
+    msg3_b = _mm_add_epi32(msg3_b, tmp_b);
+    msg3_a = _mm_sha256msg2_epu32(msg3_a, msg2_a);
+    msg3_b = _mm_sha256msg2_epu32(msg3_b, msg2_b);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    msg_b = _mm_shuffle_epi32(msg_b, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_b);
 
     // Rounds 60-63
-    msg = _mm_add_epi32(msg3, _mm_loadu_si128(K.as_ptr().add(60).cast::<__m128i>()));
-    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
-    msg = _mm_shuffle_epi32(msg, 0x0E);
-    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
-
+    let k = _mm_loadu_si128(K.as_ptr().add(60).cast::<__m128i>());
+    msg_a = _mm_add_epi32(msg3_a, k);
+    msg_b = _mm_add_epi32(msg3_b, k);
+    state1_a = _mm_sha256rnds2_epu32(state1_a, state0_a, msg_a);
+    state1_b = _mm_sha256rnds2_epu32(state1_b, state0_b, msg_b);
+    msg_a = _mm_shuffle_epi32(msg_a, 0x0E);
+    msg_b = _mm_shuffle_epi32(msg_b, 0x0E);
+    state0_a = _mm_sha256rnds2_epu32(state0_a, state1_a, msg_a);
+    state0_b = _mm_sha256rnds2_epu32(state0_b, state1_b, msg_b);
 
     // Transform 3: Update state
-    state0 = _mm_add_epi32(state0, init0);
-    state1 = _mm_add_epi32(state1, init1);
+    state0_a = _mm_add_epi32(state0_a, init0);
+    state0_b = _mm_add_epi32(state0_b, init0);
+    state1_a = _mm_add_epi32(state1_a, init1);
+    state1_b = _mm_add_epi32(state1_b, init1);
 
     // Unshuffle
-    tmp = _mm_shuffle_epi32(state0, 0x1B);
-    state1 = _mm_shuffle_epi32(state1, 0xB1);
-    state0 = _mm_blend_epi16(tmp, state1, 0xF0);
-    state1 = _mm_alignr_epi8(state1, tmp, 8);
+    tmp_a = _mm_shuffle_epi32(state0_a, 0x1B);
+    tmp_b = _mm_shuffle_epi32(state0_b, 0x1B);
+    state1_a = _mm_shuffle_epi32(state1_a, 0xB1);
+    state1_b = _mm_shuffle_epi32(state1_b, 0xB1);
+    state0_a = _mm_blend_epi16(tmp_a, state1_a, 0xF0);
+    state0_b = _mm_blend_epi16(tmp_b, state1_b, 0xF0);
+    state1_a = _mm_alignr_epi8(state1_a, tmp_a, 8);
+    state1_b = _mm_alignr_epi8(state1_b, tmp_b, 8);
 
-    // Store result (byte-swap to big-endian)
+    // Store results (byte-swap to big-endian)
     // CAST SAFETY: storeu_si128 does not require alignment.
-    _mm_storeu_si128(output.as_mut_ptr().add(0).cast::<__m128i>(), _mm_shuffle_epi8(state0, MASK));
-    _mm_storeu_si128(output.as_mut_ptr().add(16).cast::<__m128i>(), _mm_shuffle_epi8(state1, MASK));
+    _mm_storeu_si128(output[0].as_mut_ptr().add(0).cast::<__m128i>(), _mm_shuffle_epi8(state0_a, MASK));
+    _mm_storeu_si128(output[0].as_mut_ptr().add(16).cast::<__m128i>(), _mm_shuffle_epi8(state1_a, MASK));
+    _mm_storeu_si128(output[1].as_mut_ptr().add(0).cast::<__m128i>(), _mm_shuffle_epi8(state0_b, MASK));
+    _mm_storeu_si128(output[1].as_mut_ptr().add(16).cast::<__m128i>(), _mm_shuffle_epi8(state1_b, MASK));
 }
 

--- a/hashes/src/sha256/crypto/x86_shani.rs
+++ b/hashes/src/sha256/crypto/x86_shani.rs
@@ -276,3 +276,520 @@ pub(super) unsafe fn process_block(state: &mut [u32; 8], block: &[u8]) {
     _mm_storeu_si128(state.as_mut_ptr().add(4).cast::<__m128i>(), state1);
 }
 
+/// Computes `SHA256d` of a single 64-byte input using x86 SHA-NI.
+#[target_feature(enable = "sha,sse2,ssse3,sse4.1")]
+unsafe fn sha256d_64_x86(output: &mut [u8; 32], input: &[u8; 64]) {
+    // SHA256 round constants
+    #[rustfmt::skip]
+    const K: [u32; 64] = [
+        0x428A2F98, 0x71374491, 0xB5C0FBCF, 0xE9B5DBA5,
+        0x3956C25B, 0x59F111F1, 0x923F82A4, 0xAB1C5ED5,
+        0xD807AA98, 0x12835B01, 0x243185BE, 0x550C7DC3,
+        0x72BE5D74, 0x80DEB1FE, 0x9BDC06A7, 0xC19BF174,
+        0xE49B69C1, 0xEFBE4786, 0x0FC19DC6, 0x240CA1CC,
+        0x2DE92C6F, 0x4A7484AA, 0x5CB0A9DC, 0x76F988DA,
+        0x983E5152, 0xA831C66D, 0xB00327C8, 0xBF597FC7,
+        0xC6E00BF3, 0xD5A79147, 0x06CA6351, 0x14292967,
+        0x27B70A85, 0x2E1B2138, 0x4D2C6DFC, 0x53380D13,
+        0x650A7354, 0x766A0ABB, 0x81C2C92E, 0x92722C85,
+        0xA2BFE8A1, 0xA81A664B, 0xC24B8B70, 0xC76C51A3,
+        0xD192E819, 0xD6990624, 0xF40E3585, 0x106AA070,
+        0x19A4C116, 0x1E376C08, 0x2748774C, 0x34B0BCB5,
+        0x391C0CB3, 0x4ED8AA4A, 0x5B9CCA4F, 0x682E6FF3,
+        0x748F82EE, 0x78A5636F, 0x84C87814, 0x8CC70208,
+        0x90BEFFFA, 0xA4506CEB, 0xBEF9A3F7, 0xC67178F2,
+    ];
+
+    // Precomputed W[i] + K[i] for the 2nd transform (padding block).
+    #[rustfmt::skip]
+    const MIDS: [u32; 64] = [
+        0xc28a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
+        0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+        0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+        0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf374,
+        0x649b69c1, 0xf0fe4786, 0x0fe1edc6, 0x240cf254,
+        0x4fe9346f, 0x6cc984be, 0x61b9411e, 0x16f988fa,
+        0xf2c65152, 0xa88e5a6d, 0xb019fc65, 0xb9d99ec7,
+        0x9a1231c3, 0xe70eeaa0, 0xfdb1232b, 0xc7353eb0,
+        0x3069bad5, 0xcb976d5f, 0x5a0f118f, 0xdc1eeefd,
+        0x0a35b689, 0xde0b7a04, 0x58f4ca9d, 0xe15d5b16,
+        0x007f3e86, 0x37088980, 0xa507ea32, 0x6fab9537,
+        0x17406110, 0x0d8cd6f1, 0xcdaa3b6d, 0xc0bbbe37,
+        0x83613bda, 0xdb48a363, 0x0b02e931, 0x6fd15ca7,
+        0x521afaca, 0x31338431, 0x6ed41a95, 0x6d437890,
+        0xc39c91f2, 0x9eccabbd, 0xb5c9a0e6, 0x532fb63c,
+        0xd2c741c6, 0x07237ea3, 0xa4954b68, 0x4c191d76
+    ];
+
+    // Precomputed values for Transform 3 rounds 9-16.
+    // FINS[0..3]: msg2 + K[8..11]
+    // FINS[4..7]: _mm_sha256msg1_epu32(msg2, msg3)
+    // FINS[8..11]: msg2 + K[12..15]
+    #[rustfmt::skip]
+    const FINS: [u32; 12] = [
+        0x5807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+        0x80000000, 0x00000000, 0x00000000, 0x00000000,
+        0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf274,
+    ];
+
+    // Padding processed in the 3rd transform (byteswapped).
+    const FINAL: [u32; 8] = [0x80000000, 0, 0, 0, 0, 0, 0, 0x100];
+
+    #[allow(non_snake_case)]
+    let MASK: __m128i = _mm_set_epi64x(
+        0x0c0d_0e0f_0809_0a0bu64 as i64,
+        0x0405_0607_0001_0203u64 as i64,
+    );
+
+    // Preshuffled SHA256 initial hash values for x86 SHA-NI.
+    let init0: __m128i = _mm_set_epi64x(0x6a09e667bb67ae85u64 as i64, 0x510e527f9b05688cu64 as i64);
+    let init1: __m128i = _mm_set_epi64x(0x3c6ef372a54ff53au64 as i64, 0x1f83d9ab5be0cd19u64 as i64);
+
+    let (mut state0, mut state1);
+    let (abef_save, cdgh_save);
+    let (mut msg, mut tmp);
+    let (mut msg0, mut msg1, mut msg2, mut msg3);
+
+    // ------------------ Transform 1 -------------------
+
+    // Load state
+    state0 = init0;
+    state1 = init1;
+
+    // Rounds 0-3
+    msg = _mm_loadu_si128(input.as_ptr().add(0).cast::<__m128i>());
+    msg0 = _mm_shuffle_epi8(msg, MASK);
+    msg = _mm_add_epi32(msg0, _mm_loadu_si128(K.as_ptr().add(0).cast::<__m128i>()));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+
+    // Rounds 4-7
+    msg = _mm_loadu_si128(input.as_ptr().add(16).cast::<__m128i>());
+    msg1 = _mm_shuffle_epi8(msg, MASK);
+    msg = _mm_add_epi32(msg1, _mm_loadu_si128(K.as_ptr().add(4).cast::<__m128i>()));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg0 = _mm_sha256msg1_epu32(msg0, msg1);
+
+    // Rounds 8-11
+    msg = _mm_loadu_si128(input.as_ptr().add(32).cast::<__m128i>());
+    msg2 = _mm_shuffle_epi8(msg, MASK);
+    msg = _mm_add_epi32(msg2, _mm_loadu_si128(K.as_ptr().add(8).cast::<__m128i>()));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg1 = _mm_sha256msg1_epu32(msg1, msg2);
+
+    // Rounds 12-15
+    msg = _mm_loadu_si128(input.as_ptr().add(48).cast::<__m128i>());
+    msg3 = _mm_shuffle_epi8(msg, MASK);
+    msg = _mm_add_epi32(msg3, _mm_loadu_si128(K.as_ptr().add(12).cast::<__m128i>()));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    tmp = _mm_alignr_epi8(msg3, msg2, 4);
+    msg0 = _mm_add_epi32(msg0, tmp);
+    msg0 = _mm_sha256msg2_epu32(msg0, msg3);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg2 = _mm_sha256msg1_epu32(msg2, msg3);
+
+    // Rounds 16-19
+    msg = _mm_add_epi32(msg0, _mm_loadu_si128(K.as_ptr().add(16).cast::<__m128i>()));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    tmp = _mm_alignr_epi8(msg0, msg3, 4);
+    msg1 = _mm_add_epi32(msg1, tmp);
+    msg1 = _mm_sha256msg2_epu32(msg1, msg0);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg3 = _mm_sha256msg1_epu32(msg3, msg0);
+
+    // Rounds 20-23
+    msg = _mm_add_epi32(msg1, _mm_loadu_si128(K.as_ptr().add(20).cast::<__m128i>()));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    tmp = _mm_alignr_epi8(msg1, msg0, 4);
+    msg2 = _mm_add_epi32(msg2, tmp);
+    msg2 = _mm_sha256msg2_epu32(msg2, msg1);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg0 = _mm_sha256msg1_epu32(msg0, msg1);
+
+    // Rounds 24-27
+    msg = _mm_add_epi32(msg2, _mm_loadu_si128(K.as_ptr().add(24).cast::<__m128i>()));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    tmp = _mm_alignr_epi8(msg2, msg1, 4);
+    msg3 = _mm_add_epi32(msg3, tmp);
+    msg3 = _mm_sha256msg2_epu32(msg3, msg2);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg1 = _mm_sha256msg1_epu32(msg1, msg2);
+
+    // Rounds 28-31
+    msg = _mm_add_epi32(msg3, _mm_loadu_si128(K.as_ptr().add(28).cast::<__m128i>()));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    tmp = _mm_alignr_epi8(msg3, msg2, 4);
+    msg0 = _mm_add_epi32(msg0, tmp);
+    msg0 = _mm_sha256msg2_epu32(msg0, msg3);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg2 = _mm_sha256msg1_epu32(msg2, msg3);
+
+    // Rounds 32-35
+    msg = _mm_add_epi32(msg0, _mm_loadu_si128(K.as_ptr().add(32).cast::<__m128i>()));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    tmp = _mm_alignr_epi8(msg0, msg3, 4);
+    msg1 = _mm_add_epi32(msg1, tmp);
+    msg1 = _mm_sha256msg2_epu32(msg1, msg0);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg3 = _mm_sha256msg1_epu32(msg3, msg0);
+
+    // Rounds 36-39
+    msg = _mm_add_epi32(msg1, _mm_loadu_si128(K.as_ptr().add(36).cast::<__m128i>()));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    tmp = _mm_alignr_epi8(msg1, msg0, 4);
+    msg2 = _mm_add_epi32(msg2, tmp);
+    msg2 = _mm_sha256msg2_epu32(msg2, msg1);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg0 = _mm_sha256msg1_epu32(msg0, msg1);
+
+    // Rounds 40-43
+    msg = _mm_add_epi32(msg2, _mm_loadu_si128(K.as_ptr().add(40).cast::<__m128i>()));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    tmp = _mm_alignr_epi8(msg2, msg1, 4);
+    msg3 = _mm_add_epi32(msg3, tmp);
+    msg3 = _mm_sha256msg2_epu32(msg3, msg2);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg1 = _mm_sha256msg1_epu32(msg1, msg2);
+
+    // Rounds 44-47
+    msg = _mm_add_epi32(msg3, _mm_loadu_si128(K.as_ptr().add(44).cast::<__m128i>()));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    tmp = _mm_alignr_epi8(msg3, msg2, 4);
+    msg0 = _mm_add_epi32(msg0, tmp);
+    msg0 = _mm_sha256msg2_epu32(msg0, msg3);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg2 = _mm_sha256msg1_epu32(msg2, msg3);
+
+    // Rounds 48-51
+    msg = _mm_add_epi32(msg0, _mm_loadu_si128(K.as_ptr().add(48).cast::<__m128i>()));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    tmp = _mm_alignr_epi8(msg0, msg3, 4);
+    msg1 = _mm_add_epi32(msg1, tmp);
+    msg1 = _mm_sha256msg2_epu32(msg1, msg0);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg3 = _mm_sha256msg1_epu32(msg3, msg0);
+
+    // Rounds 52-55
+    msg = _mm_add_epi32(msg1, _mm_loadu_si128(K.as_ptr().add(52).cast::<__m128i>()));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    tmp = _mm_alignr_epi8(msg1, msg0, 4);
+    msg2 = _mm_add_epi32(msg2, tmp);
+    msg2 = _mm_sha256msg2_epu32(msg2, msg1);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+
+    // Rounds 56-59
+    msg = _mm_add_epi32(msg2, _mm_loadu_si128(K.as_ptr().add(56).cast::<__m128i>()));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    tmp = _mm_alignr_epi8(msg2, msg1, 4);
+    msg3 = _mm_add_epi32(msg3, tmp);
+    msg3 = _mm_sha256msg2_epu32(msg3, msg2);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+
+    // Rounds 60-63
+    msg = _mm_add_epi32(msg3, _mm_loadu_si128(K.as_ptr().add(60).cast::<__m128i>()));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+
+    // Transform 1: Update state
+    state0 = _mm_add_epi32(state0, init0);
+    state1 = _mm_add_epi32(state1, init1);
+
+    // ------------------ Transform 2 -------------------
+
+    // Save state
+    abef_save = state0;
+    cdgh_save = state1;
+
+    // Rounds 0-3
+    msg = _mm_loadu_si128(MIDS.as_ptr().add(0).cast::<__m128i>());
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+
+    // Rounds 4-7
+    msg = _mm_loadu_si128(MIDS.as_ptr().add(4).cast::<__m128i>());
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+
+    // Rounds 8-11
+    msg = _mm_loadu_si128(MIDS.as_ptr().add(8).cast::<__m128i>());
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+
+    // Rounds 12-15
+    msg = _mm_loadu_si128(MIDS.as_ptr().add(12).cast::<__m128i>());
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+
+    // Rounds 16-19
+    msg = _mm_loadu_si128(MIDS.as_ptr().add(16).cast::<__m128i>());
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+
+    // Rounds 20-23
+    msg = _mm_loadu_si128(MIDS.as_ptr().add(20).cast::<__m128i>());
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+
+    // Rounds 24-27
+    msg = _mm_loadu_si128(MIDS.as_ptr().add(24).cast::<__m128i>());
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+
+    // Rounds 28-31
+    msg = _mm_loadu_si128(MIDS.as_ptr().add(28).cast::<__m128i>());
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+
+    // Rounds 32-35
+    msg = _mm_loadu_si128(MIDS.as_ptr().add(32).cast::<__m128i>());
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+
+    // Rounds 36-39
+    msg = _mm_loadu_si128(MIDS.as_ptr().add(36).cast::<__m128i>());
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+
+    // Rounds 40-43
+    msg = _mm_loadu_si128(MIDS.as_ptr().add(40).cast::<__m128i>());
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+
+    // Rounds 44-47
+    msg = _mm_loadu_si128(MIDS.as_ptr().add(44).cast::<__m128i>());
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+
+    // Rounds 48-51
+    msg = _mm_loadu_si128(MIDS.as_ptr().add(48).cast::<__m128i>());
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+
+    // Rounds 52-55
+    msg = _mm_loadu_si128(MIDS.as_ptr().add(52).cast::<__m128i>());
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+
+    // Rounds 56-59
+    msg = _mm_loadu_si128(MIDS.as_ptr().add(56).cast::<__m128i>());
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+
+    // Rounds 60-63
+    msg = _mm_loadu_si128(MIDS.as_ptr().add(60).cast::<__m128i>());
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+
+    // Transform 2: Update state
+    state0 = _mm_add_epi32(state0, abef_save);
+    state1 = _mm_add_epi32(state1, cdgh_save);
+
+    // Unshuffle to extract hash
+    tmp = _mm_shuffle_epi32(state0, 0x1B);
+    state1 = _mm_shuffle_epi32(state1, 0xB1);
+    msg0 = _mm_blend_epi16(tmp, state1, 0xF0);
+    msg1 = _mm_alignr_epi8(state1, tmp, 8);
+
+    // ------------------ Transform 3 -------------------
+
+    // Load state
+    state0 = init0;
+    state1 = init1;
+
+    // Rounds 0-3
+    msg = _mm_add_epi32(msg0, _mm_loadu_si128(K.as_ptr().add(0).cast::<__m128i>()));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+
+    // Rounds 4-7
+    msg = _mm_add_epi32(msg1, _mm_loadu_si128(K.as_ptr().add(4).cast::<__m128i>()));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg0 = _mm_sha256msg1_epu32(msg0, msg1);
+
+    // Rounds 8-11
+    msg2 = _mm_loadu_si128(FINS.as_ptr().add(4).cast::<__m128i>());
+    msg = _mm_loadu_si128(FINS.as_ptr().add(0).cast::<__m128i>());
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg1 = _mm_sha256msg1_epu32(msg1, msg2);
+
+    // Rounds 12-15
+    msg3 = _mm_loadu_si128(FINAL.as_ptr().add(4).cast::<__m128i>());
+    msg = _mm_loadu_si128(FINS.as_ptr().add(8).cast::<__m128i>());
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    tmp = _mm_alignr_epi8(msg3, msg2, 4);
+    msg0 = _mm_add_epi32(msg0, tmp);
+    msg0 = _mm_sha256msg2_epu32(msg0, msg3);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg2 = _mm_sha256msg1_epu32(msg2, msg3);
+
+    // Rounds 16-19
+    msg = _mm_add_epi32(msg0, _mm_loadu_si128(K.as_ptr().add(16).cast::<__m128i>()));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    tmp = _mm_alignr_epi8(msg0, msg3, 4);
+    msg1 = _mm_add_epi32(msg1, tmp);
+    msg1 = _mm_sha256msg2_epu32(msg1, msg0);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg3 = _mm_sha256msg1_epu32(msg3, msg0);
+
+    // Rounds 20-23
+    msg = _mm_add_epi32(msg1, _mm_loadu_si128(K.as_ptr().add(20).cast::<__m128i>()));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    tmp = _mm_alignr_epi8(msg1, msg0, 4);
+    msg2 = _mm_add_epi32(msg2, tmp);
+    msg2 = _mm_sha256msg2_epu32(msg2, msg1);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg0 = _mm_sha256msg1_epu32(msg0, msg1);
+
+    // Rounds 24-27
+    msg = _mm_add_epi32(msg2, _mm_loadu_si128(K.as_ptr().add(24).cast::<__m128i>()));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    tmp = _mm_alignr_epi8(msg2, msg1, 4);
+    msg3 = _mm_add_epi32(msg3, tmp);
+    msg3 = _mm_sha256msg2_epu32(msg3, msg2);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg1 = _mm_sha256msg1_epu32(msg1, msg2);
+
+    // Rounds 28-31
+    msg = _mm_add_epi32(msg3, _mm_loadu_si128(K.as_ptr().add(28).cast::<__m128i>()));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    tmp = _mm_alignr_epi8(msg3, msg2, 4);
+    msg0 = _mm_add_epi32(msg0, tmp);
+    msg0 = _mm_sha256msg2_epu32(msg0, msg3);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg2 = _mm_sha256msg1_epu32(msg2, msg3);
+
+    // Rounds 32-35
+    msg = _mm_add_epi32(msg0, _mm_loadu_si128(K.as_ptr().add(32).cast::<__m128i>()));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    tmp = _mm_alignr_epi8(msg0, msg3, 4);
+    msg1 = _mm_add_epi32(msg1, tmp);
+    msg1 = _mm_sha256msg2_epu32(msg1, msg0);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg3 = _mm_sha256msg1_epu32(msg3, msg0);
+
+    // Rounds 36-39
+    msg = _mm_add_epi32(msg1, _mm_loadu_si128(K.as_ptr().add(36).cast::<__m128i>()));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    tmp = _mm_alignr_epi8(msg1, msg0, 4);
+    msg2 = _mm_add_epi32(msg2, tmp);
+    msg2 = _mm_sha256msg2_epu32(msg2, msg1);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg0 = _mm_sha256msg1_epu32(msg0, msg1);
+
+    // Rounds 40-43
+    msg = _mm_add_epi32(msg2, _mm_loadu_si128(K.as_ptr().add(40).cast::<__m128i>()));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    tmp = _mm_alignr_epi8(msg2, msg1, 4);
+    msg3 = _mm_add_epi32(msg3, tmp);
+    msg3 = _mm_sha256msg2_epu32(msg3, msg2);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg1 = _mm_sha256msg1_epu32(msg1, msg2);
+
+    // Rounds 44-47
+    msg = _mm_add_epi32(msg3, _mm_loadu_si128(K.as_ptr().add(44).cast::<__m128i>()));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    tmp = _mm_alignr_epi8(msg3, msg2, 4);
+    msg0 = _mm_add_epi32(msg0, tmp);
+    msg0 = _mm_sha256msg2_epu32(msg0, msg3);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg2 = _mm_sha256msg1_epu32(msg2, msg3);
+
+    // Rounds 48-51
+    msg = _mm_add_epi32(msg0, _mm_loadu_si128(K.as_ptr().add(48).cast::<__m128i>()));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    tmp = _mm_alignr_epi8(msg0, msg3, 4);
+    msg1 = _mm_add_epi32(msg1, tmp);
+    msg1 = _mm_sha256msg2_epu32(msg1, msg0);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+    msg3 = _mm_sha256msg1_epu32(msg3, msg0);
+
+    // Rounds 52-55
+    msg = _mm_add_epi32(msg1, _mm_loadu_si128(K.as_ptr().add(52).cast::<__m128i>()));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    tmp = _mm_alignr_epi8(msg1, msg0, 4);
+    msg2 = _mm_add_epi32(msg2, tmp);
+    msg2 = _mm_sha256msg2_epu32(msg2, msg1);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+
+    // Rounds 56-59
+    msg = _mm_add_epi32(msg2, _mm_loadu_si128(K.as_ptr().add(56).cast::<__m128i>()));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    tmp = _mm_alignr_epi8(msg2, msg1, 4);
+    msg3 = _mm_add_epi32(msg3, tmp);
+    msg3 = _mm_sha256msg2_epu32(msg3, msg2);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+
+    // Rounds 60-63
+    msg = _mm_add_epi32(msg3, _mm_loadu_si128(K.as_ptr().add(60).cast::<__m128i>()));
+    state1 = _mm_sha256rnds2_epu32(state1, state0, msg);
+    msg = _mm_shuffle_epi32(msg, 0x0E);
+    state0 = _mm_sha256rnds2_epu32(state0, state1, msg);
+
+
+    // Transform 3: Update state
+    state0 = _mm_add_epi32(state0, init0);
+    state1 = _mm_add_epi32(state1, init1);
+
+    // Unshuffle
+    tmp = _mm_shuffle_epi32(state0, 0x1B);
+    state1 = _mm_shuffle_epi32(state1, 0xB1);
+    state0 = _mm_blend_epi16(tmp, state1, 0xF0);
+    state1 = _mm_alignr_epi8(state1, tmp, 8);
+
+    // Store result (byte-swap to big-endian)
+    // CAST SAFETY: storeu_si128 does not require alignment.
+    _mm_storeu_si128(output.as_mut_ptr().add(0).cast::<__m128i>(), _mm_shuffle_epi8(state0, MASK));
+    _mm_storeu_si128(output.as_mut_ptr().add(16).cast::<__m128i>(), _mm_shuffle_epi8(state1, MASK));
+}
+

--- a/primitives/src/merkle_tree.rs
+++ b/primitives/src/merkle_tree.rs
@@ -115,7 +115,7 @@ pub(crate) trait MerkleNode: Copy + PartialEq {
 }
 
 #[cfg(feature = "std")]
-#[cfg(target_arch = "aarch64")]
+#[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
 fn calculate_root_batched(mut nodes: Vec<[u8; 32]>) -> Option<[u8; 32]> {
     if nodes.is_empty() {
         return None;
@@ -169,7 +169,7 @@ impl MerkleNode for TxMerkleNode {
     }
 
     #[cfg(feature = "std")]
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
     fn calculate_root<I: Iterator<Item = Self::Leaf>>(iter: I) -> Option<Self> {
         let nodes: Vec<[u8; 32]> = iter.map(Txid::to_byte_array).collect();
         calculate_root_batched(nodes).map(Self::from_byte_array)
@@ -187,7 +187,7 @@ impl MerkleNode for WitnessMerkleNode {
     }
 
     #[cfg(feature = "std")]
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
     fn calculate_root<I: Iterator<Item = Self::Leaf>>(iter: I) -> Option<Self> {
         let nodes: Vec<[u8; 32]> = iter.map(Wtxid::to_byte_array).collect();
         calculate_root_batched(nodes).map(Self::from_byte_array)


### PR DESCRIPTION
commit 1: add the three transforms for `sha256(sha256(64_bytes))`
commit 2: interleave 2 independent hashes to fill wasted CPU cycles. [reference](https://uops.info/html-instr/SHA256RNDS2_XMM_XMM.html)
commit 3: add x86 SHA-NI 2-way dispatch

Addresses part of https://github.com/rust-bitcoin/rust-bitcoin/issues/5540

Note: I used the same unrolled approach as in the ARM PR. I didn't follow what [Core](https://github.com/bitcoin/bitcoin/blob/master/src/crypto/sha256_x86_shani.cpp#L147-L354) does since they use helper functions instead of the unrolled version, but if matching Core's style would make it easier to compare/review, I can add a patch for that.