### PR TITLE
Update the security policy to mention repos

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,9 +1,11 @@
 # Security Policy
 
-This security policy applies to the "core" crates in the rust-bitcoin ecosystem, which are
-`bitcoin`, `secp256k1`, `bitcoin_hashes` and `bitcoin-internals`. These crates deal with
-cryptography and cryptographic algorithms, and as such, are likely locations for security
-vulnerabilities to crop up.
+This security policy applies to the "core" repositories in the rust-bitcoin ecosystem, which are:
+
+* [`rust-bitcoin`](https://github.com/rust-bitcoin/rust-bitcoin)
+* [`rust-secp256k1`](https://github.com/rust-bitcoin/rust-secp256k1)
+* [`rust-bech32`](https://github.com/rust-bitcoin/rust-bech32)
+* [`hex-conservative`](https://github.com/rust-bitcoin/hex-conservative)
 
 As a general rule, an issue is a security vulnerability if it could lead to:
 


### PR DESCRIPTION
Now that we have crate smashed the repository a bunch the security policy is a bit stale.

Use repositories in the list of things to apply our security policy to instead of individual crates. Saves us from the long list of crates now in this repository.

Also remove the mention of cryptography because now we list repos its not so relevant.

Adds `rust-bech32` because a bug in address generation could lead to loss of funds which is explicitly defined as a security issue.

Adds `hex-conservative` because we depend on it in `rust-bitcoin` so bugs there are bugs here.