### PR TITLE
Re-name consensus_encoding main traits

### DIFF
--- a/consensus_encoding/api/all-features.txt
+++ b/consensus_encoding/api/all-features.txt
@@ -1689,23 +1689,23 @@ impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::error::Length
 pub unsafe fn bitcoin_consensus_encoding::error::LengthPrefixExceedsMaxError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::error::LengthPrefixExceedsMaxError
 pub fn bitcoin_consensus_encoding::error::LengthPrefixExceedsMaxError::from(t: T) -> T
-pub struct bitcoin_consensus_encoding::SliceEncoder<'e, T: bitcoin_consensus_encoding::Encodable>
-impl<'e, T: bitcoin_consensus_encoding::Encodable> bitcoin_consensus_encoding::SliceEncoder<'e, T>
+pub struct bitcoin_consensus_encoding::SliceEncoder<'e, T: bitcoin_consensus_encoding::Encode>
+impl<'e, T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::SliceEncoder<'e, T>
 pub fn bitcoin_consensus_encoding::SliceEncoder<'e, T>::without_length_prefix(sl: &'e [T]) -> Self
-impl<'e, T: bitcoin_consensus_encoding::Encodable> core::clone::Clone for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::clone::Clone
+impl<'e, T: bitcoin_consensus_encoding::Encode> core::clone::Clone for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::clone::Clone
 pub fn bitcoin_consensus_encoding::SliceEncoder<'e, T>::clone(&self) -> Self
-impl<'e, T: bitcoin_consensus_encoding::Encodable> core::fmt::Debug for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::fmt::Debug
+impl<'e, T: bitcoin_consensus_encoding::Encode> core::fmt::Debug for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::fmt::Debug
 pub fn bitcoin_consensus_encoding::SliceEncoder<'e, T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl<T: bitcoin_consensus_encoding::Encodable> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::SliceEncoder<'_, T>
+impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::SliceEncoder<'_, T>
 pub fn bitcoin_consensus_encoding::SliceEncoder<'_, T>::advance(&mut self) -> bool
 pub fn bitcoin_consensus_encoding::SliceEncoder<'_, T>::current_chunk(&self) -> &[u8]
-impl<'e, T> core::marker::Freeze for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::marker::Freeze
-impl<'e, T> core::marker::Send for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::marker::Send, T: core::marker::Sync
-impl<'e, T> core::marker::Sync for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::marker::Sync, T: core::marker::Sync
-impl<'e, T> core::marker::Unpin for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::marker::Unpin
-impl<'e, T> core::marker::UnsafeUnpin for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::marker::UnsafeUnpin
-impl<'e, T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::panic::unwind_safe::RefUnwindSafe, T: core::panic::unwind_safe::RefUnwindSafe
-impl<'e, T> core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::panic::unwind_safe::UnwindSafe, T: core::panic::unwind_safe::RefUnwindSafe
+impl<'e, T> core::marker::Freeze for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::marker::Freeze
+impl<'e, T> core::marker::Send for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::marker::Send, T: core::marker::Sync
+impl<'e, T> core::marker::Sync for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::marker::Sync, T: core::marker::Sync
+impl<'e, T> core::marker::Unpin for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::marker::Unpin
+impl<'e, T> core::marker::UnsafeUnpin for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::marker::UnsafeUnpin
+impl<'e, T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::panic::unwind_safe::RefUnwindSafe, T: core::panic::unwind_safe::RefUnwindSafe
+impl<'e, T> core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::panic::unwind_safe::UnwindSafe, T: core::panic::unwind_safe::RefUnwindSafe
 impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::SliceEncoder<'e, T> where U: core::convert::From<T>
 pub fn bitcoin_consensus_encoding::SliceEncoder<'e, T>::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::SliceEncoder<'e, T> where U: core::convert::Into<T>
@@ -1820,29 +1820,29 @@ impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::error::Unexpe
 pub unsafe fn bitcoin_consensus_encoding::error::UnexpectedEofError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::error::UnexpectedEofError
 pub fn bitcoin_consensus_encoding::error::UnexpectedEofError::from(t: T) -> T
-pub struct bitcoin_consensus_encoding::VecDecoder<T: bitcoin_consensus_encoding::Decodable>
-impl<T: bitcoin_consensus_encoding::Decodable> bitcoin_consensus_encoding::VecDecoder<T>
+pub struct bitcoin_consensus_encoding::VecDecoder<T: bitcoin_consensus_encoding::Decode>
+impl<T: bitcoin_consensus_encoding::Decode> bitcoin_consensus_encoding::VecDecoder<T>
 pub const fn bitcoin_consensus_encoding::VecDecoder<T>::new() -> Self
 pub const fn bitcoin_consensus_encoding::VecDecoder<T>::new_with_limit(limit: usize) -> Self
-impl<T: bitcoin_consensus_encoding::Decodable> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::VecDecoder<T>
-pub type bitcoin_consensus_encoding::VecDecoder<T>::Error = bitcoin_consensus_encoding::error::VecDecoderError<<<T as bitcoin_consensus_encoding::Decodable>::Decoder as bitcoin_consensus_encoding::Decoder>::Error>
+impl<T: bitcoin_consensus_encoding::Decode> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::VecDecoder<T>
+pub type bitcoin_consensus_encoding::VecDecoder<T>::Error = bitcoin_consensus_encoding::error::VecDecoderError<<<T as bitcoin_consensus_encoding::Decode>::Decoder as bitcoin_consensus_encoding::Decoder>::Error>
 pub type bitcoin_consensus_encoding::VecDecoder<T>::Output = alloc::vec::Vec<T>
 pub fn bitcoin_consensus_encoding::VecDecoder<T>::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_consensus_encoding::VecDecoder<T>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bool, Self::Error>
 pub fn bitcoin_consensus_encoding::VecDecoder<T>::read_limit(&self) -> usize
-impl<T: bitcoin_consensus_encoding::Decodable> core::default::Default for bitcoin_consensus_encoding::VecDecoder<T>
+impl<T: bitcoin_consensus_encoding::Decode> core::default::Default for bitcoin_consensus_encoding::VecDecoder<T>
 pub fn bitcoin_consensus_encoding::VecDecoder<T>::default() -> Self
-impl<T: bitcoin_consensus_encoding::Decodable> core::fmt::Debug for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decodable>::Decoder: core::fmt::Debug
+impl<T: bitcoin_consensus_encoding::Decode> core::fmt::Debug for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decode>::Decoder: core::fmt::Debug
 pub fn bitcoin_consensus_encoding::VecDecoder<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl<T> core::clone::Clone for bitcoin_consensus_encoding::VecDecoder<T> where T: core::clone::Clone + bitcoin_consensus_encoding::Decodable, <T as bitcoin_consensus_encoding::Decodable>::Decoder: core::clone::Clone
+impl<T> core::clone::Clone for bitcoin_consensus_encoding::VecDecoder<T> where T: core::clone::Clone + bitcoin_consensus_encoding::Decode, <T as bitcoin_consensus_encoding::Decode>::Decoder: core::clone::Clone
 pub fn bitcoin_consensus_encoding::VecDecoder<T>::clone(&self) -> Self
-impl<T> core::marker::Freeze for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decodable>::Decoder: core::marker::Freeze
-impl<T> core::marker::Send for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decodable>::Decoder: core::marker::Send, T: core::marker::Send
-impl<T> core::marker::Sync for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decodable>::Decoder: core::marker::Sync, T: core::marker::Sync
-impl<T> core::marker::Unpin for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decodable>::Decoder: core::marker::Unpin, T: core::marker::Unpin
-impl<T> core::marker::UnsafeUnpin for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decodable>::Decoder: core::marker::UnsafeUnpin
-impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decodable>::Decoder: core::panic::unwind_safe::RefUnwindSafe, T: core::panic::unwind_safe::RefUnwindSafe
-impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decodable>::Decoder: core::panic::unwind_safe::UnwindSafe, T: core::panic::unwind_safe::UnwindSafe
+impl<T> core::marker::Freeze for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decode>::Decoder: core::marker::Freeze
+impl<T> core::marker::Send for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decode>::Decoder: core::marker::Send, T: core::marker::Send
+impl<T> core::marker::Sync for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decode>::Decoder: core::marker::Sync, T: core::marker::Sync
+impl<T> core::marker::Unpin for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decode>::Decoder: core::marker::Unpin, T: core::marker::Unpin
+impl<T> core::marker::UnsafeUnpin for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decode>::Decoder: core::marker::UnsafeUnpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decode>::Decoder: core::panic::unwind_safe::RefUnwindSafe, T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decode>::Decoder: core::panic::unwind_safe::UnwindSafe, T: core::panic::unwind_safe::UnwindSafe
 impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::VecDecoder<T> where U: core::convert::From<T>
 pub fn bitcoin_consensus_encoding::VecDecoder<T>::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::VecDecoder<T> where U: core::convert::Into<T>
@@ -1911,9 +1911,9 @@ impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::error::VecDec
 pub unsafe fn bitcoin_consensus_encoding::error::VecDecoderError<Err>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::error::VecDecoderError<Err>
 pub fn bitcoin_consensus_encoding::error::VecDecoderError<Err>::from(t: T) -> T
-pub trait bitcoin_consensus_encoding::Decodable
-pub type bitcoin_consensus_encoding::Decodable::Decoder: bitcoin_consensus_encoding::Decoder<Output = Self>
-pub fn bitcoin_consensus_encoding::Decodable::decoder() -> Self::Decoder
+pub trait bitcoin_consensus_encoding::Decode
+pub type bitcoin_consensus_encoding::Decode::Decoder: bitcoin_consensus_encoding::Decoder<Output = Self>
+pub fn bitcoin_consensus_encoding::Decode::decoder() -> Self::Decoder
 pub trait bitcoin_consensus_encoding::Decoder: core::marker::Sized
 pub type bitcoin_consensus_encoding::Decoder::Error
 pub type bitcoin_consensus_encoding::Decoder::Output
