### PR TITLE
hashes: Remove unnecessary clone

### DIFF
--- a/hashes/src/siphash24/mod.rs
+++ b/hashes/src/siphash24/mod.rs
@@ -63,7 +63,7 @@ impl Hash {
 
     #[cfg(hashes_fuzz)]
     pub fn from_engine(e: HashEngine) -> Self {
-        let state = e.state.clone();
+        let state = e.state;
         Hash::from_u64(state.v0 ^ state.v1 ^ state.v2 ^ state.v3)
     }
 


### PR DESCRIPTION
No need to clone. The `State` struct is `Copy` because all fields are `Copy` (I _think_).

We could remove the local var all together but what ever.

Done so I can check off [C-CALLER-CONTROL](https://rust-lang.github.io/api-guidelines/flexibility.html#c-caller-control) in #3633.