### PR TITLE
ext: Add extension trait re-exports

### DIFF
--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -102,13 +102,17 @@ pub mod ext {
     pub use crate::{
         block::{BlockCheckedExt as _, HeaderExt as _},
         key::{FullPublicKeyExt as _, LegacyPublicKeyExt as _},
-        pow::CompactTargetExt as _,
+        network::NetworkExt as _,
+        pow::{CompactTargetExt as _, TargetExt as _, WorkExt as _},
         script::{ScriptExt as _, ScriptBufExt as _, TapScriptExt as _, ScriptPubKeyExt as _, ScriptPubKeyBufExt as _, WitnessScriptExt as _, ScriptSigExt as _},
+        taproot::{TapLeafHashExt as _, TapNodeHashExt as _},
         transaction::{TxidExt as _, WtxidExt as _, OutPointExt as _, TxInExt as _, TxOutExt as _, TransactionExt as _},
         witness::WitnessExt as _,
     };
     #[cfg(feature = "bitcoinconsensus")]
     pub use crate::consensus_validation::{ScriptPubKeyExt as _, TransactionExt as _};
+    #[cfg(feature = "secp-recovery")]
+    pub use crate::key::PrivateKeyExt as _;
 }
 pub mod address;
 pub mod bip158;

--- a/consensus_encoding/src/encode/encoders.rs
+++ b/consensus_encoding/src/encode/encoders.rs
@@ -28,9 +28,7 @@ impl<'sl> BytesEncoder<'sl> {
 impl Encoder for BytesEncoder<'_> {
     fn current_chunk(&self) -> &[u8] { self.sl }
 
-    fn advance(&mut self) -> bool {
-        false
-    }
+    fn advance(&mut self) -> bool { false }
 }
 
 impl<'sl> ExactSizeEncoder for BytesEncoder<'sl> {
@@ -54,9 +52,7 @@ impl<const N: usize> Encoder for ArrayEncoder<N> {
     fn current_chunk(&self) -> &[u8] { &self.arr }
 
     #[inline]
-    fn advance(&mut self) -> bool {
-        false
-    }
+    fn advance(&mut self) -> bool { false }
 }
 
 impl<const N: usize> ExactSizeEncoder for ArrayEncoder<N> {
@@ -83,9 +79,7 @@ impl<const N: usize> Encoder for ArrayRefEncoder<'_, N> {
     fn current_chunk(&self) -> &[u8] { self.arr }
 
     #[inline]
-    fn advance(&mut self) -> bool {
-        false
-    }
+    fn advance(&mut self) -> bool { false }
 }
 
 impl<const N: usize> ExactSizeEncoder for ArrayRefEncoder<'_, N> {

--- a/consensus_encoding/src/encode/mod.rs
+++ b/consensus_encoding/src/encode/mod.rs
@@ -233,7 +233,9 @@ impl<T: Encoder> Iterator for EncoderByteIter<T> {
     fn nth(&mut self, mut n: usize) -> Option<Self::Item> {
         // This could be in a loop but we intentionally unroll one iteration so that addition is
         // only required at the beginning.
-        if let Some(b) = self.position.checked_add(n).and_then(|pos| self.enc.current_chunk().get(pos)) {
+        if let Some(b) =
+            self.position.checked_add(n).and_then(|pos| self.enc.current_chunk().get(pos))
+        {
             // length of slice is guaranteed to be at most `isize::MAX` thus is `n` so this cannot
             // overflow.
             self.position += n + 1;

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -34,9 +34,7 @@ pub mod sighash;
 
 #[doc(inline)]
 #[cfg(feature = "alloc")]
-pub use self::{
-    key::{FullPublicKey, Keypair, PrivateKey, LegacyPublicKey, XOnlyPublicKey},
-};
+pub use self::key::{FullPublicKey, Keypair, LegacyPublicKey, PrivateKey, XOnlyPublicKey};
 
 #[cfg(feature = "alloc")]
 include!("../include/newtype.rs"); // Explained in `REPO_DIR/docs/README.md`.

--- a/taproot-primitives/src/lib.rs
+++ b/taproot-primitives/src/lib.rs
@@ -29,9 +29,9 @@ use core::fmt;
 use arbitrary::{Arbitrary, Unstructured};
 #[cfg(feature = "alloc")]
 use crypto::key::UntweakedPublicKey;
-use hashes::{hash_newtype, sha256t, sha256t_tag};
 #[cfg(feature = "alloc")]
 use hashes::HashEngine;
+use hashes::{hash_newtype, sha256t, sha256t_tag};
 use secp256k1::Scalar;
 
 /// Maximum depth of a Taproot tree script spend path.


### PR DESCRIPTION
The ext module in bitcoin is supposed to hold re-exports of all extension traits. During the recent crypto and taproot-primitives moves some new extension traits were added but not re-exported from ext.

Add NetworkExt, TargetExt, WorkExt, TapLeafHashExt, TapNodeHashExt, and PrivateKeyExt extension trait re-exports to ext module.