### PR TITLE
fuzz: add `-max_total_time` option to fuzz.sh

### DIFF
--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -12,6 +12,13 @@ run
 
 in this directory.
 
+By default, `fuzz.sh` runs each target for 100 seconds. Pass
+`-max_total_time` to run for longer or shorter:
+
+```bash
+./fuzz.sh -max_total_time=300
+```
+
 ## Fuzzing with weak cryptography
 
 You may wish to replace the hashing and signing code with broken crypto,

--- a/fuzz/fuzz.sh
+++ b/fuzz/fuzz.sh
@@ -10,13 +10,42 @@ REPO_DIR=$(git rev-parse --show-toplevel)
 # shellcheck source=/dev/null
 source "$REPO_DIR/fuzz/fuzz-util.sh"
 
+target=
+max_total_time=100
+
+for arg in "$@"; do
+  case "$arg" in
+    -max_total_time=*)
+      max_total_time="${arg#-max_total_time=}"
+      ;;
+    -*)
+      echo "Unknown option: $arg"
+      exit 2
+      ;;
+    *)
+      if [ -n "$target" ]; then
+        echo "Unexpected argument: $arg"
+        exit 2
+      fi
+      target="$arg"
+      ;;
+  esac
+done
+
+case "$max_total_time" in
+  ''|*[!0-9]*)
+    echo "-max_total_time must be a non-negative integer number of seconds"
+    exit 2
+    ;;
+esac
+
 # Check that input files are correct Windows file names
 checkWindowsFiles
 
-if [ -z "${1:-}" ]; then
+if [ -z "$target" ]; then
   targetFiles="$(listTargetFiles)"
 else
-  targetFiles=fuzz_targets/"$1".rs
+  targetFiles=fuzz_targets/"$target".rs
 fi
 
 cargo --version
@@ -26,8 +55,8 @@ rustc --version
 cargo install --force --locked --version 0.12.0 cargo-fuzz
 for targetFile in $targetFiles; do
   targetName=$(targetFileToName "$targetFile")
-  echo "Fuzzing target $targetName ($targetFile)"
+  echo "Fuzzing target $targetName ($targetFile) for $max_total_time seconds"
   # cargo-fuzz will check for the corpus at fuzz/corpus/<target>
-  cargo +nightly fuzz run "$targetName" -- -runs=100000
+  cargo +nightly fuzz run "$targetName" -- -max_total_time="$max_total_time"
   checkReport "$targetName"
 done


### PR DESCRIPTION
As discussed in #6038:
- Change from iteration-based to time-based stop condition
- Add the `-max_total_time` command-line option to fuzz.sh
- Default `-max_total_time` to 100 seconds