### PR TITLE
units: scrub encoder/decoder layout

### DIFF
--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -614,21 +614,30 @@ impl TryFrom<SignedAmount> for Amount {
 }
 
 #[cfg(feature = "encoding")]
-encoding::encoder_newtype_exact! {
-    /// The encoder for the [`Amount`] type.
-    #[derive(Debug, Clone)]
-    pub struct AmountEncoder<'e>(encoding::ArrayEncoder<8>);
-}
-
-#[cfg(feature = "encoding")]
 impl encoding::Encodable for Amount {
     type Encoder<'e> = AmountEncoder<'e>;
+
     #[inline]
     fn encoder(&self) -> Self::Encoder<'_> {
         AmountEncoder::new(encoding::ArrayEncoder::without_length_prefix(
             self.to_sat().to_le_bytes(),
         ))
     }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decodable for Amount {
+    type Decoder = AmountDecoder;
+
+    #[inline]
+    fn decoder() -> Self::Decoder { AmountDecoder(encoding::ArrayDecoder::<8>::new()) }
+}
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// The encoder for the [`Amount`] type.
+    #[derive(Debug, Clone)]
+    pub struct AmountEncoder<'e>(encoding::ArrayEncoder<8>);
 }
 
 #[cfg(feature = "encoding")]
@@ -649,13 +658,6 @@ crate::decoder_newtype! {
         let a = u64::from_le_bytes(value);
         Amount::from_sat(a).map_err(AmountDecoderError::out_of_range)
     }
-}
-
-#[cfg(feature = "encoding")]
-impl encoding::Decodable for Amount {
-    type Decoder = AmountDecoder;
-    #[inline]
-    fn decoder() -> Self::Decoder { AmountDecoder(encoding::ArrayDecoder::<8>::new()) }
 }
 
 #[cfg(feature = "arbitrary")]

--- a/units/src/block.rs
+++ b/units/src/block.rs
@@ -205,13 +205,6 @@ impl TryFrom<BlockHeight> for absolute::Height {
 }
 
 #[cfg(feature = "encoding")]
-encoding::encoder_newtype_exact! {
-    /// The encoder for the [`BlockHeight`] type.
-    #[derive(Debug, Clone)]
-    pub struct BlockHeightEncoder<'e>(encoding::ArrayEncoder<4>);
-}
-
-#[cfg(feature = "encoding")]
 impl encoding::Encodable for BlockHeight {
     type Encoder<'e> = BlockHeightEncoder<'e>;
     #[inline]
@@ -220,6 +213,21 @@ impl encoding::Encodable for BlockHeight {
             self.to_u32().to_le_bytes(),
         ))
     }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decodable for BlockHeight {
+    type Decoder = BlockHeightDecoder;
+
+    #[inline]
+    fn decoder() -> Self::Decoder { BlockHeightDecoder(encoding::ArrayDecoder::<4>::new()) }
+}
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// The encoder for the [`BlockHeight`] type.
+    #[derive(Debug, Clone)]
+    pub struct BlockHeightEncoder<'e>(encoding::ArrayEncoder<4>);
 }
 
 #[cfg(feature = "encoding")]
@@ -236,13 +244,6 @@ crate::decoder_newtype! {
         let n = u32::from_le_bytes(value);
         Ok(BlockHeight::from_u32(n))
     }
-}
-
-#[cfg(feature = "encoding")]
-impl encoding::Decodable for BlockHeight {
-    type Decoder = BlockHeightDecoder;
-    #[inline]
-    fn decoder() -> Self::Decoder { BlockHeightDecoder(encoding::ArrayDecoder::<4>::new()) }
 }
 
 impl_u32_wrapper! {

--- a/units/src/locktime/absolute/mod.rs
+++ b/units/src/locktime/absolute/mod.rs
@@ -398,13 +398,6 @@ impl LockTime {
 parse_int::impl_parse_str_from_int_infallible!(LockTime, u32, from_consensus);
 
 #[cfg(feature = "encoding")]
-encoding::encoder_newtype_exact! {
-    /// The encoder for the [`LockTime`] type.
-    #[derive(Debug, Clone)]
-    pub struct LockTimeEncoder<'e>(encoding::ArrayEncoder<4>);
-}
-
-#[cfg(feature = "encoding")]
 impl encoding::Encodable for LockTime {
     type Encoder<'e> = LockTimeEncoder<'e>;
     #[inline]
@@ -413,6 +406,21 @@ impl encoding::Encodable for LockTime {
             self.to_consensus_u32().to_le_bytes(),
         ))
     }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decodable for LockTime {
+    type Decoder = LockTimeDecoder;
+
+    #[inline]
+    fn decoder() -> Self::Decoder { LockTimeDecoder(encoding::ArrayDecoder::<4>::new()) }
+}
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// The encoder for the [`LockTime`] type.
+    #[derive(Debug, Clone)]
+    pub struct LockTimeEncoder<'e>(encoding::ArrayEncoder<4>);
 }
 
 #[cfg(feature = "encoding")]
@@ -429,13 +437,6 @@ crate::decoder_newtype! {
         let n = u32::from_le_bytes(value);
         Ok(LockTime::from_consensus(n))
     }
