### PR TITLE
Release tracking PR: `internals 0.6.0`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -28,7 +28,7 @@ dependencies = [
 name = "base58ck"
 version = "0.4.0"
 dependencies = [
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "bitcoin_hashes 0.20.0",
  "hex-conservative 0.3.2",
 ]
@@ -83,7 +83,7 @@ dependencies = [
  "bincode",
  "bitcoin-consensus-encoding",
  "bitcoin-crypto",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "bitcoin-io 0.5.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
@@ -111,7 +111,7 @@ version = "0.0.0"
 name = "bitcoin-consensus-encoding"
 version = "0.2.0"
 dependencies = [
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "hex-conservative 0.3.2",
 ]
 
@@ -121,7 +121,7 @@ version = "0.1.0"
 dependencies = [
  "arbitrary",
  "base58ck 0.4.0",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "bitcoin-network-kind",
  "bitcoin_hashes 0.20.0",
  "hex-conservative 0.3.2",
@@ -154,7 +154,7 @@ checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
 
 [[package]]
 name = "bitcoin-internals"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bincode",
  "serde",
@@ -172,7 +172,7 @@ name = "bitcoin-io"
 version = "0.5.0"
 dependencies = [
  "bitcoin-consensus-encoding",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "bitcoin_hashes 0.20.0",
 ]
 
@@ -185,7 +185,7 @@ name = "bitcoin-network-kind"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "serde",
  "serde_json",
  "serde_test",
@@ -198,7 +198,7 @@ dependencies = [
  "arbitrary",
  "bitcoin 0.33.0-beta",
  "bitcoin-consensus-encoding",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "bitcoin-io 0.5.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
@@ -216,7 +216,7 @@ dependencies = [
  "arbitrary",
  "bincode",
  "bitcoin-consensus-encoding",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "bitcoin-units 0.3.0",
  "bitcoin_hashes 0.20.0",
  "hex-conservative 0.3.2",
@@ -237,7 +237,7 @@ version = "0.1.0"
 dependencies = [
  "arbitrary",
  "bitcoin-crypto",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "bitcoin_hashes 0.20.0",
  "secp256k1 0.32.0-beta.2",
  "serde",
@@ -259,7 +259,7 @@ dependencies = [
  "arbitrary",
  "bincode",
  "bitcoin-consensus-encoding",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "serde",
  "serde_json",
  "serde_test",
@@ -290,7 +290,7 @@ version = "0.20.0"
 dependencies = [
  "arbitrary",
  "bitcoin-consensus-encoding",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "cpufeatures",
  "hex-conservative 0.3.2",
  "hex-conservative 1.0.0",

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -157,7 +157,6 @@ name = "bitcoin-internals"
 version = "0.5.0"
 dependencies = [
  "bincode",
- "hex-conservative 0.3.2",
  "serde",
  "serde_json",
 ]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -28,7 +28,7 @@ dependencies = [
 name = "base58ck"
 version = "0.4.0"
 dependencies = [
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "bitcoin_hashes 0.20.0",
  "hex-conservative 0.3.2",
 ]
@@ -82,7 +82,7 @@ dependencies = [
  "bincode",
  "bitcoin-consensus-encoding",
  "bitcoin-crypto",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "bitcoin-io 0.5.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
@@ -110,7 +110,7 @@ version = "0.0.0"
 name = "bitcoin-consensus-encoding"
 version = "0.2.0"
 dependencies = [
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "hex-conservative 0.3.2",
 ]
 
@@ -120,7 +120,7 @@ version = "0.1.0"
 dependencies = [
  "arbitrary",
  "base58ck 0.4.0",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "bitcoin-network-kind",
  "bitcoin_hashes 0.20.0",
  "hex-conservative 0.3.2",
@@ -153,7 +153,7 @@ checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
 
 [[package]]
 name = "bitcoin-internals"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bincode",
  "serde",
@@ -171,7 +171,7 @@ name = "bitcoin-io"
 version = "0.5.0"
 dependencies = [
  "bitcoin-consensus-encoding",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "bitcoin_hashes 0.20.0",
 ]
 
@@ -184,7 +184,7 @@ name = "bitcoin-network-kind"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "serde",
  "serde_json",
  "serde_test",
@@ -197,7 +197,7 @@ dependencies = [
  "arbitrary",
  "bitcoin 0.33.0-beta",
  "bitcoin-consensus-encoding",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "bitcoin-io 0.5.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
@@ -215,7 +215,7 @@ dependencies = [
  "arbitrary",
  "bincode",
  "bitcoin-consensus-encoding",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "bitcoin-units 0.3.0",
  "bitcoin_hashes 0.20.0",
  "hex-conservative 0.3.2",
@@ -230,7 +230,7 @@ version = "0.1.0"
 dependencies = [
  "arbitrary",
  "bitcoin-crypto",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "bitcoin_hashes 0.20.0",
  "secp256k1 0.32.0-beta.2",
  "serde",
@@ -252,7 +252,7 @@ dependencies = [
  "arbitrary",
  "bincode",
  "bitcoin-consensus-encoding",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "serde",
  "serde_json",
  "serde_test",
@@ -274,7 +274,7 @@ version = "0.20.0"
 dependencies = [
  "arbitrary",
  "bitcoin-consensus-encoding",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "cpufeatures",
  "hex-conservative 0.3.2",
  "hex-conservative 1.0.0",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -156,7 +156,6 @@ name = "bitcoin-internals"
 version = "0.5.0"
 dependencies = [
  "bincode",
- "hex-conservative 0.3.2",
  "serde",
  "serde_json",
 ]

--- a/base58/Cargo.toml
+++ b/base58/Cargo.toml
@@ -20,7 +20,7 @@ alloc = ["hashes/alloc", "internals/alloc"]
 
 [dependencies]
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false }
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
 
 [dev-dependencies]
 hex = { package = "hex-conservative", version = "0.3.2" }

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -33,7 +33,7 @@ hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", d
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.2.0", default-features = false, features = ["alloc"] }
 hex-stable = { package = "hex-conservative", version = "1.0.0", default-features = false, features = ["alloc"] }
 hex-unstable = { package = "hex-conservative", version = "0.3.2", default-features = false, features = ["alloc"] }
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0", features = ["alloc"] }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0", features = ["alloc"] }
 io = { package = "bitcoin-io", path = "../io", version = "0.5.0", default-features = false, features = ["alloc", "hashes"] }
 network = { package = "bitcoin-network-kind", path = "../network", version = "0.1.0", default-features = false, features = ["alloc"]}
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.102.0", default-features = false, features = ["alloc", "hex"] }

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -33,7 +33,7 @@ hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", d
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.2.0", default-features = false, features = ["alloc"] }
 hex-stable = { package = "hex-conservative", version = "1.0.0", default-features = false, features = ["alloc"] }
 hex-unstable = { package = "hex-conservative", version = "0.3.2", default-features = false, features = ["alloc"] }
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0", features = ["alloc", "hex"] }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0", features = ["alloc"] }
 io = { package = "bitcoin-io", path = "../io", version = "0.5.0", default-features = false, features = ["alloc", "hashes"] }
 network = { package = "bitcoin-network-kind", path = "../network", version = "0.1.0", default-features = false, features = ["alloc"]}
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.102.0", default-features = false, features = ["alloc", "hex"] }

--- a/consensus_encoding/Cargo.toml
+++ b/consensus_encoding/Cargo.toml
@@ -20,7 +20,7 @@ std = ["alloc", "internals/std"]
 alloc = ["internals/alloc"]
 
 [dependencies]
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
 
 [dev-dependencies]
 hex = { package = "hex-conservative", version = "0.3.2" }

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -26,7 +26,7 @@ base58 = { package = "base58ck", path = "../base58", version = "0.4.0", default-
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false, features = ["hex"] }
 hex-unstable = { package = "hex-conservative", version = "0.3.2", default-features = false }
 hex-stable = { package = "hex-conservative", version = "1.0.0", default-features = false }
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0", features = ["hex"] }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
 network = { package = "bitcoin-network-kind", path = "../network", version = "0.1.0", default-features = false }
 secp256k1 = { version = "0.32.0-beta.2", default-features = false }
 

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -26,7 +26,7 @@ base58 = { package = "base58ck", path = "../base58", version = "0.4.0", default-
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false, features = ["hex"] }
 hex-unstable = { package = "hex-conservative", version = "0.3.2", default-features = false }
 hex-stable = { package = "hex-conservative", version = "1.0.0", default-features = false }
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
 network = { package = "bitcoin-network-kind", path = "../network", version = "0.1.0", default-features = false }
 secp256k1 = { version = "0.32.0-beta.2", default-features = false }
 

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -24,7 +24,7 @@ hex = ["dep:hex-stable", "dep:hex-unstable"]
 small-hash = []
 
 [dependencies]
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.2.0", default-features = false }
 
 arbitrary = { version = "1.4.1", optional = true}

--- a/internals/CHANGELOG.md
+++ b/internals/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.6.0 - 2026-05-04
+
+- Remove the hex dependency.
+- Delete `compact_size` module.
+
 # 0.5.0 - 2025-12-05
 
 - Remove `doc_auto_cfg` [#5162](https://github.com/rust-bitcoin/rust-bitcoin/pull/5162)

--- a/internals/Cargo.toml
+++ b/internals/Cargo.toml
@@ -16,13 +16,12 @@ exclude = ["api", "tests", "contrib"]
 
 [features]
 default = []
-std = ["alloc", "hex?/std"]
-alloc = ["hex?/alloc"]
+std = ["alloc"]
+alloc = []
 
 test-serde = ["serde", "dep:serde_json", "dep:bincode"]
 
 [dependencies]
-hex = { package = "hex-conservative", version = "0.3.2", default-features = false, optional = true }
 serde = { version = "1.0.195", default-features = false, optional = true }
 
 # Behind the test-serde feature.

--- a/internals/Cargo.toml
+++ b/internals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-internals"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>", "The Rust Bitcoin developers"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"

--- a/internals/src/serde.rs
+++ b/internals/src/serde.rs
@@ -313,19 +313,3 @@ macro_rules! serde_round_trip (
         assert_eq!($var, decoded);
     })
 );
-
-#[cfg(feature = "hex")]
-/// Serializes a byte slice using the `hex` crate.
-pub struct SerializeBytesAsHex<'a>(pub &'a [u8]);
-
-#[cfg(feature = "hex")]
-impl serde::Serialize for SerializeBytesAsHex<'_> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        use hex::DisplayHex;
-
-        serializer.collect_str(&format_args!("{:x}", self.0.as_hex()))
-    }
-}

--- a/io/Cargo.toml
+++ b/io/Cargo.toml
@@ -20,7 +20,7 @@ std = ["alloc", "encoding/std", "hashes?/std", "internals/std"]
 alloc = ["encoding/alloc", "hashes?/alloc", "internals/alloc"]
 
 [dependencies]
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.2.0", default-features = false }
 
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false, optional = true }

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -19,7 +19,7 @@ std = ["alloc", "internals/std"]
 alloc = ["internals/alloc", "serde?/alloc"]
 
 [dependencies]
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
 
 arbitrary = { version = "1.4.1", optional = true }
 serde = { version = "1.0.195", default-features = false, features = [ "derive" ], optional = true }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -27,7 +27,7 @@ network = { package = "bitcoin-network-kind", path = "../network", version = "0.
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.102.0", default-features = false }
 hex-stable = { package = "hex-conservative", version = "1.0.0", default-features = false, features = ["alloc"] }
 hex-unstable = { package = "hex-conservative", version = "0.3.2", default-features = false }
-internals = { package = "bitcoin-internals", path = "../internals", default-features = false }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0", default-features = false }
 io = { package = "bitcoin-io", version = "0.5.0", path = "../io", default-features = false }
 units = { package = "bitcoin-units", path = "../units", version = "0.3.0", default-features = false }
 

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -24,7 +24,7 @@ hex = ["dep:hex-stable", "dep:hex-unstable", "hashes/hex"]
 [dependencies]
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.2.0", default-features = false }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false }
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
 units = { package = "bitcoin-units", path = "../units", version = "0.3.0", default-features = false, features = [ "encoding" ] }
 
 arbitrary = { version = "1.4.1", optional = true }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -19,7 +19,7 @@ std = ["alloc", "hashes/std", "hex-stable?/std", "hex-unstable?/std", "internals
 alloc = ["hashes/alloc", "hex-stable?/alloc", "hex-unstable?/alloc", "internals/alloc", "units/alloc"]
 serde = ["dep:serde", "hashes/serde", "internals/serde", "units/serde", "alloc", "hex"]
 arbitrary = ["dep:arbitrary", "units/arbitrary"]
-hex = ["dep:hex-stable", "dep:hex-unstable", "hashes/hex", "internals/hex"]
+hex = ["dep:hex-stable", "dep:hex-unstable", "hashes/hex"]
 
 [dependencies]
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.2.0", default-features = false }

--- a/primitives/src/witness.rs
+++ b/primitives/src/witness.rs
@@ -717,13 +717,27 @@ impl serde::Serialize for Witness {
     {
         use serde::ser::SerializeSeq;
 
+        /// Serializes a byte slice using the `hex` crate.
+        struct SerializeBytesAsHex<'a>(&'a [u8]);
+
+        impl serde::Serialize for SerializeBytesAsHex<'_> {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                // Ok because serde feature enables hex.
+                use hex_unstable::DisplayHex as _;
+                serializer.collect_str(&format_args!("{:x}", self.0.as_hex()))
+            }
+        }
+
         let human_readable = serializer.is_human_readable();
         let mut seq = serializer.serialize_seq(Some(self.witness_elements))?;
 
         // Note that the `Iter` strips the varints out when iterating.
         for elem in self {
             if human_readable {
-                seq.serialize_element(&internals::serde::SerializeBytesAsHex(elem))?;
+                seq.serialize_element(&SerializeBytesAsHex(elem))?;
             } else {
                 seq.serialize_element(&elem)?;
             }

--- a/taproot-primitives/Cargo.toml
+++ b/taproot-primitives/Cargo.toml
@@ -23,7 +23,7 @@ hex = ["hashes/hex"]
 [dependencies]
 crypto = { package = "bitcoin-crypto", path = "../crypto", default-features = false }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false }
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
 
 arbitrary = { version = "1.4.1", optional = true }
 secp256k1 = { version = "0.32.0-beta.2", default-features = false }

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -19,14 +19,14 @@ std = ["alloc", "internals/std", "encoding?/std"]
 alloc = ["internals/alloc", "serde?/alloc", "encoding?/alloc"]
 
 [dependencies]
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
 
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "0.2.0", default-features = false, optional = true }
 serde = { version = "1.0.195", default-features = false, features = ["derive"], optional = true }
 arbitrary = { version = "1.4.1", optional = true }
 
 [dev-dependencies]
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0", features = ["test-serde"] }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0", features = ["test-serde"] }
 bincode = "1.3.1"
 serde = { version = "1.0.195", default-features = false, features = ["derive"] }
 serde_test = "1.0.19"


### PR DESCRIPTION
First remove the `hex` dependency by inlineing code into `primitives` then remove the `hex` dependency all together. See the last patch for more context.

We are trying to release the whole stack ATM anyways so this doesn't trigger that many more releases. 

Draft while I test this on the `0.32.x` branch. If we want to not mess this up later basically `internals` has to have its MSRV set back to 1.56 - I don't know if your current dev process or CI setup can handle different MSRVs in the repository.

Do we really want to pursue this @apoelstra - can we just do `0.35.0` as `0.32.x` + MSRV bump + `consensus_encoding`