### PR TITLE
Use check_encode in consensus comparison fuzz target

### DIFF
--- a/fuzz/fuzz_targets/bitcoin/compare_consensus_encoding.rs
+++ b/fuzz/fuzz_targets/bitcoin/compare_consensus_encoding.rs
@@ -6,7 +6,7 @@
 //! This fuzz target compares the consensus encoding produced by `bitcoin_consensus_encoding::encode_to_vec`
 //! in master branch with `bitcoin::consensus::encode::serialize` from bitcoin 0.32 for all shared types.
 
-use bitcoin_consensus_encoding::{decode_from_slice, encode_to_vec, Decoder};
+use bitcoin_consensus_encoding::{check_encode, decode_from_slice, Decoder};
 use libfuzzer_sys::fuzz_target;
 
 #[cfg(not(fuzzing))]
@@ -82,10 +82,13 @@ macro_rules! compare_encoding {
 
         match (old_result, new_result) {
             (Ok(old_obj), Ok(new_obj)) => {
-                // Encode with both the old and consensus_encoding implementations
+                // Encode with old bitcoin and then compare against new encoding
                 let old_encoded = old_bitcoin::consensus::encode::serialize(&old_obj);
-                let new_encoded = encode_to_vec(&new_obj);
-                assert_eq!(old_encoded, new_encoded);
+                // Uncomment the following two lines if you need to see the difference
+                // in serialisation.
+                // let new_encoded = bitcoin_consensus_encoding::encode_to_vec(&new_obj);
+                // assert_eq!(old_encoded, new_encoded);
+                check_encode(&new_obj, &old_encoded);
             }
             (Ok(old_obj), Err(ref err)) =>
                 if !is_known_decoder_divergence(err) {


### PR DESCRIPTION
The consensus encoding comparison fuzz target compares old encodings to new encodings between master and bitcoin 0.32. Presently, it does so by allocating a vector for the old serialisation and the new. The new check_encode function in consensus_encoding can instead be used to eliminate a Vec allocation and directly compare the encoder output of the new encoding against the encoded vector of the old encoding.

Replace encode_to_vec and assert_eq! call with use of the check_encode function.