-}
-
-#[cfg(feature = "encoding")]
-impl encoding::Decodable for LockTime {
-    type Decoder = LockTimeDecoder;
-    #[inline]
-    fn decoder() -> Self::Decoder { LockTimeDecoder(encoding::ArrayDecoder::<4>::new()) }
 }
 
 impl From<Height> for LockTime {

--- a/units/src/pow.rs
+++ b/units/src/pow.rs
@@ -303,13 +303,6 @@ impl From<CompactTarget> for Target {
 }
 
 #[cfg(feature = "encoding")]
-encoding::encoder_newtype_exact! {
-    /// The encoder for the [`CompactTarget`] type.
-    #[derive(Debug, Clone)]
-    pub struct CompactTargetEncoder<'e>(encoding::ArrayEncoder<4>);
-}
-
-#[cfg(feature = "encoding")]
 impl encoding::Encodable for CompactTarget {
     type Encoder<'e> = CompactTargetEncoder<'e>;
     #[inline]
@@ -318,6 +311,21 @@ impl encoding::Encodable for CompactTarget {
             self.to_consensus().to_le_bytes(),
         ))
     }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decodable for CompactTarget {
+    type Decoder = CompactTargetDecoder;
+
+    #[inline]
+    fn decoder() -> Self::Decoder { CompactTargetDecoder(encoding::ArrayDecoder::<4>::new()) }
+}
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// The encoder for the [`CompactTarget`] type.
+    #[derive(Debug, Clone)]
+    pub struct CompactTargetEncoder<'e>(encoding::ArrayEncoder<4>);
 }
 
 #[cfg(feature = "encoding")]
@@ -334,13 +342,6 @@ crate::decoder_newtype! {
         let n = u32::from_le_bytes(value);
         Ok(CompactTarget::from_consensus(n))
     }
-}
-
-#[cfg(feature = "encoding")]
-impl encoding::Decodable for CompactTarget {
-    type Decoder = CompactTargetDecoder;
-    #[inline]
-    fn decoder() -> Self::Decoder { CompactTargetDecoder(encoding::ArrayDecoder::<4>::new()) }
 }
 
 /// Error types for proof-of-work related integer types.

--- a/units/src/sequence.rs
+++ b/units/src/sequence.rs
@@ -259,13 +259,6 @@ impl fmt::Debug for Sequence {
 parse_int::impl_parse_str_from_int_infallible!(Sequence, u32, from_consensus);
 
 #[cfg(feature = "encoding")]
-encoding::encoder_newtype_exact! {
-    /// The encoder for the [`Sequence`] type.
-    #[derive(Debug, Clone)]
-    pub struct SequenceEncoder<'e>(encoding::ArrayEncoder<4>);
-}
-
-#[cfg(feature = "encoding")]
 impl encoding::Encodable for Sequence {
     type Encoder<'e> = SequenceEncoder<'e>;
     #[inline]
@@ -274,6 +267,21 @@ impl encoding::Encodable for Sequence {
             self.to_consensus_u32().to_le_bytes(),
         ))
     }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decodable for Sequence {
+    type Decoder = SequenceDecoder;
+
+    #[inline]
+    fn decoder() -> Self::Decoder { SequenceDecoder(encoding::ArrayDecoder::<4>::new()) }
+}
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// The encoder for the [`Sequence`] type.
+    #[derive(Debug, Clone)]
+    pub struct SequenceEncoder<'e>(encoding::ArrayEncoder<4>);
 }
 
 #[cfg(feature = "encoding")]
@@ -290,13 +298,6 @@ crate::decoder_newtype! {
         let n = u32::from_le_bytes(value);
         Ok(Sequence::from_consensus(n))
     }
-}
-
-#[cfg(feature = "encoding")]
-impl encoding::Decodable for Sequence {
-    type Decoder = SequenceDecoder;
-    #[inline]
-    fn decoder() -> Self::Decoder { SequenceDecoder(encoding::ArrayDecoder::<4>::new()) }
 }
 
 /// Error types for input sequence numbers.

--- a/units/src/time.rs
+++ b/units/src/time.rs
@@ -118,13 +118,6 @@ impl<'de> Deserialize<'de> for BlockTime {
 }
 
 #[cfg(feature = "encoding")]
-encoding::encoder_newtype_exact! {
-    /// The encoder for the [`BlockTime`] type.
-    #[derive(Debug, Clone)]
-    pub struct BlockTimeEncoder<'e>(encoding::ArrayEncoder<4>);
-}
-
-#[cfg(feature = "encoding")]
 impl encoding::Encodable for BlockTime {
     type Encoder<'e> = BlockTimeEncoder<'e>;
     #[inline]
@@ -133,6 +126,21 @@ impl encoding::Encodable for BlockTime {
             self.to_u32().to_le_bytes(),
         ))
     }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decodable for BlockTime {
+    type Decoder = BlockTimeDecoder;
+
+    #[inline]
+    fn decoder() -> Self::Decoder { BlockTimeDecoder(encoding::ArrayDecoder::<4>::new()) }
+}
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// The encoder for the [`BlockTime`] type.
+    #[derive(Debug, Clone)]
+    pub struct BlockTimeEncoder<'e>(encoding::ArrayEncoder<4>);
 }
 
 #[cfg(feature = "encoding")]
@@ -149,13 +157,6 @@ crate::decoder_newtype! {
         let n = u32::from_le_bytes(value);
         Ok(BlockTime::from_u32(n))
     }
-}
-
-#[cfg(feature = "encoding")]
-impl encoding::Decodable for BlockTime {
-    type Decoder = BlockTimeDecoder;
-    #[inline]
-    fn decoder() -> Self::Decoder { BlockTimeDecoder(encoding::ArrayDecoder::<4>::new()) }
 }
 
 /// Error types for block times.


### PR DESCRIPTION
Continuation of #5902.

Scrub the encoder/decoder layout in `units` as per policy introduced in https://github.com/rust-bitcoin/rust-bitcoin/pull/5583. Move `Decodable` impls next to the corresponding `Encodable` impls, move the encoder newtype blocks accordingly, and add `#[inline]` to the small encoding/decoding wrapper functions.

No logic change intended.