### PR TITLE
taproot-primitives: Add crate externs for public API types

### DIFF
--- a/taproot-primitives/src/lib.rs
+++ b/taproot-primitives/src/lib.rs
@@ -18,6 +18,15 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+#[cfg(feature = "arbitrary")]
+pub extern crate arbitrary;
+
+pub extern crate hashes;
+pub extern crate secp256k1;
+
+#[cfg(feature = "serde")]
+pub extern crate serde;
+
 #[rustfmt::skip] // Keep pub re-exports separate
 #[doc(no_inline)]
 pub use self::error::InvalidTaprootLeafVersionError;


### PR DESCRIPTION
Whenever a crate has types in its public API that come from another crate, that other crate should be re-exported from the crate root. taproot-primitives uses types from arbitrary, hashes, secp and serde in its public API, and thus all of these should be re-exported.

Re-export arbitrary, hashes, secp256k1 and serde from the crate root.