### PR TITLE
backport: Fix Unknown NetworkMessage encoding

### DIFF
--- a/bitcoin/src/p2p/message.rs
+++ b/bitcoin/src/p2p/message.rs
@@ -386,7 +386,8 @@ impl Encodable for NetworkMessage {
             | NetworkMessage::WtxidRelay
             | NetworkMessage::FilterClear
             | NetworkMessage::SendAddrV2 => Ok(0),
-            NetworkMessage::Unknown { payload: ref data, .. } => data.consensus_encode(writer),
+            // Don't use consensus_encode so as not to add a length suffix.
+            NetworkMessage::Unknown { payload: ref data, .. } => writer.write(data),
         }
     }
 }
@@ -840,5 +841,19 @@ mod test {
         } else {
             panic!("Wrong message type");
         }
+    }
+
+    #[test]
+    fn network_message_decode() {
+        let data = hex!("010101010101");
+
+        let message = NetworkMessage::Unknown {
+            command: CommandString::try_from_static("unknown").unwrap(),
+            payload: data.clone(),
+        };
+
+        // Unknown message should encode directly as the payload data.
+        let enc = serialize(&message);
+        assert_eq!(data.as_slice(), enc.as_slice());
     }
 }


### PR DESCRIPTION
This is a backport of #5671, with adjustments to the test case to handle the lack of encoding::Decoder types.

---

The old Encodable implementation for NetworkMessage make use of the Vec<u8> encoding for the raw payload data. This introduces a vector length prefix to the start of the encoding which causes the roundtrip for Unknown NetworkMessage types to fail. In practice, NetworkMessage will only ever be decoded through the RawNetworkMessage, where a payload length will be known. As such, this length prefix is not necessary in the encoding and can be trivially removed.

Change Unknown NetworkMessage encoding to directly write the vector of bytes instead of using Vec<u8> encoding logic.