### PR TITLE
taproot-primitives: Fix alloc feature gating and add hex feature

### DIFF
--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -38,7 +38,7 @@ io = { package = "bitcoin-io", path = "../io", version = "0.5.0", default-featur
 network = { package = "bitcoin-network-kind", path = "../network", version = "0.1.0", default-features = false, features = ["alloc"]}
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.102.0", default-features = false, features = ["alloc", "hex"] }
 secp256k1 = { version = "0.32.0-beta.2", default-features = false, features = ["alloc"] }
-taproot-primitives = { package = "bitcoin-taproot-primitives", path = "../taproot-primitives", version = "0.1.0", default-features = false, features = ["alloc"] }
+taproot-primitives = { package = "bitcoin-taproot-primitives", path = "../taproot-primitives", version = "0.1.0", default-features = false, features = ["alloc", "hex"] }
 units = { package = "bitcoin-units", path = "../units", version = "0.3.0", default-features = false, features = ["alloc"] }
 
 arbitrary = { version = "1.4.1", optional = true }

--- a/taproot-primitives/Cargo.toml
+++ b/taproot-primitives/Cargo.toml
@@ -13,15 +13,16 @@ rust-version = "1.74.0"
 exclude = ["tests", "contrib"]
 
 [features]
-default = ["std"]
+default = ["std", "hex"]
 std = ["alloc", "crypto/std", "hashes/std", "internals/std", "serde?/std", "secp256k1/std"]
 alloc = ["crypto/alloc", "hashes/alloc", "internals/alloc", "secp256k1/alloc"]
 serde = ["dep:serde", "crypto/serde", "hashes/serde", "internals/serde", "secp256k1/serde"]
 arbitrary = ["crypto/arbitrary", "dep:arbitrary", "hashes/arbitrary", "secp256k1/arbitrary"]
+hex = ["hashes/hex"]
 
 [dependencies]
 crypto = { package = "bitcoin-crypto", path = "../crypto", default-features = false }
-hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false, features = ["hex"] }
+hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
 
 arbitrary = { version = "1.4.1", optional = true }

--- a/taproot-primitives/src/lib.rs
+++ b/taproot-primitives/src/lib.rs
@@ -13,6 +13,7 @@
 #![allow(clippy::manual_range_contains)] // More readable than clippy's format.
 #![allow(clippy::uninlined_format_args)] // Allow `format!("{}", x)` instead of enforcing `format!("{x}")`
 
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 #[cfg(feature = "std")]
@@ -190,6 +191,7 @@ impl fmt::LowerHex for LeafVersion {
         fmt::LowerHex::fmt(&self.to_consensus(), f)
     }
 }
+#[cfg(feature = "alloc")]
 internals::impl_to_hex_from_lower_hex!(LeafVersion, |_| 2);
 
 impl fmt::UpperHex for LeafVersion {
@@ -281,6 +283,7 @@ impl fmt::LowerHex for FutureLeafVersion {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { fmt::LowerHex::fmt(&self.0, f) }
 }
+#[cfg(feature = "alloc")]
 internals::impl_to_hex_from_lower_hex!(FutureLeafVersion, |_| 2);
 
 impl fmt::UpperHex for FutureLeafVersion {

--- a/taproot-primitives/src/lib.rs
+++ b/taproot-primitives/src/lib.rs
@@ -66,9 +66,10 @@ hash_newtype! {
     /// This is used for computing tapscript script spend hash.
     pub struct TapLeafHash(sha256t::Hash<TapLeafTag>);
 }
-
+#[cfg(feature = "hex")]
 hashes::impl_hex_for_newtype!(TapLeafHash);
 #[cfg(feature = "serde")]
+#[cfg(feature = "hex")]
 hashes::impl_serde_for_newtype!(TapLeafHash);
 
 sha256t_tag! {
@@ -83,8 +84,10 @@ hash_newtype! {
     pub struct TapNodeHash(sha256t::Hash<TapBranchTag>);
 }
 
+#[cfg(feature = "hex")]
 hashes::impl_hex_for_newtype!(TapNodeHash);
 #[cfg(feature = "serde")]
+#[cfg(feature = "hex")]
 hashes::impl_serde_for_newtype!(TapNodeHash);
 
 sha256t_tag! {
@@ -98,8 +101,10 @@ hash_newtype! {
     pub struct TapTweakHash(sha256t::Hash<TapTweakTag>);
 }
 
+#[cfg(feature = "hex")]
 hashes::impl_hex_for_newtype!(TapTweakHash);
 #[cfg(feature = "serde")]
+#[cfg(feature = "hex")]
 hashes::impl_serde_for_newtype!(TapTweakHash);
 
 impl From<TapLeafHash> for TapNodeHash {


### PR DESCRIPTION
The new taproot-primitives crate has various issues with its feature gating that will cause problems in true alloc-less environments and where hex functionality is not desired. These should be fixed before the first release.

- Patch 1 adds a hex feature and gates all usage of hashes' hex functionality behind it.
- Patch 2 correctly gates the alloc crate's extern and remaining alloc type usage behind the alloc feature.