### PR TITLE
Llimit size of arbitrary ProprietaryKey subtype to MAX_COMPACT_SIZE

### DIFF
--- a/bitcoin/src/psbt/raw.rs
+++ b/bitcoin/src/psbt/raw.rs
@@ -222,11 +222,12 @@ where
 #[cfg(feature = "arbitrary")]
 impl<'a> Arbitrary<'a> for ProprietaryKey {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        Ok(Self {
-            prefix: Vec::<u8>::arbitrary(u)?,
-            subtype: u64::arbitrary(u)?,
-            key: Vec::<u8>::arbitrary(u)?,
-        })
+        use crate::consensus::encode::MAX_COMPACT_SIZE;
+        let subtype = u
+            .int_in_range(0..=MAX_COMPACT_SIZE)?
+            .try_into()
+            .expect("arch's `usize` is less than 4 bytes");
+        Ok(Self { prefix: Vec::<u8>::arbitrary(u)?, subtype, key: Vec::<u8>::arbitrary(u)? })
     }
 }
 


### PR DESCRIPTION
`ProprietaryKey::subtye` is a compact size, represented as u64. It shouldn't exceed MAX_COMPACT_SIZE.

My take is that `ProprietaryKey` should work with the assumption that its content is within the specified values. The errors related to encoding/decoding should happen on those interfaces, and cannot be tested through the use of arbitrary.

This is mirroring the change in `rust-psbt`: https://git.rust-bitcoin.org/rust-bitcoin/rust-psbt/pulls/109