@@ -1962,8 +1962,8 @@ pub type bitcoin_consensus_encoding::Decoder2<A, B>::Output = (<A as bitcoin_con
 pub fn bitcoin_consensus_encoding::Decoder2<A, B>::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_consensus_encoding::Decoder2<A, B>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bool, Self::Error>
 pub fn bitcoin_consensus_encoding::Decoder2<A, B>::read_limit(&self) -> usize
-impl<T: bitcoin_consensus_encoding::Decodable> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::VecDecoder<T>
-pub type bitcoin_consensus_encoding::VecDecoder<T>::Error = bitcoin_consensus_encoding::error::VecDecoderError<<<T as bitcoin_consensus_encoding::Decodable>::Decoder as bitcoin_consensus_encoding::Decoder>::Error>
+impl<T: bitcoin_consensus_encoding::Decode> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::VecDecoder<T>
+pub type bitcoin_consensus_encoding::VecDecoder<T>::Error = bitcoin_consensus_encoding::error::VecDecoderError<<<T as bitcoin_consensus_encoding::Decode>::Decoder as bitcoin_consensus_encoding::Decoder>::Error>
 pub type bitcoin_consensus_encoding::VecDecoder<T>::Output = alloc::vec::Vec<T>
 pub fn bitcoin_consensus_encoding::VecDecoder<T>::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_consensus_encoding::VecDecoder<T>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bool, Self::Error>
@@ -1974,9 +1974,9 @@ pub type bitcoin_consensus_encoding::ArrayDecoder<N>::Output = [u8; N]
 pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bool, Self::Error>
 pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::read_limit(&self) -> usize
-pub trait bitcoin_consensus_encoding::Encodable
-pub type bitcoin_consensus_encoding::Encodable::Encoder<'e> where Self: 'e: bitcoin_consensus_encoding::Encoder
-pub fn bitcoin_consensus_encoding::Encodable::encoder(&self) -> Self::Encoder
+pub trait bitcoin_consensus_encoding::Encode
+pub type bitcoin_consensus_encoding::Encode::Encoder<'e> where Self: 'e: bitcoin_consensus_encoding::Encoder
+pub fn bitcoin_consensus_encoding::Encode::encoder(&self) -> Self::Encoder
 pub trait bitcoin_consensus_encoding::Encoder
 pub fn bitcoin_consensus_encoding::Encoder::advance(&mut self) -> bool
 pub fn bitcoin_consensus_encoding::Encoder::current_chunk(&self) -> &[u8]
@@ -1998,7 +1998,7 @@ pub fn bitcoin_consensus_encoding::Encoder3<A, B, C>::current_chunk(&self) -> &[
 impl<A: bitcoin_consensus_encoding::Encoder, B: bitcoin_consensus_encoding::Encoder> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::Encoder2<A, B>
 pub fn bitcoin_consensus_encoding::Encoder2<A, B>::advance(&mut self) -> bool
 pub fn bitcoin_consensus_encoding::Encoder2<A, B>::current_chunk(&self) -> &[u8]
-impl<T: bitcoin_consensus_encoding::Encodable> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::SliceEncoder<'_, T>
+impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::SliceEncoder<'_, T>
 pub fn bitcoin_consensus_encoding::SliceEncoder<'_, T>::advance(&mut self) -> bool
 pub fn bitcoin_consensus_encoding::SliceEncoder<'_, T>::current_chunk(&self) -> &[u8]
 impl<T: bitcoin_consensus_encoding::Encoder> bitcoin_consensus_encoding::Encoder for core::option::Option<T>
@@ -2029,12 +2029,12 @@ impl<const N: usize> bitcoin_consensus_encoding::ExactSizeEncoder for bitcoin_co
 pub fn bitcoin_consensus_encoding::ArrayEncoder<N>::len(&self) -> usize
 impl<const N: usize> bitcoin_consensus_encoding::ExactSizeEncoder for bitcoin_consensus_encoding::ArrayRefEncoder<'_, N>
 pub fn bitcoin_consensus_encoding::ArrayRefEncoder<'_, N>::len(&self) -> usize
-pub fn bitcoin_consensus_encoding::decode_from_read<T, R>(reader: R) -> core::result::Result<T, bitcoin_consensus_encoding::error::ReadError<<<T as bitcoin_consensus_encoding::Decodable>::Decoder as bitcoin_consensus_encoding::Decoder>::Error>> where T: bitcoin_consensus_encoding::Decodable, R: std::io::BufRead
-pub fn bitcoin_consensus_encoding::decode_from_read_unbuffered<T, R>(reader: R) -> core::result::Result<T, bitcoin_consensus_encoding::error::ReadError<<<T as bitcoin_consensus_encoding::Decodable>::Decoder as bitcoin_consensus_encoding::Decoder>::Error>> where T: bitcoin_consensus_encoding::Decodable, R: std::io::Read
-pub fn bitcoin_consensus_encoding::decode_from_read_unbuffered_with<T, R, const BUFFER_SIZE: usize>(reader: R) -> core::result::Result<T, bitcoin_consensus_encoding::error::ReadError<<<T as bitcoin_consensus_encoding::Decodable>::Decoder as bitcoin_consensus_encoding::Decoder>::Error>> where T: bitcoin_consensus_encoding::Decodable, R: std::io::Read
-pub fn bitcoin_consensus_encoding::decode_from_slice<T: bitcoin_consensus_encoding::Decodable>(bytes: &[u8]) -> core::result::Result<T, bitcoin_consensus_encoding::error::DecodeError<<<T as bitcoin_consensus_encoding::Decodable>::Decoder as bitcoin_consensus_encoding::Decoder>::Error>>
-pub fn bitcoin_consensus_encoding::decode_from_slice_unbounded<T>(bytes: &mut &[u8]) -> core::result::Result<T, <<T as bitcoin_consensus_encoding::Decodable>::Decoder as bitcoin_consensus_encoding::Decoder>::Error> where T: bitcoin_consensus_encoding::Decodable
+pub fn bitcoin_consensus_encoding::decode_from_read<T, R>(reader: R) -> core::result::Result<T, bitcoin_consensus_encoding::error::ReadError<<<T as bitcoin_consensus_encoding::Decode>::Decoder as bitcoin_consensus_encoding::Decoder>::Error>> where T: bitcoin_consensus_encoding::Decode, R: std::io::BufRead
+pub fn bitcoin_consensus_encoding::decode_from_read_unbuffered<T, R>(reader: R) -> core::result::Result<T, bitcoin_consensus_encoding::error::ReadError<<<T as bitcoin_consensus_encoding::Decode>::Decoder as bitcoin_consensus_encoding::Decoder>::Error>> where T: bitcoin_consensus_encoding::Decode, R: std::io::Read
+pub fn bitcoin_consensus_encoding::decode_from_read_unbuffered_with<T, R, const BUFFER_SIZE: usize>(reader: R) -> core::result::Result<T, bitcoin_consensus_encoding::error::ReadError<<<T as bitcoin_consensus_encoding::Decode>::Decoder as bitcoin_consensus_encoding::Decoder>::Error>> where T: bitcoin_consensus_encoding::Decode, R: std::io::Read
+pub fn bitcoin_consensus_encoding::decode_from_slice<T: bitcoin_consensus_encoding::Decode>(bytes: &[u8]) -> core::result::Result<T, bitcoin_consensus_encoding::error::DecodeError<<<T as bitcoin_consensus_encoding::Decode>::Decoder as bitcoin_consensus_encoding::Decoder>::Error>>
+pub fn bitcoin_consensus_encoding::decode_from_slice_unbounded<T>(bytes: &mut &[u8]) -> core::result::Result<T, <<T as bitcoin_consensus_encoding::Decode>::Decoder as bitcoin_consensus_encoding::Decoder>::Error> where T: bitcoin_consensus_encoding::Decode
 pub fn bitcoin_consensus_encoding::drain_to_vec<T>(encoder: &mut T) -> alloc::vec::Vec<u8> where T: bitcoin_consensus_encoding::Encoder + ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::drain_to_writer<T, W>(encoder: &mut T, writer: W) -> core::result::Result<(), std::io::error::Error> where T: bitcoin_consensus_encoding::Encoder + ?core::marker::Sized, W: std::io::Write
-pub fn bitcoin_consensus_encoding::encode_to_vec<T>(object: &T) -> alloc::vec::Vec<u8> where T: bitcoin_consensus_encoding::Encodable + ?core::marker::Sized
-pub fn bitcoin_consensus_encoding::encode_to_writer<T, W>(object: &T, writer: W) -> core::result::Result<(), std::io::error::Error> where T: bitcoin_consensus_encoding::Encodable + ?core::marker::Sized, W: std::io::Write
+pub fn bitcoin_consensus_encoding::encode_to_vec<T>(object: &T) -> alloc::vec::Vec<u8> where T: bitcoin_consensus_encoding::Encode + ?core::marker::Sized
+pub fn bitcoin_consensus_encoding::encode_to_writer<T, W>(object: &T, writer: W) -> core::result::Result<(), std::io::error::Error> where T: bitcoin_consensus_encoding::Encode + ?core::marker::Sized, W: std::io::Write

--- a/consensus_encoding/api/alloc-only.txt
+++ b/consensus_encoding/api/alloc-only.txt
@@ -1579,23 +1579,23 @@ impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::error::Length
 pub unsafe fn bitcoin_consensus_encoding::error::LengthPrefixExceedsMaxError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::error::LengthPrefixExceedsMaxError
 pub fn bitcoin_consensus_encoding::error::LengthPrefixExceedsMaxError::from(t: T) -> T
-pub struct bitcoin_consensus_encoding::SliceEncoder<'e, T: bitcoin_consensus_encoding::Encodable>
-impl<'e, T: bitcoin_consensus_encoding::Encodable> bitcoin_consensus_encoding::SliceEncoder<'e, T>
+pub struct bitcoin_consensus_encoding::SliceEncoder<'e, T: bitcoin_consensus_encoding::Encode>
+impl<'e, T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::SliceEncoder<'e, T>
 pub fn bitcoin_consensus_encoding::SliceEncoder<'e, T>::without_length_prefix(sl: &'e [T]) -> Self
-impl<'e, T: bitcoin_consensus_encoding::Encodable> core::clone::Clone for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::clone::Clone
+impl<'e, T: bitcoin_consensus_encoding::Encode> core::clone::Clone for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::clone::Clone
 pub fn bitcoin_consensus_encoding::SliceEncoder<'e, T>::clone(&self) -> Self
-impl<'e, T: bitcoin_consensus_encoding::Encodable> core::fmt::Debug for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::fmt::Debug
+impl<'e, T: bitcoin_consensus_encoding::Encode> core::fmt::Debug for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::fmt::Debug
 pub fn bitcoin_consensus_encoding::SliceEncoder<'e, T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl<T: bitcoin_consensus_encoding::Encodable> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::SliceEncoder<'_, T>
+impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::SliceEncoder<'_, T>
 pub fn bitcoin_consensus_encoding::SliceEncoder<'_, T>::advance(&mut self) -> bool
 pub fn bitcoin_consensus_encoding::SliceEncoder<'_, T>::current_chunk(&self) -> &[u8]
-impl<'e, T> core::marker::Freeze for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::marker::Freeze
-impl<'e, T> core::marker::Send for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::marker::Send, T: core::marker::Sync
-impl<'e, T> core::marker::Sync for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::marker::Sync, T: core::marker::Sync
-impl<'e, T> core::marker::Unpin for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::marker::Unpin
-impl<'e, T> core::marker::UnsafeUnpin for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::marker::UnsafeUnpin
-impl<'e, T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::panic::unwind_safe::RefUnwindSafe, T: core::panic::unwind_safe::RefUnwindSafe
-impl<'e, T> core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::panic::unwind_safe::UnwindSafe, T: core::panic::unwind_safe::RefUnwindSafe
+impl<'e, T> core::marker::Freeze for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::marker::Freeze
+impl<'e, T> core::marker::Send for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::marker::Send, T: core::marker::Sync
+impl<'e, T> core::marker::Sync for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::marker::Sync, T: core::marker::Sync
+impl<'e, T> core::marker::Unpin for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::marker::Unpin
+impl<'e, T> core::marker::UnsafeUnpin for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::marker::UnsafeUnpin
+impl<'e, T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::panic::unwind_safe::RefUnwindSafe, T: core::panic::unwind_safe::RefUnwindSafe
+impl<'e, T> core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::panic::unwind_safe::UnwindSafe, T: core::panic::unwind_safe::RefUnwindSafe
 impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::SliceEncoder<'e, T> where U: core::convert::From<T>
 pub fn bitcoin_consensus_encoding::SliceEncoder<'e, T>::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::SliceEncoder<'e, T> where U: core::convert::Into<T>
@@ -1706,29 +1706,29 @@ impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::error::Unexpe
 pub unsafe fn bitcoin_consensus_encoding::error::UnexpectedEofError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::error::UnexpectedEofError
 pub fn bitcoin_consensus_encoding::error::UnexpectedEofError::from(t: T) -> T
-pub struct bitcoin_consensus_encoding::VecDecoder<T: bitcoin_consensus_encoding::Decodable>
-impl<T: bitcoin_consensus_encoding::Decodable> bitcoin_consensus_encoding::VecDecoder<T>
+pub struct bitcoin_consensus_encoding::VecDecoder<T: bitcoin_consensus_encoding::Decode>
+impl<T: bitcoin_consensus_encoding::Decode> bitcoin_consensus_encoding::VecDecoder<T>
 pub const fn bitcoin_consensus_encoding::VecDecoder<T>::new() -> Self
 pub const fn bitcoin_consensus_encoding::VecDecoder<T>::new_with_limit(limit: usize) -> Self
-impl<T: bitcoin_consensus_encoding::Decodable> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::VecDecoder<T>
-pub type bitcoin_consensus_encoding::VecDecoder<T>::Error = bitcoin_consensus_encoding::error::VecDecoderError<<<T as bitcoin_consensus_encoding::Decodable>::Decoder as bitcoin_consensus_encoding::Decoder>::Error>
+impl<T: bitcoin_consensus_encoding::Decode> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::VecDecoder<T>
+pub type bitcoin_consensus_encoding::VecDecoder<T>::Error = bitcoin_consensus_encoding::error::VecDecoderError<<<T as bitcoin_consensus_encoding::Decode>::Decoder as bitcoin_consensus_encoding::Decoder>::Error>
 pub type bitcoin_consensus_encoding::VecDecoder<T>::Output = alloc::vec::Vec<T>
 pub fn bitcoin_consensus_encoding::VecDecoder<T>::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_consensus_encoding::VecDecoder<T>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bool, Self::Error>
 pub fn bitcoin_consensus_encoding::VecDecoder<T>::read_limit(&self) -> usize
-impl<T: bitcoin_consensus_encoding::Decodable> core::default::Default for bitcoin_consensus_encoding::VecDecoder<T>
+impl<T: bitcoin_consensus_encoding::Decode> core::default::Default for bitcoin_consensus_encoding::VecDecoder<T>
 pub fn bitcoin_consensus_encoding::VecDecoder<T>::default() -> Self
-impl<T: bitcoin_consensus_encoding::Decodable> core::fmt::Debug for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decodable>::Decoder: core::fmt::Debug
+impl<T: bitcoin_consensus_encoding::Decode> core::fmt::Debug for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decode>::Decoder: core::fmt::Debug
 pub fn bitcoin_consensus_encoding::VecDecoder<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl<T> core::clone::Clone for bitcoin_consensus_encoding::VecDecoder<T> where T: core::clone::Clone + bitcoin_consensus_encoding::Decodable, <T as bitcoin_consensus_encoding::Decodable>::Decoder: core::clone::Clone
+impl<T> core::clone::Clone for bitcoin_consensus_encoding::VecDecoder<T> where T: core::clone::Clone + bitcoin_consensus_encoding::Decode, <T as bitcoin_consensus_encoding::Decode>::Decoder: core::clone::Clone
 pub fn bitcoin_consensus_encoding::VecDecoder<T>::clone(&self) -> Self
-impl<T> core::marker::Freeze for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decodable>::Decoder: core::marker::Freeze
-impl<T> core::marker::Send for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decodable>::Decoder: core::marker::Send, T: core::marker::Send
-impl<T> core::marker::Sync for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decodable>::Decoder: core::marker::Sync, T: core::marker::Sync
-impl<T> core::marker::Unpin for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decodable>::Decoder: core::marker::Unpin, T: core::marker::Unpin
-impl<T> core::marker::UnsafeUnpin for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decodable>::Decoder: core::marker::UnsafeUnpin
-impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decodable>::Decoder: core::panic::unwind_safe::RefUnwindSafe, T: core::panic::unwind_safe::RefUnwindSafe
-impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decodable>::Decoder: core::panic::unwind_safe::UnwindSafe, T: core::panic::unwind_safe::UnwindSafe
+impl<T> core::marker::Freeze for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decode>::Decoder: core::marker::Freeze
+impl<T> core::marker::Send for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decode>::Decoder: core::marker::Send, T: core::marker::Send
+impl<T> core::marker::Sync for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decode>::Decoder: core::marker::Sync, T: core::marker::Sync
+impl<T> core::marker::Unpin for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decode>::Decoder: core::marker::Unpin, T: core::marker::Unpin
+impl<T> core::marker::UnsafeUnpin for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decode>::Decoder: core::marker::UnsafeUnpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decode>::Decoder: core::panic::unwind_safe::RefUnwindSafe, T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decode>::Decoder: core::panic::unwind_safe::UnwindSafe, T: core::panic::unwind_safe::UnwindSafe
 impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::VecDecoder<T> where U: core::convert::From<T>
 pub fn bitcoin_consensus_encoding::VecDecoder<T>::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::VecDecoder<T> where U: core::convert::Into<T>
@@ -1795,9 +1795,9 @@ impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::error::VecDec
 pub unsafe fn bitcoin_consensus_encoding::error::VecDecoderError<Err>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::error::VecDecoderError<Err>
 pub fn bitcoin_consensus_encoding::error::VecDecoderError<Err>::from(t: T) -> T
-pub trait bitcoin_consensus_encoding::Decodable
-pub type bitcoin_consensus_encoding::Decodable::Decoder: bitcoin_consensus_encoding::Decoder<Output = Self>
-pub fn bitcoin_consensus_encoding::Decodable::decoder() -> Self::Decoder
+pub trait bitcoin_consensus_encoding::Decode
+pub type bitcoin_consensus_encoding::Decode::Decoder: bitcoin_consensus_encoding::Decoder<Output = Self>
+pub fn bitcoin_consensus_encoding::Decode::decoder() -> Self::Decoder
 pub trait bitcoin_consensus_encoding::Decoder: core::marker::Sized
 pub type bitcoin_consensus_encoding::Decoder::Error
 pub type bitcoin_consensus_encoding::Decoder::Output
@@ -1846,8 +1846,8 @@ pub type bitcoin_consensus_encoding::Decoder2<A, B>::Output = (<A as bitcoin_con
 pub fn bitcoin_consensus_encoding::Decoder2<A, B>::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_consensus_encoding::Decoder2<A, B>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bool, Self::Error>
 pub fn bitcoin_consensus_encoding::Decoder2<A, B>::read_limit(&self) -> usize
-impl<T: bitcoin_consensus_encoding::Decodable> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::VecDecoder<T>
-pub type bitcoin_consensus_encoding::VecDecoder<T>::Error = bitcoin_consensus_encoding::error::VecDecoderError<<<T as bitcoin_consensus_encoding::Decodable>::Decoder as bitcoin_consensus_encoding::Decoder>::Error>
+impl<T: bitcoin_consensus_encoding::Decode> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::VecDecoder<T>
+pub type bitcoin_consensus_encoding::VecDecoder<T>::Error = bitcoin_consensus_encoding::error::VecDecoderError<<<T as bitcoin_consensus_encoding::Decode>::Decoder as bitcoin_consensus_encoding::Decoder>::Error>
 pub type bitcoin_consensus_encoding::VecDecoder<T>::Output = alloc::vec::Vec<T>
 pub fn bitcoin_consensus_encoding::VecDecoder<T>::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_consensus_encoding::VecDecoder<T>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bool, Self::Error>
@@ -1858,9 +1858,9 @@ pub type bitcoin_consensus_encoding::ArrayDecoder<N>::Output = [u8; N]
 pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bool, Self::Error>
 pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::read_limit(&self) -> usize
-pub trait bitcoin_consensus_encoding::Encodable
-pub type bitcoin_consensus_encoding::Encodable::Encoder<'e> where Self: 'e: bitcoin_consensus_encoding::Encoder
-pub fn bitcoin_consensus_encoding::Encodable::encoder(&self) -> Self::Encoder
+pub trait bitcoin_consensus_encoding::Encode
+pub type bitcoin_consensus_encoding::Encode::Encoder<'e> where Self: 'e: bitcoin_consensus_encoding::Encoder
+pub fn bitcoin_consensus_encoding::Encode::encoder(&self) -> Self::Encoder
 pub trait bitcoin_consensus_encoding::Encoder
 pub fn bitcoin_consensus_encoding::Encoder::advance(&mut self) -> bool
 pub fn bitcoin_consensus_encoding::Encoder::current_chunk(&self) -> &[u8]
@@ -1882,7 +1882,7 @@ pub fn bitcoin_consensus_encoding::Encoder3<A, B, C>::current_chunk(&self) -> &[
 impl<A: bitcoin_consensus_encoding::Encoder, B: bitcoin_consensus_encoding::Encoder> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::Encoder2<A, B>
 pub fn bitcoin_consensus_encoding::Encoder2<A, B>::advance(&mut self) -> bool
 pub fn bitcoin_consensus_encoding::Encoder2<A, B>::current_chunk(&self) -> &[u8]
-impl<T: bitcoin_consensus_encoding::Encodable> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::SliceEncoder<'_, T>
+impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::SliceEncoder<'_, T>
 pub fn bitcoin_consensus_encoding::SliceEncoder<'_, T>::advance(&mut self) -> bool
 pub fn bitcoin_consensus_encoding::SliceEncoder<'_, T>::current_chunk(&self) -> &[u8]
 impl<T: bitcoin_consensus_encoding::Encoder> bitcoin_consensus_encoding::Encoder for core::option::Option<T>
@@ -1913,7 +1913,7 @@ impl<const N: usize> bitcoin_consensus_encoding::ExactSizeEncoder for bitcoin_co
 pub fn bitcoin_consensus_encoding::ArrayEncoder<N>::len(&self) -> usize
 impl<const N: usize> bitcoin_consensus_encoding::ExactSizeEncoder for bitcoin_consensus_encoding::ArrayRefEncoder<'_, N>
 pub fn bitcoin_consensus_encoding::ArrayRefEncoder<'_, N>::len(&self) -> usize
-pub fn bitcoin_consensus_encoding::decode_from_slice<T: bitcoin_consensus_encoding::Decodable>(bytes: &[u8]) -> core::result::Result<T, bitcoin_consensus_encoding::error::DecodeError<<<T as bitcoin_consensus_encoding::Decodable>::Decoder as bitcoin_consensus_encoding::Decoder>::Error>>
-pub fn bitcoin_consensus_encoding::decode_from_slice_unbounded<T>(bytes: &mut &[u8]) -> core::result::Result<T, <<T as bitcoin_consensus_encoding::Decodable>::Decoder as bitcoin_consensus_encoding::Decoder>::Error> where T: bitcoin_consensus_encoding::Decodable
+pub fn bitcoin_consensus_encoding::decode_from_slice<T: bitcoin_consensus_encoding::Decode>(bytes: &[u8]) -> core::result::Result<T, bitcoin_consensus_encoding::error::DecodeError<<<T as bitcoin_consensus_encoding::Decode>::Decoder as bitcoin_consensus_encoding::Decoder>::Error>>
+pub fn bitcoin_consensus_encoding::decode_from_slice_unbounded<T>(bytes: &mut &[u8]) -> core::result::Result<T, <<T as bitcoin_consensus_encoding::Decode>::Decoder as bitcoin_consensus_encoding::Decoder>::Error> where T: bitcoin_consensus_encoding::Decode
 pub fn bitcoin_consensus_encoding::drain_to_vec<T>(encoder: &mut T) -> alloc::vec::Vec<u8> where T: bitcoin_consensus_encoding::Encoder + ?core::marker::Sized
-pub fn bitcoin_consensus_encoding::encode_to_vec<T>(object: &T) -> alloc::vec::Vec<u8> where T: bitcoin_consensus_encoding::Encodable + ?core::marker::Sized
+pub fn bitcoin_consensus_encoding::encode_to_vec<T>(object: &T) -> alloc::vec::Vec<u8> where T: bitcoin_consensus_encoding::Encode + ?core::marker::Sized

--- a/consensus_encoding/api/no-features.txt
+++ b/consensus_encoding/api/no-features.txt
@@ -1204,23 +1204,23 @@ impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::EncoderByteIt
 pub unsafe fn bitcoin_consensus_encoding::EncoderByteIter<T>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::EncoderByteIter<T>
 pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::from(t: T) -> T
-pub struct bitcoin_consensus_encoding::SliceEncoder<'e, T: bitcoin_consensus_encoding::Encodable>
-impl<'e, T: bitcoin_consensus_encoding::Encodable> bitcoin_consensus_encoding::SliceEncoder<'e, T>
+pub struct bitcoin_consensus_encoding::SliceEncoder<'e, T: bitcoin_consensus_encoding::Encode>
+impl<'e, T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::SliceEncoder<'e, T>
 pub fn bitcoin_consensus_encoding::SliceEncoder<'e, T>::without_length_prefix(sl: &'e [T]) -> Self
-impl<'e, T: bitcoin_consensus_encoding::Encodable> core::clone::Clone for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::clone::Clone
+impl<'e, T: bitcoin_consensus_encoding::Encode> core::clone::Clone for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::clone::Clone
 pub fn bitcoin_consensus_encoding::SliceEncoder<'e, T>::clone(&self) -> Self
-impl<'e, T: bitcoin_consensus_encoding::Encodable> core::fmt::Debug for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::fmt::Debug
+impl<'e, T: bitcoin_consensus_encoding::Encode> core::fmt::Debug for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::fmt::Debug
 pub fn bitcoin_consensus_encoding::SliceEncoder<'e, T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl<T: bitcoin_consensus_encoding::Encodable> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::SliceEncoder<'_, T>
+impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::SliceEncoder<'_, T>
 pub fn bitcoin_consensus_encoding::SliceEncoder<'_, T>::advance(&mut self) -> bool
 pub fn bitcoin_consensus_encoding::SliceEncoder<'_, T>::current_chunk(&self) -> &[u8]
-impl<'e, T> core::marker::Freeze for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::marker::Freeze
-impl<'e, T> core::marker::Send for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::marker::Send, T: core::marker::Sync
-impl<'e, T> core::marker::Sync for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::marker::Sync, T: core::marker::Sync
-impl<'e, T> core::marker::Unpin for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::marker::Unpin
-impl<'e, T> core::marker::UnsafeUnpin for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::marker::UnsafeUnpin
-impl<'e, T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::panic::unwind_safe::RefUnwindSafe, T: core::panic::unwind_safe::RefUnwindSafe
-impl<'e, T> core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::panic::unwind_safe::UnwindSafe, T: core::panic::unwind_safe::RefUnwindSafe
+impl<'e, T> core::marker::Freeze for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::marker::Freeze
+impl<'e, T> core::marker::Send for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::marker::Send, T: core::marker::Sync
+impl<'e, T> core::marker::Sync for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::marker::Sync, T: core::marker::Sync
+impl<'e, T> core::marker::Unpin for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::marker::Unpin
+impl<'e, T> core::marker::UnsafeUnpin for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::marker::UnsafeUnpin
+impl<'e, T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::panic::unwind_safe::RefUnwindSafe, T: core::panic::unwind_safe::RefUnwindSafe
+impl<'e, T> core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::panic::unwind_safe::UnwindSafe, T: core::panic::unwind_safe::RefUnwindSafe
 impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::SliceEncoder<'e, T> where U: core::convert::From<T>
 pub fn bitcoin_consensus_encoding::SliceEncoder<'e, T>::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::SliceEncoder<'e, T> where U: core::convert::Into<T>
@@ -1315,9 +1315,9 @@ impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::error::Unexpe
 pub unsafe fn bitcoin_consensus_encoding::error::UnexpectedEofError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::error::UnexpectedEofError
 pub fn bitcoin_consensus_encoding::error::UnexpectedEofError::from(t: T) -> T
-pub trait bitcoin_consensus_encoding::Decodable
-pub type bitcoin_consensus_encoding::Decodable::Decoder: bitcoin_consensus_encoding::Decoder<Output = Self>
-pub fn bitcoin_consensus_encoding::Decodable::decoder() -> Self::Decoder
+pub trait bitcoin_consensus_encoding::Decode
+pub type bitcoin_consensus_encoding::Decode::Decoder: bitcoin_consensus_encoding::Decoder<Output = Self>
+pub fn bitcoin_consensus_encoding::Decode::decoder() -> Self::Decoder
 pub trait bitcoin_consensus_encoding::Decoder: core::marker::Sized
 pub type bitcoin_consensus_encoding::Decoder::Error
 pub type bitcoin_consensus_encoding::Decoder::Output
@@ -1366,9 +1366,9 @@ pub type bitcoin_consensus_encoding::ArrayDecoder<N>::Output = [u8; N]
 pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bool, Self::Error>
 pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::read_limit(&self) -> usize
-pub trait bitcoin_consensus_encoding::Encodable
-pub type bitcoin_consensus_encoding::Encodable::Encoder<'e> where Self: 'e: bitcoin_consensus_encoding::Encoder
-pub fn bitcoin_consensus_encoding::Encodable::encoder(&self) -> Self::Encoder
+pub trait bitcoin_consensus_encoding::Encode
+pub type bitcoin_consensus_encoding::Encode::Encoder<'e> where Self: 'e: bitcoin_consensus_encoding::Encoder
+pub fn bitcoin_consensus_encoding::Encode::encoder(&self) -> Self::Encoder
 pub trait bitcoin_consensus_encoding::Encoder
 pub fn bitcoin_consensus_encoding::Encoder::advance(&mut self) -> bool
 pub fn bitcoin_consensus_encoding::Encoder::current_chunk(&self) -> &[u8]
@@ -1390,7 +1390,7 @@ pub fn bitcoin_consensus_encoding::Encoder3<A, B, C>::current_chunk(&self) -> &[
 impl<A: bitcoin_consensus_encoding::Encoder, B: bitcoin_consensus_encoding::Encoder> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::Encoder2<A, B>
 pub fn bitcoin_consensus_encoding::Encoder2<A, B>::advance(&mut self) -> bool
 pub fn bitcoin_consensus_encoding::Encoder2<A, B>::current_chunk(&self) -> &[u8]
-impl<T: bitcoin_consensus_encoding::Encodable> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::SliceEncoder<'_, T>
+impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::SliceEncoder<'_, T>
 pub fn bitcoin_consensus_encoding::SliceEncoder<'_, T>::advance(&mut self) -> bool
 pub fn bitcoin_consensus_encoding::SliceEncoder<'_, T>::current_chunk(&self) -> &[u8]
 impl<T: bitcoin_consensus_encoding::Encoder> bitcoin_consensus_encoding::Encoder for core::option::Option<T>
@@ -1421,5 +1421,5 @@ impl<const N: usize> bitcoin_consensus_encoding::ExactSizeEncoder for bitcoin_co
 pub fn bitcoin_consensus_encoding::ArrayEncoder<N>::len(&self) -> usize
 impl<const N: usize> bitcoin_consensus_encoding::ExactSizeEncoder for bitcoin_consensus_encoding::ArrayRefEncoder<'_, N>
 pub fn bitcoin_consensus_encoding::ArrayRefEncoder<'_, N>::len(&self) -> usize
-pub fn bitcoin_consensus_encoding::decode_from_slice<T: bitcoin_consensus_encoding::Decodable>(bytes: &[u8]) -> core::result::Result<T, bitcoin_consensus_encoding::error::DecodeError<<<T as bitcoin_consensus_encoding::Decodable>::Decoder as bitcoin_consensus_encoding::Decoder>::Error>>
-pub fn bitcoin_consensus_encoding::decode_from_slice_unbounded<T>(bytes: &mut &[u8]) -> core::result::Result<T, <<T as bitcoin_consensus_encoding::Decodable>::Decoder as bitcoin_consensus_encoding::Decoder>::Error> where T: bitcoin_consensus_encoding::Decodable
+pub fn bitcoin_consensus_encoding::decode_from_slice<T: bitcoin_consensus_encoding::Decode>(bytes: &[u8]) -> core::result::Result<T, bitcoin_consensus_encoding::error::DecodeError<<<T as bitcoin_consensus_encoding::Decode>::Decoder as bitcoin_consensus_encoding::Decoder>::Error>>
+pub fn bitcoin_consensus_encoding::decode_from_slice_unbounded<T>(bytes: &mut &[u8]) -> core::result::Result<T, <<T as bitcoin_consensus_encoding::Decode>::Decoder as bitcoin_consensus_encoding::Decoder>::Error> where T: bitcoin_consensus_encoding::Decode

--- a/consensus_encoding/examples/encoder.rs
+++ b/consensus_encoding/examples/encoder.rs
@@ -3,7 +3,7 @@
 //! Example of creating an encoder that encodes a slice of encodable objects.
 
 use bitcoin_consensus_encoding as encoding;
-use encoding::{ArrayEncoder, BytesEncoder, CompactSizeEncoder, Encodable, Encoder2, SliceEncoder};
+use encoding::{ArrayEncoder, BytesEncoder, CompactSizeEncoder, Encode, Encoder2, SliceEncoder};
 
 fn main() {
     let v = vec![Inner::new(0xcafe_babe), Inner::new(0xdead_beef)];
@@ -32,7 +32,7 @@ encoding::encoder_newtype! {
     pub struct AdtEncoder<'e>(Encoder2<Encoder2<CompactSizeEncoder, SliceEncoder<'e, Inner>>, BytesEncoder<'e>>);
 }
 
-impl Encodable for Adt {
+impl Encode for Adt {
     type Encoder<'e>
         = AdtEncoder<'e>
     where
@@ -66,7 +66,7 @@ encoding::encoder_newtype_exact! {
     pub struct InnerEncoder<'e>(ArrayEncoder<4>);
 }
 
-impl Encodable for Inner {
+impl Encode for Inner {
     type Encoder<'e> = InnerEncoder<'e>;
     fn encoder(&self) -> Self::Encoder<'_> {
         InnerEncoder::new(ArrayEncoder::without_length_prefix(self.to_array()))

--- a/consensus_encoding/src/decode/decoders.rs
+++ b/consensus_encoding/src/decode/decoders.rs
@@ -7,7 +7,7 @@ use alloc::vec::Vec;
 use core::{fmt, mem};
 
 #[cfg(feature = "alloc")]
-use super::Decodable;
+use super::Decode;
 use super::Decoder;
 #[cfg(feature = "alloc")]
 use crate::compact_size::CompactSizeDecoder;
@@ -147,15 +147,15 @@ impl Decoder for ByteVecDecoder {
 ///
 /// The decoding is expected to start with expected number of items in the vector.
 #[cfg(feature = "alloc")]
-pub struct VecDecoder<T: Decodable> {
+pub struct VecDecoder<T: Decode> {
     prefix_decoder: Option<CompactSizeDecoder>,
     length: usize,
     buffer: Vec<T>,
-    decoder: Option<<T as Decodable>::Decoder>,
+    decoder: Option<<T as Decode>::Decoder>,
 }
 
 #[cfg(feature = "alloc")]
-impl<T: Decodable> fmt::Debug for VecDecoder<T>
+impl<T: Decode> fmt::Debug for VecDecoder<T>
 where
     T::Decoder: fmt::Debug,
 {
@@ -171,7 +171,7 @@ where
 }
 
 #[cfg(feature = "alloc")]
-impl<T: Decodable> Clone for VecDecoder<T>
+impl<T: Decode> Clone for VecDecoder<T>
 where
     T: Clone,
     T::Decoder: Clone,
@@ -187,7 +187,7 @@ where
 }
 
 #[cfg(feature = "alloc")]
-impl<T: Decodable> VecDecoder<T> {
+impl<T: Decode> VecDecoder<T> {
     /// Constructs a new typed vector decoder with the default limit of 4,000,000 elements.
     pub const fn new() -> Self { Self::new_with_limit(MAX_VEC_SIZE) }
 
@@ -225,14 +225,14 @@ impl<T: Decodable> VecDecoder<T> {
 }
 
 #[cfg(feature = "alloc")]
-impl<T: Decodable> Default for VecDecoder<T> {
+impl<T: Decode> Default for VecDecoder<T> {
     fn default() -> Self { Self::new() }
 }
 
 #[cfg(feature = "alloc")]
-impl<T: Decodable> Decoder for VecDecoder<T> {
+impl<T: Decode> Decoder for VecDecoder<T> {
     type Output = Vec<T>;
-    type Error = VecDecoderError<<<T as Decodable>::Decoder as Decoder>::Error>;
+    type Error = VecDecoderError<<<T as Decode>::Decoder as Decoder>::Error>;
 
     fn push_bytes(&mut self, bytes: &mut &[u8]) -> Result<bool, Self::Error> {
         use VecDecoderError as E;
@@ -914,7 +914,7 @@ mod tests {
     }
 
     #[cfg(feature = "alloc")]
-    impl Decodable for Inner {
+    impl Decode for Inner {
         type Decoder = InnerDecoder;
         fn decoder() -> Self::Decoder { InnerDecoder(ArrayDecoder::<4>::new()) }
     }
@@ -946,7 +946,7 @@ mod tests {
     }
 
     #[cfg(feature = "alloc")]
-    impl Decodable for Test {
+    impl Decode for Test {
         type Decoder = TestDecoder;
         fn decoder() -> Self::Decoder { TestDecoder(VecDecoder::new()) }
     }

--- a/consensus_encoding/src/decode/mod.rs
+++ b/consensus_encoding/src/decode/mod.rs
@@ -16,7 +16,7 @@ use crate::{DecodeError, UnconsumedError};
 /// # Examples
 ///
 /// ```
-/// use bitcoin_consensus_encoding::{decode_from_slice, Decodable, Decoder, ArrayDecoder, UnexpectedEofError};
+/// use bitcoin_consensus_encoding::{decode_from_slice, Decode, Decoder, ArrayDecoder, UnexpectedEofError};
 ///
 /// struct Foo([u8; 4]);
 ///
@@ -33,7 +33,7 @@ use crate::{DecodeError, UnconsumedError};
 ///     fn read_limit(&self) -> usize { self.0.read_limit() }
 /// }
 ///
-/// impl Decodable for Foo {
+/// impl Decode for Foo {
 ///     type Decoder = FooDecoder;
 ///     fn decoder() -> Self::Decoder { FooDecoder(ArrayDecoder::new()) }
 /// }
@@ -41,7 +41,7 @@ use crate::{DecodeError, UnconsumedError};
 /// let foo: Foo = decode_from_slice(&[0xde, 0xad, 0xbe, 0xef]).unwrap();
 /// assert_eq!(foo.0, [0xde, 0xad, 0xbe, 0xef]);
 /// ```
-pub trait Decodable {
+pub trait Decode {
     /// Associated decoder for the type.
     type Decoder: Decoder<Output = Self>;
 
@@ -107,7 +107,7 @@ pub trait Decoder: Sized {
 /// Returns an error if the decoder encounters an error while parsing the data, including
 /// insufficient data. This function also errors if the provided slice is not completely consumed
 /// during decode.
-pub fn decode_from_slice<T: Decodable>(
+pub fn decode_from_slice<T: Decode>(
     bytes: &[u8],
 ) -> Result<T, DecodeError<<T::Decoder as Decoder>::Error>> {
     let mut remaining = bytes;
@@ -134,7 +134,7 @@ pub fn decode_from_slice_unbounded<T>(
     bytes: &mut &[u8],
 ) -> Result<T, <T::Decoder as Decoder>::Error>
 where
-    T: Decodable,
+    T: Decode,
 {
     let mut decoder = T::decoder();
 
@@ -162,7 +162,7 @@ where
 #[cfg(feature = "std")]
 pub fn decode_from_read<T, R>(mut reader: R) -> Result<T, ReadError<<T::Decoder as Decoder>::Error>>
 where
-    T: Decodable,
+    T: Decode,
     R: std::io::BufRead,
 {
     let mut decoder = T::decoder();
@@ -213,7 +213,7 @@ pub fn decode_from_read_unbuffered<T, R>(
     reader: R,
 ) -> Result<T, ReadError<<T::Decoder as Decoder>::Error>>
 where
-    T: Decodable,
+    T: Decode,
     R: std::io::Read,
 {
     decode_from_read_unbuffered_with::<T, R, 4096>(reader)
@@ -240,7 +240,7 @@ pub fn decode_from_read_unbuffered_with<T, R, const BUFFER_SIZE: usize>(
     mut reader: R,
 ) -> Result<T, ReadError<<T::Decoder as Decoder>::Error>>
 where
-    T: Decodable,
+    T: Decode,
     R: std::io::Read,
 {
     let mut decoder = T::decoder();

--- a/consensus_encoding/src/encode/encoders.rs
+++ b/consensus_encoding/src/encode/encoders.rs
@@ -2,7 +2,7 @@
 
 //! Collection of "standard encoders".
 //!
-//! These encoders should not be used directly. Instead, when implementing the [`super::Encodable`]
+//! These encoders should not be used directly. Instead, when implementing the [`super::Encode`]
 //! trait on a type, you should define a newtype around one or more of these encoders, and pass
 //! through the [`Encoder`] implementation to your newtype. This avoids leaking encoding
 //! implementation details to the users of your type.
@@ -12,7 +12,7 @@
 
 use core::fmt;
 
-use super::{Encodable, Encoder, ExactSizeEncoder};
+use super::{Encode, Encoder, ExactSizeEncoder};
 
 /// An encoder for a single byte slice.
 #[derive(Debug, Clone)]
@@ -88,14 +88,14 @@ impl<const N: usize> ExactSizeEncoder for ArrayRefEncoder<'_, N> {
 }
 
 /// An encoder for a list of encodable types.
-pub struct SliceEncoder<'e, T: Encodable> {
+pub struct SliceEncoder<'e, T: Encode> {
     /// The list of references to the objects we are encoding.
     sl: &'e [T],
     /// Encoder for the current object being encoded.
     cur_enc: Option<T::Encoder<'e>>,
 }
 
-impl<'e, T: Encodable> SliceEncoder<'e, T> {
+impl<'e, T: Encode> SliceEncoder<'e, T> {
     /// Constructs an encoder which encodes the slice _without_ adding the length prefix.
     ///
     /// To encode with a length prefix consider using [`Encoder2`].
@@ -109,7 +109,7 @@ impl<'e, T: Encodable> SliceEncoder<'e, T> {
     }
 }
 
-impl<'e, T: Encodable> fmt::Debug for SliceEncoder<'e, T>
+impl<'e, T: Encode> fmt::Debug for SliceEncoder<'e, T>
 where
     T::Encoder<'e>: fmt::Debug,
 {
@@ -123,14 +123,14 @@ where
 
 // Manual impl rather than #[derive(Clone)] because derive would constrain `where T: Clone`,
 // but `T` itself is never cloned, only the associated type `T::Encoder<'e>`.
-impl<'e, T: Encodable> Clone for SliceEncoder<'e, T>
+impl<'e, T: Encode> Clone for SliceEncoder<'e, T>
 where
     T::Encoder<'e>: Clone,
 {
     fn clone(&self) -> Self { Self { sl: self.sl, cur_enc: self.cur_enc.clone() } }
 }
 
-impl<T: Encodable> Encoder for SliceEncoder<'_, T> {
+impl<T: Encode> Encoder for SliceEncoder<'_, T> {
     fn current_chunk(&self) -> &[u8] {
         // `advance` sets `cur_enc` to `None` once the slice encoder is completely exhausted.
         self.cur_enc.as_ref().map(T::Encoder::current_chunk).unwrap_or_default()

--- a/consensus_encoding/src/encode/mod.rs
+++ b/consensus_encoding/src/encode/mod.rs
@@ -16,7 +16,7 @@ pub mod encoders;
 ///
 /// ```
 /// # #[cfg(feature = "alloc")] {
-/// use bitcoin_consensus_encoding::{encoder_newtype, encode_to_vec, Encodable, ArrayEncoder};
+/// use bitcoin_consensus_encoding::{encoder_newtype, encode_to_vec, Encode, ArrayEncoder};
 ///
 /// struct Foo([u8; 4]);
 ///
@@ -24,7 +24,7 @@ pub mod encoders;
 ///     pub struct FooEncoder<'e>(ArrayEncoder<4>);
 /// }
 ///
-/// impl Encodable for Foo {
+/// impl Encode for Foo {
 ///     type Encoder<'e> = FooEncoder<'e> where Self: 'e;
 ///
 ///     fn encoder(&self) -> Self::Encoder<'_> {
@@ -36,7 +36,7 @@ pub mod encoders;
 /// assert_eq!(encode_to_vec(&foo), vec![0xde, 0xad, 0xbe, 0xef]);
 /// # }
 /// ```
-pub trait Encodable {
+pub trait Encode {
     /// The encoder associated with this type. Conceptually, the encoder is like
     /// an iterator which yields byte slices.
     type Encoder<'e>: Encoder
@@ -282,7 +282,7 @@ pub trait ExactSizeEncoder: Encoder {
 #[cfg(feature = "alloc")]
 pub fn encode_to_vec<T>(object: &T) -> Vec<u8>
 where
-    T: Encodable + ?Sized,
+    T: Encode + ?Sized,
 {
     let mut encoder = object.encoder();
     drain_to_vec(&mut encoder)
@@ -318,7 +318,7 @@ where
 #[cfg(feature = "std")]
 pub fn encode_to_writer<T, W>(object: &T, writer: W) -> Result<(), std::io::Error>
 where
-    T: Encodable + ?Sized,
+    T: Encode + ?Sized,
     W: std::io::Write,
 {
     let mut encoder = object.encoder();

--- a/consensus_encoding/src/lib.rs
+++ b/consensus_encoding/src/lib.rs
@@ -17,13 +17,13 @@
 //!
 //! # Encoding
 //!
-//! Types implement [`Encodable`] to produce an [`Encoder`], which yields encoded bytes in chunks
+//! Types implement [`Encode`] to produce an [`Encoder`], which yields encoded bytes in chunks
 //! via [`Encoder::current_chunk`] and [`Encoder::advance`]. The caller drives the process by
 //! pulling chunks until `advance` returns `false`.
 //!
 //! # Decoding
 //!
-//! Types implement [`Decodable`] to produce a [`Decoder`], which consumes bytes via
+//! Types implement [`Decode`] to produce a [`Decoder`], which consumes bytes via
 //! [`Decoder::push_bytes`] until it signals completion by returning `Ok(false)`. The caller then
 //! calls [`Decoder::end`] to obtain the decoded value.
 //!
@@ -83,7 +83,7 @@ pub use self::decode::{
     decode_from_read, decode_from_read_unbuffered, decode_from_read_unbuffered_with,
 };
 #[doc(inline)]
-pub use self::decode::{decode_from_slice, decode_from_slice_unbounded, Decodable, Decoder};
+pub use self::decode::{decode_from_slice, decode_from_slice_unbounded, Decode, Decoder};
 #[doc(inline)]
 pub use self::encode::encoders::{
     ArrayEncoder, ArrayRefEncoder, BytesEncoder, Encoder2, Encoder3, Encoder4, Encoder6,
@@ -96,7 +96,7 @@ pub use self::encode::{encode_to_vec, drain_to_vec};
 #[doc(inline)]
 pub use self::encode::{encode_to_writer, drain_to_writer};
 #[doc(inline)]
-pub use self::encode::{Encodable, Encoder, EncoderByteIter, ExactSizeEncoder};
+pub use self::encode::{Encode, Encoder, EncoderByteIter, ExactSizeEncoder};
 #[cfg(feature = "alloc")]
 #[doc(no_inline)]
 pub use self::error::LengthPrefixExceedsMaxError;

--- a/consensus_encoding/tests/api.rs
+++ b/consensus_encoding/tests/api.rs
@@ -14,7 +14,7 @@ use core::fmt;
 use bitcoin_consensus_encoding::{
     self as encoding, encoder_newtype, ArrayDecoder, ArrayEncoder, ArrayRefEncoder, BytesEncoder,
     CompactSizeDecoder, CompactSizeDecoderError, CompactSizeEncoder, CompactSizeU64Decoder,
-    Decodable, Decoder, Decoder2, Decoder3, Decoder4, Decoder6, Encodable, EncoderByteIter,
+    Decode, Decoder, Decoder2, Decoder3, Decoder4, Decoder6, Encode, EncoderByteIter,
     SliceEncoder, UnexpectedEofError,
 };
 use encoding::error::{DecodeError, UnconsumedError};
@@ -65,7 +65,7 @@ encoder_newtype! {
     pub struct FooEncoder<'e>(ArrayEncoder<4>);
 }
 
-impl Encodable for Foo {
+impl Encode for Foo {
     type Encoder<'e>
         = FooEncoder<'e>
     where
@@ -89,7 +89,7 @@ impl Decoder for FooDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl Decodable for Foo {
+impl Decode for Foo {
     type Decoder = FooDecoder;
     fn decoder() -> Self::Decoder { FooDecoder(ArrayDecoder::new()) }
 }
@@ -235,7 +235,7 @@ fn dyn_compatible() {
         b: Box<dyn encoding::ExactSizeEncoder>,
     }
     // The following traits are not dyn compatible:
-    // - `Encodable`: has a GAT (`type Encoder<'e>`)
-    // - `Decodable`: has an associated type (`type Decoder`)
+    // - `Encode`: has a GAT (`type Encoder<'e>`)
+    // - `Decode`: has an associated type (`type Decoder`)
     // - `Decoder`: has a `Sized` bound
 }

--- a/consensus_encoding/tests/compact_size.rs
+++ b/consensus_encoding/tests/compact_size.rs
@@ -5,7 +5,7 @@
 #[cfg(feature = "alloc")]
 use bitcoin_consensus_encoding::{
     decode_from_slice, encode_to_vec, CompactSizeDecoderError, CompactSizeEncoder,
-    CompactSizeU64Decoder, Decodable, Encodable,
+    CompactSizeU64Decoder, Decode, Encode,
 };
 use bitcoin_consensus_encoding::{CompactSizeDecoder, Decoder};
 
@@ -14,7 +14,7 @@ use bitcoin_consensus_encoding::{CompactSizeDecoder, Decoder};
 struct CompactSizeUsize(usize);
 
 #[cfg(feature = "alloc")]
-impl Encodable for CompactSizeUsize {
+impl Encode for CompactSizeUsize {
     type Encoder<'e>
         = CompactSizeEncoder
     where
@@ -41,7 +41,7 @@ impl Decoder for CompactSizeUsizeDecoderWrapper {
 }
 
 #[cfg(feature = "alloc")]
-impl Decodable for CompactSizeUsize {
+impl Decode for CompactSizeUsize {
     type Decoder = CompactSizeUsizeDecoderWrapper;
     fn decoder() -> Self::Decoder { CompactSizeUsizeDecoderWrapper(CompactSizeDecoder::new()) }
 }
@@ -51,7 +51,7 @@ impl Decodable for CompactSizeUsize {
 struct CompactSizeU64(u64);
 
 #[cfg(feature = "alloc")]
-impl Encodable for CompactSizeU64 {
+impl Encode for CompactSizeU64 {
     type Encoder<'e>
         = CompactSizeEncoder
     where
@@ -78,7 +78,7 @@ impl Decoder for CompactSizeU64DecoderWrapper {
 }
 
 #[cfg(feature = "alloc")]
-impl Decodable for CompactSizeU64 {
+impl Decode for CompactSizeU64 {
     type Decoder = CompactSizeU64DecoderWrapper;
     fn decoder() -> Self::Decoder { CompactSizeU64DecoderWrapper(CompactSizeU64Decoder::new()) }
 }

--- a/consensus_encoding/tests/composition.rs
+++ b/consensus_encoding/tests/composition.rs
@@ -3,8 +3,8 @@
 //! Test composition of encoders and decoders.
 
 use bitcoin_consensus_encoding::{
-    ArrayDecoder, ArrayEncoder, BytesEncoder, Decodable, Decoder, Decoder2, Decoder2Error,
-    Decoder6, Encodable, Encoder, Encoder2, Encoder3, Encoder6, UnexpectedEofError,
+    ArrayDecoder, ArrayEncoder, BytesEncoder, Decode, Decoder, Decoder2, Decoder2Error, Decoder6,
+    Encode, Encoder, Encoder2, Encoder3, Encoder6, UnexpectedEofError,
 };
 
 const EMPTY: &[u8] = &[];
@@ -16,7 +16,7 @@ struct CompositeData {
     second: [u8; 2],
 }
 
-impl Encodable for CompositeData {
+impl Encode for CompositeData {
     type Encoder<'e> = Encoder2<ArrayEncoder<4>, ArrayEncoder<2>>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -76,7 +76,7 @@ impl Decoder for CompositeDataDecoder {
     fn read_limit(&self) -> usize { self.inner.read_limit() }
 }
 
-impl Decodable for CompositeData {
+impl Decode for CompositeData {
     type Decoder = CompositeDataDecoder;
 
     fn decoder() -> Self::Decoder { CompositeDataDecoder::new() }

--- a/consensus_encoding/tests/decode.rs
+++ b/consensus_encoding/tests/decode.rs
@@ -8,7 +8,7 @@ use std::io::{Cursor, Read};
 #[cfg(feature = "std")]
 use bitcoin_consensus_encoding::{decode_from_read, decode_from_read_unbuffered, ReadError};
 use bitcoin_consensus_encoding::{
-    decode_from_slice, decode_from_slice_unbounded, ArrayDecoder, CompactSizeDecoder, Decodable,
+    decode_from_slice, decode_from_slice_unbounded, ArrayDecoder, CompactSizeDecoder, Decode,
     DecodeError, Decoder, Decoder2, UnexpectedEofError,
 };
 #[cfg(feature = "alloc")]
@@ -231,7 +231,7 @@ fn decode_byte_vec_decoder_does_not_overconsume_on_second_chunk() {
 #[derive(Debug, PartialEq)]
 struct TestArray([u8; 4]);
 
-impl Decodable for TestArray {
+impl Decode for TestArray {
     type Decoder = TestArrayDecoder;
     fn decoder() -> Self::Decoder { TestArrayDecoder { inner: ArrayDecoder::new() } }
 }
@@ -414,7 +414,7 @@ impl Decoder for InnerDecoder {
 }
 
 #[cfg(feature = "alloc")]
-impl Decodable for Inner {
+impl Decode for Inner {
     type Decoder = InnerDecoder;
     fn decoder() -> Self::Decoder { InnerDecoder(ArrayDecoder::<4>::new()) }
 }
@@ -445,7 +445,7 @@ impl Decoder for TestDecoder {
 }
 
 #[cfg(feature = "alloc")]
-impl Decodable for Test {
+impl Decode for Test {
     type Decoder = TestDecoder;
     fn decoder() -> Self::Decoder { TestDecoder(VecDecoder::new()) }
 }

--- a/consensus_encoding/tests/encode.rs
+++ b/consensus_encoding/tests/encode.rs
@@ -6,13 +6,13 @@
 use std::io::{Cursor, Write};
 
 use bitcoin_consensus_encoding::{
-    ArrayEncoder, ArrayRefEncoder, BytesEncoder, CompactSizeEncoder, Encodable, Encoder, Encoder2,
+    ArrayEncoder, ArrayRefEncoder, BytesEncoder, CompactSizeEncoder, Encode, Encoder, Encoder2,
     Encoder3, Encoder4, Encoder6, EncoderByteIter, ExactSizeEncoder, SliceEncoder,
 };
 
 struct TestBytes<'a>(&'a [u8]);
 
-impl Encodable for TestBytes<'_> {
+impl Encode for TestBytes<'_> {
     type Encoder<'e>
         = BytesEncoder<'e>
     where
@@ -23,7 +23,7 @@ impl Encodable for TestBytes<'_> {
 
 struct TestArray<const N: usize>([u8; N]);
 
-impl<const N: usize> Encodable for TestArray<N> {
+impl<const N: usize> Encode for TestArray<N> {
     type Encoder<'e>
         = ArrayEncoder<N>
     where
@@ -32,12 +32,12 @@ impl<const N: usize> Encodable for TestArray<N> {
     fn encoder(&self) -> Self::Encoder<'_> { ArrayEncoder::without_length_prefix(self.0) }
 }
 
-// Simple test type that implements Encodable.
+// Simple test type that implements Encode.
 #[cfg(feature = "alloc")]
 struct TestData(u32);
 
 #[cfg(feature = "alloc")]
-impl Encodable for TestData {
+impl Encode for TestData {
     type Encoder<'e>
         = ArrayEncoder<4>
     where
@@ -53,7 +53,7 @@ impl Encodable for TestData {
 struct EmptyData;
 
 #[cfg(feature = "alloc")]
-impl Encodable for EmptyData {
+impl Encode for EmptyData {
     type Encoder<'e>
         = ArrayEncoder<0>
     where
@@ -150,7 +150,7 @@ fn encode_slice_encoder_mixed_empty_and_data() {
     // Test SliceEncoder behavior with mixed empty and non-empty elements.
     struct TestBytesVec(Vec<u8>);
 
-    impl Encodable for TestBytesVec {
+    impl Encode for TestBytesVec {
         type Encoder<'e>
             = BytesEncoder<'e>
         where

--- a/consensus_encoding/tests/iter.rs
+++ b/consensus_encoding/tests/iter.rs
@@ -1,9 +1,9 @@
-use bitcoin_consensus_encoding::{ArrayEncoder, Encodable, Encoder2, Encoder3, EncoderByteIter};
+use bitcoin_consensus_encoding::{ArrayEncoder, Encode, Encoder2, Encoder3, EncoderByteIter};
 use hex::BytesToHexIter;
 
 struct TestArray<const N: usize>([u8; N]);
 
-impl<const N: usize> Encodable for TestArray<N> {
+impl<const N: usize> Encode for TestArray<N> {
     type Encoder<'e>
         = ArrayEncoder<N>
     where
@@ -14,7 +14,7 @@ impl<const N: usize> Encodable for TestArray<N> {
 
 struct TestCatArray<const N: usize, const M: usize>([u8; N], [u8; M]);
 
-impl<const N: usize, const M: usize> Encodable for TestCatArray<N, M> {
+impl<const N: usize, const M: usize> Encode for TestCatArray<N, M> {
     type Encoder<'e>
         = Encoder2<ArrayEncoder<N>, ArrayEncoder<M>>
     where
@@ -30,7 +30,7 @@ impl<const N: usize, const M: usize> Encodable for TestCatArray<N, M> {
 
 struct TestCatArray3<const N: usize, const M: usize, const L: usize>([u8; N], [u8; M], [u8; L]);
 
-impl<const N: usize, const M: usize, const L: usize> Encodable for TestCatArray3<N, M, L> {
+impl<const N: usize, const M: usize, const L: usize> Encode for TestCatArray3<N, M, L> {
     type Encoder<'e>
         = Encoder3<ArrayEncoder<N>, ArrayEncoder<M>, ArrayEncoder<L>>
     where

--- a/consensus_encoding/tests/wrappers.rs
+++ b/consensus_encoding/tests/wrappers.rs
@@ -3,7 +3,7 @@
 #![cfg(feature = "std")]
 
 use bitcoin_consensus_encoding as encoding;
-use encoding::{ArrayEncoder, BytesEncoder, CompactSizeEncoder, Encodable, Encoder2, SliceEncoder};
+use encoding::{ArrayEncoder, BytesEncoder, CompactSizeEncoder, Encode, Encoder2, SliceEncoder};
 
 encoding::encoder_newtype_exact! {
     /// An encoder that uses an inner `ArrayEncoder`.
@@ -20,7 +20,7 @@ fn array_encoder() {
     #[derive(Debug, Default, Clone)]
     pub struct Test(u32);
 
-    impl Encodable for Test {
+    impl Encode for Test {
         type Encoder<'e> = TestArrayEncoder<'e>;
         fn encoder(&self) -> Self::Encoder<'_> {
             TestArrayEncoder::new(ArrayEncoder::without_length_prefix(self.0.to_le_bytes()))
@@ -40,7 +40,7 @@ fn bytes_encoder_without_length_prefix() {
     #[derive(Debug, Default, Clone)]
     pub struct Test(Vec<u8>);
 
-    impl Encodable for Test {
+    impl Encode for Test {
         type Encoder<'e>
             = TestBytesEncoder<'e>
         where
@@ -67,7 +67,7 @@ fn two_encoder() {
         b: Vec<u8>,
     }
 
-    impl Encodable for Test {
+    impl Encode for Test {
         type Encoder<'e> = Encoder2<TestBytesEncoder<'e>, TestBytesEncoder<'e>>;
 
         fn encoder(&self) -> Self::Encoder<'_> {
@@ -96,7 +96,7 @@ fn slice_encoder() {
         pub struct TestEncoder<'e>(Encoder2<CompactSizeEncoder, SliceEncoder<'e, Inner>>);
     }
 
-    impl Encodable for Test {
+    impl Encode for Test {
         type Encoder<'e>
             = TestEncoder<'e>
         where
@@ -118,7 +118,7 @@ fn slice_encoder() {
         pub struct InnerArrayEncoder<'e>(ArrayEncoder<4>);
     }
 
-    impl Encodable for Inner {
+    impl Encode for Inner {
         type Encoder<'e> = InnerArrayEncoder<'e>;
         fn encoder(&self) -> Self::Encoder<'_> {
             // Big-endian to make reading the test assertion easier.

--- a/hashes/api/all-features.txt
+++ b/hashes/api/all-features.txt
@@ -3357,7 +3357,7 @@ pub trait bitcoin_hashes::IsByteArray: core::convert::AsRef<[u8]> + bitcoin_hash
 pub const bitcoin_hashes::IsByteArray::LEN: usize
 impl<const N: usize> bitcoin_hashes::IsByteArray for [u8; N]
 pub const [u8; N]::LEN: usize
-pub fn bitcoin_hashes::encode_to_engine<T, H>(object: &T, engine: &mut H) where T: bitcoin_consensus_encoding::encode::Encodable + ?core::marker::Sized, H: bitcoin_hashes::HashEngine
+pub fn bitcoin_hashes::encode_to_engine<T, H>(object: &T, engine: &mut H) where T: bitcoin_consensus_encoding::encode::Encode + ?core::marker::Sized, H: bitcoin_hashes::HashEngine
 pub type bitcoin_hashes::HkdfSha256 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha256::Hash>
 pub type bitcoin_hashes::HkdfSha512 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha512::Hash>
 pub type bitcoin_hashes::HmacSha256 = bitcoin_hashes::hmac::Hmac<bitcoin_hashes::sha256::Hash>

--- a/hashes/api/alloc-only.txt
+++ b/hashes/api/alloc-only.txt
@@ -2891,7 +2891,7 @@ pub trait bitcoin_hashes::IsByteArray: core::convert::AsRef<[u8]> + bitcoin_hash
 pub const bitcoin_hashes::IsByteArray::LEN: usize
 impl<const N: usize> bitcoin_hashes::IsByteArray for [u8; N]
 pub const [u8; N]::LEN: usize
-pub fn bitcoin_hashes::encode_to_engine<T, H>(object: &T, engine: &mut H) where T: bitcoin_consensus_encoding::encode::Encodable + ?core::marker::Sized, H: bitcoin_hashes::HashEngine
+pub fn bitcoin_hashes::encode_to_engine<T, H>(object: &T, engine: &mut H) where T: bitcoin_consensus_encoding::encode::Encode + ?core::marker::Sized, H: bitcoin_hashes::HashEngine
 pub type bitcoin_hashes::HkdfSha256 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha256::Hash>
 pub type bitcoin_hashes::HkdfSha512 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha512::Hash>
 pub type bitcoin_hashes::HmacSha256 = bitcoin_hashes::hmac::Hmac<bitcoin_hashes::sha256::Hash>

--- a/hashes/api/no-features.txt
+++ b/hashes/api/no-features.txt
@@ -2697,7 +2697,7 @@ pub trait bitcoin_hashes::IsByteArray: core::convert::AsRef<[u8]> + bitcoin_hash
 pub const bitcoin_hashes::IsByteArray::LEN: usize
 impl<const N: usize> bitcoin_hashes::IsByteArray for [u8; N]
 pub const [u8; N]::LEN: usize
-pub fn bitcoin_hashes::encode_to_engine<T, H>(object: &T, engine: &mut H) where T: bitcoin_consensus_encoding::encode::Encodable + ?core::marker::Sized, H: bitcoin_hashes::HashEngine
+pub fn bitcoin_hashes::encode_to_engine<T, H>(object: &T, engine: &mut H) where T: bitcoin_consensus_encoding::encode::Encode + ?core::marker::Sized, H: bitcoin_hashes::HashEngine
 pub type bitcoin_hashes::HkdfSha256 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha256::Hash>
 pub type bitcoin_hashes::HkdfSha512 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha512::Hash>
 pub type bitcoin_hashes::HmacSha256 = bitcoin_hashes::hmac::Hmac<bitcoin_hashes::sha256::Hash>

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -201,7 +201,7 @@ pub trait HashEngine: Clone {
 /// Encodes an object into a hash engine.
 pub fn encode_to_engine<T, H>(object: &T, engine: &mut H)
 where
-    T: encoding::Encodable + ?Sized,
+    T: encoding::Encode + ?Sized,
     H: HashEngine,
 {
     let mut encoder = object.encoder();

--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -45,7 +45,7 @@ use core::cmp;
 #[cfg(feature = "std")]
 use std::vec::Vec;
 
-use encoding::{Decodable, Decoder, Encoder};
+use encoding::{Decode, Decoder, Encoder};
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(no_inline)]
@@ -460,7 +460,7 @@ pub fn from_std_mut<T>(std_io: &mut T) -> &mut FromStd<T> { FromStd::new_mut(std
 /// If an I/O error occurs while writing to the underlying writer.
 pub fn encode_to_writer<T, W>(object: &T, writer: W) -> Result<()>
 where
-    T: encoding::Encodable + ?Sized,
+    T: encoding::Encode + ?Sized,
     W: Write,
 {
     let mut encoder = object.encoder();
@@ -504,7 +504,7 @@ pub fn decode_from_read<T, R>(
     mut reader: R,
 ) -> core::result::Result<T, ReadError<<T::Decoder as Decoder>::Error>>
 where
-    T: Decodable,
+    T: Decode,
     R: BufRead,
 {
     let mut decoder = T::decoder();
@@ -555,7 +555,7 @@ pub fn decode_from_read_unbuffered<T, R>(
     reader: R,
 ) -> core::result::Result<T, ReadError<<T::Decoder as Decoder>::Error>>
 where
-    T: Decodable,
+    T: Decode,
     R: Read,
 {
     decode_from_read_unbuffered_with::<T, R, 4096>(reader)
@@ -582,7 +582,7 @@ pub fn decode_from_read_unbuffered_with<T, R, const BUFFER_SIZE: usize>(
     mut reader: R,
 ) -> core::result::Result<T, ReadError<<T::Decoder as Decoder>::Error>>
 where
-    T: Decodable,
+    T: Decode,
     R: Read,
 {
     let mut decoder = T::decoder();
@@ -777,10 +777,10 @@ mod tests {
         assert_eq!(cursor.position(), 15);
     }
 
-    // Simple test type that implements Encodable.
+    // Simple test type that implements Encode.
     struct TestData(u32);
 
-    impl encoding::Encodable for TestData {
+    impl encoding::Encode for TestData {
         type Encoder<'e>
             = ArrayEncoder<4>
         where
@@ -804,7 +804,7 @@ mod tests {
     #[derive(Debug, PartialEq)]
     struct TestArray([u8; 4]);
 
-    impl Decodable for TestArray {
+    impl Decode for TestArray {
         type Decoder = TestArrayDecoder;
         fn decoder() -> Self::Decoder { TestArrayDecoder { inner: ArrayDecoder::new() } }
     }

--- a/p2p/src/address.rs
+++ b/p2p/src/address.rs
@@ -171,7 +171,7 @@ encoding::encoder_newtype_exact! {
     >);
 }
 
-impl encoding::Encodable for Address {
+impl encoding::Encode for Address {
     type Encoder<'e>
         = AddressEncoder<'e>
     where
@@ -225,7 +225,7 @@ impl encoding::Decoder for AddressDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for Address {
+impl encoding::Decode for Address {
     type Decoder = AddressDecoder;
     fn decoder() -> Self::Decoder {
         AddressDecoder(encoding::Decoder3::new(
@@ -251,7 +251,7 @@ encoding::encoder_newtype_exact! {
     pub struct AddrV1MessageEncoder<'e>(Encoder2<ArrayEncoder<4>, AddressEncoder<'e>>);
 }
 
-impl encoding::Encodable for AddrV1Message {
+impl encoding::Encode for AddrV1Message {
     type Encoder<'e> = AddrV1MessageEncoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -288,7 +288,7 @@ impl encoding::Decoder for AddrV1MessageDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for AddrV1Message {
+impl encoding::Decode for AddrV1Message {
     type Decoder = AddrV1MessageDecoder;
 
     fn decoder() -> Self::Decoder {
@@ -530,7 +530,7 @@ impl<'e> encoding::ExactSizeEncoder for AddrV2Encoder<'e> {
     }
 }
 
-impl encoding::Encodable for AddrV2 {
+impl encoding::Encode for AddrV2 {
     type Encoder<'e> = AddrV2Encoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> { AddrV2Encoder::new(self) }
@@ -632,7 +632,7 @@ impl encoding::Decoder for AddrV2Decoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for AddrV2 {
+impl encoding::Decode for AddrV2 {
     type Decoder = AddrV2Decoder;
 
     fn decoder() -> Self::Decoder {
@@ -805,7 +805,7 @@ encoding::encoder_newtype_exact! {
     pub struct AddrV2MessageEncoder<'e>(Encoder4<ArrayEncoder<4>, CompactSizeEncoder, AddrV2Encoder<'e>, ArrayEncoder<2>>);
 }
 
-impl encoding::Encodable for AddrV2Message {
+impl encoding::Encode for AddrV2Message {
     type Encoder<'e> = AddrV2MessageEncoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -847,7 +847,7 @@ impl encoding::Decoder for AddrV2MessageDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for AddrV2Message {
+impl encoding::Decode for AddrV2Message {
     type Decoder = AddrV2MessageDecoder;
 
     fn decoder() -> Self::Decoder {
@@ -1291,7 +1291,7 @@ mod test {
     use alloc::{format, vec};
     use std::net::IpAddr;
 
-    use encoding::{Encodable as _, Encoder as _, ExactSizeEncoder as _};
+    use encoding::{Encode as _, Encoder as _, ExactSizeEncoder as _};
     use hex_unstable::hex;
 
     use super::*;

--- a/p2p/src/bip152.rs
+++ b/p2p/src/bip152.rs
@@ -58,7 +58,7 @@ encoding::encoder_newtype! {
     pub struct PrefilledTransactionEncoder<'e>(Encoder2<CompactSizeEncoder, TransactionEncoder<'e>>);
 }
 
-impl encoding::Encodable for PrefilledTransaction {
+impl encoding::Encode for PrefilledTransaction {
     type Encoder<'e>
         = PrefilledTransactionEncoder<'e>
     where
@@ -107,7 +107,7 @@ impl encoding::Decoder for PrefilledTransactionDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for PrefilledTransaction {
+impl encoding::Decode for PrefilledTransaction {
     type Decoder = PrefilledTransactionDecoder;
 
     fn decoder() -> Self::Decoder {
@@ -234,7 +234,7 @@ encoding::encoder_newtype_exact! {
     pub struct ShortIdEncoder<'e>(ArrayEncoder<6>);
 }
 
-impl encoding::Encodable for ShortId {
+impl encoding::Encode for ShortId {
     type Encoder<'e> = ShortIdEncoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -267,7 +267,7 @@ impl encoding::Decoder for ShortIdDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for ShortId {
+impl encoding::Decode for ShortId {
     type Decoder = ShortIdDecoder;
 
     fn decoder() -> Self::Decoder { ShortIdDecoder(ShortIdInnerDecoder::new()) }
@@ -307,7 +307,7 @@ encoding::encoder_newtype! {
     );
 }
 
-impl encoding::Encodable for HeaderAndShortIds {
+impl encoding::Encode for HeaderAndShortIds {
     type Encoder<'e>
         = HeaderAndShortIdsEncoder<'e>
     where
@@ -371,7 +371,7 @@ impl encoding::Decoder for HeaderAndShortIdsDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for HeaderAndShortIds {
+impl encoding::Decode for HeaderAndShortIds {
     type Decoder = HeaderAndShortIdsDecoder;
 
     fn decoder() -> Self::Decoder {
@@ -498,7 +498,7 @@ impl HeaderAndShortIds {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 struct Offset(usize);
 
-impl encoding::Encodable for Offset {
+impl encoding::Encode for Offset {
     type Encoder<'e> = CompactSizeEncoder;
 
     fn encoder(&self) -> Self::Encoder<'_> { CompactSizeEncoder::new(self.0) }
@@ -523,7 +523,7 @@ impl encoding::Decoder for OffsetDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for Offset {
+impl encoding::Decode for Offset {
     type Decoder = OffsetDecoder;
 
     fn decoder() -> Self::Decoder { OffsetDecoder(CompactSizeDecoder::new()) }
@@ -600,7 +600,7 @@ encoding::encoder_newtype! {
     );
 }
 
-impl encoding::Encodable for BlockTransactionsRequest {
+impl encoding::Encode for BlockTransactionsRequest {
     type Encoder<'e> = BlockTransactionsRequestEncoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -639,7 +639,7 @@ impl encoding::Decoder for BlockTransactionsRequestDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for BlockTransactionsRequest {
+impl encoding::Decode for BlockTransactionsRequest {
     type Decoder = BlockTransactionsRequestDecoder;
 
     fn decoder() -> Self::Decoder {
@@ -712,7 +712,7 @@ encoding::encoder_newtype! {
     );
 }
 
-impl encoding::Encodable for BlockTransactions {
+impl encoding::Encode for BlockTransactions {
     type Encoder<'e>
         = BlockTransactionsEncoder<'e>
     where
@@ -754,7 +754,7 @@ impl encoding::Decoder for BlockTransactionsDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for BlockTransactions {
+impl encoding::Decode for BlockTransactions {
     type Decoder = BlockTransactionsDecoder;
 
     fn decoder() -> Self::Decoder {

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -135,7 +135,7 @@ encoding::encoder_newtype_exact! {
     pub struct ProtocolVersionEncoder<'e>(encoding::ArrayEncoder<4>);
 }
 
-impl encoding::Encodable for ProtocolVersion {
+impl encoding::Encode for ProtocolVersion {
     type Encoder<'e> = ProtocolVersionEncoder<'e>;
     fn encoder(&self) -> Self::Encoder<'_> {
         ProtocolVersionEncoder::new(encoding::ArrayEncoder::without_length_prefix(
@@ -176,7 +176,7 @@ impl encoding::Decoder for ProtocolVersionDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for ProtocolVersion {
+impl encoding::Decode for ProtocolVersion {
     type Decoder = ProtocolVersionDecoder;
     fn decoder() -> Self::Decoder { ProtocolVersionDecoder(encoding::ArrayDecoder::<4>::new()) }
 }
@@ -344,7 +344,7 @@ encoding::encoder_newtype_exact! {
     pub struct ServiceFlagsEncoder<'e>(encoding::ArrayEncoder<8>);
 }
 
-impl encoding::Encodable for ServiceFlags {
+impl encoding::Encode for ServiceFlags {
     type Encoder<'e> = ServiceFlagsEncoder<'e>;
     fn encoder(&self) -> Self::Encoder<'_> {
         ServiceFlagsEncoder::new(encoding::ArrayEncoder::without_length_prefix(
@@ -385,7 +385,7 @@ impl encoding::Decoder for ServiceFlagsDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for ServiceFlags {
+impl encoding::Decode for ServiceFlags {
     type Decoder = ServiceFlagsDecoder;
     fn decoder() -> Self::Decoder { ServiceFlagsDecoder(encoding::ArrayDecoder::<8>::new()) }
 }
@@ -498,7 +498,7 @@ encoding::encoder_newtype_exact! {
     pub struct MagicEncoder<'e>(ArrayEncoder<4>);
 }
 
-impl encoding::Encodable for Magic {
+impl encoding::Encode for Magic {
     type Encoder<'e> = MagicEncoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -531,7 +531,7 @@ impl encoding::Decoder for MagicDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for Magic {
+impl encoding::Decode for Magic {
     type Decoder = MagicDecoder;
 
     fn decoder() -> Self::Decoder { MagicDecoder(ArrayDecoder::new()) }

--- a/p2p/src/merkle_tree.rs
+++ b/p2p/src/merkle_tree.rs
@@ -135,7 +135,7 @@ encoding::encoder_newtype! {
     pub struct MerkleBlockEncoder<'e>(Encoder2<HeaderEncoder<'e>, PartialMerkleTreeEncoder<'e>>);
 }
 
-impl encoding::Encodable for MerkleBlock {
+impl encoding::Encode for MerkleBlock {
     type Encoder<'e> = MerkleBlockEncoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -168,7 +168,7 @@ impl encoding::Decoder for MerkleBlockDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for MerkleBlock {
+impl encoding::Decode for MerkleBlock {
     type Decoder = MerkleBlockDecoder;
     fn decoder() -> Self::Decoder {
         MerkleBlockDecoder(Decoder2::new(block::Header::decoder(), PartialMerkleTree::decoder()))
@@ -508,7 +508,7 @@ encoding::encoder_newtype! {
     );
 }
 
-impl encoding::Encodable for PartialMerkleTree {
+impl encoding::Encode for PartialMerkleTree {
     type Encoder<'e> = PartialMerkleTreeEncoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -560,7 +560,7 @@ impl encoding::Decoder for PartialMerkleTreeDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for PartialMerkleTree {
+impl encoding::Decode for PartialMerkleTree {
     type Decoder = PartialMerkleTreeDecoder;
 
     fn decoder() -> Self::Decoder {

--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -147,7 +147,7 @@ impl Decodable for CommandString {
     }
 }
 
-impl encoding::Encodable for CommandString {
+impl encoding::Encode for CommandString {
     type Encoder<'e> = CommandStringEncoder;
 
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -159,7 +159,7 @@ impl encoding::Encodable for CommandString {
     }
 }
 
-impl encoding::Decodable for CommandString {
+impl encoding::Decode for CommandString {
     type Decoder = CommandStringDecoder;
 
     fn decoder() -> Self::Decoder { CommandStringDecoder { inner: encoding::ArrayDecoder::new() } }
@@ -243,7 +243,7 @@ pub struct V1MessageHeader {
     pub checksum: [u8; 4],
 }
 
-impl encoding::Encodable for V1MessageHeader {
+impl encoding::Encode for V1MessageHeader {
     type Encoder<'e>
         = V1MessageHeaderEncoder<'e>
     where
@@ -310,7 +310,7 @@ impl encoding::Decoder for V1MessageHeaderDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for V1MessageHeader {
+impl encoding::Decode for V1MessageHeader {
     type Decoder = V1MessageHeaderDecoder;
     fn decoder() -> Self::Decoder {
         V1MessageHeaderDecoder(encoding::Decoder4::new(
@@ -340,7 +340,7 @@ encoding::encoder_newtype! {
     pub struct InventoryPayloadEncoder<'e>(Encoder2<CompactSizeEncoder, SliceEncoder<'e, message_blockdata::Inventory>>);
 }
 
-impl encoding::Encodable for InventoryPayload {
+impl encoding::Encode for InventoryPayload {
     type Encoder<'e>
         = Encoder2<CompactSizeEncoder, SliceEncoder<'e, message_blockdata::Inventory>>
     where
@@ -378,7 +378,7 @@ impl encoding::Decoder for InventoryPayloadDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for InventoryPayload {
+impl encoding::Decode for InventoryPayload {
     type Decoder = InventoryPayloadDecoder;
     fn decoder() -> Self::Decoder {
         InventoryPayloadDecoder(VecDecoder::<message_blockdata::Inventory>::new())
@@ -395,7 +395,7 @@ encoding::encoder_newtype! {
     pub struct AddrPayloadEncoder<'e>(Encoder2<CompactSizeEncoder, SliceEncoder<'e, AddrV1Message>>);
 }
 
-impl encoding::Encodable for AddrPayload {
+impl encoding::Encode for AddrPayload {
     type Encoder<'e> = AddrPayloadEncoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -430,7 +430,7 @@ impl encoding::Decoder for AddrPayloadDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for AddrPayload {
+impl encoding::Decode for AddrPayload {
     type Decoder = AddrPayloadDecoder;
     fn decoder() -> Self::Decoder { AddrPayloadDecoder(VecDecoder::new()) }
 }
@@ -445,7 +445,7 @@ encoding::encoder_newtype! {
     pub struct AddrV2PayloadEncoder<'e>(Encoder2<CompactSizeEncoder, SliceEncoder<'e, AddrV2Message>>);
 }
 
-impl encoding::Encodable for AddrV2Payload {
+impl encoding::Encode for AddrV2Payload {
     type Encoder<'e>
         = Encoder2<CompactSizeEncoder, SliceEncoder<'e, AddrV2Message>>
     where
@@ -483,7 +483,7 @@ impl encoding::Decoder for AddrV2PayloadDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for AddrV2Payload {
+impl encoding::Decode for AddrV2Payload {
     type Decoder = AddrV2PayloadDecoder;
     fn decoder() -> Self::Decoder { AddrV2PayloadDecoder(VecDecoder::new()) }
 }
@@ -520,7 +520,7 @@ impl From<FeeFilter> for FeeRate {
 impl bitcoin::consensus::encode::Encodable for FeeFilter {
     fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         use encoding::Encoder;
-        let mut encoder = encoding::Encodable::encoder(self);
+        let mut encoder = encoding::Encode::encoder(self);
         loop {
             w.write_all(encoder.current_chunk())?;
             if !encoder.advance() {
@@ -537,7 +537,7 @@ impl bitcoin::consensus::encode::Decodable for FeeFilter {
     ) -> Result<Self, bitcoin::consensus::encode::Error> {
         use encoding::Decoder;
 
-        let mut decoder = <Self as encoding::Decodable>::decoder();
+        let mut decoder = <Self as encoding::Decode>::decoder();
         let mut buffer = [0u8; 8];
 
         r.read_exact(&mut buffer)?;
@@ -565,7 +565,7 @@ encoding::encoder_newtype_exact! {
     pub struct FeeFilterEncoder<'e>(encoding::ArrayEncoder<8>);
 }
 
-impl encoding::Encodable for FeeFilter {
+impl encoding::Encode for FeeFilter {
     type Encoder<'e> = FeeFilterEncoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -610,7 +610,7 @@ impl encoding::Decoder for FeeFilterDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for FeeFilter {
+impl encoding::Decode for FeeFilter {
     type Decoder = FeeFilterDecoder;
 
     fn decoder() -> Self::Decoder { FeeFilterDecoder::new() }
@@ -644,7 +644,7 @@ encoding::encoder_newtype_exact! {
     pub struct PingEncoder<'e>(encoding::ArrayEncoder<8>);
 }
 
-impl encoding::Encodable for Ping {
+impl encoding::Encode for Ping {
     type Encoder<'e>
         = PingEncoder<'e>
     where
@@ -678,7 +678,7 @@ impl encoding::Decoder for PingDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for Ping {
+impl encoding::Decode for Ping {
     type Decoder = PingDecoder;
     fn decoder() -> Self::Decoder { PingDecoder(encoding::ArrayDecoder::<8>::new()) }
 }
@@ -701,7 +701,7 @@ encoding::encoder_newtype_exact! {
     pub struct PongEncoder<'e>(encoding::ArrayEncoder<8>);
 }
 
-impl encoding::Encodable for Pong {
+impl encoding::Encode for Pong {
     type Encoder<'e>
         = PongEncoder<'e>
     where
@@ -735,7 +735,7 @@ impl encoding::Decoder for PongDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for Pong {
+impl encoding::Decode for Pong {
     type Decoder = PongDecoder;
     fn decoder() -> Self::Decoder { PongDecoder(encoding::ArrayDecoder::<8>::new()) }
 }
@@ -985,7 +985,7 @@ impl Encodable for NetworkMessage {
     }
 }
 
-impl encoding::Encodable for NetworkMessage {
+impl encoding::Encode for NetworkMessage {
     type Encoder<'e> = NetworkMessageEncoder<'e>;
 
     #[inline]
@@ -1008,63 +1008,63 @@ impl Encodable for V1NetworkMessage {
 #[derive(Debug, Clone)]
 pub enum NetworkMessageEncoder<'e> {
     /// Encodes [`NetworkMessage::Version`]
-    Version(<message_network::VersionMessage as encoding::Encodable>::Encoder<'e>),
+    Version(<message_network::VersionMessage as encoding::Encode>::Encoder<'e>),
     /// Encodes [`NetworkMessage::Addr`]
-    Addr(<AddrPayload as encoding::Encodable>::Encoder<'e>),
+    Addr(<AddrPayload as encoding::Encode>::Encoder<'e>),
     /// Encodes [`NetworkMessage::Inv`]
-    Inv(<InventoryPayload as encoding::Encodable>::Encoder<'e>),
+    Inv(<InventoryPayload as encoding::Encode>::Encoder<'e>),
     /// Encodes [`NetworkMessage::GetData`]
-    GetData(<InventoryPayload as encoding::Encodable>::Encoder<'e>),
+    GetData(<InventoryPayload as encoding::Encode>::Encoder<'e>),
     /// Encodes [`NetworkMessage::NotFound`]
-    NotFound(<InventoryPayload as encoding::Encodable>::Encoder<'e>),
+    NotFound(<InventoryPayload as encoding::Encode>::Encoder<'e>),
     /// Encodes [`NetworkMessage::GetBlocks`]
-    GetBlocks(<message_blockdata::GetBlocksMessage as encoding::Encodable>::Encoder<'e>),
+    GetBlocks(<message_blockdata::GetBlocksMessage as encoding::Encode>::Encoder<'e>),
     /// Encodes [`NetworkMessage::GetHeaders`]
-    GetHeaders(<message_blockdata::GetHeadersMessage as encoding::Encodable>::Encoder<'e>),
+    GetHeaders(<message_blockdata::GetHeadersMessage as encoding::Encode>::Encoder<'e>),
     /// Encodes [`NetworkMessage::Tx`]
-    Tx(<transaction::Transaction as encoding::Encodable>::Encoder<'e>),
+    Tx(<transaction::Transaction as encoding::Encode>::Encoder<'e>),
     /// Encodes [`NetworkMessage::Block`]
-    Block(<block::Block as encoding::Encodable>::Encoder<'e>),
+    Block(<block::Block as encoding::Encode>::Encoder<'e>),
     /// Encodes [`NetworkMessage::Headers`]
-    Headers(<HeadersMessage as encoding::Encodable>::Encoder<'e>),
+    Headers(<HeadersMessage as encoding::Encode>::Encoder<'e>),
     /// Encodes [`NetworkMessage::Ping`]
-    Ping(<Ping as encoding::Encodable>::Encoder<'e>),
+    Ping(<Ping as encoding::Encode>::Encoder<'e>),
     /// Encodes [`NetworkMessage::Pong`]
-    Pong(<Pong as encoding::Encodable>::Encoder<'e>),
+    Pong(<Pong as encoding::Encode>::Encoder<'e>),
     /// Encodes [`NetworkMessage::MerkleBlock`]
-    MerkleBlock(<MerkleBlock as encoding::Encodable>::Encoder<'e>),
+    MerkleBlock(<MerkleBlock as encoding::Encode>::Encoder<'e>),
     /// Encodes [`NetworkMessage::FilterLoad`]
-    FilterLoad(<message_bloom::FilterLoad as encoding::Encodable>::Encoder<'e>),
+    FilterLoad(<message_bloom::FilterLoad as encoding::Encode>::Encoder<'e>),
     /// Encodes [`NetworkMessage::FilterAdd`]
-    FilterAdd(<message_bloom::FilterAdd as encoding::Encodable>::Encoder<'e>),
+    FilterAdd(<message_bloom::FilterAdd as encoding::Encode>::Encoder<'e>),
     /// Encodes [`NetworkMessage::GetCFilters`]
-    GetCFilters(<message_filter::GetCFilters as encoding::Encodable>::Encoder<'e>),
+    GetCFilters(<message_filter::GetCFilters as encoding::Encode>::Encoder<'e>),
     /// Encodes [`NetworkMessage::CFilter`]
-    CFilter(<message_filter::CFilter as encoding::Encodable>::Encoder<'e>),
+    CFilter(<message_filter::CFilter as encoding::Encode>::Encoder<'e>),
     /// Encodes [`NetworkMessage::GetCFHeaders`]
-    GetCFHeaders(<message_filter::GetCFHeaders as encoding::Encodable>::Encoder<'e>),
+    GetCFHeaders(<message_filter::GetCFHeaders as encoding::Encode>::Encoder<'e>),
     /// Encodes [`NetworkMessage::CFHeaders`]
-    CFHeaders(<message_filter::CFHeaders as encoding::Encodable>::Encoder<'e>),
+    CFHeaders(<message_filter::CFHeaders as encoding::Encode>::Encoder<'e>),
     /// Encodes [`NetworkMessage::GetCFCheckpt`]
-    GetCFCheckpt(<message_filter::GetCFCheckpt as encoding::Encodable>::Encoder<'e>),
+    GetCFCheckpt(<message_filter::GetCFCheckpt as encoding::Encode>::Encoder<'e>),
     /// Encodes [`NetworkMessage::CFCheckpt`]
-    CFCheckpt(<message_filter::CFCheckpt as encoding::Encodable>::Encoder<'e>),
+    CFCheckpt(<message_filter::CFCheckpt as encoding::Encode>::Encoder<'e>),
     /// Encodes [`NetworkMessage::SendCmpct`]
-    SendCmpct(<message_compact_blocks::SendCmpct as encoding::Encodable>::Encoder<'e>),
+    SendCmpct(<message_compact_blocks::SendCmpct as encoding::Encode>::Encoder<'e>),
     /// Encodes [`NetworkMessage::CmpctBlock`]
-    CmpctBlock(<bip152::HeaderAndShortIds as encoding::Encodable>::Encoder<'e>),
+    CmpctBlock(<bip152::HeaderAndShortIds as encoding::Encode>::Encoder<'e>),
     /// Encodes [`NetworkMessage::GetBlockTxn`]
-    GetBlockTxn(<bip152::BlockTransactionsRequest as encoding::Encodable>::Encoder<'e>),
+    GetBlockTxn(<bip152::BlockTransactionsRequest as encoding::Encode>::Encoder<'e>),
     /// Encodes [`NetworkMessage::BlockTxn`]
-    BlockTxn(<bip152::BlockTransactions as encoding::Encodable>::Encoder<'e>),
+    BlockTxn(<bip152::BlockTransactions as encoding::Encode>::Encoder<'e>),
     /// Encodes [`NetworkMessage::Alert`]
-    Alert(<message_network::Alert as encoding::Encodable>::Encoder<'e>),
+    Alert(<message_network::Alert as encoding::Encode>::Encoder<'e>),
     /// Encodes [`NetworkMessage::Reject`]
-    Reject(<message_network::Reject as encoding::Encodable>::Encoder<'e>),
+    Reject(<message_network::Reject as encoding::Encode>::Encoder<'e>),
     /// Encodes [`NetworkMessage::FeeFilter`]
-    FeeFilter(<FeeFilter as encoding::Encodable>::Encoder<'e>),
+    FeeFilter(<FeeFilter as encoding::Encode>::Encoder<'e>),
     /// Encodes [`NetworkMessage::AddrV2`]
-    AddrV2(<AddrV2Payload as encoding::Encodable>::Encoder<'e>),
+    AddrV2(<AddrV2Payload as encoding::Encode>::Encoder<'e>),
     /// Encodes zero-payload messages: verack, mempool, sendheaders, getaddr, wtxidrelay,
     /// filterclear, sendaddrv2.
     Empty,
@@ -1074,7 +1074,7 @@ pub enum NetworkMessageEncoder<'e> {
 
 impl<'e> NetworkMessageEncoder<'e> {
     fn new(msg: &'e NetworkMessage) -> Self {
-        use encoding::Encodable as _;
+        use encoding::Encode as _;
         match msg {
             NetworkMessage::Version(dat) => Self::Version(dat.encoder()),
             NetworkMessage::Addr(dat) => Self::Addr(dat.encoder()),
@@ -1205,7 +1205,7 @@ encoding::encoder_newtype! {
     );
 }
 
-impl encoding::Encodable for V1NetworkMessage {
+impl encoding::Encode for V1NetworkMessage {
     type Encoder<'e> = V1NetworkMessageEncoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -1230,12 +1230,12 @@ enum NetworkMessageDecoder {
     NotFound(InventoryPayloadDecoder),
     GetBlocks(message_blockdata::GetBlocksMessageDecoder),
     GetHeaders(message_blockdata::GetHeadersMessageDecoder),
-    Tx(<transaction::Transaction as encoding::Decodable>::Decoder),
-    Block(<block::Block as encoding::Decodable>::Decoder),
+    Tx(<transaction::Transaction as encoding::Decode>::Decoder),
+    Block(<block::Block as encoding::Decode>::Decoder),
     Headers(HeadersMessageDecoder),
     Ping(PingDecoder),
     Pong(PongDecoder),
-    MerkleBlock(<MerkleBlock as encoding::Decodable>::Decoder),
+    MerkleBlock(<MerkleBlock as encoding::Decode>::Decoder),
     FilterLoad(message_bloom::FilterLoadDecoder),
     FilterAdd(message_bloom::FilterAddDecoder),
     GetCFilters(message_filter::GetCFiltersDecoder),
@@ -1245,9 +1245,9 @@ enum NetworkMessageDecoder {
     GetCFCheckpt(message_filter::GetCFCheckptDecoder),
     CFCheckpt(message_filter::CFCheckptDecoder),
     SendCmpct(message_compact_blocks::SendCmpctDecoder),
-    CmpctBlock(<bip152::HeaderAndShortIds as encoding::Decodable>::Decoder),
-    GetBlockTxn(<bip152::BlockTransactionsRequest as encoding::Decodable>::Decoder),
-    BlockTxn(<bip152::BlockTransactions as encoding::Decodable>::Decoder),
+    CmpctBlock(<bip152::HeaderAndShortIds as encoding::Decode>::Decoder),
+    GetBlockTxn(<bip152::BlockTransactionsRequest as encoding::Decode>::Decoder),
+    BlockTxn(<bip152::BlockTransactions as encoding::Decode>::Decoder),
     Alert(message_network::AlertDecoder),
     Reject(message_network::RejectDecoder),
     FeeFilter(FeeFilterDecoder),
@@ -1265,7 +1265,7 @@ enum NetworkMessageDecoder {
 
 impl NetworkMessageDecoder {
     fn new(command: CommandString, payload_len: usize) -> Self {
-        use encoding::Decodable as _;
+        use encoding::Decode as _;
         match command.as_ref() {
             "version" => Self::Version(message_network::VersionMessage::decoder()),
             "verack" | "sendheaders" | "mempool" | "getaddr" | "wtxidrelay" | "filterclear"
@@ -1572,7 +1572,7 @@ impl encoding::Decoder for V1NetworkMessageDecoder {
     }
 }
 
-impl encoding::Decodable for V1NetworkMessage {
+impl encoding::Decode for V1NetworkMessage {
     type Decoder = V1NetworkMessageDecoder;
 
     fn decoder() -> Self::Decoder {
@@ -1619,7 +1619,7 @@ impl encoding::Encoder for V2NetworkMessageEncoder<'_> {
     }
 }
 
-impl encoding::Encodable for V2NetworkMessage {
+impl encoding::Encode for V2NetworkMessage {
     type Encoder<'e> = V2NetworkMessageEncoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -1721,7 +1721,7 @@ encoding::encoder_newtype_exact! {
     pub struct NetworkHeaderEncoder<'e>(Encoder2<HeaderEncoder<'e>, ArrayEncoder<1>>);
 }
 
-impl encoding::Encodable for NetworkHeader {
+impl encoding::Encode for NetworkHeader {
     type Encoder<'e> = NetworkHeaderEncoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -1757,7 +1757,7 @@ impl encoding::Decoder for NetworkHeaderDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for NetworkHeader {
+impl encoding::Decode for NetworkHeader {
     type Decoder = NetworkHeaderDecoder;
 
     fn decoder() -> Self::Decoder {
@@ -1806,7 +1806,7 @@ encoding::encoder_newtype! {
     pub struct HeadersMessageEncoder<'e>(Encoder2<CompactSizeEncoder, SliceEncoder<'e, NetworkHeader>>);
 }
 
-impl encoding::Encodable for HeadersMessage {
+impl encoding::Encode for HeadersMessage {
     type Encoder<'e> = HeadersMessageEncoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -1842,7 +1842,7 @@ impl encoding::Decoder for HeadersMessageDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for HeadersMessage {
+impl encoding::Decode for HeadersMessage {
     type Decoder = HeadersMessageDecoder;
 
     fn decoder() -> Self::Decoder { HeadersMessageDecoder(VecDecoder::new()) }
@@ -2058,7 +2058,7 @@ impl V2NetworkMessageDecoder {
     fn payload_decoder_from_short_id(
         short_id: u8,
     ) -> Result<NetworkMessageDecoder, V2NetworkMessageDecoderError> {
-        use encoding::Decodable as _;
+        use encoding::Decode as _;
 
         let err = V2NetworkMessageDecoderError::Payload(V1NetworkMessageDecoderError(
             V1NetworkMessageDecoderErrorInner::Payload,
@@ -2110,7 +2110,7 @@ impl V2NetworkMessageDecoder {
 
     /// Creates a payload decoder from a command string (for short ID == 0).
     fn payload_decoder_from_command(command: CommandString) -> NetworkMessageDecoder {
-        use encoding::Decodable as _;
+        use encoding::Decode as _;
 
         match command.as_ref() {
             "version" => NetworkMessageDecoder::Version(message_network::VersionMessage::decoder()),
@@ -2225,7 +2225,7 @@ impl encoding::Decoder for V2NetworkMessageDecoder {
     }
 }
 
-impl encoding::Decodable for V2NetworkMessage {
+impl encoding::Decode for V2NetworkMessage {
     type Decoder = V2NetworkMessageDecoder;
 
     fn decoder() -> Self::Decoder {
@@ -2326,7 +2326,7 @@ fn read_bytes_from_finite_reader<D: Read + ?Sized>(
 }
 
 /// Does a double-SHA256 on `data` and returns the first 4 bytes.
-fn sha2_checksum(data: &impl encoding::Encodable) -> (u64, [u8; 4]) {
+fn sha2_checksum(data: &impl encoding::Encode) -> (u64, [u8; 4]) {
     let mut engine = sha256d::HashEngine::new();
     hashes::encode_to_engine(data, &mut engine);
     let bytes_hashed = engine.n_bytes_hashed();
@@ -3238,7 +3238,7 @@ mod test {
 
     #[test]
     fn command_string_encoder() {
-        use encoding::{Encodable as _, ExactSizeEncoder as _};
+        use encoding::{Encode as _, ExactSizeEncoder as _};
 
         let cmd = CommandString::try_from_static("version").unwrap();
         let expected_bytes: [u8; 12] = [b'v', b'e', b'r', b's', b'i', b'o', b'n', 0, 0, 0, 0, 0];

--- a/p2p/src/message_blockdata.rs
+++ b/p2p/src/message_blockdata.rs
@@ -118,7 +118,7 @@ encoding::encoder_newtype_exact! {
     pub struct InventoryEncoder<'e>(Encoder2<ArrayEncoder<4>, ArrayEncoder<32>>);
 }
 
-impl encoding::Encodable for Inventory {
+impl encoding::Encode for Inventory {
     type Encoder<'e> = InventoryEncoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -174,7 +174,7 @@ impl encoding::Decoder for InventoryDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for Inventory {
+impl encoding::Decode for Inventory {
     type Decoder = InventoryDecoder;
     fn decoder() -> Self::Decoder {
         InventoryDecoder(Decoder2::new(ArrayDecoder::<4>::new(), ArrayDecoder::<32>::new()))
@@ -255,7 +255,7 @@ encoding::encoder_newtype! {
     pub struct BlockLocatorEncoder<'e>(BlockLocatorInnerEncoder<'e>);
 }
 
-impl encoding::Encodable for BlockLocator {
+impl encoding::Encode for BlockLocator {
     type Encoder<'e> = BlockLocatorEncoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -299,7 +299,7 @@ impl encoding::Decoder for BlockLocatorDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for BlockLocator {
+impl encoding::Decode for BlockLocator {
     type Decoder = BlockLocatorDecoder;
     fn decoder() -> Self::Decoder { BlockLocatorDecoder::new() }
 }
@@ -343,7 +343,7 @@ encoding::encoder_newtype! {
     pub struct GetHeadersEncoder<'e>(GetBlocksOrHeadersInnerEncoder<'e>);
 }
 
-impl encoding::Encodable for GetHeadersMessage {
+impl encoding::Encode for GetHeadersMessage {
     type Encoder<'e>
         = GetHeadersEncoder<'e>
     where
@@ -358,7 +358,7 @@ impl encoding::Encodable for GetHeadersMessage {
     }
 }
 
-impl encoding::Encodable for GetBlocksMessage {
+impl encoding::Encode for GetBlocksMessage {
     type Encoder<'e>
         = GetBlocksEncoder<'e>
     where
@@ -424,7 +424,7 @@ impl encoding::Decoder for GetBlocksMessageDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for GetBlocksMessage {
+impl encoding::Decode for GetBlocksMessage {
     type Decoder = GetBlocksMessageDecoder;
     fn decoder() -> Self::Decoder {
         GetBlocksMessageDecoder(Decoder3::new(
@@ -435,7 +435,7 @@ impl encoding::Decodable for GetBlocksMessage {
     }
 }
 
-impl encoding::Decodable for GetHeadersMessage {
+impl encoding::Decode for GetHeadersMessage {
     type Decoder = GetHeadersMessageDecoder;
     fn decoder() -> Self::Decoder {
         GetHeadersMessageDecoder(Decoder3::new(

--- a/p2p/src/message_bloom.rs
+++ b/p2p/src/message_bloom.rs
@@ -49,7 +49,7 @@ encoding::encoder_newtype_exact! {
     );
 }
 
-impl encoding::Encodable for FilterLoad {
+impl encoding::Encode for FilterLoad {
     type Encoder<'e> = FilterLoadEncoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -98,7 +98,7 @@ impl encoding::Decoder for FilterLoadDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for FilterLoad {
+impl encoding::Decode for FilterLoad {
     type Decoder = FilterLoadDecoder;
 
     fn decoder() -> Self::Decoder {
@@ -130,7 +130,7 @@ encoding::encoder_newtype_exact! {
     pub struct BloomFlagsEncoder<'e>(ArrayEncoder<1>);
 }
 
-impl encoding::Encodable for BloomFlags {
+impl encoding::Encode for BloomFlags {
     type Encoder<'e> = BloomFlagsEncoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -181,7 +181,7 @@ impl encoding::Decoder for BloomFlagsDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for BloomFlags {
+impl encoding::Decode for BloomFlags {
     type Decoder = BloomFlagsDecoder;
 
     fn decoder() -> Self::Decoder { BloomFlagsDecoder(ArrayDecoder::new()) }
@@ -222,7 +222,7 @@ encoding::encoder_newtype_exact! {
     pub struct FilterAddEncoder<'e>(Encoder2<CompactSizeEncoder, BytesEncoder<'e>>);
 }
 
-impl encoding::Encodable for FilterAdd {
+impl encoding::Encode for FilterAdd {
     type Encoder<'e> = FilterAddEncoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -258,7 +258,7 @@ impl encoding::Decoder for FilterAddDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for FilterAdd {
+impl encoding::Decode for FilterAdd {
     type Decoder = FilterAddDecoder;
 
     fn decoder() -> Self::Decoder { FilterAddDecoder(FilterAddInnerDecoder::new()) }

--- a/p2p/src/message_compact_blocks.rs
+++ b/p2p/src/message_compact_blocks.rs
@@ -28,7 +28,7 @@ encoding::encoder_newtype_exact! {
     pub struct SendCmpctEncoder<'e>(Encoder2<ArrayEncoder<1>, ArrayEncoder<8>>);
 }
 
-impl encoding::Encodable for SendCmpct {
+impl encoding::Encode for SendCmpct {
     type Encoder<'e> = SendCmpctEncoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -65,7 +65,7 @@ impl encoding::Decoder for SendCmpctDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for SendCmpct {
+impl encoding::Decode for SendCmpct {
     type Decoder = SendCmpctDecoder;
 
     fn decoder() -> Self::Decoder {

--- a/p2p/src/message_filter.rs
+++ b/p2p/src/message_filter.rs
@@ -75,7 +75,7 @@ encoding::encoder_newtype_exact! {
     pub struct FilterHashEncoder<'e>(ArrayEncoder<32>);
 }
 
-impl encoding::Encodable for FilterHash {
+impl encoding::Encode for FilterHash {
     type Encoder<'e> = FilterHashEncoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -89,7 +89,7 @@ encoding::encoder_newtype_exact! {
     pub struct FilterHeaderEncoder<'e>(ArrayEncoder<32>);
 }
 
-impl encoding::Encodable for FilterHeader {
+impl encoding::Encode for FilterHeader {
     type Encoder<'e> = FilterHeaderEncoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -122,7 +122,7 @@ impl encoding::Decoder for FilterHashDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for FilterHash {
+impl encoding::Decode for FilterHash {
     type Decoder = FilterHashDecoder;
 
     fn decoder() -> Self::Decoder { FilterHashDecoder(ArrayDecoder::new()) }
@@ -151,7 +151,7 @@ impl encoding::Decoder for FilterHeaderDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for FilterHeader {
+impl encoding::Decode for FilterHeader {
     type Decoder = FilterHeaderDecoder;
 
     fn decoder() -> Self::Decoder { FilterHeaderDecoder(ArrayDecoder::new()) }
@@ -188,7 +188,7 @@ encoding::encoder_newtype_exact! {
     pub struct GetCFiltersEncoder<'e>(Encoder3<ArrayEncoder<1>, BlockHeightEncoder<'e>, BlockHashEncoder<'e>>);
 }
 
-impl encoding::Encodable for GetCFilters {
+impl encoding::Encode for GetCFilters {
     type Encoder<'e> = GetCFiltersEncoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -225,7 +225,7 @@ impl encoding::Decoder for GetCFiltersDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for GetCFilters {
+impl encoding::Decode for GetCFilters {
     type Decoder = GetCFiltersDecoder;
 
     fn decoder() -> Self::Decoder {
@@ -262,7 +262,7 @@ encoding::encoder_newtype_exact! {
     );
 }
 
-impl encoding::Encodable for CFilter {
+impl encoding::Encode for CFilter {
     type Encoder<'e>
         = CFilterEncoder<'e>
     where
@@ -305,7 +305,7 @@ impl encoding::Decoder for CFilterDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for CFilter {
+impl encoding::Decode for CFilter {
     type Decoder = CFilterDecoder;
 
     fn decoder() -> Self::Decoder {
@@ -336,7 +336,7 @@ encoding::encoder_newtype_exact! {
     pub struct GetCFHeadersEncoder<'e>(Encoder3<ArrayEncoder<1>, BlockHeightEncoder<'e>, BlockHashEncoder<'e>>);
 }
 
-impl encoding::Encodable for GetCFHeaders {
+impl encoding::Encode for GetCFHeaders {
     type Encoder<'e> = GetCFHeadersEncoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -373,7 +373,7 @@ impl encoding::Decoder for GetCFHeadersDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for GetCFHeaders {
+impl encoding::Decode for GetCFHeaders {
     type Decoder = GetCFHeadersDecoder;
 
     fn decoder() -> Self::Decoder {
@@ -413,7 +413,7 @@ encoding::encoder_newtype! {
     );
 }
 
-impl encoding::Encodable for CFHeaders {
+impl encoding::Encode for CFHeaders {
     type Encoder<'e> = CFHeadersEncoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -461,7 +461,7 @@ impl encoding::Decoder for CFHeadersDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for CFHeaders {
+impl encoding::Decode for CFHeaders {
     type Decoder = CFHeadersDecoder;
 
     fn decoder() -> Self::Decoder {
@@ -491,7 +491,7 @@ encoding::encoder_newtype_exact! {
     pub struct GetCFCheckptEncoder<'e>(Encoder2<ArrayEncoder<1>, BlockHashEncoder<'e>>);
 }
 
-impl encoding::Encodable for GetCFCheckpt {
+impl encoding::Encode for GetCFCheckpt {
     type Encoder<'e> = GetCFCheckptEncoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -527,7 +527,7 @@ impl encoding::Decoder for GetCFCheckptDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for GetCFCheckpt {
+impl encoding::Decode for GetCFCheckpt {
     type Decoder = GetCFCheckptDecoder;
 
     fn decoder() -> Self::Decoder {
@@ -560,7 +560,7 @@ encoding::encoder_newtype! {
     );
 }
 
-impl encoding::Encodable for CFCheckpt {
+impl encoding::Encode for CFCheckpt {
     type Encoder<'e>
         = CFCheckptEncoder<'e>
     where
@@ -603,7 +603,7 @@ impl encoding::Decoder for CFCheckptDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for CFCheckpt {
+impl encoding::Decode for CFCheckpt {
     type Decoder = CFCheckptDecoder;
 
     fn decoder() -> Self::Decoder {

--- a/p2p/src/message_network.rs
+++ b/p2p/src/message_network.rs
@@ -114,7 +114,7 @@ encoding::encoder_newtype_exact! {
     );
 }
 
-impl encoding::Encodable for VersionMessage {
+impl encoding::Encode for VersionMessage {
     type Encoder<'e>
         = VersionMessageEncoder<'e>
     where
@@ -140,7 +140,7 @@ impl encoding::Encodable for VersionMessage {
     }
 }
 
-impl encoding::Decodable for VersionMessage {
+impl encoding::Decode for VersionMessage {
     type Decoder = VersionMessageDecoder;
 
     #[inline]
@@ -245,7 +245,7 @@ encoding::encoder_newtype_exact! {
     pub struct UserAgentEncoder<'e>(Encoder2<CompactSizeEncoder, BytesEncoder<'e>>);
 }
 
-impl encoding::Encodable for UserAgent {
+impl encoding::Encode for UserAgent {
     type Encoder<'e> = UserAgentEncoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -283,7 +283,7 @@ impl encoding::Decoder for UserAgentDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for UserAgent {
+impl encoding::Decode for UserAgent {
     type Decoder = UserAgentDecoder;
 
     fn decoder() -> Self::Decoder { UserAgentDecoder(UserAgentInnerDecoder::new()) }
@@ -461,7 +461,7 @@ encoding::encoder_newtype_exact! {
     pub struct RejectReasonEncoder<'e>(ArrayEncoder<1>);
 }
 
-impl encoding::Encodable for RejectReason {
+impl encoding::Encode for RejectReason {
     type Encoder<'e> = RejectReasonEncoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -503,7 +503,7 @@ impl encoding::Decoder for RejectReasonDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for RejectReason {
+impl encoding::Decode for RejectReason {
     type Decoder = RejectReasonDecoder;
 
     fn decoder() -> Self::Decoder { RejectReasonDecoder(ArrayDecoder::new()) }
@@ -558,7 +558,7 @@ encoding::encoder_newtype_exact! {
     );
 }
 
-impl encoding::Encodable for Reject {
+impl encoding::Encode for Reject {
     type Encoder<'e> = RejectEncoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -610,7 +610,7 @@ impl encoding::Decoder for RejectDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for Reject {
+impl encoding::Decode for Reject {
     type Decoder = RejectDecoder;
 
     fn decoder() -> Self::Decoder {
@@ -654,7 +654,7 @@ encoding::encoder_newtype_exact! {
     pub struct AlertEncoder<'e>(Encoder2<CompactSizeEncoder, BytesEncoder<'e>>);
 }
 
-impl encoding::Encodable for Alert {
+impl encoding::Encode for Alert {
     type Encoder<'e> = AlertEncoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -689,7 +689,7 @@ impl encoding::Decoder for AlertDecoder {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl encoding::Decodable for Alert {
+impl encoding::Decode for Alert {
     type Decoder = AlertDecoder;
 
     fn decoder() -> Self::Decoder { AlertDecoder(AlertInnerDecoder::new()) }

--- a/primitives/api/all-features.txt
+++ b/primitives/api/all-features.txt
@@ -582,25 +582,25 @@ pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::n
 pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::validate(self) -> core::result::Result<bitcoin_primitives::block::Block<bitcoin_primitives::block::Checked>, bitcoin_primitives::block::error::InvalidBlockError>
 impl<V: bitcoin_primitives::block::Validation> bitcoin_primitives::block::Block<V>
 pub fn bitcoin_primitives::block::Block<V>::block_hash(&self) -> bitcoin_primitives::BlockHash
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>
 pub type bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::Decoder = bitcoin_primitives::block::BlockDecoder
 pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::decoder() -> Self::Decoder
 impl core::convert::From<&bitcoin_primitives::block::Block> for bitcoin_primitives::BlockHash
 pub fn bitcoin_primitives::BlockHash::from(block: &bitcoin_primitives::block::Block) -> Self
 impl core::convert::From<bitcoin_primitives::block::Block> for bitcoin_primitives::BlockHash
 pub fn bitcoin_primitives::BlockHash::from(block: bitcoin_primitives::block::Block) -> Self
-impl core::str::traits::FromStr for bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked> where Self: bitcoin_consensus_encoding::decode::Decodable
+impl core::str::traits::FromStr for bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked> where Self: bitcoin_consensus_encoding::decode::Decode
 pub type bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::Err = bitcoin_primitives::block::error::ParseBlockError
 pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::block::Block
 pub fn bitcoin_primitives::block::Block::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
-impl<V: bitcoin_primitives::block::Validation> core::fmt::Display for bitcoin_primitives::block::Block<V> where Self: bitcoin_consensus_encoding::encode::Encodable
+impl<V: bitcoin_primitives::block::Validation> core::fmt::Display for bitcoin_primitives::block::Block<V> where Self: bitcoin_consensus_encoding::encode::Encode
 pub fn bitcoin_primitives::block::Block<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<V: bitcoin_primitives::block::Validation> core::fmt::LowerHex for bitcoin_primitives::block::Block<V>
 pub fn bitcoin_primitives::block::Block<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<V: bitcoin_primitives::block::Validation> core::fmt::UpperHex for bitcoin_primitives::block::Block<V>
 pub fn bitcoin_primitives::block::Block<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl<V> bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation
+impl<V> bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation
 pub type bitcoin_primitives::block::Block<V>::Encoder<'e> where Self: 'e = bitcoin_consensus_encoding::encode::encoders::Encoder2<bitcoin_primitives::block::HeaderEncoder<'e>, bitcoin_consensus_encoding::encode::encoders::Encoder2<bitcoin_consensus_encoding::compact_size::CompactSizeEncoder, bitcoin_consensus_encoding::encode::encoders::SliceEncoder<'e, bitcoin_primitives::transaction::Transaction>>>
 pub fn bitcoin_primitives::block::Block<V>::encoder(&self) -> Self::Encoder
 impl<V> core::clone::Clone for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::clone::Clone
@@ -776,10 +776,10 @@ impl bitcoin_primitives::BlockHash
 pub const fn bitcoin_primitives::BlockHash::as_byte_array(&self) -> &[u8; 32]
 pub const fn bitcoin_primitives::BlockHash::from_byte_array(bytes: [u8; 32]) -> Self
 pub const fn bitcoin_primitives::BlockHash::to_byte_array(self) -> [u8; 32]
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::BlockHash
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::BlockHash
 pub type bitcoin_primitives::BlockHash::Decoder = bitcoin_primitives::block::BlockHashDecoder
 pub fn bitcoin_primitives::BlockHash::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::BlockHash
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::BlockHash
 pub type bitcoin_primitives::BlockHash::Encoder<'e> = bitcoin_primitives::block::BlockHashEncoder<'e>
 pub fn bitcoin_primitives::BlockHash::encoder(&self) -> Self::Encoder
 impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::BlockHash
@@ -999,10 +999,10 @@ pub bitcoin_primitives::block::Header::version: bitcoin_primitives::block::Versi
 impl bitcoin_primitives::block::Header
 pub const bitcoin_primitives::block::Header::SIZE: usize
 pub fn bitcoin_primitives::block::Header::block_hash(&self) -> bitcoin_primitives::BlockHash
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::block::Header
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::block::Header
 pub type bitcoin_primitives::block::Header::Decoder = bitcoin_primitives::block::HeaderDecoder
 pub fn bitcoin_primitives::block::Header::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::block::Header
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::block::Header
 pub type bitcoin_primitives::block::Header::Encoder<'e> = bitcoin_primitives::block::HeaderEncoder<'e>
 pub fn bitcoin_primitives::block::Header::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::block::Header
@@ -1249,10 +1249,10 @@ pub const bitcoin_primitives::block::Version::TWO: Self
 pub const fn bitcoin_primitives::block::Version::from_consensus(v: i32) -> Self
 pub fn bitcoin_primitives::block::Version::is_signalling_soft_fork(self, bit: u8) -> bool
 pub const fn bitcoin_primitives::block::Version::to_consensus(self) -> i32
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::block::Version
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::block::Version
 pub type bitcoin_primitives::block::Version::Decoder = bitcoin_primitives::block::VersionDecoder
 pub fn bitcoin_primitives::block::Version::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::block::Version
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::block::Version
 pub type bitcoin_primitives::block::Version::Encoder<'e> = bitcoin_primitives::block::VersionEncoder<'e>
 pub fn bitcoin_primitives::block::Version::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::block::Version
@@ -1544,10 +1544,10 @@ impl bitcoin_primitives::merkle_tree::TxMerkleNode
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::calculate_root<I: core::iter::traits::iterator::Iterator<Item = bitcoin_primitives::Txid>>(iter: I) -> core::option::Option<Self>
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::combine(&self, other: &Self) -> Self
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::from_leaf(leaf: bitcoin_primitives::Txid) -> Self
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::merkle_tree::TxMerkleNode
 pub type bitcoin_primitives::merkle_tree::TxMerkleNode::Decoder = bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::merkle_tree::TxMerkleNode
 pub type bitcoin_primitives::merkle_tree::TxMerkleNode::Encoder<'e> = bitcoin_primitives::merkle_tree::TxMerkleNodeEncoder<'e>
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::encoder(&self) -> Self::Encoder
 impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::merkle_tree::TxMerkleNode
@@ -1758,10 +1758,10 @@ impl bitcoin_primitives::merkle_tree::WitnessMerkleNode
 pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::calculate_root<I: core::iter::traits::iterator::Iterator<Item = bitcoin_primitives::Wtxid>>(iter: I) -> core::option::Option<Self>
 pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::combine(&self, other: &Self) -> Self
 pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::from_leaf(leaf: bitcoin_primitives::Wtxid) -> Self
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::merkle_tree::WitnessMerkleNode
 pub type bitcoin_primitives::merkle_tree::WitnessMerkleNode::Decoder = bitcoin_primitives::hash_types::witness_merkle_node::WitnessMerkleNodeDecoder
 pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::merkle_tree::WitnessMerkleNode
 pub type bitcoin_primitives::merkle_tree::WitnessMerkleNode::Encoder<'e> = bitcoin_primitives::hash_types::witness_merkle_node::WitnessMerkleNodeEncoder<'e>
 pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::encoder(&self) -> Self::Encoder
 impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
@@ -2462,7 +2462,7 @@ pub fn bitcoin_primitives::script::Script<T>::hash<__H: core::hash::Hasher>(&sel
 impl<T> alloc::borrow::ToOwned for bitcoin_primitives::script::Script<T>
 pub type bitcoin_primitives::script::Script<T>::Owned = bitcoin_primitives::script::ScriptBuf<T>
 pub fn bitcoin_primitives::script::Script<T>::to_owned(&self) -> Self::Owned
-impl<T> bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::script::Script<T>
+impl<T> bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::script::Script<T>
 pub type bitcoin_primitives::script::Script<T>::Encoder<'e> where Self: 'e = bitcoin_primitives::script::ScriptEncoder<'e>
 pub fn bitcoin_primitives::script::Script<T>::encoder(&self) -> Self::Encoder
 impl<T> core::borrow::Borrow<bitcoin_primitives::script::Script<T>> for bitcoin_primitives::script::ScriptBuf<T>
@@ -2587,7 +2587,7 @@ impl<T: core::cmp::PartialOrd> core::cmp::PartialOrd<bitcoin_primitives::script:
 pub fn bitcoin_primitives::script::Script<T>::partial_cmp(&self, other: &bitcoin_primitives::script::ScriptBuf<T>) -> core::option::Option<core::cmp::Ordering>
 impl<T: core::hash::Hash> core::hash::Hash for bitcoin_primitives::script::ScriptBuf<T>
 pub fn bitcoin_primitives::script::ScriptBuf<T>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
-impl<T> bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::script::ScriptBuf<T>
+impl<T> bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::script::ScriptBuf<T>
 pub type bitcoin_primitives::script::ScriptBuf<T>::Decoder = bitcoin_primitives::script::ScriptBufDecoder<T>
 pub fn bitcoin_primitives::script::ScriptBuf<T>::decoder() -> Self::Decoder
 impl<T> core::borrow::Borrow<bitcoin_primitives::script::Script<T>> for bitcoin_primitives::script::ScriptBuf<T>
@@ -3041,13 +3041,13 @@ pub type bitcoin_primitives::script::WitnessScript = bitcoin_primitives::script:
 pub type bitcoin_primitives::script::WitnessScriptBuf = bitcoin_primitives::script::ScriptBuf<bitcoin_primitives::script::WitnessScriptTag>
 pub mod bitcoin_primitives::serde_as_consensus
 pub mod bitcoin_primitives::serde_as_consensus::opt
-pub fn bitcoin_primitives::serde_as_consensus::opt::deserialize<'d, T, D>(d: D) -> core::result::Result<core::option::Option<T>, <D as serde::de::Deserializer>::Error> where T: bitcoin_consensus_encoding::encode::Encodable + bitcoin_consensus_encoding::decode::Decodable, D: serde::de::Deserializer<'d>
-pub fn bitcoin_primitives::serde_as_consensus::opt::serialize<T, S>(t: &core::option::Option<T>, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where T: bitcoin_consensus_encoding::encode::Encodable + bitcoin_consensus_encoding::decode::Decodable, S: serde::ser::Serializer
+pub fn bitcoin_primitives::serde_as_consensus::opt::deserialize<'d, T, D>(d: D) -> core::result::Result<core::option::Option<T>, <D as serde::de::Deserializer>::Error> where T: bitcoin_consensus_encoding::encode::Encode + bitcoin_consensus_encoding::decode::Decode, D: serde::de::Deserializer<'d>
+pub fn bitcoin_primitives::serde_as_consensus::opt::serialize<T, S>(t: &core::option::Option<T>, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where T: bitcoin_consensus_encoding::encode::Encode + bitcoin_consensus_encoding::decode::Decode, S: serde::ser::Serializer
 pub mod bitcoin_primitives::serde_as_consensus::vec
-pub fn bitcoin_primitives::serde_as_consensus::vec::deserialize<'d, T, D>(d: D) -> core::result::Result<alloc::vec::Vec<T>, <D as serde::de::Deserializer>::Error> where T: bitcoin_consensus_encoding::encode::Encodable + bitcoin_consensus_encoding::decode::Decodable, D: serde::de::Deserializer<'d>
-pub fn bitcoin_primitives::serde_as_consensus::vec::serialize<T, S>(v: &[T], s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where T: bitcoin_consensus_encoding::encode::Encodable + bitcoin_consensus_encoding::decode::Decodable, S: serde::ser::Serializer
-pub fn bitcoin_primitives::serde_as_consensus::deserialize<'d, T, D>(d: D) -> core::result::Result<T, <D as serde::de::Deserializer>::Error> where T: bitcoin_consensus_encoding::encode::Encodable + bitcoin_consensus_encoding::decode::Decodable, D: serde::de::Deserializer<'d>
-pub fn bitcoin_primitives::serde_as_consensus::serialize<T, S>(value: &T, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where T: bitcoin_consensus_encoding::encode::Encodable + bitcoin_consensus_encoding::decode::Decodable, S: serde::ser::Serializer
+pub fn bitcoin_primitives::serde_as_consensus::vec::deserialize<'d, T, D>(d: D) -> core::result::Result<alloc::vec::Vec<T>, <D as serde::de::Deserializer>::Error> where T: bitcoin_consensus_encoding::encode::Encode + bitcoin_consensus_encoding::decode::Decode, D: serde::de::Deserializer<'d>
+pub fn bitcoin_primitives::serde_as_consensus::vec::serialize<T, S>(v: &[T], s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where T: bitcoin_consensus_encoding::encode::Encode + bitcoin_consensus_encoding::decode::Decode, S: serde::ser::Serializer
+pub fn bitcoin_primitives::serde_as_consensus::deserialize<'d, T, D>(d: D) -> core::result::Result<T, <D as serde::de::Deserializer>::Error> where T: bitcoin_consensus_encoding::encode::Encode + bitcoin_consensus_encoding::decode::Decode, D: serde::de::Deserializer<'d>
+pub fn bitcoin_primitives::serde_as_consensus::serialize<T, S>(value: &T, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where T: bitcoin_consensus_encoding::encode::Encode + bitcoin_consensus_encoding::decode::Decode, S: serde::ser::Serializer
 pub mod bitcoin_primitives::transaction
 pub mod bitcoin_primitives::transaction::error
 #[non_exhaustive] pub enum bitcoin_primitives::transaction::error::ParseOutPointError
@@ -3599,10 +3599,10 @@ pub bitcoin_primitives::transaction::OutPoint::vout: u32
 impl bitcoin_primitives::transaction::OutPoint
 pub const bitcoin_primitives::transaction::OutPoint::COINBASE_PREVOUT: Self
 pub const bitcoin_primitives::transaction::OutPoint::SIZE: usize
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::transaction::OutPoint
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::transaction::OutPoint
 pub type bitcoin_primitives::transaction::OutPoint::Decoder = bitcoin_primitives::transaction::OutPointDecoder
 pub fn bitcoin_primitives::transaction::OutPoint::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::transaction::OutPoint
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::transaction::OutPoint
 pub type bitcoin_primitives::transaction::OutPoint::Encoder<'e> where Self: 'e = bitcoin_primitives::transaction::OutPointEncoder<'e>
 pub fn bitcoin_primitives::transaction::OutPoint::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::transaction::OutPoint
@@ -3849,10 +3849,10 @@ pub fn bitcoin_primitives::transaction::Transaction::compute_ntxid(&self) -> bit
 pub fn bitcoin_primitives::transaction::Transaction::compute_txid(&self) -> bitcoin_primitives::Txid
 pub fn bitcoin_primitives::transaction::Transaction::compute_wtxid(&self) -> bitcoin_primitives::Wtxid
 pub fn bitcoin_primitives::transaction::Transaction::is_coinbase(&self) -> bool
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::transaction::Transaction
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::transaction::Transaction
 pub type bitcoin_primitives::transaction::Transaction::Decoder = bitcoin_primitives::transaction::TransactionDecoder
 pub fn bitcoin_primitives::transaction::Transaction::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::transaction::Transaction
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::transaction::Transaction
 pub type bitcoin_primitives::transaction::Transaction::Encoder<'e> where Self: 'e = bitcoin_primitives::transaction::TransactionEncoder<'e>
 pub fn bitcoin_primitives::transaction::Transaction::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::transaction::Transaction
@@ -4053,10 +4053,10 @@ pub bitcoin_primitives::transaction::TxIn::sequence: bitcoin_units::sequence::Se
 pub bitcoin_primitives::transaction::TxIn::witness: bitcoin_primitives::witness::Witness
 impl bitcoin_primitives::transaction::TxIn
 pub const bitcoin_primitives::transaction::TxIn::EMPTY_COINBASE: Self
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::transaction::TxIn
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::transaction::TxIn
 pub type bitcoin_primitives::transaction::TxIn::Decoder = bitcoin_primitives::transaction::TxInDecoder
 pub fn bitcoin_primitives::transaction::TxIn::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::transaction::TxIn
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::transaction::TxIn
 pub type bitcoin_primitives::transaction::TxIn::Encoder<'e> where Self: 'e = bitcoin_consensus_encoding::encode::encoders::Encoder3<bitcoin_primitives::transaction::OutPointEncoder<'e>, bitcoin_primitives::script::ScriptEncoder<'e>, bitcoin_units::sequence::SequenceEncoder<'e>>
 pub fn bitcoin_primitives::transaction::TxIn::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::transaction::TxIn
@@ -4236,10 +4236,10 @@ pub fn bitcoin_primitives::transaction::TxInEncoder<'e>::from(t: T) -> T
 pub struct bitcoin_primitives::transaction::TxOut
 pub bitcoin_primitives::transaction::TxOut::amount: bitcoin_units::amount::unsigned::encapsulate::Amount
 pub bitcoin_primitives::transaction::TxOut::script_pubkey: bitcoin_primitives::script::ScriptPubKeyBuf
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::transaction::TxOut
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::transaction::TxOut
 pub type bitcoin_primitives::transaction::TxOut::Decoder = bitcoin_primitives::transaction::TxOutDecoder
 pub fn bitcoin_primitives::transaction::TxOut::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::transaction::TxOut
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::transaction::TxOut
 pub type bitcoin_primitives::transaction::TxOut::Encoder<'e> where Self: 'e = bitcoin_consensus_encoding::encode::encoders::Encoder2<bitcoin_units::amount::unsigned::AmountEncoder<'e>, bitcoin_primitives::script::ScriptEncoder<'e>>
 pub fn bitcoin_primitives::transaction::TxOut::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::transaction::TxOut
@@ -4505,10 +4505,10 @@ pub const bitcoin_primitives::transaction::Version::TWO: Self
 pub const fn bitcoin_primitives::transaction::Version::is_standard(self) -> bool
 pub const fn bitcoin_primitives::transaction::Version::maybe_non_standard(version: u32) -> Self
 pub const fn bitcoin_primitives::transaction::Version::to_u32(self) -> u32
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::transaction::Version
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::transaction::Version
 pub type bitcoin_primitives::transaction::Version::Decoder = bitcoin_primitives::transaction::VersionDecoder
 pub fn bitcoin_primitives::transaction::Version::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::transaction::Version
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::transaction::Version
 pub type bitcoin_primitives::transaction::Version::Encoder<'e> = bitcoin_primitives::transaction::VersionEncoder<'e>
 pub fn bitcoin_primitives::transaction::Version::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::transaction::Version
@@ -5021,10 +5021,10 @@ pub const fn bitcoin_primitives::witness::Witness::new() -> Self
 pub fn bitcoin_primitives::witness::Witness::push<T: core::convert::AsRef<[u8]>>(&mut self, new_element: T)
 pub fn bitcoin_primitives::witness::Witness::size(&self) -> usize
 pub fn bitcoin_primitives::witness::Witness::to_vec(&self) -> alloc::vec::Vec<alloc::vec::Vec<u8>>
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::witness::Witness
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::witness::Witness
 pub type bitcoin_primitives::witness::Witness::Decoder = bitcoin_primitives::witness::WitnessDecoder
 pub fn bitcoin_primitives::witness::Witness::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::witness::Witness
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::witness::Witness
 pub type bitcoin_primitives::witness::Witness::Encoder<'e> where Self: 'e = bitcoin_primitives::witness::WitnessEncoder<'e>
 pub fn bitcoin_primitives::witness::Witness::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::witness::Witness
@@ -5379,25 +5379,25 @@ pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::n
 pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::validate(self) -> core::result::Result<bitcoin_primitives::block::Block<bitcoin_primitives::block::Checked>, bitcoin_primitives::block::error::InvalidBlockError>
 impl<V: bitcoin_primitives::block::Validation> bitcoin_primitives::block::Block<V>
 pub fn bitcoin_primitives::block::Block<V>::block_hash(&self) -> bitcoin_primitives::BlockHash
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>
 pub type bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::Decoder = bitcoin_primitives::block::BlockDecoder
 pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::decoder() -> Self::Decoder
 impl core::convert::From<&bitcoin_primitives::block::Block> for bitcoin_primitives::BlockHash
 pub fn bitcoin_primitives::BlockHash::from(block: &bitcoin_primitives::block::Block) -> Self
 impl core::convert::From<bitcoin_primitives::block::Block> for bitcoin_primitives::BlockHash
 pub fn bitcoin_primitives::BlockHash::from(block: bitcoin_primitives::block::Block) -> Self
-impl core::str::traits::FromStr for bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked> where Self: bitcoin_consensus_encoding::decode::Decodable
+impl core::str::traits::FromStr for bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked> where Self: bitcoin_consensus_encoding::decode::Decode
 pub type bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::Err = bitcoin_primitives::block::error::ParseBlockError
 pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::block::Block
 pub fn bitcoin_primitives::block::Block::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
-impl<V: bitcoin_primitives::block::Validation> core::fmt::Display for bitcoin_primitives::block::Block<V> where Self: bitcoin_consensus_encoding::encode::Encodable
+impl<V: bitcoin_primitives::block::Validation> core::fmt::Display for bitcoin_primitives::block::Block<V> where Self: bitcoin_consensus_encoding::encode::Encode
 pub fn bitcoin_primitives::block::Block<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<V: bitcoin_primitives::block::Validation> core::fmt::LowerHex for bitcoin_primitives::block::Block<V>
 pub fn bitcoin_primitives::block::Block<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<V: bitcoin_primitives::block::Validation> core::fmt::UpperHex for bitcoin_primitives::block::Block<V>
 pub fn bitcoin_primitives::block::Block<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl<V> bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation
+impl<V> bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation
 pub type bitcoin_primitives::block::Block<V>::Encoder<'e> where Self: 'e = bitcoin_consensus_encoding::encode::encoders::Encoder2<bitcoin_primitives::block::HeaderEncoder<'e>, bitcoin_consensus_encoding::encode::encoders::Encoder2<bitcoin_consensus_encoding::compact_size::CompactSizeEncoder, bitcoin_consensus_encoding::encode::encoders::SliceEncoder<'e, bitcoin_primitives::transaction::Transaction>>>
 pub fn bitcoin_primitives::block::Block<V>::encoder(&self) -> Self::Encoder
 impl<V> core::clone::Clone for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::clone::Clone
@@ -5446,10 +5446,10 @@ impl bitcoin_primitives::BlockHash
 pub const fn bitcoin_primitives::BlockHash::as_byte_array(&self) -> &[u8; 32]
 pub const fn bitcoin_primitives::BlockHash::from_byte_array(bytes: [u8; 32]) -> Self
 pub const fn bitcoin_primitives::BlockHash::to_byte_array(self) -> [u8; 32]
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::BlockHash
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::BlockHash
 pub type bitcoin_primitives::BlockHash::Decoder = bitcoin_primitives::block::BlockHashDecoder
 pub fn bitcoin_primitives::BlockHash::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::BlockHash
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::BlockHash
 pub type bitcoin_primitives::BlockHash::Encoder<'e> = bitcoin_primitives::block::BlockHashEncoder<'e>
 pub fn bitcoin_primitives::BlockHash::encoder(&self) -> Self::Encoder
 impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::BlockHash
@@ -5540,10 +5540,10 @@ pub bitcoin_primitives::BlockHeader::version: bitcoin_primitives::block::Version
 impl bitcoin_primitives::block::Header
 pub const bitcoin_primitives::block::Header::SIZE: usize
 pub fn bitcoin_primitives::block::Header::block_hash(&self) -> bitcoin_primitives::BlockHash
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::block::Header
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::block::Header
 pub type bitcoin_primitives::block::Header::Decoder = bitcoin_primitives::block::HeaderDecoder
 pub fn bitcoin_primitives::block::Header::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::block::Header
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::block::Header
 pub type bitcoin_primitives::block::Header::Encoder<'e> = bitcoin_primitives::block::HeaderEncoder<'e>
 pub fn bitcoin_primitives::block::Header::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::block::Header
@@ -5615,10 +5615,10 @@ pub const bitcoin_primitives::block::Version::TWO: Self
 pub const fn bitcoin_primitives::block::Version::from_consensus(v: i32) -> Self
 pub fn bitcoin_primitives::block::Version::is_signalling_soft_fork(self, bit: u8) -> bool
 pub const fn bitcoin_primitives::block::Version::to_consensus(self) -> i32
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::block::Version
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::block::Version
 pub type bitcoin_primitives::block::Version::Decoder = bitcoin_primitives::block::VersionDecoder
 pub fn bitcoin_primitives::block::Version::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::block::Version
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::block::Version
 pub type bitcoin_primitives::block::Version::Encoder<'e> = bitcoin_primitives::block::VersionEncoder<'e>
 pub fn bitcoin_primitives::block::Version::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::block::Version
@@ -5692,10 +5692,10 @@ pub bitcoin_primitives::OutPoint::vout: u32
 impl bitcoin_primitives::transaction::OutPoint
 pub const bitcoin_primitives::transaction::OutPoint::COINBASE_PREVOUT: Self
 pub const bitcoin_primitives::transaction::OutPoint::SIZE: usize
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::transaction::OutPoint
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::transaction::OutPoint
 pub type bitcoin_primitives::transaction::OutPoint::Decoder = bitcoin_primitives::transaction::OutPointDecoder
 pub fn bitcoin_primitives::transaction::OutPoint::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::transaction::OutPoint
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::transaction::OutPoint
 pub type bitcoin_primitives::transaction::OutPoint::Encoder<'e> where Self: 'e = bitcoin_primitives::transaction::OutPointEncoder<'e>
 pub fn bitcoin_primitives::transaction::OutPoint::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::transaction::OutPoint
@@ -5767,10 +5767,10 @@ pub fn bitcoin_primitives::transaction::Transaction::compute_ntxid(&self) -> bit
 pub fn bitcoin_primitives::transaction::Transaction::compute_txid(&self) -> bitcoin_primitives::Txid
 pub fn bitcoin_primitives::transaction::Transaction::compute_wtxid(&self) -> bitcoin_primitives::Wtxid
 pub fn bitcoin_primitives::transaction::Transaction::is_coinbase(&self) -> bool
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::transaction::Transaction
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::transaction::Transaction
 pub type bitcoin_primitives::transaction::Transaction::Decoder = bitcoin_primitives::transaction::TransactionDecoder
 pub fn bitcoin_primitives::transaction::Transaction::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::transaction::Transaction
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::transaction::Transaction
 pub type bitcoin_primitives::transaction::Transaction::Encoder<'e> where Self: 'e = bitcoin_primitives::transaction::TransactionEncoder<'e>
 pub fn bitcoin_primitives::transaction::Transaction::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::transaction::Transaction
@@ -5845,10 +5845,10 @@ pub const bitcoin_primitives::transaction::Version::TWO: Self
 pub const fn bitcoin_primitives::transaction::Version::is_standard(self) -> bool
 pub const fn bitcoin_primitives::transaction::Version::maybe_non_standard(version: u32) -> Self
 pub const fn bitcoin_primitives::transaction::Version::to_u32(self) -> u32
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::transaction::Version
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::transaction::Version
 pub type bitcoin_primitives::transaction::Version::Decoder = bitcoin_primitives::transaction::VersionDecoder
 pub fn bitcoin_primitives::transaction::Version::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::transaction::Version
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::transaction::Version
 pub type bitcoin_primitives::transaction::Version::Encoder<'e> = bitcoin_primitives::transaction::VersionEncoder<'e>
 pub fn bitcoin_primitives::transaction::Version::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::transaction::Version
@@ -5923,10 +5923,10 @@ pub bitcoin_primitives::TxIn::sequence: bitcoin_units::sequence::Sequence
 pub bitcoin_primitives::TxIn::witness: bitcoin_primitives::witness::Witness
 impl bitcoin_primitives::transaction::TxIn
 pub const bitcoin_primitives::transaction::TxIn::EMPTY_COINBASE: Self
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::transaction::TxIn
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::transaction::TxIn
 pub type bitcoin_primitives::transaction::TxIn::Decoder = bitcoin_primitives::transaction::TxInDecoder
 pub fn bitcoin_primitives::transaction::TxIn::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::transaction::TxIn
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::transaction::TxIn
 pub type bitcoin_primitives::transaction::TxIn::Encoder<'e> where Self: 'e = bitcoin_consensus_encoding::encode::encoders::Encoder3<bitcoin_primitives::transaction::OutPointEncoder<'e>, bitcoin_primitives::script::ScriptEncoder<'e>, bitcoin_units::sequence::SequenceEncoder<'e>>
 pub fn bitcoin_primitives::transaction::TxIn::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::transaction::TxIn
@@ -5977,10 +5977,10 @@ pub fn bitcoin_primitives::transaction::TxIn::from(t: T) -> T
 pub struct bitcoin_primitives::TxOut
 pub bitcoin_primitives::TxOut::amount: bitcoin_units::amount::unsigned::encapsulate::Amount
 pub bitcoin_primitives::TxOut::script_pubkey: bitcoin_primitives::script::ScriptPubKeyBuf
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::transaction::TxOut
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::transaction::TxOut
 pub type bitcoin_primitives::transaction::TxOut::Decoder = bitcoin_primitives::transaction::TxOutDecoder
 pub fn bitcoin_primitives::transaction::TxOut::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::transaction::TxOut
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::transaction::TxOut
 pub type bitcoin_primitives::transaction::TxOut::Encoder<'e> where Self: 'e = bitcoin_consensus_encoding::encode::encoders::Encoder2<bitcoin_units::amount::unsigned::AmountEncoder<'e>, bitcoin_primitives::script::ScriptEncoder<'e>>
 pub fn bitcoin_primitives::transaction::TxOut::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::transaction::TxOut
@@ -6124,10 +6124,10 @@ pub const fn bitcoin_primitives::witness::Witness::new() -> Self
 pub fn bitcoin_primitives::witness::Witness::push<T: core::convert::AsRef<[u8]>>(&mut self, new_element: T)
 pub fn bitcoin_primitives::witness::Witness::size(&self) -> usize
 pub fn bitcoin_primitives::witness::Witness::to_vec(&self) -> alloc::vec::Vec<alloc::vec::Vec<u8>>
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::witness::Witness
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::witness::Witness
 pub type bitcoin_primitives::witness::Witness::Decoder = bitcoin_primitives::witness::WitnessDecoder
 pub fn bitcoin_primitives::witness::Witness::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::witness::Witness
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::witness::Witness
 pub type bitcoin_primitives::witness::Witness::Encoder<'e> where Self: 'e = bitcoin_primitives::witness::WitnessEncoder<'e>
 pub fn bitcoin_primitives::witness::Witness::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::witness::Witness

--- a/primitives/api/alloc-only.txt
+++ b/primitives/api/alloc-only.txt
@@ -473,14 +473,14 @@ pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::n
 pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::validate(self) -> core::result::Result<bitcoin_primitives::block::Block<bitcoin_primitives::block::Checked>, bitcoin_primitives::block::error::InvalidBlockError>
 impl<V: bitcoin_primitives::block::Validation> bitcoin_primitives::block::Block<V>
 pub fn bitcoin_primitives::block::Block<V>::block_hash(&self) -> bitcoin_primitives::BlockHash
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>
 pub type bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::Decoder = bitcoin_primitives::block::BlockDecoder
 pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::decoder() -> Self::Decoder
 impl core::convert::From<&bitcoin_primitives::block::Block> for bitcoin_primitives::BlockHash
 pub fn bitcoin_primitives::BlockHash::from(block: &bitcoin_primitives::block::Block) -> Self
 impl core::convert::From<bitcoin_primitives::block::Block> for bitcoin_primitives::BlockHash
 pub fn bitcoin_primitives::BlockHash::from(block: bitcoin_primitives::block::Block) -> Self
-impl<V> bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation
+impl<V> bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation
 pub type bitcoin_primitives::block::Block<V>::Encoder<'e> where Self: 'e = bitcoin_consensus_encoding::encode::encoders::Encoder2<bitcoin_primitives::block::HeaderEncoder<'e>, bitcoin_consensus_encoding::encode::encoders::Encoder2<bitcoin_consensus_encoding::compact_size::CompactSizeEncoder, bitcoin_consensus_encoding::encode::encoders::SliceEncoder<'e, bitcoin_primitives::transaction::Transaction>>>
 pub fn bitcoin_primitives::block::Block<V>::encoder(&self) -> Self::Encoder
 impl<V> core::clone::Clone for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::clone::Clone
@@ -652,10 +652,10 @@ impl bitcoin_primitives::BlockHash
 pub const fn bitcoin_primitives::BlockHash::as_byte_array(&self) -> &[u8; 32]
 pub const fn bitcoin_primitives::BlockHash::from_byte_array(bytes: [u8; 32]) -> Self
 pub const fn bitcoin_primitives::BlockHash::to_byte_array(self) -> [u8; 32]
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::BlockHash
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::BlockHash
 pub type bitcoin_primitives::BlockHash::Decoder = bitcoin_primitives::block::BlockHashDecoder
 pub fn bitcoin_primitives::BlockHash::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::BlockHash
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::BlockHash
 pub type bitcoin_primitives::BlockHash::Encoder<'e> = bitcoin_primitives::block::BlockHashEncoder<'e>
 pub fn bitcoin_primitives::BlockHash::encoder(&self) -> Self::Encoder
 impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::BlockHash
@@ -855,10 +855,10 @@ pub bitcoin_primitives::block::Header::version: bitcoin_primitives::block::Versi
 impl bitcoin_primitives::block::Header
 pub const bitcoin_primitives::block::Header::SIZE: usize
 pub fn bitcoin_primitives::block::Header::block_hash(&self) -> bitcoin_primitives::BlockHash
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::block::Header
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::block::Header
 pub type bitcoin_primitives::block::Header::Decoder = bitcoin_primitives::block::HeaderDecoder
 pub fn bitcoin_primitives::block::Header::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::block::Header
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::block::Header
 pub type bitcoin_primitives::block::Header::Encoder<'e> = bitcoin_primitives::block::HeaderEncoder<'e>
 pub fn bitcoin_primitives::block::Header::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::block::Header
@@ -1000,10 +1000,10 @@ pub const bitcoin_primitives::block::Version::TWO: Self
 pub const fn bitcoin_primitives::block::Version::from_consensus(v: i32) -> Self
 pub fn bitcoin_primitives::block::Version::is_signalling_soft_fork(self, bit: u8) -> bool
 pub const fn bitcoin_primitives::block::Version::to_consensus(self) -> i32
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::block::Version
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::block::Version
 pub type bitcoin_primitives::block::Version::Decoder = bitcoin_primitives::block::VersionDecoder
 pub fn bitcoin_primitives::block::Version::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::block::Version
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::block::Version
 pub type bitcoin_primitives::block::Version::Encoder<'e> = bitcoin_primitives::block::VersionEncoder<'e>
 pub fn bitcoin_primitives::block::Version::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::block::Version
@@ -1268,10 +1268,10 @@ impl bitcoin_primitives::merkle_tree::TxMerkleNode
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::calculate_root<I: core::iter::traits::iterator::Iterator<Item = bitcoin_primitives::Txid>>(iter: I) -> core::option::Option<Self>
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::combine(&self, other: &Self) -> Self
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::from_leaf(leaf: bitcoin_primitives::Txid) -> Self
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::merkle_tree::TxMerkleNode
 pub type bitcoin_primitives::merkle_tree::TxMerkleNode::Decoder = bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::merkle_tree::TxMerkleNode
 pub type bitcoin_primitives::merkle_tree::TxMerkleNode::Encoder<'e> = bitcoin_primitives::merkle_tree::TxMerkleNodeEncoder<'e>
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::encoder(&self) -> Self::Encoder
 impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::merkle_tree::TxMerkleNode
@@ -1462,10 +1462,10 @@ impl bitcoin_primitives::merkle_tree::WitnessMerkleNode
 pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::calculate_root<I: core::iter::traits::iterator::Iterator<Item = bitcoin_primitives::Wtxid>>(iter: I) -> core::option::Option<Self>
 pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::combine(&self, other: &Self) -> Self
 pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::from_leaf(leaf: bitcoin_primitives::Wtxid) -> Self
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::merkle_tree::WitnessMerkleNode
 pub type bitcoin_primitives::merkle_tree::WitnessMerkleNode::Decoder = bitcoin_primitives::hash_types::witness_merkle_node::WitnessMerkleNodeDecoder
 pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::merkle_tree::WitnessMerkleNode
 pub type bitcoin_primitives::merkle_tree::WitnessMerkleNode::Encoder<'e> = bitcoin_primitives::hash_types::witness_merkle_node::WitnessMerkleNodeEncoder<'e>
 pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::encoder(&self) -> Self::Encoder
 impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
@@ -2029,7 +2029,7 @@ pub fn bitcoin_primitives::script::Script<T>::hash<__H: core::hash::Hasher>(&sel
 impl<T> alloc::borrow::ToOwned for bitcoin_primitives::script::Script<T>
 pub type bitcoin_primitives::script::Script<T>::Owned = bitcoin_primitives::script::ScriptBuf<T>
 pub fn bitcoin_primitives::script::Script<T>::to_owned(&self) -> Self::Owned
-impl<T> bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::script::Script<T>
+impl<T> bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::script::Script<T>
 pub type bitcoin_primitives::script::Script<T>::Encoder<'e> where Self: 'e = bitcoin_primitives::script::ScriptEncoder<'e>
 pub fn bitcoin_primitives::script::Script<T>::encoder(&self) -> Self::Encoder
 impl<T> core::borrow::Borrow<bitcoin_primitives::script::Script<T>> for bitcoin_primitives::script::ScriptBuf<T>
@@ -2141,7 +2141,7 @@ impl<T: core::cmp::PartialOrd> core::cmp::PartialOrd<bitcoin_primitives::script:
 pub fn bitcoin_primitives::script::Script<T>::partial_cmp(&self, other: &bitcoin_primitives::script::ScriptBuf<T>) -> core::option::Option<core::cmp::Ordering>
 impl<T: core::hash::Hash> core::hash::Hash for bitcoin_primitives::script::ScriptBuf<T>
 pub fn bitcoin_primitives::script::ScriptBuf<T>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
-impl<T> bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::script::ScriptBuf<T>
+impl<T> bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::script::ScriptBuf<T>
 pub type bitcoin_primitives::script::ScriptBuf<T>::Decoder = bitcoin_primitives::script::ScriptBufDecoder<T>
 pub fn bitcoin_primitives::script::ScriptBuf<T>::decoder() -> Self::Decoder
 impl<T> core::borrow::Borrow<bitcoin_primitives::script::Script<T>> for bitcoin_primitives::script::ScriptBuf<T>
@@ -2919,10 +2919,10 @@ pub bitcoin_primitives::transaction::OutPoint::vout: u32
 impl bitcoin_primitives::transaction::OutPoint
 pub const bitcoin_primitives::transaction::OutPoint::COINBASE_PREVOUT: Self
 pub const bitcoin_primitives::transaction::OutPoint::SIZE: usize
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::transaction::OutPoint
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::transaction::OutPoint
 pub type bitcoin_primitives::transaction::OutPoint::Decoder = bitcoin_primitives::transaction::OutPointDecoder
 pub fn bitcoin_primitives::transaction::OutPoint::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::transaction::OutPoint
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::transaction::OutPoint
 pub type bitcoin_primitives::transaction::OutPoint::Encoder<'e> where Self: 'e = bitcoin_primitives::transaction::OutPointEncoder<'e>
 pub fn bitcoin_primitives::transaction::OutPoint::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::transaction::OutPoint
@@ -3107,10 +3107,10 @@ pub fn bitcoin_primitives::transaction::Transaction::compute_ntxid(&self) -> bit
 pub fn bitcoin_primitives::transaction::Transaction::compute_txid(&self) -> bitcoin_primitives::Txid
 pub fn bitcoin_primitives::transaction::Transaction::compute_wtxid(&self) -> bitcoin_primitives::Wtxid
 pub fn bitcoin_primitives::transaction::Transaction::is_coinbase(&self) -> bool
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::transaction::Transaction
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::transaction::Transaction
 pub type bitcoin_primitives::transaction::Transaction::Decoder = bitcoin_primitives::transaction::TransactionDecoder
 pub fn bitcoin_primitives::transaction::Transaction::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::transaction::Transaction
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::transaction::Transaction
 pub type bitcoin_primitives::transaction::Transaction::Encoder<'e> where Self: 'e = bitcoin_primitives::transaction::TransactionEncoder<'e>
 pub fn bitcoin_primitives::transaction::Transaction::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::transaction::Transaction
@@ -3296,10 +3296,10 @@ pub bitcoin_primitives::transaction::TxIn::sequence: bitcoin_units::sequence::Se
 pub bitcoin_primitives::transaction::TxIn::witness: bitcoin_primitives::witness::Witness
 impl bitcoin_primitives::transaction::TxIn
 pub const bitcoin_primitives::transaction::TxIn::EMPTY_COINBASE: Self
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::transaction::TxIn
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::transaction::TxIn
 pub type bitcoin_primitives::transaction::TxIn::Decoder = bitcoin_primitives::transaction::TxInDecoder
 pub fn bitcoin_primitives::transaction::TxIn::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::transaction::TxIn
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::transaction::TxIn
 pub type bitcoin_primitives::transaction::TxIn::Encoder<'e> where Self: 'e = bitcoin_consensus_encoding::encode::encoders::Encoder3<bitcoin_primitives::transaction::OutPointEncoder<'e>, bitcoin_primitives::script::ScriptEncoder<'e>, bitcoin_units::sequence::SequenceEncoder<'e>>
 pub fn bitcoin_primitives::transaction::TxIn::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::transaction::TxIn
@@ -3475,10 +3475,10 @@ pub fn bitcoin_primitives::transaction::TxInEncoder<'e>::from(t: T) -> T
 pub struct bitcoin_primitives::transaction::TxOut
 pub bitcoin_primitives::transaction::TxOut::amount: bitcoin_units::amount::unsigned::encapsulate::Amount
 pub bitcoin_primitives::transaction::TxOut::script_pubkey: bitcoin_primitives::script::ScriptPubKeyBuf
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::transaction::TxOut
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::transaction::TxOut
 pub type bitcoin_primitives::transaction::TxOut::Decoder = bitcoin_primitives::transaction::TxOutDecoder
 pub fn bitcoin_primitives::transaction::TxOut::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::transaction::TxOut
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::transaction::TxOut
 pub type bitcoin_primitives::transaction::TxOut::Encoder<'e> where Self: 'e = bitcoin_consensus_encoding::encode::encoders::Encoder2<bitcoin_units::amount::unsigned::AmountEncoder<'e>, bitcoin_primitives::script::ScriptEncoder<'e>>
 pub fn bitcoin_primitives::transaction::TxOut::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::transaction::TxOut
@@ -3722,10 +3722,10 @@ pub const bitcoin_primitives::transaction::Version::TWO: Self
 pub const fn bitcoin_primitives::transaction::Version::is_standard(self) -> bool
 pub const fn bitcoin_primitives::transaction::Version::maybe_non_standard(version: u32) -> Self
 pub const fn bitcoin_primitives::transaction::Version::to_u32(self) -> u32
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::transaction::Version
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::transaction::Version
 pub type bitcoin_primitives::transaction::Version::Decoder = bitcoin_primitives::transaction::VersionDecoder
 pub fn bitcoin_primitives::transaction::Version::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::transaction::Version
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::transaction::Version
 pub type bitcoin_primitives::transaction::Version::Encoder<'e> = bitcoin_primitives::transaction::VersionEncoder<'e>
 pub fn bitcoin_primitives::transaction::Version::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::transaction::Version
@@ -4204,10 +4204,10 @@ pub const fn bitcoin_primitives::witness::Witness::new() -> Self
 pub fn bitcoin_primitives::witness::Witness::push<T: core::convert::AsRef<[u8]>>(&mut self, new_element: T)
 pub fn bitcoin_primitives::witness::Witness::size(&self) -> usize
 pub fn bitcoin_primitives::witness::Witness::to_vec(&self) -> alloc::vec::Vec<alloc::vec::Vec<u8>>
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::witness::Witness
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::witness::Witness
 pub type bitcoin_primitives::witness::Witness::Decoder = bitcoin_primitives::witness::WitnessDecoder
 pub fn bitcoin_primitives::witness::Witness::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::witness::Witness
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::witness::Witness
 pub type bitcoin_primitives::witness::Witness::Encoder<'e> where Self: 'e = bitcoin_primitives::witness::WitnessEncoder<'e>
 pub fn bitcoin_primitives::witness::Witness::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::witness::Witness
@@ -4553,14 +4553,14 @@ pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::n
 pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::validate(self) -> core::result::Result<bitcoin_primitives::block::Block<bitcoin_primitives::block::Checked>, bitcoin_primitives::block::error::InvalidBlockError>
 impl<V: bitcoin_primitives::block::Validation> bitcoin_primitives::block::Block<V>
 pub fn bitcoin_primitives::block::Block<V>::block_hash(&self) -> bitcoin_primitives::BlockHash
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>
 pub type bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::Decoder = bitcoin_primitives::block::BlockDecoder
 pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::decoder() -> Self::Decoder
 impl core::convert::From<&bitcoin_primitives::block::Block> for bitcoin_primitives::BlockHash
 pub fn bitcoin_primitives::BlockHash::from(block: &bitcoin_primitives::block::Block) -> Self
 impl core::convert::From<bitcoin_primitives::block::Block> for bitcoin_primitives::BlockHash
 pub fn bitcoin_primitives::BlockHash::from(block: bitcoin_primitives::block::Block) -> Self
-impl<V> bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation
+impl<V> bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation
 pub type bitcoin_primitives::block::Block<V>::Encoder<'e> where Self: 'e = bitcoin_consensus_encoding::encode::encoders::Encoder2<bitcoin_primitives::block::HeaderEncoder<'e>, bitcoin_consensus_encoding::encode::encoders::Encoder2<bitcoin_consensus_encoding::compact_size::CompactSizeEncoder, bitcoin_consensus_encoding::encode::encoders::SliceEncoder<'e, bitcoin_primitives::transaction::Transaction>>>
 pub fn bitcoin_primitives::block::Block<V>::encoder(&self) -> Self::Encoder
 impl<V> core::clone::Clone for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::clone::Clone
@@ -4607,10 +4607,10 @@ impl bitcoin_primitives::BlockHash
 pub const fn bitcoin_primitives::BlockHash::as_byte_array(&self) -> &[u8; 32]
 pub const fn bitcoin_primitives::BlockHash::from_byte_array(bytes: [u8; 32]) -> Self
 pub const fn bitcoin_primitives::BlockHash::to_byte_array(self) -> [u8; 32]
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::BlockHash
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::BlockHash
 pub type bitcoin_primitives::BlockHash::Decoder = bitcoin_primitives::block::BlockHashDecoder
 pub fn bitcoin_primitives::BlockHash::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::BlockHash
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::BlockHash
 pub type bitcoin_primitives::BlockHash::Encoder<'e> = bitcoin_primitives::block::BlockHashEncoder<'e>
 pub fn bitcoin_primitives::BlockHash::encoder(&self) -> Self::Encoder
 impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::BlockHash
@@ -4683,10 +4683,10 @@ pub bitcoin_primitives::BlockHeader::version: bitcoin_primitives::block::Version
 impl bitcoin_primitives::block::Header
 pub const bitcoin_primitives::block::Header::SIZE: usize
 pub fn bitcoin_primitives::block::Header::block_hash(&self) -> bitcoin_primitives::BlockHash
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::block::Header
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::block::Header
 pub type bitcoin_primitives::block::Header::Decoder = bitcoin_primitives::block::HeaderDecoder
 pub fn bitcoin_primitives::block::Header::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::block::Header
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::block::Header
 pub type bitcoin_primitives::block::Header::Encoder<'e> = bitcoin_primitives::block::HeaderEncoder<'e>
 pub fn bitcoin_primitives::block::Header::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::block::Header
@@ -4745,10 +4745,10 @@ pub const bitcoin_primitives::block::Version::TWO: Self
 pub const fn bitcoin_primitives::block::Version::from_consensus(v: i32) -> Self
 pub fn bitcoin_primitives::block::Version::is_signalling_soft_fork(self, bit: u8) -> bool
 pub const fn bitcoin_primitives::block::Version::to_consensus(self) -> i32
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::block::Version
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::block::Version
 pub type bitcoin_primitives::block::Version::Decoder = bitcoin_primitives::block::VersionDecoder
 pub fn bitcoin_primitives::block::Version::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::block::Version
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::block::Version
 pub type bitcoin_primitives::block::Version::Encoder<'e> = bitcoin_primitives::block::VersionEncoder<'e>
 pub fn bitcoin_primitives::block::Version::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::block::Version
@@ -4815,10 +4815,10 @@ pub bitcoin_primitives::OutPoint::vout: u32
 impl bitcoin_primitives::transaction::OutPoint
 pub const bitcoin_primitives::transaction::OutPoint::COINBASE_PREVOUT: Self
 pub const bitcoin_primitives::transaction::OutPoint::SIZE: usize
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::transaction::OutPoint
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::transaction::OutPoint
 pub type bitcoin_primitives::transaction::OutPoint::Decoder = bitcoin_primitives::transaction::OutPointDecoder
 pub fn bitcoin_primitives::transaction::OutPoint::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::transaction::OutPoint
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::transaction::OutPoint
 pub type bitcoin_primitives::transaction::OutPoint::Encoder<'e> where Self: 'e = bitcoin_primitives::transaction::OutPointEncoder<'e>
 pub fn bitcoin_primitives::transaction::OutPoint::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::transaction::OutPoint
@@ -4876,10 +4876,10 @@ pub fn bitcoin_primitives::transaction::Transaction::compute_ntxid(&self) -> bit
 pub fn bitcoin_primitives::transaction::Transaction::compute_txid(&self) -> bitcoin_primitives::Txid
 pub fn bitcoin_primitives::transaction::Transaction::compute_wtxid(&self) -> bitcoin_primitives::Wtxid
 pub fn bitcoin_primitives::transaction::Transaction::is_coinbase(&self) -> bool
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::transaction::Transaction
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::transaction::Transaction
 pub type bitcoin_primitives::transaction::Transaction::Decoder = bitcoin_primitives::transaction::TransactionDecoder
 pub fn bitcoin_primitives::transaction::Transaction::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::transaction::Transaction
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::transaction::Transaction
 pub type bitcoin_primitives::transaction::Transaction::Encoder<'e> where Self: 'e = bitcoin_primitives::transaction::TransactionEncoder<'e>
 pub fn bitcoin_primitives::transaction::Transaction::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::transaction::Transaction
@@ -4941,10 +4941,10 @@ pub const bitcoin_primitives::transaction::Version::TWO: Self
 pub const fn bitcoin_primitives::transaction::Version::is_standard(self) -> bool
 pub const fn bitcoin_primitives::transaction::Version::maybe_non_standard(version: u32) -> Self
 pub const fn bitcoin_primitives::transaction::Version::to_u32(self) -> u32
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::transaction::Version
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::transaction::Version
 pub type bitcoin_primitives::transaction::Version::Decoder = bitcoin_primitives::transaction::VersionDecoder
 pub fn bitcoin_primitives::transaction::Version::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::transaction::Version
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::transaction::Version
 pub type bitcoin_primitives::transaction::Version::Encoder<'e> = bitcoin_primitives::transaction::VersionEncoder<'e>
 pub fn bitcoin_primitives::transaction::Version::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::transaction::Version
@@ -5012,10 +5012,10 @@ pub bitcoin_primitives::TxIn::sequence: bitcoin_units::sequence::Sequence
 pub bitcoin_primitives::TxIn::witness: bitcoin_primitives::witness::Witness
 impl bitcoin_primitives::transaction::TxIn
 pub const bitcoin_primitives::transaction::TxIn::EMPTY_COINBASE: Self
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::transaction::TxIn
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::transaction::TxIn
 pub type bitcoin_primitives::transaction::TxIn::Decoder = bitcoin_primitives::transaction::TxInDecoder
 pub fn bitcoin_primitives::transaction::TxIn::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::transaction::TxIn
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::transaction::TxIn
 pub type bitcoin_primitives::transaction::TxIn::Encoder<'e> where Self: 'e = bitcoin_consensus_encoding::encode::encoders::Encoder3<bitcoin_primitives::transaction::OutPointEncoder<'e>, bitcoin_primitives::script::ScriptEncoder<'e>, bitcoin_units::sequence::SequenceEncoder<'e>>
 pub fn bitcoin_primitives::transaction::TxIn::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::transaction::TxIn
@@ -5064,10 +5064,10 @@ pub fn bitcoin_primitives::transaction::TxIn::from(t: T) -> T
 pub struct bitcoin_primitives::TxOut
 pub bitcoin_primitives::TxOut::amount: bitcoin_units::amount::unsigned::encapsulate::Amount
 pub bitcoin_primitives::TxOut::script_pubkey: bitcoin_primitives::script::ScriptPubKeyBuf
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::transaction::TxOut
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::transaction::TxOut
 pub type bitcoin_primitives::transaction::TxOut::Decoder = bitcoin_primitives::transaction::TxOutDecoder
 pub fn bitcoin_primitives::transaction::TxOut::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::transaction::TxOut
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::transaction::TxOut
 pub type bitcoin_primitives::transaction::TxOut::Encoder<'e> where Self: 'e = bitcoin_consensus_encoding::encode::encoders::Encoder2<bitcoin_units::amount::unsigned::AmountEncoder<'e>, bitcoin_primitives::script::ScriptEncoder<'e>>
 pub fn bitcoin_primitives::transaction::TxOut::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::transaction::TxOut
@@ -5190,10 +5190,10 @@ pub const fn bitcoin_primitives::witness::Witness::new() -> Self
 pub fn bitcoin_primitives::witness::Witness::push<T: core::convert::AsRef<[u8]>>(&mut self, new_element: T)
 pub fn bitcoin_primitives::witness::Witness::size(&self) -> usize
 pub fn bitcoin_primitives::witness::Witness::to_vec(&self) -> alloc::vec::Vec<alloc::vec::Vec<u8>>
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::witness::Witness
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::witness::Witness
 pub type bitcoin_primitives::witness::Witness::Decoder = bitcoin_primitives::witness::WitnessDecoder
 pub fn bitcoin_primitives::witness::Witness::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::witness::Witness
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::witness::Witness
 pub type bitcoin_primitives::witness::Witness::Encoder<'e> where Self: 'e = bitcoin_primitives::witness::WitnessEncoder<'e>
 pub fn bitcoin_primitives::witness::Witness::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::witness::Witness

--- a/primitives/api/no-features.txt
+++ b/primitives/api/no-features.txt
@@ -208,10 +208,10 @@ impl bitcoin_primitives::BlockHash
 pub const fn bitcoin_primitives::BlockHash::as_byte_array(&self) -> &[u8; 32]
 pub const fn bitcoin_primitives::BlockHash::from_byte_array(bytes: [u8; 32]) -> Self
 pub const fn bitcoin_primitives::BlockHash::to_byte_array(self) -> [u8; 32]
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::BlockHash
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::BlockHash
 pub type bitcoin_primitives::BlockHash::Decoder = bitcoin_primitives::block::BlockHashDecoder
 pub fn bitcoin_primitives::BlockHash::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::BlockHash
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::BlockHash
 pub type bitcoin_primitives::BlockHash::Encoder<'e> = bitcoin_primitives::block::BlockHashEncoder<'e>
 pub fn bitcoin_primitives::BlockHash::encoder(&self) -> Self::Encoder
 impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::BlockHash
@@ -389,10 +389,10 @@ pub bitcoin_primitives::block::Header::version: bitcoin_primitives::block::Versi
 impl bitcoin_primitives::block::Header
 pub const bitcoin_primitives::block::Header::SIZE: usize
 pub fn bitcoin_primitives::block::Header::block_hash(&self) -> bitcoin_primitives::BlockHash
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::block::Header
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::block::Header
 pub type bitcoin_primitives::block::Header::Decoder = bitcoin_primitives::block::HeaderDecoder
 pub fn bitcoin_primitives::block::Header::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::block::Header
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::block::Header
 pub type bitcoin_primitives::block::Header::Encoder<'e> = bitcoin_primitives::block::HeaderEncoder<'e>
 pub fn bitcoin_primitives::block::Header::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::block::Header
@@ -522,10 +522,10 @@ pub const bitcoin_primitives::block::Version::TWO: Self
 pub const fn bitcoin_primitives::block::Version::from_consensus(v: i32) -> Self
 pub fn bitcoin_primitives::block::Version::is_signalling_soft_fork(self, bit: u8) -> bool
 pub const fn bitcoin_primitives::block::Version::to_consensus(self) -> i32
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::block::Version
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::block::Version
 pub type bitcoin_primitives::block::Version::Decoder = bitcoin_primitives::block::VersionDecoder
 pub fn bitcoin_primitives::block::Version::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::block::Version
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::block::Version
 pub type bitcoin_primitives::block::Version::Encoder<'e> = bitcoin_primitives::block::VersionEncoder<'e>
 pub fn bitcoin_primitives::block::Version::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::block::Version
@@ -758,10 +758,10 @@ impl bitcoin_primitives::merkle_tree::TxMerkleNode
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::calculate_root<I: core::iter::traits::iterator::Iterator<Item = bitcoin_primitives::Txid>>(iter: I) -> core::option::Option<Self>
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::combine(&self, other: &Self) -> Self
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::from_leaf(leaf: bitcoin_primitives::Txid) -> Self
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::merkle_tree::TxMerkleNode
 pub type bitcoin_primitives::merkle_tree::TxMerkleNode::Decoder = bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::merkle_tree::TxMerkleNode
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::merkle_tree::TxMerkleNode
 pub type bitcoin_primitives::merkle_tree::TxMerkleNode::Encoder<'e> = bitcoin_primitives::merkle_tree::TxMerkleNodeEncoder<'e>
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::encoder(&self) -> Self::Encoder
 impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::merkle_tree::TxMerkleNode
@@ -934,10 +934,10 @@ impl bitcoin_primitives::merkle_tree::WitnessMerkleNode
 pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::calculate_root<I: core::iter::traits::iterator::Iterator<Item = bitcoin_primitives::Wtxid>>(iter: I) -> core::option::Option<Self>
 pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::combine(&self, other: &Self) -> Self
 pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::from_leaf(leaf: bitcoin_primitives::Wtxid) -> Self
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::merkle_tree::WitnessMerkleNode
 pub type bitcoin_primitives::merkle_tree::WitnessMerkleNode::Decoder = bitcoin_primitives::hash_types::witness_merkle_node::WitnessMerkleNodeDecoder
 pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::merkle_tree::WitnessMerkleNode
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::merkle_tree::WitnessMerkleNode
 pub type bitcoin_primitives::merkle_tree::WitnessMerkleNode::Encoder<'e> = bitcoin_primitives::hash_types::witness_merkle_node::WitnessMerkleNodeEncoder<'e>
 pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::encoder(&self) -> Self::Encoder
 impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::merkle_tree::WitnessMerkleNode
@@ -1203,10 +1203,10 @@ pub bitcoin_primitives::transaction::OutPoint::vout: u32
 impl bitcoin_primitives::transaction::OutPoint
 pub const bitcoin_primitives::transaction::OutPoint::COINBASE_PREVOUT: Self
 pub const bitcoin_primitives::transaction::OutPoint::SIZE: usize
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::transaction::OutPoint
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::transaction::OutPoint
 pub type bitcoin_primitives::transaction::OutPoint::Decoder = bitcoin_primitives::transaction::OutPointDecoder
 pub fn bitcoin_primitives::transaction::OutPoint::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::transaction::OutPoint
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::transaction::OutPoint
 pub type bitcoin_primitives::transaction::OutPoint::Encoder<'e> where Self: 'e = bitcoin_primitives::transaction::OutPointEncoder<'e>
 pub fn bitcoin_primitives::transaction::OutPoint::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::transaction::OutPoint
@@ -1425,10 +1425,10 @@ pub const bitcoin_primitives::transaction::Version::TWO: Self
 pub const fn bitcoin_primitives::transaction::Version::is_standard(self) -> bool
 pub const fn bitcoin_primitives::transaction::Version::maybe_non_standard(version: u32) -> Self
 pub const fn bitcoin_primitives::transaction::Version::to_u32(self) -> u32
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::transaction::Version
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::transaction::Version
 pub type bitcoin_primitives::transaction::Version::Decoder = bitcoin_primitives::transaction::VersionDecoder
 pub fn bitcoin_primitives::transaction::Version::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::transaction::Version
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::transaction::Version
 pub type bitcoin_primitives::transaction::Version::Encoder<'e> = bitcoin_primitives::transaction::VersionEncoder<'e>
 pub fn bitcoin_primitives::transaction::Version::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::transaction::Version
@@ -1658,10 +1658,10 @@ impl bitcoin_primitives::BlockHash
 pub const fn bitcoin_primitives::BlockHash::as_byte_array(&self) -> &[u8; 32]
 pub const fn bitcoin_primitives::BlockHash::from_byte_array(bytes: [u8; 32]) -> Self
 pub const fn bitcoin_primitives::BlockHash::to_byte_array(self) -> [u8; 32]
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::BlockHash
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::BlockHash
 pub type bitcoin_primitives::BlockHash::Decoder = bitcoin_primitives::block::BlockHashDecoder
 pub fn bitcoin_primitives::BlockHash::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::BlockHash
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::BlockHash
 pub type bitcoin_primitives::BlockHash::Encoder<'e> = bitcoin_primitives::block::BlockHashEncoder<'e>
 pub fn bitcoin_primitives::BlockHash::encoder(&self) -> Self::Encoder
 impl core::borrow::Borrow<[u8; 32]> for bitcoin_primitives::BlockHash
@@ -1726,10 +1726,10 @@ pub bitcoin_primitives::BlockHeader::version: bitcoin_primitives::block::Version
 impl bitcoin_primitives::block::Header
 pub const bitcoin_primitives::block::Header::SIZE: usize
 pub fn bitcoin_primitives::block::Header::block_hash(&self) -> bitcoin_primitives::BlockHash
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::block::Header
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::block::Header
 pub type bitcoin_primitives::block::Header::Decoder = bitcoin_primitives::block::HeaderDecoder
 pub fn bitcoin_primitives::block::Header::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::block::Header
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::block::Header
 pub type bitcoin_primitives::block::Header::Encoder<'e> = bitcoin_primitives::block::HeaderEncoder<'e>
 pub fn bitcoin_primitives::block::Header::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::block::Header
@@ -1784,10 +1784,10 @@ pub const bitcoin_primitives::block::Version::TWO: Self
 pub const fn bitcoin_primitives::block::Version::from_consensus(v: i32) -> Self
 pub fn bitcoin_primitives::block::Version::is_signalling_soft_fork(self, bit: u8) -> bool
 pub const fn bitcoin_primitives::block::Version::to_consensus(self) -> i32
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::block::Version
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::block::Version
 pub type bitcoin_primitives::block::Version::Decoder = bitcoin_primitives::block::VersionDecoder
 pub fn bitcoin_primitives::block::Version::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::block::Version
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::block::Version
 pub type bitcoin_primitives::block::Version::Encoder<'e> = bitcoin_primitives::block::VersionEncoder<'e>
 pub fn bitcoin_primitives::block::Version::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::block::Version
@@ -1848,10 +1848,10 @@ pub bitcoin_primitives::OutPoint::vout: u32
 impl bitcoin_primitives::transaction::OutPoint
 pub const bitcoin_primitives::transaction::OutPoint::COINBASE_PREVOUT: Self
 pub const bitcoin_primitives::transaction::OutPoint::SIZE: usize
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::transaction::OutPoint
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::transaction::OutPoint
 pub type bitcoin_primitives::transaction::OutPoint::Decoder = bitcoin_primitives::transaction::OutPointDecoder
 pub fn bitcoin_primitives::transaction::OutPoint::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::transaction::OutPoint
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::transaction::OutPoint
 pub type bitcoin_primitives::transaction::OutPoint::Encoder<'e> where Self: 'e = bitcoin_primitives::transaction::OutPointEncoder<'e>
 pub fn bitcoin_primitives::transaction::OutPoint::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::transaction::OutPoint
@@ -1902,10 +1902,10 @@ pub const bitcoin_primitives::transaction::Version::TWO: Self
 pub const fn bitcoin_primitives::transaction::Version::is_standard(self) -> bool
 pub const fn bitcoin_primitives::transaction::Version::maybe_non_standard(version: u32) -> Self
 pub const fn bitcoin_primitives::transaction::Version::to_u32(self) -> u32
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_primitives::transaction::Version
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::transaction::Version
 pub type bitcoin_primitives::transaction::Version::Decoder = bitcoin_primitives::transaction::VersionDecoder
 pub fn bitcoin_primitives::transaction::Version::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_primitives::transaction::Version
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::transaction::Version
 pub type bitcoin_primitives::transaction::Version::Encoder<'e> = bitcoin_primitives::transaction::VersionEncoder<'e>
 pub fn bitcoin_primitives::transaction::Version::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::transaction::Version

--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -286,7 +286,7 @@ mod sealed {
 #[cfg(feature = "hex")]
 impl core::str::FromStr for Block<Unchecked>
 where
-    Self: encoding::Decodable,
+    Self: encoding::Decode,
 {
     type Err = ParseBlockError;
 
@@ -299,7 +299,7 @@ where
 #[cfg(feature = "hex")]
 impl<V: Validation> fmt::Display for Block<V>
 where
-    Self: encoding::Encodable,
+    Self: encoding::Encode,
 {
     #[allow(clippy::use_self)]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -333,7 +333,7 @@ encoding::encoder_newtype! {
 }
 
 #[cfg(feature = "alloc")]
-impl<V> encoding::Encodable for Block<V>
+impl<V> encoding::Encode for Block<V>
 where
     V: Validation,
 {
@@ -374,7 +374,7 @@ crate::decoder_newtype! {
 }
 
 #[cfg(feature = "alloc")]
-impl encoding::Decodable for Block<Unchecked> {
+impl encoding::Decode for Block<Unchecked> {
     type Decoder = BlockDecoder;
     fn decoder() -> Self::Decoder {
         BlockDecoder(Decoder2::new(Header::decoder(), VecDecoder::<Transaction>::new()))
@@ -540,7 +540,7 @@ encoding::encoder_newtype_exact! {
     );
 }
 
-impl encoding::Encodable for Header {
+impl encoding::Encode for Header {
     type Encoder<'e> = HeaderEncoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -607,7 +607,7 @@ impl HeaderDecoder {
     }
 }
 
-impl encoding::Decodable for Header {
+impl encoding::Decode for Header {
     type Decoder = HeaderDecoder;
     fn decoder() -> Self::Decoder {
         HeaderDecoder(Decoder6::new(
@@ -734,7 +734,7 @@ encoding::encoder_newtype_exact! {
     pub struct VersionEncoder<'e>(encoding::ArrayEncoder<4>);
 }
 
-impl encoding::Encodable for Version {
+impl encoding::Encode for Version {
     type Encoder<'e> = VersionEncoder<'e>;
     fn encoder(&self) -> Self::Encoder<'_> {
         VersionEncoder::new(encoding::ArrayEncoder::without_length_prefix(
@@ -758,7 +758,7 @@ crate::decoder_newtype! {
     }
 }
 
-impl encoding::Decodable for Version {
+impl encoding::Decode for Version {
     type Decoder = VersionDecoder;
     fn decoder() -> Self::Decoder { VersionDecoder(encoding::ArrayDecoder::<4>::new()) }
 }
@@ -1024,8 +1024,8 @@ mod tests {
     use core::str::FromStr as _;
 
     #[cfg(feature = "alloc")]
-    use encoding::Decodable as _;
-    use encoding::{Decoder as _, Encodable as _, Encoder as _};
+    use encoding::Decode as _;
+    use encoding::{Decoder as _, Encode as _, Encoder as _};
     #[cfg(feature = "alloc")]
     #[cfg(feature = "hex")]
     #[cfg(feature = "serde")]

--- a/primitives/src/hash_types/block_hash.rs
+++ b/primitives/src/hash_types/block_hash.rs
@@ -30,7 +30,7 @@ type Inner = sha256d::Hash;
 
 include!("./generic.rs");
 
-impl encoding::Encodable for BlockHash {
+impl encoding::Encode for BlockHash {
     type Encoder<'e> = BlockHashEncoder<'e>;
     #[inline]
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -40,7 +40,7 @@ impl encoding::Encodable for BlockHash {
     }
 }
 
-impl encoding::Decodable for BlockHash {
+impl encoding::Decode for BlockHash {
     type Decoder = BlockHashDecoder;
     #[inline]
     fn decoder() -> Self::Decoder { BlockHashDecoder(encoding::ArrayDecoder::<32>::new()) }
@@ -94,7 +94,7 @@ mod tests {
     #[test]
     fn decoder_full_read_limit() {
         assert_eq!(BlockHashDecoder::default().read_limit(), 32);
-        assert_eq!(<BlockHash as encoding::Decodable>::decoder().read_limit(), 32);
+        assert_eq!(<BlockHash as encoding::Decode>::decoder().read_limit(), 32);
     }
 
     #[test]

--- a/primitives/src/hash_types/mod.rs
+++ b/primitives/src/hash_types/mod.rs
@@ -201,55 +201,6 @@ pub mod serde_details {
 mod tests {
     use super::*;
 
-    macro_rules! byte_array_roundtrip_test {
-        ($name:ident, $ty:ident, $len:expr, $byte:expr $(, $check:ident)?) => {
-            #[test]
-            fn $name() {
-                let bytes = [$byte; $len];
-                let value = $ty::from_byte_array(bytes);
-
-                assert_eq!(value.to_byte_array(), bytes);
-                $(
-                    let _ = stringify!($check);
-                    assert_eq!(value.as_byte_array(), &bytes);
-                )?
-            }
-        };
-    }
-
-    macro_rules! hex_roundtrip_test {
-        (display, $name:ident, $ty:ident, $len:expr, $byte:expr) => {
-            #[test]
-            #[cfg(feature = "hex")]
-            fn $name() {
-                let value = $ty::from_byte_array([$byte; $len]);
-                let parsed = alloc::format!("{value}").parse::<$ty>().unwrap();
-
-                assert_eq!(parsed, value);
-            }
-        };
-        (lower, $name:ident, $ty:ident, $len:expr, $byte:expr) => {
-            #[test]
-            #[cfg(feature = "hex")]
-            fn $name() {
-                let value = $ty::from_byte_array([$byte; $len]);
-                let parsed = alloc::format!("{value:x}").parse::<$ty>().unwrap();
-
-                assert_eq!(parsed, value);
-            }
-        };
-        (upper, $name:ident, $ty:ident, $len:expr, $byte:expr) => {
-            #[test]
-            #[cfg(feature = "hex")]
-            fn $name() {
-                let value = $ty::from_byte_array([$byte; $len]);
-                let parsed = alloc::format!("{:X}", value).parse::<$ty>().unwrap();
-
-                assert_eq!(parsed, value);
-            }
-        };
-    }
-
     #[cfg(feature = "serde")]
     const DUMMY_TXID_HEX_STR: &str =
         "e567952fb6cc33857f392efa3a46c995a28f69cca4bb1b37e0204dab1ec7a389";
@@ -310,39 +261,116 @@ mod tests {
         assert_eq!(borrowed_slice, tc.as_byte_array());
     }
 
-    byte_array_roundtrip_test!(txid_byte_array_roundtrip, Txid, 32, 0x12);
-    byte_array_roundtrip_test!(ntxid_byte_array_roundtrip, Ntxid, 32, 0x13, as_byte_array);
-    byte_array_roundtrip_test!(wtxid_byte_array_roundtrip, Wtxid, 32, 0x14, as_byte_array);
-    byte_array_roundtrip_test!(block_hash_byte_array_roundtrip, BlockHash, 32, 0x15);
-    byte_array_roundtrip_test!(tx_merkle_node_byte_array_roundtrip, TxMerkleNode, 32, 0x16);
-    byte_array_roundtrip_test!(witness_merkle_node_byte_array_roundtrip, WitnessMerkleNode, 32, 0x17);
-    byte_array_roundtrip_test!(witness_commitment_byte_array_roundtrip, WitnessCommitment, 32, 0x18, as_byte_array);
-    byte_array_roundtrip_test!(script_hash_byte_array_roundtrip, ScriptHash, 20, 0x19, as_byte_array);
-    byte_array_roundtrip_test!(wscript_hash_byte_array_roundtrip, WScriptHash, 32, 0x1a, as_byte_array);
+    macro_rules! byte_array_roundtrip_test {
+        ($($name:ident, $ty:ident, $len:expr, $byte:expr $(, $check:ident)?);* $(;)?) => {
+            $(
+                #[test]
+                fn $name() {
+                    let bytes = [$byte; $len];
+                    let value = $ty::from_byte_array(bytes);
 
-    hex_roundtrip_test!(display, txid_display_roundtrip, Txid, 32, 0x1b);
-    hex_roundtrip_test!(lower, ntxid_lower_hex_roundtrip, Ntxid, 32, 0x1c);
-    hex_roundtrip_test!(lower, block_hash_lower_hex_roundtrip, BlockHash, 32, 0x1d);
-    hex_roundtrip_test!(lower, tx_merkle_node_lower_hex_roundtrip, TxMerkleNode, 32, 0x1e);
-    hex_roundtrip_test!(lower, witness_merkle_node_lower_hex_roundtrip, WitnessMerkleNode, 32, 0x1f);
-    hex_roundtrip_test!(lower, witness_commitment_lower_hex_roundtrip, WitnessCommitment, 32, 0x20);
-    hex_roundtrip_test!(lower, script_hash_lower_hex_roundtrip, ScriptHash, 20, 0x21);
-    hex_roundtrip_test!(lower, wscript_hash_lower_hex_roundtrip, WScriptHash, 32, 0x22);
-    hex_roundtrip_test!(display, ntxid_display_roundtrip, Ntxid, 32, 0x23);
-    hex_roundtrip_test!(display, wtxid_display_roundtrip, Wtxid, 32, 0x24);
-    hex_roundtrip_test!(display, block_hash_display_roundtrip, BlockHash, 32, 0x25);
-    hex_roundtrip_test!(display, tx_merkle_node_display_roundtrip, TxMerkleNode, 32, 0x26);
-    hex_roundtrip_test!(display, witness_merkle_node_display_roundtrip, WitnessMerkleNode, 32, 0x27);
-    hex_roundtrip_test!(display, witness_commitment_display_roundtrip, WitnessCommitment, 32, 0x28);
-    hex_roundtrip_test!(display, script_hash_display_roundtrip, ScriptHash, 20, 0x29);
-    hex_roundtrip_test!(display, wscript_hash_display_roundtrip, WScriptHash, 32, 0x2a);
-    hex_roundtrip_test!(upper, txid_upper_hex_roundtrip, Txid, 32, 0x2b);
-    hex_roundtrip_test!(upper, ntxid_upper_hex_roundtrip, Ntxid, 32, 0x2c);
-    hex_roundtrip_test!(upper, wtxid_upper_hex_roundtrip, Wtxid, 32, 0x2d);
-    hex_roundtrip_test!(upper, block_hash_upper_hex_roundtrip, BlockHash, 32, 0x2e);
-    hex_roundtrip_test!(upper, tx_merkle_node_upper_hex_roundtrip, TxMerkleNode, 32, 0x2f);
-    hex_roundtrip_test!(upper, witness_merkle_node_upper_hex_roundtrip, WitnessMerkleNode, 32, 0x30);
-    hex_roundtrip_test!(upper, witness_commitment_upper_hex_roundtrip, WitnessCommitment, 32, 0x31);
-    hex_roundtrip_test!(upper, script_hash_upper_hex_roundtrip, ScriptHash, 20, 0x32);
-    hex_roundtrip_test!(upper, wscript_hash_upper_hex_roundtrip, WScriptHash, 32, 0x33);
+                    assert_eq!(value.to_byte_array(), bytes);
+                    $(
+                        let _ = stringify!($check);
+                        assert_eq!(value.as_byte_array(), &bytes);
+                    )?
+                }
+            )*
+        }
+    }
+
+    #[rustfmt::skip]
+    byte_array_roundtrip_test! {
+        txid_byte_array_roundtrip, Txid, 32, 0x12;
+        ntxid_byte_array_roundtrip, Ntxid, 32, 0x13, as_byte_array;
+        wtxid_byte_array_roundtrip, Wtxid, 32, 0x14, as_byte_array;
+        block_hash_byte_array_roundtrip, BlockHash, 32, 0x15;
+        tx_merkle_node_byte_array_roundtrip, TxMerkleNode, 32, 0x16;
+        witness_merkle_node_byte_array_roundtrip, WitnessMerkleNode, 32, 0x17;
+        witness_commitment_byte_array_roundtrip, WitnessCommitment, 32, 0x18, as_byte_array;
+        script_hash_byte_array_roundtrip, ScriptHash, 20, 0x19, as_byte_array;
+        wscript_hash_byte_array_roundtrip, WScriptHash, 32, 0x1a, as_byte_array;
+    }
+
+    macro_rules! hex_roundtrip_test_display {
+        ($($name:ident, $ty:ident, $len:expr, $byte:expr);* $(;)?) => {
+            $(
+                #[test]
+                #[cfg(feature = "hex")]
+                fn $name() {
+                    let value = $ty::from_byte_array([$byte; $len]);
+                    let parsed = alloc::format!("{value}").parse::<$ty>().unwrap();
+
+                    assert_eq!(parsed, value);
+                }
+            )*
+        };
+    }
+
+    macro_rules! hex_roundtrip_test_lower_hex {
+        ($($name:ident, $ty:ident, $len:expr, $byte:expr);* $(;)?) => {
+            $(
+                #[test]
+                #[cfg(feature = "hex")]
+                fn $name() {
+                    let value = $ty::from_byte_array([$byte; $len]);
+                    let parsed = alloc::format!("{value:x}").parse::<$ty>().unwrap();
+
+                    assert_eq!(parsed, value);
+                }
+            )*
+        };
+    }
+
+    macro_rules! hex_roundtrip_test_upper_hex {
+        ($($name:ident, $ty:ident, $len:expr, $byte:expr);* $(;)?) => {
+            $(
+                #[test]
+                #[cfg(feature = "hex")]
+                fn $name() {
+                    let value = $ty::from_byte_array([$byte; $len]);
+                    let parsed = alloc::format!("{:X}", value).parse::<$ty>().unwrap();
+
+                    assert_eq!(parsed, value);
+                }
+            )*
+        };
+    }
+
+    #[rustfmt::skip]
+    hex_roundtrip_test_display! {
+        txid_display_roundtrip, Txid, 32, 0x1b;
+        ntxid_display_roundtrip, Ntxid, 32, 0x23;
+        wtxid_display_roundtrip, Wtxid, 32, 0x24;
+        block_hash_display_roundtrip, BlockHash, 32, 0x25;
+        tx_merkle_node_display_roundtrip, TxMerkleNode, 32, 0x26;
+        witness_merkle_node_display_roundtrip, WitnessMerkleNode, 32, 0x27;
+        witness_commitment_display_roundtrip, WitnessCommitment, 32, 0x28;
+        script_hash_display_roundtrip, ScriptHash, 20, 0x29;
+        wscript_hash_display_roundtrip, WScriptHash, 32, 0x2a;
+    }
+
+    #[rustfmt::skip]
+    hex_roundtrip_test_lower_hex! {
+        ntxid_lower_hex_roundtrip, Ntxid, 32, 0x1c;
+        block_hash_lower_hex_roundtrip, BlockHash, 32, 0x1d;
+        tx_merkle_node_lower_hex_roundtrip, TxMerkleNode, 32, 0x1e;
+        witness_merkle_node_lower_hex_roundtrip, WitnessMerkleNode, 32, 0x1f;
+        witness_commitment_lower_hex_roundtrip, WitnessCommitment, 32, 0x20;
+        script_hash_lower_hex_roundtrip, ScriptHash, 20, 0x21;
+        wscript_hash_lower_hex_roundtrip, WScriptHash, 32, 0x22;
+    }
+
+    #[rustfmt::skip]
+    hex_roundtrip_test_upper_hex! {
+        txid_upper_hex_roundtrip, Txid, 32, 0x2b;
+        ntxid_upper_hex_roundtrip, Ntxid, 32, 0x2c;
+        wtxid_upper_hex_roundtrip, Wtxid, 32, 0x2d;
+        block_hash_upper_hex_roundtrip, BlockHash, 32, 0x2e;
+        tx_merkle_node_upper_hex_roundtrip, TxMerkleNode, 32, 0x2f;
+        witness_merkle_node_upper_hex_roundtrip, WitnessMerkleNode, 32, 0x30;
+        witness_commitment_upper_hex_roundtrip, WitnessCommitment, 32, 0x31;
+        script_hash_upper_hex_roundtrip, ScriptHash, 20, 0x32;
+        wscript_hash_upper_hex_roundtrip, WScriptHash, 32, 0x33;
+    }
 }

--- a/primitives/src/hash_types/transaction_merkle_node.rs
+++ b/primitives/src/hash_types/transaction_merkle_node.rs
@@ -50,7 +50,7 @@ impl TxMerkleNode {
     }
 }
 
-impl encoding::Encodable for TxMerkleNode {
+impl encoding::Encode for TxMerkleNode {
     type Encoder<'e> = TxMerkleNodeEncoder<'e>;
     #[inline]
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -60,7 +60,7 @@ impl encoding::Encodable for TxMerkleNode {
     }
 }
 
-impl encoding::Decodable for TxMerkleNode {
+impl encoding::Decode for TxMerkleNode {
     type Decoder = TxMerkleNodeDecoder;
     #[inline]
     fn decoder() -> Self::Decoder { TxMerkleNodeDecoder(encoding::ArrayDecoder::<32>::new()) }
@@ -114,7 +114,7 @@ mod tests {
     #[test]
     fn decoder_full_read_limit() {
         assert_eq!(TxMerkleNodeDecoder::default().read_limit(), 32);
-        assert_eq!(<TxMerkleNode as encoding::Decodable>::decoder().read_limit(), 32);
+        assert_eq!(<TxMerkleNode as encoding::Decode>::decoder().read_limit(), 32);
     }
 
     #[test]

--- a/primitives/src/hash_types/witness_merkle_node.rs
+++ b/primitives/src/hash_types/witness_merkle_node.rs
@@ -50,7 +50,7 @@ impl WitnessMerkleNode {
     }
 }
 
-impl encoding::Encodable for WitnessMerkleNode {
+impl encoding::Encode for WitnessMerkleNode {
     type Encoder<'e> = WitnessMerkleNodeEncoder<'e>;
     #[inline]
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -60,7 +60,7 @@ impl encoding::Encodable for WitnessMerkleNode {
     }
 }
 
-impl encoding::Decodable for WitnessMerkleNode {
+impl encoding::Decode for WitnessMerkleNode {
     type Decoder = WitnessMerkleNodeDecoder;
     #[inline]
     fn decoder() -> Self::Decoder { WitnessMerkleNodeDecoder(encoding::ArrayDecoder::<32>::new()) }
@@ -124,7 +124,7 @@ mod tests {
         assert_eq!(WitnessMerkleNodeDecoder::new().read_limit(), 32);
         // These two are the same decoder but we want 100% coverage.
         assert_eq!(WitnessMerkleNodeDecoder::default().read_limit(), 32);
-        assert_eq!(<WitnessMerkleNode as encoding::Decodable>::decoder().read_limit(), 32);
+        assert_eq!(<WitnessMerkleNode as encoding::Decode>::decoder().read_limit(), 32);
     }
 
     #[test]

--- a/primitives/src/hex_codec.rs
+++ b/primitives/src/hex_codec.rs
@@ -12,24 +12,24 @@ use core::convert::Infallible;
 use core::fmt;
 use core::fmt::Write as _;
 
-use encoding::{Decodable, Decoder, Encodable, EncoderByteIter};
+use encoding::{Decode, Decoder, EncoderByteIter, Encode};
 use hex_unstable::{BytesToHexIter, Case};
 use internals::write_err;
 
-/// Hex encoding wrapper type for `Encodable` + `Decodable` types.
+/// Hex encoding wrapper type for `Encode` + `Decode` types.
 ///
 /// Implements `Display`, `Debug`, `LowerHex`, and `UpperHex` as well as an inherent `from_str`
 /// method that returns `T`.
 pub(crate) struct HexPrimitive<'a, T>(pub(crate) &'a T);
 
-impl<'a, T: Encodable + Decodable> IntoIterator for &HexPrimitive<'a, T> {
+impl<'a, T: Encode + Decode> IntoIterator for &HexPrimitive<'a, T> {
     type Item = u8;
     type IntoIter = EncoderByteIter<T::Encoder<'a>>;
 
     fn into_iter(self) -> Self::IntoIter { EncoderByteIter::new(self.0.encoder()) }
 }
 
-impl<T: Decodable> HexPrimitive<'_, T> {
+impl<T: Decode> HexPrimitive<'_, T> {
     /// Parses a given string into an instance of the type `T`.
     ///
     /// Since `FromStr` would return an instance of `Self` and thus a &T, this function
@@ -71,8 +71,8 @@ impl<T: Decodable> HexPrimitive<'_, T> {
     }
 }
 
-impl<T: Encodable> HexPrimitive<'_, T> {
-    /// Writes an Encodable object to the given formatter in the requested case.
+impl<T: Encode> HexPrimitive<'_, T> {
+    /// Writes an encodable object to the given formatter in the requested case.
     #[inline]
     fn fmt_hex(&self, f: &mut fmt::Formatter, case: Case) -> fmt::Result {
         // Closure to write a given pad character out a given number of times.
@@ -128,28 +128,28 @@ impl<T: Encodable> HexPrimitive<'_, T> {
     }
 }
 
-impl<T: Encodable> fmt::Display for HexPrimitive<'_, T> {
+impl<T: Encode> fmt::Display for HexPrimitive<'_, T> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(self, f) }
 }
 
-impl<T: Encodable> fmt::Debug for HexPrimitive<'_, T> {
+impl<T: Encode> fmt::Debug for HexPrimitive<'_, T> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(self, f) }
 }
 
-impl<T: Encodable> fmt::LowerHex for HexPrimitive<'_, T> {
+impl<T: Encode> fmt::LowerHex for HexPrimitive<'_, T> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { self.fmt_hex(f, Case::Lower) }
 }
 
-impl<T: Encodable> fmt::UpperHex for HexPrimitive<'_, T> {
+impl<T: Encode> fmt::UpperHex for HexPrimitive<'_, T> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { self.fmt_hex(f, Case::Upper) }
 }
 
-/// An error type for errors that can occur during parsing of a `Decodable` type from hex.
-pub(crate) enum ParsePrimitiveError<T: Decodable> {
+/// An error type for errors that can occur during parsing of a `Decode` type from hex.
+pub(crate) enum ParsePrimitiveError<T: Decode> {
     /// Tried to decode an odd length string
     OddLengthString(hex_unstable::OddLengthStringError),
     /// Encountered an invalid hex character
@@ -158,13 +158,13 @@ pub(crate) enum ParsePrimitiveError<T: Decodable> {
     Decode(encoding::DecodeError<<T::Decoder as encoding::Decoder>::Error>),
 }
 
-impl<T: Decodable> From<Infallible> for ParsePrimitiveError<T> {
+impl<T: Decode> From<Infallible> for ParsePrimitiveError<T> {
     fn from(never: Infallible) -> Self { match never {} }
 }
 
 // Manual impls for Debug, Clone, PartialEq and Eq so that errors which wrap
 // `ParsePrimitiveError` can properly derive the defaults.
-impl<T: Decodable> fmt::Debug for ParsePrimitiveError<T> {
+impl<T: Decode> fmt::Debug for ParsePrimitiveError<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::OddLengthString(ref e) => write_err!(f, "odd length string"; e),
@@ -175,9 +175,9 @@ impl<T: Decodable> fmt::Debug for ParsePrimitiveError<T> {
     }
 }
 
-impl<T: Decodable> Clone for ParsePrimitiveError<T>
+impl<T: Decode> Clone for ParsePrimitiveError<T>
 where
-    <<T as Decodable>::Decoder as Decoder>::Error: Clone,
+    <<T as Decode>::Decoder as Decoder>::Error: Clone,
 {
     fn clone(&self) -> Self {
         match self {
@@ -188,9 +188,9 @@ where
     }
 }
 
-impl<T: Decodable> PartialEq for ParsePrimitiveError<T>
+impl<T: Decode> PartialEq for ParsePrimitiveError<T>
 where
-    <<T as Decodable>::Decoder as Decoder>::Error: PartialEq,
+    <<T as Decode>::Decoder as Decoder>::Error: PartialEq,
 {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
@@ -202,25 +202,25 @@ where
     }
 }
 
-impl<T: Decodable> Eq for ParsePrimitiveError<T> where
-    <<T as Decodable>::Decoder as Decoder>::Error: PartialEq
+impl<T: Decode> Eq for ParsePrimitiveError<T> where
+    <<T as Decode>::Decoder as Decoder>::Error: PartialEq
 {
 }
 
-impl<T: Decodable> fmt::Display for ParsePrimitiveError<T> {
+impl<T: Decode> fmt::Display for ParsePrimitiveError<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { fmt::Debug::fmt(&self, f) }
 }
 
-impl<T: Decodable> From<hex_unstable::OddLengthStringError> for ParsePrimitiveError<T> {
+impl<T: Decode> From<hex_unstable::OddLengthStringError> for ParsePrimitiveError<T> {
     fn from(err: hex_unstable::OddLengthStringError) -> Self { Self::OddLengthString(err) }
 }
 
-impl<T: Decodable> From<hex_unstable::InvalidCharError> for ParsePrimitiveError<T> {
+impl<T: Decode> From<hex_unstable::InvalidCharError> for ParsePrimitiveError<T> {
     fn from(err: hex_unstable::InvalidCharError) -> Self { Self::InvalidChar(err) }
 }
 
 #[cfg(feature = "std")]
-impl<T: Decodable> std::error::Error for ParsePrimitiveError<T> {
+impl<T: Decode> std::error::Error for ParsePrimitiveError<T> {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::OddLengthString(ref e) => Some(e),

--- a/primitives/src/script/borrowed.rs
+++ b/primitives/src/script/borrowed.rs
@@ -10,7 +10,7 @@ use core::ops::{
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
-use encoding::{BytesEncoder, CompactSizeEncoder, Encodable, Encoder2};
+use encoding::{BytesEncoder, CompactSizeEncoder, Encode, Encoder2};
 
 use super::ScriptBuf;
 use crate::prelude::{Box, ToOwned, Vec};
@@ -189,7 +189,7 @@ encoding::encoder_newtype_exact! {
     pub struct ScriptEncoder<'e>(Encoder2<CompactSizeEncoder, BytesEncoder<'e>>);
 }
 
-impl<T> Encodable for Script<T> {
+impl<T> Encode for Script<T> {
     type Encoder<'e>
         = ScriptEncoder<'e>
     where

--- a/primitives/src/script/owned.rs
+++ b/primitives/src/script/owned.rs
@@ -211,7 +211,7 @@ impl<T> encoding::Decoder for ScriptBufDecoder<T> {
     fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
-impl<T> encoding::Decodable for ScriptBuf<T> {
+impl<T> encoding::Decode for ScriptBuf<T> {
     type Decoder = ScriptBufDecoder<T>;
     fn decoder() -> Self::Decoder { ScriptBufDecoder(ByteVecDecoder::new(), PhantomData) }
 }

--- a/primitives/src/script/tests.rs
+++ b/primitives/src/script/tests.rs
@@ -4,7 +4,7 @@ use alloc::string::ToString;
 use alloc::{format, vec};
 use core::ops::Bound;
 
-use encoding::{Decodable, Decoder as _};
+use encoding::{Decode, Decoder as _};
 use hashes::{hash160, sha256};
 
 use super::*;
@@ -609,7 +609,7 @@ fn decoder_error_display() {
 
     let bytes = vec![0x01_u8];
     let mut push = bytes.as_slice();
-    let mut decoder = <ScriptBuf as Decodable>::Decoder::default();
+    let mut decoder = <ScriptBuf as Decode>::Decoder::default();
     decoder.push_bytes(&mut push).unwrap();
 
     let err = decoder.end().unwrap_err();

--- a/primitives/src/serde_as_consensus.rs
+++ b/primitives/src/serde_as_consensus.rs
@@ -8,7 +8,7 @@
 //!
 //! Use with `#[serde(with = "bitcoin_primitives::serde_as_consensus")]`.
 //!
-//! This module works with any type `T` that implements both [`Encodable`] and [`Decodable`].
+//! This module works with any type `T` that implements both [`Encode`] and [`Decode`].
 //! In human-readable formats (like JSON), the value is serialized as a hex string.
 //! In non-human-readable formats (like bincode), raw bytes are used.
 //!
@@ -36,7 +36,7 @@
 use core::fmt;
 use core::marker::PhantomData;
 
-use encoding::{Decodable, Encodable};
+use encoding::{Decode, Encode};
 use serde::{de, Deserializer, Serializer};
 
 use crate::hex_codec::HexPrimitive;
@@ -45,11 +45,11 @@ use crate::hex_codec::HexPrimitive;
 ///
 /// # Type Parameters
 ///
-/// * `T` - The type to serialize, must implement [`Encodable`] and [`Decodable`]
+/// * `T` - The type to serialize, must implement [`Encode`] and [`Decode`]
 /// * `S` - The serializer type
 pub fn serialize<T, S>(value: &T, s: S) -> Result<S::Ok, S::Error>
 where
-    T: Encodable + Decodable,
+    T: Encode + Decode,
     S: Serializer,
 {
     if s.is_human_readable() {
@@ -66,11 +66,11 @@ where
 ///
 /// # Type Parameters
 ///
-/// * `T` - The type to deserialize, must implement [`Encodable`] and [`Decodable`]
+/// * `T` - The type to deserialize, must implement [`Encode`] and [`Decode`]
 /// * `D` - The deserializer type
 pub fn deserialize<'d, T, D>(d: D) -> Result<T, D::Error>
 where
-    T: Encodable + Decodable,
+    T: Encode + Decode,
     D: Deserializer<'d>,
 {
     if d.is_human_readable() {
@@ -86,7 +86,7 @@ where
 
         impl<'de, T> serde::de::Visitor<'de> for BytesVisitor<T>
         where
-            T: Encodable + Decodable,
+            T: Encode + Decode,
         {
             type Value = T;
 
@@ -121,25 +121,25 @@ pub mod opt {
     //! **WARNING:**
     //!
     //! This module is specifically for using `serde` to be able to serialize any object that is
-    //! `Encodable`/`Decodable` if said object is in an `Option`.
+    //! `Encode`/`Decode` if said object is in an `Option`.
     //!
     //! Use with `#[serde(with = "bitcoin_primitives::serde_as_consensus::opt")]`.
 
     use core::fmt;
     use core::marker::PhantomData;
 
-    use encoding::{Decodable, Encodable};
+    use encoding::{Decode, Encode};
     use serde::{de, Deserializer, Serializer};
 
     #[allow(clippy::ref_option)] // API forced by serde.
     pub fn serialize<T, S>(t: &Option<T>, s: S) -> Result<S::Ok, S::Error>
     where
-        T: Encodable + Decodable,
+        T: Encode + Decode,
         S: Serializer,
     {
         struct AsConsensus<'a, T>(&'a T);
 
-        impl<T: Encodable + Decodable> serde::Serialize for AsConsensus<'_, T> {
+        impl<T: Encode + Decode> serde::Serialize for AsConsensus<'_, T> {
             fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
                 super::serialize(self.0, s)
             }
@@ -153,19 +153,19 @@ pub mod opt {
 
     pub fn deserialize<'d, T, D>(d: D) -> Result<Option<T>, D::Error>
     where
-        T: Encodable + Decodable,
+        T: Encode + Decode,
         D: Deserializer<'d>,
     {
         struct OptVisitor<X>(PhantomData<X>);
 
         impl<'de, X> de::Visitor<'de> for OptVisitor<X>
         where
-            X: Encodable + Decodable,
+            X: Encode + Decode,
         {
             type Value = Option<X>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                write!(formatter, "an Option<T> where T: encoding::Decodable")
+                write!(formatter, "an Option<T> where T: encoding::Decode")
             }
 
             fn visit_none<E>(self) -> Result<Self::Value, E>
@@ -193,7 +193,7 @@ pub mod vec {
     //!
     //! This is not a consensus encoded vector (i.e, with length prefix). This module is
     //! specifically for using `serde` to be able to serialize any object that is
-    //! `Encodable`/`Decodable` if said object is in a `Vec`.
+    //! `Encode`/`Decode` if said object is in a `Vec`.
     //!
     //! Use with `#[serde(with = "bitcoin_primitives::serde_as_consensus::vec")]`.
 
@@ -201,19 +201,19 @@ pub mod vec {
     use core::fmt;
     use core::marker::PhantomData;
 
-    use encoding::{Decodable, Encodable};
+    use encoding::{Decode, Encode};
     use serde::{de, Deserializer, Serializer};
 
     pub fn serialize<T, S>(v: &[T], s: S) -> Result<S::Ok, S::Error>
     where
-        T: Encodable + Decodable,
+        T: Encode + Decode,
         S: Serializer,
     {
         use serde::ser::SerializeSeq;
 
         struct AsConsensus<'a, T>(&'a T);
 
-        impl<T: Encodable + Decodable> serde::Serialize for AsConsensus<'_, T> {
+        impl<T: Encode + Decode> serde::Serialize for AsConsensus<'_, T> {
             fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
                 super::serialize(self.0, s)
             }
@@ -228,14 +228,14 @@ pub mod vec {
 
     pub fn deserialize<'d, T, D>(d: D) -> Result<Vec<T>, D::Error>
     where
-        T: Encodable + Decodable,
+        T: Encode + Decode,
         D: Deserializer<'d>,
     {
         struct VecVisitor<X>(PhantomData<X>);
 
         impl<'de, X> de::Visitor<'de> for VecVisitor<X>
         where
-            X: Encodable + Decodable,
+            X: Encode + Decode,
         {
             type Value = Vec<X>;
 
@@ -251,7 +251,7 @@ pub mod vec {
 
                 impl<'de, X> de::Deserialize<'de> for Wrap<X>
                 where
-                    X: Encodable + Decodable,
+                    X: Encode + Decode,
                 {
                     fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
                         super::deserialize::<X, D>(d).map(Wrap)

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -19,7 +19,7 @@ use arbitrary::{Arbitrary, Unstructured};
 use encoding::{ArrayEncoder, BytesEncoder, Encoder2};
 #[cfg(feature = "alloc")]
 use encoding::{
-    CompactSizeEncoder, Decoder2, Decoder3, Encodable as _, Encoder3, Encoder6, SliceEncoder,
+    CompactSizeEncoder, Decoder2, Decoder3, Encode as _, Encoder3, Encoder6, SliceEncoder,
     VecDecoder,
 };
 #[cfg(feature = "alloc")]
@@ -352,7 +352,7 @@ encoding::encoder_newtype! {
 }
 
 #[cfg(feature = "alloc")]
-impl encoding::Encodable for Transaction {
+impl encoding::Encode for Transaction {
     type Encoder<'e>
         = TransactionEncoder<'e>
     where
@@ -652,7 +652,7 @@ impl encoding::Decoder for TransactionDecoder {
 }
 
 #[cfg(feature = "alloc")]
-impl encoding::Decodable for Transaction {
+impl encoding::Decode for Transaction {
     type Decoder = TransactionDecoder;
     fn decoder() -> Self::Decoder { TransactionDecoder::new() }
 }
@@ -760,7 +760,7 @@ encoding::encoder_newtype_exact! {
 }
 
 #[cfg(feature = "alloc")]
-impl encoding::Encodable for TxIn {
+impl encoding::Encode for TxIn {
     type Encoder<'e>
         = Encoder3<OutPointEncoder<'e>, ScriptEncoder<'e>, SequenceEncoder<'e>>
     where
@@ -855,7 +855,7 @@ crate::decoder_newtype! {
 }
 
 #[cfg(feature = "alloc")]
-impl encoding::Decodable for TxIn {
+impl encoding::Decode for TxIn {
     type Decoder = TxInDecoder;
     fn decoder() -> Self::Decoder {
         TxInDecoder(Decoder3::new(
@@ -894,7 +894,7 @@ encoding::encoder_newtype_exact! {
 }
 
 #[cfg(feature = "alloc")]
-impl encoding::Encodable for TxOut {
+impl encoding::Encode for TxOut {
     type Encoder<'e>
         = Encoder2<AmountEncoder<'e>, ScriptEncoder<'e>>
     where
@@ -928,7 +928,7 @@ crate::decoder_newtype! {
 }
 
 #[cfg(feature = "alloc")]
-impl encoding::Decodable for TxOut {
+impl encoding::Decode for TxOut {
     type Decoder = TxOutDecoder;
     fn decoder() -> Self::Decoder {
         TxOutDecoder(Decoder2::new(AmountDecoder::new(), ScriptPubKeyBufDecoder::new()))
@@ -965,7 +965,7 @@ encoding::encoder_newtype_exact! {
     pub struct OutPointEncoder<'e>(Encoder2<BytesEncoder<'e>, ArrayEncoder<4>>);
 }
 
-impl encoding::Encodable for OutPoint {
+impl encoding::Encode for OutPoint {
     type Encoder<'e>
         = OutPointEncoder<'e>
     where
@@ -1047,7 +1047,7 @@ crate::decoder_newtype! {
     }
 }
 
-impl encoding::Decodable for OutPoint {
+impl encoding::Decode for OutPoint {
     type Decoder = OutPointDecoder;
     fn decoder() -> Self::Decoder { OutPointDecoder::default() }
 }
@@ -1248,7 +1248,7 @@ encoding::encoder_newtype_exact! {
     pub struct VersionEncoder<'e>(encoding::ArrayEncoder<4>);
 }
 
-impl encoding::Encodable for Version {
+impl encoding::Encode for Version {
     type Encoder<'e> = VersionEncoder<'e>;
     fn encoder(&self) -> Self::Encoder<'_> {
         VersionEncoder::new(encoding::ArrayEncoder::without_length_prefix(
@@ -1272,7 +1272,7 @@ crate::decoder_newtype! {
     }
 }
 
-impl encoding::Decodable for Version {
+impl encoding::Decode for Version {
     type Decoder = VersionDecoder;
     fn decoder() -> Self::Decoder { VersionDecoder(encoding::ArrayDecoder::<4>::new()) }
 }
@@ -1622,7 +1622,7 @@ mod tests {
     #[cfg(feature = "std")]
     use std::error::Error as _;
 
-    use encoding::{Decodable as _, Decoder as _, Encoder as _};
+    use encoding::{Decode as _, Decoder as _, Encoder as _};
     #[cfg(feature = "hex")]
     use hex_unstable::hex;
 

--- a/primitives/src/witness.rs
+++ b/primitives/src/witness.rs
@@ -279,7 +279,7 @@ fn decode_cursor(bytes: &[u8], start_of_indices: usize, index: usize) -> Option<
 #[derive(Debug, Clone)]
 pub struct WitnessEncoder<'e>(Encoder2<CompactSizeEncoder, BytesEncoder<'e>>);
 
-impl encoding::Encodable for Witness {
+impl encoding::Encode for Witness {
     type Encoder<'e>
         = WitnessEncoder<'e>
     where
@@ -524,7 +524,7 @@ impl encoding::Decoder for WitnessDecoder {
     }
 }
 
-impl encoding::Decodable for Witness {
+impl encoding::Decode for Witness {
     type Decoder = WitnessDecoder;
     fn decoder() -> Self::Decoder { WitnessDecoder::default() }
 }
@@ -1008,9 +1008,9 @@ mod test {
     use std::error::Error as _;
 
     #[cfg(feature = "alloc")]
-    use encoding::Decodable as _;
+    use encoding::Decode as _;
     #[cfg(feature = "alloc")]
-    use encoding::Encodable as _;
+    use encoding::Encode as _;
     use encoding::Encoder as _;
 
     use super::*;

--- a/primitives/tests/encoding.rs
+++ b/primitives/tests/encoding.rs
@@ -13,7 +13,7 @@ use bitcoin_primitives::{
     absolute, Amount, Block, BlockHash, BlockHeader, BlockTime, BlockVersion, CompactTarget,
     ScriptPubKeyBuf, ScriptSigBuf, Sequence, Witness,
 };
-use encoding::{Decodable as _, Decoder as _, Encodable as _, Encoder as _};
+use encoding::{Decode as _, Decoder as _, Encode as _, Encoder as _};
 use hex_unstable::hex;
 
 const TC_TXID_BYTES: [u8; 32] = [

--- a/units/api/all-features.txt
+++ b/units/api/all-features.txt
@@ -305,10 +305,10 @@ pub fn bitcoin_units::locktime::absolute::LockTime::is_satisfied_by(self, height
 pub fn bitcoin_units::locktime::absolute::LockTime::is_satisfied_by_height(self, height: bitcoin_units::locktime::absolute::Height) -> core::result::Result<bool, bitcoin_units::locktime::absolute::error::IncompatibleHeightError>
 pub fn bitcoin_units::locktime::absolute::LockTime::is_satisfied_by_time(self, mtp: bitcoin_units::locktime::absolute::MedianTimePast) -> core::result::Result<bool, bitcoin_units::locktime::absolute::error::IncompatibleTimeError>
 pub fn bitcoin_units::locktime::absolute::LockTime::to_consensus_u32(self) -> u32
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_units::locktime::absolute::LockTime
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_units::locktime::absolute::LockTime
 pub type bitcoin_units::locktime::absolute::LockTime::Decoder = bitcoin_units::locktime::absolute::LockTimeDecoder
 pub fn bitcoin_units::locktime::absolute::LockTime::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_units::locktime::absolute::LockTime
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_units::locktime::absolute::LockTime
 pub type bitcoin_units::locktime::absolute::LockTime::Encoder<'e> = bitcoin_units::locktime::absolute::LockTimeEncoder<'e>
 pub fn bitcoin_units::locktime::absolute::LockTime::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_units::locktime::absolute::LockTime
@@ -1701,10 +1701,10 @@ pub const bitcoin_units::Amount::MAX: Self
 pub const bitcoin_units::Amount::MIN: Self
 pub const fn bitcoin_units::Amount::from_sat(satoshi: u64) -> core::result::Result<Self, bitcoin_units::amount::error::OutOfRangeError>
 pub const fn bitcoin_units::Amount::to_sat(self) -> u64
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_units::Amount
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_units::Amount
 pub type bitcoin_units::Amount::Decoder = bitcoin_units::amount::AmountDecoder
 pub fn bitcoin_units::Amount::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_units::Amount
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_units::Amount
 pub type bitcoin_units::Amount::Encoder<'e> = bitcoin_units::amount::AmountEncoder<'e>
 pub fn bitcoin_units::Amount::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_units::Amount
@@ -2978,10 +2978,10 @@ pub const fn bitcoin_units::block::BlockHeight::to_u32(self) -> u32
 impl bitcoin_units::block::BlockHeight
 pub fn bitcoin_units::block::BlockHeight::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::PrefixedHexError>
 pub fn bitcoin_units::block::BlockHeight::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError>
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_units::block::BlockHeight
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_units::block::BlockHeight
 pub type bitcoin_units::block::BlockHeight::Decoder = bitcoin_units::block::BlockHeightDecoder
 pub fn bitcoin_units::block::BlockHeight::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_units::block::BlockHeight
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_units::block::BlockHeight
 pub type bitcoin_units::block::BlockHeight::Encoder<'e> = bitcoin_units::block::BlockHeightEncoder<'e>
 pub fn bitcoin_units::block::BlockHeight::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_units::block::BlockHeight
@@ -4299,10 +4299,10 @@ pub fn bitcoin_units::locktime::absolute::LockTime::is_satisfied_by(self, height
 pub fn bitcoin_units::locktime::absolute::LockTime::is_satisfied_by_height(self, height: bitcoin_units::locktime::absolute::Height) -> core::result::Result<bool, bitcoin_units::locktime::absolute::error::IncompatibleHeightError>
 pub fn bitcoin_units::locktime::absolute::LockTime::is_satisfied_by_time(self, mtp: bitcoin_units::locktime::absolute::MedianTimePast) -> core::result::Result<bool, bitcoin_units::locktime::absolute::error::IncompatibleTimeError>
 pub fn bitcoin_units::locktime::absolute::LockTime::to_consensus_u32(self) -> u32
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_units::locktime::absolute::LockTime
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_units::locktime::absolute::LockTime
 pub type bitcoin_units::locktime::absolute::LockTime::Decoder = bitcoin_units::locktime::absolute::LockTimeDecoder
 pub fn bitcoin_units::locktime::absolute::LockTime::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_units::locktime::absolute::LockTime
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_units::locktime::absolute::LockTime
 pub type bitcoin_units::locktime::absolute::LockTime::Encoder<'e> = bitcoin_units::locktime::absolute::LockTimeEncoder<'e>
 pub fn bitcoin_units::locktime::absolute::LockTime::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_units::locktime::absolute::LockTime
@@ -6489,10 +6489,10 @@ pub fn bitcoin_units::pow::CompactTarget::from_hex(s: &str) -> core::result::Res
 pub fn bitcoin_units::pow::CompactTarget::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError> where Self: core::marker::Sized
 pub const fn bitcoin_units::pow::CompactTarget::to_consensus(self) -> u32
 pub fn bitcoin_units::pow::CompactTarget::to_hex(self) -> alloc::string::String
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_units::pow::CompactTarget
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_units::pow::CompactTarget
 pub type bitcoin_units::pow::CompactTarget::Decoder = bitcoin_units::pow::CompactTargetDecoder
 pub fn bitcoin_units::pow::CompactTarget::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_units::pow::CompactTarget
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_units::pow::CompactTarget
 pub type bitcoin_units::pow::CompactTarget::Encoder<'e> = bitcoin_units::pow::CompactTargetEncoder<'e>
 pub fn bitcoin_units::pow::CompactTarget::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_units::pow::CompactTarget
@@ -8750,10 +8750,10 @@ pub fn bitcoin_units::sequence::Sequence::is_time_locked(self) -> bool
 pub const fn bitcoin_units::sequence::Sequence::to_consensus_u32(self) -> u32
 pub fn bitcoin_units::sequence::Sequence::to_hex(self) -> alloc::string::String
 pub fn bitcoin_units::sequence::Sequence::to_relative_lock_time(self) -> core::option::Option<bitcoin_units::locktime::relative::LockTime>
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_units::sequence::Sequence
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_units::sequence::Sequence
 pub type bitcoin_units::sequence::Sequence::Decoder = bitcoin_units::sequence::SequenceDecoder
 pub fn bitcoin_units::sequence::Sequence::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_units::sequence::Sequence
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_units::sequence::Sequence
 pub type bitcoin_units::sequence::Sequence::Encoder<'e> = bitcoin_units::sequence::SequenceEncoder<'e>
 pub fn bitcoin_units::sequence::Sequence::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_units::sequence::Sequence
@@ -9024,10 +9024,10 @@ pub fn bitcoin_units::BlockTime::from_unprefixed_hex(s: &str) -> core::result::R
 impl bitcoin_units::BlockTime
 pub const fn bitcoin_units::BlockTime::from_u32(t: u32) -> Self
 pub const fn bitcoin_units::BlockTime::to_u32(self) -> u32
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_units::BlockTime
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_units::BlockTime
 pub type bitcoin_units::BlockTime::Decoder = bitcoin_units::time::BlockTimeDecoder
 pub fn bitcoin_units::BlockTime::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_units::BlockTime
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_units::BlockTime
 pub type bitcoin_units::BlockTime::Encoder<'e> = bitcoin_units::time::BlockTimeEncoder<'e>
 pub fn bitcoin_units::BlockTime::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_units::BlockTime
@@ -10030,10 +10030,10 @@ pub const bitcoin_units::Amount::MAX: Self
 pub const bitcoin_units::Amount::MIN: Self
 pub const fn bitcoin_units::Amount::from_sat(satoshi: u64) -> core::result::Result<Self, bitcoin_units::amount::error::OutOfRangeError>
 pub const fn bitcoin_units::Amount::to_sat(self) -> u64
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_units::Amount
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_units::Amount
 pub type bitcoin_units::Amount::Decoder = bitcoin_units::amount::AmountDecoder
 pub fn bitcoin_units::Amount::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_units::Amount
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_units::Amount
 pub type bitcoin_units::Amount::Encoder<'e> = bitcoin_units::amount::AmountEncoder<'e>
 pub fn bitcoin_units::Amount::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_units::Amount
@@ -10294,10 +10294,10 @@ pub const fn bitcoin_units::block::BlockHeight::to_u32(self) -> u32
 impl bitcoin_units::block::BlockHeight
 pub fn bitcoin_units::block::BlockHeight::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::PrefixedHexError>
 pub fn bitcoin_units::block::BlockHeight::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError>
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_units::block::BlockHeight
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_units::block::BlockHeight
 pub type bitcoin_units::block::BlockHeight::Decoder = bitcoin_units::block::BlockHeightDecoder
 pub fn bitcoin_units::block::BlockHeight::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_units::block::BlockHeight
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_units::block::BlockHeight
 pub type bitcoin_units::block::BlockHeight::Encoder<'e> = bitcoin_units::block::BlockHeightEncoder<'e>
 pub fn bitcoin_units::block::BlockHeight::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_units::block::BlockHeight
@@ -10875,10 +10875,10 @@ pub fn bitcoin_units::BlockTime::from_unprefixed_hex(s: &str) -> core::result::R
 impl bitcoin_units::BlockTime
 pub const fn bitcoin_units::BlockTime::from_u32(t: u32) -> Self
 pub const fn bitcoin_units::BlockTime::to_u32(self) -> u32
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_units::BlockTime
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_units::BlockTime
 pub type bitcoin_units::BlockTime::Decoder = bitcoin_units::time::BlockTimeDecoder
 pub fn bitcoin_units::BlockTime::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_units::BlockTime
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_units::BlockTime
 pub type bitcoin_units::BlockTime::Encoder<'e> = bitcoin_units::time::BlockTimeEncoder<'e>
 pub fn bitcoin_units::BlockTime::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_units::BlockTime
@@ -10967,10 +10967,10 @@ pub fn bitcoin_units::pow::CompactTarget::from_hex(s: &str) -> core::result::Res
 pub fn bitcoin_units::pow::CompactTarget::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError> where Self: core::marker::Sized
 pub const fn bitcoin_units::pow::CompactTarget::to_consensus(self) -> u32
 pub fn bitcoin_units::pow::CompactTarget::to_hex(self) -> alloc::string::String
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_units::pow::CompactTarget
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_units::pow::CompactTarget
 pub type bitcoin_units::pow::CompactTarget::Decoder = bitcoin_units::pow::CompactTargetDecoder
 pub fn bitcoin_units::pow::CompactTarget::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_units::pow::CompactTarget
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_units::pow::CompactTarget
 pub type bitcoin_units::pow::CompactTarget::Encoder<'e> = bitcoin_units::pow::CompactTargetEncoder<'e>
 pub fn bitcoin_units::pow::CompactTarget::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_units::pow::CompactTarget
@@ -11268,10 +11268,10 @@ pub fn bitcoin_units::sequence::Sequence::is_time_locked(self) -> bool
 pub const fn bitcoin_units::sequence::Sequence::to_consensus_u32(self) -> u32
 pub fn bitcoin_units::sequence::Sequence::to_hex(self) -> alloc::string::String
 pub fn bitcoin_units::sequence::Sequence::to_relative_lock_time(self) -> core::option::Option<bitcoin_units::locktime::relative::LockTime>
-impl bitcoin_consensus_encoding::decode::Decodable for bitcoin_units::sequence::Sequence
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_units::sequence::Sequence
 pub type bitcoin_units::sequence::Sequence::Decoder = bitcoin_units::sequence::SequenceDecoder
 pub fn bitcoin_units::sequence::Sequence::decoder() -> Self::Decoder
-impl bitcoin_consensus_encoding::encode::Encodable for bitcoin_units::sequence::Sequence
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_units::sequence::Sequence
 pub type bitcoin_units::sequence::Sequence::Encoder<'e> = bitcoin_units::sequence::SequenceEncoder<'e>
 pub fn bitcoin_units::sequence::Sequence::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_units::sequence::Sequence

--- a/units/src/amount/error.rs
+++ b/units/src/amount/error.rs
@@ -526,7 +526,7 @@ mod tests {
     use std::error::Error;
 
     #[cfg(feature = "encoding")]
-    use encoding::{Decodable as _, Decoder as _};
+    use encoding::{Decode as _, Decoder as _};
 
     #[cfg(feature = "alloc")]
     use super::{ParseAmountError, ParseAmountErrorInner, ParseErrorInner};

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -614,7 +614,7 @@ impl TryFrom<SignedAmount> for Amount {
 }
 
 #[cfg(feature = "encoding")]
-impl encoding::Encodable for Amount {
+impl encoding::Encode for Amount {
     type Encoder<'e> = AmountEncoder<'e>;
 
     #[inline]
@@ -626,7 +626,7 @@ impl encoding::Encodable for Amount {
 }
 
 #[cfg(feature = "encoding")]
-impl encoding::Decodable for Amount {
+impl encoding::Decode for Amount {
     type Decoder = AmountDecoder;
 
     #[inline]

--- a/units/src/block.rs
+++ b/units/src/block.rs
@@ -205,7 +205,7 @@ impl TryFrom<BlockHeight> for absolute::Height {
 }
 
 #[cfg(feature = "encoding")]
-impl encoding::Encodable for BlockHeight {
+impl encoding::Encode for BlockHeight {
     type Encoder<'e> = BlockHeightEncoder<'e>;
     #[inline]
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -216,7 +216,7 @@ impl encoding::Encodable for BlockHeight {
 }
 
 #[cfg(feature = "encoding")]
-impl encoding::Decodable for BlockHeight {
+impl encoding::Decode for BlockHeight {
     type Decoder = BlockHeightDecoder;
 
     #[inline]
@@ -695,7 +695,7 @@ mod tests {
     use std::error::Error;
 
     #[cfg(feature = "encoding")]
-    use encoding::{Decodable as _, Decoder as _, UnexpectedEofError};
+    use encoding::{Decode as _, Decoder as _, UnexpectedEofError};
 
     use super::*;
     use crate::relative::{NumberOf512Seconds, TimeOverflowError};

--- a/units/src/locktime/absolute/error.rs
+++ b/units/src/locktime/absolute/error.rs
@@ -358,7 +358,7 @@ mod tests {
 
     #[cfg(feature = "alloc")]
     #[cfg(feature = "encoding")]
-    use encoding::{Decodable as _, Decoder as _};
+    use encoding::{Decode as _, Decoder as _};
 
     #[cfg(feature = "alloc")]
     use super::LockTimeUnit;

--- a/units/src/locktime/absolute/mod.rs
+++ b/units/src/locktime/absolute/mod.rs
@@ -398,7 +398,7 @@ impl LockTime {
 parse_int::impl_parse_str_from_int_infallible!(LockTime, u32, from_consensus);
 
 #[cfg(feature = "encoding")]
-impl encoding::Encodable for LockTime {
+impl encoding::Encode for LockTime {
     type Encoder<'e> = LockTimeEncoder<'e>;
     #[inline]
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -409,7 +409,7 @@ impl encoding::Encodable for LockTime {
 }
 
 #[cfg(feature = "encoding")]
-impl encoding::Decodable for LockTime {
+impl encoding::Decode for LockTime {
     type Decoder = LockTimeDecoder;
 
     #[inline]

--- a/units/src/pow.rs
+++ b/units/src/pow.rs
@@ -303,7 +303,7 @@ impl From<CompactTarget> for Target {
 }
 
 #[cfg(feature = "encoding")]
-impl encoding::Encodable for CompactTarget {
+impl encoding::Encode for CompactTarget {
     type Encoder<'e> = CompactTargetEncoder<'e>;
     #[inline]
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -314,7 +314,7 @@ impl encoding::Encodable for CompactTarget {
 }
 
 #[cfg(feature = "encoding")]
-impl encoding::Decodable for CompactTarget {
+impl encoding::Decode for CompactTarget {
     type Decoder = CompactTargetDecoder;
 
     #[inline]
@@ -1513,7 +1513,7 @@ mod tests {
     fn compact_target_decoder_read_limit() {
         // read_limit is one u32 = 4 bytes for empty decoder
         assert_eq!(CompactTargetDecoder::default().read_limit(), 4);
-        assert_eq!(<CompactTarget as encoding::Decodable>::decoder().read_limit(), 4);
+        assert_eq!(<CompactTarget as encoding::Decode>::decoder().read_limit(), 4);
     }
 
     #[test]

--- a/units/src/sequence.rs
+++ b/units/src/sequence.rs
@@ -259,7 +259,7 @@ impl fmt::Debug for Sequence {
 parse_int::impl_parse_str_from_int_infallible!(Sequence, u32, from_consensus);
 
 #[cfg(feature = "encoding")]
-impl encoding::Encodable for Sequence {
+impl encoding::Encode for Sequence {
     type Encoder<'e> = SequenceEncoder<'e>;
     #[inline]
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -270,7 +270,7 @@ impl encoding::Encodable for Sequence {
 }
 
 #[cfg(feature = "encoding")]
-impl encoding::Decodable for Sequence {
+impl encoding::Decode for Sequence {
     type Decoder = SequenceDecoder;
 
     #[inline]
@@ -392,7 +392,7 @@ mod tests {
     #[cfg(feature = "encoding")]
     use encoding::UnexpectedEofError;
     #[cfg(feature = "encoding")]
-    use encoding::{Decodable as _, Decoder as _};
+    use encoding::{Decode as _, Decoder as _};
 
     use super::*;
 

--- a/units/src/time.rs
+++ b/units/src/time.rs
@@ -118,7 +118,7 @@ impl<'de> Deserialize<'de> for BlockTime {
 }
 
 #[cfg(feature = "encoding")]
-impl encoding::Encodable for BlockTime {
+impl encoding::Encode for BlockTime {
     type Encoder<'e> = BlockTimeEncoder<'e>;
     #[inline]
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -129,7 +129,7 @@ impl encoding::Encodable for BlockTime {
 }
 
 #[cfg(feature = "encoding")]
-impl encoding::Decodable for BlockTime {
+impl encoding::Decode for BlockTime {
     type Decoder = BlockTimeDecoder;
 
     #[inline]

--- a/units/tests/encoding.rs
+++ b/units/tests/encoding.rs
@@ -11,7 +11,7 @@ use bitcoin_units::block::BlockHeightDecoder;
 use bitcoin_units::sequence::SequenceDecoder;
 use bitcoin_units::time::BlockTimeDecoder;
 use bitcoin_units::{Amount, BlockHeight, BlockTime, Sequence};
-use encoding::{encode_to_vec, Decodable as _, Decoder as _};
+use encoding::{encode_to_vec, Decode as _, Decoder as _};
 
 /// Tests round-trip encoding/decoding for a list of values.
 ///


### PR DESCRIPTION
When we did the first implementation of the `consensus_encoding` crate we used the same names for the public traits as the old encoding code.

In hindsight we should have used the more Rusty terms `Encode` and `Decode` instead of `Encodable` and `Decodable`.

Bonus points the new names are easier to spell.

Do trivial-ish rename. Leave the `EncodableBytesIter` as is because the fix to it is non-trivial. Leave the old encoding traits as they are because they are destined for the grave very soon anyways.

Close: #1741