### PR TITLE
ci: Change encodable coverage to check for Encode trait

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -240,7 +240,7 @@ jobs:
         run: contrib/check-error-reexports.sh
 
   Encodable-coverage:
-    name: Check Encodable fuzz coverage - stable toolchain
+    name: Check Encode fuzz coverage - stable toolchain
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -251,7 +251,7 @@ jobs:
           persist-credentials: false
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6 # stable
-      - name: "Check Encodable coverage"
+      - name: "Check Encode coverage"
         run: ./contrib/check-encodable-coverage.sh
 
   DiffMutants:

--- a/contrib/check-encodable-coverage.sh
+++ b/contrib/check-encodable-coverage.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 
 REPO_DIR=$(git rev-parse --show-toplevel)
 FUZZ_FILE="$REPO_DIR/fuzz/fuzz_targets/bitcoin/compare_consensus_encoding.rs"
-TRAIT_IMPL_JS="$REPO_DIR/target/doc/trait.impl/bitcoin_consensus_encoding/encode/trait.Encodable.js"
+TRAIT_IMPL_JS="$REPO_DIR/target/doc/trait.impl/bitcoin_consensus_encoding/encode/trait.Encode.js"
 
 # Known exclusions (types that don't exist in old_bitcoin 0.32 or are generic).
 # Add types here that have new Encodable but no old_bitcoin equivalent.
@@ -29,18 +29,18 @@ main() {
     missing=$(find_missing_types "$new_types" "$fuzz_types")
 
     if [ -n "$missing" ]; then
-        echo "The following types implement encoding::Encodable but are not in the fuzz test:" >&2
+        echo "The following types implement encoding::Encode but are not in the fuzz test:" >&2
         for type in $missing; do
             echo "  - $type" >&2
         done
         err "Either add them to compare_consensus_encoding.rs or add to EXCLUSIONS in this script"
     fi
 
-    echo "All encoding::Encodable types are covered (or excluded)"
+    echo "All encoding::Encode types are covered (or excluded)"
 }
 
 generate_docs() {
-    echo "Generating docs to discover Encodable implementors..."
+    echo "Generating docs to discover Encode implementors..."
     cargo doc --workspace --no-deps --quiet
 }
 
@@ -56,7 +56,7 @@ extract_new_types() {
     tr '>' '\n' < "$TRAIT_IMPL_JS" \
         | grep -oE '^[A-Z][a-zA-Z0-9_]+<' \
         | sed 's/<$//' \
-        | grep -v '^Encodable$' \
+        | grep -v '^Encode$' \
         | sort -u
 }
 


### PR DESCRIPTION
The Encodable trait was recently renamed to Encode, but this script was not similarly updated. As such, the CI now fails due to an incorrect docs file path.

Change Encodable to Encode in encodable coverage check to track new trait name.