### PR TITLE
taproot-primitives: Remove crypto dependency

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -236,7 +236,6 @@ name = "bitcoin-taproot-primitives"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "bitcoin-crypto",
  "bitcoin-internals 0.5.0",
  "bitcoin_hashes 0.20.0",
  "secp256k1 0.32.0-beta.2",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -229,7 +229,6 @@ name = "bitcoin-taproot-primitives"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "bitcoin-crypto",
  "bitcoin-internals 0.5.0",
  "bitcoin_hashes 0.20.0",
  "secp256k1 0.32.0-beta.2",

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -12,7 +12,7 @@ use crate::internal_macros::define_extension_trait;
 use crate::script::{self, PushBytes, WitnessScriptBuf};
 #[cfg(feature = "secp-recovery")]
 use crate::sign_message::MessageSignature;
-use crate::taproot::{TapNodeHash, TapTweakHash};
+use crate::taproot::{TapNodeHash, TapTweakHash, TapTweakHashExt as _};
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 pub use secp256k1::{constants, Parity, Verification};

--- a/bitcoin/src/taproot/mod.rs
+++ b/bitcoin/src/taproot/mod.rs
@@ -99,10 +99,35 @@ crate::internal_macros::define_extension_trait! {
     }
 }
 
+crate::internal_macros::define_extension_trait! {
+    /// Extension functionality for the [`TapTweakHash`] type.
+    pub trait TapTweakHashExt impl for TapTweakHash {
+        /// Constructs a new BIP-0341 [`TapTweakHash`] from key and Merkle root. Produces `H_taptweak(P||R)` where
+        /// `P` is the internal key and `R` is the Merkle root.
+        fn from_key_and_merkle_root<K: Into<UntweakedPublicKey>>(
+            internal_key: K,
+            merkle_root: Option<TapNodeHash>,
+        ) -> Self {
+            let internal_key = internal_key.into();
+            let mut eng = sha256t::Hash::<TapTweakTag>::engine();
+            // always hash the key
+            eng.input(&internal_key.serialize().0);
+            if let Some(h) = merkle_root {
+                eng.input(h.as_ref());
+            } else {
+                // nothing to hash
+            }
+            let inner = sha256t::Hash::<TapTweakTag>::from_engine(eng);
+            Self::from_byte_array(inner.to_byte_array())
+        }
+    }
+}
+
 mod sealed {
     pub trait Sealed {}
     impl Sealed for super::TapLeafHash {}
     impl Sealed for super::TapNodeHash {}
+    impl Sealed for super::TapTweakHash {}
 }
 
 /// Computes branch hash given two hashes of the nodes underneath it and returns

--- a/taproot-primitives/Cargo.toml
+++ b/taproot-primitives/Cargo.toml
@@ -14,14 +14,13 @@ exclude = ["tests", "contrib"]
 
 [features]
 default = ["std", "hex"]
-std = ["alloc", "crypto/std", "hashes/std", "internals/std", "serde?/std", "secp256k1/std"]
-alloc = ["crypto/alloc", "hashes/alloc", "internals/alloc", "secp256k1/alloc"]
-serde = ["dep:serde", "crypto/serde", "hashes/serde", "internals/serde", "secp256k1/serde"]
-arbitrary = ["crypto/arbitrary", "dep:arbitrary", "secp256k1/arbitrary"]
+std = ["alloc", "hashes/std", "internals/std", "serde?/std", "secp256k1/std"]
+alloc = ["hashes/alloc", "internals/alloc", "secp256k1/alloc"]
+serde = ["dep:serde", "hashes/serde", "internals/serde", "secp256k1/serde"]
+arbitrary = ["dep:arbitrary", "secp256k1/arbitrary"]
 hex = ["hashes/hex"]
 
 [dependencies]
-crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.2.0", default-features = false }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.20.0", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
 

--- a/taproot-primitives/src/lib.rs
+++ b/taproot-primitives/src/lib.rs
@@ -36,10 +36,6 @@ use core::fmt;
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
-#[cfg(feature = "alloc")]
-use crypto::key::UntweakedPublicKey;
-#[cfg(feature = "alloc")]
-use hashes::HashEngine;
 use hashes::{hash_newtype, sha256t, sha256t_tag};
 use secp256k1::Scalar;
 
@@ -122,26 +118,6 @@ impl From<TapLeafHash> for TapNodeHash {
 }
 
 impl TapTweakHash {
-    /// Constructs a new BIP-0341 [`TapTweakHash`] from key and Merkle root. Produces `H_taptweak(P||R)` where
-    /// `P` is the internal key and `R` is the Merkle root.
-    #[cfg(feature = "alloc")]
-    pub fn from_key_and_merkle_root<K: Into<UntweakedPublicKey>>(
-        internal_key: K,
-        merkle_root: Option<TapNodeHash>,
-    ) -> Self {
-        let internal_key = internal_key.into();
-        let mut eng = sha256t::Hash::<TapTweakTag>::engine();
-        // always hash the key
-        eng.input(&internal_key.serialize().0);
-        if let Some(h) = merkle_root {
-            eng.input(h.as_ref());
-        } else {
-            // nothing to hash
-        }
-        let inner = sha256t::Hash::<TapTweakTag>::from_engine(eng);
-        Self::from_byte_array(inner.to_byte_array())
-    }
-
     /// Converts a `TapTweakHash` into a `Scalar` ready for use with key tweaking API.
     #[allow(clippy::missing_panics_doc)]
     pub fn to_scalar(self) -> Scalar {


### PR DESCRIPTION
The from_key_and_merkle_root method on the TapTweakHash type is the only part of the taproot-primitives crate that causes a dependency on the crypto crate. By moving this back to bitcoin, we can remove the dependency on crypto, which allows these types to stabilise in primitives without waiting on crypto to stabilise.

 - Patch 1 removes from_key_and_merkle_root from TapTweakHash, moving it back to bitcoin in an extension trait.
 - Patch 2 drops the crypto dependency for taproot-primitives.
