### PR TITLE
p2p: Remove `bitcoin` dependency

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -197,7 +197,6 @@ name = "bitcoin-p2p-messages"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "bitcoin 0.33.0-beta",
  "bitcoin-consensus-encoding",
  "bitcoin-internals 0.5.0",
  "bitcoin-network-kind",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -196,7 +196,6 @@ name = "bitcoin-p2p-messages"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "bitcoin 0.33.0-beta",
  "bitcoin-consensus-encoding",
  "bitcoin-internals 0.5.0",
  "bitcoin-network-kind",

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -15,16 +15,15 @@ exclude = ["tests", "contrib"]
 
 [features]
 default = ["std"]
-std = ["encoding/std", "hashes/std", "network/std", "hex-stable/std", "hex-unstable/std", "internals/std", "units/std", "bitcoin/std", "primitives/std"]
-arbitrary = ["dep:arbitrary", "bitcoin/arbitrary"]
+std = ["encoding/std", "hashes/std", "network/std", "hex-stable/std", "hex-unstable/std", "internals/std", "units/std", "primitives/std"]
+arbitrary = ["dep:arbitrary", "primitives/arbitrary"]
 serde = ["dep:serde", "hashes/serde"]
 
 [dependencies]
-bitcoin = { path = "../bitcoin/", default-features = false }
-encoding = { package = "bitcoin-consensus-encoding", version = "0.2.0", path = "../consensus_encoding", default-features = false }
+encoding = { package = "bitcoin-consensus-encoding", version = "0.2.0", path = "../consensus_encoding", features = ["alloc"], default-features = false }
 hashes = { package = "bitcoin_hashes", version = "0.20.0", path = "../hashes", default-features = false }
 network = { package = "bitcoin-network-kind", path = "../network", version = "0.1.0", default-features = false }
-primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.102.0", default-features = false }
+primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.102.0", features = ["hex", "alloc"], default-features = false }
 hex-stable = { package = "hex-conservative", version = "1.0.0", default-features = false, features = ["alloc"] }
 hex-unstable = { package = "hex-conservative", version = "0.3.2", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", default-features = false }

--- a/p2p/src/merkle_tree.rs
+++ b/p2p/src/merkle_tree.rs
@@ -64,7 +64,7 @@ impl MerkleBlock {
     ///     d3ee3738d9e1446618c4571d1090db022100e2ac980643b0b82c0e88ffdfec6b64e3e6ba35e7ba5fdd7d\
     ///     5d6cc8d25c6b241501ffffffff0100f2052a010000001976a914404371705fa9bd789a2fcd52d2c580b6\
     ///     5d35549d88ac00000000").unwrap();
-    /// let block: Block = bitcoin::consensus::deserialize(&block_bytes).unwrap();
+    /// let block: Block = encoding::decode_from_slice(&block_bytes).unwrap();
     /// let block = block.validate().expect("valid block");
     ///
     /// // Constructs a new Merkle block containing a single transaction


### PR DESCRIPTION
Boom.

`hex` is brought in from `primitives` as it is an unconditional dependency. `arbitrary` is brought in from `primitives` as opposed to `bitcoin`. `primitives` and `encoding` need `alloc`. One doc line is updated.