### PR TITLE
fuzz: remove stale psbt fuzz targets from `cron-daily-fuzz.yml`

### DIFF
--- a/.github/workflows/cron-daily-fuzz.yml
+++ b/.github/workflows/cron-daily-fuzz.yml
@@ -20,14 +20,12 @@ jobs:
       matrix:
         fuzz_target: [
           bitcoin_arbitrary_block,
-          bitcoin_arbitrary_psbt,
           bitcoin_arbitrary_script,
           bitcoin_arbitrary_transaction,
           bitcoin_arbitrary_witness,
           bitcoin_compare_consensus_encoding,
           bitcoin_deserialize_block,
           bitcoin_deserialize_prefilled_transaction,
-          bitcoin_deserialize_psbt,
           bitcoin_deserialize_script,
           bitcoin_deserialize_transaction,
           bitcoin_deserialize_witness,

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,6 +10,8 @@ publish = false
 cargo-fuzz = true
 
 [dependencies]
+# We shouldn't need an explicit version on the next line, but Andrew's tools
+# choke on it otherwise. See https://github.com/nix-community/crate2nix/issues/373
 bitcoin = { path = "../bitcoin", version = "0.33.0-beta", features = [ "serde", "arbitrary" ] }
 old_bitcoin = { version = "0.32.8", package = "bitcoin" }
 bitcoin_consensus_encoding = { path = "../consensus_encoding", package = "bitcoin-consensus-encoding" }

--- a/fuzz/generate-files.sh
+++ b/fuzz/generate-files.sh
@@ -22,7 +22,9 @@ publish = false
 cargo-fuzz = true
 
 [dependencies]
-bitcoin = { path = "../bitcoin", features = [ "serde", "arbitrary" ] }
+# We shouldn't need an explicit version on the next line, but Andrew's tools
+# choke on it otherwise. See https://github.com/nix-community/crate2nix/issues/373
+bitcoin = { path = "../bitcoin", version = "0.33.0-beta", features = [ "serde", "arbitrary" ] }
 old_bitcoin = { version = "0.32.8", package = "bitcoin" }
 bitcoin_consensus_encoding = { path = "../consensus_encoding", package = "bitcoin-consensus-encoding" }
 p2p = { path = "../p2p", package = "bitcoin-p2p-messages", features = ["arbitrary"] }


### PR DESCRIPTION
Remove stale psbt fuzz targets from `cron-daily-fuzz.yml` (which were removed as part of #6056) by running `fuzz/generate-files.sh`.

Partly addresses #6102.