### PR TITLE
Improve Arbitrary impl for Xpriv

### DIFF
--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -1180,7 +1180,20 @@ impl<'a> Arbitrary<'a> for Xpub {
 #[cfg(feature = "arbitrary")]
 impl<'a> Arbitrary<'a> for Xpriv {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        Ok(Self::new_master(NetworkKind::arbitrary(u)?, u.arbitrary()?))
+        let depth = u.arbitrary()?;
+        let (parent_fingerprint, child_number) = match depth {
+            0 => (Fingerprint::default(), ChildNumber::ZERO_NORMAL),
+            _ => (u.arbitrary()?, u.arbitrary()?),
+        };
+
+        Ok(Self {
+            network: u.arbitrary()?,
+            depth,
+            parent_fingerprint,
+            child_number,
+            private_key: u.arbitrary()?,
+            chain_code: u.arbitrary()?,
+        })
     }
 }
 


### PR DESCRIPTION
Construct an arbitrary `Xpriv` directly, instead of through `new_master` which only constructs master keys, where
- `depth` is `0`
- `parent_fingerprint` is the zero fingerprint
- `child_number` is `ChildNumber::ZERO_NORMAL`

This improves fuzzing coverage by also constructing non-master `Xpriv` instances.