### PR TITLE
p2p: Fix AddrV1MessageDecoder Doc comment

### DIFF
--- a/p2p/src/address.rs
+++ b/p2p/src/address.rs
@@ -264,7 +264,7 @@ impl encoding::Encodable for AddrV1Message {
 
 type AddrV1MessageInnerDecoder = Decoder2<ArrayDecoder<4>, AddressDecoder>;
 
-/// The decoder for an [`AddrV2Message`].
+/// The decoder for an [`AddrV1Message`].
 #[derive(Debug, Clone)]
 pub struct AddrV1MessageDecoder(AddrV1MessageInnerDecoder);
 


### PR DESCRIPTION
Fix AddrV1 Decoder Typographical Error

Correct the doc comment on `AddrV1MessageDecoder` to correctly mention the `AddrV1Message` as the message format it is decoding, and not `AddrV2Message`.