### PR TITLE
Apply small idiomatic refactors across workspace

### DIFF
--- a/consensus_encoding/src/decode/decoders.rs
+++ b/consensus_encoding/src/decode/decoders.rs
@@ -135,11 +135,9 @@ impl Decoder for ByteVecDecoder {
     }
 
     fn read_limit(&self) -> usize {
-        if let Some(prefix_decoder) = &self.prefix_decoder {
-            prefix_decoder.read_limit()
-        } else {
-            self.bytes_expected - self.bytes_written
-        }
+        self.prefix_decoder
+            .as_ref()
+            .map_or(self.bytes_expected - self.bytes_written, CompactSizeDecoder::read_limit)
     }
 }
 
@@ -296,19 +294,16 @@ impl<T: Decode> Decoder for VecDecoder<T> {
     }
 
     fn read_limit(&self) -> usize {
-        if let Some(prefix_decoder) = &self.prefix_decoder {
-            prefix_decoder.read_limit()
-        } else if let Some(decoder) = &self.decoder {
-            decoder.read_limit()
-        } else if self.buffer.len() == self.length {
-            // Totally done.
-            0
-        } else {
-            let items_left_to_decode = self.length - self.buffer.len();
-            let decoder = T::decoder();
-            // This could be inaccurate (eg 1 for a `ByteVecDecoder`) but its the best we can do.
-            let limit_per_decoder = decoder.read_limit();
-            items_left_to_decode * limit_per_decoder
+        match (&self.prefix_decoder, &self.decoder) {
+            (Some(pd), _) => pd.read_limit(),
+            (None, Some(d)) => d.read_limit(),
+            (None, None) if self.buffer.len() == self.length => 0, // Totally done
+            (None, None) => {
+                let items_left_to_decode = self.length - self.buffer.len();
+                // This could be inaccurate (eg 1 for a `ByteVecDecoder`) but its the best we can do.
+                let limit_per_decoder = T::decoder().read_limit();
+                items_left_to_decode * limit_per_decoder
+            }
         }
     }
 }

--- a/consensus_encoding/src/encode/mod.rs
+++ b/consensus_encoding/src/encode/mod.rs
@@ -355,10 +355,5 @@ impl<T: Encoder> Encoder for Option<T> {
         }
     }
 
-    fn advance(&mut self) -> bool {
-        match self {
-            Some(encoder) => encoder.advance(),
-            None => false,
-        }
-    }
+    fn advance(&mut self) -> bool { self.as_mut().is_some_and(Encoder::advance) }
 }

--- a/crypto/src/key.rs
+++ b/crypto/src/key.rs
@@ -871,7 +871,7 @@ impl FullPublicKey {
         msg: secp256k1::Message,
         sig: ecdsa::Signature,
     ) -> Result<(), secp256k1::Error> {
-        Ok(secp256k1::ecdsa::verify(&sig.signature, msg, &self.to_inner())?)
+        secp256k1::ecdsa::verify(&sig.signature, msg, &self.to_inner())
     }
 }
 

--- a/p2p/src/address.rs
+++ b/p2p/src/address.rs
@@ -516,9 +516,10 @@ impl AddrV2Decoder {
     fn to_fixed_size_slice<const N: usize>(
         addr_bytes: Vec<u8>,
     ) -> Result<[u8; N], AddrV2DecoderError> {
-        Ok(addr_bytes.try_into().map_err(|e: Vec<u8>| {
-            AddrV2DecoderError::InvalidAddressLength { expected: N, got: e.len() }
-        })?)
+        addr_bytes.try_into().map_err(|e: Vec<u8>| AddrV2DecoderError::InvalidAddressLength {
+            expected: N,
+            got: e.len(),
+        })
     }
 }
 

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -146,7 +146,7 @@ impl encoding::Decoder for ProtocolVersionDecoder {
 
     #[inline]
     fn push_bytes(&mut self, bytes: &mut &[u8]) -> Result<bool, Self::Error> {
-        Ok(self.0.push_bytes(bytes).map_err(ProtocolVersionDecoderError)?)
+        self.0.push_bytes(bytes).map_err(ProtocolVersionDecoderError)
     }
 
     #[inline]
@@ -340,7 +340,7 @@ impl encoding::Decoder for ServiceFlagsDecoder {
 
     #[inline]
     fn push_bytes(&mut self, bytes: &mut &[u8]) -> Result<bool, Self::Error> {
-        Ok(self.0.push_bytes(bytes).map_err(ServiceFlagsDecoderError)?)
+        self.0.push_bytes(bytes).map_err(ServiceFlagsDecoderError)
     }
 
     #[inline]

--- a/primitives/src/script/owned.rs
+++ b/primitives/src/script/owned.rs
@@ -199,7 +199,7 @@ impl<T> encoding::Decoder for ScriptBufDecoder<T> {
 
     #[inline]
     fn push_bytes(&mut self, bytes: &mut &[u8]) -> Result<bool, Self::Error> {
-        Ok(self.0.push_bytes(bytes).map_err(ScriptBufDecoderError)?)
+        self.0.push_bytes(bytes).map_err(ScriptBufDecoderError)
     }
 
     #[inline]

--- a/units/src/amount/signed.rs
+++ b/units/src/amount/signed.rs
@@ -141,8 +141,7 @@ impl SignedAmount {
                 is_greater_than_max: true,
             }))
         })?;
