### PR TITLE
fuzz: rewrite hashes_json target using Arbitrary

### DIFF
--- a/fuzz/fuzz_targets/hashes/json.rs
+++ b/fuzz/fuzz_targets/hashes/json.rs
@@ -1,31 +1,48 @@
 #![cfg_attr(fuzzing, no_main)]
 #![cfg_attr(not(fuzzing), allow(unused))]
 
-use bitcoin::hashes::{ripemd160, sha1, sha256d, sha512, Hmac};
+use bitcoin::hashes::{ripemd160, sha1, sha256d, sha512, Hash, Hmac};
 use libfuzzer_sys::fuzz_target;
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
 struct Hmacs {
     sha1: Hmac<sha1::Hash>,
     sha512: Hmac<sha512::Hash>,
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
 struct Main {
     hmacs: Hmacs,
     ripemd: ripemd160::Hash,
     sha2d: sha256d::Hash,
 }
 
-#[cfg(not(fuzzing))]
-fn main() {}
+impl<'a> arbitrary::Arbitrary<'a> for Main {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let sha1_bytes: [u8; 20] = u.arbitrary()?;
+        let sha512_bytes: [u8; 64] = u.arbitrary()?;
+        let ripemd_bytes: [u8; 20] = u.arbitrary()?;
+        let sha2d_bytes: [u8; 32] = u.arbitrary()?;
 
-fn do_test(data: &[u8]) {
-    if let Ok(m) = serde_json::from_slice::<Main>(data) {
-        let vec = serde_json::to_vec(&m).unwrap();
-        assert_eq!(data, &vec[..]);
+        Ok(Self  {
+            hmacs: Hmacs {
+                sha1: Hmac::<sha1::Hash>::from_byte_array(sha1_bytes),
+                sha512: Hmac::<sha512::Hash>::from_byte_array(sha512_bytes),
+            },
+            ripemd: ripemd160::Hash::from_byte_array(ripemd_bytes),
+            sha2d: sha256d::Hash::from_byte_array(sha2d_bytes),
+        })
     }
 }
 
-fuzz_target!(|data| { do_test(data) });
+#[cfg(not(fuzzing))]
+fn main() {}
+
+fn do_test(data: Main) {
+    let json_string = serde_json::to_string(&data).expect("Serialization failed");
+    let decoded: Main = serde_json::from_str(&json_string).expect("Deserialization failed");
+    assert_eq!(data, decoded);
+}
+
+fuzz_target!(|data: Main| { do_test(data) });


### PR DESCRIPTION
The current hashes_json fuzz target is inefficient because it feeds raw bytes directly to the JSON parser, leading to ~99% malformed instances.

Replace raw byte parsing with structure-aware fuzzing using the `Arbitrary` trait. This ensures every iteration performs a valid roundtrip (Struct -> JSON -> Struct) and focuses the fuzzer on the library logic rather than JSON syntax.

Efficiency Comparison

* Before: 1993 DONE cov: 1400 ft: 4463 exec/s: 996 (High coverage due to parsing noise).
* After:  1995 DONE cov: 543 ft: 558 exec/s: 665 (Concentrated coverage on internal hash logic).

While the raw cov number is lower, it is much more meaningful as it targets the library's hash/JSON interaction instead of the parser's syntax handling.

Fixes #6089