### PR TITLE
p2p: Remove `io` dependency

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -200,7 +200,6 @@ dependencies = [
  "bitcoin 0.33.0-beta",
  "bitcoin-consensus-encoding",
  "bitcoin-internals 0.5.0",
- "bitcoin-io 0.5.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
  "bitcoin-units 0.3.0",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -199,7 +199,6 @@ dependencies = [
  "bitcoin 0.33.0-beta",
  "bitcoin-consensus-encoding",
  "bitcoin-internals 0.5.0",
- "bitcoin-io 0.5.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
  "bitcoin-units 0.3.0",

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["tests", "contrib"]
 
 [features]
 default = ["std"]
-std = ["encoding/std", "hashes/std", "network/std", "hex-stable/std", "hex-unstable/std", "internals/std", "io/std", "units/std", "bitcoin/std", "primitives/std"]
+std = ["encoding/std", "hashes/std", "network/std", "hex-stable/std", "hex-unstable/std", "internals/std", "units/std", "bitcoin/std", "primitives/std"]
 arbitrary = ["dep:arbitrary", "bitcoin/arbitrary"]
 serde = ["dep:serde", "hashes/serde"]
 
@@ -28,7 +28,6 @@ primitives = { package = "bitcoin-primitives", path = "../primitives", version =
 hex-stable = { package = "hex-conservative", version = "1.0.0", default-features = false, features = ["alloc"] }
 hex-unstable = { package = "hex-conservative", version = "0.3.2", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", default-features = false }
-io = { package = "bitcoin-io", version = "0.5.0", path = "../io", default-features = false }
 units = { package = "bitcoin-units", path = "../units", version = "0.3.0", default-features = false }
 
 arbitrary = { version = "1.4.1", optional = true }


### PR DESCRIPTION
No longer required for this crate. I assume we want to remove this.