### PR TITLE
Deprecate psbt module

### DIFF
--- a/bitcoin/examples/ecdsa-psbt.rs
+++ b/bitcoin/examples/ecdsa-psbt.rs
@@ -28,6 +28,10 @@
 //!    `bt listunspent`
 //!
 
+// The `psbt` module is deprecated. For a drop in replacement consider
+// https://git.rust-bitcoin.org/rust-bitcoin/rust-psbt
+#![allow(deprecated)]
+
 use std::collections::BTreeMap;
 use std::fmt;
 use std::str::FromStr;

--- a/bitcoin/examples/taproot-psbt.rs
+++ b/bitcoin/examples/taproot-psbt.rs
@@ -1,5 +1,9 @@
 //! Example of taproot PSBT workflow
 
+// The `bitcoin::psbt` module is deprecated. For a drop in replacement
+// consider https://git.rust-bitcoin.org/rust-bitcoin/rust-psbt
+#![allow(deprecated)]
+
 // We use the alias `alias bt='bitcoin-cli -regtest'` for brevity.
 
 // Step 0 - Wipe the `regtest` data directory to start from a clean slate.

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -109,6 +109,7 @@ pub mod merkle_tree;
 pub mod network;
 pub mod policy;
 pub mod pow;
+#[deprecated(since = "0.32.9", note = "Please see https://git.rust-bitcoin.org/rust-bitcoin/rust-psbt")]
 pub mod psbt;
 pub mod sign_message;
 pub mod taproot;

--- a/bitcoin/tests/bip_174.rs
+++ b/bitcoin/tests/bip_174.rs
@@ -1,6 +1,10 @@
 //! Tests PSBT integration vectors from BIP 174
 //! defined at <https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#test-vectors>
 
+// The `bitcoin::psbt` module is deprecated. For a drop in replacement
+// consider https://git.rust-bitcoin.org/rust-bitcoin/rust-psbt
+#![allow(deprecated)]
+
 use std::collections::BTreeMap;
 use std::str::FromStr;
 

--- a/bitcoin/tests/psbt-sign-taproot.rs
+++ b/bitcoin/tests/psbt-sign-taproot.rs
@@ -1,4 +1,7 @@
 #![cfg(not(feature = "rand-std"))]
+// The `bitcoin::psbt` module is deprecated. For a drop in replacement
+// consider https://git.rust-bitcoin.org/rust-bitcoin/rust-psbt
+#![allow(deprecated)]
 
 use std::collections::BTreeMap;
 use std::str::FromStr;

--- a/bitcoin/tests/serde.rs
+++ b/bitcoin/tests/serde.rs
@@ -32,7 +32,9 @@ use bitcoin::blockdata::witness::Witness;
 use bitcoin::consensus::encode::deserialize;
 use bitcoin::hashes::{hash160, ripemd160, sha256, sha256d, Hash};
 use bitcoin::hex::FromHex;
+#[allow(deprecated)]           // psbt module is deprecated.
 use bitcoin::psbt::raw::{self, Key, Pair, ProprietaryKey};
+#[allow(deprecated)]           // psbt module is deprecated.
 use bitcoin::psbt::{Input, Output, Psbt, PsbtSighashType};
 use bitcoin::sighash::{EcdsaSighashType, TapSighashType};
 use bitcoin::taproot::{self, ControlBlock, LeafVersion, TapTree, TaprootBuilder};
@@ -218,6 +220,7 @@ fn serde_regression_public_key() {
 }
 
 #[test]
+#[allow(deprecated)]           // psbt module is deprecated.
 fn serde_regression_psbt() {
     let tx = Transaction {
         version: transaction::Version::ONE,
@@ -321,6 +324,7 @@ fn serde_regression_psbt() {
 }
 
 #[test]
+#[allow(deprecated)]           // psbt module is deprecated.
 fn serde_regression_raw_pair() {
     let pair = Pair {
         key: Key { type_value: 1u8, key: vec![0u8, 1u8, 2u8, 3u8] },
@@ -332,6 +336,7 @@ fn serde_regression_raw_pair() {
 }
 
 #[test]
+#[allow(deprecated)]           // psbt module is deprecated.
 fn serde_regression_proprietary_key() {
     let key = ProprietaryKey {
         prefix: vec![0u8, 1u8, 2u8, 3u8],

--- a/fuzz/fuzz_targets/bitcoin/deserialize_psbt.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_psbt.rs
@@ -1,5 +1,8 @@
 use honggfuzz::fuzz;
 
+// The `bitcoin::psbt` module is deprecated. For a drop in replacement
+// consider https://git.rust-bitcoin.org/rust-bitcoin/rust-psbt
+#[allow(deprecated)]
 fn do_test(data: &[u8]) {
     let psbt: Result<bitcoin::psbt::Psbt, _> = bitcoin::psbt::Psbt::deserialize(data);
     match psbt {


### PR DESCRIPTION
Development of the `psbt` module has moved to a new crate located on the forge at https://git.rust-bitcoin.org/rust-bitcoin/rust-psbt.

The plan is to deprecate it here on the `0.32.x` branch and then delete the code from `master` (so beta releases will not include it).

Currently the latest release of `psbt-v2 0.3.0` is a drop in replacement for the code in the `0.32` releases.