### PR TITLE
Replace and remove `serialize/deserialize` in `p2p` tests

### DIFF
--- a/p2p/src/address.rs
+++ b/p2p/src/address.rs
@@ -1291,7 +1291,6 @@ mod test {
     use alloc::{format, vec};
     use std::net::IpAddr;
 
-    use bitcoin::consensus::encode::{deserialize, serialize};
     use encoding::{Encodable as _, Encoder as _, ExactSizeEncoder as _};
     use hex_unstable::hex;
 
@@ -1396,13 +1395,11 @@ mod test {
 
         let ip_bytes = hex!("010401020304");
         let ip = AddrV2::Ipv4(Ipv4Addr::new(1, 2, 3, 4));
-        assert_eq!(serialize(&ip), ip_bytes);
         assert_eq!(encoding::encode_to_vec(&ip).as_slice(), ip_bytes);
 
         let ip_bytes = hex!("02101a1b2a2b3a3b4a4b5a5b6a6b7a7b8a8b");
         let ip =
             AddrV2::Ipv6("1a1b:2a2b:3a3b:4a4b:5a5b:6a6b:7a7b:8a8b".parse::<Ipv6Addr>().unwrap());
-        assert_eq!(serialize(&ip), ip_bytes);
         assert_eq!(encoding::encode_to_vec(&ip).as_slice(), ip_bytes);
 
         let tor_bytes =
@@ -1413,7 +1410,6 @@ mod test {
             )
             .unwrap(),
         );
-        assert_eq!(serialize(&ip), tor_bytes);
         assert_eq!(encoding::encode_to_vec(&ip), tor_bytes);
 
         let i2p_bytes =
@@ -1424,17 +1420,14 @@ mod test {
             )
             .unwrap(),
         );
-        assert_eq!(serialize(&ip), i2p_bytes);
         assert_eq!(encoding::encode_to_vec(&ip).as_slice(), i2p_bytes);
 
         let cjdns_bytes = hex!("0610fc010001000200030004000500060007");
         let ip = AddrV2::Cjdns("fc01:1:2:3:4:5:6:7".parse::<Ipv6Addr>().unwrap());
-        assert_eq!(serialize(&ip), cjdns_bytes);
         assert_eq!(encoding::encode_to_vec(&ip).as_slice(), cjdns_bytes);
 
         let unk_bytes = hex!("aa0401020304");
         let ip = AddrV2::Unknown(170, hex!("01020304").to_vec());
-        assert_eq!(serialize(&ip), unk_bytes);
         assert_eq!(encoding::encode_to_vec(&ip).as_slice(), unk_bytes);
     }
 
