### PR TITLE
Adjust fuzz target and decoders to match 0.32 behaviour

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -57,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.8"
+version = "0.32.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e499f9fc0407f50fe98af744ab44fa67d409f76b6772e1689ec8485eb0c0f66"
+checksum = "9cf93e61f2dbc3e3c41234ca26a65e2c0b0975c52e0f069ab9893ebbede584d3"
 dependencies = [
  "base58ck 0.1.0",
  "bech32",
@@ -136,7 +136,7 @@ name = "bitcoin-fuzz"
 version = "0.0.1"
 dependencies = [
  "arbitrary",
- "bitcoin 0.32.8",
+ "bitcoin 0.32.9",
  "bitcoin 0.33.0-beta",
  "bitcoin-consensus-encoding",
  "bitcoin-p2p-messages",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -56,9 +56,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.8"
+version = "0.32.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e499f9fc0407f50fe98af744ab44fa67d409f76b6772e1689ec8485eb0c0f66"
+checksum = "9cf93e61f2dbc3e3c41234ca26a65e2c0b0975c52e0f069ab9893ebbede584d3"
 dependencies = [
  "base58ck 0.1.0",
  "bech32",
@@ -135,7 +135,7 @@ name = "bitcoin-fuzz"
 version = "0.0.1"
 dependencies = [
  "arbitrary",
- "bitcoin 0.32.8",
+ "bitcoin 0.32.9",
  "bitcoin 0.33.0-beta",
  "bitcoin-consensus-encoding",
  "bitcoin-p2p-messages",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,7 +13,7 @@ cargo-fuzz = true
 # We shouldn't need an explicit version on the next line, but Andrew's tools
 # choke on it otherwise. See https://github.com/nix-community/crate2nix/issues/373
 bitcoin = { path = "../bitcoin", version = "0.33.0-beta", features = [ "serde", "arbitrary" ] }
-old_bitcoin = { version = "0.32.8", package = "bitcoin" }
+old_bitcoin = { version = "0.32.9", package = "bitcoin" }
 bitcoin_consensus_encoding = { path = "../consensus_encoding", package = "bitcoin-consensus-encoding" }
 p2p = { path = "../p2p", package = "bitcoin-p2p-messages", features = ["arbitrary"] }
 

--- a/fuzz/fuzz_targets/bitcoin/compare_consensus_encoding.rs
+++ b/fuzz/fuzz_targets/bitcoin/compare_consensus_encoding.rs
@@ -54,6 +54,8 @@ fn is_known_decoder_divergence(err: &(dyn std::error::Error + 'static)) -> bool 
             s == "transaction has no outputs"
                 || s.starts_with("sum of output values ")
                 || s.starts_with("duplicate input")
+                || s.starts_with("null prevout in non-coinbase transaction")
+                || s.starts_with("coinbase scriptSig too")
         }) {
             return true;
         }
@@ -104,22 +106,31 @@ fn read_compact_size(data: &mut &[u8]) -> Option<u64> {
     decoder.end().ok()
 }
 
-/// Returns `true` if `data`, interpreted as an `AddrV2Message`, contains a TorV2 (network_id 0x03) address.
+/// Returns `true` if `data`, interpreted as an `AddrV2Message`, should be skipped.
 ///
 /// `AddrV2Message` is encoded as: `time(u32) || services(compact-size u64) || AddrV2`.
 /// The AddrV2 network_id follows the variable-length services field, so a fixed offset check is wrong.
-fn addrv2_message_has_torv2(data: &[u8]) -> bool {
+///
+/// Skips if:
+/// - The AddrV2 network_id is 0x03 (TorV2), which was removed in bitcoin 0.33+.
+/// - The services field is greater than 0x0200_0000, which the old decoder does not support.
+fn addrv2_message_should_skip(data: &[u8]) -> bool {
     (|| -> Option<bool> {
         let mut rest = data.get(4..)?; // skip time (u32 LE, 4 bytes)
-        read_compact_size(&mut rest)?; // skip services (compact-size u64)
-        Some(*rest.first()? == 0x03) // check AddrV2 network_id byte
+        let services = read_compact_size(&mut rest)?; // read services (compact-size u64)
+        let network_id = *rest.first()?; // check AddrV2 network_id byte
+        Some(network_id == 0x03 || services > 0x0200_0000)
     })()
     .unwrap_or(false)
 }
 
 /// Returns `true` if `data`, interpreted as an `AddrV2Payload` (`Vec<AddrV2Message>`),
-/// contains any TorV2 (network_id 0x03) address.
-fn addrv2_payload_has_torv2(data: &[u8]) -> bool {
+/// contains any message that should be skipped.
+///
+/// Skips if any message has:
+/// - A TorV2 (network_id 0x03) address, which was removed in bitcoin 0.33+.
+/// - A services field greater than 0x0200_0000, which the old decoder does not support.
+fn addrv2_payload_should_skip(data: &[u8]) -> bool {
     (|| -> Option<bool> {
         let mut rest = data;
         let count = read_compact_size(&mut rest)?;
@@ -130,6 +141,9 @@ fn addrv2_payload_has_torv2(data: &[u8]) -> bool {
                 if addr_type == 0x03 {
                     return Some(true);
                 }
+            }
+            if message.services.to_u64() > 0x0200_0000 {
+                return Some(true);
             }
         }
         Some(false)
@@ -202,14 +216,15 @@ fn do_test(data: &[u8]) {
 
     // TorV2 (network_id 0x03) was removed from AddrV2 in bitcoin 0.33+. Bitcoin 0.32 decodes TorV2
     // as a distinct variant whose encoding differs from the new crate's AddrV2::Unknown(3, ...).
-    // Skip inputs that would be decoded as TorV2 to avoid a false encoding mismatch.
+    // ServiceFlags > 0x0200_0000 are not supported by the old decoder.
+    // Skip inputs that would trigger either known divergence.
     if data.first() != Some(&0x03) {
         compare_encoding!(data, p2p::address::AddrV2, old_bitcoin::p2p::address::AddrV2);
     }
-    if !addrv2_message_has_torv2(data) {
+    if !addrv2_message_should_skip(data) {
         compare_encoding!(data, p2p::address::AddrV2Message, old_bitcoin::p2p::address::AddrV2Message);
     }
-    if !addrv2_payload_has_torv2(data) {
+    if !addrv2_payload_should_skip(data) {
         compare_encoding!(data, p2p::message::AddrV2Payload, Vec<old_bitcoin::p2p::address::AddrV2Message>);
     }
     // Inventory::Error (type_id=0) encodes differently between old/new bitcoin: old omits the

--- a/fuzz/generate-files.sh
+++ b/fuzz/generate-files.sh
@@ -26,7 +26,7 @@ cargo-fuzz = true
 # We shouldn't need an explicit version on the next line, but Andrew's tools
 # choke on it otherwise. See https://github.com/nix-community/crate2nix/issues/373
 bitcoin = { path = "../bitcoin", version = "0.33.0-beta", features = [ "serde", "arbitrary" ] }
-old_bitcoin = { version = "0.32.8", package = "bitcoin" }
+old_bitcoin = { version = "0.32.9", package = "bitcoin" }
 bitcoin_consensus_encoding = { path = "../consensus_encoding", package = "bitcoin-consensus-encoding" }
 p2p = { path = "../p2p", package = "bitcoin-p2p-messages", features = ["arbitrary"] }
 

--- a/p2p/src/address.rs
+++ b/p2p/src/address.rs
@@ -534,6 +534,12 @@ impl encoding::Decoder for AddrV2Decoder {
     #[inline]
     fn end(self) -> Result<Self::Output, Self::Error> {
         let (net_type, addr_bytes) = self.0.end().map_err(AddrV2DecoderError::Decoder)?;
+        if addr_bytes.len() > 512 {
+            return Err(AddrV2DecoderError::InvalidAddressLength {
+                expected: 512,
+                got: addr_bytes.len(),
+            });
+        }
         match u8::from_le_bytes(net_type) {
             1 => {
                 let octets = Self::to_fixed_size_slice::<4>(addr_bytes)?;

--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -20,7 +20,7 @@ use encoding::{
 use hashes::{sha256d, HashEngine};
 use primitives::block::{self, HeaderDecoder, HeaderEncoder};
 use primitives::transaction;
-use units::FeeRate;
+use units::{Amount, FeeRate};
 
 use self::error::V1NetworkMessageDecoderErrorInner;
 use crate::address::{AddrV1Message, AddrV2Message};
@@ -34,8 +34,8 @@ use crate::{
 #[doc(no_inline)]
 pub use self::error::{
     AddrPayloadDecoderError, AddrV2PayloadDecoderError, CommandStringDecoderError,
-    CommandStringError, HeadersMessageDecoderError, InventoryPayloadDecoderError,
-    NetworkHeaderDecoderError, PingDecoderError, PongDecoderError,
+    CommandStringError, FeeFilterDecoderError, HeadersMessageDecoderError,
+    InventoryPayloadDecoderError, NetworkHeaderDecoderError, PingDecoderError, PongDecoderError,
     V1MessageHeaderDecoderError, V1NetworkMessageDecoderError, V2NetworkMessageDecoderError
 };
 
@@ -516,21 +516,31 @@ impl Default for FeeFilterDecoder {
 
 impl encoding::Decoder for FeeFilterDecoder {
     type Output = FeeFilter;
-    type Error = encoding::UnexpectedEofError;
+    type Error = FeeFilterDecoderError;
 
     fn push_bytes(&mut self, bytes: &mut &[u8]) -> Result<bool, Self::Error> {
-        self.0.push_bytes(bytes)
+        self.0.push_bytes(bytes).map_err(FeeFilterDecoderError::UnexpectedEof)
     }
 
     fn end(self) -> Result<Self::Output, Self::Error> {
-        let array = self.0.end()?;
+        let array = self.0.end().map_err(FeeFilterDecoderError::UnexpectedEof)?;
         let kvb = u64::from_le_bytes(array);
 
         // BIP-0133 specifies feefilter as int64_t (signed), but negative values and values
-        // exceeding u32::MAX are invalid for fee rates. We saturate both cases to FeeRate::MAX.
-        let fee_rate = kvb.try_into().ok().map_or(FeeRate::MAX, FeeRate::from_sat_per_kvb);
+        // exceeding Amount::MAX_MONEY are invalid for fee rates.
+        // https://github.com/bitcoin/bitcoin/blob/8396b7f2a3be4be7bb2ffc152f87b4cab95dd84e/src/net_processing.cpp#L4984
+        if kvb > Amount::MAX_MONEY.to_sat() {
+            Err(FeeFilterDecoderError::InvalidFeeRate(kvb))
+        } else {
+            // We can't directly construct using kvb with any public constructors on FeeRate
+            // because the rate can be up to Amount::MAX_MONEY which overflows all of them.
+            // Instead, we construct a 1 sat/kvb and multiply by our kvb.
+            let fee_rate = FeeRate::from_sat_per_kvb(1)
+                .checked_mul(kvb)
+                .expect("Amount::MAX_MONEY * 1000 < u64::MAX");
 
-        Ok(FeeFilter(fee_rate))
+            Ok(FeeFilter(fee_rate))
+        }
     }
 
     fn read_limit(&self) -> usize { self.0.read_limit() }
@@ -2118,6 +2128,46 @@ pub mod error {
         fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
     }
 
+    /// An error consensus decoding a [`FeeFilter`].
+    ///
+    /// [`FeeFilter`]: super::FeeFilter
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[non_exhaustive]
+    pub enum FeeFilterDecoderError {
+        /// Unexpected end of data.
+        UnexpectedEof(encoding::UnexpectedEofError),
+        /// Fee rate value is out of valid range (must be in the range 0 to [`Amount::MAX_MONEY`]).
+        ///
+        /// If an error of this variant is thrown while decoding a `V1NetworkMessage`, the message
+        /// should be ignored.
+        ///
+        /// [`Amount::MAX_MONEY`]: units::Amount::MAX_MONEY
+        InvalidFeeRate(u64),
+    }
+
+    impl From<Infallible> for FeeFilterDecoderError {
+        fn from(never: Infallible) -> Self { match never {} }
+    }
+
+    impl fmt::Display for FeeFilterDecoderError {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            match self {
+                Self::UnexpectedEof(e) => write_err!(f, "feefilter decoder error"; e),
+                Self::InvalidFeeRate(v) => write!(f, "invalid fee rate value {}", v),
+            }
+        }
+    }
+
+    #[cfg(feature = "std")]
+    impl std::error::Error for FeeFilterDecoderError {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            match self {
+                Self::UnexpectedEof(e) => Some(e),
+                Self::InvalidFeeRate(_) => None,
+            }
+        }
+    }
+
     /// Error decoding a raw network message.
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct V1NetworkMessageDecoderError(pub(super) V1NetworkMessageDecoderErrorInner);
@@ -2851,6 +2901,35 @@ mod test {
 
         let enc = encoding::encode_to_vec(&decoded);
         assert_eq!(data.as_slice(), enc.as_slice());
+    }
+
+    #[test]
+    fn fee_filter_decode_edge_cases() {
+        let max_money = units::Amount::MAX_MONEY.to_sat();
+
+        // 0 to Amount::MAX_MONEY is valid
+        let bytes = 0u64.to_le_bytes();
+        assert_eq!(
+            encoding::decode_from_slice::<FeeFilter>(&bytes).unwrap(),
+            FeeFilter(FeeRate::ZERO)
+        );
+        let bytes = max_money.to_le_bytes();
+        let max_feerate = FeeFilter(
+            FeeRate::from_sat_per_kvb(1).checked_mul(Amount::MAX_MONEY.to_sat()).unwrap(),
+        );
+        assert_eq!(encoding::decode_from_slice::<FeeFilter>(&bytes).unwrap(), max_feerate);
+
+        // Invalid cases
+        let bytes = (max_money + 1).to_le_bytes();
+        assert!(matches!(
+            encoding::decode_from_slice::<FeeFilter>(&bytes).unwrap_err(),
+            encoding::DecodeError::Parse(FeeFilterDecoderError::InvalidFeeRate(_)),
+        ));
+        let bytes = u64::MAX.to_le_bytes();
+        assert!(matches!(
+            encoding::decode_from_slice::<FeeFilter>(&bytes).unwrap_err(),
+            encoding::DecodeError::Parse(FeeFilterDecoderError::InvalidFeeRate(_)),
+        ));
     }
 
     #[test]


### PR DESCRIPTION
The compare_consensus_encoding fuzz target should guarantee that master and the most recent 0.32 match in encoding and decoding behaviour for all types that can be encoded and decoded. The transaction decoder has more validation arms on master than 0.32 and the AddrV2 type has been rebuilt, missing some error cases.

- Patch 1 adds more ignores for transaction errors and adjusts the AddrV2Message ignores for the 64 bit service flags.
- Patch 2 adds an error case to AddrV2 with > 512 bytes.
- Patch 3 changes the FeeFilter to error for invalid feerate values instead of saturating.
- Patch 4 bumps the old bitcoin version for the fuzz target.