### PR TITLE
Fix found mutants

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -11,7 +11,7 @@ exclude_re = [
     "deserialize", # Skip serde mutation tests
     "serde_details::<impl de::Visitor<'_>", # Skip serde mutation tests
     "Iterator", # Mutating operations in an iterator can result in an infinite loop
-    "<impl .*Decodable for .*>::decoder", # Mutant replacing Default::default() is equivalent to returning new()
+    "<impl .*Decode for .*>::decoder", # Mutant replacing Default::default() is equivalent to returning new()
     "<impl .*Decoder for .*>::read_limit", # Function is for optimization and does not need to be tested.
 
 


### PR DESCRIPTION
The MISSED mutants were a result of the change of trait name from `Decodable` to `Decode`, the `mutants.toml` has an exclude regex that skips the path that replaces the Decoder with its default impl which is now stale after the rewrite.

Update the regex path to the current Decoder trait `Decode` from the previous, now stale `Decodable`.

closes #6111 