### PR TITLE
Release tracking PR: `bitcoin-taproot-primitives 0.1.0`

### DIFF
--- a/taproot-primitives/Cargo.toml
+++ b/taproot-primitives/Cargo.toml
@@ -17,7 +17,7 @@ default = ["std", "hex"]
 std = ["alloc", "crypto/std", "hashes/std", "internals/std", "serde?/std", "secp256k1/std"]
 alloc = ["crypto/alloc", "hashes/alloc", "internals/alloc", "secp256k1/alloc"]
 serde = ["dep:serde", "crypto/serde", "hashes/serde", "internals/serde", "secp256k1/serde"]
-arbitrary = ["crypto/arbitrary", "dep:arbitrary", "hashes/arbitrary", "secp256k1/arbitrary"]
+arbitrary = ["crypto/arbitrary", "dep:arbitrary", "secp256k1/arbitrary"]
 hex = ["hashes/hex"]
 
 [dependencies]


### PR DESCRIPTION
The taproot-primitives crate has already had a version bump patch merged. However, the manifest still has issues that prevent publishing.

Drop hashes/arbitrary feature in the taproot-primitives manifest to complete the 0.1 release.