### PR TITLE
Don't abuse psbt Deserialize

### DIFF
--- a/bitcoin/src/taproot/mod.rs
+++ b/bitcoin/src/taproot/mod.rs
@@ -18,6 +18,8 @@ use internals::array::ArrayExt;
 #[allow(unused)] // MSRV polyfill
 use internals::slice::SliceExt;
 use io::Write;
+#[cfg(feature = "serde")]
+use serde::Deserialize;
 
 use crate::consensus::Encodable;
 use crate::crypto::key::{
@@ -48,8 +50,6 @@ pub use self::error::{
     InvalidMerkleBranchSizeError, InvalidMerkleTreeDepthError, InvalidTaprootLeafVersionError,
     SigFromSliceError, TaprootBuilderError, TaprootError,
 };
-#[cfg(feature = "arbitrary")]
-use crate::psbt::serialize::Deserialize;
 #[doc(inline)]
 pub use crate::XOnlyPublicKey;
 
@@ -1470,7 +1470,8 @@ impl<'a> Arbitrary<'a> for TapLeaf {
 #[cfg(feature = "arbitrary")]
 impl<'a> Arbitrary<'a> for TapTree {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        Ok(Self::deserialize(u.arbitrary()?).map_err(|_| arbitrary::Error::IncorrectFormat)?)
+        let node_info = NodeInfo::arbitrary(u)?;
+        Ok(Self(node_info))
     }
 }
 


### PR DESCRIPTION
I'm not sure what is the intention of this code or exactly how the derives are working in the `taproot` module because we are importing `psbt::serialize::Deserialize` and then using it in `serde` derives?

Also the `TapTree` arbitrary stuff is a bit odd, that is what led me here while I was attempting to delete the `psbt` module.

So, I don't know if this is a bug or an internal change? Introduced in commit: `37c9fce2a684 Implement Arbitrary for psbt types`.