### PR TITLE
Fix found mutants

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -54,6 +54,9 @@ exclude_re = [
     "primitives/.* <impl Decoder for WitnessDecoder>::push_bytes", # Replacing == with != causes an infinite loop
     "primitives/.* WitnessDecoder::resize_if_needed", # Replacing *= with += still resizes the buffer making the mutant untestable.
     "primitives/.* WitnessDecoder::reserve_batch", # Mutations cause an infinite loop
+    "primitives/.* <impl encoding::Encoder for WitnessesEncoder<'_>>::advance -> bool", # Replacing with `true` cause an infinite loop
+    "primitives/.* <impl encoding::Encoder for WitnessEncoder<'_>>::advance -> bool", # Replacing with `true` cause an infinite loop
+    "primitives/.* == with != in <impl encoding::Decoder for WitnessDecoder>::push_bytes", # Replacing == with != causes an infinite loop
     "primitives/.* replace \\+ with \\* in MerkleNode::calculate_root", # Replacing + with * causes an infinite loop
     "primitives/.* replace == with != in MerkleNode::calculate_root", # Replacing == with != isn't caught unless alloc is disabled.
     # TODO: remove after x86 SIMD support lands (https://github.com/rust-bitcoin/rust-bitcoin/issues/5540)

--- a/primitives/src/merkle_tree.rs
+++ b/primitives/src/merkle_tree.rs
@@ -131,7 +131,7 @@ fn calculate_root_batched(mut nodes: Vec<[u8; 32]>) -> Option<[u8; 32]> {
 
         // if odd count, duplicate last element
         if nodes.len() % 2 != 0 {
-            let last = *nodes.last().expect("nodes is not emoty");
+            let last = *nodes.last().expect("nodes is not empty");
             nodes.push(last);
         }
 

--- a/primitives/src/merkle_tree.rs
+++ b/primitives/src/merkle_tree.rs
@@ -196,6 +196,9 @@ impl MerkleNode for WitnessMerkleNode {
 
 #[cfg(test)]
 mod tests {
+    use hashes::HashEngine;
+
+    use super::MerkleNode;
     use crate::hash_types::*;
 
     // Helper to make a Txid, TxMerkleNode pair with a single number byte array
@@ -387,5 +390,79 @@ mod tests {
         let leaf = Wtxid::from_byte_array([2; 32]);
         let root = WitnessMerkleNode::calculate_root([leaf, leaf].into_iter());
         assert!(root.is_none(), "Duplicate witness leaves should return None");
+    }
+
+    // The tests below exercise the default trait `MerkleNode::calculate_root`
+    // implementation. On std+x86_64/aarch64, both `TxMerkleNode` and
+    // `WitnessMerkleNode` override `calculate_root` with the batched version,
+    // this is a test-only impl that uses the default `calculate_root` to kill
+    // mutants
+    #[derive(Clone, Copy, Eq, PartialEq)]
+    struct TestLeaf([u8; 32]);
+
+    impl AsRef<[u8]> for TestLeaf {
+        fn as_ref(&self) -> &[u8] { &self.0 }
+    }
+
+    impl crate::transaction::TxIdentifier for TestLeaf {}
+
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    struct TestNode([u8; 32]);
+
+    impl super::MerkleNode for TestNode {
+        type Leaf = TestLeaf;
+
+        fn from_leaf(leaf: Self::Leaf) -> Self { Self(leaf.0) }
+
+        fn combine(&self, other: &Self) -> Self {
+            let mut engine = hashes::sha256d::Hash::engine();
+            engine.input(&self.0);
+            engine.input(&other.0);
+            Self(hashes::sha256d::Hash::from_engine(engine).to_byte_array())
+        }
+    }
+
+    // Asserts the default (stack-based) `TestNode::calculate_root` produces
+    // the same result as the optimized `TxMerkleNode::calculate_root`.
+    #[track_caller]
+    fn assert_roots_match(leaf_bytes: &[u8]) {
+        let test_root = TestNode::calculate_root(leaf_bytes.iter().map(|&b| TestLeaf([b; 32])));
+        let tx_root = TxMerkleNode::calculate_root(
+            leaf_bytes.iter().map(|&b| Txid::from_byte_array([b; 32])),
+        );
+        assert_eq!(test_root.map(|n| n.0), tx_root.map(TxMerkleNode::to_byte_array));
+    }
+
+    #[test]
+    fn calculate_root_empty() { assert_roots_match(&[]); }
+
+    #[test]
+    fn calculate_root_single_leaf() { assert_roots_match(&[1]); }
+
+    #[test]
+    fn calculate_root_two_leaves() { assert_roots_match(&[1, 2]); }
+
+    #[test]
+    fn calculate_root_duplicate_leaves() { assert_roots_match(&[3, 3]); }
+
+    #[test]
+    fn calculate_root_four_leaves() { assert_roots_match(&[1, 2, 3, 4]); }
+
+    #[test]
+    fn calculate_root_three_leaves_unbalanced() { assert_roots_match(&[1, 2, 3]); }
+
+    #[test]
+    fn calculate_root_five_leaves_unbalanced() { assert_roots_match(&[1, 2, 3, 4, 5]); }
+
+    #[test]
+    fn calculate_root_seven_leaves_unbalanced() { assert_roots_match(&[1, 2, 3, 4, 5, 6, 7]); }
+
+    #[test]
+    fn calculate_root_correct_root_value() {
+        assert_roots_match(&[10, 20]);
+        // Verify ordering matters: combine(a, b) != combine(b, a).
+        let (_, node1) = make_leaf_node(10);
+        let (_, node2) = make_leaf_node(20);
+        assert_ne!(node1.combine(&node2), node2.combine(&node1));
     }
 }


### PR DESCRIPTION
In #6035 cargo mutants found some mutants that were getting MISSED or TIMEOUT, this is due to the target environment the CI runner is on, it by default uses `std`  as `all-features` is turned on and is ran on an `x86_64` machine, This leaves the codepath `MerkleNode::calculate_root` unused, untested by the test suite, causing all generated mutants for that path to be missed. ec07f27ea6d2ff0a486c733a55217704c58f44a0 implements `TestNode` which uses the default `MerkleNode::calculate_root` path and provides test cases asserting the implementation is correct, and gets hit by the generated mutants.

57fa327909a714f1458272c89992ef3175a291d8 asks cargo-mutants to skip generating mutants for the Encode/Decode methods `advance`, `push_bytes` as the mutations generated cause an infinite loop which times out.

21c26f56192cb0f2d4741e2fa7c4809380a15836 Is a typo fix from `emoty` to `empty`