### PR TITLE
bitcoin: Fix error re-exports

### DIFF
--- a/bitcoin/src/blockdata/mod.rs
+++ b/bitcoin/src/blockdata/mod.rs
@@ -84,8 +84,9 @@ pub mod locktime {
         pub use units::locktime::relative::{error, LockTime, NumberOf512Seconds, NumberOfBlocks};
         #[doc(no_inline)]
         pub use units::locktime::relative::{
-            DisabledLockTimeError, InvalidHeightError, InvalidTimeError, IsSatisfiedByError,
-            IsSatisfiedByHeightError, IsSatisfiedByTimeError, TimeOverflowError,
+            DisabledLockTimeError, IncompatibleHeightError, IncompatibleTimeError,
+            InvalidHeightError, InvalidTimeError, IsSatisfiedByError, IsSatisfiedByHeightError,
+            IsSatisfiedByTimeError, TimeOverflowError,
         };
 
         #[deprecated(since = "TBD", note = "use `NumberOfBlocks` instead")]

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -241,9 +241,14 @@ pub mod amount {
     #[doc(inline)]
     pub use units::amount::{Amount, AmountDecoder, AmountEncoder, SignedAmount};
     #[doc(no_inline)]
-    pub use units::amount::{
-        AmountDecoderError, Denomination, Display, OutOfRangeError, ParseAmountError,
-        ParseDenominationError, ParseError,
+    pub use units::amount::{Denomination, Display};
+
+    #[doc(no_inline)]
+    pub use self::error::{
+        AmountDecoderError, BadPositionError, InputTooLargeError, InvalidCharacterError,
+        MissingDenominationError, MissingDigitsError, OutOfRangeError, ParseAmountError,
+        ParseDenominationError, ParseError, PossiblyConfusingDenominationError, TooPreciseError,
+        UnknownDenominationError,
     };
 
     /// Error types for bitcoin amounts.


### PR DESCRIPTION
Through the various recent patches to fix error re-exports, the state of the re-exports somehow wound up out of sync and causing problems with the re-export check.

Add re-exports for errors in bitcoin::amount, ::relative and ::absolute modules.

Closes #6017