### PR TITLE
taproot-primitives: Remove crypto dependency

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -192,7 +192,6 @@ name = "bitcoin-taproot-primitives"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "bitcoin-crypto",
  "bitcoin-internals",
  "bitcoin_hashes",
  "secp256k1",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -191,7 +191,6 @@ name = "bitcoin-taproot-primitives"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "bitcoin-crypto",
  "bitcoin-internals",
  "bitcoin_hashes",
  "secp256k1",

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -12,7 +12,7 @@ use crate::internal_macros::define_extension_trait;
 use crate::script::{self, PushBytes, WitnessScriptBuf};
 #[cfg(feature = "secp-recovery")]
 use crate::sign_message::MessageSignature;
-use crate::taproot::{TapNodeHash, TapTweakHash};
+use crate::taproot::{TapNodeHash, TapTweakHash, TapTweakHashExt as _};
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 pub use secp256k1::{constants, Parity, Verification};

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -8,11 +8,13 @@
 use core::borrow::Borrow;
 use core::ops::Deref;
 
+use crypto::sighash::TapTweakHashExt as _;
+
 use crate::internal_macros::define_extension_trait;
 use crate::script::{self, PushBytes, WitnessScriptBuf};
 #[cfg(feature = "secp-recovery")]
 use crate::sign_message::MessageSignature;
-use crate::taproot::{TapNodeHash, TapTweakHash, TapTweakHashExt as _};
+use crate::taproot::{TapNodeHash, TapTweakHash};
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 pub use secp256k1::{constants, Parity, Verification};

--- a/bitcoin/src/taproot/mod.rs
+++ b/bitcoin/src/taproot/mod.rs
@@ -31,6 +31,8 @@ use crate::{hex, TapScript, TapScriptBuf};
 #[doc(inline)]
 pub use crate::crypto::taproot::{SerializedSignature, Signature};
 #[doc(inline)]
+pub use crypto::sighash::TapTweakHashExt;
+#[doc(inline)]
 pub use merkle_branch::TaprootMerkleBranch;
 #[doc(inline)]
 pub use merkle_branch::TaprootMerkleBranchBuf;
@@ -95,30 +97,6 @@ crate::internal_macros::define_extension_trait! {
         /// Computes the [`TapNodeHash`] from a script and a leaf version.
         fn from_script(script: &TapScript, ver: LeafVersion) -> Self {
             Self::from(TapLeafHash::from_script(script, ver))
-        }
-    }
-}
-
-crate::internal_macros::define_extension_trait! {
-    /// Extension functionality for the [`TapTweakHash`] type.
-    pub trait TapTweakHashExt impl for TapTweakHash {
-        /// Constructs a new BIP-0341 [`TapTweakHash`] from key and Merkle root. Produces `H_taptweak(P||R)` where
-        /// `P` is the internal key and `R` is the Merkle root.
-        fn from_key_and_merkle_root<K: Into<UntweakedPublicKey>>(
-            internal_key: K,
-            merkle_root: Option<TapNodeHash>,
-        ) -> Self {
-            let internal_key = internal_key.into();
-            let mut eng = sha256t::Hash::<TapTweakTag>::engine();
-            // always hash the key
-            eng.input(&internal_key.serialize().0);
-            if let Some(h) = merkle_root {
-                eng.input(h.as_ref());
-            } else {
-                // nothing to hash
-            }
-            let inner = sha256t::Hash::<TapTweakTag>::from_engine(eng);
-            Self::from_byte_array(inner.to_byte_array())
         }
     }
 }

--- a/bitcoin/src/taproot/mod.rs
+++ b/bitcoin/src/taproot/mod.rs
@@ -99,10 +99,35 @@ crate::internal_macros::define_extension_trait! {
     }
 }
 
