### PR TITLE
0.32.x: Remove cargo workspace patch

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -22,9 +22,19 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "base58ck"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
+dependencies = [
+ "bitcoin-internals",
+ "bitcoin_hashes 0.14.0",
+]
+
+[[package]]
+name = "base58ck"
 version = "0.1.100"
 dependencies = [
- "bitcoin_hashes",
+ "bitcoin_hashes 0.14.0",
  "hex-conservative",
 ]
 
@@ -55,13 +65,13 @@ name = "bitcoin"
 version = "0.32.100"
 dependencies = [
  "arbitrary",
- "base58ck",
+ "base58ck 0.1.0",
  "base64",
  "bech32",
  "bincode",
- "bitcoin-io",
- "bitcoin-units",
- "bitcoin_hashes",
+ "bitcoin-io 0.1.1",
+ "bitcoin-units 0.1.3",
+ "bitcoin_hashes 0.14.0",
  "bitcoinconsensus",
  "hex-conservative",
  "hex_lit",
@@ -85,8 +95,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin-internals"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17e5b76b88667412087beea1882980ad843b660490bbf6cce0a6cfc999c5b989"
+
+[[package]]
 name = "bitcoin-io"
 version = "0.1.100"
+
+[[package]]
+name = "bitcoin-private"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
+
+[[package]]
+name = "bitcoin-units"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346568ebaab2918487cea76dd55dae13c27bb618cdb737c952e69eb2017c4118"
+dependencies = [
+ "arbitrary",
+ "bitcoin-internals",
+ "serde",
+]
 
 [[package]]
 name = "bitcoin-units"
@@ -100,9 +139,29 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
+dependencies = [
+ "bitcoin-private",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
+dependencies = [
+ "bitcoin-io 0.1.1",
+ "hex-conservative",
+ "serde",
+]
+
+[[package]]
+name = "bitcoin_hashes"
 version = "0.14.100"
 dependencies = [
- "bitcoin-io",
+ "bitcoin-io 0.1.1",
  "hex-conservative",
  "schemars",
  "serde",
@@ -354,7 +413,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e0cc0f1cf93f4969faf3ea1c7d8a9faed25918d96affa959720823dfe86d4f3"
 dependencies = [
- "bitcoin_hashes",
+ "bitcoin_hashes 0.12.0",
  "rand",
  "secp256k1-sys",
  "serde",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -22,9 +22,19 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "base58ck"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
+dependencies = [
+ "bitcoin-internals",
+ "bitcoin_hashes 0.14.1",
+]
+
+[[package]]
+name = "base58ck"
 version = "0.1.100"
 dependencies = [
- "bitcoin_hashes",
+ "bitcoin_hashes 0.14.1",
  "hex-conservative",
 ]
 
@@ -54,13 +64,13 @@ name = "bitcoin"
 version = "0.32.100"
 dependencies = [
  "arbitrary",
- "base58ck",
+ "base58ck 0.1.0",
  "base64",
  "bech32",
  "bincode",
- "bitcoin-io",
- "bitcoin-units",
- "bitcoin_hashes",
+ "bitcoin-io 0.1.4",
+ "bitcoin-units 0.1.3",
+ "bitcoin_hashes 0.14.1",
  "bitcoinconsensus",
  "hex-conservative",
  "hex_lit",
@@ -84,8 +94,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin-internals"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
+
+[[package]]
 name = "bitcoin-io"
 version = "0.1.100"
+
+[[package]]
+name = "bitcoin-units"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346568ebaab2918487cea76dd55dae13c27bb618cdb737c952e69eb2017c4118"
+dependencies = [
+ "arbitrary",
+ "bitcoin-internals",
+ "serde",
+]
 
 [[package]]
 name = "bitcoin-units"
@@ -99,9 +132,20 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
+dependencies = [
+ "bitcoin-io 0.1.4",
+ "hex-conservative",
+ "serde",
+]
+
+[[package]]
+name = "bitcoin_hashes"
 version = "0.14.100"
 dependencies = [
- "bitcoin-io",
+ "bitcoin-io 0.1.4",
  "hex-conservative",
  "schemars",
  "serde",
@@ -343,7 +387,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e0cc0f1cf93f4969faf3ea1c7d8a9faed25918d96affa959720823dfe86d4f3"
 dependencies = [
- "bitcoin_hashes",
+ "bitcoin_hashes 0.14.1",
  "rand",
  "secp256k1-sys",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,18 +5,3 @@ resolver = "2"
 [workspace.metadata.rbmt.toolchains]
 nightly = "nightly-2026-03-27"
 stable = "1.91.1"
-
-[patch.crates-io.base58ck]
-path = "base58"
-
-[patch.crates-io.bitcoin]
-path = "bitcoin"
-
-[patch.crates-io.bitcoin_hashes]
-path = "hashes"
-
-[patch.crates-io.bitcoin-io]
-path = "io"
-
-[patch.crates-io.bitcoin-units]
-path = "units"


### PR DESCRIPTION
This branch is for releasing the individual crates within it. They need to work with the published versions of their dependencies before they can be released. Removing the patch shows that they do.

If a single PR requires an update to one of the local dependencies then a path section must be added to the Cargo.toml so that it uses the local changes. This flags that crate must be released first.

Remove the patch section so the default is to use the published versions and a change is required to use the local versions.