### PR TITLE
Release tracking PR: `consensus_encoding 1.0.0`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -109,7 +109,7 @@ version = "0.0.0"
 
 [[package]]
 name = "bitcoin-consensus-encoding"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "bitcoin-internals 0.5.0",
  "hex-conservative 1.1.0",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -108,7 +108,7 @@ version = "0.0.0"
 
 [[package]]
 name = "bitcoin-consensus-encoding"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "bitcoin-internals 0.5.0",
  "hex-conservative 1.1.0",

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -31,7 +31,7 @@ bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
 crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.2.0", default-features = false, features = ["alloc"] }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false, features = ["alloc", "hex"] }
 key-expression = { package = "bitcoin-key-expression", path = "../key_expression", version = "0.0.0", default-features = false, features = ["alloc"] }
-encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.2.0", default-features = false, features = ["alloc"] }
+encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0", default-features = false, features = ["alloc"] }
 hex = { package = "hex-conservative", version = "1.1.0", default-features = false, features = ["alloc"] }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0", features = ["alloc", "hex"] }
 io = { package = "bitcoin-io", path = "../io", version = "0.5.0", default-features = false, features = ["alloc", "hashes"] }

--- a/consensus_encoding/CHANGELOG.md
+++ b/consensus_encoding/CHANGELOG.md
@@ -1,3 +1,23 @@
+# 1.0.0 - 2026-05-22
+
+Props to the team, our first `1.0` release from this repository. That
+is no small feat. Extra props to Nick, he kicked this crate off and
+worked hard on it. Props also to Kix for the overall design and
+original work, his efforts don't really get fair visibility in the git
+log. Poelstra, as usual patiently reviewing and merging.
+
+Team Rust Bitcoin - LFG.
+
+- Replace `bool` on `Decoder` trait with the `DecoderStatus` type (includes Encoder side too) [#6189](https://github.com/rust-bitcoin/rust-bitcoin/pull/6189)
+- Add checked decode functions [#6195](https://github.com/rust-bitcoin/rust-bitcoin/pull/6195)
+- Re-name main traits [#6028](https://github.com/rust-bitcoin/rust-bitcoin/pull/60428)
+- Change `EncodableByteIter` to `EncoderByteIter` [#6044](https://github.com/rust-bitcoin/rust-bitcoin/pull/6044)
+- Encoder/decoder improvements [#6004](https://github.com/rust-bitcoin/rust-bitcoin/pull/6004)
+- Re-name `flush_to` functions to `drain_to` [#6064](https://github.com/rust-bitcoin/rust-bitcoin/pull/6064)
+
+Please note `Encodable` is now `Encode` and `Decodable` is now `Decode` but the old names are still
+used for the old consensus encoding code in `rust-bticoin`.
+
 # 0.2.0 - 2026-04-08
 
 This release is breaking and causes our whole stack to have to be re-released ...

--- a/consensus_encoding/Cargo.toml
+++ b/consensus_encoding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-consensus-encoding"
-version = "0.2.0"
+version = "1.0.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>", "Nick Johnson <nick@yonson.dev>", "Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 homepage = "https://rust-bitcoin.org/"

--- a/consensus_encoding/README.md
+++ b/consensus_encoding/README.md
@@ -1,13 +1,16 @@
 # Bitcoin Consensus Encoding
 
-This crate provides traits that can be used to encode/decode objects in a consensus-consistent way.
+Sans-IO encoding and decoding support used by the `rust-bitcoin` ecosystem for objects that have a
+consensus-specified byte encoding.
 
-## `consensus_encoding 0.1.0`
+## History
 
-This is the start of the `v1.0.0` release candidate cycle. We will
-endeavour to not release breaking changes unless totally necessary and
-will honour semver rules as usual. From this release forward we will
-semver trick as possible in subsequent releases to assist downstream
-users testing these releases.
+Historically `rust-bitcoin` supported consensus encoding/decoding by way of the
+[`bitcoin::consensus`](https://docs.rs/bitcoin/0.32.0/bitcoin/consensus/) module. This code
+included the `std::io::Error` type which turned out to be the cause of a lot of pain, including
+but not restricted to, creation of the [`bitcoin_io`](https://crates.io/crates/bitcoin-io) crate.
 
-Thanks for your patience and help.
+The solution was to re-write the consensus encoding/decoding logic using the sans-IO paradigm.
+
+As part of developing this crate we fuzz against the latest `bitcoin 0.32` release. If interested
+see `rust-bitcoin/fuzz/fuzz_targets/bitcoin/compare_consensus_encoding.rs`.

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -24,7 +24,7 @@ small-hash = []
 
 [dependencies]
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
-encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.2.0", default-features = false }
+encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0", default-features = false }
 
 arbitrary = { version = "1.4.1", optional = true}
 hex = { package = "hex-conservative", version = "1.1.0", default-features = false, optional = true }

--- a/io/Cargo.toml
+++ b/io/Cargo.toml
@@ -21,7 +21,7 @@ alloc = ["encoding/alloc", "hashes?/alloc", "internals/alloc"]
 
 [dependencies]
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
-encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.2.0", default-features = false }
+encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0", default-features = false }
 
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false, optional = true }
 

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -20,7 +20,7 @@ arbitrary = ["dep:arbitrary", "primitives/arbitrary"]
 serde = ["dep:serde", "hashes/serde"]
 
 [dependencies]
-encoding = { package = "bitcoin-consensus-encoding", version = "0.2.0", path = "../consensus_encoding", features = ["alloc"], default-features = false }
+encoding = { package = "bitcoin-consensus-encoding", version = "1.0.0", path = "../consensus_encoding", features = ["alloc"], default-features = false }
 hashes = { package = "bitcoin_hashes", version = "0.20.0", path = "../hashes", default-features = false }
 network = { package = "bitcoin-network-kind", path = "../network", version = "0.1.0", default-features = false }
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.102.0", features = ["hex", "alloc"], default-features = false }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -22,7 +22,7 @@ arbitrary = ["dep:arbitrary", "units/arbitrary"]
 hex = ["dep:hex", "hashes/hex", "internals/hex"]
 
 [dependencies]
-encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.2.0", default-features = false }
+encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0", default-features = false }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
 units = { package = "bitcoin-units", path = "../units", version = "0.3.0", default-features = false, features = [ "encoding" ] }

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -21,7 +21,7 @@ alloc = ["internals/alloc", "serde?/alloc", "encoding?/alloc"]
 [dependencies]
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
 
-encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.2.0", default-features = false, optional = true }
+encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0", default-features = false, optional = true }
 serde = { version = "1.0.195", default-features = false, features = ["derive"], optional = true }
 arbitrary = { version = "1.4.1", optional = true }
 


### PR DESCRIPTION
In preparation for releasing `v1.0.0` add a changelog, bump the version, update all downstream crates, and update the lockfiles.

Patch 1 updates the readme and closes #6132.