+crate::internal_macros::define_extension_trait! {
+    /// Extension functionality for the [`TapTweakHash`] type.
+    pub trait TapTweakHashExt impl for TapTweakHash {
+        /// Constructs a new BIP-0341 [`TapTweakHash`] from key and Merkle root. Produces `H_taptweak(P||R)` where
+        /// `P` is the internal key and `R` is the Merkle root.
+        fn from_key_and_merkle_root<K: Into<UntweakedPublicKey>>(
+            internal_key: K,
+            merkle_root: Option<TapNodeHash>,
+        ) -> Self {
+            let internal_key = internal_key.into();
+            let mut eng = sha256t::Hash::<TapTweakTag>::engine();
+            // always hash the key
+            eng.input(&internal_key.serialize().0);
+            if let Some(h) = merkle_root {
+                eng.input(h.as_ref());
+            } else {
+                // nothing to hash
+            }
+            let inner = sha256t::Hash::<TapTweakTag>::from_engine(eng);
+            Self::from_byte_array(inner.to_byte_array())
+        }
+    }
+}
+
 mod sealed {
     pub trait Sealed {}
     impl Sealed for super::TapLeafHash {}
     impl Sealed for super::TapNodeHash {}
+    impl Sealed for super::TapTweakHash {}
 }
 
 /// Computes branch hash given two hashes of the nodes underneath it and returns

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -15,11 +15,11 @@ exclude = ["tests", "contrib"]
 
 [features]
 default = ["std"]
-std = ["alloc", "base58/std", "hashes/std", "hex-stable/std", "hex-unstable/std", "internals/std", "io/std", "network/std", "secp256k1/std", "serde?/std"]
+std = ["alloc", "base58/std", "hashes/std", "hex-stable/std", "hex-unstable/std", "internals/std", "io/std", "network/std", "secp256k1/std", "serde?/std", "taproot-primitives/std"]
 rand = ["secp256k1/rand"]
-alloc = ["base58/alloc", "hashes/alloc", "hex-stable/alloc", "hex-unstable/alloc", "internals/alloc", "io/alloc", "network/alloc", "secp256k1/alloc", "serde?/alloc"]
-serde = ["dep:serde", "hashes/serde", "internals/serde", "secp256k1/serde"]
-arbitrary = ["dep:arbitrary", "secp256k1/arbitrary"]
+alloc = ["base58/alloc", "hashes/alloc", "hex-stable/alloc", "hex-unstable/alloc", "internals/alloc", "io/alloc", "network/alloc", "secp256k1/alloc", "serde?/alloc", "taproot-primitives/alloc"]
+serde = ["dep:serde", "hashes/serde", "internals/serde", "secp256k1/serde", "taproot-primitives/serde"]
+arbitrary = ["dep:arbitrary", "secp256k1/arbitrary", "taproot-primitives/arbitrary"]
 
 [dependencies]
 base58 = { package = "base58ck", path = "../base58", version = "0.4.0", default-features = false }
@@ -30,6 +30,7 @@ internals = { package = "bitcoin-internals", path = "../internals", version = "0
 io = { package = "bitcoin-io", path = "../io", version = "0.5.0", default-features = false, features = ["hashes"] }
 network = { package = "bitcoin-network-kind", path = "../network", version = "0.1.0", default-features = false }
 secp256k1 = { version = "0.32.0-beta.2", default-features = false }
+taproot-primitives = { package = "bitcoin-taproot-primitives", path = "../taproot-primitives", version = "0.1.0", default-features = false, features = ["hex"] }
 
 arbitrary = { version = "1.4.1", optional = true }
 serde = { version = "1.0.195", default-features = false, features = ["derive"], optional = true }

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -15,15 +15,12 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
-pub extern crate hex_stable as hex;
-
 pub extern crate base58;
-
-pub extern crate network;
-
+pub extern crate hex_stable as hex;
 pub extern crate io;
-
+pub extern crate network;
 pub extern crate secp256k1;
+pub extern crate taproot_primitives;
 
 #[cfg(feature = "alloc")]
 pub mod ecdsa;

--- a/crypto/src/sighash.rs
+++ b/crypto/src/sighash.rs
@@ -13,7 +13,12 @@ use core::{fmt, str};
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
+use hashes::{sha256t, HashEngine as _};
+use taproot_primitives::{TapNodeHash, TapTweakHash, TapTweakTag};
 
+use crate::key::UntweakedPublicKey;
+
+#[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(no_inline)]
 pub use self::error::{
     InvalidSighashTypeError, NonStandardSighashTypeError, SighashTypeParseError,
@@ -223,6 +228,35 @@ impl From<EcdsaSighashType> for TapSighashType {
             EcdsaSighashType::NonePlusAnyoneCanPay => Self::NonePlusAnyoneCanPay,
             EcdsaSighashType::SinglePlusAnyoneCanPay => Self::SinglePlusAnyoneCanPay,
         }
+    }
+}
+
+/// Extension functionality for the [`TapTweakHash`] type.
+pub trait TapTweakHashExt {
+    /// Constructs a new BIP-0341 [`TapTweakHash`] from key and Merkle root. Produces `H_taptweak(P||R)` where
+    /// `P` is the internal key and `R` is the Merkle root.
+    fn from_key_and_merkle_root<K: Into<UntweakedPublicKey>>(
+        internal_key: K,
+        merkle_root: Option<TapNodeHash>,
+    ) -> Self;
+}
+
+impl TapTweakHashExt for TapTweakHash {
+    fn from_key_and_merkle_root<K: Into<UntweakedPublicKey>>(
+        internal_key: K,
+        merkle_root: Option<TapNodeHash>,
+    ) -> Self {
+        let internal_key = internal_key.into();
+        let mut eng = sha256t::Hash::<TapTweakTag>::engine();
+        // always hash the key
+        eng.input(&internal_key.serialize().0);
+        if let Some(h) = merkle_root {
+            eng.input(h.as_ref());
+        } else {
+            // nothing to hash
+        }
+        let inner = sha256t::Hash::<TapTweakTag>::from_engine(eng);
+        Self::from_byte_array(inner.to_byte_array())
     }
 }
 

