### PR TITLE
crypto: Remove unused test from ecdsa

### DIFF
--- a/crypto/src/ecdsa.rs
+++ b/crypto/src/ecdsa.rs
@@ -351,27 +351,9 @@ impl<'a> Arbitrary<'a> for Signature {
 
 #[cfg(test)]
 mod tests {
-    use alloc::vec;
-    #[cfg(feature = "std")]
-    use std::io::Write;
-
     use super::*;
 
     const TEST_SIGNATURE_HEX: &str = "3046022100839c1fbc5304de944f697c9f4b1d01d1faeba32d751c0f7acb21ac8a0f436a72022100e89bd46bb3a5a62adc679f659b7ce876d83ee297c7a5587b2011c4fcc72eab45";
-
-    #[test]
-    #[cfg(feature = "std")]
-    fn write_serialized_signature() {
-        let sig = Signature {
-            signature: secp256k1::ecdsa::Signature::from_str(TEST_SIGNATURE_HEX).unwrap(),
-            sighash_type: EcdsaSighashType::All,
-        };
-
-        let mut buf = vec![];
-        buf.write_all(&sig.serialize()).expect("write failed");
-
-        assert_eq!(sig.to_vec(), buf);
-    }
 
     #[test]
     fn iterate_serialized_signature() {


### PR DESCRIPTION
In ecdsa, the write_serialized_signature test was used to test the serialize_to_writer method on the ecdsa::Signature. Since this was removed as part of the bitcoin-io dep removal, the test should also be removed.

Remove write_serialized_signature test case from ecdsa tests module.