### PR TITLE
Enable multiple tests in single macro call

### DIFF
--- a/consensus_encoding/src/lib.rs
+++ b/consensus_encoding/src/lib.rs
@@ -91,10 +91,10 @@ pub use self::encode::encoders::{
 };
 #[cfg(feature = "alloc")]
 #[doc(inline)]
-pub use self::encode::{encode_to_vec, drain_to_vec};
+pub use self::encode::{drain_to_vec, encode_to_vec};
 #[cfg(feature = "std")]
 #[doc(inline)]
-pub use self::encode::{encode_to_writer, drain_to_writer};
+pub use self::encode::{drain_to_writer, encode_to_writer};
 #[doc(inline)]
 pub use self::encode::{Encodable, Encoder, EncoderByteIter, ExactSizeEncoder};
 #[cfg(feature = "alloc")]

--- a/crypto/src/key.rs
+++ b/crypto/src/key.rs
@@ -634,9 +634,7 @@ impl LegacyPublicKey {
     pub fn force_compressed(self) -> FullPublicKey { FullPublicKey::from_secp(self.to_inner()) }
 
     /// Serializes the public key to bytes.
-    pub fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
-    }
+    pub fn to_vec(self) -> Vec<u8> { self.to_bytes().to_vec() }
 
     /// Serializes the public key to bytes.
     pub fn to_bytes(self) -> SerializedLegacyPublicKey {

--- a/hashes/src/sha256/crypto/avx2.rs
+++ b/hashes/src/sha256/crypto/avx2.rs
@@ -32,11 +32,28 @@ unsafe fn Add(x: __m256i, y: __m256i) -> __m256i { _mm256_add_epi32(x, y) }
 unsafe fn Add3(x: __m256i, y: __m256i, z: __m256i) -> __m256i { Add(Add(x, y), z) }
 
 #[inline(always)]
-unsafe fn Add4(x: __m256i, y: __m256i, z: __m256i, w: __m256i) -> __m256i { Add(Add(x, y), Add(z, w)) }
+unsafe fn Add4(x: __m256i, y: __m256i, z: __m256i, w: __m256i) -> __m256i {
+    Add(Add(x, y), Add(z, w))
+}
 
-macro_rules! inc2 { ($w:ident, $a:expr) => {{ $w = Add($w, $a); $w }}; }
-macro_rules! inc3 { ($w:ident, $a:expr, $b:expr) => {{ $w = Add3($w, $a, $b); $w }}; }
-macro_rules! inc4 { ($w:ident, $a:expr, $b:expr, $c:expr) => {{ $w = Add4($w, $a, $b, $c); $w }}; }
+macro_rules! inc2 {
+    ($w:ident, $a:expr) => {{
+        $w = Add($w, $a);
+        $w
+    }};
+}
+macro_rules! inc3 {
+    ($w:ident, $a:expr, $b:expr) => {{
+        $w = Add3($w, $a, $b);
+        $w
+    }};
+}
+macro_rules! inc4 {
+    ($w:ident, $a:expr, $b:expr, $c:expr) => {{
+        $w = Add4($w, $a, $b, $c);
+        $w
+    }};
+}
 
 #[inline(always)]
 unsafe fn Xor(x: __m256i, y: __m256i) -> __m256i { _mm256_xor_si256(x, y) }
@@ -64,12 +81,20 @@ unsafe fn Maj(x: __m256i, y: __m256i, z: __m256i) -> __m256i { Or(And(x, y), And
 
 #[inline(always)]
 unsafe fn Sigma0(x: __m256i) -> __m256i {
-    Xor3(Or(ShR::<2>(x), ShL::<30>(x)), Or(ShR::<13>(x), ShL::<19>(x)), Or(ShR::<22>(x), ShL::<10>(x)))
+    Xor3(
+        Or(ShR::<2>(x), ShL::<30>(x)),
+        Or(ShR::<13>(x), ShL::<19>(x)),
+        Or(ShR::<22>(x), ShL::<10>(x)),
+    )
 }
 
 #[inline(always)]
 unsafe fn Sigma1(x: __m256i) -> __m256i {
-    Xor3(Or(ShR::<6>(x), ShL::<26>(x)), Or(ShR::<11>(x), ShL::<21>(x)), Or(ShR::<25>(x), ShL::<7>(x)))
+    Xor3(
+        Or(ShR::<6>(x), ShL::<26>(x)),
+        Or(ShR::<11>(x), ShL::<21>(x)),
+        Or(ShR::<25>(x), ShL::<7>(x)),
+    )
 }
 
 #[inline(always)]
@@ -104,18 +129,24 @@ unsafe fn Read8(input: &[[u8; 64]; 8], offset: usize) -> __m256i {
         i32::from_le_bytes(input[6][offset..offset + 4].try_into().unwrap()),
         i32::from_le_bytes(input[7][offset..offset + 4].try_into().unwrap()),
     );
-    _mm256_shuffle_epi8(ret, _mm256_set_epi32(
-        0x0C0D0E0F, 0x08090A0B, 0x04050607, 0x00010203,
-        0x0C0D0E0F, 0x08090A0B, 0x04050607, 0x00010203,
-    ))
+    _mm256_shuffle_epi8(
+        ret,
+        _mm256_set_epi32(
+            0x0C0D0E0F, 0x08090A0B, 0x04050607, 0x00010203, 0x0C0D0E0F, 0x08090A0B, 0x04050607,
+            0x00010203,
+        ),
+    )
 }
 
 #[inline(always)]
 unsafe fn Write8(output: &mut [[u8; 32]; 8], offset: usize, v: __m256i) {
-    let v = _mm256_shuffle_epi8(v, _mm256_set_epi32(
-        0x0C0D0E0F, 0x08090A0B, 0x04050607, 0x00010203,
-        0x0C0D0E0F, 0x08090A0B, 0x04050607, 0x00010203,
-    ));
+    let v = _mm256_shuffle_epi8(
+        v,
+        _mm256_set_epi32(
+            0x0C0D0E0F, 0x08090A0B, 0x04050607, 0x00010203, 0x0C0D0E0F, 0x08090A0B, 0x04050607,
+            0x00010203,
+        ),
+    );
     output[0][offset..offset + 4].copy_from_slice(&_mm256_extract_epi32::<7>(v).to_le_bytes());
     output[1][offset..offset + 4].copy_from_slice(&_mm256_extract_epi32::<6>(v).to_le_bytes());
     output[2][offset..offset + 4].copy_from_slice(&_mm256_extract_epi32::<5>(v).to_le_bytes());
@@ -143,22 +174,230 @@ pub(super) unsafe fn sha256d_64_8way(output: &mut [[u8; 32]; 8], input: &[[u8; 6
     let (mut w8, mut w9, mut w10, mut w11, mut w12, mut w13, mut w14, mut w15);
 
     // Rounds 0-15: message schedule comes directly from the input
-    round!(a, b, c, d, e, f, g, h, Add(K(0x428a2f98), { w0 = Read8(input, 0); w0 }));
-    round!(h, a, b, c, d, e, f, g, Add(K(0x71374491), { w1 = Read8(input, 4); w1 }));
-    round!(g, h, a, b, c, d, e, f, Add(K(0xb5c0fbcf), { w2 = Read8(input, 8); w2 }));
-    round!(f, g, h, a, b, c, d, e, Add(K(0xe9b5dba5), { w3 = Read8(input, 12); w3 }));
-    round!(e, f, g, h, a, b, c, d, Add(K(0x3956c25b), { w4 = Read8(input, 16); w4 }));
-    round!(d, e, f, g, h, a, b, c, Add(K(0x59f111f1), { w5 = Read8(input, 20); w5 }));
-    round!(c, d, e, f, g, h, a, b, Add(K(0x923f82a4), { w6 = Read8(input, 24); w6 }));
-    round!(b, c, d, e, f, g, h, a, Add(K(0xab1c5ed5), { w7 = Read8(input, 28); w7 }));
-    round!(a, b, c, d, e, f, g, h, Add(K(0xd807aa98), { w8 = Read8(input, 32); w8 }));
-    round!(h, a, b, c, d, e, f, g, Add(K(0x12835b01), { w9 = Read8(input, 36); w9 }));
-    round!(g, h, a, b, c, d, e, f, Add(K(0x243185be), { w10 = Read8(input, 40); w10 }));
-    round!(f, g, h, a, b, c, d, e, Add(K(0x550c7dc3), { w11 = Read8(input, 44); w11 }));
-    round!(e, f, g, h, a, b, c, d, Add(K(0x72be5d74), { w12 = Read8(input, 48); w12 }));
-    round!(d, e, f, g, h, a, b, c, Add(K(0x80deb1fe), { w13 = Read8(input, 52); w13 }));
-    round!(c, d, e, f, g, h, a, b, Add(K(0x9bdc06a7), { w14 = Read8(input, 56); w14 }));
-    round!(b, c, d, e, f, g, h, a, Add(K(0xc19bf174), { w15 = Read8(input, 60); w15 }));
+    round!(
+        a,
+        b,
+        c,
+        d,
+        e,
+        f,
+        g,
+        h,
+        Add(K(0x428a2f98), {
+            w0 = Read8(input, 0);
+            w0
+        })
+    );
+    round!(
+        h,
+        a,
+        b,
+        c,
+        d,
+        e,
+        f,
+        g,
+        Add(K(0x71374491), {
+            w1 = Read8(input, 4);
+            w1
+        })
+    );
+    round!(
+        g,
+        h,
+        a,
+        b,
+        c,
+        d,
+        e,
+        f,
+        Add(K(0xb5c0fbcf), {
+            w2 = Read8(input, 8);
+            w2
+        })
+    );
+    round!(
+        f,
+        g,
+        h,
+        a,
+        b,
+        c,
+        d,
+        e,
+        Add(K(0xe9b5dba5), {
+            w3 = Read8(input, 12);
+            w3
+        })
+    );
+    round!(
+        e,
+        f,
+        g,
+        h,
+        a,
+        b,
+        c,
+        d,
+        Add(K(0x3956c25b), {
+            w4 = Read8(input, 16);
+            w4
+        })
+    );
+    round!(
+        d,
+        e,
+        f,
+        g,
+        h,
+        a,
+        b,
+        c,
+        Add(K(0x59f111f1), {
+            w5 = Read8(input, 20);
+            w5
+        })
+    );
+    round!(
+        c,
+        d,
+        e,
+        f,
+        g,
+        h,
+        a,
+        b,
+        Add(K(0x923f82a4), {
+            w6 = Read8(input, 24);
+            w6
+        })
+    );
+    round!(
+        b,
+        c,
+        d,
+        e,
+        f,
+        g,
+        h,
+        a,
+        Add(K(0xab1c5ed5), {
+            w7 = Read8(input, 28);
+            w7
+        })
+    );
+    round!(
+        a,
+        b,
+        c,
+        d,
+        e,
+        f,
+        g,
+        h,
+        Add(K(0xd807aa98), {
+            w8 = Read8(input, 32);
+            w8
+        })
+    );
+    round!(
+        h,
+        a,
+        b,
+        c,
+        d,
+        e,
+        f,
+        g,
+        Add(K(0x12835b01), {
+            w9 = Read8(input, 36);
+            w9
+        })
+    );
+    round!(
+        g,
+        h,
+        a,
+        b,
+        c,
+        d,
+        e,
+        f,
+        Add(K(0x243185be), {
+            w10 = Read8(input, 40);
+            w10
+        })
+    );
+    round!(
+        f,
+        g,
+        h,
+        a,
+        b,
+        c,
+        d,
+        e,
+        Add(K(0x550c7dc3), {
+            w11 = Read8(input, 44);
+            w11
+        })
+    );
+    round!(
+        e,
+        f,
+        g,
+        h,
+        a,
+        b,
+        c,
+        d,
+        Add(K(0x72be5d74), {
+            w12 = Read8(input, 48);
+            w12
+        })
+    );
+    round!(
+        d,
+        e,
+        f,
+        g,
+        h,
+        a,
+        b,
+        c,
+        Add(K(0x80deb1fe), {
+            w13 = Read8(input, 52);
+            w13
+        })
+    );
+    round!(
+        c,
+        d,
+        e,
+        f,
+        g,
+        h,
+        a,
+        b,
+        Add(K(0x9bdc06a7), {
+            w14 = Read8(input, 56);
+            w14
+        })
+    );
+    round!(
+        b,
+        c,
+        d,
+        e,
+        f,
+        g,
+        h,
+        a,
+        Add(K(0xc19bf174), {
+            w15 = Read8(input, 60);
+            w15
+        })
+    );
 
     // Rounds 16-63: expanded message schedule
     round!(a, b, c, d, e, f, g, h, Add(K(0xe49b69c1), inc4!(w0, sigma1(w14), w9, sigma0(w1))));
@@ -342,16 +581,130 @@ pub(super) unsafe fn sha256d_64_8way(output: &mut [[u8; 32]; 8], input: &[[u8; 6
     round!(f, g, h, a, b, c, d, e, Add(K(0x240ca1cc), inc3!(w3, sigma1(w1), sigma0(w4))));
     round!(e, f, g, h, a, b, c, d, Add(K(0x2de92c6f), inc3!(w4, sigma1(w2), sigma0(w5))));
     round!(d, e, f, g, h, a, b, c, Add(K(0x4a7484aa), inc3!(w5, sigma1(w3), sigma0(w6))));
-    round!(c, d, e, f, g, h, a, b, Add(K(0x5cb0a9dc), inc4!(w6, sigma1(w4), K(0x00000100), sigma0(w7))));
+    round!(
+        c,
+        d,
+        e,
+        f,
+        g,
+        h,
+        a,
+        b,
+        Add(K(0x5cb0a9dc), inc4!(w6, sigma1(w4), K(0x00000100), sigma0(w7)))
+    );
     round!(b, c, d, e, f, g, h, a, Add(K(0x76f988da), inc4!(w7, sigma1(w5), w0, K(0x11002000))));
-    round!(a, b, c, d, e, f, g, h, Add(K(0x983e5152), { w8 = Add3(K(0x80000000), sigma1(w6), w1); w8 }));
-    round!(h, a, b, c, d, e, f, g, Add(K(0xa831c66d), { w9 = Add(sigma1(w7), w2); w9 }));
-    round!(g, h, a, b, c, d, e, f, Add(K(0xb00327c8), { w10 = Add(sigma1(w8), w3); w10 }));
-    round!(f, g, h, a, b, c, d, e, Add(K(0xbf597fc7), { w11 = Add(sigma1(w9), w4); w11 }));
-    round!(e, f, g, h, a, b, c, d, Add(K(0xc6e00bf3), { w12 = Add(sigma1(w10), w5); w12 }));
-    round!(d, e, f, g, h, a, b, c, Add(K(0xd5a79147), { w13 = Add(sigma1(w11), w6); w13 }));
-    round!(c, d, e, f, g, h, a, b, Add(K(0x06ca6351), { w14 = Add3(sigma1(w12), w7, K(0x00400022)); w14 }));
-    round!(b, c, d, e, f, g, h, a, Add(K(0x14292967), { w15 = Add4(K(0x00000100), sigma1(w13), w8, sigma0(w0)); w15 }));
+    round!(
+        a,
+        b,
+        c,
+        d,
+        e,
+        f,
+        g,
+        h,
+        Add(K(0x983e5152), {
+            w8 = Add3(K(0x80000000), sigma1(w6), w1);
+            w8
+        })
+    );
+    round!(
+        h,
+        a,
+        b,
+        c,
+        d,
+        e,
+        f,
+        g,
+        Add(K(0xa831c66d), {
+            w9 = Add(sigma1(w7), w2);
+            w9
+        })
+    );
+    round!(
+        g,
+        h,
+        a,
+        b,
+        c,
+        d,
+        e,
+        f,
+        Add(K(0xb00327c8), {
+            w10 = Add(sigma1(w8), w3);
+            w10
+        })
+    );
+    round!(
+        f,
+        g,
+        h,
+        a,
+        b,
+        c,
+        d,
+        e,
+        Add(K(0xbf597fc7), {
+            w11 = Add(sigma1(w9), w4);
+            w11
+        })
+    );
+    round!(
+        e,
+        f,
+        g,
+        h,
+        a,
+        b,
+        c,
+        d,
+        Add(K(0xc6e00bf3), {
+            w12 = Add(sigma1(w10), w5);
+            w12
+        })
+    );
+    round!(
+        d,
+        e,
+        f,
+        g,
+        h,
+        a,
+        b,
+        c,
+        Add(K(0xd5a79147), {
+            w13 = Add(sigma1(w11), w6);
+            w13
+        })
+    );
+    round!(
+        c,
+        d,
+        e,
+        f,
+        g,
+        h,
+        a,
+        b,
+        Add(K(0x06ca6351), {
+            w14 = Add3(sigma1(w12), w7, K(0x00400022));
+            w14
+        })
+    );
+    round!(
+        b,
+        c,
+        d,
+        e,
+        f,
+        g,
+        h,
+        a,
+        Add(K(0x14292967), {
+            w15 = Add4(K(0x00000100), sigma1(w13), w8, sigma0(w0));
+            w15
+        })
+    );
     round!(a, b, c, d, e, f, g, h, Add(K(0x27b70a85), inc4!(w0, sigma1(w14), w9, sigma0(w1))));
     round!(h, a, b, c, d, e, f, g, Add(K(0x2e1b2138), inc4!(w1, sigma1(w15), w10, sigma0(w2))));
     round!(g, h, a, b, c, d, e, f, Add(K(0x4d2c6dfc), inc4!(w2, sigma1(w0), w11, sigma0(w3))));

--- a/hashes/src/sha256/crypto/sse41.rs
+++ b/hashes/src/sha256/crypto/sse41.rs
@@ -30,11 +30,28 @@ unsafe fn Add(x: __m128i, y: __m128i) -> __m128i { _mm_add_epi32(x, y) }
 unsafe fn Add3(x: __m128i, y: __m128i, z: __m128i) -> __m128i { Add(Add(x, y), z) }
 
 #[inline(always)]
-unsafe fn Add4(x: __m128i, y: __m128i, z: __m128i, w: __m128i) -> __m128i { Add(Add(x, y), Add(z, w)) }
+unsafe fn Add4(x: __m128i, y: __m128i, z: __m128i, w: __m128i) -> __m128i {
+    Add(Add(x, y), Add(z, w))
+}
 
-macro_rules! inc2 { ($w:ident, $a:expr) => {{ $w = Add($w, $a); $w }}; }
-macro_rules! inc3 { ($w:ident, $a:expr, $b:expr) => {{ $w = Add3($w, $a, $b); $w }}; }
-macro_rules! inc4 { ($w:ident, $a:expr, $b:expr, $c:expr) => {{ $w = Add4($w, $a, $b, $c); $w }}; }
+macro_rules! inc2 {
+    ($w:ident, $a:expr) => {{
+        $w = Add($w, $a);
+        $w
+    }};
+}
+macro_rules! inc3 {
+    ($w:ident, $a:expr, $b:expr) => {{
+        $w = Add3($w, $a, $b);
+        $w
+    }};
+}
+macro_rules! inc4 {
+    ($w:ident, $a:expr, $b:expr, $c:expr) => {{
+        $w = Add4($w, $a, $b, $c);
+        $w
+    }};
+}
 
 #[inline(always)]
 unsafe fn Xor(x: __m128i, y: __m128i) -> __m128i { _mm_xor_si128(x, y) }
@@ -62,12 +79,20 @@ unsafe fn Maj(x: __m128i, y: __m128i, z: __m128i) -> __m128i { Or(And(x, y), And
 
 #[inline(always)]
 unsafe fn Sigma0(x: __m128i) -> __m128i {
-    Xor3(Or(ShR::<2>(x), ShL::<30>(x)), Or(ShR::<13>(x), ShL::<19>(x)), Or(ShR::<22>(x), ShL::<10>(x)))
+    Xor3(
+        Or(ShR::<2>(x), ShL::<30>(x)),
+        Or(ShR::<13>(x), ShL::<19>(x)),
+        Or(ShR::<22>(x), ShL::<10>(x)),
+    )
 }
 
 #[inline(always)]
 unsafe fn Sigma1(x: __m128i) -> __m128i {
-    Xor3(Or(ShR::<6>(x), ShL::<26>(x)), Or(ShR::<11>(x), ShL::<21>(x)), Or(ShR::<25>(x), ShL::<7>(x)))
+    Xor3(
+        Or(ShR::<6>(x), ShL::<26>(x)),
+        Or(ShR::<11>(x), ShL::<21>(x)),
+        Or(ShR::<25>(x), ShL::<7>(x)),
+    )
 }
 
 #[inline(always)]
@@ -127,22 +152,230 @@ pub(super) unsafe fn sha256d_64_4way(output: &mut [[u8; 32]; 4], input: &[[u8; 6
     let (mut w8, mut w9, mut w10, mut w11, mut w12, mut w13, mut w14, mut w15);
 
     // Rounds 0-15: message schedule comes directly from the input
-    round!(a, b, c, d, e, f, g, h, Add(K(0x428a2f98), { w0 = Read4(input, 0); w0 }));
-    round!(h, a, b, c, d, e, f, g, Add(K(0x71374491), { w1 = Read4(input, 4); w1 }));
-    round!(g, h, a, b, c, d, e, f, Add(K(0xb5c0fbcf), { w2 = Read4(input, 8); w2 }));
-    round!(f, g, h, a, b, c, d, e, Add(K(0xe9b5dba5), { w3 = Read4(input, 12); w3 }));
-    round!(e, f, g, h, a, b, c, d, Add(K(0x3956c25b), { w4 = Read4(input, 16); w4 }));
-    round!(d, e, f, g, h, a, b, c, Add(K(0x59f111f1), { w5 = Read4(input, 20); w5 }));
-    round!(c, d, e, f, g, h, a, b, Add(K(0x923f82a4), { w6 = Read4(input, 24); w6 }));
-    round!(b, c, d, e, f, g, h, a, Add(K(0xab1c5ed5), { w7 = Read4(input, 28); w7 }));
-    round!(a, b, c, d, e, f, g, h, Add(K(0xd807aa98), { w8 = Read4(input, 32); w8 }));
-    round!(h, a, b, c, d, e, f, g, Add(K(0x12835b01), { w9 = Read4(input, 36); w9 }));
-    round!(g, h, a, b, c, d, e, f, Add(K(0x243185be), { w10 = Read4(input, 40); w10 }));
-    round!(f, g, h, a, b, c, d, e, Add(K(0x550c7dc3), { w11 = Read4(input, 44); w11 }));
-    round!(e, f, g, h, a, b, c, d, Add(K(0x72be5d74), { w12 = Read4(input, 48); w12 }));
-    round!(d, e, f, g, h, a, b, c, Add(K(0x80deb1fe), { w13 = Read4(input, 52); w13 }));
-    round!(c, d, e, f, g, h, a, b, Add(K(0x9bdc06a7), { w14 = Read4(input, 56); w14 }));
-    round!(b, c, d, e, f, g, h, a, Add(K(0xc19bf174), { w15 = Read4(input, 60); w15 }));
+    round!(
+        a,
+        b,
+        c,
+        d,
+        e,
+        f,
+        g,
+        h,
+        Add(K(0x428a2f98), {
+            w0 = Read4(input, 0);
+            w0
+        })
+    );
+    round!(
+        h,
+        a,
+        b,
+        c,
+        d,
+        e,
+        f,
+        g,
+        Add(K(0x71374491), {
+            w1 = Read4(input, 4);
+            w1
+        })
+    );
+    round!(
+        g,
+        h,
+        a,
+        b,
+        c,
+        d,
+        e,
+        f,
+        Add(K(0xb5c0fbcf), {
+            w2 = Read4(input, 8);
+            w2
+        })
+    );
+    round!(
+        f,
+        g,
+        h,
+        a,
+        b,
+        c,
+        d,
+        e,
+        Add(K(0xe9b5dba5), {
+            w3 = Read4(input, 12);
+            w3
+        })
+    );
+    round!(
+        e,
+        f,
+        g,
+        h,
+        a,
+        b,
+        c,
+        d,
+        Add(K(0x3956c25b), {
+            w4 = Read4(input, 16);
+            w4
+        })
+    );
+    round!(
+        d,
+        e,
+        f,
+        g,
+        h,
+        a,
+        b,
+        c,
+        Add(K(0x59f111f1), {
+            w5 = Read4(input, 20);
+            w5
+        })
+    );
+    round!(
+        c,
+        d,
+        e,
+        f,
+        g,
+        h,
+        a,
+        b,
+        Add(K(0x923f82a4), {
+            w6 = Read4(input, 24);
+            w6
+        })
+    );
+    round!(
+        b,
+        c,
+        d,
+        e,
+        f,
+        g,
+        h,
+        a,
+        Add(K(0xab1c5ed5), {
+            w7 = Read4(input, 28);
+            w7
+        })
+    );
+    round!(
+        a,
+        b,
+        c,
+        d,
+        e,
+        f,
+        g,
+        h,
+        Add(K(0xd807aa98), {
+            w8 = Read4(input, 32);
+            w8
+        })
+    );
+    round!(
+        h,
+        a,
+        b,
+        c,
+        d,
+        e,
+        f,
+        g,
+        Add(K(0x12835b01), {
+            w9 = Read4(input, 36);
+            w9
+        })
+    );
+    round!(
+        g,
+        h,
+        a,
+        b,
+        c,
+        d,
+        e,
+        f,
+        Add(K(0x243185be), {
+            w10 = Read4(input, 40);
+            w10
+        })
+    );
+    round!(
+        f,
+        g,
+        h,
+        a,
+        b,
+        c,
+        d,
+        e,
+        Add(K(0x550c7dc3), {
+            w11 = Read4(input, 44);
+            w11
+        })
+    );
+    round!(
+        e,
+        f,
+        g,
+        h,
+        a,
+        b,
+        c,
+        d,
+        Add(K(0x72be5d74), {
+            w12 = Read4(input, 48);
+            w12
+        })
+    );
+    round!(
+        d,
+        e,
+        f,
+        g,
+        h,
+        a,
+        b,
+        c,
+        Add(K(0x80deb1fe), {
+            w13 = Read4(input, 52);
+            w13
+        })
+    );
+    round!(
+        c,
+        d,
+        e,
+        f,
+        g,
+        h,
+        a,
+        b,
+        Add(K(0x9bdc06a7), {
+            w14 = Read4(input, 56);
+            w14
+        })
+    );
+    round!(
+        b,
+        c,
+        d,
+        e,
+        f,
+        g,
+        h,
+        a,
+        Add(K(0xc19bf174), {
+            w15 = Read4(input, 60);
+            w15
+        })
+    );
 
     // Rounds 16-63: expanded message schedule
     round!(a, b, c, d, e, f, g, h, Add(K(0xe49b69c1), inc4!(w0, sigma1(w14), w9, sigma0(w1))));
@@ -327,16 +560,130 @@ pub(super) unsafe fn sha256d_64_4way(output: &mut [[u8; 32]; 4], input: &[[u8; 6
     round!(f, g, h, a, b, c, d, e, Add(K(0x240ca1cc), inc3!(w3, sigma1(w1), sigma0(w4))));
     round!(e, f, g, h, a, b, c, d, Add(K(0x2de92c6f), inc3!(w4, sigma1(w2), sigma0(w5))));
     round!(d, e, f, g, h, a, b, c, Add(K(0x4a7484aa), inc3!(w5, sigma1(w3), sigma0(w6))));
-    round!(c, d, e, f, g, h, a, b, Add(K(0x5cb0a9dc), inc4!(w6, sigma1(w4), K(0x00000100), sigma0(w7))));
+    round!(
+        c,
+        d,
+        e,
+        f,
+        g,
+        h,
+        a,
+        b,
+        Add(K(0x5cb0a9dc), inc4!(w6, sigma1(w4), K(0x00000100), sigma0(w7)))
+    );
     round!(b, c, d, e, f, g, h, a, Add(K(0x76f988da), inc4!(w7, sigma1(w5), w0, K(0x11002000))));
-    round!(a, b, c, d, e, f, g, h, Add(K(0x983e5152), { w8 = Add3(K(0x80000000), sigma1(w6), w1); w8 }));
-    round!(h, a, b, c, d, e, f, g, Add(K(0xa831c66d), { w9 = Add(sigma1(w7), w2); w9 }));
-    round!(g, h, a, b, c, d, e, f, Add(K(0xb00327c8), { w10 = Add(sigma1(w8), w3); w10 }));
-    round!(f, g, h, a, b, c, d, e, Add(K(0xbf597fc7), { w11 = Add(sigma1(w9), w4); w11 }));
-    round!(e, f, g, h, a, b, c, d, Add(K(0xc6e00bf3), { w12 = Add(sigma1(w10), w5); w12 }));
-    round!(d, e, f, g, h, a, b, c, Add(K(0xd5a79147), { w13 = Add(sigma1(w11), w6); w13 }));
-    round!(c, d, e, f, g, h, a, b, Add(K(0x06ca6351), { w14 = Add3(sigma1(w12), w7, K(0x00400022)); w14 }));
-    round!(b, c, d, e, f, g, h, a, Add(K(0x14292967), { w15 = Add4(K(0x00000100), sigma1(w13), w8, sigma0(w0)); w15 }));
+    round!(
+        a,
+        b,
+        c,
+        d,
+        e,
+        f,
+        g,
+        h,
+        Add(K(0x983e5152), {
+            w8 = Add3(K(0x80000000), sigma1(w6), w1);
+            w8
+        })
+    );
+    round!(
+        h,
+        a,
+        b,
+        c,
+        d,
+        e,
+        f,
+        g,
+        Add(K(0xa831c66d), {
+            w9 = Add(sigma1(w7), w2);
+            w9
+        })
+    );
+    round!(
+        g,
+        h,
+        a,
+        b,
+        c,
+        d,
+        e,
+        f,
+        Add(K(0xb00327c8), {
+            w10 = Add(sigma1(w8), w3);
+            w10
+        })
+    );
+    round!(
+        f,
+        g,
+        h,
+        a,
+        b,
+        c,
+        d,
+        e,
+        Add(K(0xbf597fc7), {
+            w11 = Add(sigma1(w9), w4);
+            w11
+        })
+    );
+    round!(
+        e,
+        f,
+        g,
+        h,
+        a,
+        b,
+        c,
+        d,
+        Add(K(0xc6e00bf3), {
+            w12 = Add(sigma1(w10), w5);
+            w12
+        })
+    );
+    round!(
+        d,
+        e,
+        f,
+        g,
+        h,
+        a,
+        b,
+        c,
+        Add(K(0xd5a79147), {
+            w13 = Add(sigma1(w11), w6);
+            w13
+        })
+    );
+    round!(
+        c,
+        d,
+        e,
+        f,
+        g,
+        h,
+        a,
+        b,
+        Add(K(0x06ca6351), {
+            w14 = Add3(sigma1(w12), w7, K(0x00400022));
+            w14
+        })
+    );
+    round!(
+        b,
+        c,
+        d,
+        e,
+        f,
+        g,
+        h,
+        a,
+        Add(K(0x14292967), {
+            w15 = Add4(K(0x00000100), sigma1(w13), w8, sigma0(w0));
+            w15
+        })
+    );
     round!(a, b, c, d, e, f, g, h, Add(K(0x27b70a85), inc4!(w0, sigma1(w14), w9, sigma0(w1))));
     round!(h, a, b, c, d, e, f, g, Add(K(0x2e1b2138), inc4!(w1, sigma1(w15), w10, sigma0(w2))));
     round!(g, h, a, b, c, d, e, f, Add(K(0x4d2c6dfc), inc4!(w2, sigma1(w0), w11, sigma0(w3))));

--- a/p2p/src/bip152.rs
+++ b/p2p/src/bip152.rs
@@ -1132,15 +1132,17 @@ mod test {
                 // test deserialization
                 let mut raw: Vec<u8> = vec![0u8; 32];
                 raw.extend(testcase.0.clone());
-                let btr: BlockTransactionsRequest = encoding::decode_from_slice(&raw.clone()).unwrap();
+                let btr: BlockTransactionsRequest =
+                    encoding::decode_from_slice(&raw.clone()).unwrap();
                 assert_eq!(testcase.1, btr.indices().unwrap());
             }
             {
                 // test serialization
-                let raw: Vec<u8> = encoding::encode_to_vec(&BlockTransactionsRequest::from_indices_unchecked(
-                    BlockHash::from_byte_array([0; 32]),
-                    testcase.1,
-                ));
+                let raw: Vec<u8> =
+                    encoding::encode_to_vec(&BlockTransactionsRequest::from_indices_unchecked(
+                        BlockHash::from_byte_array([0; 32]),
+                        testcase.1,
+                    ));
                 let mut expected_raw: Vec<u8> = [0u8; 32].to_vec();
                 expected_raw.extend(testcase.0);
                 assert_eq!(expected_raw, raw);

--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -2936,7 +2936,10 @@ mod test {
 
         // Test serializing.
         let cs = CommandString("Andrew".into());
-        assert_eq!(encoding::encode_to_vec(&cs), [0x41u8, 0x6e, 0x64, 0x72, 0x65, 0x77, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(
+            encoding::encode_to_vec(&cs),
+            [0x41u8, 0x6e, 0x64, 0x72, 0x65, 0x77, 0, 0, 0, 0, 0, 0]
+        );
 
         // Test deserializing
         let cs: Result<CommandString, _> =

--- a/p2p/src/message_network.rs
+++ b/p2p/src/message_network.rs
@@ -973,8 +973,10 @@ mod tests {
         let reject_tx_conflict = hex!("027478121474786e2d6d656d706f6f6c2d636f6e666c69637405df54d3860b3c41806a3546ab48279300affacf4b88591b229141dcf2f47004");
         let reject_tx_nonfinal = hex!("02747840096e6f6e2d66696e616c259bbe6c83db8bbdfca7ca303b19413dc245d9f2371b344ede5f8b1339a5460b");
 
-        let decode_result_conflict: Result<Reject, _> = encoding::decode_from_slice(&reject_tx_conflict);
-        let decode_result_nonfinal: Result<Reject, _> = encoding::decode_from_slice(&reject_tx_nonfinal);
+        let decode_result_conflict: Result<Reject, _> =
+            encoding::decode_from_slice(&reject_tx_conflict);
+        let decode_result_nonfinal: Result<Reject, _> =
+            encoding::decode_from_slice(&reject_tx_nonfinal);
 
         assert!(decode_result_conflict.is_ok());
         assert!(decode_result_nonfinal.is_ok());

--- a/primitives/src/hash_types/mod.rs
+++ b/primitives/src/hash_types/mod.rs
@@ -201,55 +201,6 @@ pub mod serde_details {
 mod tests {
     use super::*;
 
-    macro_rules! byte_array_roundtrip_test {
-        ($name:ident, $ty:ident, $len:expr, $byte:expr $(, $check:ident)?) => {
-            #[test]
-            fn $name() {
-                let bytes = [$byte; $len];
-                let value = $ty::from_byte_array(bytes);
-
-                assert_eq!(value.to_byte_array(), bytes);
-                $(
-                    let _ = stringify!($check);
-                    assert_eq!(value.as_byte_array(), &bytes);
-                )?
-            }
-        };
-    }
-
-    macro_rules! hex_roundtrip_test {
-        (display, $name:ident, $ty:ident, $len:expr, $byte:expr) => {
-            #[test]
-            #[cfg(feature = "hex")]
-            fn $name() {
-                let value = $ty::from_byte_array([$byte; $len]);
-                let parsed = alloc::format!("{value}").parse::<$ty>().unwrap();
-
-                assert_eq!(parsed, value);
-            }
-        };
-        (lower, $name:ident, $ty:ident, $len:expr, $byte:expr) => {
-            #[test]
-            #[cfg(feature = "hex")]
-            fn $name() {
-                let value = $ty::from_byte_array([$byte; $len]);
-                let parsed = alloc::format!("{value:x}").parse::<$ty>().unwrap();
-
-                assert_eq!(parsed, value);
-            }
-        };
-        (upper, $name:ident, $ty:ident, $len:expr, $byte:expr) => {
-            #[test]
-            #[cfg(feature = "hex")]
-            fn $name() {
-                let value = $ty::from_byte_array([$byte; $len]);
-                let parsed = alloc::format!("{:X}", value).parse::<$ty>().unwrap();
-
-                assert_eq!(parsed, value);
-            }
-        };
-    }
-
     #[cfg(feature = "serde")]
     const DUMMY_TXID_HEX_STR: &str =
         "e567952fb6cc33857f392efa3a46c995a28f69cca4bb1b37e0204dab1ec7a389";
@@ -310,39 +261,116 @@ mod tests {
         assert_eq!(borrowed_slice, tc.as_byte_array());
     }
 
-    byte_array_roundtrip_test!(txid_byte_array_roundtrip, Txid, 32, 0x12);
-    byte_array_roundtrip_test!(ntxid_byte_array_roundtrip, Ntxid, 32, 0x13, as_byte_array);
-    byte_array_roundtrip_test!(wtxid_byte_array_roundtrip, Wtxid, 32, 0x14, as_byte_array);
-    byte_array_roundtrip_test!(block_hash_byte_array_roundtrip, BlockHash, 32, 0x15);
-    byte_array_roundtrip_test!(tx_merkle_node_byte_array_roundtrip, TxMerkleNode, 32, 0x16);
-    byte_array_roundtrip_test!(witness_merkle_node_byte_array_roundtrip, WitnessMerkleNode, 32, 0x17);
-    byte_array_roundtrip_test!(witness_commitment_byte_array_roundtrip, WitnessCommitment, 32, 0x18, as_byte_array);
-    byte_array_roundtrip_test!(script_hash_byte_array_roundtrip, ScriptHash, 20, 0x19, as_byte_array);
-    byte_array_roundtrip_test!(wscript_hash_byte_array_roundtrip, WScriptHash, 32, 0x1a, as_byte_array);
+    macro_rules! byte_array_roundtrip_test {
+        ($($name:ident, $ty:ident, $len:expr, $byte:expr $(, $check:ident)?);* $(;)?) => {
+            $(
+                #[test]
+                fn $name() {
+                    let bytes = [$byte; $len];
+                    let value = $ty::from_byte_array(bytes);
 
-    hex_roundtrip_test!(display, txid_display_roundtrip, Txid, 32, 0x1b);
-    hex_roundtrip_test!(lower, ntxid_lower_hex_roundtrip, Ntxid, 32, 0x1c);
-    hex_roundtrip_test!(lower, block_hash_lower_hex_roundtrip, BlockHash, 32, 0x1d);
-    hex_roundtrip_test!(lower, tx_merkle_node_lower_hex_roundtrip, TxMerkleNode, 32, 0x1e);
-    hex_roundtrip_test!(lower, witness_merkle_node_lower_hex_roundtrip, WitnessMerkleNode, 32, 0x1f);
-    hex_roundtrip_test!(lower, witness_commitment_lower_hex_roundtrip, WitnessCommitment, 32, 0x20);
-    hex_roundtrip_test!(lower, script_hash_lower_hex_roundtrip, ScriptHash, 20, 0x21);
-    hex_roundtrip_test!(lower, wscript_hash_lower_hex_roundtrip, WScriptHash, 32, 0x22);
-    hex_roundtrip_test!(display, ntxid_display_roundtrip, Ntxid, 32, 0x23);
-    hex_roundtrip_test!(display, wtxid_display_roundtrip, Wtxid, 32, 0x24);
-    hex_roundtrip_test!(display, block_hash_display_roundtrip, BlockHash, 32, 0x25);
-    hex_roundtrip_test!(display, tx_merkle_node_display_roundtrip, TxMerkleNode, 32, 0x26);
-    hex_roundtrip_test!(display, witness_merkle_node_display_roundtrip, WitnessMerkleNode, 32, 0x27);
-    hex_roundtrip_test!(display, witness_commitment_display_roundtrip, WitnessCommitment, 32, 0x28);
-    hex_roundtrip_test!(display, script_hash_display_roundtrip, ScriptHash, 20, 0x29);
-    hex_roundtrip_test!(display, wscript_hash_display_roundtrip, WScriptHash, 32, 0x2a);
-    hex_roundtrip_test!(upper, txid_upper_hex_roundtrip, Txid, 32, 0x2b);
-    hex_roundtrip_test!(upper, ntxid_upper_hex_roundtrip, Ntxid, 32, 0x2c);
-    hex_roundtrip_test!(upper, wtxid_upper_hex_roundtrip, Wtxid, 32, 0x2d);
-    hex_roundtrip_test!(upper, block_hash_upper_hex_roundtrip, BlockHash, 32, 0x2e);
-    hex_roundtrip_test!(upper, tx_merkle_node_upper_hex_roundtrip, TxMerkleNode, 32, 0x2f);
-    hex_roundtrip_test!(upper, witness_merkle_node_upper_hex_roundtrip, WitnessMerkleNode, 32, 0x30);
-    hex_roundtrip_test!(upper, witness_commitment_upper_hex_roundtrip, WitnessCommitment, 32, 0x31);
-    hex_roundtrip_test!(upper, script_hash_upper_hex_roundtrip, ScriptHash, 20, 0x32);
-    hex_roundtrip_test!(upper, wscript_hash_upper_hex_roundtrip, WScriptHash, 32, 0x33);
+                    assert_eq!(value.to_byte_array(), bytes);
+                    $(
+                        let _ = stringify!($check);
+                        assert_eq!(value.as_byte_array(), &bytes);
+                    )?
+                }
+            )*
+        }
+    }
+
+    #[rustfmt::skip]
+    byte_array_roundtrip_test! {
+        txid_byte_array_roundtrip, Txid, 32, 0x12;
+        ntxid_byte_array_roundtrip, Ntxid, 32, 0x13, as_byte_array;
+        wtxid_byte_array_roundtrip, Wtxid, 32, 0x14, as_byte_array;
+        block_hash_byte_array_roundtrip, BlockHash, 32, 0x15;
+        tx_merkle_node_byte_array_roundtrip, TxMerkleNode, 32, 0x16;
+        witness_merkle_node_byte_array_roundtrip, WitnessMerkleNode, 32, 0x17;
+        witness_commitment_byte_array_roundtrip, WitnessCommitment, 32, 0x18, as_byte_array;
+        script_hash_byte_array_roundtrip, ScriptHash, 20, 0x19, as_byte_array;
+        wscript_hash_byte_array_roundtrip, WScriptHash, 32, 0x1a, as_byte_array;
+    }
+
+    macro_rules! hex_roundtrip_test_display {
+        ($($name:ident, $ty:ident, $len:expr, $byte:expr);* $(;)?) => {
+            $(
+                #[test]
+                #[cfg(feature = "hex")]
+                fn $name() {
+                    let value = $ty::from_byte_array([$byte; $len]);
+                    let parsed = alloc::format!("{value}").parse::<$ty>().unwrap();
+
+                    assert_eq!(parsed, value);
+                }
+            )*
+        };
+    }
+
+    macro_rules! hex_roundtrip_test_lower_hex {
+        ($($name:ident, $ty:ident, $len:expr, $byte:expr);* $(;)?) => {
+            $(
+                #[test]
+                #[cfg(feature = "hex")]
+                fn $name() {
+                    let value = $ty::from_byte_array([$byte; $len]);
+                    let parsed = alloc::format!("{value:x}").parse::<$ty>().unwrap();
+
+                    assert_eq!(parsed, value);
+                }
+            )*
+        };
+    }
+
+    macro_rules! hex_roundtrip_test_upper_hex {
+        ($($name:ident, $ty:ident, $len:expr, $byte:expr);* $(;)?) => {
+            $(
+                #[test]
+                #[cfg(feature = "hex")]
+                fn $name() {
+                    let value = $ty::from_byte_array([$byte; $len]);
+                    let parsed = alloc::format!("{:X}", value).parse::<$ty>().unwrap();
+
+                    assert_eq!(parsed, value);
+                }
+            )*
+        };
+    }
+
+    #[rustfmt::skip]
+    hex_roundtrip_test_display! {
+        txid_display_roundtrip, Txid, 32, 0x1b;
+        ntxid_display_roundtrip, Ntxid, 32, 0x23;
+        wtxid_display_roundtrip, Wtxid, 32, 0x24;
+        block_hash_display_roundtrip, BlockHash, 32, 0x25;
+        tx_merkle_node_display_roundtrip, TxMerkleNode, 32, 0x26;
+        witness_merkle_node_display_roundtrip, WitnessMerkleNode, 32, 0x27;
+        witness_commitment_display_roundtrip, WitnessCommitment, 32, 0x28;
+        script_hash_display_roundtrip, ScriptHash, 20, 0x29;
+        wscript_hash_display_roundtrip, WScriptHash, 32, 0x2a;
+    }
+
+    #[rustfmt::skip]
+    hex_roundtrip_test_lower_hex! {
+        ntxid_lower_hex_roundtrip, Ntxid, 32, 0x1c;
+        block_hash_lower_hex_roundtrip, BlockHash, 32, 0x1d;
+        tx_merkle_node_lower_hex_roundtrip, TxMerkleNode, 32, 0x1e;
+        witness_merkle_node_lower_hex_roundtrip, WitnessMerkleNode, 32, 0x1f;
+        witness_commitment_lower_hex_roundtrip, WitnessCommitment, 32, 0x20;
+        script_hash_lower_hex_roundtrip, ScriptHash, 20, 0x21;
+        wscript_hash_lower_hex_roundtrip, WScriptHash, 32, 0x22;
+    }
+
+    #[rustfmt::skip]
+    hex_roundtrip_test_upper_hex! {
+        txid_upper_hex_roundtrip, Txid, 32, 0x2b;
+        ntxid_upper_hex_roundtrip, Ntxid, 32, 0x2c;
+        wtxid_upper_hex_roundtrip, Wtxid, 32, 0x2d;
+        block_hash_upper_hex_roundtrip, BlockHash, 32, 0x2e;
+        tx_merkle_node_upper_hex_roundtrip, TxMerkleNode, 32, 0x2f;
+        witness_merkle_node_upper_hex_roundtrip, WitnessMerkleNode, 32, 0x30;
+        witness_commitment_upper_hex_roundtrip, WitnessCommitment, 32, 0x31;
+        script_hash_upper_hex_roundtrip, ScriptHash, 20, 0x32;
+        wscript_hash_upper_hex_roundtrip, WScriptHash, 32, 0x33;
+    }
 }


### PR DESCRIPTION
Instead of calling the macro to define each test in a single call add support for multiple tests in one call. Makes the code more terse at the cost of macro complexity. Requires splitting one macro into three and removing the flag at the front (display, lower, upper). Add `rustfmt::skip` so that we can then run the formatter.

