### PR TITLE
Add TryFrom<&str> for FromStr types (#1802)

### DIFF
--- a/bitcoin/src/util/tryfrom_str.rs
+++ b/bitcoin/src/util/tryfrom_str.rs
@@ -1,0 +1,41 @@
+//! Helper macros for implementing TryFrom<&str> for types with FromStr
+
+/// Implement TryFrom<&str> and related traits for a type that has FromStr
+#[macro_export]
+macro_rules! impl_tryfrom_str {
+    ($type:ty) => {
+        impl TryFrom<&str> for $type {
+            type Error = <$type as core::str::FromStr>::Err;
+            
+            fn try_from(s: &str) -> Result<Self, Self::Error> {
+                s.parse()
+            }
+        }
+        
+        impl TryFrom<&mut str> for $type {
+            type Error = <$type as core::str::FromStr>::Err;
+            
+            fn try_from(s: &mut str) -> Result<Self, Self::Error> {
+                s.parse()
+            }
+        }
+        
+        impl TryFrom<String> for $type {
+            type Error = <$type as core::str::FromStr>::Err;
+            
+            fn try_from(s: String) -> Result<Self, Self::Error> {
+                s.parse()
+            }
+        }
+        
+        impl TryFrom<&String> for $type {
+            type Error = <$type as core::str::FromStr>::Err;
+            
+            fn try_from(s: &String) -> Result<Self, Self::Error> {
+                s.parse()
+            }
+        }
+    };
+}
+
+pub use impl_tryfrom_str;


### PR DESCRIPTION
## Summary
Adds `impl_tryfrom_str!` macro to implement TryFrom for types with FromStr.

## Usage
```rust
impl_tryfrom_str!(MyType);
```

Implements:
- `TryFrom<&str>`
- `TryFrom<&mut str>`
- `TryFrom<String>`
- `TryFrom<&String>`

Fixes #1802

---
🍊 Contributed via [Code Orange Dev School](https://github.com/code-orange-dev)