@@ -1445,47 +1438,37 @@ mod test {
         // Valid IPv4.
         let ip_bytes = hex!("010401020304");
         let want = AddrV2::Ipv4(Ipv4Addr::new(1, 2, 3, 4));
-        let ip: AddrV2 = deserialize(&ip_bytes).unwrap();
-        assert_eq!(ip, want);
         let ip: AddrV2 = encoding::decode_from_slice(&ip_bytes).unwrap();
         assert_eq!(ip, want);
 
         // Invalid IPv4, valid length but address itself is shorter.
         let invalid = hex!("01040102");
-        deserialize::<AddrV2>(&invalid).unwrap_err();
         encoding::decode_from_slice::<AddrV2>(&invalid).unwrap_err();
 
         // Invalid IPv4, with bogus length.
         let invalid = hex!("010501020304");
-        assert!(deserialize::<AddrV2>(&invalid).is_err());
         encoding::decode_from_slice::<AddrV2>(&invalid).unwrap_err();
 
         // Invalid IPv4, with extreme length.
         let extreme = hex!("01fd010201020304");
-        assert!(deserialize::<AddrV2>(&extreme).is_err());
         encoding::decode_from_slice::<AddrV2>(&extreme).unwrap_err();
 
         // Valid IPv6.
         let ipv6_bytes = hex!("02100102030405060708090a0b0c0d0e0f10");
         let want = AddrV2::Ipv6("102:304:506:708:90a:b0c:d0e:f10".parse::<Ipv6Addr>().unwrap());
-        let ip: AddrV2 = deserialize(&ipv6_bytes).unwrap();
-        assert_eq!(ip, want);
         let ip: AddrV2 = encoding::decode_from_slice(&ipv6_bytes).unwrap();
         assert_eq!(ip, want);
 
         // Invalid IPv6, with bogus length.
         let bogus = hex!("020400");
-        assert!(deserialize::<AddrV2>(&bogus).is_err());
         assert!(encoding::decode_from_slice::<AddrV2>(&bogus).is_err());
 
         // Invalid IPv6, contains embedded IPv4.
         let embedded = hex!("021000000000000000000000ffff01020304");
-        assert!(deserialize::<AddrV2>(&embedded).is_err());
         assert!(encoding::decode_from_slice::<AddrV2>(&embedded).is_err());
 
         // Invalid IPv6, contains embedded TORv2.
         let torish = hex!("0210fd87d87eeb430102030405060708090a");
-        assert!(deserialize::<AddrV2>(&torish).is_err());
         assert!(encoding::decode_from_slice::<AddrV2>(&torish).is_err());
 
         // Valid TORv3.
@@ -1493,14 +1476,11 @@ mod test {
             hex!("042079bcc625184b05194975c28b66b66b0469f7f6556fb1ac3189a79b40dda32f1f");
         let want =
             AddrV2::TorV3(hex!("79bcc625184b05194975c28b66b66b0469f7f6556fb1ac3189a79b40dda32f1f"));
-        let ip: AddrV2 = deserialize(&tor_bytes).unwrap();
-        assert_eq!(ip, want);
         let ip: AddrV2 = encoding::decode_from_slice(&tor_bytes).unwrap();
         assert_eq!(ip, want);
 
         // Invalid TORv3, with bogus length.
         let invalid = hex!("040000");
-        assert!(deserialize::<AddrV2>(&invalid).is_err());
         assert!(encoding::decode_from_slice::<AddrV2>(&invalid).is_err());
 
         // Valid I2P.
@@ -1508,52 +1488,40 @@ mod test {
             hex!("0520a2894dabaec08c0051a481a6dac88b64f98232ae42d4b6fd2fa81952dfe36a87");
         let want =
             AddrV2::I2p(hex!("a2894dabaec08c0051a481a6dac88b64f98232ae42d4b6fd2fa81952dfe36a87"));
-        let i2p: AddrV2 = deserialize(&i2p_bytes).unwrap();
-        assert_eq!(i2p, want);
         let ip: AddrV2 = encoding::decode_from_slice(&i2p_bytes).unwrap();
         assert_eq!(ip, want);
 
         // Invalid I2P, with bogus length.
         let invalid = hex!("050300");
-        assert!(deserialize::<AddrV2>(&invalid).is_err());
         assert!(encoding::decode_from_slice::<AddrV2>(&invalid).is_err());
 
         // Valid CJDNS.
         let cjdns_bytes = hex!("0610fc000001000200030004000500060007");
         let want = AddrV2::Cjdns("fc00:1:2:3:4:5:6:7".parse::<Ipv6Addr>().unwrap());
-        let ip: AddrV2 = deserialize(&cjdns_bytes).unwrap();
-        assert_eq!(ip, want);
         let ip: AddrV2 = encoding::decode_from_slice(&cjdns_bytes).unwrap();
         assert_eq!(ip, want);
 
         // Invalid CJDNS, incorrect marker
         let invalid = hex!("0610fd000001000200030004000500060007");
-        assert!(deserialize::<AddrV2>(&invalid).is_err());
         assert!(encoding::decode_from_slice::<AddrV2>(&invalid).is_err());
 
         // Invalid CJDNS, with bogus length.
         let invalid = hex!("060100");
-        assert!(deserialize::<AddrV2>(&invalid).is_err());
         assert!(encoding::decode_from_slice::<AddrV2>(&invalid).is_err());
 
         // Unknown, with extreme length.
         let invalid = hex!("aafe0000000201020304050607");
-        assert!(deserialize::<AddrV2>(&invalid).is_err());
         assert!(encoding::decode_from_slice::<AddrV2>(&invalid).is_err());
 
         // Unknown, with reasonable length.
         let unk_bytes = hex!("aa0401020304");
         let want = AddrV2::Unknown(170, hex!("01020304").to_vec());
-        let ip: AddrV2 = deserialize(&unk_bytes).unwrap();
-        assert_eq!(ip, want);
         let ip: AddrV2 = encoding::decode_from_slice(&unk_bytes).unwrap();
         assert_eq!(ip, want);
 
         // Unknown, with zero length.
         let unk_bytes = hex!("aa00");
         let want = AddrV2::Unknown(170, vec![]);
-        let ip: AddrV2 = deserialize(&unk_bytes).unwrap();
-        assert_eq!(ip, want);
         let ip: AddrV2 = encoding::decode_from_slice(&unk_bytes).unwrap();
         assert_eq!(ip, want);
     }
@@ -1561,30 +1529,6 @@ mod test {
     #[test]
     fn addrv2message() {
         let raw = hex!("0261bc6649019902abab208d79627683fd4804010409090909208d");
-        let addresses: AddrV2Payload = deserialize(&raw).unwrap();
-
-        assert_eq!(
-            addresses.0,
-            vec![
-                AddrV2Message {
-                    services: ServiceFlags::NETWORK,
-                    time: 0x4966_bc61,
-                    port: 8333,
-                    addr: AddrV2::Unknown(153, hex!("abab").to_vec())
-                },
-                AddrV2Message {
-                    services: ServiceFlags::NETWORK_LIMITED
-                        | ServiceFlags::WITNESS
-                        | ServiceFlags::COMPACT_FILTERS,
-                    time: 0x8376_6279,
-                    port: 8333,
-                    addr: AddrV2::Ipv4(Ipv4Addr::new(9, 9, 9, 9))
-                },
-            ]
-        );
-
-        assert_eq!(serialize(&addresses), raw);
-
         let addresses: AddrV2Payload = encoding::decode_from_slice(&raw).unwrap();
 
         assert_eq!(

--- a/p2p/src/bip152.rs
+++ b/p2p/src/bip152.rs
@@ -1040,7 +1040,6 @@ impl<'a> Arbitrary<'a> for BlockTransactionsRequest {
 mod test {
     use alloc::vec;
 
-    use bitcoin::consensus::encode::{deserialize, serialize};
     use bitcoin::merkle_tree::TxMerkleNode;
     use primitives::locktime::absolute;
     use primitives::{
@@ -1105,11 +1104,11 @@ mod test {
         let raw_block = hex::decode_to_vec("000000206c750a364035aefd5f81508a08769975116d9195312ee4520dceac39e1fdc62c4dc67473b8e354358c1e610afeaff7410858bd45df43e2940f8a62bd3d5e3ac943c2975cffff7f200000000002020000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff04016b0101ffffffff020006062a0100000001510000000000000000266a24aa21a9ed4a3d9f3343dafcc0d6f6d4310f2ee5ce273ed34edca6c75db3a73e7f368734200120000000000000000000000000000000000000000000000000000000000000000000000000020000000001021fc20ba2bd745507b8e00679e3b362558f9457db374ca28ffa5243f4c23a4d5f00000000171600147c9dea14ffbcaec4b575e03f05ceb7a81cd3fcbffdffffff915d689be87b43337f42e26033df59807b768223368f189a023d0242d837768900000000171600147c9dea14ffbcaec4b575e03f05ceb7a81cd3fcbffdffffff0200cdf5050000000017a9146803c72d9154a6a20f404bed6d3dcee07986235a8700e1f5050000000017a9144e6a4c7cb5b5562904843bdf816342f4db9f5797870247304402205e9bf6e70eb0e4b495bf483fd8e6e02da64900f290ef8aaa64bb32600d973c450220670896f5d0e5f33473e5f399ab680cc1d25c2d2afd15abd722f04978f28be887012103e4e4d9312b2261af508b367d8ba9be4f01b61d6d6e78bec499845b4f410bcf2702473044022045ac80596a6ac9c8c572f94708709adaf106677221122e08daf8b9741a04f66a022003ccd52a3b78f8fd08058fc04fc0cffa5f4c196c84eae9e37e2a85babe731b57012103e4e4d9312b2261af508b367d8ba9be4f01b61d6d6e78bec499845b4f410bcf276a000000").unwrap();
         let raw_compact = hex::decode_to_vec("000000206c750a364035aefd5f81508a08769975116d9195312ee4520dceac39e1fdc62c4dc67473b8e354358c1e610afeaff7410858bd45df43e2940f8a62bd3d5e3ac943c2975cffff7f2000000000a4df3c3744da89fa010a6979e971450100020000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff04016b0101ffffffff020006062a0100000001510000000000000000266a24aa21a9ed4a3d9f3343dafcc0d6f6d4310f2ee5ce273ed34edca6c75db3a73e7f368734200120000000000000000000000000000000000000000000000000000000000000000000000000").unwrap();
 
-        let block: Block = deserialize(&raw_block).unwrap();
+        let block: Block = encoding::decode_from_slice(&raw_block).unwrap();
         let block = block.assume_checked(None);
         let nonce = 18_053_200_567_810_711_460;
         let compact = HeaderAndShortIds::from_block(&block, nonce, 2, &[]).unwrap();
-        let compact_expected = deserialize(&raw_compact).unwrap();
+        let compact_expected = encoding::decode_from_slice(&raw_compact).unwrap();
 
         assert_eq!(compact, compact_expected);
     }
@@ -1133,12 +1132,12 @@ mod test {
                 // test deserialization
                 let mut raw: Vec<u8> = vec![0u8; 32];
                 raw.extend(testcase.0.clone());
-                let btr: BlockTransactionsRequest = deserialize(&raw.clone()).unwrap();
+                let btr: BlockTransactionsRequest = encoding::decode_from_slice(&raw.clone()).unwrap();
                 assert_eq!(testcase.1, btr.indices().unwrap());
             }
             {
                 // test serialization
-                let raw: Vec<u8> = serialize(&&BlockTransactionsRequest::from_indices_unchecked(
+                let raw: Vec<u8> = encoding::encode_to_vec(&BlockTransactionsRequest::from_indices_unchecked(
                     BlockHash::from_byte_array([0; 32]),
                     testcase.1,
                 ));
@@ -1152,7 +1151,7 @@ mod test {
                 // test that we return Err() if deserialization fails (and don't panic)
                 let mut raw: Vec<u8> = [0u8; 32].to_vec();
                 raw.extend(errorcase);
-                assert!(deserialize::<BlockTransactionsRequest>(&raw).is_err());
+                assert!(encoding::decode_from_slice::<BlockTransactionsRequest>(&raw).is_err());
             }
         }
     }

--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -2743,7 +2743,6 @@ mod test {
     use alloc::vec;
     use std::net::Ipv4Addr;
 
-    use bitcoin::consensus::encode::{deserialize, deserialize_partial, serialize};
     use hex_unstable::hex;
     use primitives::transaction::{Transaction, Txid};
     use primitives::{Block, BlockHash};
@@ -2767,14 +2766,14 @@ mod test {
     #[test]
     #[allow(clippy::too_many_lines)]
     fn full_round_ser_der_raw_network_message() {
-        let version_msg: VersionMessage = deserialize(&hex!("721101000100000000000000e6e0845300000000010000000000000000000000000000000000ffff0000000000000100000000000000fd87d87eeb4364f22cf54dca59412db7208d47d920cffce83ee8102f5361746f7368693a302e392e39392f2c9f040001")).unwrap();
-        let tx: Transaction = deserialize(&hex!("0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000")).unwrap();
-        let block: Block = deserialize(&hex!("00608e2e094d41aecfbcbf8fe70cb60be57516b07db1bafee4c4de5dad760000000000004aec16eab3be95abe9c54e01cf850c14b8c5cad1bc6b2e73e811db5d5998ada404503e66fcff031b4ebd99d701010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff3402983a000404503e6604f1f617271083bc3d6600000000000000000007bb1b0a636b706f6f6c0d506f72746c616e642e484f444cffffffff0200f2052a010000001976a9142ce72b25fe97b52638c199acfaa5e3891ddfed5b88ac0000000000000000266a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf90120000000000000000000000000000000000000000000000000000000000000000000000000")).unwrap();
-        let header: block::Header = deserialize(&hex!("010000004ddccd549d28f385ab457e98d1b11ce80bfea2c5ab93015ade4973e400000000bf4473e53794beae34e64fccc471dace6ae544180816f89591894e0f417a914cd74d6e49ffff001d323b3a7b")).unwrap();
+        let version_msg: VersionMessage = encoding::decode_from_slice(&hex!("721101000100000000000000e6e0845300000000010000000000000000000000000000000000ffff0000000000000100000000000000fd87d87eeb4364f22cf54dca59412db7208d47d920cffce83ee8102f5361746f7368693a302e392e39392f2c9f040001")).unwrap();
+        let tx: Transaction = encoding::decode_from_slice(&hex!("0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000")).unwrap();
+        let block: Block = encoding::decode_from_slice(&hex!("00608e2e094d41aecfbcbf8fe70cb60be57516b07db1bafee4c4de5dad760000000000004aec16eab3be95abe9c54e01cf850c14b8c5cad1bc6b2e73e811db5d5998ada404503e66fcff031b4ebd99d701010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff3402983a000404503e6604f1f617271083bc3d6600000000000000000007bb1b0a636b706f6f6c0d506f72746c616e642e484f444cffffffff0200f2052a010000001976a9142ce72b25fe97b52638c199acfaa5e3891ddfed5b88ac0000000000000000266a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf90120000000000000000000000000000000000000000000000000000000000000000000000000")).unwrap();
+        let header: block::Header = encoding::decode_from_slice(&hex!("010000004ddccd549d28f385ab457e98d1b11ce80bfea2c5ab93015ade4973e400000000bf4473e53794beae34e64fccc471dace6ae544180816f89591894e0f417a914cd74d6e49ffff001d323b3a7b")).unwrap();
         let script = &hex!("1976a91431a420903c05a0a7de2de40c9f02ebedbacdc17288ac");
-        let merkle_block: MerkleBlock = deserialize(&hex!("0100000079cda856b143d9db2c1caff01d1aecc8630d30625d10e8b4b8b0000000000000b50cc069d6a3e33e3ff84a5c41d9d3febe7c770fdcc96b2c3ff60abe184f196367291b4d4c86041b8fa45d630100000001b50cc069d6a3e33e3ff84a5c41d9d3febe7c770fdcc96b2c3ff60abe184f19630101")).unwrap();
-        let cmptblock = deserialize(&hex!("00000030d923ad36ff2d955abab07f8a0a6e813bc6e066b973e780c5e36674cad5d1cd1f6e265f2a17a0d35cbe701fe9d06e2c6324cfe135f6233e8b767bfa3fb4479b71115dc562ffff7f2006000000000000000000000000010002000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0302ee00ffffffff0100f9029500000000015100000000")).unwrap();
-        let blocktxn = deserialize(&hex!("2e93c0cff39ff605020072d96bc3a8d20b8447e294d08092351c8583e08d9b5a01020000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff0402dc0000ffffffff0200f90295000000001976a9142b4569203694fc997e13f2c0a1383b9e16c77a0d88ac0000000000000000266a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf90120000000000000000000000000000000000000000000000000000000000000000000000000")).unwrap();
+        let merkle_block: MerkleBlock = encoding::decode_from_slice(&hex!("0100000079cda856b143d9db2c1caff01d1aecc8630d30625d10e8b4b8b0000000000000b50cc069d6a3e33e3ff84a5c41d9d3febe7c770fdcc96b2c3ff60abe184f196367291b4d4c86041b8fa45d630100000001b50cc069d6a3e33e3ff84a5c41d9d3febe7c770fdcc96b2c3ff60abe184f19630101")).unwrap();
+        let cmptblock = encoding::decode_from_slice(&hex!("00000030d923ad36ff2d955abab07f8a0a6e813bc6e066b973e780c5e36674cad5d1cd1f6e265f2a17a0d35cbe701fe9d06e2c6324cfe135f6233e8b767bfa3fb4479b71115dc562ffff7f2006000000000000000000000000010002000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0302ee00ffffffff0100f9029500000000015100000000")).unwrap();
+        let blocktxn = encoding::decode_from_slice(&hex!("2e93c0cff39ff605020072d96bc3a8d20b8447e294d08092351c8583e08d9b5a01020000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff0402dc0000ffffffff0200f90295000000001976a9142b4569203694fc997e13f2c0a1383b9e16c77a0d88ac0000000000000000266a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf90120000000000000000000000000000000000000000000000000000000000000000000000000")).unwrap();
 
         let msgs = [
             NetworkMessage::Version(version_msg),
@@ -2890,20 +2889,15 @@ mod test {
         ];
 
         for msg in &msgs {
-            // V1 messages via legacy encoding traits.
             let raw_msg = V1NetworkMessage::new(Magic::from_bytes([57, 0, 0, 0]), msg.clone());
-            assert_eq!(deserialize::<V1NetworkMessage>(&serialize(&raw_msg)).unwrap(), raw_msg);
-
             // V1 messages via encoding traits.
             let encoded = encoding::encode_to_vec(&raw_msg);
             let decoded = encoding::decode_from_slice::<V1NetworkMessage>(&encoded).unwrap();
             assert_eq!(decoded, raw_msg);
 
-            // V2 messages. legacy encoding
+            // V2 messages via encoding traits
             let v2_msg = V2NetworkMessage::new(msg.clone());
-            assert_eq!(deserialize::<V2NetworkMessage>(&serialize(&v2_msg)).unwrap(), v2_msg);
 
-            // V2 messages via new consensus-encoding
             let v2_encoded = encoding::encode_to_vec(&v2_msg);
             let v2_decoded = encoding::decode_from_slice::<V2NetworkMessage>(&v2_encoded).unwrap();
             assert_eq!(v2_decoded, v2_msg);
@@ -2921,30 +2915,30 @@ mod test {
 
         // Test serializing.
         let cs = CommandString("Andrew".into());
-        assert_eq!(serialize(&cs), [0x41u8, 0x6e, 0x64, 0x72, 0x65, 0x77, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(encoding::encode_to_vec(&cs), [0x41u8, 0x6e, 0x64, 0x72, 0x65, 0x77, 0, 0, 0, 0, 0, 0]);
 
         // Test deserializing
         let cs: Result<CommandString, _> =
-            deserialize(&[0x41u8, 0x6e, 0x64, 0x72, 0x65, 0x77, 0, 0, 0, 0, 0, 0]);
+            encoding::decode_from_slice(&[0x41u8, 0x6e, 0x64, 0x72, 0x65, 0x77, 0, 0, 0, 0, 0, 0]);
         assert!(cs.is_ok());
         assert_eq!(cs.as_ref().unwrap().to_string(), "Andrew".to_owned());
         assert_eq!(cs.unwrap(), CommandString::try_from_static("Andrew").unwrap());
 
         // Test that embedded null bytes are preserved while trailing nulls are trimmed
         let cs: Result<CommandString, _> =
-            deserialize(&[0, 0x41u8, 0x6e, 0x64, 0, 0x72, 0x65, 0x77, 0, 0, 0, 0]);
+            encoding::decode_from_slice(&[0, 0x41u8, 0x6e, 0x64, 0, 0x72, 0x65, 0x77, 0, 0, 0, 0]);
         assert!(cs.is_ok());
         assert_eq!(cs.as_ref().unwrap().to_string(), "\0And\0rew".to_owned());
         assert_eq!(cs.unwrap(), CommandString::try_from_static("\0And\0rew").unwrap());
 
         // Invalid CommandString, must be ASCII
-        assert!(deserialize::<CommandString>(&[
+        assert!(encoding::decode_from_slice::<CommandString>(&[
             0, 0x41u8, 0x6e, 0xa4, 0, 0x72, 0x65, 0x77, 0, 0, 0, 0
         ])
         .is_err());
 
         // Invalid CommandString, must be 12 bytes
-        assert!(deserialize::<CommandString>(&[
+        assert!(encoding::decode_from_slice::<CommandString>(&[
             0x41u8, 0x6e, 0x64, 0x72, 0x65, 0x77, 0, 0, 0, 0, 0
         ])
         .is_err());
@@ -2953,7 +2947,7 @@ mod test {
     #[test]
     #[rustfmt::skip]
     fn serialize_verack() {
-        assert_eq!(serialize(&V1NetworkMessage::new(Magic::BITCOIN, NetworkMessage::Verack)),
+        assert_eq!(encoding::encode_to_vec(&V1NetworkMessage::new(Magic::BITCOIN, NetworkMessage::Verack)),
                        [0xf9, 0xbe, 0xb4, 0xd9, 0x76, 0x65, 0x72, 0x61,
                         0x63, 0x6B, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                         0x00, 0x00, 0x00, 0x00, 0x5d, 0xf6, 0xe0, 0xe2]);
@@ -2962,7 +2956,7 @@ mod test {
     #[test]
     fn serialize_v2_verack() {
         assert_eq!(
-            serialize(&V2NetworkMessage::new(NetworkMessage::Verack)),
+            encoding::encode_to_vec(&V2NetworkMessage::new(NetworkMessage::Verack)),
             [
                 0x00, // Full command encoding flag.
                 0x76, 0x65, 0x72, 0x61, 0x63, 0x6B, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -2996,7 +2990,7 @@ mod test {
     #[test]
     #[rustfmt::skip]
     fn serialize_mempool() {
-        assert_eq!(serialize(&V1NetworkMessage::new(Magic::BITCOIN, NetworkMessage::MemPool)),
+        assert_eq!(encoding::encode_to_vec(&V1NetworkMessage::new(Magic::BITCOIN, NetworkMessage::MemPool)),
                        [0xf9, 0xbe, 0xb4, 0xd9, 0x6d, 0x65, 0x6d, 0x70,
                         0x6f, 0x6f, 0x6c, 0x00, 0x00, 0x00, 0x00, 0x00,
                         0x00, 0x00, 0x00, 0x00, 0x5d, 0xf6, 0xe0, 0xe2]);
@@ -3005,7 +2999,7 @@ mod test {
     #[test]
     fn serialize_v2_mempool() {
         assert_eq!(
-            serialize(&V2NetworkMessage::new(NetworkMessage::MemPool)),
+            encoding::encode_to_vec(&V2NetworkMessage::new(NetworkMessage::MemPool)),
             [
                 0x0F, // MemPool command short ID
             ]
@@ -3015,7 +3009,7 @@ mod test {
     #[test]
     #[rustfmt::skip]
     fn serialize_getaddr() {
-        assert_eq!(serialize(&V1NetworkMessage::new(Magic::BITCOIN, NetworkMessage::GetAddr)),
+        assert_eq!(encoding::encode_to_vec(&V1NetworkMessage::new(Magic::BITCOIN, NetworkMessage::GetAddr)),
                        [0xf9, 0xbe, 0xb4, 0xd9, 0x67, 0x65, 0x74, 0x61,
                         0x64, 0x64, 0x72, 0x00, 0x00, 0x00, 0x00, 0x00,
                         0x00, 0x00, 0x00, 0x00, 0x5d, 0xf6, 0xe0, 0xe2]);
@@ -3024,7 +3018,7 @@ mod test {
     #[test]
     fn serialize_v2_getaddr() {
         assert_eq!(
-            serialize(&V2NetworkMessage::new(NetworkMessage::GetAddr)),
+            encoding::encode_to_vec(&V2NetworkMessage::new(NetworkMessage::GetAddr)),
             [
                 0x00, // Full command encoding flag.
                 0x67, 0x65, 0x74, 0x61, 0x64, 0x64, 0x72, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -3035,7 +3029,7 @@ mod test {
     #[test]
     fn deserialize_getaddr() {
         #[rustfmt::skip]
-        let msg = deserialize(&[
+        let msg = encoding::decode_from_slice(&[
             0xf9, 0xbe, 0xb4, 0xd9, 0x67, 0x65, 0x74, 0x61,
             0x64, 0x64, 0x72, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x5d, 0xf6, 0xe0, 0xe2
@@ -3049,7 +3043,7 @@ mod test {
 
     #[test]
     fn deserialize_v2_getaddr() {
-        let msg = deserialize(&[
+        let msg = encoding::decode_from_slice(&[
             0x00, // Full command encoding flag
             0x67, 0x65, 0x74, 0x61, 0x64, 0x64, 0x72, 0x00, 0x00, 0x00, 0x00, 0x00,
         ]);
@@ -3063,7 +3057,7 @@ mod test {
     #[test]
     fn deserialize_version() {
         #[rustfmt::skip]
-        let msg = deserialize::<V1NetworkMessage>(&[
+        let msg = encoding::decode_from_slice::<V1NetworkMessage>(&[
             0xf9, 0xbe, 0xb4, 0xd9, 0x76, 0x65, 0x72, 0x73,
             0x69, 0x6f, 0x6e, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x66, 0x00, 0x00, 0x00, 0xbe, 0x61, 0xb8, 0x27,
@@ -3107,7 +3101,7 @@ mod test {
     #[test]
     fn deserialize_v2_version() {
         #[rustfmt::skip]
-        let msg = deserialize::<V2NetworkMessage>(&[
+        let msg = encoding::decode_from_slice::<V2NetworkMessage>(&[
             0x00, // Full command encoding flag
             0x76, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x00, 0x00, 0x00, 0x00, 0x00, // "version" command
             0x7f, 0x11, 0x01, 0x00, // version: 70015
@@ -3145,7 +3139,7 @@ mod test {
     #[test]
     fn deserialize_partial_message() {
         #[rustfmt::skip]
-        let data = [
+        let data: [u8; 128] = [
             0xf9, 0xbe, 0xb4, 0xd9, 0x76, 0x65, 0x72, 0x73,
             0x69, 0x6f, 0x6e, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x66, 0x00, 0x00, 0x00, 0xbe, 0x61, 0xb8, 0x27,
@@ -3163,11 +3157,11 @@ mod test {
             0x69, 0x3a, 0x30, 0x2e, 0x31, 0x37, 0x2e, 0x31,
             0x2f, 0x93, 0x8c, 0x08, 0x00, 0x01, 0x00, 0x00
         ];
-        let msg = deserialize_partial::<V1NetworkMessage>(&data);
+        let msg = encoding::decode_from_slice_unbounded::<V1NetworkMessage>(&mut data.as_ref());
         assert!(msg.is_ok());
 
-        let (msg, consumed) = msg.unwrap();
-        assert_eq!(consumed, data.to_vec().len() - 2);
+        let msg = msg.unwrap();
+        assert_eq!(encoding::encode_to_vec(&msg).len(), data.to_vec().len() - 2);
         assert_eq!(msg.magic, Magic::BITCOIN);
         if let NetworkMessage::Version(version_msg) = msg.payload {
             assert_eq!(version_msg.version, ProtocolVersion::INVALID_CB_NO_BAN_VERSION);
@@ -3189,27 +3183,14 @@ mod test {
     }
 
     #[test]
-    fn serialize_checkeddata() {
-        let cd = CheckedData::new(vec![1u8, 2, 3, 4, 5]);
-        assert_eq!(serialize(&cd), [5, 0, 0, 0, 162, 107, 175, 90, 1, 2, 3, 4, 5]);
-    }
-
-    #[test]
-    fn deserialize_checkeddata() {
-        let cd: Result<CheckedData, _> =
-            deserialize(&[5u8, 0, 0, 0, 162, 107, 175, 90, 1, 2, 3, 4, 5]);
-        assert_eq!(cd.ok(), Some(CheckedData::new(vec![1u8, 2, 3, 4, 5])));
-    }
-
-    #[test]
     fn headers_message() {
-        let block_900_000 = deserialize::<block::Header>(
+        let block_900_000 = encoding::decode_from_slice::<block::Header>(
             &hex!("00a0ab20247d4d9f582f9750344cdf62c46d81d046be960340960100000000000000000070f96945530651135839d8adc3f40e595118ec74c7ad81a3d17bb022e554fb0c937f4268743702177ad05f92")
         ).unwrap();
-        let block_900_001 = deserialize::<block::Header>(
+        let block_900_001 = encoding::decode_from_slice::<block::Header>(
             &hex!("00e000208a96960d6d1ca4ee4a283fd83da309b8d5d2bfed380501000000000000000000371c9ffd63d75fb36c57d58eb842d23c0e7ec049daf16d94cc38805c346e9d52e880426874370217973dc83b")
         ).unwrap();
-        let block_900_002 = deserialize::<block::Header>(
+        let block_900_002 = encoding::decode_from_slice::<block::Header>(
             &hex!("0400ff3ffc834fac4e1eb2ae41f1f9776e0f8e24a6090603ffa8010000000000000000002efba7e7280aa60f0a650f29e30332d52e11af57bc58cc6e71f343851f016c676182426874370217e3615653")
         ).unwrap();
         let header_900_000 = NetworkHeader { header: block_900_000, length: 0 };
@@ -3230,7 +3211,7 @@ mod test {
         let _ = decoder.push_bytes(&mut data.as_slice());
         let decoded = decoder.end().unwrap();
 
-        let enc = serialize(&decoded);
+        let enc = encoding::encode_to_vec(&decoded);
         assert_eq!(data.as_slice(), enc.as_slice());
     }
 

--- a/p2p/src/message_blockdata.rs
+++ b/p2p/src/message_blockdata.rs
@@ -597,7 +597,6 @@ impl<'a> Arbitrary<'a> for Inventory {
 
 #[cfg(test)]
 mod tests {
-    use bitcoin::consensus::encode::{deserialize, serialize};
     use hex_unstable::hex;
 
     use super::*;
@@ -607,15 +606,15 @@ mod tests {
         let from_sat = hex!("72110100014a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b0000000000000000000000000000000000000000000000000000000000000000");
         let genhash = hex!("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
 
-        let decode: Result<GetBlocksMessage, _> = deserialize(&from_sat);
+        let decode: Result<GetBlocksMessage, _> = encoding::decode_from_slice(&from_sat);
         assert!(decode.is_ok());
         let real_decode = decode.unwrap();
         assert_eq!(real_decode.version.0, 70002);
         assert_eq!(real_decode.locator_hashes.hashes().len(), 1);
-        assert_eq!(serialize(&real_decode.locator_hashes.hashes()[0]), genhash);
+        assert_eq!(encoding::encode_to_vec(&real_decode.locator_hashes.hashes()[0]), genhash);
         assert_eq!(real_decode.stop_hash, BlockHash::GENESIS_PREVIOUS_BLOCK_HASH);
 
-        assert_eq!(serialize(&real_decode), from_sat);
+        assert_eq!(encoding::encode_to_vec(&real_decode), from_sat);
     }
 
     #[test]
@@ -623,14 +622,14 @@ mod tests {
         let from_sat = hex!("72110100014a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b0000000000000000000000000000000000000000000000000000000000000000");
         let genhash = hex!("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
 
-        let decode: Result<GetHeadersMessage, _> = deserialize(&from_sat);
+        let decode: Result<GetHeadersMessage, _> = encoding::decode_from_slice(&from_sat);
         assert!(decode.is_ok());
         let real_decode = decode.unwrap();
         assert_eq!(real_decode.version.0, 70002);
         assert_eq!(real_decode.locator_hashes.hashes().len(), 1);
-        assert_eq!(serialize(&real_decode.locator_hashes.hashes()[0]), genhash);
+        assert_eq!(encoding::encode_to_vec(&real_decode.locator_hashes.hashes()[0]), genhash);
         assert_eq!(real_decode.stop_hash, BlockHash::GENESIS_PREVIOUS_BLOCK_HASH);
 
-        assert_eq!(serialize(&real_decode), from_sat);
+        assert_eq!(encoding::encode_to_vec(&real_decode), from_sat);
     }
 }

--- a/p2p/src/message_network.rs
+++ b/p2p/src/message_network.rs
@@ -934,7 +934,6 @@ impl<'a> Arbitrary<'a> for Alert {
 mod tests {
     use alloc::string::ToString;
 
-    use bitcoin::consensus::encode::{deserialize, serialize};
     use hex_unstable::hex;
 
     use super::*;
@@ -974,8 +973,8 @@ mod tests {
         let reject_tx_conflict = hex!("027478121474786e2d6d656d706f6f6c2d636f6e666c69637405df54d3860b3c41806a3546ab48279300affacf4b88591b229141dcf2f47004");
         let reject_tx_nonfinal = hex!("02747840096e6f6e2d66696e616c259bbe6c83db8bbdfca7ca303b19413dc245d9f2371b344ede5f8b1339a5460b");
 
-        let decode_result_conflict: Result<Reject, _> = deserialize(&reject_tx_conflict);
-        let decode_result_nonfinal: Result<Reject, _> = deserialize(&reject_tx_nonfinal);
+        let decode_result_conflict: Result<Reject, _> = encoding::decode_from_slice(&reject_tx_conflict);
+        let decode_result_nonfinal: Result<Reject, _> = encoding::decode_from_slice(&reject_tx_nonfinal);
 
         assert!(decode_result_conflict.is_ok());
         assert!(decode_result_nonfinal.is_ok());
@@ -1002,14 +1001,14 @@ mod tests {
             nonfinal.hash
         );
 
-        assert_eq!(serialize(&conflict), reject_tx_conflict);
-        assert_eq!(serialize(&nonfinal), reject_tx_nonfinal);
+        assert_eq!(encoding::encode_to_vec(&conflict), reject_tx_conflict);
+        assert_eq!(encoding::encode_to_vec(&nonfinal), reject_tx_nonfinal);
     }
 
     #[test]
     fn alert_message_test() {
         let alert_hex = hex!("60010000000000000000000000ffffff7f00000000ffffff7ffeffff7f01ffffff7f00000000ffffff7f00ffffff7f002f555247454e543a20416c657274206b657920636f6d70726f6d697365642c207570677261646520726571756972656400");
-        let alert: Alert = deserialize(&alert_hex).unwrap();
+        let alert: Alert = encoding::decode_from_slice(&alert_hex).unwrap();
         assert!(alert.is_final_alert());
     }
 


### PR DESCRIPTION
Before we start gutting the old consensus implementations this updates the test cases to use the new encoding logic so coverage remains the same. Either:
- `serialize/deserialize` are replaced with the `encoding` counterparts
- `encoding` is already covered alongside the legacy functions, so calls to legacy functions are removed
- In the case of `CheckedData`, the checksum of a V1 message will be computed directly after #6076. `CheckedData` may be removed, so the tests are removed here.