### PR TITLE
fuzz: Harden `hashes_json` fuzzing

### DIFF
--- a/.github/workflows/cron-daily-fuzz.yml
+++ b/.github/workflows/cron-daily-fuzz.yml
@@ -105,6 +105,7 @@ jobs:
           consensus_encoding_decode_byte_vec,
           consensus_encoding_decode_compact_size,
           consensus_encoding_decode_decoder2,
+          hashes_arbitrary_json,
           hashes_json,
           hashes_ripemd160,
           hashes_sha1,

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -651,6 +651,13 @@ doc = false
 bench = false
 
 [[bin]]
+name = "hashes_arbitrary_json"
+path = "fuzz_targets/hashes/arbitrary_json.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
 name = "hashes_json"
 path = "fuzz_targets/hashes/json.rs"
 test = false

--- a/fuzz/fuzz_targets/hashes/arbitrary_json.rs
+++ b/fuzz/fuzz_targets/hashes/arbitrary_json.rs
@@ -1,0 +1,50 @@
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use arbitrary::{Arbitrary, Unstructured};
+use bitcoin::hashes::{ripemd160, sha1, sha256d, sha512, Hmac};
+use libfuzzer_sys::fuzz_target;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
+struct Hmacs {
+    sha1: Hmac<sha1::Hash>,
+    sha512: Hmac<sha512::Hash>,
+}
+
+impl<'a> Arbitrary<'a> for Hmacs {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Self {
+            sha1: u.arbitrary()?,
+            sha512: u.arbitrary()?,
+        })
+    }
+}
+
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
+struct Main {
+    hmacs: Hmacs,
+    ripemd: ripemd160::Hash,
+    sha2d: sha256d::Hash,
+}
+
+impl<'a> Arbitrary<'a> for Main {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Self {
+            hmacs: u.arbitrary()?,
+            ripemd: u.arbitrary()?,
+            sha2d: u.arbitrary()?,
+        })
+    }
+}
+
+#[cfg(not(fuzzing))]
+fn main() {}
+
+fn do_test(data: Main) {
+    let vec = serde_json::to_vec(&data).unwrap();
+    let reparsed = serde_json::from_slice::<Main>(&vec).unwrap();
+    assert_eq!(reparsed, data);
+}
+
+fuzz_target!(|data: Main| { do_test(data) });

--- a/fuzz/fuzz_targets/hashes/json.rs
+++ b/fuzz/fuzz_targets/hashes/json.rs
@@ -5,13 +5,13 @@ use bitcoin::hashes::{ripemd160, sha1, sha256d, sha512, Hmac};
 use libfuzzer_sys::fuzz_target;
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
 struct Hmacs {
     sha1: Hmac<sha1::Hash>,
     sha512: Hmac<sha512::Hash>,
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
 struct Main {
     hmacs: Hmacs,
     ripemd: ripemd160::Hash,
@@ -24,7 +24,8 @@ fn main() {}
 fn do_test(data: &[u8]) {
     if let Ok(m) = serde_json::from_slice::<Main>(data) {
         let vec = serde_json::to_vec(&m).unwrap();
-        assert_eq!(data, &vec[..]);
+        let reparsed = serde_json::from_slice::<Main>(&vec).unwrap();
+        assert_eq!(reparsed, m);
     }
 }
 

--- a/hashes/api/all-features.txt
+++ b/hashes/api/all-features.txt
@@ -282,6 +282,8 @@ impl<T> core::convert::From<T> for bitcoin_hashes::hkdf::error::MaxLengthError
 pub fn bitcoin_hashes::hkdf::error::MaxLengthError::from(t: T) -> T
 pub mod bitcoin_hashes::hmac
 #[repr(transparent)] pub struct bitcoin_hashes::hmac::Hmac<T: bitcoin_hashes::Hash>(_)
+impl<'a, T: bitcoin_hashes::Hash + arbitrary::Arbitrary<'a>> arbitrary::Arbitrary<'a> for bitcoin_hashes::hmac::Hmac<T>
+pub fn bitcoin_hashes::hmac::Hmac<T>::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
 impl<'de, T: bitcoin_hashes::Hash + serde::de::Deserialize<'de>> serde::de::Deserialize<'de> for bitcoin_hashes::hmac::Hmac<T>
 pub fn bitcoin_hashes::hmac::Hmac<T>::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
 impl<T: bitcoin_hashes::Hash + core::fmt::Debug> core::fmt::Debug for bitcoin_hashes::hmac::Hmac<T>
@@ -2172,6 +2174,8 @@ pub unsafe fn bitcoin_hashes::hkdf::Hkdf<T>::clone_to_uninit(&self, dest: *mut u
 impl<T> core::convert::From<T> for bitcoin_hashes::hkdf::Hkdf<T>
 pub fn bitcoin_hashes::hkdf::Hkdf<T>::from(t: T) -> T
 #[repr(transparent)] pub struct bitcoin_hashes::Hmac<T: bitcoin_hashes::Hash>(_)
+impl<'a, T: bitcoin_hashes::Hash + arbitrary::Arbitrary<'a>> arbitrary::Arbitrary<'a> for bitcoin_hashes::hmac::Hmac<T>
+pub fn bitcoin_hashes::hmac::Hmac<T>::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
 impl<'de, T: bitcoin_hashes::Hash + serde::de::Deserialize<'de>> serde::de::Deserialize<'de> for bitcoin_hashes::hmac::Hmac<T>
 pub fn bitcoin_hashes::hmac::Hmac<T>::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
 impl<T: bitcoin_hashes::Hash + core::fmt::Debug> core::fmt::Debug for bitcoin_hashes::hmac::Hmac<T>

--- a/hashes/src/hmac/mod.rs
+++ b/hashes/src/hmac/mod.rs
@@ -73,6 +73,13 @@ impl<'de, T: Hash + Deserialize<'de>> Deserialize<'de> for Hmac<T> {
     }
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a, T: Hash + arbitrary::Arbitrary<'a>> arbitrary::Arbitrary<'a> for Hmac<T> {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Self(u.arbitrary()?))
+    }
+}
+
 /// Pair of underlying hash engines, used for the inner and outer hash of HMAC.
 #[derive(Debug, Clone)]
 pub struct HmacEngine<T: HashEngine> {


### PR DESCRIPTION
The `hashes_json` fuzz target currently checks the wrong property: it compares input JSON bytes against reserialized output bytes, which makes semantically equivalent inputs fail because of insignificant (e.g. whitespace) formatting differences.

This PR hardens the `hashes_json` target by checking semantic roundtrip equality instead of binary equality, and adds a separate `hashes_arbitrary_json` target for structured JSON roundtrip fuzzing.

Patch 1 adds an `Arbitrary` impl for `Hmac`.
Patch 2 adds `hashes_arbitrary_json` to add structured roundtrip fuzzing
Patch 3 fixes `hashes_json` to assert semantic roundtrip equality.

Partly addresses #6089.