### PR TITLE
Implement `AsRef<PushBytes>` for generic hashes

### DIFF
--- a/bitcoin/src/blockdata/script/push_bytes.rs
+++ b/bitcoin/src/blockdata/script/push_bytes.rs
@@ -6,6 +6,7 @@ use core::fmt;
 use core::ops::{Deref, DerefMut};
 
 use crate::crypto::{ecdsa, taproot};
+use crate::internal_macros::impl_asref_push_bytes;
 use crate::prelude::{Borrow, BorrowMut};
 use crate::script;
 
@@ -434,6 +435,14 @@ impl AsRef<PushBytes> for taproot::SerializedSignature {
         <&PushBytes>::try_from(<Self as AsRef<[u8]>>::as_ref(self))
             .expect("max length 65 bytes is valid")
     }
+}
+
+impl_asref_push_bytes! {
+    hashes::ripemd160::Hash,
+    hashes::hash160::Hash,
+    hashes::sha1::Hash,
+    hashes::sha256::Hash,
+    hashes::sha256d::Hash,
 }
 
 /// Possible errors that can arise from [`PushBytes::read_scriptint`].

--- a/bitcoin/src/internal_macros.rs
+++ b/bitcoin/src/internal_macros.rs
@@ -48,7 +48,7 @@ include!("../include/array_newtype.rs");
 
 #[rustfmt::skip]
 macro_rules! impl_asref_push_bytes {
-    ($($hashtype:ident),*) => {
+    ($($hashtype:ty),* $(,)?) => {
         $(
             impl AsRef<$crate::script::PushBytes> for $hashtype {
                 fn as_ref(&self) -> &$crate::script::PushBytes {


### PR DESCRIPTION
Some hash types provided by the `bitcoin_hashes` crate are natively supported by the Bitcoin script and it seems natural that the users might want to compute the hash from a preimage and push it into the script. This is already doable by simply calling
`.push_slice(hash.as_byte_array())` because of the impls on `&[u8; N]` however, we do support these casts in case of other hash types to make it more convenient to push them into script and signal that it is usual to put these objects into script.

To close the gap, this commit adds implementations for the missing hashes.