### PR TITLE
crypto: Remove bitcoin-io dependency

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -95,7 +95,6 @@ dependencies = [
  "arbitrary",
  "base58ck",
  "bitcoin-internals",
- "bitcoin-io",
  "bitcoin-network-kind",
  "bitcoin_hashes",
  "hex-conservative 0.3.2",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -94,7 +94,6 @@ dependencies = [
  "arbitrary",
  "base58ck",
  "bitcoin-internals",
- "bitcoin-io",
  "bitcoin-network-kind",
  "bitcoin_hashes",
  "hex-conservative 0.3.2",

--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -170,7 +170,7 @@ impl<T> Deserialize for ScriptBuf<T> {
 impl Serialize for LegacyPublicKey {
     fn serialize(&self) -> Vec<u8> {
         let mut buf = Vec::new();
-        self.write_into(&mut buf).expect("vecs don't error");
+        buf.write_all(&self.to_bytes()).expect("vecs don't error");
         buf
     }
 }

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -15,9 +15,9 @@ exclude = ["tests", "contrib"]
 
 [features]
 default = ["std"]
-std = ["alloc", "base58/std", "hashes/std", "hex-stable/std", "hex-unstable/std", "internals/std", "io/std", "network/std", "secp256k1/std", "serde?/std"]
+std = ["alloc", "base58/std", "hashes/std", "hex-stable/std", "hex-unstable/std", "internals/std", "network/std", "secp256k1/std", "serde?/std"]
 rand = ["secp256k1/rand"]
-alloc = ["base58/alloc", "hashes/alloc", "hex-stable/alloc", "hex-unstable/alloc", "internals/alloc", "io/alloc", "network/alloc", "secp256k1/alloc", "serde?/alloc"]
+alloc = ["base58/alloc", "hashes/alloc", "hex-stable/alloc", "hex-unstable/alloc", "internals/alloc", "network/alloc", "secp256k1/alloc", "serde?/alloc"]
 serde = ["dep:serde", "hashes/serde", "internals/serde", "secp256k1/serde"]
 arbitrary = ["dep:arbitrary", "secp256k1/arbitrary"]
 
@@ -27,7 +27,6 @@ hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", d
 hex-unstable = { package = "hex-conservative", version = "0.3.2", default-features = false }
 hex-stable = { package = "hex-conservative", version = "1.0.0", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0", features = ["hex"] }
-io = { package = "bitcoin-io", path = "../io", version = "0.5.0", default-features = false, features = ["hashes"] }
 network = { package = "bitcoin-network-kind", path = "../network", version = "0.1.0", default-features = false }
 secp256k1 = { version = "0.32.0-beta.2", default-features = false }
 

--- a/crypto/src/ecdsa.rs
+++ b/crypto/src/ecdsa.rs
@@ -14,7 +14,6 @@ use core::{fmt, iter};
 use arbitrary::{Arbitrary, Unstructured};
 use hex_unstable::DisplayHex;
 use internals::impl_to_hex_from_lower_hex;
-use io::Write;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -81,17 +80,6 @@ impl Signature {
             .chain(iter::once(self.sighash_type as u8))
             .collect()
     }
-
-    /// Serializes an ECDSA signature (inner secp256k1 signature in DER format) to a `writer`.
-    ///
-    /// # Errors
-    ///
-    /// If the signature bytes cannot be written to the provided `writer`.
-    #[inline]
-    pub fn serialize_to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), io::Error> {
-        let sig = self.serialize();
-        sig.write_to(writer)
-    }
 }
 
 impl fmt::Display for Signature {
@@ -152,16 +140,6 @@ impl SerializedSignature {
     /// Returns an iterator over bytes of the signature.
     #[inline]
     pub fn iter(&self) -> core::slice::Iter<'_, u8> { self.into_iter() }
-
-    /// Writes this serialized signature to a `writer`.
-    ///
-    /// # Errors
-    ///
-    /// If the signature bytes cannot be written to the provided `writer`.
-    #[inline]
-    pub fn write_to<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), io::Error> {
-        writer.write_all(self)
-    }
 }
 
 impl fmt::Debug for SerializedSignature {
@@ -374,12 +352,15 @@ impl<'a> Arbitrary<'a> for Signature {
 #[cfg(test)]
 mod tests {
     use alloc::vec;
+    #[cfg(feature = "std")]
+    use std::io::Write;
 
     use super::*;
 
     const TEST_SIGNATURE_HEX: &str = "3046022100839c1fbc5304de944f697c9f4b1d01d1faeba32d751c0f7acb21ac8a0f436a72022100e89bd46bb3a5a62adc679f659b7ce876d83ee297c7a5587b2011c4fcc72eab45";
 
     #[test]
+    #[cfg(feature = "std")]
     fn write_serialized_signature() {
         let sig = Signature {
             signature: secp256k1::ecdsa::Signature::from_str(TEST_SIGNATURE_HEX).unwrap(),
@@ -387,7 +368,7 @@ mod tests {
         };
 
         let mut buf = vec![];
-        sig.serialize_to_writer(&mut buf).expect("write failed");
+        buf.write_all(&sig.serialize()).expect("write failed");
 
         assert_eq!(sig.to_vec(), buf);
     }

--- a/crypto/src/key.rs
+++ b/crypto/src/key.rs
@@ -18,7 +18,6 @@ use hex_unstable::DisplayHex;
 use internals::array::ArrayExt;
 use internals::array_vec::ArrayVec;
 use internals::impl_to_hex_from_lower_hex;
-use io::{Read, Write};
 use network::NetworkKind;
 #[cfg(feature = "rand")]
 #[cfg(feature = "std")]
@@ -633,50 +632,9 @@ impl LegacyPublicKey {
     /// information on the [`LegacyPublicKey`].
     pub fn force_compressed(self) -> FullPublicKey { FullPublicKey::from_secp(self.to_inner()) }
 
-    /// Writes the public key into a writer.
-    ///
-    /// # Errors
-    ///
-    /// Errors if the bytes fail to write to the provided writer.
-    pub fn write_into<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), io::Error> {
-        self.with_serialized(|bytes| writer.write_all(bytes))
-    }
-
-    /// Reads the public key from a reader.
-    ///
-    /// This internally reads the first byte before reading the rest, so
-    /// use of a `BufReader` is recommended.
-    ///
-    /// # Errors
-    ///
-    /// Errors if the reader fails to read, or the read bytes are not a valid public key.
-    pub fn read_from<R: Read + ?Sized>(reader: &mut R) -> Result<Self, io::Error> {
-        let mut bytes = [0; 65];
-
-        reader.read_exact(&mut bytes[0..1])?;
-        let bytes = if bytes[0] < 4 { &mut bytes[..33] } else { &mut bytes[..65] };
-
-        reader.read_exact(&mut bytes[1..])?;
-        Self::from_slice(bytes).map_err(|e| {
-            // Need a static string for no-std io
-            #[cfg(feature = "std")]
-            let reason = e;
-            #[cfg(not(feature = "std"))]
-            let reason = match e {
-                FromSliceError::Secp256k1(_) => "secp256k1 error",
-                FromSliceError::InvalidKeyPrefix(_) => "invalid key prefix",
-                FromSliceError::InvalidLength(_) => "invalid length",
-            };
-            io::Error::new(io::ErrorKind::InvalidData, reason)
-        })
-    }
-
     /// Serializes the public key to bytes.
-    #[allow(clippy::missing_panics_doc)]
     pub fn to_vec(self) -> Vec<u8> {
-        let mut buf = Vec::new();
-        self.write_into(&mut buf).expect("vecs don't error");
-        buf
+        self.to_bytes().to_vec()
     }
 
     /// Serializes the public key to bytes.
@@ -870,38 +828,6 @@ impl FullPublicKey {
     /// Returns bitcoin 160-bit hash of the public key for witness program.
     pub fn wpubkey_hash(&self) -> WPubkeyHash {
         WPubkeyHash::from_byte_array(hash160::Hash::hash(&self.to_bytes()).to_byte_array())
-    }
-
-    /// Writes the public key into a writer.
-    ///
-    /// # Errors
-    ///
-    /// Errors if the bytes fail to write to the provided writer.
-    pub fn write_into<W: io::Write + ?Sized>(&self, writer: &mut W) -> Result<(), io::Error> {
-        writer.write_all(&self.to_bytes())
-    }
-
-    /// Reads the public key from a reader.
-    ///
-    /// This internally reads the first byte before reading the rest, so
-    /// use of a `BufReader` is recommended.
-    ///
-    /// # Errors
-    ///
-    /// Errors if the reader fails to read, or the read bytes are not a valid public key.
-    pub fn read_from<R: io::Read + ?Sized>(reader: &mut R) -> Result<Self, io::Error> {
-        let mut bytes = [0; 33];
-
-        reader.read_exact(&mut bytes)?;
-        #[allow(unused_variables)] // e when std not enabled
-        Self::from_bytes(bytes).map_err(|e| {
-            // Need a static string for no-std io
-            #[cfg(feature = "std")]
-            let reason = e;
-            #[cfg(not(feature = "std"))]
-            let reason = "secp256k1 error";
-            io::Error::new(io::ErrorKind::InvalidData, reason)
-        })
     }
 
     /// Serializes the public key.
@@ -1915,55 +1841,6 @@ mod tests {
         assert_tokens(&pk.readable(), &[Token::BorrowedStr(PK_STR)]);
         assert_tokens(&pk_u.compact(), &[Token::BorrowedBytes(&PK_BYTES_U[..])]);
         assert_tokens(&pk_u.readable(), &[Token::BorrowedStr(PK_STR_U)]);
-    }
-
-    fn random_key(mut seed: u8) -> LegacyPublicKey {
-        loop {
-            let mut data = [0; 65];
-            for byte in &mut data[..] {
-                *byte = seed;
-                // totally a rng
-                seed = seed.wrapping_mul(41).wrapping_add(43);
-            }
-            if data[0] % 2 == 0 {
-                data[0] = 4;
-                if let Ok(key) = LegacyPublicKey::from_slice(&data[..]) {
-                    return key;
-                }
-            } else {
-                data[0] = 2 + (data[0] >> 7);
-                if let Ok(key) = LegacyPublicKey::from_slice(&data[..33]) {
-                    return key;
-                }
-            }
-        }
-    }
-
-    #[test]
-    fn pubkey_read_write() {
-        const N_KEYS: usize = 20;
-        let keys: Vec<_> = (0..N_KEYS).map(|i| random_key(i as u8)).collect();
-
-        let mut v = vec![];
-        for k in &keys {
-            k.write_into(&mut v).expect("writing into vec");
-        }
-
-        let mut reader = v.as_slice();
-        let mut dec_keys = vec![];
-        for _ in 0..N_KEYS {
-            dec_keys.push(LegacyPublicKey::read_from(&mut reader).expect("reading from vec"));
-        }
-        assert_eq!(keys, dec_keys);
-        assert!(LegacyPublicKey::read_from(&mut reader).is_err());
-
-        // sanity checks
-        let mut empty: &[u8] = &[];
-        assert!(LegacyPublicKey::read_from(&mut empty).is_err());
-        assert!(LegacyPublicKey::read_from(&mut &[0; 33][..]).is_err());
-        assert!(LegacyPublicKey::read_from(&mut &[2; 32][..]).is_err());
-        assert!(LegacyPublicKey::read_from(&mut &[0; 65][..]).is_err());
-        assert!(LegacyPublicKey::read_from(&mut &[4; 64][..]).is_err());
     }
 
     #[test]

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -21,8 +21,6 @@ pub extern crate base58;
 
 pub extern crate network;
 
-pub extern crate io;
-
 pub extern crate secp256k1;
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
As mentioned here: https://github.com/rust-bitcoin/rust-bitcoin/pull/6042#issuecomment-4282534076, the bitcoin-io dependency in crypto is largely unnecessary. By removing the handful of methods that rely on it, the introduction of proper alloc feature gating can also be greatly simplified.

- Patch 1 removes io write helpers from Signature and SerializedSignature
- Patch 2 removes read_from and write_into in public key types.
- Patch 3 removes the io re-export, the dependency from the manifest and updates the lock files.