### PR TITLE
p2p: Use `V1MessageHeaderDecoder` in `V1NetworkMessageDecoder`

### DIFF
--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -1400,8 +1400,8 @@ impl encoding::Decoder for V1NetworkMessageDecoder {
     fn push_bytes(&mut self, bytes: &mut &[u8]) -> Result<bool, Self::Error> {
         match &mut self.state {
             DecoderState::ReadingHeader { header_decoder } => {
-                let need_more = header_decoder.push_bytes(bytes).map_err(|_| {
-                    V1NetworkMessageDecoderError(V1NetworkMessageDecoderErrorInner::Header)
+                let need_more = header_decoder.push_bytes(bytes).map_err(|e| {
+                    V1NetworkMessageDecoderError(V1NetworkMessageDecoderErrorInner::Header(e))
                 })?;
 
                 if !need_more {
@@ -1417,8 +1417,8 @@ impl encoding::Decoder for V1NetworkMessageDecoder {
                         unreachable!("we are in ReadingHeader state")
                     };
 
-                    let header = header_decoder.end().map_err(|_| {
-                        V1NetworkMessageDecoderError(V1NetworkMessageDecoderErrorInner::Header)
+                    let header = header_decoder.end().map_err(|e| {
+                        V1NetworkMessageDecoderError(V1NetworkMessageDecoderErrorInner::Header(e))
                     })?;
                     let payload_len = usize::try_from(header.length)
                         .expect("u32 -> usize cast ok for >= 32-bit platforms");
@@ -1449,8 +1449,11 @@ impl encoding::Decoder for V1NetworkMessageDecoder {
 
     fn end(self) -> Result<Self::Output, Self::Error> {
         match self.state {
-            DecoderState::ReadingHeader { .. } =>
-                Err(V1NetworkMessageDecoderError(V1NetworkMessageDecoderErrorInner::Header)),
+            DecoderState::ReadingHeader { header_decoder } => Err(header_decoder
+                .end()
+                .map_err(V1NetworkMessageDecoderErrorInner::Header)
+                .map_err(V1NetworkMessageDecoderError)
+                .expect_err("push_bytes() moves to ReadingPayload on header_decoder completion")),
             DecoderState::ReadingPayload { magic, length, checksum, payload_decoder, .. } => {
                 let payload = payload_decoder.end()?;
                 let (_, expected_checksum) = sha2_checksum(&payload);
@@ -1985,6 +1988,11 @@ pub mod error {
         }
     }
 
+    #[cfg(feature = "std")]
+    impl std::error::Error for V1MessageHeaderDecoderError {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
+    }
+
     /// An error decoding a [`InventoryPayload`].
     ///
     /// [`InventoryPayload`]: super::InventoryPayload
@@ -2103,7 +2111,7 @@ pub mod error {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub(super) enum V1NetworkMessageDecoderErrorInner {
         /// Error decoding the message header.
-        Header,
+        Header(V1MessageHeaderDecoderError),
         /// Payload length exceeds maximum allowed message size.
         PayloadTooLarge,
         /// Error decoding the message payload.
@@ -2117,8 +2125,8 @@ pub mod error {
     impl fmt::Display for V1NetworkMessageDecoderError {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             match self.0 {
-                V1NetworkMessageDecoderErrorInner::Header => {
-                    write!(f, "error decoding message header")
+                V1NetworkMessageDecoderErrorInner::Header(ref e) => {
+                    write_err!(f, "error decoding message header"; e)
                 }
                 V1NetworkMessageDecoderErrorInner::PayloadTooLarge => {
                     write!(f, "payload length exceeds maximum allowed message size")
@@ -2141,7 +2149,7 @@ pub mod error {
     impl std::error::Error for V1NetworkMessageDecoderError {
         fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
             match self.0 {
-                V1NetworkMessageDecoderErrorInner::Header => None,
+                V1NetworkMessageDecoderErrorInner::Header(ref e) => Some(e),
                 V1NetworkMessageDecoderErrorInner::PayloadTooLarge => None,
                 V1NetworkMessageDecoderErrorInner::Payload => None,
                 V1NetworkMessageDecoderErrorInner::InvalidChecksum { expected: _, actual: _ } =>

--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -1377,8 +1377,8 @@ enum DecoderState {
         >,
     },
     ReadingPayload {
-        magic_bytes: [u8; 4],
-        payload_len_bytes: [u8; 4],
+        magic: Magic,
+        length: u32,
         checksum: [u8; 4],
         payload_decoder: NetworkMessageDecoder,
     },
@@ -1432,7 +1432,8 @@ impl encoding::Decoder for V1NetworkMessageDecoder {
                             V1NetworkMessageDecoderError(V1NetworkMessageDecoderErrorInner::Header)
                         })?;
 
-                    let payload_len = u32::from_le_bytes(payload_len_bytes) as usize;
+                    let length = u32::from_le_bytes(payload_len_bytes);
+                    let payload_len = length as usize;
                     if payload_len > MAX_MSG_SIZE {
                         return Err(V1NetworkMessageDecoderError(
                             V1NetworkMessageDecoderErrorInner::PayloadTooLarge,
@@ -1441,8 +1442,8 @@ impl encoding::Decoder for V1NetworkMessageDecoder {
 
                     let payload_decoder = NetworkMessageDecoder::new(command, payload_len);
                     self.state = DecoderState::ReadingPayload {
-                        magic_bytes,
-                        payload_len_bytes,
+                        magic: Magic::from_bytes(magic_bytes),
+                        length,
                         checksum,
                         payload_decoder,
                     };
@@ -1462,13 +1463,7 @@ impl encoding::Decoder for V1NetworkMessageDecoder {
         match self.state {
             DecoderState::ReadingHeader { .. } =>
                 Err(V1NetworkMessageDecoderError(V1NetworkMessageDecoderErrorInner::Header)),
-            DecoderState::ReadingPayload {
-                magic_bytes,
-                payload_len_bytes,
-                checksum,
-                payload_decoder,
-                ..
-            } => {
+            DecoderState::ReadingPayload { magic, length, checksum, payload_decoder, .. } => {
                 let payload = payload_decoder.end()?;
                 let (_, expected_checksum) = sha2_checksum(&payload);
                 if checksum != expected_checksum {
@@ -1480,12 +1475,7 @@ impl encoding::Decoder for V1NetworkMessageDecoder {
                     ));
                 }
 
-                Ok(V1NetworkMessage {
-                    magic: Magic::from_bytes(magic_bytes),
-                    payload,
-                    payload_len: u32::from_le_bytes(payload_len_bytes),
-                    checksum,
-                })
+                Ok(V1NetworkMessage { magic, payload, payload_len: length, checksum })
             }
         }
     }

--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -1369,12 +1369,7 @@ impl encoding::Decoder for NetworkMessageDecoder {
 #[derive(Debug, Clone)]
 enum DecoderState {
     ReadingHeader {
-        header_decoder: encoding::Decoder4<
-            encoding::ArrayDecoder<4>,
-            CommandStringDecoder,
-            encoding::ArrayDecoder<4>,
-            encoding::ArrayDecoder<4>,
-        >,
+        header_decoder: V1MessageHeaderDecoder,
     },
     ReadingPayload {
         magic: Magic,
@@ -1385,7 +1380,7 @@ enum DecoderState {
 }
 
 impl Default for DecoderState {
-    fn default() -> Self { Self::ReadingHeader { header_decoder: encoding::Decoder4::default() } }
+    fn default() -> Self { Self::ReadingHeader { header_decoder: V1MessageHeaderDecoder::default() } }
 }
 
 /// Decoder for [`V1NetworkMessage`].
@@ -1414,12 +1409,7 @@ impl encoding::Decoder for V1NetworkMessageDecoder {
                     let old_state = core::mem::replace(
                         &mut self.state,
                         DecoderState::ReadingHeader {
-                            header_decoder: encoding::Decoder4::new(
-                                encoding::ArrayDecoder::new(),
-                                CommandStringDecoder { inner: encoding::ArrayDecoder::new() },
-                                encoding::ArrayDecoder::new(),
-                                encoding::ArrayDecoder::new(),
-                            ),
+                            header_decoder: <V1MessageHeader as encoding::Decode>::decoder(),
                         },
                     );
 
@@ -1427,24 +1417,22 @@ impl encoding::Decoder for V1NetworkMessageDecoder {
                         unreachable!("we are in ReadingHeader state")
                     };
 
-                    let (magic_bytes, command, payload_len_bytes, checksum) =
-                        header_decoder.end().map_err(|_| {
-                            V1NetworkMessageDecoderError(V1NetworkMessageDecoderErrorInner::Header)
-                        })?;
-
-                    let length = u32::from_le_bytes(payload_len_bytes);
-                    let payload_len = length as usize;
+                    let header = header_decoder.end().map_err(|_| {
+                        V1NetworkMessageDecoderError(V1NetworkMessageDecoderErrorInner::Header)
+                    })?;
+                    let payload_len = usize::try_from(header.length)
+                        .expect("u32 -> usize cast ok for >= 32-bit platforms");
                     if payload_len > MAX_MSG_SIZE {
                         return Err(V1NetworkMessageDecoderError(
                             V1NetworkMessageDecoderErrorInner::PayloadTooLarge,
                         ));
                     }
 
-                    let payload_decoder = NetworkMessageDecoder::new(command, payload_len);
+                    let payload_decoder = NetworkMessageDecoder::new(header.command, payload_len);
                     self.state = DecoderState::ReadingPayload {
-                        magic: Magic::from_bytes(magic_bytes),
-                        length,
-                        checksum,
+                        magic: header.magic,
+                        length: header.length,
+                        checksum: header.checksum,
                         payload_decoder,
                     };
 


### PR DESCRIPTION
The V1NetworkMessageDecoder decodes the header fields at the start of the decoding process using a manually defined Decoder4. Since the header fields that it decodes are exactly equivalent to the existing encoding of the V1MessageHeader, the decoder for the header should be used. This also provides an opportunity to wrap the header decoder error to provide more information to the user than the current error does.

- Patch 1 replaces magic_bytes and payload_len_bytes byte array fields with magic and length parsed type fields in V1NetworkMessageDecoder inner state.
- Patch 2 adds the usage of V1MessageHeaderDecoder to the header decoding in V1NetworkMessageDecoder.
- Patch 3 adds the V1MessageHeaderDecoderError as an internal value on the V1NetworkMessageDecoderInner::Header variant.