### PR TITLE
Introduce signing functions on sighash types

### DIFF
--- a/bitcoin/examples/sign-tx-segwit-v0.rs
+++ b/bitcoin/examples/sign-tx-segwit-v0.rs
@@ -7,8 +7,8 @@ use bitcoin::key::WPubkeyHash;
 use bitcoin::locktime::absolute;
 use bitcoin::sighash::{EcdsaSighashType, SighashCache};
 use bitcoin::{
-    ecdsa, transaction, Address, Amount, Network, OutPoint, PrivateKey, ScriptPubKeyBuf,
-    ScriptSigBuf, Sequence, Transaction, TxIn, TxOut, Txid, Witness,
+    transaction, Address, Amount, Network, OutPoint, PrivateKey, ScriptPubKeyBuf, ScriptSigBuf,
+    Sequence, Transaction, TxIn, TxOut, Txid, Witness,
 };
 
 const DUMMY_UTXO_AMOUNT: Amount = Amount::from_sat_u32(20_000_000);
@@ -66,7 +66,7 @@ fn main() {
         .expect("failed to create sighash");
 
     // Sign the sighash using the private key.
-    let signature = ecdsa::Signature { signature: sk.raw_ecdsa_sign(sighash), sighash_type };
+    let signature = sighash.sign(&sk, sighash_type);
 
     // Update the witness stack.
     let pk = sk.to_public_key();

--- a/bitcoin/examples/sign-tx-taproot.rs
+++ b/bitcoin/examples/sign-tx-taproot.rs
@@ -64,12 +64,9 @@ fn main() {
         .taproot_key_spend_signature_hash(input_index, &prevouts, sighash_type)
         .expect("failed to construct sighash");
 
-    // Sign the sighash using the secp256k1 library (exported by rust-bitcoin).
+    // Sign the sighash and update the witness stack.
     let tweaked: TweakedKeypair = keypair.tap_tweak(None);
-    let signature = tweaked.as_keypair().raw_bip340_sign(&sighash.to_byte_array());
-
-    // Update the witness stack.
-    let signature = bitcoin::taproot::Signature { signature, sighash_type };
+    let signature = sighash.sign_key_spend(&tweaked, sighash_type);
     *sighasher.witness_mut(input_index).unwrap() = Witness::p2tr_key_spend(&signature);
 
     // Get the signed transaction.

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -118,7 +118,7 @@ pub trait TapTweak {
     /// # Returns
     ///
     /// The tweaked key, with the required parity.
-    fn tap_tweak(self, merkle_root: Option<TapNodeHash>) -> Self::TweakedAux;
+    fn tap_tweak(&self, merkle_root: Option<TapNodeHash>) -> Self::TweakedAux;
 
     /// Directly converts an [`UntweakedPublicKey`] to a [`TweakedPublicKey`].
     ///
@@ -144,8 +144,8 @@ impl TapTweak for UntweakedPublicKey {
     /// # Returns
     ///
     /// The tweaked key and its parity.
-    fn tap_tweak(self, merkle_root: Option<TapNodeHash>) -> TweakedPublicKey {
-        let tweak = TapTweakHash::from_key_and_merkle_root(self, merkle_root).to_scalar();
+    fn tap_tweak(&self, merkle_root: Option<TapNodeHash>) -> TweakedPublicKey {
+        let tweak = TapTweakHash::from_key_and_merkle_root(*self, merkle_root).to_scalar();
         let output_key = self.add_tweak(&tweak).expect("Tap tweak failed");
 
         debug_assert!(self.tweak_add_check(&output_key, tweak));
@@ -171,8 +171,8 @@ impl TapTweak for UntweakedKeypair {
     /// # Returns
     ///
     /// The tweaked keypair.
-    fn tap_tweak(self, merkle_root: Option<TapNodeHash>) -> TweakedKeypair {
-        let pubkey = XOnlyPublicKey::from_keypair(&self);
+    fn tap_tweak(&self, merkle_root: Option<TapNodeHash>) -> TweakedKeypair {
+        let pubkey = XOnlyPublicKey::from_keypair(self);
         let tweak = TapTweakHash::from_key_and_merkle_root(pubkey, merkle_root).to_scalar();
         let tweaked = self.as_inner().add_xonly_tweak(&tweak).expect("Tap tweak failed");
         TweakedKeypair::dangerous_assume_tweaked(Self::from(tweaked))

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -16,6 +16,8 @@ use core::str;
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
+use crypto::key::{TweakedKeypair, UntweakedKeypair};
+use crypto::{ecdsa, taproot, PrivateKey};
 use hashes::{hash_newtype, sha256, sha256d, sha256t, sha256t_tag};
 use io::Write;
 
@@ -81,10 +83,24 @@ impl_message_from_hash!(SegwitV0Sighash);
 impl LegacySighash {
     fn engine() -> sha256d::HashEngine { sha256d::Hash::engine() }
     fn from_engine(e: sha256d::HashEngine) -> Self { Self(sha256d::Hash::from_engine(e)) }
+
+    /// Signs this sighash using `pk`.
+    ///
+    /// `sighash_type` must be the same as that used to create the sighash.
+    pub fn sign(&self, pk: &PrivateKey, sighash_type: EcdsaSighashType) -> ecdsa::Signature {
+        ecdsa::Signature { signature: pk.raw_ecdsa_sign(*self), sighash_type }
+    }
 }
 impl SegwitV0Sighash {
     fn engine() -> sha256d::HashEngine { sha256d::Hash::engine() }
     fn from_engine(e: sha256d::HashEngine) -> Self { Self(sha256d::Hash::from_engine(e)) }
+
+    /// Signs this sighash using `pk`.
+    ///
+    /// `sighash_type` must be the same as that used to create the sighash.
+    pub fn sign(&self, pk: &PrivateKey, sighash_type: EcdsaSighashType) -> ecdsa::Signature {
+        ecdsa::Signature { signature: pk.raw_ecdsa_sign(*self), sighash_type }
+    }
 }
 
 sha256t_tag! {
@@ -101,6 +117,38 @@ hash_newtype! {
 hashes::impl_hex_for_newtype!(TapSighash);
 #[cfg(feature = "serde")]
 hashes::impl_serde_for_newtype!(TapSighash);
+
+impl TapSighash {
+    /// Signs the sighash for a P2TR key-path spending transaction with the
+    /// [`TweakedKeypair`] and creates a Taproot signature as defined in [BIP-340].
+    ///
+    /// For P2TR script-path spend use [`TapSighash::sign_script_spend`].
+    ///
+    /// [BIP-340]: https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki
+    pub fn sign_key_spend(
+        &self,
+        keypair: &TweakedKeypair,
+        sighash_type: TapSighashType,
+    ) -> taproot::Signature {
+        let signature = keypair.as_keypair().raw_bip340_sign(self.as_ref());
+        taproot::Signature { signature, sighash_type }
+    }
+
+    /// Signs the sighash with an [`UntweakedKeypair`] without applying a tweak and creates a
+    /// taproot signature as defined in [BIP-340].
+    ///
+    /// For P2TR key spend use [`TapSighash::sign_key_spend`].
+    ///
+    /// [BIP-340]: https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki
+    pub fn sign_script_spend(
+        &self,
+        keypair: &UntweakedKeypair,
+        sighash_type: TapSighashType,
+    ) -> taproot::Signature {
+        let signature = keypair.raw_bip340_sign(self.as_ref());
+        taproot::Signature { signature, sighash_type }
+    }
+}
 
 /// Efficiently calculates signature hash message for legacy, SegWit and Taproot inputs.
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Although the private key types have raw signing functions on them that allow users to bypass secp, they still present a rough interface for signing compared to directly signing on the sighash types that result from the SighashCache. For the TapSighash, this requires a change to the TapTweak trait.

Introduce signing functions on LegacySighash, SegwitV0Sighash and TapSighash.