--- a/taproot-primitives/Cargo.toml
+++ b/taproot-primitives/Cargo.toml
@@ -14,14 +14,13 @@ exclude = ["tests", "contrib"]
 
 [features]
 default = ["std", "hex"]
-std = ["alloc", "crypto/std", "hashes/std", "internals/std", "serde?/std", "secp256k1/std"]
-alloc = ["crypto/alloc", "hashes/alloc", "internals/alloc", "secp256k1/alloc"]
-serde = ["dep:serde", "crypto/serde", "hashes/serde", "internals/serde", "secp256k1/serde"]
-arbitrary = ["crypto/arbitrary", "dep:arbitrary", "hashes/arbitrary", "secp256k1/arbitrary"]
+std = ["alloc", "hashes/std", "internals/std", "serde?/std", "secp256k1/std"]
+alloc = ["hashes/alloc", "internals/alloc", "secp256k1/alloc"]
+serde = ["dep:serde", "hashes/serde", "internals/serde", "secp256k1/serde"]
+arbitrary = ["dep:arbitrary", "hashes/arbitrary", "secp256k1/arbitrary"]
 hex = ["hashes/hex"]
 
 [dependencies]
-crypto = { package = "bitcoin-crypto", path = "../crypto", default-features = false }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
 

--- a/taproot-primitives/src/lib.rs
+++ b/taproot-primitives/src/lib.rs
@@ -27,11 +27,7 @@ use core::fmt;
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
-#[cfg(feature = "alloc")]
-use crypto::key::UntweakedPublicKey;
 use hashes::{hash_newtype, sha256t, sha256t_tag};
-#[cfg(feature = "alloc")]
-use hashes::HashEngine;
 use secp256k1::Scalar;
 
 /// Maximum depth of a Taproot tree script spend path.
@@ -113,26 +109,6 @@ impl From<TapLeafHash> for TapNodeHash {
 }
 
 impl TapTweakHash {
-    /// Constructs a new BIP-0341 [`TapTweakHash`] from key and Merkle root. Produces `H_taptweak(P||R)` where
-    /// `P` is the internal key and `R` is the Merkle root.
-    #[cfg(feature = "alloc")]
-    pub fn from_key_and_merkle_root<K: Into<UntweakedPublicKey>>(
-        internal_key: K,
-        merkle_root: Option<TapNodeHash>,
-    ) -> Self {
-        let internal_key = internal_key.into();
-        let mut eng = sha256t::Hash::<TapTweakTag>::engine();
-        // always hash the key
-        eng.input(&internal_key.serialize().0);
-        if let Some(h) = merkle_root {
-            eng.input(h.as_ref());
-        } else {
-            // nothing to hash
-        }
-        let inner = sha256t::Hash::<TapTweakTag>::from_engine(eng);
-        Self::from_byte_array(inner.to_byte_array())
-    }
-
     /// Converts a `TapTweakHash` into a `Scalar` ready for use with key tweaking API.
     #[allow(clippy::missing_panics_doc)]
     pub fn to_scalar(self) -> Scalar {


### PR DESCRIPTION
The from_key_and_merkle_root method on the TapTweakHash type is the only part of the taproot-primitives crate that causes a dependency on the crypto crate. By moving this back to bitcoin, we can remove the dependency on crypto, which paves the way for further movement of sighash types to crypto.

- Patch 1 removes from_key_and_merkle_root from TapTweakHash, moving it back to bitcoin in an extension trait.
- Patch 2 drops the crypto dependency for taproot-primitives.
