### PR TITLE
fix: rustfmt formatting across workspace

### DIFF
--- a/consensus_encoding/src/lib.rs
+++ b/consensus_encoding/src/lib.rs
@@ -91,10 +91,10 @@ pub use self::encode::encoders::{
 };
 #[cfg(feature = "alloc")]
 #[doc(inline)]
-pub use self::encode::{encode_to_vec, drain_to_vec};
+pub use self::encode::{drain_to_vec, encode_to_vec};
 #[cfg(feature = "std")]
 #[doc(inline)]
-pub use self::encode::{encode_to_writer, drain_to_writer};
+pub use self::encode::{drain_to_writer, encode_to_writer};
 #[doc(inline)]
 pub use self::encode::{Encode, Encoder, EncoderByteIter, ExactSizeEncoder};
 #[cfg(feature = "alloc")]

--- a/consensus_encoding/tests/api.rs
+++ b/consensus_encoding/tests/api.rs
@@ -13,9 +13,9 @@ use core::fmt;
 
 use bitcoin_consensus_encoding::{
     self as encoding, encoder_newtype, ArrayDecoder, ArrayEncoder, ArrayRefEncoder, BytesEncoder,
-    CompactSizeDecoder, CompactSizeDecoderError, CompactSizeEncoder, CompactSizeU64Decoder,
-    Decode, Decoder, Decoder2, Decoder3, Decoder4, Decoder6, Encode, EncoderByteIter,
-    SliceEncoder, UnexpectedEofError,
+    CompactSizeDecoder, CompactSizeDecoderError, CompactSizeEncoder, CompactSizeU64Decoder, Decode,
+    Decoder, Decoder2, Decoder3, Decoder4, Decoder6, Encode, EncoderByteIter, SliceEncoder,
+    UnexpectedEofError,
 };
 use encoding::error::{DecodeError, UnconsumedError};
 #[cfg(feature = "std")]

--- a/fuzz/fuzz_targets/bitcoin/compare_consensus_encoding.rs
+++ b/fuzz/fuzz_targets/bitcoin/compare_consensus_encoding.rs
@@ -6,9 +6,8 @@
 //! This fuzz target compares the consensus encoding produced by `bitcoin_consensus_encoding::encode_to_vec`
 //! in master branch with `bitcoin::consensus::encode::serialize` from bitcoin 0.32 for all shared types.
 
+use bitcoin_consensus_encoding::{decode_from_slice, encode_to_vec, Decoder};
 use libfuzzer_sys::fuzz_target;
-
-use bitcoin_consensus_encoding::{Decoder, decode_from_slice, encode_to_vec};
 
 #[cfg(not(fuzzing))]
 fn main() {}
