### PR TITLE
Use stacked attributes over #[cfg(all(...))]

### DIFF
--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -36,7 +36,8 @@ use crate::{Transaction, Wtxid};
 pub use units::block::{BlockHeight, BlockHeightDecoder, BlockHeightEncoder, BlockHeightInterval, BlockMtp, BlockMtpInterval};
 
 #[rustfmt::skip]                // Keep public re-exports separate.
-#[cfg(all(feature = "hex", feature = "alloc"))]
+#[cfg(feature = "hex")]
+#[cfg(feature = "alloc")]
 #[doc(no_inline)]
 pub use self::error::ParseBlockError;
 #[cfg(feature = "hex")]

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -52,7 +52,8 @@ use crate::witness::{WitnessDecoder, WitnessEncoder};
 use crate::{absolute, Amount, ScriptPubKeyBuf, ScriptSigBuf, Sequence, Weight, Witness};
 
 #[rustfmt::skip]            // Keep public re-exports separate.
-#[cfg(all(feature = "hex", feature = "alloc"))]
+#[cfg(feature = "hex")]
+#[cfg(feature = "alloc")]
 #[doc(no_inline)]
 pub use self::error::{ParseTransactionError, ParseOutPointError};
 #[doc(no_inline)]
@@ -1273,9 +1274,11 @@ pub mod error {
 
     #[cfg(feature = "alloc")]
     use super::OutPoint;
-    #[cfg(all(feature = "hex", feature = "alloc"))]
+    #[cfg(feature = "hex")]
+    #[cfg(feature = "alloc")]
     use super::{parse_int, Transaction};
-    #[cfg(all(feature = "hex", feature = "alloc"))]
+    #[cfg(feature = "hex")]
+    #[cfg(feature = "alloc")]
     use crate::hex_codec::ParsePrimitiveError;
     #[cfg(feature = "alloc")]
     use crate::locktime::absolute::LockTimeDecoderError;


### PR DESCRIPTION
Per our policy, feature gates should use stacked attributes instead of #[cfg(all(...))]. Presumably due to changes at the same time as this policy was introduced, there remain a few uses of the old style in primitives.