### PR TITLE
hashes: Add `drain_to_engine` function

### DIFF
--- a/hashes/api/all-features.txt
+++ b/hashes/api/all-features.txt
@@ -3357,6 +3357,7 @@ pub trait bitcoin_hashes::IsByteArray: core::convert::AsRef<[u8]> + bitcoin_hash
 pub const bitcoin_hashes::IsByteArray::LEN: usize
 impl<const N: usize> bitcoin_hashes::IsByteArray for [u8; N]
 pub const [u8; N]::LEN: usize
+pub fn bitcoin_hashes::drain_to_engine<T, H>(encoder: &mut T, engine: &mut H) where T: bitcoin_consensus_encoding::encode::Encoder + ?core::marker::Sized, H: bitcoin_hashes::HashEngine
 pub fn bitcoin_hashes::encode_to_engine<T, H>(object: &T, engine: &mut H) where T: bitcoin_consensus_encoding::encode::Encode + ?core::marker::Sized, H: bitcoin_hashes::HashEngine
 pub type bitcoin_hashes::HkdfSha256 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha256::Hash>
 pub type bitcoin_hashes::HkdfSha512 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha512::Hash>

--- a/hashes/api/alloc-only.txt
+++ b/hashes/api/alloc-only.txt
@@ -2891,6 +2891,7 @@ pub trait bitcoin_hashes::IsByteArray: core::convert::AsRef<[u8]> + bitcoin_hash
 pub const bitcoin_hashes::IsByteArray::LEN: usize
 impl<const N: usize> bitcoin_hashes::IsByteArray for [u8; N]
 pub const [u8; N]::LEN: usize
+pub fn bitcoin_hashes::drain_to_engine<T, H>(encoder: &mut T, engine: &mut H) where T: bitcoin_consensus_encoding::encode::Encoder + ?core::marker::Sized, H: bitcoin_hashes::HashEngine
 pub fn bitcoin_hashes::encode_to_engine<T, H>(object: &T, engine: &mut H) where T: bitcoin_consensus_encoding::encode::Encode + ?core::marker::Sized, H: bitcoin_hashes::HashEngine
 pub type bitcoin_hashes::HkdfSha256 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha256::Hash>
 pub type bitcoin_hashes::HkdfSha512 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha512::Hash>

--- a/hashes/api/no-features.txt
+++ b/hashes/api/no-features.txt
@@ -2697,6 +2697,7 @@ pub trait bitcoin_hashes::IsByteArray: core::convert::AsRef<[u8]> + bitcoin_hash
 pub const bitcoin_hashes::IsByteArray::LEN: usize
 impl<const N: usize> bitcoin_hashes::IsByteArray for [u8; N]
 pub const [u8; N]::LEN: usize
+pub fn bitcoin_hashes::drain_to_engine<T, H>(encoder: &mut T, engine: &mut H) where T: bitcoin_consensus_encoding::encode::Encoder + ?core::marker::Sized, H: bitcoin_hashes::HashEngine
 pub fn bitcoin_hashes::encode_to_engine<T, H>(object: &T, engine: &mut H) where T: bitcoin_consensus_encoding::encode::Encode + ?core::marker::Sized, H: bitcoin_hashes::HashEngine
 pub type bitcoin_hashes::HkdfSha256 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha256::Hash>
 pub type bitcoin_hashes::HkdfSha512 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha512::Hash>

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -117,8 +117,6 @@ pub mod siphash24;
 use core::fmt::{self, Write as _};
 use core::{convert, hash};
 
-use encoding::Encoder;
-
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
 pub use self::{
@@ -205,6 +203,15 @@ where
     H: HashEngine,
 {
     let mut encoder = object.encoder();
+    drain_to_engine(&mut encoder, engine);
+}
+
+/// Drain the output of an [`encoding::Encoder`] into a hash engine.
+pub fn drain_to_engine<T, H>(encoder: &mut T, engine: &mut H)
+where
+    T: encoding::Encoder + ?Sized,
+    H: HashEngine,
+{
     loop {
         engine.input(encoder.current_chunk());
         if !encoder.advance() {


### PR DESCRIPTION
This PR is likely blocking the `hashes 1.0.0` release. Replaces #5972 because of original author does not want to run the API checker script.

Add a function that pairs with `encode_to_engine`. This is similar to the APIs `encode_to_writer`/`drain_to_writer` in other crates.
    
Note, use one level of path on the `Encoder` to be uniform with the code in `encode_to_engine`.
