### PR TITLE
p2p: backport add a hash value to Inventory's Error variant to 0.32.x

### DIFF
--- a/bitcoin/src/p2p/message.rs
+++ b/bitcoin/src/p2p/message.rs
@@ -603,7 +603,6 @@ mod test {
             )]),
             NetworkMessage::Inv(vec![Inventory::Block(hash([8u8; 32]).into())]),
             NetworkMessage::GetData(vec![Inventory::Transaction(hash([45u8; 32]).into())]),
-            NetworkMessage::NotFound(vec![Inventory::Error]),
             NetworkMessage::GetBlocks(GetBlocksMessage::new(
                 vec![hash([1u8; 32]).into(), hash([4u8; 32]).into()],
                 hash([5u8; 32]).into(),
@@ -693,6 +692,22 @@ mod test {
             let raw_msg = RawNetworkMessage::new(Magic::from_bytes([57, 0, 0, 0]), msg);
             assert_eq!(deserialize::<RawNetworkMessage>(&serialize(&raw_msg)).unwrap(), raw_msg);
         }
+    }
+
+    #[test]
+    fn inventory_error_round_trip_test() {
+        // Inventory::Error decodes as Unknown { inv_type: 0, .. } for backwards compatibility.
+        let raw_msg = RawNetworkMessage::new(
+            Magic::from_bytes([57, 0, 0, 0]),
+            NetworkMessage::NotFound(vec![Inventory::Error]),
+        );
+        assert_eq!(
+            deserialize::<RawNetworkMessage>(&serialize(&raw_msg)).unwrap(),
+            RawNetworkMessage::new(
+                Magic::from_bytes([57, 0, 0, 0]),
+                NetworkMessage::NotFound(vec![Inventory::Unknown { inv_type: 0, hash: [0u8; 32] }]),
+            ),
+        );
     }
 
     #[test]

--- a/bitcoin/src/p2p/message_blockdata.rs
+++ b/bitcoin/src/p2p/message_blockdata.rs
@@ -18,7 +18,15 @@ use crate::p2p;
 /// An inventory item.
 #[derive(PartialEq, Eq, Clone, Debug, Copy, Hash, PartialOrd, Ord)]
 pub enum Inventory {
-    /// Error --- these inventories can be ignored
+    /// Error --- these inventories can be ignored.
+    ///
+    /// This variant is never produced by decoding. Use [`is_error()`](Self::is_error)
+    /// instead to check if a decoded item represents an error.
+    ///
+    /// When deserializing type 0 inventory items from the wire, they are decoded as
+    /// `Unknown { inv_type: 0, .. }` instead. This variant exists for backwards
+    /// compatibility in case calling code constructs it directly (e.g.,
+    /// `NetworkMessage::Inv(vec![Inventory::Error])`).
     Error,
     /// Transaction
     Transaction(Txid),
@@ -44,10 +52,12 @@ pub enum Inventory {
 impl Inventory {
     /// Return the item value represented as a SHA256-d hash.
     ///
-    /// Returns [None] only for [Inventory::Error].
+    /// This always returns `Some`, never `None` even for the `Error` variant.
+    /// The `Option` return type remains for backwards compatibility.
     pub fn network_hash(&self) -> Option<[u8; 32]> {
         match self {
-            Inventory::Error => None,
+            // The hash of the Error varient is meaningless, but should always be sent.
+            Inventory::Error => Some([0; 32]),
             Inventory::Transaction(t) => Some(t.to_byte_array()),
             Inventory::Block(b) => Some(b.to_byte_array()),
             Inventory::CompactBlock(b) => Some(b.to_byte_array()),
@@ -56,6 +66,14 @@ impl Inventory {
             Inventory::WitnessBlock(b) => Some(b.to_byte_array()),
             Inventory::Unknown { hash, .. } => Some(*hash),
         }
+    }
+
+    /// Returns true if this is an Error inventory item (type 0).
+    ///
+    /// Error items are internally represented as `Unknown { inv_type: 0, .. }`
+    /// to enable symmetric encoding/decoding while maintaining backwards compatibility.
+    pub fn is_error(&self) -> bool {
+        matches!(self, Inventory::Error | Inventory::Unknown { inv_type: 0, .. })
     }
 }
 
@@ -85,10 +103,7 @@ impl Decodable for Inventory {
     fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
         let inv_type: u32 = Decodable::consensus_decode(r)?;
         Ok(match inv_type {
-            0 => {
-                sha256d::Hash::consensus_decode(r)?;
-                Inventory::Error
-            },
+            0 => Inventory::Unknown { inv_type: 0, hash: Decodable::consensus_decode(r)? },
             1 => Inventory::Transaction(Decodable::consensus_decode(r)?),
             2 => Inventory::Block(Decodable::consensus_decode(r)?),
             4 => Inventory::CompactBlock(Decodable::consensus_decode(r)?),
@@ -151,7 +166,7 @@ mod tests {
     use hashes::Hash;
     use hex::test_hex_unwrap as hex;
 
-    use super::{GetBlocksMessage, GetHeadersMessage};
+    use super::{GetBlocksMessage, GetHeadersMessage, Inventory};
     use crate::consensus::encode::{deserialize, serialize};
 
     #[test]
@@ -168,6 +183,13 @@ mod tests {
         assert_eq!(real_decode.stop_hash, Hash::all_zeros());
 
         assert_eq!(serialize(&real_decode), from_sat);
+    }
+
+    #[test]
+    fn inventory_error_is_error_test() {
+        assert!(Inventory::Error.is_error());
+        assert!(Inventory::Unknown { inv_type: 0, hash: [0u8; 32] }.is_error());
+        assert!(!Inventory::Unknown { inv_type: 1, hash: [0u8; 32] }.is_error());
     }
 
     #[test]


### PR DESCRIPTION
Backporting #3789 for the 0.32.x consensus_encoding fuzzing: https://github.com/rust-bitcoin/rust-bitcoin/pull/6140#issuecomment-4409398179

Simply cherry-picking the change won't work since it is not backwards compatible. We had a recent tweak to the `0.32.x` decoding logic in #6140 which makes sure the reader consumes 32 bytes, but it still doesn't hold on to them, so the fuzztests fail when comparing 32 random fuzz input bytes to 32 zeroes.

This tweaked backport abuses the `Unknown` variant and decodes errors into it in order to hang on to the bytes in an API backwards compatible way. I believe this change would allow us to remove this skip in the differential fuzz tests: https://github.com/rust-bitcoin/rust-bitcoin/blob/5485a49d10e808a238c0dffb3a46a1153fa2c31a/fuzz/fuzz_targets/bitcoin/compare_consensus_encoding.rs#L230-L234