### PR TITLE
Release Tracking PR: The whole stack up to `bitcoin 0.32.10`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.9"
+version = "0.32.10"
 dependencies = [
  "arbitrary",
  "base58ck",

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "bitcoin-io",
  "hex-conservative",

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -90,7 +90,7 @@ version = "0.1.4"
 
 [[package]]
 name = "bitcoin-units"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "arbitrary",
  "serde",

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -22,7 +22,7 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "base58ck"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bitcoin_hashes",
  "hex-conservative",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.9"
+version = "0.32.10"
 dependencies = [
  "arbitrary",
  "base58ck",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -99,7 +99,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "bitcoin-io",
  "hex-conservative",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -22,7 +22,7 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "base58ck"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bitcoin_hashes",
  "hex-conservative",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -89,7 +89,7 @@ version = "0.1.4"
 
 [[package]]
 name = "bitcoin-units"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "arbitrary",
  "serde",

--- a/base58/CHANGELOG.md
+++ b/base58/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.1 - 2026-05-23
+
+- Remove the `internals` dependency [#6200](https://github.com/rust-bitcoin/rust-bitcoin/pull/6200)
+
 # 0.1.0 - 2024-03-14
 
 Initial release of the `base58ck` crate. This crate was cut out of

--- a/base58/Cargo.toml
+++ b/base58/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base58ck"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"

--- a/bitcoin/CHANGELOG.md
+++ b/bitcoin/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.32.10 - 2026-04-23
+
+
+- Fix bug in `LeafVerison::Future`'s `Display` output [#6208](https://github.com/rust-bitcoin/rust-bitcoin/pull/6208)
+- Manually revert `VarInt` range check [#6182](https://github.com/rust-bitcoin/rust-bitcoin/pull/6182)
+- Backport - p2p: Add a hash value to `Inventory`'s `Error` variant [#6147](https://github.com/rust-bitcoin/rust-bitcoin/pull/6147)
+- Backport - p2p: Error on `RawNetworkMessage` decode if payload partly consumed [#6140](https://github.com/rust-bitcoin/rust-bitcoin/pull/6140)
+- Backport - p2p: Error on invalid `FeeRate` in `FeeFilter` decode [#6142](https://github.com/rust-bitcoin/rust-bitcoin/pull/6142)
+- Backport - Validate ASCII and preserve embedded nulls in `CommandString` parsing [#6136](https://github.com/rust-bitcoin/rust-bitcoin/pull/6136)
+- Remove the `internals` dependency [#6200](https://github.com/rust-bitcoin/rust-bitcoin/pull/6200)
+
 # 0.32.9 - 2025-03-26
 
 - Backport - Fix `Unknown` `NetworkMessage` encoding [#6106](https://github.com/rust-bitcoin/rust-bitcoin/pull/6106)

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin"
-version = "0.32.9"
+version = "0.32.10"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"

--- a/hashes/CHANGELOG.md
+++ b/hashes/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.14.2 - 2026-05-23
+
+* Enable `alloc` feature from `schemars` feature and fix feature gating.
+* Remove the `internals` dependency [#6200](https://github.com/rust-bitcoin/rust-bitcoin/pull/6200)
+
 # 0.14.1 - 2025-12-03
 
 * remove `doc_auto_cfg`

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin_hashes"
-version = "0.14.1"
+version = "0.14.2"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin"

--- a/io/CHANGELOG.md
+++ b/io/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.5 - 2026-05-26
+
+* Trivial docs fix.
+
 # 0.1.4 - 2025-10-30
 
 * Remove `doc_auto_cfg`

--- a/units/CHANGELOG.md
+++ b/units/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.4 - 2026-05-23
+
+* Remove the `internals` dependency [#6200](https://github.com/rust-bitcoin/rust-bitcoin/pull/6200)
+
 # 0.1.3 - 2026-04-19
 
 * Backport `Arbitrary` to `0.32.x` [#5085](https://github.com/rust-bitcoin/rust-bitcoin/pull/5085)

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-units"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"


### PR DESCRIPTION
Includes releases of `io`,  `hashes`, `base58`, `units`, and `bitcoin`.

Before we do #6126 lets do this one so we have a clean slate. 

After #6126 we will be maintaining two separate `0.32` series of releases (each with different MSRV). To assist manitenance lets make them as close to the same as possible (hence the formatting, open to any other ideas also?).
