### PR TITLE
consensus_encoding: Change `EncodableByteIter` to `EncoderByteIter`

### DIFF
--- a/consensus_encoding/api/all-features.txt
+++ b/consensus_encoding/api/all-features.txt
@@ -1432,53 +1432,6 @@ impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::Decoder6<A, B
 pub unsafe fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>
 pub fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::from(t: T) -> T
-pub struct bitcoin_consensus_encoding::EncodableByteIter<'e, T: bitcoin_consensus_encoding::Encodable + ?core::marker::Sized + 'e>
-impl<'e, T: bitcoin_consensus_encoding::Encodable + ?core::marker::Sized + 'e> bitcoin_consensus_encoding::EncodableByteIter<'e, T>
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::new(encodable: &'e T) -> Self
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::peek_chunk(&mut self) -> &[u8]
-impl<'e, T: bitcoin_consensus_encoding::Encodable + ?core::marker::Sized + 'e> core::clone::Clone for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::clone::Clone
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::clone(&self) -> Self
-impl<'e, T: bitcoin_consensus_encoding::Encodable + ?core::marker::Sized + 'e> core::iter::traits::iterator::Iterator for bitcoin_consensus_encoding::EncodableByteIter<'e, T>
-pub type bitcoin_consensus_encoding::EncodableByteIter<'e, T>::Item = u8
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::next(&mut self) -> core::option::Option<Self::Item>
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::nth(&mut self, n: usize) -> core::option::Option<Self::Item>
-impl<'e, T: core::fmt::Debug + bitcoin_consensus_encoding::Encodable + ?core::marker::Sized + 'e> core::fmt::Debug for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::fmt::Debug
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl<'e, T> core::iter::traits::exact_size::ExactSizeIterator for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where T: bitcoin_consensus_encoding::Encodable + ?core::marker::Sized + 'e, <T as bitcoin_consensus_encoding::Encodable>::Encoder: bitcoin_consensus_encoding::ExactSizeEncoder
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::len(&self) -> usize
-impl<'e, T> core::marker::Freeze for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::marker::Freeze, T: ?core::marker::Sized
-impl<'e, T> core::marker::Send for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::marker::Send, T: ?core::marker::Sized
-impl<'e, T> core::marker::Sync for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::marker::Sync, T: ?core::marker::Sized
-impl<'e, T> core::marker::Unpin for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::marker::Unpin, T: ?core::marker::Sized
-impl<'e, T> core::marker::UnsafeUnpin for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::marker::UnsafeUnpin, T: ?core::marker::Sized
-impl<'e, T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::panic::unwind_safe::RefUnwindSafe, T: ?core::marker::Sized
-impl<'e, T> core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::panic::unwind_safe::UnwindSafe, T: ?core::marker::Sized
-impl<I> core::iter::traits::collect::IntoIterator for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where I: core::iter::traits::iterator::Iterator
-pub type bitcoin_consensus_encoding::EncodableByteIter<'e, T>::IntoIter = I
-pub type bitcoin_consensus_encoding::EncodableByteIter<'e, T>::Item = <I as core::iter::traits::iterator::Iterator>::Item
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::into_iter(self) -> I
-impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where U: core::convert::From<T>
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where U: core::convert::Into<T>
-pub type bitcoin_consensus_encoding::EncodableByteIter<'e, T>::Error = core::convert::Infallible
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where U: core::convert::TryFrom<T>
-pub type bitcoin_consensus_encoding::EncodableByteIter<'e, T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where T: core::clone::Clone
-pub type bitcoin_consensus_encoding::EncodableByteIter<'e, T>::Owned = T
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::clone_into(&self, target: &mut T)
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::to_owned(&self) -> T
-impl<T> core::any::Any for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where T: 'static + ?core::marker::Sized
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where T: ?core::marker::Sized
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where T: ?core::marker::Sized
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where T: core::clone::Clone
-pub unsafe fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for bitcoin_consensus_encoding::EncodableByteIter<'e, T>
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::from(t: T) -> T
 pub struct bitcoin_consensus_encoding::Encoder2<A, B>
 impl<A, B> bitcoin_consensus_encoding::Encoder2<A, B>
 pub const fn bitcoin_consensus_encoding::Encoder2<A, B>::new(enc_1: A, enc_2: B) -> Self
@@ -1643,6 +1596,53 @@ impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::Encoder6<A, B
 pub unsafe fn bitcoin_consensus_encoding::Encoder6<A, B, C, D, E, F>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::Encoder6<A, B, C, D, E, F>
 pub fn bitcoin_consensus_encoding::Encoder6<A, B, C, D, E, F>::from(t: T) -> T
+pub struct bitcoin_consensus_encoding::EncoderByteIter<T: bitcoin_consensus_encoding::Encoder>
+impl<T: bitcoin_consensus_encoding::Encoder> bitcoin_consensus_encoding::EncoderByteIter<T>
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::new(encoder: T) -> Self
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::peek_chunk(&mut self) -> &[u8]
+impl<T: bitcoin_consensus_encoding::Encoder> core::iter::traits::iterator::Iterator for bitcoin_consensus_encoding::EncoderByteIter<T>
+pub type bitcoin_consensus_encoding::EncoderByteIter<T>::Item = u8
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::next(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::nth(&mut self, n: usize) -> core::option::Option<Self::Item>
+impl<T: core::clone::Clone + bitcoin_consensus_encoding::Encoder> core::clone::Clone for bitcoin_consensus_encoding::EncoderByteIter<T>
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::clone(&self) -> bitcoin_consensus_encoding::EncoderByteIter<T>
+impl<T: core::fmt::Debug + bitcoin_consensus_encoding::Encoder> core::fmt::Debug for bitcoin_consensus_encoding::EncoderByteIter<T>
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<T> core::iter::traits::exact_size::ExactSizeIterator for bitcoin_consensus_encoding::EncoderByteIter<T> where T: bitcoin_consensus_encoding::Encoder + bitcoin_consensus_encoding::ExactSizeEncoder
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::len(&self) -> usize
+impl<T> core::marker::Freeze for bitcoin_consensus_encoding::EncoderByteIter<T> where T: core::marker::Freeze
+impl<T> core::marker::Send for bitcoin_consensus_encoding::EncoderByteIter<T> where T: core::marker::Send
+impl<T> core::marker::Sync for bitcoin_consensus_encoding::EncoderByteIter<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bitcoin_consensus_encoding::EncoderByteIter<T> where T: core::marker::Unpin
+impl<T> core::marker::UnsafeUnpin for bitcoin_consensus_encoding::EncoderByteIter<T> where T: core::marker::UnsafeUnpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::EncoderByteIter<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::EncoderByteIter<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<I> core::iter::traits::collect::IntoIterator for bitcoin_consensus_encoding::EncoderByteIter<T> where I: core::iter::traits::iterator::Iterator
+pub type bitcoin_consensus_encoding::EncoderByteIter<T>::IntoIter = I
+pub type bitcoin_consensus_encoding::EncoderByteIter<T>::Item = <I as core::iter::traits::iterator::Iterator>::Item
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::into_iter(self) -> I
+impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::EncoderByteIter<T> where U: core::convert::From<T>
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::EncoderByteIter<T> where U: core::convert::Into<T>
+pub type bitcoin_consensus_encoding::EncoderByteIter<T>::Error = core::convert::Infallible
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::EncoderByteIter<T> where U: core::convert::TryFrom<T>
+pub type bitcoin_consensus_encoding::EncoderByteIter<T>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::EncoderByteIter<T> where T: core::clone::Clone
+pub type bitcoin_consensus_encoding::EncoderByteIter<T>::Owned = T
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::clone_into(&self, target: &mut T)
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::to_owned(&self) -> T
+impl<T> core::any::Any for bitcoin_consensus_encoding::EncoderByteIter<T> where T: 'static + ?core::marker::Sized
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::EncoderByteIter<T> where T: ?core::marker::Sized
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::EncoderByteIter<T> where T: ?core::marker::Sized
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::EncoderByteIter<T> where T: core::clone::Clone
+pub unsafe fn bitcoin_consensus_encoding::EncoderByteIter<T>::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_consensus_encoding::EncoderByteIter<T>
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::from(t: T) -> T
 pub struct bitcoin_consensus_encoding::LengthPrefixExceedsMaxError
 impl core::clone::Clone for bitcoin_consensus_encoding::error::LengthPrefixExceedsMaxError
 pub fn bitcoin_consensus_encoding::error::LengthPrefixExceedsMaxError::clone(&self) -> bitcoin_consensus_encoding::error::LengthPrefixExceedsMaxError

--- a/consensus_encoding/api/alloc-only.txt
+++ b/consensus_encoding/api/alloc-only.txt
@@ -1324,53 +1324,6 @@ impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::Decoder6<A, B
 pub unsafe fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>
 pub fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::from(t: T) -> T
-pub struct bitcoin_consensus_encoding::EncodableByteIter<'e, T: bitcoin_consensus_encoding::Encodable + ?core::marker::Sized + 'e>
-impl<'e, T: bitcoin_consensus_encoding::Encodable + ?core::marker::Sized + 'e> bitcoin_consensus_encoding::EncodableByteIter<'e, T>
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::new(encodable: &'e T) -> Self
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::peek_chunk(&mut self) -> &[u8]
-impl<'e, T: bitcoin_consensus_encoding::Encodable + ?core::marker::Sized + 'e> core::clone::Clone for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::clone::Clone
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::clone(&self) -> Self
-impl<'e, T: bitcoin_consensus_encoding::Encodable + ?core::marker::Sized + 'e> core::iter::traits::iterator::Iterator for bitcoin_consensus_encoding::EncodableByteIter<'e, T>
-pub type bitcoin_consensus_encoding::EncodableByteIter<'e, T>::Item = u8
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::next(&mut self) -> core::option::Option<Self::Item>
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::nth(&mut self, n: usize) -> core::option::Option<Self::Item>
-impl<'e, T: core::fmt::Debug + bitcoin_consensus_encoding::Encodable + ?core::marker::Sized + 'e> core::fmt::Debug for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::fmt::Debug
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl<'e, T> core::iter::traits::exact_size::ExactSizeIterator for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where T: bitcoin_consensus_encoding::Encodable + ?core::marker::Sized + 'e, <T as bitcoin_consensus_encoding::Encodable>::Encoder: bitcoin_consensus_encoding::ExactSizeEncoder
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::len(&self) -> usize
-impl<'e, T> core::marker::Freeze for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::marker::Freeze, T: ?core::marker::Sized
-impl<'e, T> core::marker::Send for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::marker::Send, T: ?core::marker::Sized
-impl<'e, T> core::marker::Sync for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::marker::Sync, T: ?core::marker::Sized
-impl<'e, T> core::marker::Unpin for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::marker::Unpin, T: ?core::marker::Sized
-impl<'e, T> core::marker::UnsafeUnpin for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::marker::UnsafeUnpin, T: ?core::marker::Sized
-impl<'e, T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::panic::unwind_safe::RefUnwindSafe, T: ?core::marker::Sized
-impl<'e, T> core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::panic::unwind_safe::UnwindSafe, T: ?core::marker::Sized
-impl<I> core::iter::traits::collect::IntoIterator for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where I: core::iter::traits::iterator::Iterator
-pub type bitcoin_consensus_encoding::EncodableByteIter<'e, T>::IntoIter = I
-pub type bitcoin_consensus_encoding::EncodableByteIter<'e, T>::Item = <I as core::iter::traits::iterator::Iterator>::Item
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::into_iter(self) -> I
-impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where U: core::convert::From<T>
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where U: core::convert::Into<T>
-pub type bitcoin_consensus_encoding::EncodableByteIter<'e, T>::Error = core::convert::Infallible
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where U: core::convert::TryFrom<T>
-pub type bitcoin_consensus_encoding::EncodableByteIter<'e, T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where T: core::clone::Clone
-pub type bitcoin_consensus_encoding::EncodableByteIter<'e, T>::Owned = T
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::clone_into(&self, target: &mut T)
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::to_owned(&self) -> T
-impl<T> core::any::Any for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where T: 'static + ?core::marker::Sized
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where T: ?core::marker::Sized
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where T: ?core::marker::Sized
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where T: core::clone::Clone
-pub unsafe fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for bitcoin_consensus_encoding::EncodableByteIter<'e, T>
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::from(t: T) -> T
 pub struct bitcoin_consensus_encoding::Encoder2<A, B>
 impl<A, B> bitcoin_consensus_encoding::Encoder2<A, B>
 pub const fn bitcoin_consensus_encoding::Encoder2<A, B>::new(enc_1: A, enc_2: B) -> Self
@@ -1535,6 +1488,53 @@ impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::Encoder6<A, B
 pub unsafe fn bitcoin_consensus_encoding::Encoder6<A, B, C, D, E, F>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::Encoder6<A, B, C, D, E, F>
 pub fn bitcoin_consensus_encoding::Encoder6<A, B, C, D, E, F>::from(t: T) -> T
+pub struct bitcoin_consensus_encoding::EncoderByteIter<T: bitcoin_consensus_encoding::Encoder>
+impl<T: bitcoin_consensus_encoding::Encoder> bitcoin_consensus_encoding::EncoderByteIter<T>
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::new(encoder: T) -> Self
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::peek_chunk(&mut self) -> &[u8]
+impl<T: bitcoin_consensus_encoding::Encoder> core::iter::traits::iterator::Iterator for bitcoin_consensus_encoding::EncoderByteIter<T>
+pub type bitcoin_consensus_encoding::EncoderByteIter<T>::Item = u8
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::next(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::nth(&mut self, n: usize) -> core::option::Option<Self::Item>
+impl<T: core::clone::Clone + bitcoin_consensus_encoding::Encoder> core::clone::Clone for bitcoin_consensus_encoding::EncoderByteIter<T>
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::clone(&self) -> bitcoin_consensus_encoding::EncoderByteIter<T>
+impl<T: core::fmt::Debug + bitcoin_consensus_encoding::Encoder> core::fmt::Debug for bitcoin_consensus_encoding::EncoderByteIter<T>
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<T> core::iter::traits::exact_size::ExactSizeIterator for bitcoin_consensus_encoding::EncoderByteIter<T> where T: bitcoin_consensus_encoding::Encoder + bitcoin_consensus_encoding::ExactSizeEncoder
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::len(&self) -> usize
+impl<T> core::marker::Freeze for bitcoin_consensus_encoding::EncoderByteIter<T> where T: core::marker::Freeze
+impl<T> core::marker::Send for bitcoin_consensus_encoding::EncoderByteIter<T> where T: core::marker::Send
+impl<T> core::marker::Sync for bitcoin_consensus_encoding::EncoderByteIter<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bitcoin_consensus_encoding::EncoderByteIter<T> where T: core::marker::Unpin
+impl<T> core::marker::UnsafeUnpin for bitcoin_consensus_encoding::EncoderByteIter<T> where T: core::marker::UnsafeUnpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::EncoderByteIter<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::EncoderByteIter<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<I> core::iter::traits::collect::IntoIterator for bitcoin_consensus_encoding::EncoderByteIter<T> where I: core::iter::traits::iterator::Iterator
+pub type bitcoin_consensus_encoding::EncoderByteIter<T>::IntoIter = I
+pub type bitcoin_consensus_encoding::EncoderByteIter<T>::Item = <I as core::iter::traits::iterator::Iterator>::Item
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::into_iter(self) -> I
+impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::EncoderByteIter<T> where U: core::convert::From<T>
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::EncoderByteIter<T> where U: core::convert::Into<T>
+pub type bitcoin_consensus_encoding::EncoderByteIter<T>::Error = core::convert::Infallible
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::EncoderByteIter<T> where U: core::convert::TryFrom<T>
+pub type bitcoin_consensus_encoding::EncoderByteIter<T>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::EncoderByteIter<T> where T: core::clone::Clone
+pub type bitcoin_consensus_encoding::EncoderByteIter<T>::Owned = T
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::clone_into(&self, target: &mut T)
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::to_owned(&self) -> T
+impl<T> core::any::Any for bitcoin_consensus_encoding::EncoderByteIter<T> where T: 'static + ?core::marker::Sized
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::EncoderByteIter<T> where T: ?core::marker::Sized
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::EncoderByteIter<T> where T: ?core::marker::Sized
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::EncoderByteIter<T> where T: core::clone::Clone
+pub unsafe fn bitcoin_consensus_encoding::EncoderByteIter<T>::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_consensus_encoding::EncoderByteIter<T>
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::from(t: T) -> T
 pub struct bitcoin_consensus_encoding::LengthPrefixExceedsMaxError
 impl core::clone::Clone for bitcoin_consensus_encoding::error::LengthPrefixExceedsMaxError
 pub fn bitcoin_consensus_encoding::error::LengthPrefixExceedsMaxError::clone(&self) -> bitcoin_consensus_encoding::error::LengthPrefixExceedsMaxError

--- a/consensus_encoding/api/no-features.txt
+++ b/consensus_encoding/api/no-features.txt
@@ -1013,49 +1013,6 @@ impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::Decoder6<A, B
 pub unsafe fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>
 pub fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::from(t: T) -> T
-pub struct bitcoin_consensus_encoding::EncodableByteIter<'e, T: bitcoin_consensus_encoding::Encodable + ?core::marker::Sized + 'e>
-impl<'e, T: bitcoin_consensus_encoding::Encodable + ?core::marker::Sized + 'e> bitcoin_consensus_encoding::EncodableByteIter<'e, T>
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::new(encodable: &'e T) -> Self
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::peek_chunk(&mut self) -> &[u8]
-impl<'e, T: bitcoin_consensus_encoding::Encodable + ?core::marker::Sized + 'e> core::clone::Clone for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::clone::Clone
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::clone(&self) -> Self
-impl<'e, T: bitcoin_consensus_encoding::Encodable + ?core::marker::Sized + 'e> core::iter::traits::iterator::Iterator for bitcoin_consensus_encoding::EncodableByteIter<'e, T>
-pub type bitcoin_consensus_encoding::EncodableByteIter<'e, T>::Item = u8
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::next(&mut self) -> core::option::Option<Self::Item>
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::nth(&mut self, n: usize) -> core::option::Option<Self::Item>
-impl<'e, T: core::fmt::Debug + bitcoin_consensus_encoding::Encodable + ?core::marker::Sized + 'e> core::fmt::Debug for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::fmt::Debug
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl<'e, T> core::iter::traits::exact_size::ExactSizeIterator for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where T: bitcoin_consensus_encoding::Encodable + ?core::marker::Sized + 'e, <T as bitcoin_consensus_encoding::Encodable>::Encoder: bitcoin_consensus_encoding::ExactSizeEncoder
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::len(&self) -> usize
-impl<'e, T> core::marker::Freeze for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::marker::Freeze, T: ?core::marker::Sized
-impl<'e, T> core::marker::Send for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::marker::Send, T: ?core::marker::Sized
-impl<'e, T> core::marker::Sync for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::marker::Sync, T: ?core::marker::Sized
-impl<'e, T> core::marker::Unpin for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::marker::Unpin, T: ?core::marker::Sized
-impl<'e, T> core::marker::UnsafeUnpin for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::marker::UnsafeUnpin, T: ?core::marker::Sized
-impl<'e, T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::panic::unwind_safe::RefUnwindSafe, T: ?core::marker::Sized
-impl<'e, T> core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where <T as bitcoin_consensus_encoding::Encodable>::Encoder: core::panic::unwind_safe::UnwindSafe, T: ?core::marker::Sized
-impl<I> core::iter::traits::collect::IntoIterator for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where I: core::iter::traits::iterator::Iterator
-pub type bitcoin_consensus_encoding::EncodableByteIter<'e, T>::IntoIter = I
-pub type bitcoin_consensus_encoding::EncodableByteIter<'e, T>::Item = <I as core::iter::traits::iterator::Iterator>::Item
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::into_iter(self) -> I
-impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where U: core::convert::From<T>
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where U: core::convert::Into<T>
-pub type bitcoin_consensus_encoding::EncodableByteIter<'e, T>::Error = core::convert::Infallible
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where U: core::convert::TryFrom<T>
-pub type bitcoin_consensus_encoding::EncodableByteIter<'e, T>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where T: 'static + ?core::marker::Sized
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where T: ?core::marker::Sized
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where T: ?core::marker::Sized
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::EncodableByteIter<'e, T> where T: core::clone::Clone
-pub unsafe fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for bitcoin_consensus_encoding::EncodableByteIter<'e, T>
-pub fn bitcoin_consensus_encoding::EncodableByteIter<'e, T>::from(t: T) -> T
 pub struct bitcoin_consensus_encoding::Encoder2<A, B>
 impl<A, B> bitcoin_consensus_encoding::Encoder2<A, B>
 pub const fn bitcoin_consensus_encoding::Encoder2<A, B>::new(enc_1: A, enc_2: B) -> Self
@@ -1204,6 +1161,49 @@ impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::Encoder6<A, B
 pub unsafe fn bitcoin_consensus_encoding::Encoder6<A, B, C, D, E, F>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::Encoder6<A, B, C, D, E, F>
 pub fn bitcoin_consensus_encoding::Encoder6<A, B, C, D, E, F>::from(t: T) -> T
+pub struct bitcoin_consensus_encoding::EncoderByteIter<T: bitcoin_consensus_encoding::Encoder>
+impl<T: bitcoin_consensus_encoding::Encoder> bitcoin_consensus_encoding::EncoderByteIter<T>
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::new(encoder: T) -> Self
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::peek_chunk(&mut self) -> &[u8]
+impl<T: bitcoin_consensus_encoding::Encoder> core::iter::traits::iterator::Iterator for bitcoin_consensus_encoding::EncoderByteIter<T>
+pub type bitcoin_consensus_encoding::EncoderByteIter<T>::Item = u8
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::next(&mut self) -> core::option::Option<Self::Item>
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::nth(&mut self, n: usize) -> core::option::Option<Self::Item>
+impl<T: core::clone::Clone + bitcoin_consensus_encoding::Encoder> core::clone::Clone for bitcoin_consensus_encoding::EncoderByteIter<T>
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::clone(&self) -> bitcoin_consensus_encoding::EncoderByteIter<T>
+impl<T: core::fmt::Debug + bitcoin_consensus_encoding::Encoder> core::fmt::Debug for bitcoin_consensus_encoding::EncoderByteIter<T>
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<T> core::iter::traits::exact_size::ExactSizeIterator for bitcoin_consensus_encoding::EncoderByteIter<T> where T: bitcoin_consensus_encoding::Encoder + bitcoin_consensus_encoding::ExactSizeEncoder
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::len(&self) -> usize
+impl<T> core::marker::Freeze for bitcoin_consensus_encoding::EncoderByteIter<T> where T: core::marker::Freeze
+impl<T> core::marker::Send for bitcoin_consensus_encoding::EncoderByteIter<T> where T: core::marker::Send
+impl<T> core::marker::Sync for bitcoin_consensus_encoding::EncoderByteIter<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bitcoin_consensus_encoding::EncoderByteIter<T> where T: core::marker::Unpin
+impl<T> core::marker::UnsafeUnpin for bitcoin_consensus_encoding::EncoderByteIter<T> where T: core::marker::UnsafeUnpin
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::EncoderByteIter<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::EncoderByteIter<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<I> core::iter::traits::collect::IntoIterator for bitcoin_consensus_encoding::EncoderByteIter<T> where I: core::iter::traits::iterator::Iterator
+pub type bitcoin_consensus_encoding::EncoderByteIter<T>::IntoIter = I
+pub type bitcoin_consensus_encoding::EncoderByteIter<T>::Item = <I as core::iter::traits::iterator::Iterator>::Item
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::into_iter(self) -> I
+impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::EncoderByteIter<T> where U: core::convert::From<T>
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::EncoderByteIter<T> where U: core::convert::Into<T>
+pub type bitcoin_consensus_encoding::EncoderByteIter<T>::Error = core::convert::Infallible
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::EncoderByteIter<T> where U: core::convert::TryFrom<T>
+pub type bitcoin_consensus_encoding::EncoderByteIter<T>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for bitcoin_consensus_encoding::EncoderByteIter<T> where T: 'static + ?core::marker::Sized
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::EncoderByteIter<T> where T: ?core::marker::Sized
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::EncoderByteIter<T> where T: ?core::marker::Sized
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::EncoderByteIter<T> where T: core::clone::Clone
+pub unsafe fn bitcoin_consensus_encoding::EncoderByteIter<T>::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_consensus_encoding::EncoderByteIter<T>
+pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::from(t: T) -> T
 pub struct bitcoin_consensus_encoding::SliceEncoder<'e, T: bitcoin_consensus_encoding::Encodable>
 impl<'e, T: bitcoin_consensus_encoding::Encodable> bitcoin_consensus_encoding::SliceEncoder<'e, T>
 pub fn bitcoin_consensus_encoding::SliceEncoder<'e, T>::without_length_prefix(sl: &'e [T]) -> Self

--- a/consensus_encoding/src/encode/mod.rs
+++ b/consensus_encoding/src/encode/mod.rs
@@ -172,18 +172,18 @@ macro_rules! encoder_newtype_exact {
     }
 }
 
-/// Yields bytes from any [`Encodable`] instance.
+/// Yields bytes from any [`Encoder`] instance.
 ///
 /// **Important** this iterator is **not** fused! Call `fuse` if you need it to be fused.
-#[derive(Debug)]
-pub struct EncodableByteIter<'e, T: Encodable + ?Sized + 'e> {
-    enc: T::Encoder<'e>,
+#[derive(Debug, Clone)]
+pub struct EncoderByteIter<T: Encoder> {
+    enc: T,
     position: usize,
 }
 
-impl<'e, T: Encodable + ?Sized + 'e> EncodableByteIter<'e, T> {
-    /// Constructs a new byte iterator around a provided encodable.
-    pub fn new(encodable: &'e T) -> Self { Self { enc: encodable.encoder(), position: 0 } }
+impl<T: Encoder> EncoderByteIter<T> {
+    /// Constructs a new byte iterator around a provided encoder.
+    pub fn new(encoder: T) -> Self { Self { enc: encoder, position: 0 } }
 
     /// Returns the remaining bytes in the next non-empty chunk.
     ///
@@ -213,16 +213,7 @@ impl<'e, T: Encodable + ?Sized + 'e> EncodableByteIter<'e, T> {
     }
 }
 
-// Manual impl rather than #[derive(Clone)] because derive would constrain `where T: Clone`,
-// but `T` itself is never cloned, only the associated type `T::Encoder<'e>`.
-impl<'e, T: Encodable + ?Sized + 'e> Clone for EncodableByteIter<'e, T>
-where
-    T::Encoder<'e>: Clone,
-{
-    fn clone(&self) -> Self { Self { enc: self.enc.clone(), position: self.position } }
-}
-
-impl<'e, T: Encodable + ?Sized + 'e> Iterator for EncodableByteIter<'e, T> {
+impl<T: Encoder> Iterator for EncoderByteIter<T> {
     type Item = u8;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -265,10 +256,9 @@ impl<'e, T: Encodable + ?Sized + 'e> Iterator for EncodableByteIter<'e, T> {
     }
 }
 
-impl<'e, T> ExactSizeIterator for EncodableByteIter<'e, T>
+impl<T> ExactSizeIterator for EncoderByteIter<T>
 where
-    T: Encodable + ?Sized + 'e,
-    T::Encoder<'e>: ExactSizeEncoder,
+    T: Encoder + ExactSizeEncoder,
 {
     fn len(&self) -> usize { self.enc.len() - self.position }
 }

--- a/consensus_encoding/src/lib.rs
+++ b/consensus_encoding/src/lib.rs
@@ -96,7 +96,7 @@ pub use self::encode::{encode_to_vec, flush_to_vec};
 #[doc(inline)]
 pub use self::encode::{encode_to_writer, flush_to_writer};
 #[doc(inline)]
-pub use self::encode::{Encodable, EncodableByteIter, Encoder, ExactSizeEncoder};
+pub use self::encode::{Encodable, Encoder, EncoderByteIter, ExactSizeEncoder};
 #[cfg(feature = "alloc")]
 #[doc(no_inline)]
 pub use self::error::LengthPrefixExceedsMaxError;

--- a/consensus_encoding/tests/api.rs
+++ b/consensus_encoding/tests/api.rs
@@ -14,7 +14,7 @@ use core::fmt;
 use bitcoin_consensus_encoding::{
     self as encoding, encoder_newtype, ArrayDecoder, ArrayEncoder, ArrayRefEncoder, BytesEncoder,
     CompactSizeDecoder, CompactSizeDecoderError, CompactSizeEncoder, CompactSizeU64Decoder,
-    Decodable, Decoder, Decoder2, Decoder3, Decoder4, Decoder6, Encodable, EncodableByteIter,
+    Decodable, Decoder, Decoder2, Decoder3, Decoder4, Decoder6, Encodable, EncoderByteIter,
     SliceEncoder, UnexpectedEofError,
 };
 use encoding::error::{DecodeError, UnconsumedError};
@@ -43,7 +43,7 @@ struct Structs {
     j: Decoder3<D, D, D>,
     k: Decoder4<D, D, D, D>,
     l: Decoder6<D, D, D, D, D, D>,
-    m: EncodableByteIter<'static, Foo>,
+    m: EncoderByteIter<FooEncoder<'static>>,
     n: SliceEncoder<'static, Foo>,
     #[cfg(feature = "alloc")]
     o: VecDecoder<Foo>,
@@ -112,7 +112,7 @@ struct Clone {
     // j: Decoder3<D, D, D>,
     // k: Decoder4<D, D, D, D>,
     // l: Decoder6<D, D, D, D, D, D>,
-    m: EncodableByteIter<'static, Foo>,
+    m: EncoderByteIter<FooEncoder<'static>>,
     n: SliceEncoder<'static, Foo>,
     #[cfg(feature = "alloc")]
     o: VecDecoder<Foo>,
@@ -202,7 +202,7 @@ fn api_all_non_error_types_have_non_empty_debug() {
     let debug = format!("{:?}", Decoder6::new(d(), d(), d(), d(), d(), d()));
     assert!(!debug.is_empty());
 
-    let debug = format!("{:?}", EncodableByteIter::new(&Foo::dummy()));
+    let debug = format!("{:?}", EncoderByteIter::new(Foo::dummy().encoder()));
     assert!(!debug.is_empty());
     let debug = format!("{:?}", SliceEncoder::without_length_prefix(&[Foo::dummy()]));
     assert!(!debug.is_empty());

--- a/consensus_encoding/tests/encode.rs
+++ b/consensus_encoding/tests/encode.rs
@@ -6,8 +6,8 @@
 use std::io::{Cursor, Write};
 
 use bitcoin_consensus_encoding::{
-    ArrayEncoder, ArrayRefEncoder, BytesEncoder, CompactSizeEncoder, Encodable, EncodableByteIter,
-    Encoder, Encoder2, Encoder3, Encoder4, Encoder6, ExactSizeEncoder, SliceEncoder,
+    ArrayEncoder, ArrayRefEncoder, BytesEncoder, CompactSizeEncoder, Encodable, Encoder, Encoder2,
+    Encoder3, Encoder4, Encoder6, EncoderByteIter, ExactSizeEncoder, SliceEncoder,
 };
 
 struct TestBytes<'a>(&'a [u8]);
@@ -617,7 +617,7 @@ fn encode_compact_size() {
 #[test]
 fn iter_encoder() {
     let test_array = TestArray([1u8, 2, 3, 4]);
-    let mut iter = EncodableByteIter::new(&test_array);
+    let mut iter = EncoderByteIter::new(test_array.encoder());
 
     assert_eq!(iter.len(), 4);
 

--- a/consensus_encoding/tests/iter.rs
+++ b/consensus_encoding/tests/iter.rs
@@ -1,4 +1,4 @@
-use bitcoin_consensus_encoding::{ArrayEncoder, Encodable, EncodableByteIter, Encoder2, Encoder3};
+use bitcoin_consensus_encoding::{ArrayEncoder, Encodable, Encoder2, Encoder3, EncoderByteIter};
 use hex::BytesToHexIter;
 
 struct TestArray<const N: usize>([u8; N]);
@@ -48,7 +48,7 @@ impl<const N: usize, const M: usize, const L: usize> Encodable for TestCatArray3
 #[test]
 fn hex_iter() {
     let data = TestArray([255u8, 240, 9, 135]);
-    let byte_iter = EncodableByteIter::new(&data);
+    let byte_iter = EncoderByteIter::new(data.encoder());
     let mut iter = BytesToHexIter::new(byte_iter, hex::Case::Upper);
 
     let expect_str = "FFF00987";
@@ -63,7 +63,7 @@ fn hex_iter() {
 #[test]
 fn hex_iter_cat_encoder() {
     let data = TestCatArray([222u8, 173], [190u8, 239]);
-    let byte_iter = EncodableByteIter::new(&data);
+    let byte_iter = EncoderByteIter::new(data.encoder());
     let mut iter = BytesToHexIter::new(byte_iter, hex::Case::Lower);
 
     let expect_str = "deadbeef";
@@ -80,19 +80,19 @@ fn hex_iter_cat_encoder() {
 #[test]
 fn nth() {
     let data = TestArray([255u8, 240, 9, 135]);
-    let mut byte_iter = EncodableByteIter::new(&data);
+    let mut byte_iter = EncoderByteIter::new(data.encoder());
     assert_eq!(byte_iter.nth(2).unwrap(), 9);
     assert_eq!(byte_iter.nth(0).unwrap(), 135);
     assert!(byte_iter.nth(42).is_none());
 
     let data = TestCatArray([222u8, 173], [190u8, 239]);
-    let mut byte_iter = EncodableByteIter::new(&data);
+    let mut byte_iter = EncoderByteIter::new(data.encoder());
     assert_eq!(byte_iter.nth(1).unwrap(), 173);
     assert_eq!(byte_iter.nth(1).unwrap(), 239);
     assert!(byte_iter.nth(42).is_none());
 
     let data = TestCatArray3([0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]);
-    let mut byte_iter = EncodableByteIter::new(&data);
+    let mut byte_iter = EncoderByteIter::new(data.encoder());
     assert_eq!(byte_iter.nth(5).unwrap(), 5);
     assert_eq!(byte_iter.peek_chunk(), [6, 7]);
 }
@@ -100,13 +100,13 @@ fn nth() {
 #[test]
 fn peek_chunk() {
     let data = TestArray([255u8, 240, 9, 135]);
-    let mut byte_iter = EncodableByteIter::new(&data);
+    let mut byte_iter = EncoderByteIter::new(data.encoder());
     assert_eq!(byte_iter.peek_chunk(), [255u8, 240, 9, 135]);
     assert_eq!(byte_iter.next().unwrap(), 255);
     assert_eq!(byte_iter.peek_chunk(), [240, 9, 135]);
 
     let data = TestCatArray([222u8, 173], [190u8, 239]);
-    let mut byte_iter = EncodableByteIter::new(&data);
+    let mut byte_iter = EncoderByteIter::new(data.encoder());
     assert_eq!(byte_iter.peek_chunk(), [222u8, 173]);
     assert_eq!(byte_iter.next().unwrap(), 222);
     assert_eq!(byte_iter.peek_chunk(), [173]);
@@ -114,7 +114,7 @@ fn peek_chunk() {
     assert_eq!(byte_iter.peek_chunk(), [190, 239]);
 
     let data = TestCatArray([], [21u8, 42]);
-    let mut byte_iter = EncodableByteIter::new(&data);
+    let mut byte_iter = EncoderByteIter::new(data.encoder());
     assert_eq!(byte_iter.peek_chunk(), [21, 42]);
     assert_eq!(byte_iter.next().unwrap(), 21);
     assert_eq!(byte_iter.peek_chunk(), [42]);

--- a/primitives/src/hex_codec.rs
+++ b/primitives/src/hex_codec.rs
@@ -12,7 +12,7 @@ use core::convert::Infallible;
 use core::fmt;
 use core::fmt::Write as _;
 
-use encoding::{Decodable, Decoder, Encodable, EncodableByteIter};
+use encoding::{Decodable, Decoder, Encodable, EncoderByteIter};
 use hex_unstable::{BytesToHexIter, Case};
 use internals::write_err;
 
@@ -24,9 +24,9 @@ pub(crate) struct HexPrimitive<'a, T>(pub(crate) &'a T);
 
 impl<'a, T: Encodable + Decodable> IntoIterator for &HexPrimitive<'a, T> {
     type Item = u8;
-    type IntoIter = EncodableByteIter<'a, T>;
+    type IntoIter = EncoderByteIter<T::Encoder<'a>>;
 
-    fn into_iter(self) -> Self::IntoIter { EncodableByteIter::new(self.0) }
+    fn into_iter(self) -> Self::IntoIter { EncoderByteIter::new(self.0.encoder()) }
 }
 
 impl<T: Decodable> HexPrimitive<'_, T> {
@@ -84,8 +84,8 @@ impl<T: Encodable> HexPrimitive<'_, T> {
         };
 
         // Count hex chars
-        let len = EncodableByteIter::new(self.0).count() * 2;
-        let iter = BytesToHexIter::new(EncodableByteIter::new(self.0), case);
+        let len = EncoderByteIter::new(self.0.encoder()).count() * 2;
+        let iter = BytesToHexIter::new(EncoderByteIter::new(self.0.encoder()), case);
 
         let extra_len = if f.alternate() { 2 } else { 0 };
         let total_len = len + extra_len;

--- a/primitives/src/script/borrowed.rs
+++ b/primitives/src/script/borrowed.rs
@@ -134,7 +134,7 @@ impl<T> Script<T> {
     pub fn to_hex_string_prefixed(&self) -> String {
         use hex_unstable::{BytesToHexIter, Case};
 
-        let iter = encoding::EncodableByteIter::new(self);
+        let iter = encoding::EncoderByteIter::new(self.encoder());
         BytesToHexIter::new(iter, Case::Lower).collect()
     }
 


### PR DESCRIPTION
The EncodableByteIter is currently trait bounded on Encodable. It would be better if it were instead simplified to be bounded on Encoder, and renamed to EncoderByteIter, since it is ultimately only a wrapper around an Encoder, not a special type interacting with Encodable.

Change EncodableByteIter to take an Encoder type directly.
Add Clone derive now that trait bounds allow for it.

Closes #6023 