### PR TITLE
Fix docs and lint jobs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
-          ref: 906ffd4bcfe02242e36eaeea9761a87586ffd86f
+          ref: 5c62710e87cd5390319f88e7a92942022df9c0f3
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@stable
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
-          ref: 906ffd4bcfe02242e36eaeea9761a87586ffd86f
+          ref: 5c62710e87cd5390319f88e7a92942022df9c0f3
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@v1
@@ -82,7 +82,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
-          ref: 906ffd4bcfe02242e36eaeea9761a87586ffd86f
+          ref: 5c62710e87cd5390319f88e7a92942022df9c0f3
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@stable
@@ -108,7 +108,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
-          ref: 906ffd4bcfe02242e36eaeea9761a87586ffd86f
+          ref: 5c62710e87cd5390319f88e7a92942022df9c0f3
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@v1
@@ -135,7 +135,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
-          ref: 906ffd4bcfe02242e36eaeea9761a87586ffd86f
+          ref: 5c62710e87cd5390319f88e7a92942022df9c0f3
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@stable
@@ -159,7 +159,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
-          ref: 906ffd4bcfe02242e36eaeea9761a87586ffd86f
+          ref: 5c62710e87cd5390319f88e7a92942022df9c0f3
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@v1
@@ -185,7 +185,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
-          ref: 906ffd4bcfe02242e36eaeea9761a87586ffd86f
+          ref: 5c62710e87cd5390319f88e7a92942022df9c0f3
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@v1

--- a/bitcoin/src/consensus/encode.rs
+++ b/bitcoin/src/consensus/encode.rs
@@ -528,7 +528,7 @@ impl Decodable for VarInt {
         match varint {
             Ok(v) => {
                 if v.0 > MAX_COMPACT_SIZE as u64 {
-                    Err(Error::OversizedVarInt.into())
+                    Err(Error::OversizedVarInt)
                 } else {
                     Ok(v)
                 }

--- a/hashes/contrib/extra_tests.sh
+++ b/hashes/contrib/extra_tests.sh
@@ -4,7 +4,7 @@ set -ex
 
 REPO_DIR=$(git rev-parse --show-toplevel)
 
-if [ "$DO_SCHEMARS_TESTS" = true ]; then
+if [ "${DO_SCHEMARS_TESTS:=false}" = true ]; then
     pushd "$REPO_DIR/hashes/extended_tests/schemars" > /dev/null
     cargo test
     popd > /dev/null


### PR DESCRIPTION
CI is failing the docs job and lint job on the 0.32.x branch (eg #6036). Fix the lint and update the version of `run_task` being used to pick up `--no-deps` (because of our friend `doc(auto_cfg)` still in secp).
