### PR TITLE
Release tracking PR: `key-expression v0.1.0`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -179,7 +179,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-key-expression"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "arbitrary",
  "base58ck 0.4.0",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-key-expression"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "arbitrary",
  "base58ck 0.4.0",

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -30,7 +30,7 @@ base58 = { package = "base58ck", path = "../base58", version = "0.4.0", default-
 bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
 crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.2.0", default-features = false, features = ["alloc"] }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.0.0", default-features = false, features = ["alloc", "hex"] }
-key-expression = { package = "bitcoin-key-expression", path = "../key_expression", version = "0.0.0", default-features = false, features = ["alloc"] }
+key-expression = { package = "bitcoin-key-expression", path = "../key_expression", version = "0.1.0", default-features = false, features = ["alloc"] }
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0", default-features = false, features = ["alloc"] }
 hex = { package = "hex-conservative", version = "1.1.0", default-features = false, features = ["alloc"] }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0", features = ["alloc", "hex"] }

--- a/key_expression/CHANGELOG.md
+++ b/key_expression/CHANGELOG.md
@@ -2,8 +2,16 @@
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-05-28
+
+- Split relative and absolute `bip32` derivation paths [#6232](https://github.com/rust-bitcoin/rust-bitcoin/pull/6232)
+- Validate master key seed length [#6212](https://github.com/rust-bitcoin/rust-bitcoin/pull/6212)
+- Make child number a newtype `ChildNumber(u32)` [#6192](https://github.com/rust-bitcoin/rust-bitcoin/pull/6192)
+- Move `bip32` module to key-expression crate [#6009](https://github.com/rust-bitcoin/rust-bitcoin/pull/6009)
+
 ## 0.0.0 - Initial dummy release
 
 - Empty crate to reserve the name on crates.io
 
-[Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-key-expression-0.0.0...HEAD
+[Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-key-expression-0.1.0...HEAD
+[0.1.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-key-expression-0.0.0...bitcoin-key-expression-0.1.0

--- a/key_expression/Cargo.toml
+++ b/key_expression/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-key-expression"
-version = "0.0.0"
+version = "0.1.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin"


### PR DESCRIPTION
With the bip32 module moved, the key-expression crate should now have a new version release before the next bitcoin release.

Bump key-expression version number to 0.1.0.
Update changelog.
Adjust bitcoin manifest to match new version number.
Update lock files.