### PR TITLE
Remove uses of old encoding traits

### DIFF
--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -31,7 +31,7 @@ bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
 crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.2.0", default-features = false, features = ["alloc", "hex"] }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.0.0", default-features = false, features = ["alloc", "hex"] }
 key-expression = { package = "bitcoin-key-expression", path = "../key_expression", version = "0.1.0", default-features = false, features = ["alloc"] }
-encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0", default-features = false, features = ["alloc"] }
+encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0", default-features = false, features = ["alloc", "hex"] }
 hex = { package = "hex-conservative", version = "1.1.0", default-features = false, features = ["alloc"] }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0", features = ["alloc", "hex"] }
 io = { package = "bitcoin-io", path = "../io", version = "0.5.0", default-features = false, features = ["alloc", "hashes"] }

--- a/bitcoin/examples/io.rs
+++ b/bitcoin/examples/io.rs
@@ -7,8 +7,8 @@
 //! this we provide the `bitcoin_io` crate which provides `io::Read`, `io::BufRead`, and
 //! `io::Write`. This module demonstrates its usage.
 
-use bitcoin::consensus::{Decodable, Encodable as _};
 use bitcoin::{OutPoint, Txid};
+use encoding::{Encode, ExactSizeEncoder};
 
 fn main() {
     // Encode/Decode a `rust-bitcoin` type to/from a stdlib type.
@@ -33,13 +33,12 @@ fn encode_decode_from_stdlib_type() {
     let mut v = Vec::new();
 
     // Under the hood we implement our `io` traits for a bunch of stdlib types so this just works.
-    let _bytes_written = data.consensus_encode(&mut v).expect("failed to encode to writer");
+    io::encode_to_writer(&data, &mut v).expect("failed to encode to writer");
 
     // Slices implement `std::io::Read`.
-    let mut reader = v.as_ref();
+    let reader = v.as_ref();
 
-    let _: OutPoint =
-        Decodable::consensus_decode(&mut reader).expect("failed to decode from reader");
+    let _: OutPoint = io::decode_from_read(reader).expect("failed to decode from reader");
 }
 
 /// Encodes to a custom type by implementing the `bitcoin_io::Write` trait.
@@ -68,7 +67,9 @@ fn encode_to_custom_type() {
     let data = dummy_utxo();
 
     let mut counter = WriteCounter { count: 0 };
-    let bytes_written = data.consensus_encode(&mut counter).expect("failed to encode to writer");
+    let mut encoder = data.encoder();
+    let bytes_written = encoder.len();
+    io::drain_to_writer(&mut encoder, &mut counter).expect("failed to encode to writer");
     assert_eq!(bytes_written, 36); // 32 bytes for txid + 4 bytes for vout.
 }
 
@@ -87,7 +88,9 @@ fn encode_using_wrapper() {
     // let bytes_written = data.consensus_encode(&mut counter)?;
 
     let mut counter = io::FromStd::new(WriteCounter::new());
-    let bytes_written = data.consensus_encode(&mut counter).expect("failed to encode to writer");
+    let mut encoder = data.encoder();
+    let bytes_written = encoder.len();
+    io::drain_to_writer(&mut encoder, &mut counter).expect("failed to encode to writer");
     assert_eq!(bytes_written, 36); // 32 bytes for txid + 4 bytes for vout.
     assert_eq!(bytes_written, counter.get_ref().written());
 

--- a/bitcoin/examples/script.rs
+++ b/bitcoin/examples/script.rs
@@ -7,7 +7,7 @@
 //!
 //! [`CompactSize`]: <https://en.bitcoin.it/wiki/Protocol_documentation#Variable_length_integer>
 
-use bitcoin::consensus::encode;
+use bitcoin::encoding;
 use bitcoin::key::WPubkeyHash;
 use bitcoin::{script, WitnessScriptBuf};
 
@@ -37,7 +37,7 @@ fn main() {
     println!("hex created using `LowerHex`: {hex_lower_hex_trait}");
 
     // The `deserialize_hex` function requires the length prefix.
-    assert!(encode::deserialize_hex::<WitnessScriptBuf>(&hex_lower_hex_trait).is_err());
+    assert!(encoding::decode_from_hex::<WitnessScriptBuf>(&hex_lower_hex_trait).is_err());
     // And so does `from_hex_prefixed`.
     assert!(WitnessScriptBuf::from_hex_prefixed(&hex_lower_hex_trait).is_err());
     // But we provide an explicit constructor that does not.
@@ -54,25 +54,25 @@ fn main() {
     let decoded = WitnessScriptBuf::from_hex_prefixed(&hex_inherent).unwrap(); // Defined in `ScriptBufExt`.
     assert_eq!(decoded, script_code);
     // We can also parse the output of `to_hex_string_prefixed` using `deserialize_hex`.
-    let decoded = encode::deserialize_hex::<WitnessScriptBuf>(&hex_inherent).unwrap();
+    let decoded = encoding::decode_from_hex::<WitnessScriptBuf>(&hex_inherent).unwrap();
     assert_eq!(decoded, script_code);
 
     // We also support encode/decode using `consensus::encode` functions.
-    let encoded = encode::serialize_hex(&script_code);
+    let encoded = encoding::encode_to_hex(script_code.as_script(), hex::Case::Lower);
     println!("hex created using consensus::encode::serialize_hex: {encoded}");
 
-    let decoded: WitnessScriptBuf = encode::deserialize_hex(&encoded).unwrap();
+    let decoded: WitnessScriptBuf = encoding::decode_from_hex(&encoded).unwrap();
     assert_eq!(decoded, script_code);
 
     // And we can mix these two calls because both include the length prefix.
-    let encoded = encode::serialize_hex(&script_code);
+    let encoded = encoding::encode_to_hex(script_code.as_script(), hex::Case::Lower);
     let decoded = WitnessScriptBuf::from_hex_prefixed(&encoded).unwrap();
     assert_eq!(decoded, script_code);
 
     // Encode/decode using a byte vector.
-    let encoded = encode::serialize(&script_code);
+    let encoded = encoding::encode_to_vec(script_code.as_script());
     assert_eq!(&encoded[1..], script_code.as_bytes()); // Shows that prefix is the first byte.
-    let decoded: WitnessScriptBuf = encode::deserialize(&encoded).unwrap();
+    let decoded: WitnessScriptBuf = encoding::decode_from_slice(&encoded).unwrap();
     assert_eq!(decoded, script_code);
 
     // to/from bytes excludes the prefix, these are not encoding/decoding functions so this is sane.

--- a/bitcoin/examples/sighash.rs
+++ b/bitcoin/examples/sighash.rs
@@ -1,6 +1,6 @@
 use bitcoin::ext::*;
 use bitcoin::{
-    consensus, ecdsa, sighash, Amount, FullPublicKey, ScriptPubKey, ScriptPubKeyBuf, Transaction,
+    ecdsa, encoding, sighash, Amount, FullPublicKey, ScriptPubKey, ScriptPubKeyBuf, Transaction,
     WitnessScript,
 };
 use hex::hex;
@@ -21,7 +21,7 @@ use hex::hex;
 /// * `inp_idx` - the spending tx input index
 /// * `amount` - the ref tx output amount.
 fn compute_sighash_p2wpkh(raw_tx: &[u8], inp_idx: usize, amount: Amount) {
-    let tx: Transaction = consensus::deserialize(raw_tx).unwrap();
+    let tx: Transaction = encoding::decode_from_slice(raw_tx).unwrap();
     let inp = &tx.inputs[inp_idx];
     let witness = &inp.witness;
     println!("Witness: {witness:?}");
@@ -60,7 +60,7 @@ fn compute_sighash_p2wpkh(raw_tx: &[u8], inp_idx: usize, amount: Amount) {
 /// * `inp_idx` - the spending tx input index
 /// * `script_pubkey_bytes_opt` - the Option with scriptPubKey bytes. If None, it's p2sh case, i.e., reftx output's scriptPubKey.type is "scripthash". In this case scriptPubkey is extracted from the spending transaction's scriptSig. If Some(), it's p2ms case, i.e., reftx output's scriptPubKey.type is "multisig", and the scriptPubkey is supplied from the referenced output.
 fn compute_sighash_legacy(raw_tx: &[u8], inp_idx: usize, script_pubkey_bytes_opt: Option<&[u8]>) {
-    let tx: Transaction = consensus::deserialize(raw_tx).unwrap();
+    let tx: Transaction = encoding::decode_from_slice(raw_tx).unwrap();
     let inp = &tx.inputs[inp_idx];
     let script_sig = &inp.script_sig;
     println!("scriptSig is: {script_sig}");
@@ -105,7 +105,7 @@ fn compute_sighash_legacy(raw_tx: &[u8], inp_idx: usize, script_pubkey_bytes_opt
 /// * `inp_idx` - the spending tx input index
 /// * `amount` - the ref tx output amount.
 fn compute_sighash_p2wsh(raw_tx: &[u8], inp_idx: usize, amount: Amount) {
-    let tx: Transaction = consensus::deserialize(raw_tx).unwrap();
+    let tx: Transaction = encoding::decode_from_slice(raw_tx).unwrap();
     let inp = &tx.inputs[inp_idx];
     let witness = &inp.witness;
     println!("witness {witness:?}");

--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -560,7 +560,7 @@ mod test {
 
     use super::*;
     #[cfg(feature = "std")]
-    use crate::consensus::encode::deserialize;
+    use crate::encoding::decode_from_slice;
     #[cfg(feature = "std")]
     use crate::ScriptPubKeyBuf;
 
@@ -575,7 +575,8 @@ mod test {
         let testdata = serde_json::from_str::<Value>(data).unwrap().as_array().unwrap().clone();
         for t in testdata.iter().skip(1) {
             let block_hash = t.get(1).unwrap().as_str().unwrap().parse::<BlockHash>().unwrap();
-            let block: Block = deserialize(&hex(t.get(2).unwrap().as_str().unwrap())).unwrap();
+            let block: Block =
+                decode_from_slice(&hex(t.get(2).unwrap().as_str().unwrap())).unwrap();
             let block = block.assume_checked(None);
             assert_eq!(block.block_hash(), block_hash);
             let scripts = t.get(3).unwrap().as_array().unwrap();

--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -44,7 +44,7 @@ use internals::array::ArrayExt as _;
 use io::{BufRead, Write};
 
 use crate::block::{Block, BlockHash, Checked};
-use crate::consensus::{ReadExt, WriteExt};
+use crate::encoding::{CompactSizeEncoder, CompactSizeU64Decoder, ExactSizeEncoder as _};
 use crate::prelude::{BTreeSet, Borrow, Vec};
 use crate::script::{ScriptPubKey, ScriptPubKeyExt as _};
 use crate::transaction::OutPoint;
@@ -220,7 +220,8 @@ impl GcsFilterReader {
         I::Item: Borrow<[u8]>,
         R: BufRead + ?Sized,
     {
-        let n_elements = reader.read_compact_size().map_err(Error::InvalidCompactSize)?;
+        let n_elements = io::decode_from_read_with::<CompactSizeU64Decoder, _>(&mut *reader)
+            .map_err(Error::InvalidCompactSize)?;
         // map hashes to [0, n_elements << grp]
         let nm = n_elements * self.m;
         let mut mapped =
@@ -263,7 +264,8 @@ impl GcsFilterReader {
         I::Item: Borrow<[u8]>,
         R: BufRead + ?Sized,
     {
-        let n_elements = reader.read_compact_size().map_err(Error::InvalidCompactSize)?;
+        let n_elements = io::decode_from_read_with::<CompactSizeU64Decoder, _>(&mut *reader)
+            .map_err(Error::InvalidCompactSize)?;
         // map hashes to [0, n_elements << grp]
         let nm = n_elements * self.m;
         let mut mapped =
@@ -338,7 +340,9 @@ impl<'a, W: Write> GcsFilterWriter<'a, W> {
         mapped.sort_unstable();
 
         // write number of elements as varint
-        let mut wrote = self.writer.emit_compact_size(mapped.len())?;
+        let mut encoder = CompactSizeEncoder::new(mapped.len());
+        let mut wrote = encoder.len();
+        io::drain_to_writer(&mut encoder, &mut self.writer)?;
 
         // write out deltas of sorted values into a Golomb-Rice coded bit stream
         let mut writer = BitStreamWriter::new(self.writer);
@@ -501,7 +505,6 @@ pub mod error {
 
     use internals::write_err;
 
-    use crate::consensus;
     use crate::transaction::OutPoint;
 
     /// Errors for blockfilter.
@@ -511,7 +514,7 @@ pub mod error {
         /// Missing UTXO, cannot calculate script filter.
         UtxoMissing(OutPoint),
         /// Invalid CompactSize encoded element count in the filter.
-        InvalidCompactSize(consensus::Error),
+        InvalidCompactSize(io::ReadError<encoding::CompactSizeDecoderError>),
         /// I/O error reading or writing binary serialization of the filter.
         Io(io::Error),
     }
@@ -697,33 +700,35 @@ mod test {
 
     #[test]
     fn malformed_filter_count_errors() {
-        use crate::consensus::Error::Parse as ConsensusParse;
-        use crate::consensus::ParseError::{MissingData, NonMinimalCompactSize};
+        // Check the inner private error type via text
+        fn assert_error_string(result: Result<bool, Error>, substring: &str) {
+            match result {
+                Err(Error::InvalidCompactSize(io::ReadError::Decode(c_err))) => {
+                    let err_msg = format!("{}", c_err);
+                    assert!(err_msg.contains(substring));
+                }
+                _ => panic!("Incorrect error type: {:?}", result),
+            }
+        }
 
         let query = [hex!("000000")];
         let reader = GcsFilterReader::new(0, 0, M, P);
 
         let mut bytes = &[0xfd][..];
         let result = reader.match_any(&mut bytes, query.iter().map(|v| v.as_slice()));
-        assert!(matches!(result, Err(Error::InvalidCompactSize(ConsensusParse(MissingData)))));
+        assert_error_string(result, "required at least");
 
         let mut bytes = &[0xfd][..];
         let result = reader.match_all(&mut bytes, query.iter().map(|v| v.as_slice()));
-        assert!(matches!(result, Err(Error::InvalidCompactSize(ConsensusParse(MissingData)))));
+        assert_error_string(result, "required at least");
 
         let mut bytes = &[0xfd, 0xfc, 0x00][..];
         let result = reader.match_any(&mut bytes, query.iter().map(|v| v.as_slice()));
-        assert!(matches!(
-            result,
-            Err(Error::InvalidCompactSize(ConsensusParse(NonMinimalCompactSize)))
-        ));
+        assert_error_string(result, "not encoded minimally");
 
         let mut bytes = &[0xfd, 0xfc, 0x00][..];
         let result = reader.match_all(&mut bytes, query.iter().map(|v| v.as_slice()));
-        assert!(matches!(
-            result,
-            Err(Error::InvalidCompactSize(ConsensusParse(NonMinimalCompactSize)))
-        ));
+        assert_error_string(result, "not encoded minimally");
     }
 
     #[test]

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -412,7 +412,7 @@ mod tests {
     use hex::hex;
 
     use super::*;
-    use crate::consensus::encode::{deserialize, serialize};
+    use crate::encoding::{decode_from_slice, encode_to_vec};
     use crate::pow::test_utils::{u128_to_work, u64_to_work};
     use crate::script::{ScriptPubKeyBuf, ScriptSigBuf};
     use crate::transaction::{OutPoint, Transaction, TxIn, TxOut, Txid};
@@ -422,7 +422,7 @@ mod tests {
     fn coinbase_and_bip34() {
         // testnet block 100,000
         const BLOCK_HEX: &str = "0200000035ab154183570282ce9afc0b494c9fc6a3cfea05aa8c1add2ecc56490000000038ba3d78e4500a5a7570dbe61960398add4410d278b21cd9708e6d9743f374d544fc055227f1001c29c1ea3b0101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff3703a08601000427f1001c046a510100522cfabe6d6d0000000000000000000068692066726f6d20706f6f6c7365727665726aac1eeeed88ffffffff0100f2052a010000001976a914912e2b234f941f30b18afbb4fa46171214bf66c888ac00000000";
-        let block: Block = deserialize(&hex!(BLOCK_HEX)).unwrap();
+        let block: Block = decode_from_slice(&hex!(BLOCK_HEX)).unwrap();
         let block = block.assume_checked(None);
 
         let cb_txid = "d574f343976d8e70d91cb278d21044dd8a396019e6db70755a0a50e4783dba38";
@@ -432,28 +432,28 @@ mod tests {
 
         // block with 3-byte bip34 push for height 0x03010000 (non-minimal 1)
         const BAD_HEX: &str = "0200000035ab154183570282ce9afc0b494c9fc6a3cfea05aa8c1add2ecc56490000000038ba3d78e4500a5a7570dbe61960398add4410d278b21cd9708e6d9743f374d544fc055227f1001c29c1ea3b0101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff3703010000000427f1001c046a510100522cfabe6d6d0000000000000000000068692066726f6d20706f6f6c7365727665726aac1eeeed88ffffffff0100f2052a010000001976a914912e2b234f941f30b18afbb4fa46171214bf66c888ac00000000";
-        let bad: Block = deserialize(&hex!(BAD_HEX)).unwrap();
+        let bad: Block = decode_from_slice(&hex!(BAD_HEX)).unwrap();
         let bad = bad.assume_checked(None);
 
         assert_eq!(bad.bip34_block_height(), Err(super::Bip34Error::NonMinimalPush));
 
         // Block 15 on Testnet4 has height of 0x5f (15 PUSHNUM)
         const BLOCK_HEX_SMALL_HEIGHT_15: &str = "000000200fd8c4c1e88f313b561b2724542ff9be1bc54a7dab8db8ef6359d48a00000000705bf9145e6d3c413702cc61f32e4e7bfe3117b1eb928071a59adcf75694a3fb07d83866ffff001dcf4c5e8401010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff095f00062f4077697a2fffffffff0200f2052a010000001976a9140a59837ccd4df25adc31cdad39be6a8d97557ed688ac0000000000000000266a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf90120000000000000000000000000000000000000000000000000000000000000000000000000";
-        let block: Block = deserialize(&hex!(BLOCK_HEX_SMALL_HEIGHT_15)).unwrap();
+        let block: Block = decode_from_slice(&hex!(BLOCK_HEX_SMALL_HEIGHT_15)).unwrap();
         let block = block.assume_checked(None);
 
         assert_eq!(block.bip34_block_height(), Ok(15));
 
         // Block 42 on Testnet4 has height of 0x012a (42)
         const BLOCK_HEX_SMALL_HEIGHT_42: &str = "000000202803addb5a3f42f3e8d6c8536598b2d872b04f3b4f0698c26afdb17300000000463dd9a37a5d3d5c05f9c80a1485b41f1f513dee00338bbc33f5a6e836fce0345dda3866ffff001d872b9def01010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff09012a062f4077697a2fffffffff0200f2052a010000001976a9140a59837ccd4df25adc31cdad39be6a8d97557ed688ac0000000000000000266a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf90120000000000000000000000000000000000000000000000000000000000000000000000000";
-        let block: Block = deserialize(&hex!(BLOCK_HEX_SMALL_HEIGHT_42)).unwrap();
+        let block: Block = decode_from_slice(&hex!(BLOCK_HEX_SMALL_HEIGHT_42)).unwrap();
         let block = block.assume_checked(None);
 
         assert_eq!(block.bip34_block_height(), Ok(42));
 
         // Block 42 on Testnet4 using OP_PUSHDATA1 0x4c012a (42) instead of 0x012a (42)
         const BLOCK_HEX_SMALL_HEIGHT_42_WRONG: &str = "000000202803addb5a3f42f3e8d6c8536598b2d872b04f3b4f0698c26afdb17300000000463dd9a37a5d3d5c05f9c80a1485b41f1f513dee00338bbc33f5a6e836fce0345dda3866ffff001d872b9def01010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff0a4c012a062f4077697a2fffffffff0200f2052a010000001976a9140a59837ccd4df25adc31cdad39be6a8d97557ed688ac0000000000000000266a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf90120000000000000000000000000000000000000000000000000000000000000000000000000";
-        let block: Block = deserialize(&hex!(BLOCK_HEX_SMALL_HEIGHT_42_WRONG)).unwrap();
+        let block: Block = decode_from_slice(&hex!(BLOCK_HEX_SMALL_HEIGHT_42_WRONG)).unwrap();
         let block = block.assume_checked(None);
 
         assert_eq!(block.bip34_block_height(), Err(super::Bip34Error::NonMinimalPush));
@@ -461,7 +461,7 @@ mod tests {
         // Block with a 5 byte height properly minimally encoded
         // this is an overflow for ScriptNum (i32) parsing
         const BLOCK_HEX_5_BYTE_HEIGHT: &str = "000000202803addb5a3f42f3e8d6c8536598b2d872b04f3b4f0698c26afdb17300000000463dd9a37a5d3d5c05f9c80a1485b41f1f513dee00338bbc33f5a6e836fce0345dda3866ffff001d872b9def01010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff0d052a2a2a2a2a062f4077697a2fffffffff0200f2052a010000001976a9140a59837ccd4df25adc31cdad39be6a8d97557ed688ac0000000000000000266a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf90120000000000000000000000000000000000000000000000000000000000000000000000000";
-        let block: Block = deserialize(&hex!(BLOCK_HEX_5_BYTE_HEIGHT)).unwrap();
+        let block: Block = decode_from_slice(&hex!(BLOCK_HEX_5_BYTE_HEIGHT)).unwrap();
         let block = block.assume_checked(None);
 
         assert_eq!(block.bip34_block_height(), Err(super::Bip34Error::NotPresent));
@@ -478,8 +478,8 @@ mod tests {
         let merkle = hex!("bf4473e53794beae34e64fccc471dace6ae544180816f89591894e0f417a914c");
         let work = u128_to_work(0x100010001_u128);
 
-        let decode: Result<Block, _> = deserialize(&some_block);
-        let bad_decode: Result<Block, _> = deserialize(&cutoff_block);
+        let decode: Result<Block, _> = decode_from_slice(&some_block);
+        let bad_decode: Result<Block, _> = decode_from_slice(&cutoff_block);
 
         assert!(decode.is_ok());
         assert!(bad_decode.is_err());
@@ -494,12 +494,12 @@ mod tests {
             Block::new_unchecked(header, transactions.clone()).assume_checked(witness_root);
 
         assert_eq!(real_decode.header().version, Version::from_consensus(1));
-        assert_eq!(serialize(&real_decode.header().prev_blockhash), prevhash);
+        assert_eq!(encode_to_vec(&real_decode.header().prev_blockhash), prevhash);
         assert_eq!(
             real_decode.header().merkle_root,
             block::compute_merkle_root(&transactions).unwrap()
         );
-        assert_eq!(serialize(&real_decode.header().merkle_root), merkle);
+        assert_eq!(encode_to_vec(&real_decode.header().merkle_root), merkle);
         assert_eq!(real_decode.header().time, BlockTime::from_u32(1231965655));
         assert_eq!(real_decode.header().bits, CompactTarget::from_consensus(486604799));
         assert_eq!(real_decode.header().nonce, 2067413810);
@@ -516,7 +516,7 @@ mod tests {
         assert_eq!(block_base_size(real_decode.transactions()), some_block.len());
         assert_eq!(real_decode.weight(), Weight::from_vb_unchecked(some_block.len().to_u64()));
 
-        assert_eq!(serialize(&real_decode), some_block);
+        assert_eq!(encode_to_vec(&real_decode), some_block);
     }
 
     // Check testnet block 000000000000045e0b1660b6445b5e5c5ab63c9a4f956be7e1e69be04fa4497b
@@ -525,7 +525,7 @@ mod tests {
         let params = Params::new(Network::Testnet(TestnetVersion::V3));
         let segwit_block = include_bytes!("../../tests/data/testnet_block_000000000000045e0b1660b6445b5e5c5ab63c9a4f956be7e1e69be04fa4497b.raw").to_vec();
 
-        let decode: Result<Block, _> = deserialize(&segwit_block);
+        let decode: Result<Block, _> = decode_from_slice(&segwit_block);
 
         let prevhash = hex!("2aa2f2ca794ccbd40c16e2f3333f6b8b683f9e7179b2c4d74906000000000000");
         let merkle = hex!("10bc26e70a2f672ad420a6153dd0c28b40a6002c55531bfc99bf8994a8e8f67e");
@@ -542,8 +542,8 @@ mod tests {
             Block::new_unchecked(header, transactions.clone()).assume_checked(witness_root);
 
         assert_eq!(real_decode.header().version, Version::from_consensus(0x2000_0000)); // VERSIONBITS but no bits set
-        assert_eq!(serialize(&real_decode.header().prev_blockhash), prevhash);
-        assert_eq!(serialize(&real_decode.header().merkle_root), merkle);
+        assert_eq!(encode_to_vec(&real_decode.header().prev_blockhash), prevhash);
+        assert_eq!(encode_to_vec(&real_decode.header().merkle_root), merkle);
         assert_eq!(
             real_decode.header().merkle_root,
             block::compute_merkle_root(&transactions).unwrap()
@@ -563,14 +563,14 @@ mod tests {
         assert_eq!(block_base_size(real_decode.transactions()), 4283);
         assert_eq!(real_decode.weight(), Weight::from_wu(17168));
 
-        assert_eq!(serialize(&real_decode), segwit_block);
+        assert_eq!(encode_to_vec(&real_decode), segwit_block);
     }
 
     #[test]
     fn validate_pow() {
         let some_header = hex!("010000004ddccd549d28f385ab457e98d1b11ce80bfea2c5ab93015ade4973e400000000bf4473e53794beae34e64fccc471dace6ae544180816f89591894e0f417a914cd74d6e49ffff001d323b3a7b");
         let some_header: Header =
-            deserialize(&some_header).expect("can't deserialize correct block header");
+            decode_from_slice(&some_header).expect("can't deserialize correct block header");
         assert_eq!(
             some_header.validate_pow(some_header.target()).unwrap(),
             some_header.block_hash()
@@ -593,7 +593,7 @@ mod tests {
 
     fn header() -> Header {
         let header = hex!("010000004ddccd549d28f385ab457e98d1b11ce80bfea2c5ab93015ade4973e400000000bf4473e53794beae34e64fccc471dace6ae544180816f89591894e0f417a914cd74d6e49ffff001d323b3a7b");
-        deserialize(&header).expect("can't deserialize correct block header")
+        decode_from_slice(&header).expect("can't deserialize correct block header")
     }
 
     #[test]
@@ -690,7 +690,7 @@ mod tests {
     fn coinbase_bip34_height_with_coinbase_type() {
         // testnet block 100,000
         const BLOCK_HEX: &str = "0200000035ab154183570282ce9afc0b494c9fc6a3cfea05aa8c1add2ecc56490000000038ba3d78e4500a5a7570dbe61960398add4410d278b21cd9708e6d9743f374d544fc055227f1001c29c1ea3b0101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff3703a08601000427f1001c046a510100522cfabe6d6d0000000000000000000068692066726f6d20706f6f6c7365727665726aac1eeeed88ffffffff0100f2052a010000001976a914912e2b234f941f30b18afbb4fa46171214bf66c888ac00000000";
-        let block: Block = deserialize(&hex!(BLOCK_HEX)).unwrap();
+        let block: Block = decode_from_slice(&hex!(BLOCK_HEX)).unwrap();
         let block = block.assume_checked(None);
 
         // Test that BIP-0034 height extraction works with the Coinbase type

--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -289,7 +289,7 @@ mod test {
     use hex::hex;
 
     use super::*;
-    use crate::consensus::encode::serialize;
+    use crate::encoding::encode_to_vec;
     use crate::network::params;
     use crate::Txid;
 
@@ -301,12 +301,12 @@ mod test {
         assert_eq!(gen.inputs.len(), 1);
         assert_eq!(gen.inputs[0].previous_output.txid, Txid::COINBASE_PREVOUT);
         assert_eq!(gen.inputs[0].previous_output.vout, 0xFFFFFFFF);
-        assert_eq!(serialize(&gen.inputs[0].script_sig),
+        assert_eq!(encode_to_vec(gen.inputs[0].script_sig.as_script()),
                    hex!("4d04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73"));
 
         assert_eq!(gen.inputs[0].sequence, Sequence::MAX);
         assert_eq!(gen.outputs.len(), 1);
-        assert_eq!(serialize(&gen.outputs[0].script_pubkey),
+        assert_eq!(encode_to_vec(gen.outputs[0].script_pubkey.as_script()),
                    hex!("434104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac"));
         assert_eq!(gen.outputs[0].amount, "50 BTC".parse::<Amount>().unwrap());
         assert_eq!(gen.lock_time, absolute::LockTime::ZERO);

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -10,12 +10,12 @@ use super::{
     RedeemScriptSizeError, Script, ScriptHash, ScriptHashableTag, ScriptPubKey, ScriptSig,
     TapScript, WScriptHash, WitnessScript, WitnessScriptSizeError,
 };
-use crate::consensus::Encodable;
+use crate::encoding::{Encode, ExactSizeEncoder};
 use crate::key::{LegacyPublicKey, UntweakedPublicKey, WPubkeyHash};
 use crate::opcodes::all::*;
 use crate::opcodes::{self, Opcode, OpcodeExt as _};
 use crate::policy::{DUST_RELAY_TX_FEE, MAX_OP_RETURN_RELAY};
-use crate::prelude::{sink, String, ToString};
+use crate::prelude::{String, ToString};
 use crate::script::{self, ScriptPubKeyBufExt as _};
 use crate::taproot::{LeafVersion, TapLeafHash, TapLeafHashExt as _, TapNodeHash};
 use crate::witness_program::P2A_PROGRAM;
@@ -549,11 +549,11 @@ internal_macros::define_extension_trait! {
                 } else if self.is_witness_program() {
                     32 + 4 + 1 + (107 / 4) + 4 + // The spend cost copied from Core
                     8 + // The serialized size of the TxOut's amount field
-                    self.consensus_encode(&mut sink()).expect("sinks don't error").to_u64() // The serialized size of this script_pubkey
+                    self.encoder().len().to_u64() // The serialized size of this script_pubkey
                 } else {
                     32 + 4 + 1 + 107 + 4 + // The spend cost copied from Core
                     8 + // The serialized size of the TxOut's amount field
-                    self.consensus_encode(&mut sink()).expect("sinks don't error").to_u64() // The serialized size of this script_pubkey
+                    self.encoder().len().to_u64() // The serialized size of this script_pubkey
                 })?
                 / 1000; // divide by 1000 like in Core to get value as it cancels out DEFAULT_MIN_RELAY_TX_FEE
                         // Note: We ensure the division happens at the end, since Core performs the division at the end.

--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -5,8 +5,8 @@ use alloc::string::ToString;
 use hex::hex;
 
 use super::*;
-use crate::consensus::encode::{deserialize, serialize};
 use crate::crypto::key::{FullPublicKey, LegacyPublicKey, XOnlyPublicKey};
+use crate::encoding::{decode_from_slice, encode_to_vec};
 use crate::script::borrowed::{ScriptPubKeyExt as _, ScriptPubKeyExtPriv as _, TapScriptExt as _};
 use crate::script::owned::ScriptSigBufExt as _;
 use crate::script::witness_program::WitnessProgram;
@@ -358,9 +358,9 @@ fn script_builder_verify() {
 #[test]
 fn script_serialize() {
     let hex_script = hex!("6c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52");
-    let script: Result<ScriptBuf, _> = deserialize(&hex_script);
+    let script: Result<ScriptBuf, _> = decode_from_slice(&hex_script);
     assert!(script.is_ok());
-    assert_eq!(serialize(&script.unwrap()), &hex_script as &[u8]);
+    assert_eq!(encode_to_vec(script.unwrap().as_script()), &hex_script as &[u8]);
 }
 
 #[test]

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -1308,21 +1308,19 @@ mod tests {
     use hex::hex;
 
     use super::*;
-    use crate::consensus::encode::deserialize;
     use crate::constants::WITNESS_SCALE_FACTOR;
+    use crate::encoding::decode_from_slice;
     use crate::hex;
 
     const SOME_TX: &str = "0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000";
 
     #[test]
     fn encode_to_unsized_writer() {
-        let mut buf = [0u8; 1024];
         let raw_tx = hex!(SOME_TX);
-        let tx: Transaction = Decodable::consensus_decode(&mut raw_tx.as_slice()).unwrap();
+        let tx: Transaction = encoding::decode_from_slice(raw_tx.as_slice()).unwrap();
 
-        let size = tx.consensus_encode(&mut &mut buf[..]).unwrap();
-        assert_eq!(size, SOME_TX.len() / 2);
-        assert_eq!(raw_tx, &buf[..size]);
+        let buf = encoding::encode_to_vec(&tx);
+        assert_eq!(raw_tx.as_slice(), buf.as_slice());
     }
 
     #[test]
@@ -1333,14 +1331,14 @@ mod tests {
         let genesis = constants::genesis_block(Network::Bitcoin);
         assert!(genesis.transactions()[0].is_coinbase());
         let tx_bytes = hex!("0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000");
-        let tx: Transaction = deserialize(&tx_bytes).unwrap();
+        let tx: Transaction = decode_from_slice(&tx_bytes).unwrap();
         assert!(!tx.is_coinbase());
     }
 
     #[test]
     fn nonsegwit_transaction() {
         let tx_bytes = hex!("0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000");
-        let tx: Result<Transaction, _> = deserialize(&tx_bytes);
+        let tx: Result<Transaction, _> = decode_from_slice(&tx_bytes);
         assert!(tx.is_ok());
         let realtx = tx.unwrap();
         // All these tests aren't really needed because if they fail, the hash check at the end
@@ -1380,7 +1378,7 @@ mod tests {
             0e626347d28d60b0a2d6cbb41de51740644b9fb3ba7751040121028fa937ca8cba2197a37c007176ed89410\
             55d3bcb8627d085e94553e62f057dcc00000000"
         );
-        let tx: Result<Transaction, _> = deserialize(&tx_bytes);
+        let tx: Result<Transaction, _> = decode_from_slice(&tx_bytes);
         assert!(tx.is_ok());
         let realtx = tx.unwrap();
         // All these tests aren't really needed because if they fail, the hash check at the end
@@ -1431,7 +1429,7 @@ mod tests {
             con_serde::With::<con_serde::Hex>::deserialize::<'_, Transaction, _>(&mut deserializer)
                 .unwrap();
         let tx_bytes = hex::decode_to_vec(&json[1..(json.len() - 1)]).unwrap();
-        let expected = deserialize::<Transaction>(&tx_bytes).unwrap();
+        let expected = decode_from_slice::<Transaction>(&tx_bytes).unwrap();
         assert_eq!(tx, expected);
         let mut bytes = Vec::new();
         let mut serializer = serde_json::Serializer::new(&mut bytes);
@@ -1472,7 +1470,7 @@ mod tests {
              5a2b5e0e09a535e61690647021023222ceec58b94bd25925dd9743dae6b928737491bd940fc5dd7c6f5d5f\
              2adc1e53ae00000000"
         );
-        let tx: Transaction = deserialize(&tx_bytes).unwrap();
+        let tx: Transaction = decode_from_slice(&tx_bytes).unwrap();
 
         assert_eq!(
             format!("{:x}", tx.compute_wtxid()),
@@ -1494,7 +1492,7 @@ mod tests {
              bcfd08473d2b76b02a48f8c69088ac0000000000000000296a273236303039343836393731373233313237\
              3633313032313332353630353838373931323132373000000000"
         );
-        let tx: Transaction = deserialize(&tx_bytes).unwrap();
+        let tx: Transaction = decode_from_slice(&tx_bytes).unwrap();
 
         assert_eq!(
             format!("{:x}", tx.compute_wtxid()),
@@ -1510,7 +1508,7 @@ mod tests {
     fn huge_witness() {
         let hex =
             hex::decode_to_vec(include_str!("../../tests/data/huge_witness.hex").trim()).unwrap();
-        deserialize::<Transaction>(&hex).unwrap();
+        decode_from_slice::<Transaction>(&hex).unwrap();
     }
 
     #[test]
@@ -1523,13 +1521,13 @@ mod tests {
         use crate::witness::Witness;
 
         // a random recent SegWit transaction from blockchain using both old and SegWit inputs
-        let mut spending: Transaction = deserialize(hex!("020000000001031cfbc8f54fbfa4a33a30068841371f80dbfe166211242213188428f437445c91000000006a47304402206fbcec8d2d2e740d824d3d36cc345b37d9f65d665a99f5bd5c9e8d42270a03a8022013959632492332200c2908459547bf8dbf97c65ab1a28dec377d6f1d41d3d63e012103d7279dfb90ce17fe139ba60a7c41ddf605b25e1c07a4ddcb9dfef4e7d6710f48feffffff476222484f5e35b3f0e43f65fc76e21d8be7818dd6a989c160b1e5039b7835fc00000000171600140914414d3c94af70ac7e25407b0689e0baa10c77feffffffa83d954a62568bbc99cc644c62eb7383d7c2a2563041a0aeb891a6a4055895570000000017160014795d04cc2d4f31480d9a3710993fbd80d04301dffeffffff06fef72f000000000017a91476fd7035cd26f1a32a5ab979e056713aac25796887a5000f00000000001976a914b8332d502a529571c6af4be66399cd33379071c588ac3fda0500000000001976a914fc1d692f8de10ae33295f090bea5fe49527d975c88ac522e1b00000000001976a914808406b54d1044c429ac54c0e189b0d8061667e088ac6eb68501000000001976a914dfab6085f3a8fb3e6710206a5a959313c5618f4d88acbba20000000000001976a914eb3026552d7e3f3073457d0bee5d4757de48160d88ac0002483045022100bee24b63212939d33d513e767bc79300051f7a0d433c3fcf1e0e3bf03b9eb1d70220588dc45a9ce3a939103b4459ce47500b64e23ab118dfc03c9caa7d6bfc32b9c601210354fd80328da0f9ae6eef2b3a81f74f9a6f66761fadf96f1d1d22b1fd6845876402483045022100e29c7e3a5efc10da6269e5fc20b6a1cb8beb92130cc52c67e46ef40aaa5cac5f0220644dd1b049727d991aece98a105563416e10a5ac4221abac7d16931842d5c322012103960b87412d6e169f30e12106bdf70122aabb9eb61f455518322a18b920a4dfa887d30700")
+        let mut spending: Transaction = decode_from_slice(hex!("020000000001031cfbc8f54fbfa4a33a30068841371f80dbfe166211242213188428f437445c91000000006a47304402206fbcec8d2d2e740d824d3d36cc345b37d9f65d665a99f5bd5c9e8d42270a03a8022013959632492332200c2908459547bf8dbf97c65ab1a28dec377d6f1d41d3d63e012103d7279dfb90ce17fe139ba60a7c41ddf605b25e1c07a4ddcb9dfef4e7d6710f48feffffff476222484f5e35b3f0e43f65fc76e21d8be7818dd6a989c160b1e5039b7835fc00000000171600140914414d3c94af70ac7e25407b0689e0baa10c77feffffffa83d954a62568bbc99cc644c62eb7383d7c2a2563041a0aeb891a6a4055895570000000017160014795d04cc2d4f31480d9a3710993fbd80d04301dffeffffff06fef72f000000000017a91476fd7035cd26f1a32a5ab979e056713aac25796887a5000f00000000001976a914b8332d502a529571c6af4be66399cd33379071c588ac3fda0500000000001976a914fc1d692f8de10ae33295f090bea5fe49527d975c88ac522e1b00000000001976a914808406b54d1044c429ac54c0e189b0d8061667e088ac6eb68501000000001976a914dfab6085f3a8fb3e6710206a5a959313c5618f4d88acbba20000000000001976a914eb3026552d7e3f3073457d0bee5d4757de48160d88ac0002483045022100bee24b63212939d33d513e767bc79300051f7a0d433c3fcf1e0e3bf03b9eb1d70220588dc45a9ce3a939103b4459ce47500b64e23ab118dfc03c9caa7d6bfc32b9c601210354fd80328da0f9ae6eef2b3a81f74f9a6f66761fadf96f1d1d22b1fd6845876402483045022100e29c7e3a5efc10da6269e5fc20b6a1cb8beb92130cc52c67e46ef40aaa5cac5f0220644dd1b049727d991aece98a105563416e10a5ac4221abac7d16931842d5c322012103960b87412d6e169f30e12106bdf70122aabb9eb61f455518322a18b920a4dfa887d30700")
             .as_slice()).unwrap();
-        let spent1: Transaction = deserialize(hex!("020000000001040aacd2c49f5f3c0968cfa8caf9d5761436d95385252e3abb4de8f5dcf8a582f20000000017160014bcadb2baea98af0d9a902e53a7e9adff43b191e9feffffff96cd3c93cac3db114aafe753122bd7d1afa5aa4155ae04b3256344ecca69d72001000000171600141d9984579ceb5c67ebfbfb47124f056662fe7adbfeffffffc878dd74d3a44072eae6178bb94b9253177db1a5aaa6d068eb0e4db7631762e20000000017160014df2a48cdc53dae1aba7aa71cb1f9de089d75aac3feffffffe49f99275bc8363f5f593f4eec371c51f62c34ff11cc6d8d778787d340d6896c0100000017160014229b3b297a0587e03375ab4174ef56eeb0968735feffffff03360d0f00000000001976a9149f44b06f6ee92ddbc4686f71afe528c09727a5c788ac24281b00000000001976a9140277b4f68ff20307a2a9f9b4487a38b501eb955888ac227c0000000000001976a9148020cd422f55eef8747a9d418f5441030f7c9c7788ac0247304402204aa3bd9682f9a8e101505f6358aacd1749ecf53a62b8370b97d59243b3d6984f02200384ad449870b0e6e89c92505880411285ecd41cf11e7439b973f13bad97e53901210205b392ffcb83124b1c7ce6dd594688198ef600d34500a7f3552d67947bbe392802473044022033dfd8d190a4ae36b9f60999b217c775b96eb10dee3a1ff50fb6a75325719106022005872e4e36d194e49ced2ebcf8bb9d843d842e7b7e0eb042f4028396088d292f012103c9d7cbf369410b090480de2aa15c6c73d91b9ffa7d88b90724614b70be41e98e0247304402207d952de9e59e4684efed069797e3e2d993e9f98ec8a9ccd599de43005fe3f713022076d190cc93d9513fc061b1ba565afac574e02027c9efbfa1d7b71ab8dbb21e0501210313ad44bc030cc6cb111798c2bf3d2139418d751c1e79ec4e837ce360cc03b97a024730440220029e75edb5e9413eb98d684d62a077b17fa5b7cc19349c1e8cc6c4733b7b7452022048d4b9cae594f03741029ff841e35996ef233701c1ea9aa55c301362ea2e2f68012103590657108a72feb8dc1dec022cf6a230bb23dc7aaa52f4032384853b9f8388baf9d20700")
+        let spent1: Transaction = decode_from_slice(hex!("020000000001040aacd2c49f5f3c0968cfa8caf9d5761436d95385252e3abb4de8f5dcf8a582f20000000017160014bcadb2baea98af0d9a902e53a7e9adff43b191e9feffffff96cd3c93cac3db114aafe753122bd7d1afa5aa4155ae04b3256344ecca69d72001000000171600141d9984579ceb5c67ebfbfb47124f056662fe7adbfeffffffc878dd74d3a44072eae6178bb94b9253177db1a5aaa6d068eb0e4db7631762e20000000017160014df2a48cdc53dae1aba7aa71cb1f9de089d75aac3feffffffe49f99275bc8363f5f593f4eec371c51f62c34ff11cc6d8d778787d340d6896c0100000017160014229b3b297a0587e03375ab4174ef56eeb0968735feffffff03360d0f00000000001976a9149f44b06f6ee92ddbc4686f71afe528c09727a5c788ac24281b00000000001976a9140277b4f68ff20307a2a9f9b4487a38b501eb955888ac227c0000000000001976a9148020cd422f55eef8747a9d418f5441030f7c9c7788ac0247304402204aa3bd9682f9a8e101505f6358aacd1749ecf53a62b8370b97d59243b3d6984f02200384ad449870b0e6e89c92505880411285ecd41cf11e7439b973f13bad97e53901210205b392ffcb83124b1c7ce6dd594688198ef600d34500a7f3552d67947bbe392802473044022033dfd8d190a4ae36b9f60999b217c775b96eb10dee3a1ff50fb6a75325719106022005872e4e36d194e49ced2ebcf8bb9d843d842e7b7e0eb042f4028396088d292f012103c9d7cbf369410b090480de2aa15c6c73d91b9ffa7d88b90724614b70be41e98e0247304402207d952de9e59e4684efed069797e3e2d993e9f98ec8a9ccd599de43005fe3f713022076d190cc93d9513fc061b1ba565afac574e02027c9efbfa1d7b71ab8dbb21e0501210313ad44bc030cc6cb111798c2bf3d2139418d751c1e79ec4e837ce360cc03b97a024730440220029e75edb5e9413eb98d684d62a077b17fa5b7cc19349c1e8cc6c4733b7b7452022048d4b9cae594f03741029ff841e35996ef233701c1ea9aa55c301362ea2e2f68012103590657108a72feb8dc1dec022cf6a230bb23dc7aaa52f4032384853b9f8388baf9d20700")
             .as_slice()).unwrap();
-        let spent2: Transaction = deserialize(hex!("0200000000010166c3d39490dc827a2594c7b17b7d37445e1f4b372179649cd2ce4475e3641bbb0100000017160014e69aa750e9bff1aca1e32e57328b641b611fc817fdffffff01e87c5d010000000017a914f3890da1b99e44cd3d52f7bcea6a1351658ea7be87024830450221009eb97597953dc288de30060ba02d4e91b2bde1af2ecf679c7f5ab5989549aa8002202a98f8c3bd1a5a31c0d72950dd6e2e3870c6c5819a6c3db740e91ebbbc5ef4800121023f3d3b8e74b807e32217dea2c75c8d0bd46b8665b3a2d9b3cb310959de52a09bc9d20700")
+        let spent2: Transaction = decode_from_slice(hex!("0200000000010166c3d39490dc827a2594c7b17b7d37445e1f4b372179649cd2ce4475e3641bbb0100000017160014e69aa750e9bff1aca1e32e57328b641b611fc817fdffffff01e87c5d010000000017a914f3890da1b99e44cd3d52f7bcea6a1351658ea7be87024830450221009eb97597953dc288de30060ba02d4e91b2bde1af2ecf679c7f5ab5989549aa8002202a98f8c3bd1a5a31c0d72950dd6e2e3870c6c5819a6c3db740e91ebbbc5ef4800121023f3d3b8e74b807e32217dea2c75c8d0bd46b8665b3a2d9b3cb310959de52a09bc9d20700")
             .as_slice()).unwrap();
-        let spent3: Transaction = deserialize(hex!("01000000027a1120a30cef95422638e8dab9dedf720ec614b1b21e451a4957a5969afb869d000000006a47304402200ecc318a829a6cad4aa9db152adbf09b0cd2de36f47b53f5dade3bc7ef086ca702205722cda7404edd6012eedd79b2d6f24c0a0c657df1a442d0a2166614fb164a4701210372f4b97b34e9c408741cd1fc97bcc7ffdda6941213ccfde1cb4075c0f17aab06ffffffffc23b43e5a18e5a66087c0d5e64d58e8e21fcf83ce3f5e4f7ecb902b0e80a7fb6010000006b483045022100f10076a0ea4b4cf8816ed27a1065883efca230933bf2ff81d5db6258691ff75202206b001ef87624e76244377f57f0c84bc5127d0dd3f6e0ef28b276f176badb223a01210309a3a61776afd39de4ed29b622cd399d99ecd942909c36a8696cfd22fc5b5a1affffffff0200127a000000000017a914f895e1dd9b29cb228e9b06a15204e3b57feaf7cc8769311d09000000001976a9144d00da12aaa51849d2583ae64525d4a06cd70fde88ac00000000")
+        let spent3: Transaction = decode_from_slice(hex!("01000000027a1120a30cef95422638e8dab9dedf720ec614b1b21e451a4957a5969afb869d000000006a47304402200ecc318a829a6cad4aa9db152adbf09b0cd2de36f47b53f5dade3bc7ef086ca702205722cda7404edd6012eedd79b2d6f24c0a0c657df1a442d0a2166614fb164a4701210372f4b97b34e9c408741cd1fc97bcc7ffdda6941213ccfde1cb4075c0f17aab06ffffffffc23b43e5a18e5a66087c0d5e64d58e8e21fcf83ce3f5e4f7ecb902b0e80a7fb6010000006b483045022100f10076a0ea4b4cf8816ed27a1065883efca230933bf2ff81d5db6258691ff75202206b001ef87624e76244377f57f0c84bc5127d0dd3f6e0ef28b276f176badb223a01210309a3a61776afd39de4ed29b622cd399d99ecd942909c36a8696cfd22fc5b5a1affffffff0200127a000000000017a914f895e1dd9b29cb228e9b06a15204e3b57feaf7cc8769311d09000000001976a9144d00da12aaa51849d2583ae64525d4a06cd70fde88ac00000000")
             .as_slice()).unwrap();
 
         let mut spent = HashMap::new();
@@ -1631,7 +1629,8 @@ mod tests {
 
         for (is_segwit, tx, expected_weight) in &txs {
             let txin_weight = if *is_segwit { TxIn::segwit_weight } else { TxIn::legacy_weight };
-            let tx: Transaction = deserialize(hex::decode_to_vec(tx).unwrap().as_slice()).unwrap();
+            let tx: Transaction =
+                decode_from_slice(hex::decode_to_vec(tx).unwrap().as_slice()).unwrap();
             assert_eq!(*is_segwit, tx.uses_segwit_serialization());
 
             let mut calculated_weight = empty_transaction_weight
@@ -1764,7 +1763,7 @@ mod tests {
         // All we need is to trigger 3 cases for prevout
         fn return_p2sh(_outpoint: &OutPoint) -> Option<TxOut> {
             Some(
-                deserialize(&hex!(
+                decode_from_slice(&hex!(
                     "cc721b000000000017a91428203c10cc8f18a77412caaa83dabaf62b8fbb0f87"
                 ))
                 .unwrap(),
@@ -1772,7 +1771,7 @@ mod tests {
         }
         fn return_p2wpkh(_outpoint: &OutPoint) -> Option<TxOut> {
             Some(
-                deserialize(&hex!(
+                decode_from_slice(&hex!(
                     "e695779d000000001600141c6977423aa4b82a0d7f8496cdf3fc2f8b4f580c"
                 ))
                 .unwrap(),
@@ -1780,7 +1779,7 @@ mod tests {
         }
         fn return_p2wsh(_outpoint: &OutPoint) -> Option<TxOut> {
             Some(
-                deserialize(&hex!(
+                decode_from_slice(&hex!(
                     "66b51e0900000000220020dbd6c9d5141617eff823176aa226eb69153c1e31334ac37469251a2539fc5c2b"
                 ))
                 .unwrap(),
@@ -1790,7 +1789,7 @@ mod tests {
 
         for (hx, expected, spent_fn, expected_none) in tx_hexes.iter() {
             let tx_bytes = hex::decode_to_vec(hx).unwrap();
-            let tx: Transaction = deserialize(&tx_bytes).unwrap();
+            let tx: Transaction = decode_from_slice(&tx_bytes).unwrap();
             assert_eq!(tx.total_sigop_cost(spent_fn), *expected);
             assert_eq!(tx.total_sigop_cost(return_none), *expected_none);
         }
@@ -1822,7 +1821,7 @@ mod tests {
              5d5aca00000000"
         );
 
-        let tx = Transaction::consensus_decode::<&[u8]>(&mut tx_raw.as_ref()).unwrap();
+        let tx: Transaction = encoding::decode_from_slice(tx_raw.as_ref()).unwrap();
         let input_weights = vec![
             InputWeightPrediction::P2WPKH_MAX,
             InputWeightPrediction::ground_p2wpkh(1),

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -252,12 +252,12 @@ mod sealed {
 
 #[cfg(test)]
 mod test {
-    use alloc::vec::Vec;
-
     use hex::{hex, DisplayHex};
 
     use super::*;
-    use crate::consensus::{deserialize, encode, serialize};
+    use crate::encoding::{
+        decode_from_slice, drain_to_vec, encode_to_vec, BytesEncoder, CompactSizeEncoder, Encoder2,
+    };
     use crate::sighash::EcdsaSighashType;
     use crate::taproot::LeafVersion;
     use crate::Transaction;
@@ -290,16 +290,25 @@ mod test {
         let vec = vec![el_0, el_1];
 
         // Puts a CompactSize at the front as well as one at the front of each element.
-        let want_ser: Vec<u8> = encode::serialize(&vec);
+        let want_ser = {
+            let mut out = drain_to_vec(&mut CompactSizeEncoder::new(vec.len()));
+            for item in &vec {
+                out.extend_from_slice(&drain_to_vec(&mut Encoder2::new(
+                    CompactSizeEncoder::new(item.len()),
+                    BytesEncoder::without_length_prefix(item),
+                )));
+            }
+            out
+        };
 
         // `from_slice` expects bytes slices _without_ leading `CompactSize`.
         let got_witness = Witness::from_slice(&vec);
         assert_eq!(got_witness, want_witness);
 
-        let got_ser = encode::serialize(&got_witness);
+        let got_ser = encode_to_vec(&got_witness);
         assert_eq!(got_ser, want_ser);
 
-        let roundtrip: Witness = encode::deserialize(&got_ser).unwrap();
+        let roundtrip: Witness = decode_from_slice(&got_ser).unwrap();
         assert_eq!(roundtrip, want_witness)
     }
 
@@ -406,7 +415,7 @@ mod test {
     fn tx() {
         const S: &str = "02000000000102b44f26b275b8ad7b81146ba3dbecd081f9c1ea0dc05b97516f56045cfcd3df030100000000ffffffff1cb4749ae827c0b75f3d0a31e63efc8c71b47b5e3634a4c698cd53661cab09170100000000ffffffff020b3a0500000000001976a9143ea74de92762212c96f4dd66c4d72a4deb20b75788ac630500000000000016001493a8dfd1f0b6a600ab01df52b138cda0b82bb7080248304502210084622878c94f4c356ce49c8e33a063ec90f6ee9c0208540888cfab056cd1fca9022014e8dbfdfa46d318c6887afd92dcfa54510e057565e091d64d2ee3a66488f82c0121026e181ffb98ebfe5a64c983073398ea4bcd1548e7b971b4c175346a25a1c12e950247304402203ef00489a0d549114977df2820fab02df75bebb374f5eee9e615107121658cfa02204751f2d1784f8e841bff6d3bcf2396af2f1a5537c0e4397224873fbd3bfbe9cf012102ae6aa498ce2dd204e9180e71b4fb1260fe3d1a95c8025b34e56a9adf5f278af200000000";
         let tx_bytes = hex!(S);
-        let tx: Transaction = deserialize(&tx_bytes).unwrap();
+        let tx: Transaction = decode_from_slice(&tx_bytes).unwrap();
 
         let expected_wit = ["304502210084622878c94f4c356ce49c8e33a063ec90f6ee9c0208540888cfab056cd1fca9022014e8dbfdfa46d318c6887afd92dcfa54510e057565e091d64d2ee3a66488f82c01", "026e181ffb98ebfe5a64c983073398ea4bcd1548e7b971b4c175346a25a1c12e95"];
         for (i, wit_el) in tx.inputs[0].witness.iter().enumerate() {
@@ -423,7 +432,7 @@ mod test {
         assert_eq!(expected_wit[0], tx.inputs[0].witness[0].to_lower_hex_string());
         assert_eq!(expected_wit[1], tx.inputs[0].witness[1].to_lower_hex_string());
 
-        let tx_bytes_back = serialize(&tx);
+        let tx_bytes_back = encode_to_vec(&tx);
         assert_eq!(tx_bytes_back, tx_bytes);
     }
 
@@ -448,9 +457,9 @@ mod test {
     #[test]
     fn fuzz_cases() {
         let bytes = hex!("26ff0000000000c94ce592cf7a4cbb68eb00ce374300000057cd0000000000000026");
-        assert!(deserialize::<Witness>(&bytes).is_err()); // OversizedVectorAllocation
+        assert!(decode_from_slice::<Witness>(&bytes).is_err()); // OversizedVectorAllocation
 
         let bytes = hex!("24000000ffffffffffffffffffffffff");
-        assert!(deserialize::<Witness>(&bytes).is_err()); // OversizedVectorAllocation
+        assert!(decode_from_slice::<Witness>(&bytes).is_err()); // OversizedVectorAllocation
     }
 }

--- a/bitcoin/src/consensus_validation.rs
+++ b/bitcoin/src/consensus_validation.rs
@@ -5,9 +5,9 @@
 //! Relies on the `bitcoinconsensus` crate that uses Bitcoin Core libconsensus to perform validation.
 
 use crate::amount::Amount;
-use crate::consensus::encode;
 #[cfg(doc)]
 use crate::consensus_validation;
+use crate::encoding;
 use crate::internal_macros::define_extension_trait;
 use crate::script::ScriptPubKey;
 use crate::transaction::{OutPoint, Transaction, TxOut};
@@ -98,7 +98,7 @@ where
     S: FnMut(&OutPoint) -> Option<TxOut>,
     F: Into<u32>,
 {
-    let serialized_tx = encode::serialize(tx);
+    let serialized_tx = encoding::encode_to_vec(tx);
     let flags: u32 = flags.into();
     for (idx, input) in tx.inputs.iter().enumerate() {
         if let Some(output) = spent(&input.previous_output) {

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -1700,9 +1700,18 @@ mod tests {
             })
         }
 
+        fn tx_deser_hex<'de, D>(deserializer: D) -> Result<Transaction, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            use serde::de::{Deserialize, Error};
+
+            let hex_str = String::deserialize(deserializer)?;
+            crate::encoding::decode_from_hex(&hex_str).map_err(D::Error::custom)
+        }
+
         use secp256k1::SecretKey;
 
-        use crate::consensus::serde as con_serde;
         use crate::crypto::key::XOnlyPublicKey;
         use crate::key::{Keypair, PrivateKey, TapTweak};
         use crate::taproot::TapNodeHash;
@@ -1719,7 +1728,7 @@ mod tests {
         #[derive(serde::Deserialize)]
         #[serde(rename_all = "camelCase")]
         struct KpsGiven {
-            #[serde(with = "con_serde::With::<con_serde::Hex>")]
+            #[serde(deserialize_with = "tx_deser_hex")]
             raw_unsigned_tx: Transaction,
             utxos_spent: Vec<UtxoSpent>,
         }

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -18,6 +18,7 @@ use core::str;
 use arbitrary::{Arbitrary, Unstructured};
 use crypto::key::{TweakedKeypair, UntweakedKeypair};
 use crypto::{ecdsa, taproot, PrivateKey};
+use encoding::CompactSizeEncoder;
 use hashes::{hash_newtype, sha256, sha256d, sha256t, sha256t_tag};
 use io::Write;
 
@@ -714,20 +715,18 @@ impl<R: Borrow<Transaction>> SighashCache<R> {
             script_pubkey: &crate::script::Script<T>,
             sighash_type: u32,
         ) -> Result<(), io::Error> {
-            use crate::consensus::encode::WriteExt;
-
             let (sighash, anyone_can_pay) =
                 EcdsaSighashType::from_consensus(sighash_type).split_anyonecanpay_flag();
 
             io::encode_to_writer(&self_.version, &mut writer)?;
             // Add all inputs necessary..
             if anyone_can_pay {
-                writer.emit_compact_size(1u8)?;
+                io::drain_to_writer(&mut CompactSizeEncoder::new(1), &mut writer)?;
                 io::encode_to_writer(&self_.inputs[input_index].previous_output, &mut writer)?;
                 io::encode_to_writer(script_pubkey, &mut writer)?;
                 io::encode_to_writer(&self_.inputs[input_index].sequence, &mut writer)?;
             } else {
-                writer.emit_compact_size(self_.inputs.len())?;
+                io::drain_to_writer(&mut CompactSizeEncoder::new(self_.inputs.len()), &mut writer)?;
                 for (n, input) in self_.inputs.iter().enumerate() {
                     io::encode_to_writer(&input.previous_output, &mut writer)?;
                     if n == input_index {
@@ -758,7 +757,7 @@ impl<R: Borrow<Transaction>> SighashCache<R> {
                     // sign all outputs up to and including this one, but erase
                     // all of them except for this one
                     let count = input_index.min(self_.outputs.len() - 1);
-                    writer.emit_compact_size(count + 1)?;
+                    io::drain_to_writer(&mut CompactSizeEncoder::new(count + 1), &mut writer)?;
                     for _ in 0..count {
                         // consensus encoding of the "NULL txout" - max amount, empty script_pubkey
                         writer
@@ -767,7 +766,7 @@ impl<R: Borrow<Transaction>> SighashCache<R> {
                     io::encode_to_writer(&self_.outputs[count], &mut writer)?;
                 }
                 EcdsaSighashType::None => {
-                    writer.emit_compact_size(0u8)?;
+                    io::drain_to_writer(&mut CompactSizeEncoder::new(0), &mut writer)?;
                 }
                 _ => unreachable!(),
             };

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -973,7 +973,7 @@ impl<E> EncodeSigningDataResult<E> {
     /// the recommended pattern to handle this is:
     ///
     /// ```rust
-    /// # use bitcoin::consensus::deserialize;
+    /// # use bitcoin::encoding::decode_from_slice;
     /// # use bitcoin::hashes::sha256d;
     /// # use bitcoin::sighash::SighashCache;
     /// # use bitcoin::Transaction;
@@ -984,7 +984,7 @@ impl<E> EncodeSigningDataResult<E> {
     /// # let sighash_u32 = 0u32;
     /// # const SOME_TX: &'static str = "0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000";
     /// # let raw_tx = hex::decode_to_vec(SOME_TX).unwrap();
-    /// # let tx: Transaction = deserialize(&raw_tx).unwrap();
+    /// # let tx: Transaction = decode_from_slice(&raw_tx).unwrap();
     /// let cache = SighashCache::new(&tx);
     /// if cache.legacy_encode_signing_data_to(&mut writer, input_index, &script_pubkey, sighash_u32)
     ///         .is_sighash_single_bug()
@@ -1349,13 +1349,14 @@ where
 mod tests {
     #[cfg(feature = "serde")]
     use alloc::string::String;
+    #[cfg(feature = "serde")]
     use alloc::vec::Vec;
 
     use hashes::HashEngine;
     use hex::hex;
 
     use super::*;
-    use crate::consensus::deserialize;
+    use crate::encoding::decode_from_slice;
     use crate::locktime::absolute;
     use crate::script::{ScriptPubKey, ScriptPubKeyBuf, TapScriptBuf, WitnessScriptBuf};
     use crate::{hex, TxIn};
@@ -1402,7 +1403,7 @@ mod tests {
             hash_type: i64,
             expected_result: &str,
         ) {
-            let tx: Transaction = deserialize(&hex::decode_to_vec(tx).unwrap()[..]).unwrap();
+            let tx: Transaction = decode_from_slice(&hex::decode_to_vec(tx).unwrap()[..]).unwrap();
             let script = ScriptPubKeyBuf::from(hex::decode_to_vec(script).unwrap());
             let mut raw_expected = hex::decode_to_vec(expected_result).unwrap();
             raw_expected.reverse();
@@ -1637,9 +1638,11 @@ mod tests {
         script_leaf_hash: Option<&str>,
     ) {
         let tx_bytes = hex::decode_to_vec(tx_hex).unwrap();
-        let tx: Transaction = deserialize(&tx_bytes).unwrap();
+        let tx: Transaction = decode_from_slice(&tx_bytes).unwrap();
         let prevout_bytes = hex::decode_to_vec(prevout_hex).unwrap();
-        let prevouts: Vec<TxOut> = deserialize(&prevout_bytes).unwrap();
+        let prevouts =
+            encoding::decode_from_slice_with::<encoding::VecDecoder<TxOut>>(&prevout_bytes)
+                .unwrap();
         let annex_inner;
         let annex = match annex_hex {
             Some(annex_hex) => {
@@ -1860,7 +1863,7 @@ mod tests {
 
     #[test]
     fn bip143_p2wpkh() {
-        let tx = deserialize::<Transaction>(
+        let tx = decode_from_slice::<Transaction>(
             &hex!(
                 "0100000002fff7f7881a8099afa6940d42d1e7f6362bec38171ea3edf433541db4e4ad969f000000\
                 0000eeffffffef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a01000000\
@@ -1904,7 +1907,7 @@ mod tests {
 
     #[test]
     fn bip143_p2wpkh_nested_in_p2sh() {
-        let tx = deserialize::<Transaction>(
+        let tx = decode_from_slice::<Transaction>(
             &hex!(
                 "0100000001db6b1b20aa0fd7b23880be2ecbd4a98130974cf4748fb66092ac4d3ceb1a5477010000\
                 0000feffffff02b8b4eb0b000000001976a914a457b684d7f0d539a46a45bbc043f35b59d0d96388ac00\
@@ -1949,7 +1952,7 @@ mod tests {
     // prepended to all the script_code hex it is the length byte, it gets added when we consensus
     // encode a script.
     fn bip143_p2wsh_nested_in_p2sh_data() -> (Transaction, WitnessScriptBuf, Amount) {
-        let tx = deserialize::<Transaction>(&hex!(
+        let tx = decode_from_slice::<Transaction>(&hex!(
             "010000000136641869ca081e70f394c6948e8af409e18b619df2ed74aa106c1ca29787b96e0100000000\
              ffffffff0200e9a435000000001976a914389ffce9cd9ae88dcc0631e88a821ffdbe9bfe2688acc0832f\
              05000000001976a9147480a33f950689af511e6e84c138dbbd3c3ee41588ac00000000"

--- a/bitcoin/src/sign_message.rs
+++ b/bitcoin/src/sign_message.rs
@@ -5,9 +5,9 @@
 //! This module provides signature related functions including secp256k1 signature recovery when
 //! library is used with the `secp-recovery` feature.
 
+use encoding::CompactSizeEncoder;
 use hashes::{sha256d, HashEngine};
 
-use crate::consensus::encode::WriteExt;
 #[cfg(feature = "secp-recovery")]
 use crate::key::PrivateKeyExt as _;
 #[cfg(feature = "secp-recovery")]
@@ -169,7 +169,7 @@ pub fn signed_msg_hash(msg: impl AsRef<[u8]>) -> sha256d::Hash {
     let msg_bytes = msg.as_ref();
     let mut engine = sha256d::Hash::engine();
     engine.input(BITCOIN_SIGNED_MSG_PREFIX);
-    engine.emit_compact_size(msg_bytes.len()).expect("engines don't error");
+    hashes::drain_to_engine(&mut CompactSizeEncoder::new(msg_bytes.len()), &mut engine);
     engine.input(msg_bytes);
     sha256d::Hash::from_engine(engine)
 }

--- a/bitcoin/src/taproot/mod.rs
+++ b/bitcoin/src/taproot/mod.rs
@@ -21,7 +21,6 @@ use io::Write;
 #[cfg(feature = "serde")]
 use serde::Deserialize;
 
-use crate::consensus::Encodable;
 use crate::crypto::key::{
     SerializedXOnlyPublicKey, TapTweak, TweakedPublicKey, UntweakedPublicKey,
 };
@@ -69,8 +68,8 @@ crate::internal_macros::define_extension_trait! {
         /// Computes the leaf hash from components.
         fn from_script(script: &TapScript, ver: LeafVersion) -> Self {
             let mut eng = sha256t::Hash::<TapLeafTag>::engine();
-            ver.to_consensus().consensus_encode(&mut eng).expect("engines don't error");
-            script.consensus_encode(&mut eng).expect("engines don't error");
+            eng.input(&[ver.to_consensus()]);
+            hashes::encode_to_engine(script, &mut eng);
             let inner = sha256t::Hash::<TapLeafTag>::from_engine(eng);
             Self::from_byte_array(inner.to_byte_array())
         }

--- a/fuzz/fuzz_targets/bitcoin/arbitrary_block.rs
+++ b/fuzz/fuzz_targets/bitcoin/arbitrary_block.rs
@@ -2,14 +2,14 @@
 #![cfg_attr(not(fuzzing), allow(unused))]
 
 use bitcoin::block::{self, Block, BlockCheckedExt as _};
-use bitcoin::consensus::{deserialize, serialize};
+use bitcoin::encoding::{decode_from_slice, encode_to_vec};
 use libfuzzer_sys::fuzz_target;
 
 #[cfg(not(fuzzing))]
 fn main() {}
 
 fn do_test(block: Block) {
-    let serialized = serialize(&block);
+    let serialized = encode_to_vec(&block);
 
     // Manually call all compute functions with unchecked block data.
     let (header, transactions) = block.clone().into_parts();
@@ -24,7 +24,7 @@ fn do_test(block: Block) {
         block.weight();
     }
 
-    let deserialized: Result<Block, _> = deserialize(serialized.as_slice());
+    let deserialized: Result<Block, _> = decode_from_slice(serialized.as_slice());
     assert_eq!(deserialized.unwrap(), block);
 }
 

--- a/fuzz/fuzz_targets/bitcoin/arbitrary_script.rs
+++ b/fuzz/fuzz_targets/bitcoin/arbitrary_script.rs
@@ -3,7 +3,7 @@
 
 use arbitrary::{Arbitrary, Unstructured};
 use bitcoin::address::Address;
-use bitcoin::consensus::serialize;
+use bitcoin::encoding::encode_to_vec;
 use bitcoin::script::{self, ScriptBuf, ScriptExt as _, ScriptPubKeyExt as _};
 use bitcoin::Network;
 use libfuzzer_sys::fuzz_target;
@@ -16,7 +16,7 @@ fn do_test(data: &[u8]) {
     let s = ScriptBuf::arbitrary(&mut u);
 
     if let Ok(script_buf) = s {
-        let serialized = serialize(&script_buf);
+        let serialized = encode_to_vec(script_buf.as_script());
         let _: Result<Vec<script::Instruction>, script::Error> =
             script_buf.instructions().collect();
 
@@ -45,7 +45,7 @@ fn do_test(data: &[u8]) {
             }
         }
         assert_eq!(builder.into_script(), script_buf);
-        assert_eq!(serialized, &serialize(&script_buf)[..]);
+        assert_eq!(serialized, &encode_to_vec(script_buf.as_script())[..]);
 
         // Check if valid address and if that address roundtrips.
         if let Ok(addr) = Address::from_script(&script_buf, Network::Bitcoin) {

--- a/fuzz/fuzz_targets/bitcoin/arbitrary_transaction.rs
+++ b/fuzz/fuzz_targets/bitcoin/arbitrary_transaction.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(fuzzing, no_main)]
 #![cfg_attr(not(fuzzing), allow(unused))]
 
-use bitcoin::consensus::{deserialize, serialize};
+use bitcoin::encoding::{decode_from_slice, encode_to_vec};
 use bitcoin::transaction::TransactionExt as _;
 use bitcoin::Transaction;
 use libfuzzer_sys::fuzz_target;
@@ -10,8 +10,8 @@ use libfuzzer_sys::fuzz_target;
 fn main() {}
 
 fn do_test(mut tx: Transaction) {
-    let serialized = serialize(&tx);
-    let deserialized: Result<Transaction, _> = deserialize(serialized.as_slice());
+    let serialized = encode_to_vec(&tx);
+    let deserialized: Result<Transaction, _> = decode_from_slice(serialized.as_slice());
     assert_eq!(deserialized.unwrap(), tx);
 
     let len = serialized.len();
@@ -19,7 +19,7 @@ fn do_test(mut tx: Transaction) {
     for input in &mut tx.inputs {
         input.witness = bitcoin::witness::Witness::default();
     }
-    let no_witness_len = bitcoin::consensus::encode::serialize(&tx).len();
+    let no_witness_len = encode_to_vec(&tx).len();
     // For 0-input transactions, `no_witness_len` will be incorrect because
     // we serialize as SegWit even after "stripping the witnesses". We need
     // to drop two bytes (i.e. eight weight). Similarly, calculated_weight is

--- a/fuzz/fuzz_targets/bitcoin/arbitrary_witness.rs
+++ b/fuzz/fuzz_targets/bitcoin/arbitrary_witness.rs
@@ -2,7 +2,7 @@
 #![cfg_attr(not(fuzzing), allow(unused))]
 
 use bitcoin::blockdata::witness::WitnessExt;
-use bitcoin::consensus::{deserialize, serialize};
+use bitcoin::encoding::{decode_from_slice, encode_to_vec};
 use bitcoin::Witness;
 use libfuzzer_sys::fuzz_target;
 
@@ -13,12 +13,12 @@ fn do_test(data: (Witness, Vec<u8>)) {
     let mut witness = data.0;
     let element_bytes = data.1;
 
-    let serialized = serialize(&witness);
+    let serialized = encode_to_vec(&witness);
 
     let _ = witness.witness_script();
     let _ = witness.taproot_leaf_script();
 
-    let deserialized: Result<Witness, _> = deserialize(serialized.as_slice());
+    let deserialized: Result<Witness, _> = decode_from_slice(serialized.as_slice());
     assert_eq!(deserialized.unwrap(), witness);
 
     witness.push(element_bytes.as_slice());

--- a/fuzz/fuzz_targets/bitcoin/deserialize_block.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_block.rs
@@ -1,18 +1,19 @@
 #![cfg_attr(fuzzing, no_main)]
 #![cfg_attr(not(fuzzing), allow(unused))]
 
+use bitcoin::encoding::{decode_from_slice, encode_to_vec};
 use libfuzzer_sys::fuzz_target;
 
 #[cfg(not(fuzzing))]
 fn main() {}
 
 fn do_test(data: &[u8]) {
-    let block_result: Result<bitcoin::Block, _> = bitcoin::consensus::encode::deserialize(data);
+    let block_result: Result<bitcoin::Block, _> = decode_from_slice(data);
 
     match block_result {
         Err(_) => {}
         Ok(block) => {
-            let ser = bitcoin::consensus::encode::serialize(&block);
+            let ser = encode_to_vec(&block);
             assert_eq!(&ser[..], data);
         }
     }

--- a/fuzz/fuzz_targets/bitcoin/deserialize_script.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_script.rs
@@ -8,12 +8,12 @@ fn main() {}
 
 fn do_test(data: &[u8]) {
     let script_result: Result<bitcoin::ScriptPubKeyBuf, _> =
-        bitcoin::consensus::encode::deserialize(data);
+        bitcoin::encoding::decode_from_slice(data);
 
     match script_result {
         Err(_) => {}
         Ok(script) => {
-            let ser = bitcoin::consensus::encode::serialize(&script);
+            let ser = bitcoin::encoding::encode_to_vec(script.as_script());
             assert_eq!(&ser[..], data);
         }
     }

--- a/fuzz/fuzz_targets/bitcoin/deserialize_transaction.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_transaction.rs
@@ -1,18 +1,19 @@
 #![cfg_attr(fuzzing, no_main)]
 #![cfg_attr(not(fuzzing), allow(unused))]
 
+use bitcoin::encoding::{decode_from_slice, encode_to_vec};
 use libfuzzer_sys::fuzz_target;
 
 #[cfg(not(fuzzing))]
 fn main() {}
 
 fn do_test(data: &[u8]) {
-    let tx_result: Result<bitcoin::Transaction, _> = bitcoin::consensus::encode::deserialize(data);
+    let tx_result: Result<bitcoin::Transaction, _> = decode_from_slice(data);
 
     match tx_result {
         Err(_) => {}
         Ok(tx) => {
-            let ser = bitcoin::consensus::encode::serialize(&tx);
+            let ser = encode_to_vec(&tx);
             assert_eq!(&ser[..], data);
         }
     }

--- a/fuzz/fuzz_targets/bitcoin/deserialize_witness.rs
+++ b/fuzz/fuzz_targets/bitcoin/deserialize_witness.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(fuzzing, no_main)]
 #![cfg_attr(not(fuzzing), allow(unused))]
 
+use bitcoin::encoding::{decode_from_slice, encode_to_vec};
 use bitcoin::witness::Witness;
 use libfuzzer_sys::fuzz_target;
 
@@ -8,12 +9,12 @@ use libfuzzer_sys::fuzz_target;
 fn main() {}
 
 fn do_test(data: &[u8]) {
-    let witness_result: Result<Witness, _> = bitcoin::consensus::encode::deserialize(data);
+    let witness_result: Result<Witness, _> = decode_from_slice(data);
 
     match witness_result {
         Err(_) => {}
         Ok(witness) => {
-            let ser = bitcoin::consensus::encode::serialize(&witness);
+            let ser = encode_to_vec(&witness);
             assert_eq!(&ser[..], data);
         }
     }

--- a/fuzz/fuzz_targets/bitcoin/parse_outpoint.rs
+++ b/fuzz/fuzz_targets/bitcoin/parse_outpoint.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(fuzzing, no_main)]
 #![cfg_attr(not(fuzzing), allow(unused))]
 
-use bitcoin::consensus::encode;
+use bitcoin::encoding;
 use bitcoin::transaction::OutPoint;
 use libfuzzer_sys::fuzz_target;
 
@@ -31,9 +31,9 @@ fn do_test(data: &[u8]) {
         }
         Err(_) => {
             // If we can't deserialize as a string, try consensus deserializing
-            let res: Result<OutPoint, _> = encode::deserialize(data);
+            let res: Result<OutPoint, _> = encoding::decode_from_slice(data);
             if let Ok(deser) = res {
-                let ser = encode::serialize(&deser);
+                let ser = encoding::encode_to_vec(&deser);
                 assert_eq!(ser, data);
                 let string = deser.to_string();
                 match string.parse::<OutPoint>() {


### PR DESCRIPTION
Throughout the bitcoin code, there are various uses of the old encoding traits used to implement functionality. With the introduction of the new encoding and decoding implementations, all of these can be replaced with the new implementations to remove the dependency on bitcoin.

- Patch 1 replaces consensus use in the bitcoin code.
- Patch 2 replaces consensus use in the bitcoin tests.
- Patch 3 replaces con_serde use in the bip_341_sighash_tests test in sighash.
- Patch 4 replaces consensus use in examples.
- Patch 5 replaces consensus use in fuzz targets.