@@ -31,8 +30,8 @@ fn main() {}
 /// - `TransactionDecoderError` with "no outputs": The new `TransactionDecoder` rejects
 ///   transactions with zero outputs; the old decoder accepted them.
 fn is_known_decoder_divergence(err: &(dyn std::error::Error + 'static)) -> bool {
-    use bitcoin_consensus_encoding::LengthPrefixExceedsMaxError;
     use bitcoin::blockdata::transaction::TransactionDecoderError;
+    use bitcoin_consensus_encoding::LengthPrefixExceedsMaxError;
     use p2p::message::error::CommandStringDecoderError;
 
     let mut current: Option<&(dyn std::error::Error + 'static)> = Some(err);
@@ -40,13 +39,18 @@ fn is_known_decoder_divergence(err: &(dyn std::error::Error + 'static)) -> bool 
         if e.downcast_ref::<bitcoin::amount::OutOfRangeError>().is_some() {
             return true;
         }
-        if matches!(e.downcast_ref::<CommandStringDecoderError>(), Some(CommandStringDecoderError::NotAscii)) {
+        if matches!(
+            e.downcast_ref::<CommandStringDecoderError>(),
+            Some(CommandStringDecoderError::NotAscii)
+        ) {
             return true;
         }
         if e.downcast_ref::<LengthPrefixExceedsMaxError>().is_some() {
             return true;
         }
-        if e.downcast_ref::<TransactionDecoderError>().is_some_and(|e| e.to_string() == "transaction has no outputs") {
+        if e.downcast_ref::<TransactionDecoderError>()
+            .is_some_and(|e| e.to_string() == "transaction has no outputs")
+        {
             return true;
         }
         current = e.source();
@@ -76,15 +80,14 @@ macro_rules! compare_encoding {
                 let old_encoded = old_bitcoin::consensus::encode::serialize(&old_obj);
                 let new_encoded = encode_to_vec(&new_obj);
                 assert_eq!(old_encoded, new_encoded);
-            },
-            (Ok(old_obj), Err(ref err)) => {
+            }
+            (Ok(old_obj), Err(ref err)) =>
                 if !is_known_decoder_divergence(err) {
                     panic!("Decoded with old decoder only: {:?}, {:?} {:?}", $data, old_obj, err);
-                }
-            },
+                },
             (Err(err), Ok(new_obj)) => {
                 panic!("Decoded with new decoder only: {:?}, {:?} {:?}", $data, new_obj, err);
-            },
+            }
             (_, _) => {}
         }
     }};
@@ -117,8 +120,8 @@ fn addrv2_payload_has_torv2(data: &[u8]) -> bool {
         let mut rest = data;
         let count = read_compact_size(&mut rest)?;
         for _ in 0..count {
-            let message: p2p::address::AddrV2Message
-                = bitcoin::encoding::decode_from_slice_unbounded(&mut rest).ok()?;
+            let message: p2p::address::AddrV2Message =
+                bitcoin::encoding::decode_from_slice_unbounded(&mut rest).ok()?;
             if let p2p::address::AddrV2::Unknown(addr_type, _) = message.addr {
                 if addr_type == 0x03 {
                     return Some(true);

--- a/hashes/src/sha256/crypto/avx2.rs
+++ b/hashes/src/sha256/crypto/avx2.rs
@@ -32,10 +32,17 @@ unsafe fn Add(x: __m256i, y: __m256i) -> __m256i { _mm256_add_epi32(x, y) }
 unsafe fn Add3(x: __m256i, y: __m256i, z: __m256i) -> __m256i { Add(Add(x, y), z) }
 
 #[inline(always)]
-unsafe fn Add4(x: __m256i, y: __m256i, z: __m256i, w: __m256i) -> __m256i { Add(Add(x, y), Add(z, w)) }
+unsafe fn Add4(x: __m256i, y: __m256i, z: __m256i, w: __m256i) -> __m256i {
+    Add(Add(x, y), Add(z, w))
+}
 
+#[rustfmt::skip]
 macro_rules! inc2 { ($w:ident, $a:expr) => {{ $w = Add($w, $a); $w }}; }
+
+#[rustfmt::skip]
 macro_rules! inc3 { ($w:ident, $a:expr, $b:expr) => {{ $w = Add3($w, $a, $b); $w }}; }
+
+#[rustfmt::skip]
 macro_rules! inc4 { ($w:ident, $a:expr, $b:expr, $c:expr) => {{ $w = Add4($w, $a, $b, $c); $w }}; }
 
 #[inline(always)]
@@ -64,12 +71,20 @@ unsafe fn Maj(x: __m256i, y: __m256i, z: __m256i) -> __m256i { Or(And(x, y), And
 
 #[inline(always)]
 unsafe fn Sigma0(x: __m256i) -> __m256i {
-    Xor3(Or(ShR::<2>(x), ShL::<30>(x)), Or(ShR::<13>(x), ShL::<19>(x)), Or(ShR::<22>(x), ShL::<10>(x)))
+    Xor3(
+        Or(ShR::<2>(x), ShL::<30>(x)),
+        Or(ShR::<13>(x), ShL::<19>(x)),
+        Or(ShR::<22>(x), ShL::<10>(x)),
+    )
 }
 
 #[inline(always)]
 unsafe fn Sigma1(x: __m256i) -> __m256i {
-    Xor3(Or(ShR::<6>(x), ShL::<26>(x)), Or(ShR::<11>(x), ShL::<21>(x)), Or(ShR::<25>(x), ShL::<7>(x)))
+    Xor3(
+        Or(ShR::<6>(x), ShL::<26>(x)),
+        Or(ShR::<11>(x), ShL::<21>(x)),
+        Or(ShR::<25>(x), ShL::<7>(x)),
+    )
 }
 
 #[inline(always)]
@@ -93,6 +108,7 @@ macro_rules! round {
 }
 
 #[inline(always)]
+#[rustfmt::skip]
 unsafe fn Read8(input: &[[u8; 64]; 8], offset: usize) -> __m256i {
     let ret = _mm256_set_epi32(
         i32::from_le_bytes(input[0][offset..offset + 4].try_into().unwrap()),
@@ -111,6 +127,7 @@ unsafe fn Read8(input: &[[u8; 64]; 8], offset: usize) -> __m256i {
 }
 
 #[inline(always)]
+#[rustfmt::skip]
 unsafe fn Write8(output: &mut [[u8; 32]; 8], offset: usize, v: __m256i) {
     let v = _mm256_shuffle_epi8(v, _mm256_set_epi32(
         0x0C0D0E0F, 0x08090A0B, 0x04050607, 0x00010203,
@@ -128,6 +145,7 @@ unsafe fn Write8(output: &mut [[u8; 32]; 8], offset: usize, v: __m256i) {
 
 /// Computes `SHA256d` of eight 64-byte inputs in parallel using AVX2
 #[target_feature(enable = "avx,avx2")]
+#[rustfmt::skip]
 pub(super) unsafe fn sha256d_64_8way(output: &mut [[u8; 32]; 8], input: &[[u8; 64]; 8]) {
     // ------------------ Transform 1 -------------------
     let mut a = K(0x6a09e667);

--- a/hashes/src/sha256/crypto/sse41.rs
+++ b/hashes/src/sha256/crypto/sse41.rs
@@ -30,10 +30,17 @@ unsafe fn Add(x: __m128i, y: __m128i) -> __m128i { _mm_add_epi32(x, y) }
 unsafe fn Add3(x: __m128i, y: __m128i, z: __m128i) -> __m128i { Add(Add(x, y), z) }
 
 #[inline(always)]
-unsafe fn Add4(x: __m128i, y: __m128i, z: __m128i, w: __m128i) -> __m128i { Add(Add(x, y), Add(z, w)) }
+unsafe fn Add4(x: __m128i, y: __m128i, z: __m128i, w: __m128i) -> __m128i {
+    Add(Add(x, y), Add(z, w))
+}
 
+#[rustfmt::skip]
 macro_rules! inc2 { ($w:ident, $a:expr) => {{ $w = Add($w, $a); $w }}; }
+
+#[rustfmt::skip]
 macro_rules! inc3 { ($w:ident, $a:expr, $b:expr) => {{ $w = Add3($w, $a, $b); $w }}; }
+
+#[rustfmt::skip]
 macro_rules! inc4 { ($w:ident, $a:expr, $b:expr, $c:expr) => {{ $w = Add4($w, $a, $b, $c); $w }}; }
 
 #[inline(always)]
@@ -62,12 +69,20 @@ unsafe fn Maj(x: __m128i, y: __m128i, z: __m128i) -> __m128i { Or(And(x, y), And
 
 #[inline(always)]
 unsafe fn Sigma0(x: __m128i) -> __m128i {
-    Xor3(Or(ShR::<2>(x), ShL::<30>(x)), Or(ShR::<13>(x), ShL::<19>(x)), Or(ShR::<22>(x), ShL::<10>(x)))
+    Xor3(
+        Or(ShR::<2>(x), ShL::<30>(x)),
+        Or(ShR::<13>(x), ShL::<19>(x)),
+        Or(ShR::<22>(x), ShL::<10>(x)),
+    )
 }
 
 #[inline(always)]
 unsafe fn Sigma1(x: __m128i) -> __m128i {
-    Xor3(Or(ShR::<6>(x), ShL::<26>(x)), Or(ShR::<11>(x), ShL::<21>(x)), Or(ShR::<25>(x), ShL::<7>(x)))
+    Xor3(
+        Or(ShR::<6>(x), ShL::<26>(x)),
+        Or(ShR::<11>(x), ShL::<21>(x)),
+        Or(ShR::<25>(x), ShL::<7>(x)),
+    )
 }
 
 #[inline(always)]
@@ -112,6 +127,7 @@ unsafe fn Write4(output: &mut [[u8; 32]; 4], offset: usize, v: __m128i) {
 
 /// Computes `SHA256d` of four 64-byte inputs in parallel using SSE4.1
 #[target_feature(enable = "sse2,ssse3,sse4.1")]
+#[rustfmt::skip]
 pub(super) unsafe fn sha256d_64_4way(output: &mut [[u8; 32]; 4], input: &[[u8; 64]; 4]) {
     // ------------------ Transform 1 -------------------
     let mut a = K(0x6a09e667);

--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -2585,7 +2585,10 @@ mod test {
 
         // Test serializing.
         let cs = CommandString("Andrew".into());
-        assert_eq!(encoding::encode_to_vec(&cs), [0x41u8, 0x6e, 0x64, 0x72, 0x65, 0x77, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(
+            encoding::encode_to_vec(&cs),
+            [0x41u8, 0x6e, 0x64, 0x72, 0x65, 0x77, 0, 0, 0, 0, 0, 0]
+        );
 
         // Test deserializing
         let cs: Result<CommandString, _> =

--- a/p2p/src/message_network.rs
+++ b/p2p/src/message_network.rs
@@ -928,8 +928,10 @@ mod tests {
         let reject_tx_conflict = hex!("027478121474786e2d6d656d706f6f6c2d636f6e666c69637405df54d3860b3c41806a3546ab48279300affacf4b88591b229141dcf2f47004");
         let reject_tx_nonfinal = hex!("02747840096e6f6e2d66696e616c259bbe6c83db8bbdfca7ca303b19413dc245d9f2371b344ede5f8b1339a5460b");
 
-        let decode_result_conflict: Result<Reject, _> = encoding::decode_from_slice(&reject_tx_conflict);
-        let decode_result_nonfinal: Result<Reject, _> = encoding::decode_from_slice(&reject_tx_nonfinal);
+        let decode_result_conflict: Result<Reject, _> =
+            encoding::decode_from_slice(&reject_tx_conflict);
+        let decode_result_nonfinal: Result<Reject, _> =
+            encoding::decode_from_slice(&reject_tx_nonfinal);
 
         assert!(decode_result_conflict.is_ok());
         assert!(decode_result_nonfinal.is_ok());

--- a/primitives/src/hex_codec.rs
+++ b/primitives/src/hex_codec.rs
@@ -12,7 +12,7 @@ use core::convert::Infallible;
 use core::fmt;
 use core::fmt::Write as _;
 
-use encoding::{Decode, Decoder, EncoderByteIter, Encode};
+use encoding::{Decode, Decoder, Encode, EncoderByteIter};
 use hex_unstable::{BytesToHexIter, Case};
 use internals::write_err;
 


### PR DESCRIPTION
While setting up my dev environment, I noticed a handful of files weren't 
passing `just fmt`. This PR applies rustfmt formatting to bring them in line 
with the project's `rustfmt.toml` config.

Ran using the pinned nightly toolchain (`nightly-2026-03-27`, rustfmt 
1.9.0-nightly) as installed by `just toolchains`. Running `just fmt` after 
this patch produces no further changes.

No logic changes formatting only.
