### PR TITLE
fuzz: Remove allocations in roundtrip targets

### DIFF
--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -1,8 +1,9 @@
 //! Shared utilities for fuzz targets.
 
 use std::fmt;
+use std::ops::Deref;
 
-use bitcoin_consensus_encoding::{decode_from_slice, encode_to_vec, Decode, Decoder, Encode};
+use bitcoin_consensus_encoding::{decode_from_slice, Decode, Decoder, Encode, Encoder};
 
 /// Checks roundtrip decode -> encode for a type.
 ///
@@ -14,8 +15,7 @@ where
     <<T as Decode>::Decoder as Decoder>::Error: fmt::Debug,
 {
     if let Ok(base_decoded) = decode_from_slice::<T>(data) {
-        let encoded = encode_to_vec(&base_decoded);
-        let decoded = decode_from_slice::<T>(&encoded).unwrap();
+        let decoded = stream_encode_decode::<_, T>(&base_decoded);
         assert_eq!(base_decoded, decoded);
     }
 }
@@ -26,13 +26,31 @@ where
 /// unsized counterpart (e.g. `ScriptPubKey`), so encoding must go through the deref.
 pub fn check_script_roundtrip<T>(data: &[u8])
 where
-    T: Decode + PartialEq + fmt::Debug + std::ops::Deref,
-    <T as std::ops::Deref>::Target: Encode,
+    T: Decode + PartialEq + fmt::Debug + Deref,
+    <T as Deref>::Target: Encode,
     <<T as Decode>::Decoder as Decoder>::Error: fmt::Debug,
 {
     if let Ok(base_decoded) = decode_from_slice::<T>(data) {
-        let encoded = encode_to_vec(&*base_decoded);
-        let decoded = decode_from_slice::<T>(&encoded).unwrap();
+        let decoded = stream_encode_decode::<<T as Deref>::Target, T>(&*base_decoded);
         assert_eq!(base_decoded, decoded);
     }
+}
+
+#[inline]
+fn stream_encode_decode<E, D>(encodable: &E) -> D
+where
+    E: Encode + ?Sized,
+    D: Decode,
+    <<D as Decode>::Decoder as Decoder>::Error: fmt::Debug,
+{
+    let mut encoder = encodable.encoder();
+    let mut decoder = D::decoder();
+    loop {
+        let mut chunk = encoder.current_chunk();
+        while !chunk.is_empty() && decoder.push_bytes(&mut chunk).unwrap() {}
+        if !chunk.is_empty() || !encoder.advance() {
+            break;
+        }
+    }
+    decoder.end().unwrap()
 }


### PR DESCRIPTION
The roundtrip fuzz targets rely on functions in lib.rs that decode, encode and decode again. In this process, a Vec allocation is made as an intermediate step to hold the encoded object. Since the encoded data is ignored, this allocation can instead be replaced by a direct push of the encoder chunks into the decoder.

Replace Vec allocation with direct writes from encoder to decoder in roundtrip fuzz targets.