### PR TITLE
Suppress ci output

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,9 @@ name: Continuous integration
 
 permissions: {}
 
+env:
+  RBMT_LOG_LEVEL: "progress"
+
 jobs:
   Test:
     name: Test - ${{ matrix.toolchain }} toolchain, ${{ matrix.dep }} deps


### PR DESCRIPTION
Closes #6075

I opted to use "progress" instead of "quiet" as it is still a substantial reduction in verbosity but still gives the ability to watch the CI in cases where a dev is probing the CI for some reason.

The rbmt pinned version is that of its latest release https://github.com/rust-bitcoin/rust-bitcoin-maintainer-tools/releases/tag/cargo-rbmt-0.2.1. A way to pin to release versions moving forward will come in a followup PR