### PR TITLE
include: Add Readme for `include/` directory

### DIFF
--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -79,7 +79,7 @@ pub extern crate serde;
 
 mod internal_macros;
 
-include!("../include/newtype.rs"); // Explained in `REPO_DIR/docs/README.md`.
+include!("../include/newtype.rs"); // Explained in `REPO_DIR/include/README.md`.
 
 pub mod ext {
     //! Re-export all the extension traits so downstream can use wildcard imports.

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -31,7 +31,7 @@ pub mod taproot;
 #[doc(inline)]
 pub use self::key::{FullPublicKey, Keypair, LegacyPublicKey, PrivateKey, XOnlyPublicKey};
 
-include!("../include/newtype.rs"); // Explained in `REPO_DIR/docs/README.md`.
+include!("../include/newtype.rs"); // Explained in `REPO_DIR/include/README.md`.
 #[cfg(feature = "alloc")]
 include!("../include/asref_push_bytes.rs");
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,10 +11,3 @@ hold and a PR made to the `docs/` tree or in the Discussions section to debate i
 ## Dependency tree
 
 The `./dep-tree` file was generated using `just gen-dep-tree`.
-
-## include! usage
-
-In this repository, the `include` directory holds shared source code that can be used in any of the
-crates through the `include!` macro. Generally, files in the `include` directory should be written
-such that their content can be included once at the top level of a crate (e.g. in `lib.rs`), and
-then used throughout, rather than calling `include!` at each usage site.

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -303,7 +303,7 @@ pub fn debug_hex<'a>(
     Ok(())
 }
 
-include!("../include/newtype.rs"); // Explained in `REPO_DIR/docs/README.md`.
+include!("../include/newtype.rs"); // Explained in `REPO_DIR/include/README.md`.
 
 #[cfg(test)]
 mod tests {

--- a/include/README.md
+++ b/include/README.md
@@ -1,0 +1,21 @@
+# Rust Bitcoin - Shared Macros
+
+This directory holds shared source code that can be used in any of the crates through the
+[`include!`] macro. Generally files in this directory are written such that their content can be
+included once at the top level of a crate (e.g. in `lib.rs`), and then used throughout, rather than
+calling [`include!`] at each usage site.
+
+The intent is to follow the DRY principle for code that needs to be reused across crates without
+creating a dedicated helper crate (we previously explored this with `bitcoin-internals`, and are now
+moving macros out of it. See PR [#6231]).
+
+## Conventions
+
+* Each file is included once at a stable module boundary in the consuming crate (often `lib.rs`,
+  but sometimes an internal module such as `internal_macros.rs` or `pow.rs`), rather than at every
+  usage site.
+* Included items live in the namespace of the module that performs the `include!` and inherit that
+  module's visibility rules.
+
+[`include!`]: https://doc.rust-lang.org/std/macro.include.html
+[#6231]: https://github.com/rust-bitcoin/rust-bitcoin/pull/6231

--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -616,7 +616,7 @@ where
 }
 
 #[cfg(feature = "std")]
-include!("../include/newtype.rs"); // Explained in `REPO_DIR/docs/README.md`.
+include!("../include/newtype.rs"); // Explained in `REPO_DIR/include/README.md`.
 
 #[cfg(test)]
 mod tests {

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -129,7 +129,7 @@ pub(crate) fn compact_size_encode(value: usize) -> ArrayVec<u8, 9> {
 }
 
 #[cfg(feature = "alloc")]
-include!("../include/newtype.rs"); // Explained in `REPO_DIR/docs/README.md`.
+include!("../include/newtype.rs"); // Explained in `REPO_DIR/include/README.md`.
 include!("../include/decoder_newtype.rs"); // decoder_newtype! macro
 #[cfg(feature = "alloc")]
 include!("../include/asref_push_bytes.rs"); // impl_asref_push_bytes! macro


### PR DESCRIPTION
Adds a readme describing the purpose, intent and usages of the `include!/` directory across the project.

reviewed and edited by ChatGPT.

closes #6095 