### PR TITLE
Release tracking PR: `bitcoin-units 0.1.3`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -99,7 +99,7 @@ version = "0.1.2"
 
 [[package]]
 name = "bitcoin-units"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "arbitrary",
  "bitcoin-internals",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -98,7 +98,7 @@ version = "0.1.2"
 
 [[package]]
 name = "bitcoin-units"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "arbitrary",
  "bitcoin-internals",

--- a/units/CHANGELOG.md
+++ b/units/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.3 - 2026-04-19
+
+* Backport `Arbitrary` to `0.32.x` [#5085](https://github.com/rust-bitcoin/rust-bitcoin/pull/5085)
+* Backport: Add CompactSize range check to deserialization [#5921](https://github.com/rust-bitcoin/rust-bitcoin/pull/5921)
+
 # 0.1.2 - 2024-07-01
 
 * Remove enable of `alloc` feature in the `internals` dependency.

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-units"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"


### PR DESCRIPTION
Release a few backports. This release is coming from the `0.32.x` branch for the first time (thanks to #5440). The `bitcoin_hashes 0.14.1` tag is already on this branch.

In preparation for release add a changelog entry, bump the version, and update the lock files. 
