### PR TITLE
Release tracking PR: `bitcoin-crypto 0.2.0`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-crypto"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "arbitrary",
  "base58ck",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-crypto"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "arbitrary",
  "base58ck",

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -28,7 +28,7 @@ arbitrary = ["crypto/arbitrary", "dep:arbitrary", "units/arbitrary", "primitives
 [dependencies]
 base58 = { package = "base58ck", path = "../base58", version = "0.4.0", default-features = false, features = ["alloc"] }
 bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
-crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.1.0", default-features = false, features = ["alloc"] }
+crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.2.0", default-features = false, features = ["alloc"] }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false, features = ["alloc", "hex"] }
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.2.0", default-features = false, features = ["alloc"] }
 hex-stable = { package = "hex-conservative", version = "1.0.0", default-features = false, features = ["alloc"] }

--- a/crypto/CHANGELOG.md
+++ b/crypto/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.2.0 - 2026-04-27
+
+- Re-export types and extern crates [#5858](https://github.com/rust-bitcoin/rust-bitcoin/pull/5858)
+- Remove error conversion `From` impls [#6041](https://github.com/rust-bitcoin/rust-bitcoin/pull/6041)
+- Remove `bitcoin-io` dependency [#6049](https://github.com/rust-bitcoin/rust-bitcoin/pull/6049)
+
 # 0.1.0 - Initial migration
 
 - Migrate all code from `rust-bitcoin::crypto::ecdsa` to this crate.

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-crypto"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin"

--- a/taproot-primitives/Cargo.toml
+++ b/taproot-primitives/Cargo.toml
@@ -21,7 +21,7 @@ arbitrary = ["crypto/arbitrary", "dep:arbitrary", "hashes/arbitrary", "secp256k1
 hex = ["hashes/hex"]
 
 [dependencies]
-crypto = { package = "bitcoin-crypto", path = "../crypto", default-features = false }
+crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.2.0", default-features = false }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
 


### PR DESCRIPTION
As a very generous gift to back up my whinge yesterday the world gave us an example immediately that we probably should do release tracking PRs for all releases. Not that that will guarantee to stop me making mistakes though ...

Do a point release for the re-exports patch that we wanted in `v0.1`. Adds to the public API, ok to do in a point release for pre-1.0 crate.

In preparation add a changelog entry, bump the version number, and update the lock files.