### PR TITLE
chore: Fix emitted rbmt test warnings

### DIFF
--- a/bitcoin/examples/sign-tx-segwit-v0.rs
+++ b/bitcoin/examples/sign-tx-segwit-v0.rs
@@ -69,7 +69,7 @@ fn main() {
     let signature = ecdsa::Signature { signature: sk.raw_ecdsa_sign(sighash), sighash_type };
 
     // Update the witness stack.
-    let pk = sk.public_key().force_compressed();
+    let pk = sk.to_public_key().force_compressed();
     *sighasher.witness_mut(input_index).unwrap() = Witness::p2wpkh(signature, pk);
 
     // Get the signed transaction.
@@ -84,7 +84,7 @@ fn main() {
 /// In a real application these would be actual secrets.
 fn senders_keys() -> (PrivateKey, WPubkeyHash) {
     let sk = PrivateKey::generate();
-    let pk = sk.public_key();
+    let pk = sk.to_public_key();
     let wpkh = pk.wpubkey_hash().expect("key is compressed");
 
     (sk, wpkh)

--- a/bitcoin/tests/bip_174.rs
+++ b/bitcoin/tests/bip_174.rs
@@ -119,7 +119,7 @@ fn build_extended_private_key() -> Xpriv {
     let xpriv = extended_private_key.parse::<Xpriv>().unwrap();
 
     let sk = WifKey::from_wif(seed).unwrap();
-    let seeded = Xpriv::new_master(NetworkKind::Test, &sk.private_key.to_bytes());
+    let seeded = Xpriv::new_master(NetworkKind::Test, &sk.private_key.to_secret_vec());
     assert_eq!(xpriv, seeded);
 
     xpriv
@@ -315,7 +315,7 @@ fn parse_and_verify_keys(
         let derived_priv =
             ext_priv.derive_xpriv(&path).expect("derivation path too long").to_private_key();
         assert_eq!(wif_priv.private_key, derived_priv);
-        let derived_pub = derived_priv.public_key();
+        let derived_pub = derived_priv.to_public_key();
         key_map.insert(derived_pub, derived_priv);
     }
     key_map

--- a/bitcoin/tests/serde.rs
+++ b/bitcoin/tests/serde.rs
@@ -55,7 +55,7 @@ fn serde_regression_absolute_lock_time_time() {
 
 #[test]
 fn serde_regression_relative_lock_time_height() {
-    let t = relative::LockTime::from(relative::Height::from(0xCAFE_u16));
+    let t = relative::LockTime::from(relative::NumberOfBlocks::from(0xCAFE_u16));
 
     let got = serialize(&t).unwrap();
     let want = include_bytes!("data/serde/relative_lock_time_blocks_bincode") as &[_];
@@ -64,7 +64,9 @@ fn serde_regression_relative_lock_time_height() {
 
 #[test]
 fn serde_regression_relative_lock_time_time() {
-    let t = relative::LockTime::from(relative::Time::from_512_second_intervals(0xFACE_u16));
+    let t = relative::LockTime::from(relative::NumberOf512Seconds::from_512_second_intervals(
+        0xFACE_u16,
+    ));
 
     let got = serialize(&t).unwrap();
     let want = include_bytes!("data/serde/relative_lock_time_seconds_bincode") as &[_];

--- a/consensus_encoding/src/error.rs
+++ b/consensus_encoding/src/error.rs
@@ -141,7 +141,6 @@ impl From<Infallible> for CompactSizeDecoderError {
 
 impl core::fmt::Display for CompactSizeDecoderError {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        use internals::write_err;
         use CompactSizeDecoderErrorInner as E;
 
         match self.0 {


### PR DESCRIPTION
Running `cargo rbmt test --toolchain msrv --lock-file minimal` emits warnings related to use of deprecated types, methods and unused imports in `bitcoin`, `consensus_encoding` crates. This PR addresses the warnings and uses the recommended interface.

Patches are made per module fix, but happy to squash it all into one patch if that makes reviewing easier.