-        Ok(Self::from_sat(amount)
-            .map_err(|e| ParseAmountError(ParseAmountErrorInner::OutOfRange(e)))?)
+        Self::from_sat(amount).map_err(|e| ParseAmountError(ParseAmountErrorInner::OutOfRange(e)))
     }
 
     /// Converts from a value expressing a decimal number of bitcoin to a [`SignedAmount`].

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -282,8 +282,7 @@ impl Amount {
     pub fn from_sat_hex(s: &str) -> Result<Self, ParseAmountError> {
         let amount = parse_int::hex_u64_prefixed(s)
             .map_err(|e| ParseAmountError(ParseAmountErrorInner::PrefixedHex(e)))?;
-        Ok(Self::from_sat(amount)
-            .map_err(|e| ParseAmountError(ParseAmountErrorInner::OutOfRange(e)))?)
+        Self::from_sat(amount).map_err(|e| ParseAmountError(ParseAmountErrorInner::OutOfRange(e)))
     }
 
     /// Constructs a new `Amount` from an unprefixed hex string.
@@ -296,8 +295,7 @@ impl Amount {
     pub fn from_sat_unprefixed_hex(s: &str) -> Result<Self, ParseAmountError> {
         let amount = parse_int::hex_u64_unprefixed(s)
             .map_err(|e| ParseAmountError(ParseAmountErrorInner::UnprefixedHex(e)))?;
-        Ok(Self::from_sat(amount)
-            .map_err(|e| ParseAmountError(ParseAmountErrorInner::OutOfRange(e)))?)
+        Self::from_sat(amount).map_err(|e| ParseAmountError(ParseAmountErrorInner::OutOfRange(e)))
     }
 
     /// Constructs a new object that implements [`fmt::Display`] in the given [`Denomination`].

--- a/units/src/locktime/relative/mod.rs
+++ b/units/src/locktime/relative/mod.rs
@@ -325,11 +325,7 @@ impl LockTime {
     /// ```
     #[inline]
     pub fn is_implied_by_sequence(self, other: Sequence) -> bool {
-        if let Ok(other) = Self::from_sequence(other) {
-            self.is_implied_by(other)
-        } else {
-            false
-        }
+        Self::from_sequence(other).is_ok_and(|other| self.is_implied_by(other))
     }
 }
 
@@ -620,14 +616,10 @@ impl NumberOf512Seconds {
         chain_tip: crate::BlockMtp,
         utxo_mined_at: crate::BlockMtp,
     ) -> Result<bool, InvalidTimeError> {
-        match chain_tip.checked_sub(utxo_mined_at) {
-            Some(diff) => {
-                // The locktime check in Core during block validation uses the MTP of the previous
-                // block - which is `chain_tip` here.
-                Ok(self.to_seconds() <= diff.to_u32())
-            }
-            None => Err(InvalidTimeError { chain_tip, utxo_mined_at }),
-        }
+        chain_tip
+            .checked_sub(utxo_mined_at)
+            .ok_or(InvalidTimeError { chain_tip, utxo_mined_at })
+            .map(|diff| self.to_seconds() <= diff.to_u32())
     }
 }
 


### PR DESCRIPTION
This PR applies a set of small idiomatic refactors across several crates in the workspace.

The changes primarily focus on simplifying control flow and removing redundant Result wrapping/unwrapping patterns while preserving existing behavior.

Included changes:
- Remove needless `Ok(...?)` patterns by directly returning `Result`s.
- Simplify nested `if let` / `match` flows using `Option` and `Result` combinators where it improves readability.
- Minor cleanup of some decoder/encoder implementations.

Most of these changes were initially surfaced while running:

```bash
cargo clippy --all-features --all-targets -- \
    -D warnings \
    -D clippy::pedantic \
    -D clippy::nursery
```