### PR TITLE
0.32.x: Add `consensus_encoding` to types present in units 1.0

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -19,7 +19,7 @@ name = "base58ck"
 version = "0.1.100"
 dependencies = [
  "bitcoin_hashes 0.14.100 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex-conservative",
+ "hex-conservative 0.2.2",
 ]
 
 [[package]]
@@ -62,17 +62,27 @@ dependencies = [
  "base64",
  "bech32",
  "bincode",
+ "bitcoin-consensus-encoding",
  "bitcoin-io 0.1.100 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitcoin-units 0.1.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin-units",
  "bitcoin_hashes 0.14.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoinconsensus",
- "hex-conservative",
+ "hex-conservative 0.2.2",
  "hex_lit",
  "ordered",
  "secp256k1",
  "serde",
  "serde_json",
  "serde_test",
+]
+
+[[package]]
+name = "bitcoin-consensus-encoding"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2d6094e2a1ba3c93b5a596fe5a10d1a10c3c6e06785cde89f693a044c01aa40"
+dependencies = [
+ "bitcoin-internals",
 ]
 
 [[package]]
@@ -84,6 +94,15 @@ dependencies = [
  "serde",
  "serde_cbor",
  "serde_json",
+]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a30a22d1f112dde8e16be7b45c63645dc165cef254f835b3e1e9553e485cfa64"
+dependencies = [
+ "hex-conservative 0.3.0",
 ]
 
 [[package]]
@@ -107,19 +126,10 @@ name = "bitcoin-units"
 version = "0.1.100"
 dependencies = [
  "arbitrary",
+ "bitcoin-consensus-encoding",
  "serde",
  "serde_json",
  "serde_test",
-]
-
-[[package]]
-name = "bitcoin-units"
-version = "0.1.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bad157b78d0d1b22c4cbb6a35a566211fc4d14866a37f2c780652b50f3b845"
-dependencies = [
- "arbitrary",
- "serde",
 ]
 
 [[package]]
@@ -136,7 +146,7 @@ name = "bitcoin_hashes"
 version = "0.14.100"
 dependencies = [
  "bitcoin-io 0.1.100 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex-conservative",
+ "hex-conservative 0.2.2",
  "schemars",
  "serde",
  "serde_json",
@@ -150,7 +160,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9901a56e133a1fc86eeb1113e2591f45f4682451ca893bff494d2f88918e3f"
 dependencies = [
  "bitcoin-io 0.1.100 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex-conservative",
+ "hex-conservative 0.2.2",
  "serde",
 ]
 
@@ -209,6 +219,15 @@ name = "hex-conservative"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "hex-conservative"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4afe881d0527571892c4034822e59bb10c6c991cce6abe8199b6f5cf10766f55"
 dependencies = [
  "arrayvec",
 ]

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -16,20 +16,19 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "base58ck"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
+version = "0.1.100"
 dependencies = [
- "bitcoin-internals",
- "bitcoin_hashes 0.14.0",
+ "bitcoin_hashes 0.14.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex-conservative",
 ]
 
 [[package]]
 name = "base58ck"
 version = "0.1.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec5dc7e09f7bb15f0062da7c03086d6b71a2c84e0af4fccbbc7d8c6559847816"
 dependencies = [
- "bitcoin_hashes 0.14.0",
- "hex-conservative",
+ "bitcoin_hashes 0.14.100 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -59,13 +58,13 @@ name = "bitcoin"
 version = "0.32.100"
 dependencies = [
  "arbitrary",
- "base58ck 0.1.0",
+ "base58ck 0.1.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64",
  "bech32",
  "bincode",
- "bitcoin-io 0.1.1",
- "bitcoin-units 0.1.3",
- "bitcoin_hashes 0.14.0",
+ "bitcoin-io 0.1.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin-units 0.1.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin_hashes 0.14.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoinconsensus",
  "hex-conservative",
  "hex_lit",
@@ -88,20 +87,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitcoin-internals"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
-
-[[package]]
 name = "bitcoin-io"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17e5b76b88667412087beea1882980ad843b660490bbf6cce0a6cfc999c5b989"
+version = "0.1.100"
 
 [[package]]
 name = "bitcoin-io"
 version = "0.1.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11301df0b06f22dea7bb1916403fdd88a371031e495c49b8f96931b28189e175"
 
 [[package]]
 name = "bitcoin-private"
@@ -111,23 +104,22 @@ checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
 
 [[package]]
 name = "bitcoin-units"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346568ebaab2918487cea76dd55dae13c27bb618cdb737c952e69eb2017c4118"
-dependencies = [
- "arbitrary",
- "bitcoin-internals",
- "serde",
-]
-
-[[package]]
-name = "bitcoin-units"
 version = "0.1.100"
 dependencies = [
  "arbitrary",
  "serde",
  "serde_json",
  "serde_test",
+]
+
+[[package]]
+name = "bitcoin-units"
+version = "0.1.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57bad157b78d0d1b22c4cbb6a35a566211fc4d14866a37f2c780652b50f3b845"
+dependencies = [
+ "arbitrary",
+ "serde",
 ]
 
 [[package]]
@@ -141,25 +133,25 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
-dependencies = [
- "bitcoin-io 0.1.1",
- "hex-conservative",
- "serde",
-]
-
-[[package]]
-name = "bitcoin_hashes"
 version = "0.14.100"
 dependencies = [
- "bitcoin-io 0.1.1",
+ "bitcoin-io 0.1.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-conservative",
  "schemars",
  "serde",
  "serde_json",
  "serde_test",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9901a56e133a1fc86eeb1113e2591f45f4682451ca893bff494d2f88918e3f"
+dependencies = [
+ "bitcoin-io 0.1.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex-conservative",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -19,7 +19,7 @@ name = "base58ck"
 version = "0.1.100"
 dependencies = [
  "bitcoin_hashes 0.14.100 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex-conservative",
+ "hex-conservative 0.2.2",
 ]
 
 [[package]]
@@ -61,17 +61,27 @@ dependencies = [
  "base64",
  "bech32",
  "bincode",
+ "bitcoin-consensus-encoding",
  "bitcoin-io 0.1.100 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitcoin-units 0.1.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin-units",
  "bitcoin_hashes 0.14.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoinconsensus",
- "hex-conservative",
+ "hex-conservative 0.2.2",
  "hex_lit",
  "ordered",
  "secp256k1",
  "serde",
  "serde_json",
  "serde_test",
+]
+
+[[package]]
+name = "bitcoin-consensus-encoding"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2d6094e2a1ba3c93b5a596fe5a10d1a10c3c6e06785cde89f693a044c01aa40"
+dependencies = [
+ "bitcoin-internals",
 ]
 
 [[package]]
@@ -83,6 +93,15 @@ dependencies = [
  "serde",
  "serde_cbor",
  "serde_json",
+]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a30a22d1f112dde8e16be7b45c63645dc165cef254f835b3e1e9553e485cfa64"
+dependencies = [
+ "hex-conservative 0.3.2",
 ]
 
 [[package]]
@@ -100,19 +119,10 @@ name = "bitcoin-units"
 version = "0.1.100"
 dependencies = [
  "arbitrary",
+ "bitcoin-consensus-encoding",
  "serde",
  "serde_json",
  "serde_test",
-]
-
-[[package]]
-name = "bitcoin-units"
-version = "0.1.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bad157b78d0d1b22c4cbb6a35a566211fc4d14866a37f2c780652b50f3b845"
-dependencies = [
- "arbitrary",
- "serde",
 ]
 
 [[package]]
@@ -120,7 +130,7 @@ name = "bitcoin_hashes"
 version = "0.14.100"
 dependencies = [
  "bitcoin-io 0.1.100 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex-conservative",
+ "hex-conservative 0.2.2",
  "schemars",
  "serde",
  "serde_json",
@@ -134,7 +144,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9901a56e133a1fc86eeb1113e2591f45f4682451ca893bff494d2f88918e3f"
 dependencies = [
  "bitcoin-io 0.1.100 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex-conservative",
+ "hex-conservative 0.2.2",
  "serde",
 ]
 
@@ -203,6 +213,15 @@ name = "hex-conservative"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "hex-conservative"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830e599c2904b08f0834ee6337d8fe8f0ed4a63b5d9e7a7f49c0ffa06d08d360"
 dependencies = [
  "arrayvec",
 ]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -4,45 +4,44 @@ version = 3
 
 [[package]]
 name = "arbitrary"
-version = "1.0.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "237430fd6ed3740afe94eefcc278ae21e050285be882804e0d6e8695f0c94691"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
-
-[[package]]
-name = "base58ck"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
-dependencies = [
- "bitcoin-internals",
- "bitcoin_hashes 0.14.1",
-]
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "base58ck"
 version = "0.1.100"
 dependencies = [
- "bitcoin_hashes 0.14.1",
+ "bitcoin_hashes 0.14.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-conservative",
 ]
 
 [[package]]
-name = "base64"
-version = "0.21.3"
+name = "base58ck"
+version = "0.1.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414dcefbc63d77c526a76b3afcf6fbb9b5e2791c19c3aa2297733208750c6e53"
+checksum = "ec5dc7e09f7bb15f0062da7c03086d6b71a2c84e0af4fccbbc7d8c6559847816"
+dependencies = [
+ "bitcoin_hashes 0.14.100 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "bech32"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
+checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 
 [[package]]
 name = "bincode"
@@ -58,13 +57,13 @@ name = "bitcoin"
 version = "0.32.100"
 dependencies = [
  "arbitrary",
- "base58ck 0.1.0",
+ "base58ck 0.1.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64",
  "bech32",
  "bincode",
- "bitcoin-io 0.1.4",
- "bitcoin-units 0.1.3",
- "bitcoin_hashes 0.14.1",
+ "bitcoin-io 0.1.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin-units 0.1.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin_hashes 0.14.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoinconsensus",
  "hex-conservative",
  "hex_lit",
@@ -87,31 +86,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitcoin-internals"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
-
-[[package]]
-name = "bitcoin-io"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
-
-[[package]]
 name = "bitcoin-io"
 version = "0.1.100"
 
 [[package]]
-name = "bitcoin-units"
-version = "0.1.3"
+name = "bitcoin-io"
+version = "0.1.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346568ebaab2918487cea76dd55dae13c27bb618cdb737c952e69eb2017c4118"
-dependencies = [
- "arbitrary",
- "bitcoin-internals",
- "serde",
-]
+checksum = "11301df0b06f22dea7bb1916403fdd88a371031e495c49b8f96931b28189e175"
 
 [[package]]
 name = "bitcoin-units"
@@ -124,13 +106,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitcoin_hashes"
-version = "0.14.1"
+name = "bitcoin-units"
+version = "0.1.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
+checksum = "57bad157b78d0d1b22c4cbb6a35a566211fc4d14866a37f2c780652b50f3b845"
 dependencies = [
- "bitcoin-io 0.1.4",
- "hex-conservative",
+ "arbitrary",
  "serde",
 ]
 
@@ -138,12 +119,23 @@ dependencies = [
 name = "bitcoin_hashes"
 version = "0.14.100"
 dependencies = [
- "bitcoin-io 0.1.4",
+ "bitcoin-io 0.1.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-conservative",
  "schemars",
  "serde",
  "serde_json",
  "serde_test",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9901a56e133a1fc86eeb1113e2591f45f4682451ca893bff494d2f88918e3f"
+dependencies = [
+ "bitcoin-io 0.1.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex-conservative",
+ "serde",
 ]
 
 [[package]]
@@ -157,33 +149,43 @@ dependencies = [
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.11"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "getrandom"
-version = "0.2.9"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
@@ -192,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "1.7.1"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
+checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
 
 [[package]]
 name = "hex-conservative"
@@ -213,38 +215,45 @@ checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
 
 [[package]]
 name = "honggfuzz"
-version = "0.5.55"
+version = "0.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "848e9c511092e0daa0a35a63e8e6e475a3e8f870741448b9f6028d69b142f18e"
+checksum = "4d6510a410acedd7a7683b3a45dafdc5ccf3c72d6addaa373497005964fc4e23"
 dependencies = [
  "lazy_static",
  "memmap2",
  "rustc_version",
+ "semver",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.142"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "memchr"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memmap2"
-version = "0.5.10"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
 ]
@@ -257,33 +266,36 @@ checksum = "7f0642533dea0bb58bd5cae31bafc1872429f0f12ac8c61fe2b4ba44f80b959b"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.63"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -311,24 +323,18 @@ dependencies = [
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
-
-[[package]]
 name = "schemars"
-version = "0.8.12"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c613288622e5f0c3fdc5dbd4db1c5fbe752746b1d1a56a0630b78fd00de44f"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "serde",
@@ -337,11 +343,11 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0cc0f1cf93f4969faf3ea1c7d8a9faed25918d96affa959720823dfe86d4f3"
+checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "bitcoin_hashes 0.14.1",
+ "bitcoin_hashes 0.14.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand",
  "secp256k1-sys",
  "serde",
@@ -349,25 +355,26 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1433bd67156263443f14d603720b082dd3121779323fce20cba2aa07b874bc1b"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "semver"
-version = "1.0.17"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.156"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "314b5b092c0ade17c00142951e50ced110ec27cea304b1037c6969246c2469a4"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -383,10 +390,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.156"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7e29c4601e36bcec74a223228dce795f4cd3616341a4af93520ca1a837c087d"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -395,29 +411,37 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.96"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
- "ryu",
+ "memchr",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
 name = "serde_test"
-version = "1.0.160"
+version = "1.0.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c95a500e3923258f7fc3a16bf29934e403aef5ca1096e184d85e3b1926675e8"
+checksum = "7f901ee573cab6b3060453d2d5f0bae4e6d628c23c0a962ff9b5f1d7c8d4f1ed"
 dependencies = [
  "serde",
 ]
 
 [[package]]
-name = "syn"
-version = "1.0.109"
+name = "shlex"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -426,12 +450,38 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/base58/Cargo.toml
+++ b/base58/Cargo.toml
@@ -24,7 +24,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-hashes = { package = "bitcoin_hashes", version = "0.14.0", default-features = false, features = ["alloc"] }
+hashes = { package = "bitcoin_hashes", version = "0.14.100", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 hex = { package = "hex-conservative", version = "0.2.2", default-features = false, features = ["alloc"] }

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -22,6 +22,7 @@ std = ["base58/std", "bech32/std", "hashes/std", "hex/std", "io/std", "secp256k1
 rand-std = ["secp256k1/rand-std", "std"]
 rand = ["secp256k1/rand"]
 serde = ["actual-serde", "hashes/serde", "secp256k1/serde", "units/serde"]
+encoding = ["dep:encoding", "units/encoding"]
 secp-lowmemory = ["secp256k1/lowmemory"]
 secp-recovery = ["secp256k1/recovery"]
 bitcoinconsensus-std = ["bitcoinconsensus/std", "std"]
@@ -39,9 +40,10 @@ hex = { package = "hex-conservative", version = "0.2.2", default-features = fals
 hex_lit = "0.1.1"
 io = { package = "bitcoin-io", version = "0.1.100", default-features = false, features = ["alloc"] }
 secp256k1 = { version = "0.29.0", default-features = false, features = ["hashes", "alloc"] }
-units = { package = "bitcoin-units", version = "0.1.100", default-features = false, features = ["alloc"] }
+units = { package = "bitcoin-units", path = "../units", version = "0.1.100", default-features = false, features = ["alloc"] }
 
 base64 = { version = "0.21.3", optional = true }
+encoding = { package = "bitcoin-consensus-encoding", version = "1.0", default-features = false, optional = true }
 ordered = { version = "0.2.0", optional = true }
 # Only use this feature for no-std builds, otherwise use bitcoinconsensus-std.
 bitcoinconsensus = { version = "0.105.0+25.1", default-features = false, optional = true }

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -32,14 +32,14 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-base58 = { package = "base58ck", version = "0.1.0", default-features = false }
+base58 = { package = "base58ck", version = "0.1.100", default-features = false }
 bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
-hashes = { package = "bitcoin_hashes", version = "0.14.0", default-features = false, features = ["alloc", "io"] }
+hashes = { package = "bitcoin_hashes", version = "0.14.100", default-features = false, features = ["alloc", "io"] }
 hex = { package = "hex-conservative", version = "0.2.2", default-features = false, features = ["alloc"] }
 hex_lit = "0.1.1"
-io = { package = "bitcoin-io", version = "0.1.1", default-features = false, features = ["alloc"] }
+io = { package = "bitcoin-io", version = "0.1.100", default-features = false, features = ["alloc"] }
 secp256k1 = { version = "0.29.0", default-features = false, features = ["hashes", "alloc"] }
-units = { package = "bitcoin-units", version = "0.1.3", default-features = false, features = ["alloc"] }
+units = { package = "bitcoin-units", version = "0.1.100", default-features = false, features = ["alloc"] }
 
 base64 = { version = "0.21.3", optional = true }
 ordered = { version = "0.2.0", optional = true }

--- a/bitcoin/api/all-features.txt
+++ b/bitcoin/api/all-features.txt
@@ -42,6 +42,11 @@ impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::locktime::abs
 pub fn bitcoin::blockdata::locktime::absolute::LockTime::consensus_decode<R: bitcoin_io::Read + ?core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
 impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::locktime::absolute::LockTime
 pub fn bitcoin::blockdata::locktime::absolute::LockTime::consensus_encode<W: bitcoin_io::Write + ?core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin::blockdata::locktime::absolute::LockTime
+pub type bitcoin::blockdata::locktime::absolute::LockTime::Decoder = bitcoin::blockdata::locktime::absolute::LockTimeDecoder
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin::blockdata::locktime::absolute::LockTime
+pub type bitcoin::blockdata::locktime::absolute::LockTime::Encoder<'e> = bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e>
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin::blockdata::locktime::absolute::LockTime
 pub fn bitcoin::blockdata::locktime::absolute::LockTime::clone(&self) -> bitcoin::blockdata::locktime::absolute::LockTime
 impl core::cmp::Eq for bitcoin::blockdata::locktime::absolute::LockTime
@@ -115,6 +120,149 @@ impl<T> serde_core::de::DeserializeOwned for bitcoin::blockdata::locktime::absol
 impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::locktime::absolute::LockTime where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::locktime::absolute::LockTime where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::locktime::absolute::LockTime::vzip(self) -> V
+pub struct bitcoin::absolute::LockTimeDecoder(_)
+impl bitcoin::blockdata::locktime::absolute::LockTimeDecoder
+pub const fn bitcoin::blockdata::locktime::absolute::LockTimeDecoder::new() -> Self
+impl bitcoin_consensus_encoding::decode::Decoder for bitcoin::blockdata::locktime::absolute::LockTimeDecoder
+pub type bitcoin::blockdata::locktime::absolute::LockTimeDecoder::Error = bitcoin::blockdata::locktime::absolute::LockTimeDecoderError
+pub type bitcoin::blockdata::locktime::absolute::LockTimeDecoder::Output = bitcoin::blockdata::locktime::absolute::LockTime
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeDecoder::read_limit(&self) -> usize
+impl core::clone::Clone for bitcoin::blockdata::locktime::absolute::LockTimeDecoder
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeDecoder::clone(&self) -> bitcoin::blockdata::locktime::absolute::LockTimeDecoder
+impl core::default::Default for bitcoin::blockdata::locktime::absolute::LockTimeDecoder
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeDecoder::default() -> Self
+impl core::fmt::Debug for bitcoin::blockdata::locktime::absolute::LockTimeDecoder
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeDecoder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitcoin::blockdata::locktime::absolute::LockTimeDecoder
+impl core::marker::Send for bitcoin::blockdata::locktime::absolute::LockTimeDecoder
+impl core::marker::Sync for bitcoin::blockdata::locktime::absolute::LockTimeDecoder
+impl core::marker::Unpin for bitcoin::blockdata::locktime::absolute::LockTimeDecoder
+impl core::marker::UnsafeUnpin for bitcoin::blockdata::locktime::absolute::LockTimeDecoder
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::absolute::LockTimeDecoder
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::absolute::LockTimeDecoder
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::locktime::absolute::LockTimeDecoder where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::locktime::absolute::LockTimeDecoder where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<T, U> core::convert::Into<U> for bitcoin::blockdata::locktime::absolute::LockTimeDecoder where U: core::convert::From<T>
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeDecoder::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::locktime::absolute::LockTimeDecoder where U: core::convert::Into<T>
+pub type bitcoin::blockdata::locktime::absolute::LockTimeDecoder::Error = core::convert::Infallible
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeDecoder::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin::blockdata::locktime::absolute::LockTimeDecoder where U: core::convert::TryFrom<T>
+pub type bitcoin::blockdata::locktime::absolute::LockTimeDecoder::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin::blockdata::locktime::absolute::LockTimeDecoder where T: core::clone::Clone
+pub type bitcoin::blockdata::locktime::absolute::LockTimeDecoder::Owned = T
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeDecoder::clone_into(&self, target: &mut T)
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeDecoder::to_owned(&self) -> T
+impl<T> core::any::Any for bitcoin::blockdata::locktime::absolute::LockTimeDecoder where T: 'static + ?core::marker::Sized
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeDecoder::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin::blockdata::locktime::absolute::LockTimeDecoder where T: ?core::marker::Sized
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeDecoder::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin::blockdata::locktime::absolute::LockTimeDecoder where T: ?core::marker::Sized
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeDecoder::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin::blockdata::locktime::absolute::LockTimeDecoder where T: core::clone::Clone
+pub unsafe fn bitcoin::blockdata::locktime::absolute::LockTimeDecoder::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin::blockdata::locktime::absolute::LockTimeDecoder
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeDecoder::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::locktime::absolute::LockTimeDecoder where T: ?core::marker::Sized
+impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::locktime::absolute::LockTimeDecoder where V: ppv_lite86::types::MultiLane<T>
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeDecoder::vzip(self) -> V
+pub struct bitcoin::absolute::LockTimeDecoderError(_)
+impl core::clone::Clone for bitcoin::blockdata::locktime::absolute::LockTimeDecoderError
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeDecoderError::clone(&self) -> bitcoin::blockdata::locktime::absolute::LockTimeDecoderError
+impl core::cmp::Eq for bitcoin::blockdata::locktime::absolute::LockTimeDecoderError
+impl core::cmp::PartialEq for bitcoin::blockdata::locktime::absolute::LockTimeDecoderError
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeDecoderError::eq(&self, other: &bitcoin::blockdata::locktime::absolute::LockTimeDecoderError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin::blockdata::locktime::absolute::LockTimeDecoderError
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeDecoderError::from(never: core::convert::Infallible) -> Self
+impl core::error::Error for bitcoin::blockdata::locktime::absolute::LockTimeDecoderError
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeDecoderError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl core::fmt::Debug for bitcoin::blockdata::locktime::absolute::LockTimeDecoderError
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin::blockdata::locktime::absolute::LockTimeDecoderError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::locktime::absolute::LockTimeDecoderError
+impl core::marker::Freeze for bitcoin::blockdata::locktime::absolute::LockTimeDecoderError
+impl core::marker::Send for bitcoin::blockdata::locktime::absolute::LockTimeDecoderError
+impl core::marker::Sync for bitcoin::blockdata::locktime::absolute::LockTimeDecoderError
+impl core::marker::Unpin for bitcoin::blockdata::locktime::absolute::LockTimeDecoderError
+impl core::marker::UnsafeUnpin for bitcoin::blockdata::locktime::absolute::LockTimeDecoderError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::absolute::LockTimeDecoderError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::absolute::LockTimeDecoderError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::locktime::absolute::LockTimeDecoderError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::locktime::absolute::LockTimeDecoderError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<T, U> core::convert::Into<U> for bitcoin::blockdata::locktime::absolute::LockTimeDecoderError where U: core::convert::From<T>
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeDecoderError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::locktime::absolute::LockTimeDecoderError where U: core::convert::Into<T>
+pub type bitcoin::blockdata::locktime::absolute::LockTimeDecoderError::Error = core::convert::Infallible
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeDecoderError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin::blockdata::locktime::absolute::LockTimeDecoderError where U: core::convert::TryFrom<T>
+pub type bitcoin::blockdata::locktime::absolute::LockTimeDecoderError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeDecoderError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin::blockdata::locktime::absolute::LockTimeDecoderError where T: core::clone::Clone
+pub type bitcoin::blockdata::locktime::absolute::LockTimeDecoderError::Owned = T
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeDecoderError::clone_into(&self, target: &mut T)
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeDecoderError::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin::blockdata::locktime::absolute::LockTimeDecoderError where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeDecoderError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin::blockdata::locktime::absolute::LockTimeDecoderError where T: 'static + ?core::marker::Sized
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeDecoderError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin::blockdata::locktime::absolute::LockTimeDecoderError where T: ?core::marker::Sized
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeDecoderError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin::blockdata::locktime::absolute::LockTimeDecoderError where T: ?core::marker::Sized
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeDecoderError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin::blockdata::locktime::absolute::LockTimeDecoderError where T: core::clone::Clone
+pub unsafe fn bitcoin::blockdata::locktime::absolute::LockTimeDecoderError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin::blockdata::locktime::absolute::LockTimeDecoderError
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeDecoderError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::locktime::absolute::LockTimeDecoderError where T: ?core::marker::Sized
+impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::locktime::absolute::LockTimeDecoderError where V: ppv_lite86::types::MultiLane<T>
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeDecoderError::vzip(self) -> V
+pub struct bitcoin::absolute::LockTimeEncoder<'e>(_, _)
+impl<'e> bitcoin_consensus_encoding::encode::Encoder for bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e>
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e>::advance(&mut self) -> bitcoin_consensus_encoding::encode::EncoderStatus
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e>::current_chunk(&self) -> &[u8]
+impl<'e> bitcoin_consensus_encoding::encode::ExactSizeEncoder for bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e>
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e>::len(&self) -> usize
+impl<'e> core::clone::Clone for bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e>
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e>::clone(&self) -> bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e>
+impl<'e> core::fmt::Debug for bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e>
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<'e> core::marker::Freeze for bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e>
+impl<'e> core::marker::Send for bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e>
+impl<'e> core::marker::Sync for bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e>
+impl<'e> core::marker::Unpin for bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e>
+impl<'e> core::marker::UnsafeUnpin for bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e>
+impl<'e> core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e>
+impl<'e> core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e>
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<T, U> core::convert::Into<U> for bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e> where U: core::convert::From<T>
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e> where U: core::convert::Into<T>
+pub type bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e>::Error = core::convert::Infallible
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e> where U: core::convert::TryFrom<T>
+pub type bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e> where T: core::clone::Clone
+pub type bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e>::Owned = T
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e>::clone_into(&self, target: &mut T)
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e>::to_owned(&self) -> T
+impl<T> core::any::Any for bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e> where T: 'static + ?core::marker::Sized
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e> where T: ?core::marker::Sized
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e> where T: ?core::marker::Sized
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e>::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e> where T: core::clone::Clone
+pub unsafe fn bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e>::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e>
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e>::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e> where T: ?core::marker::Sized
+impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e> where V: ppv_lite86::types::MultiLane<T>
+pub fn bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e>::vzip(self) -> V
 pub mod bitcoin::address
 pub mod bitcoin::address::error
 #[non_exhaustive] pub enum bitcoin::address::error::FromScriptError
@@ -3617,6 +3765,9 @@ pub use bitcoin::blockdata::locktime::absolute::Time
 pub enum bitcoin::blockdata::locktime::absolute::LockTime
 pub bitcoin::blockdata::locktime::absolute::LockTime::Blocks(bitcoin_units::locktime::absolute::Height)
 pub bitcoin::blockdata::locktime::absolute::LockTime::Seconds(bitcoin_units::locktime::absolute::Time)
+pub struct bitcoin::blockdata::locktime::absolute::LockTimeDecoder(_)
+pub struct bitcoin::blockdata::locktime::absolute::LockTimeDecoderError(_)
+pub struct bitcoin::blockdata::locktime::absolute::LockTimeEncoder<'e>(_, _)
 pub mod bitcoin::blockdata::locktime::relative
 pub use bitcoin::blockdata::locktime::relative::Height
 pub use bitcoin::blockdata::locktime::relative::Time
@@ -10485,6 +10636,9 @@ pub use bitcoin::locktime::absolute::Time
 pub enum bitcoin::locktime::absolute::LockTime
 pub bitcoin::locktime::absolute::LockTime::Blocks(bitcoin_units::locktime::absolute::Height)
 pub bitcoin::locktime::absolute::LockTime::Seconds(bitcoin_units::locktime::absolute::Time)
+pub struct bitcoin::locktime::absolute::LockTimeDecoder(_)
+pub struct bitcoin::locktime::absolute::LockTimeDecoderError(_)
+pub struct bitcoin::locktime::absolute::LockTimeEncoder<'e>(_, _)
 pub mod bitcoin::locktime::relative
 pub use bitcoin::locktime::relative::Height
 pub use bitcoin::locktime::relative::Time

--- a/bitcoin/api/all-features.txt
+++ b/bitcoin/api/all-features.txt
@@ -2,6 +2,7 @@ pub mod bitcoin
 pub extern crate bitcoin::base58
 pub extern crate bitcoin::base64
 pub extern crate bitcoin::bech32
+pub extern crate bitcoin::encoding
 pub extern crate bitcoin::hashes
 pub extern crate bitcoin::hex
 pub extern crate bitcoin::io
@@ -71,12 +72,12 @@ pub type bitcoin::blockdata::locktime::absolute::LockTime::Err = bitcoin_units::
 pub fn bitcoin::blockdata::locktime::absolute::LockTime::from_str(s: &str) -> core::result::Result<Self, Self::Err>
 impl ordered::ArbitraryOrd for bitcoin::blockdata::locktime::absolute::LockTime
 pub fn bitcoin::blockdata::locktime::absolute::LockTime::arbitrary_cmp(&self, other: &Self) -> core::cmp::Ordering
-impl serde::ser::Serialize for bitcoin::blockdata::locktime::absolute::LockTime
-pub fn bitcoin::blockdata::locktime::absolute::LockTime::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+impl serde_core::ser::Serialize for bitcoin::blockdata::locktime::absolute::LockTime
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error> where S: serde_core::ser::Serializer
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin::blockdata::locktime::absolute::LockTime
 pub fn bitcoin::blockdata::locktime::absolute::LockTime::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::locktime::absolute::LockTime
-pub fn bitcoin::blockdata::locktime::absolute::LockTime::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::blockdata::locktime::absolute::LockTime
+pub fn bitcoin::blockdata::locktime::absolute::LockTime::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde_core::de::Deserializer>::Error> where D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin::blockdata::locktime::absolute::LockTime
 impl core::marker::Send for bitcoin::blockdata::locktime::absolute::LockTime
 impl core::marker::Sync for bitcoin::blockdata::locktime::absolute::LockTime
@@ -84,6 +85,8 @@ impl core::marker::Unpin for bitcoin::blockdata::locktime::absolute::LockTime
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::locktime::absolute::LockTime
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::absolute::LockTime
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::absolute::LockTime
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::locktime::absolute::LockTime where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::locktime::absolute::LockTime where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::locktime::absolute::LockTime where U: core::convert::From<T>
 pub fn bitcoin::blockdata::locktime::absolute::LockTime::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::locktime::absolute::LockTime where U: core::convert::Into<T>
@@ -108,7 +111,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::locktime::absolute::L
 pub unsafe fn bitcoin::blockdata::locktime::absolute::LockTime::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::locktime::absolute::LockTime
 pub fn bitcoin::blockdata::locktime::absolute::LockTime::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::blockdata::locktime::absolute::LockTime where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::blockdata::locktime::absolute::LockTime where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::locktime::absolute::LockTime where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::locktime::absolute::LockTime where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::locktime::absolute::LockTime::vzip(self) -> V
 pub mod bitcoin::address
@@ -141,6 +145,8 @@ impl core::marker::Unpin for bitcoin::address::error::FromScriptError
 impl core::marker::UnsafeUnpin for bitcoin::address::error::FromScriptError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::error::FromScriptError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::address::error::FromScriptError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::address::error::FromScriptError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::address::error::FromScriptError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::address::error::FromScriptError where U: core::convert::From<T>
 pub fn bitcoin::address::error::FromScriptError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::address::error::FromScriptError where U: core::convert::Into<T>
@@ -165,6 +171,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::address::error::FromScriptError 
 pub unsafe fn bitcoin::address::error::FromScriptError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::address::error::FromScriptError
 pub fn bitcoin::address::error::FromScriptError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::address::error::FromScriptError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::address::error::FromScriptError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::address::error::FromScriptError::vzip(self) -> V
 #[non_exhaustive] pub enum bitcoin::address::error::P2shError
@@ -189,6 +196,8 @@ impl core::marker::Unpin for bitcoin::address::error::P2shError
 impl core::marker::UnsafeUnpin for bitcoin::address::error::P2shError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::error::P2shError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::address::error::P2shError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::address::error::P2shError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::address::error::P2shError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::address::error::P2shError where U: core::convert::From<T>
 pub fn bitcoin::address::error::P2shError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::address::error::P2shError where U: core::convert::Into<T>
@@ -213,6 +222,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::address::error::P2shError where 
 pub unsafe fn bitcoin::address::error::P2shError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::address::error::P2shError
 pub fn bitcoin::address::error::P2shError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::address::error::P2shError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::address::error::P2shError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::address::error::P2shError::vzip(self) -> V
 #[non_exhaustive] pub enum bitcoin::address::error::ParseError
@@ -263,6 +273,8 @@ impl core::marker::Unpin for bitcoin::address::error::ParseError
 impl core::marker::UnsafeUnpin for bitcoin::address::error::ParseError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::error::ParseError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::address::error::ParseError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::address::error::ParseError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::address::error::ParseError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::address::error::ParseError where U: core::convert::From<T>
 pub fn bitcoin::address::error::ParseError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::address::error::ParseError where U: core::convert::Into<T>
@@ -287,6 +299,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::address::error::ParseError where
 pub unsafe fn bitcoin::address::error::ParseError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::address::error::ParseError
 pub fn bitcoin::address::error::ParseError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::address::error::ParseError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::address::error::ParseError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::address::error::ParseError::vzip(self) -> V
 pub struct bitcoin::address::error::InvalidBase58PayloadLengthError
@@ -309,6 +322,8 @@ impl core::marker::Unpin for bitcoin::address::error::InvalidBase58PayloadLength
 impl core::marker::UnsafeUnpin for bitcoin::address::error::InvalidBase58PayloadLengthError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::error::InvalidBase58PayloadLengthError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::address::error::InvalidBase58PayloadLengthError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::address::error::InvalidBase58PayloadLengthError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::address::error::InvalidBase58PayloadLengthError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::address::error::InvalidBase58PayloadLengthError where U: core::convert::From<T>
 pub fn bitcoin::address::error::InvalidBase58PayloadLengthError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::address::error::InvalidBase58PayloadLengthError where U: core::convert::Into<T>
@@ -333,6 +348,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::address::error::InvalidBase58Pay
 pub unsafe fn bitcoin::address::error::InvalidBase58PayloadLengthError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::address::error::InvalidBase58PayloadLengthError
 pub fn bitcoin::address::error::InvalidBase58PayloadLengthError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::address::error::InvalidBase58PayloadLengthError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::address::error::InvalidBase58PayloadLengthError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::address::error::InvalidBase58PayloadLengthError::vzip(self) -> V
 pub struct bitcoin::address::error::InvalidLegacyPrefixError
@@ -355,6 +371,8 @@ impl core::marker::Unpin for bitcoin::address::error::InvalidLegacyPrefixError
 impl core::marker::UnsafeUnpin for bitcoin::address::error::InvalidLegacyPrefixError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::error::InvalidLegacyPrefixError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::address::error::InvalidLegacyPrefixError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::address::error::InvalidLegacyPrefixError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::address::error::InvalidLegacyPrefixError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::address::error::InvalidLegacyPrefixError where U: core::convert::From<T>
 pub fn bitcoin::address::error::InvalidLegacyPrefixError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::address::error::InvalidLegacyPrefixError where U: core::convert::Into<T>
@@ -379,6 +397,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::address::error::InvalidLegacyPre
 pub unsafe fn bitcoin::address::error::InvalidLegacyPrefixError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::address::error::InvalidLegacyPrefixError
 pub fn bitcoin::address::error::InvalidLegacyPrefixError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::address::error::InvalidLegacyPrefixError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::address::error::InvalidLegacyPrefixError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::address::error::InvalidLegacyPrefixError::vzip(self) -> V
 pub struct bitcoin::address::error::LegacyAddressTooLongError
@@ -401,6 +420,8 @@ impl core::marker::Unpin for bitcoin::address::error::LegacyAddressTooLongError
 impl core::marker::UnsafeUnpin for bitcoin::address::error::LegacyAddressTooLongError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::error::LegacyAddressTooLongError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::address::error::LegacyAddressTooLongError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::address::error::LegacyAddressTooLongError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::address::error::LegacyAddressTooLongError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::address::error::LegacyAddressTooLongError where U: core::convert::From<T>
 pub fn bitcoin::address::error::LegacyAddressTooLongError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::address::error::LegacyAddressTooLongError where U: core::convert::Into<T>
@@ -425,6 +446,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::address::error::LegacyAddressToo
 pub unsafe fn bitcoin::address::error::LegacyAddressTooLongError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::address::error::LegacyAddressTooLongError
 pub fn bitcoin::address::error::LegacyAddressTooLongError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::address::error::LegacyAddressTooLongError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::address::error::LegacyAddressTooLongError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::address::error::LegacyAddressTooLongError::vzip(self) -> V
 pub struct bitcoin::address::error::NetworkValidationError
@@ -445,6 +467,8 @@ impl core::marker::Unpin for bitcoin::address::error::NetworkValidationError
 impl core::marker::UnsafeUnpin for bitcoin::address::error::NetworkValidationError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::error::NetworkValidationError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::address::error::NetworkValidationError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::address::error::NetworkValidationError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::address::error::NetworkValidationError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::address::error::NetworkValidationError where U: core::convert::From<T>
 pub fn bitcoin::address::error::NetworkValidationError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::address::error::NetworkValidationError where U: core::convert::Into<T>
@@ -469,6 +493,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::address::error::NetworkValidatio
 pub unsafe fn bitcoin::address::error::NetworkValidationError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::address::error::NetworkValidationError
 pub fn bitcoin::address::error::NetworkValidationError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::address::error::NetworkValidationError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::address::error::NetworkValidationError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::address::error::NetworkValidationError::vzip(self) -> V
 #[non_exhaustive] pub struct bitcoin::address::error::UnknownAddressTypeError(pub alloc::string::String)
@@ -490,6 +515,8 @@ impl core::marker::Unpin for bitcoin::address::error::UnknownAddressTypeError
 impl core::marker::UnsafeUnpin for bitcoin::address::error::UnknownAddressTypeError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::error::UnknownAddressTypeError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::address::error::UnknownAddressTypeError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::address::error::UnknownAddressTypeError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::address::error::UnknownAddressTypeError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::address::error::UnknownAddressTypeError where U: core::convert::From<T>
 pub fn bitcoin::address::error::UnknownAddressTypeError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::address::error::UnknownAddressTypeError where U: core::convert::Into<T>
@@ -514,6 +541,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::address::error::UnknownAddressTy
 pub unsafe fn bitcoin::address::error::UnknownAddressTypeError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::address::error::UnknownAddressTypeError
 pub fn bitcoin::address::error::UnknownAddressTypeError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::address::error::UnknownAddressTypeError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::address::error::UnknownAddressTypeError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::address::error::UnknownAddressTypeError::vzip(self) -> V
 #[non_exhaustive] pub struct bitcoin::address::error::UnknownHrpError(pub alloc::string::String)
@@ -535,6 +563,8 @@ impl core::marker::Unpin for bitcoin::address::error::UnknownHrpError
 impl core::marker::UnsafeUnpin for bitcoin::address::error::UnknownHrpError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::error::UnknownHrpError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::address::error::UnknownHrpError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::address::error::UnknownHrpError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::address::error::UnknownHrpError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::address::error::UnknownHrpError where U: core::convert::From<T>
 pub fn bitcoin::address::error::UnknownHrpError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::address::error::UnknownHrpError where U: core::convert::Into<T>
@@ -559,6 +589,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::address::error::UnknownHrpError 
 pub unsafe fn bitcoin::address::error::UnknownHrpError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::address::error::UnknownHrpError
 pub fn bitcoin::address::error::UnknownHrpError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::address::error::UnknownHrpError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::address::error::UnknownHrpError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::address::error::UnknownHrpError::vzip(self) -> V
 #[non_exhaustive] pub enum bitcoin::address::AddressData
@@ -589,6 +620,8 @@ impl core::marker::Unpin for bitcoin::address::AddressData
 impl core::marker::UnsafeUnpin for bitcoin::address::AddressData
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::AddressData
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::address::AddressData
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::address::AddressData where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::address::AddressData where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::address::AddressData where U: core::convert::From<T>
 pub fn bitcoin::address::AddressData::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::address::AddressData where U: core::convert::Into<T>
@@ -611,6 +644,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::address::AddressData where T: co
 pub unsafe fn bitcoin::address::AddressData::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::address::AddressData
 pub fn bitcoin::address::AddressData::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::address::AddressData where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::address::AddressData where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::address::AddressData::vzip(self) -> V
 #[non_exhaustive] pub enum bitcoin::address::AddressType
@@ -646,6 +680,8 @@ impl core::marker::Unpin for bitcoin::address::AddressType
 impl core::marker::UnsafeUnpin for bitcoin::address::AddressType
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::AddressType
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::address::AddressType
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::address::AddressType where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::address::AddressType where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::address::AddressType where U: core::convert::From<T>
 pub fn bitcoin::address::AddressType::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::address::AddressType where U: core::convert::Into<T>
@@ -670,6 +706,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::address::AddressType where T: co
 pub unsafe fn bitcoin::address::AddressType::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::address::AddressType
 pub fn bitcoin::address::AddressType::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::address::AddressType where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::address::AddressType where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::address::AddressType::vzip(self) -> V
 #[non_exhaustive] pub enum bitcoin::address::FromScriptError
@@ -704,6 +741,8 @@ impl core::marker::Unpin for bitcoin::address::KnownHrp
 impl core::marker::UnsafeUnpin for bitcoin::address::KnownHrp
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::KnownHrp
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::address::KnownHrp
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::address::KnownHrp where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::address::KnownHrp where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::address::KnownHrp where U: core::convert::From<T>
 pub fn bitcoin::address::KnownHrp::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::address::KnownHrp where U: core::convert::Into<T>
@@ -726,6 +765,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::address::KnownHrp where T: core:
 pub unsafe fn bitcoin::address::KnownHrp::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::address::KnownHrp
 pub fn bitcoin::address::KnownHrp::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::address::KnownHrp where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::address::KnownHrp where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::address::KnownHrp::vzip(self) -> V
 pub enum bitcoin::address::NetworkChecked
@@ -752,6 +792,8 @@ impl core::marker::Unpin for bitcoin::address::NetworkChecked
 impl core::marker::UnsafeUnpin for bitcoin::address::NetworkChecked
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::NetworkChecked
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::address::NetworkChecked
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::address::NetworkChecked where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::address::NetworkChecked where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::address::NetworkChecked where U: core::convert::From<T>
 pub fn bitcoin::address::NetworkChecked::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::address::NetworkChecked where U: core::convert::Into<T>
@@ -774,6 +816,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::address::NetworkChecked where T:
 pub unsafe fn bitcoin::address::NetworkChecked::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::address::NetworkChecked
 pub fn bitcoin::address::NetworkChecked::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::address::NetworkChecked where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::address::NetworkChecked where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::address::NetworkChecked::vzip(self) -> V
 pub enum bitcoin::address::NetworkUnchecked
@@ -800,6 +843,8 @@ impl core::marker::Unpin for bitcoin::address::NetworkUnchecked
 impl core::marker::UnsafeUnpin for bitcoin::address::NetworkUnchecked
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::NetworkUnchecked
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::address::NetworkUnchecked
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::address::NetworkUnchecked where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::address::NetworkUnchecked where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::address::NetworkUnchecked where U: core::convert::From<T>
 pub fn bitcoin::address::NetworkUnchecked::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::address::NetworkUnchecked where U: core::convert::Into<T>
@@ -822,6 +867,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::address::NetworkUnchecked where 
 pub unsafe fn bitcoin::address::NetworkUnchecked::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::address::NetworkUnchecked
 pub fn bitcoin::address::NetworkUnchecked::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::address::NetworkUnchecked where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::address::NetworkUnchecked where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::address::NetworkUnchecked::vzip(self) -> V
 #[non_exhaustive] pub enum bitcoin::address::P2shError
@@ -875,10 +921,10 @@ pub fn bitcoin::address::Address::fmt(&self, fmt: &mut core::fmt::Formatter<'_>)
 impl core::str::traits::FromStr for bitcoin::address::Address<bitcoin::address::NetworkUnchecked>
 pub type bitcoin::address::Address<bitcoin::address::NetworkUnchecked>::Err = bitcoin::address::error::ParseError
 pub fn bitcoin::address::Address<bitcoin::address::NetworkUnchecked>::from_str(s: &str) -> core::result::Result<bitcoin::address::Address<bitcoin::address::NetworkUnchecked>, bitcoin::address::error::ParseError>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::address::Address<bitcoin::address::NetworkUnchecked>
-pub fn bitcoin::address::Address<bitcoin::address::NetworkUnchecked>::deserialize<D>(deserializer: D) -> core::result::Result<bitcoin::address::Address<bitcoin::address::NetworkUnchecked>, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
-impl<N: bitcoin::address::NetworkValidation> serde::ser::Serialize for bitcoin::address::Address<N>
-pub fn bitcoin::address::Address<N>::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::address::Address<bitcoin::address::NetworkUnchecked>
+pub fn bitcoin::address::Address<bitcoin::address::NetworkUnchecked>::deserialize<D>(deserializer: D) -> core::result::Result<bitcoin::address::Address<bitcoin::address::NetworkUnchecked>, <D as serde_core::de::Deserializer>::Error> where D: serde_core::de::Deserializer<'de>
+impl<N: bitcoin::address::NetworkValidation> serde_core::ser::Serialize for bitcoin::address::Address<N>
+pub fn bitcoin::address::Address<N>::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error> where S: serde_core::ser::Serializer
 impl<V: bitcoin::address::NetworkValidation> core::fmt::Debug for bitcoin::address::Address<V>
 pub fn bitcoin::address::Address<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<V> core::clone::Clone for bitcoin::address::Address<V> where V: bitcoin::address::NetworkValidation + core::clone::Clone
@@ -900,6 +946,8 @@ impl<V> core::marker::Unpin for bitcoin::address::Address<V>
 impl<V> core::marker::UnsafeUnpin for bitcoin::address::Address<V>
 impl<V> core::panic::unwind_safe::RefUnwindSafe for bitcoin::address::Address<V> where V: core::panic::unwind_safe::RefUnwindSafe
 impl<V> core::panic::unwind_safe::UnwindSafe for bitcoin::address::Address<V> where V: core::panic::unwind_safe::UnwindSafe
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::address::Address<V> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::address::Address<V> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::address::Address<V> where U: core::convert::From<T>
 pub fn bitcoin::address::Address<V>::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::address::Address<V> where U: core::convert::Into<T>
@@ -924,7 +972,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::address::Address<V> where T: cor
 pub unsafe fn bitcoin::address::Address<V>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::address::Address<V>
 pub fn bitcoin::address::Address<V>::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::address::Address<V> where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::address::Address<V> where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::address::Address<V> where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::address::Address<V> where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::address::Address<V>::vzip(self) -> V
 pub struct bitcoin::address::InvalidBase58PayloadLengthError
@@ -967,6 +1016,8 @@ impl core::marker::Unpin for bitcoin::bip152::Error
 impl core::marker::UnsafeUnpin for bitcoin::bip152::Error
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip152::Error
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip152::Error
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::bip152::Error where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::bip152::Error where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::bip152::Error where U: core::convert::From<T>
 pub fn bitcoin::bip152::Error::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::bip152::Error where U: core::convert::Into<T>
@@ -991,6 +1042,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::bip152::Error where T: core::clo
 pub unsafe fn bitcoin::bip152::Error::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::bip152::Error
 pub fn bitcoin::bip152::Error::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::bip152::Error where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::bip152::Error where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::bip152::Error::vzip(self) -> V
 pub struct bitcoin::bip152::BlockTransactions
@@ -1026,6 +1078,8 @@ impl core::marker::Unpin for bitcoin::bip152::BlockTransactions
 impl core::marker::UnsafeUnpin for bitcoin::bip152::BlockTransactions
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip152::BlockTransactions
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip152::BlockTransactions
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::bip152::BlockTransactions where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::bip152::BlockTransactions where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::bip152::BlockTransactions where U: core::convert::From<T>
 pub fn bitcoin::bip152::BlockTransactions::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::bip152::BlockTransactions where U: core::convert::Into<T>
@@ -1048,6 +1102,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::bip152::BlockTransactions where 
 pub unsafe fn bitcoin::bip152::BlockTransactions::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::bip152::BlockTransactions
 pub fn bitcoin::bip152::BlockTransactions::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::bip152::BlockTransactions where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::bip152::BlockTransactions where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::bip152::BlockTransactions::vzip(self) -> V
 pub struct bitcoin::bip152::BlockTransactionsRequest
@@ -1080,6 +1135,8 @@ impl core::marker::Unpin for bitcoin::bip152::BlockTransactionsRequest
 impl core::marker::UnsafeUnpin for bitcoin::bip152::BlockTransactionsRequest
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip152::BlockTransactionsRequest
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip152::BlockTransactionsRequest
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::bip152::BlockTransactionsRequest where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::bip152::BlockTransactionsRequest where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::bip152::BlockTransactionsRequest where U: core::convert::From<T>
 pub fn bitcoin::bip152::BlockTransactionsRequest::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::bip152::BlockTransactionsRequest where U: core::convert::Into<T>
@@ -1102,6 +1159,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::bip152::BlockTransactionsRequest
 pub unsafe fn bitcoin::bip152::BlockTransactionsRequest::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::bip152::BlockTransactionsRequest
 pub fn bitcoin::bip152::BlockTransactionsRequest::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::bip152::BlockTransactionsRequest where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::bip152::BlockTransactionsRequest where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::bip152::BlockTransactionsRequest::vzip(self) -> V
 pub struct bitcoin::bip152::HeaderAndShortIds
@@ -1139,6 +1197,8 @@ impl core::marker::Unpin for bitcoin::bip152::HeaderAndShortIds
 impl core::marker::UnsafeUnpin for bitcoin::bip152::HeaderAndShortIds
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip152::HeaderAndShortIds
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip152::HeaderAndShortIds
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::bip152::HeaderAndShortIds where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::bip152::HeaderAndShortIds where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::bip152::HeaderAndShortIds where U: core::convert::From<T>
 pub fn bitcoin::bip152::HeaderAndShortIds::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::bip152::HeaderAndShortIds where U: core::convert::Into<T>
@@ -1161,6 +1221,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::bip152::HeaderAndShortIds where 
 pub unsafe fn bitcoin::bip152::HeaderAndShortIds::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::bip152::HeaderAndShortIds
 pub fn bitcoin::bip152::HeaderAndShortIds::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::bip152::HeaderAndShortIds where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::bip152::HeaderAndShortIds where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::bip152::HeaderAndShortIds::vzip(self) -> V
 pub struct bitcoin::bip152::PrefilledTransaction
@@ -1195,6 +1256,8 @@ impl core::marker::Unpin for bitcoin::bip152::PrefilledTransaction
 impl core::marker::UnsafeUnpin for bitcoin::bip152::PrefilledTransaction
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip152::PrefilledTransaction
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip152::PrefilledTransaction
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::bip152::PrefilledTransaction where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::bip152::PrefilledTransaction where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::bip152::PrefilledTransaction where U: core::convert::From<T>
 pub fn bitcoin::bip152::PrefilledTransaction::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::bip152::PrefilledTransaction where U: core::convert::Into<T>
@@ -1217,6 +1280,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::bip152::PrefilledTransaction whe
 pub unsafe fn bitcoin::bip152::PrefilledTransaction::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::bip152::PrefilledTransaction
 pub fn bitcoin::bip152::PrefilledTransaction::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::bip152::PrefilledTransaction where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::bip152::PrefilledTransaction where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::bip152::PrefilledTransaction::vzip(self) -> V
 pub struct bitcoin::bip152::ShortId(_)
@@ -1273,8 +1337,8 @@ impl core::marker::StructuralPartialEq for bitcoin::bip152::ShortId
 impl core::str::traits::FromStr for bitcoin::bip152::ShortId
 pub type bitcoin::bip152::ShortId::Err = hex_conservative::error::HexToArrayError
 pub fn bitcoin::bip152::ShortId::from_str(s: &str) -> core::result::Result<Self, Self::Err>
-impl serde::ser::Serialize for bitcoin::bip152::ShortId
-pub fn bitcoin::bip152::ShortId::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+impl serde_core::ser::Serialize for bitcoin::bip152::ShortId
+pub fn bitcoin::bip152::ShortId::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin::bip152::ShortId
 pub fn bitcoin::bip152::ShortId::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
 impl<'a> core::convert::From<&'a [u8; 6]> for bitcoin::bip152::ShortId
@@ -1284,8 +1348,8 @@ pub fn bitcoin::bip152::ShortId::from(data: [u8; 6]) -> Self
 impl<'a> core::convert::TryFrom<&'a [u8]> for bitcoin::bip152::ShortId
 pub type bitcoin::bip152::ShortId::Error = core::array::TryFromSliceError
 pub fn bitcoin::bip152::ShortId::try_from(data: &'a [u8]) -> core::result::Result<Self, Self::Error>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::bip152::ShortId
-pub fn bitcoin::bip152::ShortId::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::bip152::ShortId, <D as serde::de::Deserializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::bip152::ShortId
+pub fn bitcoin::bip152::ShortId::deserialize<D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::bip152::ShortId, <D as serde_core::de::Deserializer>::Error>
 impl<I> core::ops::index::Index<I> for bitcoin::bip152::ShortId where [u8]: core::ops::index::Index<I>
 pub type bitcoin::bip152::ShortId::Output = <[u8] as core::ops::index::Index<I>>::Output
 pub fn bitcoin::bip152::ShortId::index(&self, index: I) -> &Self::Output
@@ -1296,6 +1360,8 @@ impl core::marker::Unpin for bitcoin::bip152::ShortId
 impl core::marker::UnsafeUnpin for bitcoin::bip152::ShortId
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip152::ShortId
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip152::ShortId
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::bip152::ShortId where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::bip152::ShortId where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::bip152::ShortId where U: core::convert::From<T>
 pub fn bitcoin::bip152::ShortId::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::bip152::ShortId where U: core::convert::Into<T>
@@ -1320,7 +1386,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::bip152::ShortId where T: core::c
 pub unsafe fn bitcoin::bip152::ShortId::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::bip152::ShortId
 pub fn bitcoin::bip152::ShortId::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::bip152::ShortId where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::bip152::ShortId where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::bip152::ShortId where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::bip152::ShortId where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::bip152::ShortId::vzip(self) -> V
 #[non_exhaustive] pub struct bitcoin::bip152::TxIndexOutOfRangeError(_)
@@ -1342,6 +1409,8 @@ impl core::marker::Unpin for bitcoin::bip152::TxIndexOutOfRangeError
 impl core::marker::UnsafeUnpin for bitcoin::bip152::TxIndexOutOfRangeError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip152::TxIndexOutOfRangeError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip152::TxIndexOutOfRangeError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::bip152::TxIndexOutOfRangeError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::bip152::TxIndexOutOfRangeError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::bip152::TxIndexOutOfRangeError where U: core::convert::From<T>
 pub fn bitcoin::bip152::TxIndexOutOfRangeError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::bip152::TxIndexOutOfRangeError where U: core::convert::Into<T>
@@ -1366,6 +1435,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::bip152::TxIndexOutOfRangeError w
 pub unsafe fn bitcoin::bip152::TxIndexOutOfRangeError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::bip152::TxIndexOutOfRangeError
 pub fn bitcoin::bip152::TxIndexOutOfRangeError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::bip152::TxIndexOutOfRangeError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::bip152::TxIndexOutOfRangeError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::bip152::TxIndexOutOfRangeError::vzip(self) -> V
 pub mod bitcoin::bip158
@@ -1389,6 +1459,8 @@ impl core::marker::Unpin for bitcoin::bip158::Error
 impl core::marker::UnsafeUnpin for bitcoin::bip158::Error
 impl !core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::Error
 impl !core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::Error
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::bip158::Error where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::bip158::Error where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::bip158::Error where U: core::convert::From<T>
 pub fn bitcoin::bip158::Error::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::bip158::Error where U: core::convert::Into<T>
@@ -1407,6 +1479,7 @@ impl<T> core::borrow::BorrowMut<T> for bitcoin::bip158::Error where T: ?core::ma
 pub fn bitcoin::bip158::Error::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for bitcoin::bip158::Error
 pub fn bitcoin::bip158::Error::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::bip158::Error where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::bip158::Error where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::bip158::Error::vzip(self) -> V
 pub struct bitcoin::bip158::BitStreamReader<'a, R: ?core::marker::Sized>
@@ -1420,6 +1493,8 @@ impl<'a, R> core::marker::Unpin for bitcoin::bip158::BitStreamReader<'a, R> wher
 impl<'a, R> core::marker::UnsafeUnpin for bitcoin::bip158::BitStreamReader<'a, R> where R: ?core::marker::Sized
 impl<'a, R> core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::BitStreamReader<'a, R> where R: core::panic::unwind_safe::RefUnwindSafe + ?core::marker::Sized
 impl<'a, R> !core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::BitStreamReader<'a, R>
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::bip158::BitStreamReader<'a, R> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::bip158::BitStreamReader<'a, R> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::bip158::BitStreamReader<'a, R> where U: core::convert::From<T>
 pub fn bitcoin::bip158::BitStreamReader<'a, R>::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::bip158::BitStreamReader<'a, R> where U: core::convert::Into<T>
@@ -1436,6 +1511,7 @@ impl<T> core::borrow::BorrowMut<T> for bitcoin::bip158::BitStreamReader<'a, R> w
 pub fn bitcoin::bip158::BitStreamReader<'a, R>::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for bitcoin::bip158::BitStreamReader<'a, R>
 pub fn bitcoin::bip158::BitStreamReader<'a, R>::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::bip158::BitStreamReader<'a, R> where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::bip158::BitStreamReader<'a, R> where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::bip158::BitStreamReader<'a, R>::vzip(self) -> V
 pub struct bitcoin::bip158::BitStreamWriter<'a, W>
@@ -1450,6 +1526,8 @@ impl<'a, W> core::marker::Unpin for bitcoin::bip158::BitStreamWriter<'a, W>
 impl<'a, W> core::marker::UnsafeUnpin for bitcoin::bip158::BitStreamWriter<'a, W>
 impl<'a, W> core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::BitStreamWriter<'a, W> where W: core::panic::unwind_safe::RefUnwindSafe
 impl<'a, W> !core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::BitStreamWriter<'a, W>
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::bip158::BitStreamWriter<'a, W> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::bip158::BitStreamWriter<'a, W> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::bip158::BitStreamWriter<'a, W> where U: core::convert::From<T>
 pub fn bitcoin::bip158::BitStreamWriter<'a, W>::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::bip158::BitStreamWriter<'a, W> where U: core::convert::Into<T>
@@ -1466,6 +1544,7 @@ impl<T> core::borrow::BorrowMut<T> for bitcoin::bip158::BitStreamWriter<'a, W> w
 pub fn bitcoin::bip158::BitStreamWriter<'a, W>::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for bitcoin::bip158::BitStreamWriter<'a, W>
 pub fn bitcoin::bip158::BitStreamWriter<'a, W>::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::bip158::BitStreamWriter<'a, W> where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::bip158::BitStreamWriter<'a, W> where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::bip158::BitStreamWriter<'a, W>::vzip(self) -> V
 pub struct bitcoin::bip158::BlockFilter
@@ -1491,6 +1570,8 @@ impl core::marker::Unpin for bitcoin::bip158::BlockFilter
 impl core::marker::UnsafeUnpin for bitcoin::bip158::BlockFilter
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::BlockFilter
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::BlockFilter
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::bip158::BlockFilter where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::bip158::BlockFilter where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::bip158::BlockFilter where U: core::convert::From<T>
 pub fn bitcoin::bip158::BlockFilter::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::bip158::BlockFilter where U: core::convert::Into<T>
@@ -1513,6 +1594,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::bip158::BlockFilter where T: cor
 pub unsafe fn bitcoin::bip158::BlockFilter::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::bip158::BlockFilter
 pub fn bitcoin::bip158::BlockFilter::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::bip158::BlockFilter where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::bip158::BlockFilter where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::bip158::BlockFilter::vzip(self) -> V
 pub struct bitcoin::bip158::BlockFilterReader
@@ -1527,6 +1609,8 @@ impl core::marker::Unpin for bitcoin::bip158::BlockFilterReader
 impl core::marker::UnsafeUnpin for bitcoin::bip158::BlockFilterReader
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::BlockFilterReader
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::BlockFilterReader
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::bip158::BlockFilterReader where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::bip158::BlockFilterReader where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::bip158::BlockFilterReader where U: core::convert::From<T>
 pub fn bitcoin::bip158::BlockFilterReader::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::bip158::BlockFilterReader where U: core::convert::Into<T>
@@ -1543,6 +1627,7 @@ impl<T> core::borrow::BorrowMut<T> for bitcoin::bip158::BlockFilterReader where 
 pub fn bitcoin::bip158::BlockFilterReader::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for bitcoin::bip158::BlockFilterReader
 pub fn bitcoin::bip158::BlockFilterReader::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::bip158::BlockFilterReader where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::bip158::BlockFilterReader where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::bip158::BlockFilterReader::vzip(self) -> V
 pub struct bitcoin::bip158::BlockFilterWriter<'a, W>
@@ -1559,6 +1644,8 @@ impl<'a, W> core::marker::Unpin for bitcoin::bip158::BlockFilterWriter<'a, W>
 impl<'a, W> core::marker::UnsafeUnpin for bitcoin::bip158::BlockFilterWriter<'a, W>
 impl<'a, W> core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::BlockFilterWriter<'a, W> where W: core::panic::unwind_safe::RefUnwindSafe
 impl<'a, W> !core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::BlockFilterWriter<'a, W>
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::bip158::BlockFilterWriter<'a, W> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::bip158::BlockFilterWriter<'a, W> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::bip158::BlockFilterWriter<'a, W> where U: core::convert::From<T>
 pub fn bitcoin::bip158::BlockFilterWriter<'a, W>::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::bip158::BlockFilterWriter<'a, W> where U: core::convert::Into<T>
@@ -1575,6 +1662,7 @@ impl<T> core::borrow::BorrowMut<T> for bitcoin::bip158::BlockFilterWriter<'a, W>
 pub fn bitcoin::bip158::BlockFilterWriter<'a, W>::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for bitcoin::bip158::BlockFilterWriter<'a, W>
 pub fn bitcoin::bip158::BlockFilterWriter<'a, W>::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::bip158::BlockFilterWriter<'a, W> where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::bip158::BlockFilterWriter<'a, W> where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::bip158::BlockFilterWriter<'a, W>::vzip(self) -> V
 pub struct bitcoin::bip158::FilterHash(_)
@@ -1633,12 +1721,12 @@ impl core::marker::StructuralPartialEq for bitcoin::bip158::FilterHash
 impl core::str::traits::FromStr for bitcoin::bip158::FilterHash
 pub type bitcoin::bip158::FilterHash::Err = hex_conservative::error::HexToArrayError
 pub fn bitcoin::bip158::FilterHash::from_str(s: &str) -> core::result::Result<bitcoin::bip158::FilterHash, Self::Err>
-impl serde::ser::Serialize for bitcoin::bip158::FilterHash
-pub fn bitcoin::bip158::FilterHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+impl serde_core::ser::Serialize for bitcoin::bip158::FilterHash
+pub fn bitcoin::bip158::FilterHash::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin::bip158::FilterHash
 pub fn bitcoin::bip158::FilterHash::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::bip158::FilterHash
-pub fn bitcoin::bip158::FilterHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::bip158::FilterHash, <D as serde::de::Deserializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::bip158::FilterHash
+pub fn bitcoin::bip158::FilterHash::deserialize<D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::bip158::FilterHash, <D as serde_core::de::Deserializer>::Error>
 impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::bip158::FilterHash
 pub type bitcoin::bip158::FilterHash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
 pub fn bitcoin::bip158::FilterHash::index(&self, index: I) -> &Self::Output
@@ -1649,6 +1737,8 @@ impl core::marker::Unpin for bitcoin::bip158::FilterHash
 impl core::marker::UnsafeUnpin for bitcoin::bip158::FilterHash
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::FilterHash
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::FilterHash
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::bip158::FilterHash where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::bip158::FilterHash where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::bip158::FilterHash where U: core::convert::From<T>
 pub fn bitcoin::bip158::FilterHash::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::bip158::FilterHash where U: core::convert::Into<T>
@@ -1673,7 +1763,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::bip158::FilterHash where T: core
 pub unsafe fn bitcoin::bip158::FilterHash::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::bip158::FilterHash
 pub fn bitcoin::bip158::FilterHash::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::bip158::FilterHash where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::bip158::FilterHash where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::bip158::FilterHash where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::bip158::FilterHash where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::bip158::FilterHash::vzip(self) -> V
 pub struct bitcoin::bip158::FilterHeader(_)
@@ -1731,12 +1822,12 @@ impl core::marker::StructuralPartialEq for bitcoin::bip158::FilterHeader
 impl core::str::traits::FromStr for bitcoin::bip158::FilterHeader
 pub type bitcoin::bip158::FilterHeader::Err = hex_conservative::error::HexToArrayError
 pub fn bitcoin::bip158::FilterHeader::from_str(s: &str) -> core::result::Result<bitcoin::bip158::FilterHeader, Self::Err>
-impl serde::ser::Serialize for bitcoin::bip158::FilterHeader
-pub fn bitcoin::bip158::FilterHeader::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+impl serde_core::ser::Serialize for bitcoin::bip158::FilterHeader
+pub fn bitcoin::bip158::FilterHeader::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin::bip158::FilterHeader
 pub fn bitcoin::bip158::FilterHeader::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::bip158::FilterHeader
-pub fn bitcoin::bip158::FilterHeader::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::bip158::FilterHeader, <D as serde::de::Deserializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::bip158::FilterHeader
+pub fn bitcoin::bip158::FilterHeader::deserialize<D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::bip158::FilterHeader, <D as serde_core::de::Deserializer>::Error>
 impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::bip158::FilterHeader
 pub type bitcoin::bip158::FilterHeader::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
 pub fn bitcoin::bip158::FilterHeader::index(&self, index: I) -> &Self::Output
@@ -1747,6 +1838,8 @@ impl core::marker::Unpin for bitcoin::bip158::FilterHeader
 impl core::marker::UnsafeUnpin for bitcoin::bip158::FilterHeader
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::FilterHeader
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::FilterHeader
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::bip158::FilterHeader where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::bip158::FilterHeader where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::bip158::FilterHeader where U: core::convert::From<T>
 pub fn bitcoin::bip158::FilterHeader::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::bip158::FilterHeader where U: core::convert::Into<T>
@@ -1771,7 +1864,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::bip158::FilterHeader where T: co
 pub unsafe fn bitcoin::bip158::FilterHeader::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::bip158::FilterHeader
 pub fn bitcoin::bip158::FilterHeader::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::bip158::FilterHeader where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::bip158::FilterHeader where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::bip158::FilterHeader where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::bip158::FilterHeader where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::bip158::FilterHeader::vzip(self) -> V
 pub struct bitcoin::bip158::GcsFilterReader
@@ -1786,6 +1880,8 @@ impl core::marker::Unpin for bitcoin::bip158::GcsFilterReader
 impl core::marker::UnsafeUnpin for bitcoin::bip158::GcsFilterReader
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::GcsFilterReader
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::GcsFilterReader
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::bip158::GcsFilterReader where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::bip158::GcsFilterReader where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::bip158::GcsFilterReader where U: core::convert::From<T>
 pub fn bitcoin::bip158::GcsFilterReader::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::bip158::GcsFilterReader where U: core::convert::Into<T>
@@ -1802,6 +1898,7 @@ impl<T> core::borrow::BorrowMut<T> for bitcoin::bip158::GcsFilterReader where T:
 pub fn bitcoin::bip158::GcsFilterReader::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for bitcoin::bip158::GcsFilterReader
 pub fn bitcoin::bip158::GcsFilterReader::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::bip158::GcsFilterReader where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::bip158::GcsFilterReader where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::bip158::GcsFilterReader::vzip(self) -> V
 pub struct bitcoin::bip158::GcsFilterWriter<'a, W>
@@ -1816,6 +1913,8 @@ impl<'a, W> core::marker::Unpin for bitcoin::bip158::GcsFilterWriter<'a, W>
 impl<'a, W> core::marker::UnsafeUnpin for bitcoin::bip158::GcsFilterWriter<'a, W>
 impl<'a, W> core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip158::GcsFilterWriter<'a, W> where W: core::panic::unwind_safe::RefUnwindSafe
 impl<'a, W> !core::panic::unwind_safe::UnwindSafe for bitcoin::bip158::GcsFilterWriter<'a, W>
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::bip158::GcsFilterWriter<'a, W> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::bip158::GcsFilterWriter<'a, W> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::bip158::GcsFilterWriter<'a, W> where U: core::convert::From<T>
 pub fn bitcoin::bip158::GcsFilterWriter<'a, W>::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::bip158::GcsFilterWriter<'a, W> where U: core::convert::Into<T>
@@ -1832,6 +1931,7 @@ impl<T> core::borrow::BorrowMut<T> for bitcoin::bip158::GcsFilterWriter<'a, W> w
 pub fn bitcoin::bip158::GcsFilterWriter<'a, W>::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for bitcoin::bip158::GcsFilterWriter<'a, W>
 pub fn bitcoin::bip158::GcsFilterWriter<'a, W>::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::bip158::GcsFilterWriter<'a, W> where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::bip158::GcsFilterWriter<'a, W> where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::bip158::GcsFilterWriter<'a, W>::vzip(self) -> V
 pub mod bitcoin::bip32
@@ -1873,10 +1973,10 @@ impl core::marker::StructuralPartialEq for bitcoin::bip32::ChildNumber
 impl core::str::traits::FromStr for bitcoin::bip32::ChildNumber
 pub type bitcoin::bip32::ChildNumber::Err = bitcoin::bip32::Error
 pub fn bitcoin::bip32::ChildNumber::from_str(inp: &str) -> core::result::Result<bitcoin::bip32::ChildNumber, bitcoin::bip32::Error>
-impl serde::ser::Serialize for bitcoin::bip32::ChildNumber
-pub fn bitcoin::bip32::ChildNumber::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
-impl<'de> serde::de::Deserialize<'de> for bitcoin::bip32::ChildNumber
-pub fn bitcoin::bip32::ChildNumber::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+impl serde_core::ser::Serialize for bitcoin::bip32::ChildNumber
+pub fn bitcoin::bip32::ChildNumber::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error> where S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::bip32::ChildNumber
+pub fn bitcoin::bip32::ChildNumber::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde_core::de::Deserializer>::Error> where D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin::bip32::ChildNumber
 impl core::marker::Send for bitcoin::bip32::ChildNumber
 impl core::marker::Sync for bitcoin::bip32::ChildNumber
@@ -1884,6 +1984,8 @@ impl core::marker::Unpin for bitcoin::bip32::ChildNumber
 impl core::marker::UnsafeUnpin for bitcoin::bip32::ChildNumber
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip32::ChildNumber
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip32::ChildNumber
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::bip32::ChildNumber where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::bip32::ChildNumber where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::bip32::ChildNumber where U: core::convert::From<T>
 pub fn bitcoin::bip32::ChildNumber::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::bip32::ChildNumber where U: core::convert::Into<T>
@@ -1908,7 +2010,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::bip32::ChildNumber where T: core
 pub unsafe fn bitcoin::bip32::ChildNumber::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::bip32::ChildNumber
 pub fn bitcoin::bip32::ChildNumber::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::bip32::ChildNumber where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::bip32::ChildNumber where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::bip32::ChildNumber where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::bip32::ChildNumber where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::bip32::ChildNumber::vzip(self) -> V
 #[non_exhaustive] pub enum bitcoin::bip32::Error
@@ -1952,6 +2055,8 @@ impl core::marker::Unpin for bitcoin::bip32::Error
 impl core::marker::UnsafeUnpin for bitcoin::bip32::Error
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip32::Error
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip32::Error
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::bip32::Error where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::bip32::Error where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::bip32::Error where U: core::convert::From<T>
 pub fn bitcoin::bip32::Error::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::bip32::Error where U: core::convert::Into<T>
@@ -1976,6 +2081,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::bip32::Error where T: core::clon
 pub unsafe fn bitcoin::bip32::Error::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::bip32::Error
 pub fn bitcoin::bip32::Error::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::bip32::Error where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::bip32::Error where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::bip32::Error::vzip(self) -> V
 pub struct bitcoin::bip32::ChainCode(_)
@@ -2024,8 +2130,8 @@ impl core::marker::StructuralPartialEq for bitcoin::bip32::ChainCode
 impl core::str::traits::FromStr for bitcoin::bip32::ChainCode
 pub type bitcoin::bip32::ChainCode::Err = hex_conservative::error::HexToArrayError
 pub fn bitcoin::bip32::ChainCode::from_str(s: &str) -> core::result::Result<Self, Self::Err>
-impl serde::ser::Serialize for bitcoin::bip32::ChainCode
-pub fn bitcoin::bip32::ChainCode::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+impl serde_core::ser::Serialize for bitcoin::bip32::ChainCode
+pub fn bitcoin::bip32::ChainCode::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 impl<'a> core::convert::From<&'a [u8; 32]> for bitcoin::bip32::ChainCode
 pub fn bitcoin::bip32::ChainCode::from(data: &'a [u8; 32]) -> Self
 impl<'a> core::convert::From<[u8; 32]> for bitcoin::bip32::ChainCode
@@ -2033,8 +2139,8 @@ pub fn bitcoin::bip32::ChainCode::from(data: [u8; 32]) -> Self
 impl<'a> core::convert::TryFrom<&'a [u8]> for bitcoin::bip32::ChainCode
 pub type bitcoin::bip32::ChainCode::Error = core::array::TryFromSliceError
 pub fn bitcoin::bip32::ChainCode::try_from(data: &'a [u8]) -> core::result::Result<Self, Self::Error>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::bip32::ChainCode
-pub fn bitcoin::bip32::ChainCode::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::bip32::ChainCode, <D as serde::de::Deserializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::bip32::ChainCode
+pub fn bitcoin::bip32::ChainCode::deserialize<D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::bip32::ChainCode, <D as serde_core::de::Deserializer>::Error>
 impl<I> core::ops::index::Index<I> for bitcoin::bip32::ChainCode where [u8]: core::ops::index::Index<I>
 pub type bitcoin::bip32::ChainCode::Output = <[u8] as core::ops::index::Index<I>>::Output
 pub fn bitcoin::bip32::ChainCode::index(&self, index: I) -> &Self::Output
@@ -2045,6 +2151,8 @@ impl core::marker::Unpin for bitcoin::bip32::ChainCode
 impl core::marker::UnsafeUnpin for bitcoin::bip32::ChainCode
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip32::ChainCode
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip32::ChainCode
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::bip32::ChainCode where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::bip32::ChainCode where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::bip32::ChainCode where U: core::convert::From<T>
 pub fn bitcoin::bip32::ChainCode::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::bip32::ChainCode where U: core::convert::Into<T>
@@ -2069,7 +2177,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::bip32::ChainCode where T: core::
 pub unsafe fn bitcoin::bip32::ChainCode::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::bip32::ChainCode
 pub fn bitcoin::bip32::ChainCode::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::bip32::ChainCode where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::bip32::ChainCode where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::bip32::ChainCode where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::bip32::ChainCode where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::bip32::ChainCode::vzip(self) -> V
 pub struct bitcoin::bip32::DerivationPath(_)
@@ -2111,16 +2220,16 @@ impl core::marker::StructuralPartialEq for bitcoin::bip32::DerivationPath
 impl core::str::traits::FromStr for bitcoin::bip32::DerivationPath
 pub type bitcoin::bip32::DerivationPath::Err = bitcoin::bip32::Error
 pub fn bitcoin::bip32::DerivationPath::from_str(path: &str) -> core::result::Result<bitcoin::bip32::DerivationPath, bitcoin::bip32::Error>
-impl serde::ser::Serialize for bitcoin::bip32::DerivationPath
-pub fn bitcoin::bip32::DerivationPath::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+impl serde_core::ser::Serialize for bitcoin::bip32::DerivationPath
+pub fn bitcoin::bip32::DerivationPath::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error> where S: serde_core::ser::Serializer
 impl<'a> core::convert::From<&'a [bitcoin::bip32::ChildNumber]> for bitcoin::bip32::DerivationPath
 pub fn bitcoin::bip32::DerivationPath::from(numbers: &'a [bitcoin::bip32::ChildNumber]) -> Self
 impl<'a> core::iter::traits::collect::IntoIterator for &'a bitcoin::bip32::DerivationPath
 pub type &'a bitcoin::bip32::DerivationPath::IntoIter = core::slice::iter::Iter<'a, bitcoin::bip32::ChildNumber>
 pub type &'a bitcoin::bip32::DerivationPath::Item = &'a bitcoin::bip32::ChildNumber
 pub fn &'a bitcoin::bip32::DerivationPath::into_iter(self) -> Self::IntoIter
-impl<'de> serde::de::Deserialize<'de> for bitcoin::bip32::DerivationPath
-pub fn bitcoin::bip32::DerivationPath::deserialize<D>(deserializer: D) -> core::result::Result<bitcoin::bip32::DerivationPath, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::bip32::DerivationPath
+pub fn bitcoin::bip32::DerivationPath::deserialize<D>(deserializer: D) -> core::result::Result<bitcoin::bip32::DerivationPath, <D as serde_core::de::Deserializer>::Error> where D: serde_core::de::Deserializer<'de>
 impl<I> core::ops::index::Index<I> for bitcoin::bip32::DerivationPath where alloc::vec::Vec<bitcoin::bip32::ChildNumber>: core::ops::index::Index<I>
 pub type bitcoin::bip32::DerivationPath::Output = <alloc::vec::Vec<bitcoin::bip32::ChildNumber> as core::ops::index::Index<I>>::Output
 pub fn bitcoin::bip32::DerivationPath::index(&self, index: I) -> &Self::Output
@@ -2131,6 +2240,8 @@ impl core::marker::Unpin for bitcoin::bip32::DerivationPath
 impl core::marker::UnsafeUnpin for bitcoin::bip32::DerivationPath
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip32::DerivationPath
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip32::DerivationPath
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::bip32::DerivationPath where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::bip32::DerivationPath where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::bip32::DerivationPath where U: core::convert::From<T>
 pub fn bitcoin::bip32::DerivationPath::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::bip32::DerivationPath where U: core::convert::Into<T>
@@ -2157,7 +2268,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::bip32::DerivationPath where T: c
 pub unsafe fn bitcoin::bip32::DerivationPath::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::bip32::DerivationPath
 pub fn bitcoin::bip32::DerivationPath::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::bip32::DerivationPath where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::bip32::DerivationPath where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::bip32::DerivationPath where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::bip32::DerivationPath where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::bip32::DerivationPath::vzip(self) -> V
 pub struct bitcoin::bip32::DerivationPathIterator<'a>
@@ -2178,6 +2290,8 @@ pub type bitcoin::bip32::DerivationPathIterator<'a>::IntoIter = I
 pub type bitcoin::bip32::DerivationPathIterator<'a>::Item = <I as core::iter::traits::iterator::Iterator>::Item
 pub fn bitcoin::bip32::DerivationPathIterator<'a>::into_iter(self) -> I
 impl<I> rand::seq::IteratorRandom for bitcoin::bip32::DerivationPathIterator<'a> where I: core::iter::traits::iterator::Iterator
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::bip32::DerivationPathIterator<'a> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::bip32::DerivationPathIterator<'a> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::bip32::DerivationPathIterator<'a> where U: core::convert::From<T>
 pub fn bitcoin::bip32::DerivationPathIterator<'a>::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::bip32::DerivationPathIterator<'a> where U: core::convert::Into<T>
@@ -2194,6 +2308,7 @@ impl<T> core::borrow::BorrowMut<T> for bitcoin::bip32::DerivationPathIterator<'a
 pub fn bitcoin::bip32::DerivationPathIterator<'a>::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for bitcoin::bip32::DerivationPathIterator<'a>
 pub fn bitcoin::bip32::DerivationPathIterator<'a>::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::bip32::DerivationPathIterator<'a> where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::bip32::DerivationPathIterator<'a> where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::bip32::DerivationPathIterator<'a>::vzip(self) -> V
 pub struct bitcoin::bip32::Fingerprint(_)
@@ -2244,8 +2359,8 @@ impl core::marker::StructuralPartialEq for bitcoin::bip32::Fingerprint
 impl core::str::traits::FromStr for bitcoin::bip32::Fingerprint
 pub type bitcoin::bip32::Fingerprint::Err = hex_conservative::error::HexToArrayError
 pub fn bitcoin::bip32::Fingerprint::from_str(s: &str) -> core::result::Result<Self, Self::Err>
-impl serde::ser::Serialize for bitcoin::bip32::Fingerprint
-pub fn bitcoin::bip32::Fingerprint::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+impl serde_core::ser::Serialize for bitcoin::bip32::Fingerprint
+pub fn bitcoin::bip32::Fingerprint::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 impl<'a> core::convert::From<&'a [u8; 4]> for bitcoin::bip32::Fingerprint
 pub fn bitcoin::bip32::Fingerprint::from(data: &'a [u8; 4]) -> Self
 impl<'a> core::convert::From<[u8; 4]> for bitcoin::bip32::Fingerprint
@@ -2253,8 +2368,8 @@ pub fn bitcoin::bip32::Fingerprint::from(data: [u8; 4]) -> Self
 impl<'a> core::convert::TryFrom<&'a [u8]> for bitcoin::bip32::Fingerprint
 pub type bitcoin::bip32::Fingerprint::Error = core::array::TryFromSliceError
 pub fn bitcoin::bip32::Fingerprint::try_from(data: &'a [u8]) -> core::result::Result<Self, Self::Error>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::bip32::Fingerprint
-pub fn bitcoin::bip32::Fingerprint::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::bip32::Fingerprint, <D as serde::de::Deserializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::bip32::Fingerprint
+pub fn bitcoin::bip32::Fingerprint::deserialize<D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::bip32::Fingerprint, <D as serde_core::de::Deserializer>::Error>
 impl<I> core::ops::index::Index<I> for bitcoin::bip32::Fingerprint where [u8]: core::ops::index::Index<I>
 pub type bitcoin::bip32::Fingerprint::Output = <[u8] as core::ops::index::Index<I>>::Output
 pub fn bitcoin::bip32::Fingerprint::index(&self, index: I) -> &Self::Output
@@ -2265,6 +2380,8 @@ impl core::marker::Unpin for bitcoin::bip32::Fingerprint
 impl core::marker::UnsafeUnpin for bitcoin::bip32::Fingerprint
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip32::Fingerprint
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip32::Fingerprint
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::bip32::Fingerprint where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::bip32::Fingerprint where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::bip32::Fingerprint where U: core::convert::From<T>
 pub fn bitcoin::bip32::Fingerprint::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::bip32::Fingerprint where U: core::convert::Into<T>
@@ -2289,7 +2406,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::bip32::Fingerprint where T: core
 pub unsafe fn bitcoin::bip32::Fingerprint::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::bip32::Fingerprint
 pub fn bitcoin::bip32::Fingerprint::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::bip32::Fingerprint where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::bip32::Fingerprint where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::bip32::Fingerprint where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::bip32::Fingerprint where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::bip32::Fingerprint::vzip(self) -> V
 pub struct bitcoin::bip32::InvalidBase58PayloadLengthError
@@ -2312,6 +2430,8 @@ impl core::marker::Unpin for bitcoin::bip32::InvalidBase58PayloadLengthError
 impl core::marker::UnsafeUnpin for bitcoin::bip32::InvalidBase58PayloadLengthError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip32::InvalidBase58PayloadLengthError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip32::InvalidBase58PayloadLengthError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::bip32::InvalidBase58PayloadLengthError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::bip32::InvalidBase58PayloadLengthError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::bip32::InvalidBase58PayloadLengthError where U: core::convert::From<T>
 pub fn bitcoin::bip32::InvalidBase58PayloadLengthError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::bip32::InvalidBase58PayloadLengthError where U: core::convert::Into<T>
@@ -2336,6 +2456,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::bip32::InvalidBase58PayloadLengt
 pub unsafe fn bitcoin::bip32::InvalidBase58PayloadLengthError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::bip32::InvalidBase58PayloadLengthError
 pub fn bitcoin::bip32::InvalidBase58PayloadLengthError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::bip32::InvalidBase58PayloadLengthError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::bip32::InvalidBase58PayloadLengthError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::bip32::InvalidBase58PayloadLengthError::vzip(self) -> V
 pub struct bitcoin::bip32::XKeyIdentifier(_)
@@ -2393,10 +2514,10 @@ impl core::marker::StructuralPartialEq for bitcoin::bip32::XKeyIdentifier
 impl core::str::traits::FromStr for bitcoin::bip32::XKeyIdentifier
 pub type bitcoin::bip32::XKeyIdentifier::Err = hex_conservative::error::HexToArrayError
 pub fn bitcoin::bip32::XKeyIdentifier::from_str(s: &str) -> core::result::Result<bitcoin::bip32::XKeyIdentifier, Self::Err>
-impl serde::ser::Serialize for bitcoin::bip32::XKeyIdentifier
-pub fn bitcoin::bip32::XKeyIdentifier::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::bip32::XKeyIdentifier
-pub fn bitcoin::bip32::XKeyIdentifier::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::bip32::XKeyIdentifier, <D as serde::de::Deserializer>::Error>
+impl serde_core::ser::Serialize for bitcoin::bip32::XKeyIdentifier
+pub fn bitcoin::bip32::XKeyIdentifier::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::bip32::XKeyIdentifier
+pub fn bitcoin::bip32::XKeyIdentifier::deserialize<D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::bip32::XKeyIdentifier, <D as serde_core::de::Deserializer>::Error>
 impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::bip32::XKeyIdentifier
 pub type bitcoin::bip32::XKeyIdentifier::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
 pub fn bitcoin::bip32::XKeyIdentifier::index(&self, index: I) -> &Self::Output
@@ -2407,6 +2528,8 @@ impl core::marker::Unpin for bitcoin::bip32::XKeyIdentifier
 impl core::marker::UnsafeUnpin for bitcoin::bip32::XKeyIdentifier
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip32::XKeyIdentifier
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip32::XKeyIdentifier
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::bip32::XKeyIdentifier where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::bip32::XKeyIdentifier where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::bip32::XKeyIdentifier where U: core::convert::From<T>
 pub fn bitcoin::bip32::XKeyIdentifier::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::bip32::XKeyIdentifier where U: core::convert::Into<T>
@@ -2431,7 +2554,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::bip32::XKeyIdentifier where T: c
 pub unsafe fn bitcoin::bip32::XKeyIdentifier::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::bip32::XKeyIdentifier
 pub fn bitcoin::bip32::XKeyIdentifier::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::bip32::XKeyIdentifier where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::bip32::XKeyIdentifier where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::bip32::XKeyIdentifier where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::bip32::XKeyIdentifier where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::bip32::XKeyIdentifier::vzip(self) -> V
 pub struct bitcoin::bip32::Xpriv
@@ -2467,10 +2591,10 @@ impl core::marker::StructuralPartialEq for bitcoin::bip32::Xpriv
 impl core::str::traits::FromStr for bitcoin::bip32::Xpriv
 pub type bitcoin::bip32::Xpriv::Err = bitcoin::bip32::Error
 pub fn bitcoin::bip32::Xpriv::from_str(inp: &str) -> core::result::Result<bitcoin::bip32::Xpriv, bitcoin::bip32::Error>
-impl serde::ser::Serialize for bitcoin::bip32::Xpriv
-pub fn bitcoin::bip32::Xpriv::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
-impl<'de> serde::de::Deserialize<'de> for bitcoin::bip32::Xpriv
-pub fn bitcoin::bip32::Xpriv::deserialize<D>(deserializer: D) -> core::result::Result<bitcoin::bip32::Xpriv, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+impl serde_core::ser::Serialize for bitcoin::bip32::Xpriv
+pub fn bitcoin::bip32::Xpriv::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error> where S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::bip32::Xpriv
+pub fn bitcoin::bip32::Xpriv::deserialize<D>(deserializer: D) -> core::result::Result<bitcoin::bip32::Xpriv, <D as serde_core::de::Deserializer>::Error> where D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin::bip32::Xpriv
 impl core::marker::Send for bitcoin::bip32::Xpriv
 impl core::marker::Sync for bitcoin::bip32::Xpriv
@@ -2478,6 +2602,8 @@ impl core::marker::Unpin for bitcoin::bip32::Xpriv
 impl core::marker::UnsafeUnpin for bitcoin::bip32::Xpriv
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip32::Xpriv
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip32::Xpriv
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::bip32::Xpriv where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::bip32::Xpriv where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::bip32::Xpriv where U: core::convert::From<T>
 pub fn bitcoin::bip32::Xpriv::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::bip32::Xpriv where U: core::convert::Into<T>
@@ -2502,7 +2628,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::bip32::Xpriv where T: core::clon
 pub unsafe fn bitcoin::bip32::Xpriv::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::bip32::Xpriv
 pub fn bitcoin::bip32::Xpriv::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::bip32::Xpriv where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::bip32::Xpriv where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::bip32::Xpriv where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::bip32::Xpriv where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::bip32::Xpriv::vzip(self) -> V
 pub struct bitcoin::bip32::Xpub
@@ -2543,10 +2670,10 @@ impl core::marker::StructuralPartialEq for bitcoin::bip32::Xpub
 impl core::str::traits::FromStr for bitcoin::bip32::Xpub
 pub type bitcoin::bip32::Xpub::Err = bitcoin::bip32::Error
 pub fn bitcoin::bip32::Xpub::from_str(inp: &str) -> core::result::Result<bitcoin::bip32::Xpub, bitcoin::bip32::Error>
-impl serde::ser::Serialize for bitcoin::bip32::Xpub
-pub fn bitcoin::bip32::Xpub::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
-impl<'de> serde::de::Deserialize<'de> for bitcoin::bip32::Xpub
-pub fn bitcoin::bip32::Xpub::deserialize<D>(deserializer: D) -> core::result::Result<bitcoin::bip32::Xpub, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+impl serde_core::ser::Serialize for bitcoin::bip32::Xpub
+pub fn bitcoin::bip32::Xpub::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error> where S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::bip32::Xpub
+pub fn bitcoin::bip32::Xpub::deserialize<D>(deserializer: D) -> core::result::Result<bitcoin::bip32::Xpub, <D as serde_core::de::Deserializer>::Error> where D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin::bip32::Xpub
 impl core::marker::Send for bitcoin::bip32::Xpub
 impl core::marker::Sync for bitcoin::bip32::Xpub
@@ -2554,6 +2681,8 @@ impl core::marker::Unpin for bitcoin::bip32::Xpub
 impl core::marker::UnsafeUnpin for bitcoin::bip32::Xpub
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::bip32::Xpub
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::bip32::Xpub
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::bip32::Xpub where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::bip32::Xpub where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::bip32::Xpub where U: core::convert::From<T>
 pub fn bitcoin::bip32::Xpub::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::bip32::Xpub where U: core::convert::Into<T>
@@ -2578,7 +2707,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::bip32::Xpub where T: core::clone
 pub unsafe fn bitcoin::bip32::Xpub::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::bip32::Xpub
 pub fn bitcoin::bip32::Xpub::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::bip32::Xpub where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::bip32::Xpub where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::bip32::Xpub where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::bip32::Xpub where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::bip32::Xpub::vzip(self) -> V
 pub trait bitcoin::bip32::IntoDerivationPath
@@ -2620,6 +2750,8 @@ impl core::marker::Unpin for bitcoin::blockdata::block::Bip34Error
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::block::Bip34Error
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::block::Bip34Error
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::block::Bip34Error
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::block::Bip34Error where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::block::Bip34Error where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::block::Bip34Error where U: core::convert::From<T>
 pub fn bitcoin::blockdata::block::Bip34Error::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::block::Bip34Error where U: core::convert::Into<T>
@@ -2644,6 +2776,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::block::Bip34Error whe
 pub unsafe fn bitcoin::blockdata::block::Bip34Error::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::block::Bip34Error
 pub fn bitcoin::blockdata::block::Bip34Error::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::block::Bip34Error where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::block::Bip34Error where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::block::Bip34Error::vzip(self) -> V
 #[non_exhaustive] pub enum bitcoin::block::ValidationError
@@ -2669,6 +2802,8 @@ impl core::marker::Unpin for bitcoin::blockdata::block::ValidationError
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::block::ValidationError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::block::ValidationError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::block::ValidationError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::block::ValidationError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::block::ValidationError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::block::ValidationError where U: core::convert::From<T>
 pub fn bitcoin::blockdata::block::ValidationError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::block::ValidationError where U: core::convert::Into<T>
@@ -2693,6 +2828,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::block::ValidationErro
 pub unsafe fn bitcoin::blockdata::block::ValidationError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::block::ValidationError
 pub fn bitcoin::blockdata::block::ValidationError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::block::ValidationError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::block::ValidationError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::block::ValidationError::vzip(self) -> V
 pub struct bitcoin::block::Block
@@ -2726,12 +2862,12 @@ pub fn bitcoin::blockdata::block::BlockHash::from(block: bitcoin::blockdata::blo
 impl core::fmt::Debug for bitcoin::blockdata::block::Block
 pub fn bitcoin::blockdata::block::Block::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for bitcoin::blockdata::block::Block
-impl serde::ser::Serialize for bitcoin::blockdata::block::Block
-pub fn bitcoin::blockdata::block::Block::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl serde_core::ser::Serialize for bitcoin::blockdata::block::Block
+pub fn bitcoin::blockdata::block::Block::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin::blockdata::block::Block
 pub fn bitcoin::blockdata::block::Block::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::block::Block
-pub fn bitcoin::blockdata::block::Block::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::blockdata::block::Block
+pub fn bitcoin::blockdata::block::Block::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin::blockdata::block::Block
 impl core::marker::Send for bitcoin::blockdata::block::Block
 impl core::marker::Sync for bitcoin::blockdata::block::Block
@@ -2739,6 +2875,8 @@ impl core::marker::Unpin for bitcoin::blockdata::block::Block
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::block::Block
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::block::Block
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::block::Block
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::block::Block where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::block::Block where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::block::Block where U: core::convert::From<T>
 pub fn bitcoin::blockdata::block::Block::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::block::Block where U: core::convert::Into<T>
@@ -2761,7 +2899,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::block::Block where T:
 pub unsafe fn bitcoin::blockdata::block::Block::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::block::Block
 pub fn bitcoin::blockdata::block::Block::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::blockdata::block::Block where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::blockdata::block::Block where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::block::Block where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::block::Block where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::block::Block::vzip(self) -> V
 pub struct bitcoin::block::BlockHash(_)
@@ -2823,12 +2962,12 @@ impl core::marker::StructuralPartialEq for bitcoin::blockdata::block::BlockHash
 impl core::str::traits::FromStr for bitcoin::blockdata::block::BlockHash
 pub type bitcoin::blockdata::block::BlockHash::Err = hex_conservative::error::HexToArrayError
 pub fn bitcoin::blockdata::block::BlockHash::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::block::BlockHash, Self::Err>
-impl serde::ser::Serialize for bitcoin::blockdata::block::BlockHash
-pub fn bitcoin::blockdata::block::BlockHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+impl serde_core::ser::Serialize for bitcoin::blockdata::block::BlockHash
+pub fn bitcoin::blockdata::block::BlockHash::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin::blockdata::block::BlockHash
 pub fn bitcoin::blockdata::block::BlockHash::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::block::BlockHash
-pub fn bitcoin::blockdata::block::BlockHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::blockdata::block::BlockHash, <D as serde::de::Deserializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::blockdata::block::BlockHash
+pub fn bitcoin::blockdata::block::BlockHash::deserialize<D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::blockdata::block::BlockHash, <D as serde_core::de::Deserializer>::Error>
 impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::blockdata::block::BlockHash
 pub type bitcoin::blockdata::block::BlockHash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
 pub fn bitcoin::blockdata::block::BlockHash::index(&self, index: I) -> &Self::Output
@@ -2839,6 +2978,8 @@ impl core::marker::Unpin for bitcoin::blockdata::block::BlockHash
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::block::BlockHash
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::block::BlockHash
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::block::BlockHash
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::block::BlockHash where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::block::BlockHash where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::block::BlockHash where U: core::convert::From<T>
 pub fn bitcoin::blockdata::block::BlockHash::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::block::BlockHash where U: core::convert::Into<T>
@@ -2863,7 +3004,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::block::BlockHash wher
 pub unsafe fn bitcoin::blockdata::block::BlockHash::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::block::BlockHash
 pub fn bitcoin::blockdata::block::BlockHash::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::blockdata::block::BlockHash where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::blockdata::block::BlockHash where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::block::BlockHash where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::block::BlockHash where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::block::BlockHash::vzip(self) -> V
 pub struct bitcoin::block::Header
@@ -2901,12 +3043,12 @@ impl core::hash::Hash for bitcoin::blockdata::block::Header
 pub fn bitcoin::blockdata::block::Header::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for bitcoin::blockdata::block::Header
 impl core::marker::StructuralPartialEq for bitcoin::blockdata::block::Header
-impl serde::ser::Serialize for bitcoin::blockdata::block::Header
-pub fn bitcoin::blockdata::block::Header::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl serde_core::ser::Serialize for bitcoin::blockdata::block::Header
+pub fn bitcoin::blockdata::block::Header::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin::blockdata::block::Header
 pub fn bitcoin::blockdata::block::Header::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::block::Header
-pub fn bitcoin::blockdata::block::Header::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::blockdata::block::Header
+pub fn bitcoin::blockdata::block::Header::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin::blockdata::block::Header
 impl core::marker::Send for bitcoin::blockdata::block::Header
 impl core::marker::Sync for bitcoin::blockdata::block::Header
@@ -2914,6 +3056,8 @@ impl core::marker::Unpin for bitcoin::blockdata::block::Header
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::block::Header
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::block::Header
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::block::Header
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::block::Header where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::block::Header where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::block::Header where U: core::convert::From<T>
 pub fn bitcoin::blockdata::block::Header::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::block::Header where U: core::convert::Into<T>
@@ -2936,7 +3080,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::block::Header where T
 pub unsafe fn bitcoin::blockdata::block::Header::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::block::Header
 pub fn bitcoin::blockdata::block::Header::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::blockdata::block::Header where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::blockdata::block::Header where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::block::Header where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::block::Header where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::block::Header::vzip(self) -> V
 pub struct bitcoin::block::TxMerkleNode(_)
@@ -2996,12 +3141,12 @@ impl core::marker::StructuralPartialEq for bitcoin::blockdata::block::TxMerkleNo
 impl core::str::traits::FromStr for bitcoin::blockdata::block::TxMerkleNode
 pub type bitcoin::blockdata::block::TxMerkleNode::Err = hex_conservative::error::HexToArrayError
 pub fn bitcoin::blockdata::block::TxMerkleNode::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::block::TxMerkleNode, Self::Err>
-impl serde::ser::Serialize for bitcoin::blockdata::block::TxMerkleNode
-pub fn bitcoin::blockdata::block::TxMerkleNode::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+impl serde_core::ser::Serialize for bitcoin::blockdata::block::TxMerkleNode
+pub fn bitcoin::blockdata::block::TxMerkleNode::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin::blockdata::block::TxMerkleNode
 pub fn bitcoin::blockdata::block::TxMerkleNode::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::block::TxMerkleNode
-pub fn bitcoin::blockdata::block::TxMerkleNode::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::blockdata::block::TxMerkleNode, <D as serde::de::Deserializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::blockdata::block::TxMerkleNode
+pub fn bitcoin::blockdata::block::TxMerkleNode::deserialize<D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::blockdata::block::TxMerkleNode, <D as serde_core::de::Deserializer>::Error>
 impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::blockdata::block::TxMerkleNode
 pub type bitcoin::blockdata::block::TxMerkleNode::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
 pub fn bitcoin::blockdata::block::TxMerkleNode::index(&self, index: I) -> &Self::Output
@@ -3012,6 +3157,8 @@ impl core::marker::Unpin for bitcoin::blockdata::block::TxMerkleNode
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::block::TxMerkleNode
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::block::TxMerkleNode
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::block::TxMerkleNode
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::block::TxMerkleNode where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::block::TxMerkleNode where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::block::TxMerkleNode where U: core::convert::From<T>
 pub fn bitcoin::blockdata::block::TxMerkleNode::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::block::TxMerkleNode where U: core::convert::Into<T>
@@ -3036,7 +3183,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::block::TxMerkleNode w
 pub unsafe fn bitcoin::blockdata::block::TxMerkleNode::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::block::TxMerkleNode
 pub fn bitcoin::blockdata::block::TxMerkleNode::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::blockdata::block::TxMerkleNode where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::blockdata::block::TxMerkleNode where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::block::TxMerkleNode where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::block::TxMerkleNode where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::block::TxMerkleNode::vzip(self) -> V
 pub struct bitcoin::block::Version(_)
@@ -3068,12 +3216,12 @@ impl core::hash::Hash for bitcoin::blockdata::block::Version
 pub fn bitcoin::blockdata::block::Version::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for bitcoin::blockdata::block::Version
 impl core::marker::StructuralPartialEq for bitcoin::blockdata::block::Version
-impl serde::ser::Serialize for bitcoin::blockdata::block::Version
-pub fn bitcoin::blockdata::block::Version::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl serde_core::ser::Serialize for bitcoin::blockdata::block::Version
+pub fn bitcoin::blockdata::block::Version::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin::blockdata::block::Version
 pub fn bitcoin::blockdata::block::Version::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::block::Version
-pub fn bitcoin::blockdata::block::Version::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::blockdata::block::Version
+pub fn bitcoin::blockdata::block::Version::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin::blockdata::block::Version
 impl core::marker::Send for bitcoin::blockdata::block::Version
 impl core::marker::Sync for bitcoin::blockdata::block::Version
@@ -3081,6 +3229,8 @@ impl core::marker::Unpin for bitcoin::blockdata::block::Version
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::block::Version
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::block::Version
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::block::Version
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::block::Version where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::block::Version where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::block::Version where U: core::convert::From<T>
 pub fn bitcoin::blockdata::block::Version::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::block::Version where U: core::convert::Into<T>
@@ -3103,7 +3253,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::block::Version where 
 pub unsafe fn bitcoin::blockdata::block::Version::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::block::Version
 pub fn bitcoin::blockdata::block::Version::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::blockdata::block::Version where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::blockdata::block::Version where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::block::Version where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::block::Version where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::block::Version::vzip(self) -> V
 pub struct bitcoin::block::WitnessCommitment(_)
@@ -3157,10 +3308,10 @@ impl core::marker::StructuralPartialEq for bitcoin::blockdata::block::WitnessCom
 impl core::str::traits::FromStr for bitcoin::blockdata::block::WitnessCommitment
 pub type bitcoin::blockdata::block::WitnessCommitment::Err = hex_conservative::error::HexToArrayError
 pub fn bitcoin::blockdata::block::WitnessCommitment::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::block::WitnessCommitment, Self::Err>
-impl serde::ser::Serialize for bitcoin::blockdata::block::WitnessCommitment
-pub fn bitcoin::blockdata::block::WitnessCommitment::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::block::WitnessCommitment
-pub fn bitcoin::blockdata::block::WitnessCommitment::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::blockdata::block::WitnessCommitment, <D as serde::de::Deserializer>::Error>
+impl serde_core::ser::Serialize for bitcoin::blockdata::block::WitnessCommitment
+pub fn bitcoin::blockdata::block::WitnessCommitment::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::blockdata::block::WitnessCommitment
+pub fn bitcoin::blockdata::block::WitnessCommitment::deserialize<D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::blockdata::block::WitnessCommitment, <D as serde_core::de::Deserializer>::Error>
 impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::blockdata::block::WitnessCommitment
 pub type bitcoin::blockdata::block::WitnessCommitment::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
 pub fn bitcoin::blockdata::block::WitnessCommitment::index(&self, index: I) -> &Self::Output
@@ -3171,6 +3322,8 @@ impl core::marker::Unpin for bitcoin::blockdata::block::WitnessCommitment
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::block::WitnessCommitment
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::block::WitnessCommitment
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::block::WitnessCommitment
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::block::WitnessCommitment where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::block::WitnessCommitment where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::block::WitnessCommitment where U: core::convert::From<T>
 pub fn bitcoin::blockdata::block::WitnessCommitment::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::block::WitnessCommitment where U: core::convert::Into<T>
@@ -3195,7 +3348,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::block::WitnessCommitm
 pub unsafe fn bitcoin::blockdata::block::WitnessCommitment::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::block::WitnessCommitment
 pub fn bitcoin::blockdata::block::WitnessCommitment::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::blockdata::block::WitnessCommitment where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::blockdata::block::WitnessCommitment where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::block::WitnessCommitment where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::block::WitnessCommitment where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::block::WitnessCommitment::vzip(self) -> V
 pub struct bitcoin::block::WitnessMerkleNode(_)
@@ -3255,10 +3409,10 @@ impl core::marker::StructuralPartialEq for bitcoin::blockdata::block::WitnessMer
 impl core::str::traits::FromStr for bitcoin::blockdata::block::WitnessMerkleNode
 pub type bitcoin::blockdata::block::WitnessMerkleNode::Err = hex_conservative::error::HexToArrayError
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::block::WitnessMerkleNode, Self::Err>
-impl serde::ser::Serialize for bitcoin::blockdata::block::WitnessMerkleNode
-pub fn bitcoin::blockdata::block::WitnessMerkleNode::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::block::WitnessMerkleNode
-pub fn bitcoin::blockdata::block::WitnessMerkleNode::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::blockdata::block::WitnessMerkleNode, <D as serde::de::Deserializer>::Error>
+impl serde_core::ser::Serialize for bitcoin::blockdata::block::WitnessMerkleNode
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::blockdata::block::WitnessMerkleNode
+pub fn bitcoin::blockdata::block::WitnessMerkleNode::deserialize<D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::blockdata::block::WitnessMerkleNode, <D as serde_core::de::Deserializer>::Error>
 impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::blockdata::block::WitnessMerkleNode
 pub type bitcoin::blockdata::block::WitnessMerkleNode::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::index(&self, index: I) -> &Self::Output
@@ -3269,6 +3423,8 @@ impl core::marker::Unpin for bitcoin::blockdata::block::WitnessMerkleNode
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::block::WitnessMerkleNode
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::block::WitnessMerkleNode
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::block::WitnessMerkleNode
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::block::WitnessMerkleNode where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::block::WitnessMerkleNode where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::block::WitnessMerkleNode where U: core::convert::From<T>
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::block::WitnessMerkleNode where U: core::convert::Into<T>
@@ -3293,7 +3449,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::block::WitnessMerkleN
 pub unsafe fn bitcoin::blockdata::block::WitnessMerkleNode::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::block::WitnessMerkleNode
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::blockdata::block::WitnessMerkleNode where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::blockdata::block::WitnessMerkleNode where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::block::WitnessMerkleNode where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::block::WitnessMerkleNode where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::block::WitnessMerkleNode::vzip(self) -> V
 pub mod bitcoin::blockdata
@@ -3382,8 +3539,8 @@ impl core::marker::StructuralPartialEq for bitcoin::blockdata::constants::ChainH
 impl core::str::traits::FromStr for bitcoin::blockdata::constants::ChainHash
 pub type bitcoin::blockdata::constants::ChainHash::Err = hex_conservative::error::HexToArrayError
 pub fn bitcoin::blockdata::constants::ChainHash::from_str(s: &str) -> core::result::Result<Self, Self::Err>
-impl serde::ser::Serialize for bitcoin::blockdata::constants::ChainHash
-pub fn bitcoin::blockdata::constants::ChainHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+impl serde_core::ser::Serialize for bitcoin::blockdata::constants::ChainHash
+pub fn bitcoin::blockdata::constants::ChainHash::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 impl<'a> core::convert::From<&'a [u8; 32]> for bitcoin::blockdata::constants::ChainHash
 pub fn bitcoin::blockdata::constants::ChainHash::from(data: &'a [u8; 32]) -> Self
 impl<'a> core::convert::From<[u8; 32]> for bitcoin::blockdata::constants::ChainHash
@@ -3391,8 +3548,8 @@ pub fn bitcoin::blockdata::constants::ChainHash::from(data: [u8; 32]) -> Self
 impl<'a> core::convert::TryFrom<&'a [u8]> for bitcoin::blockdata::constants::ChainHash
 pub type bitcoin::blockdata::constants::ChainHash::Error = core::array::TryFromSliceError
 pub fn bitcoin::blockdata::constants::ChainHash::try_from(data: &'a [u8]) -> core::result::Result<Self, Self::Error>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::constants::ChainHash
-pub fn bitcoin::blockdata::constants::ChainHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::blockdata::constants::ChainHash, <D as serde::de::Deserializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::blockdata::constants::ChainHash
+pub fn bitcoin::blockdata::constants::ChainHash::deserialize<D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::blockdata::constants::ChainHash, <D as serde_core::de::Deserializer>::Error>
 impl<I> core::ops::index::Index<I> for bitcoin::blockdata::constants::ChainHash where [u8]: core::ops::index::Index<I>
 pub type bitcoin::blockdata::constants::ChainHash::Output = <[u8] as core::ops::index::Index<I>>::Output
 pub fn bitcoin::blockdata::constants::ChainHash::index(&self, index: I) -> &Self::Output
@@ -3403,6 +3560,8 @@ impl core::marker::Unpin for bitcoin::blockdata::constants::ChainHash
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::constants::ChainHash
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::constants::ChainHash
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::constants::ChainHash
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::constants::ChainHash where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::constants::ChainHash where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::constants::ChainHash where U: core::convert::From<T>
 pub fn bitcoin::blockdata::constants::ChainHash::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::constants::ChainHash where U: core::convert::Into<T>
@@ -3427,7 +3586,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::constants::ChainHash 
 pub unsafe fn bitcoin::blockdata::constants::ChainHash::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::constants::ChainHash
 pub fn bitcoin::blockdata::constants::ChainHash::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::blockdata::constants::ChainHash where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::blockdata::constants::ChainHash where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::constants::ChainHash where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::constants::ChainHash where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::constants::ChainHash::vzip(self) -> V
 pub const bitcoin::blockdata::constants::COINBASE_MATURITY: u32
@@ -3508,10 +3668,10 @@ impl core::marker::Copy for bitcoin::blockdata::locktime::relative::LockTime
 impl core::marker::StructuralPartialEq for bitcoin::blockdata::locktime::relative::LockTime
 impl ordered::ArbitraryOrd for bitcoin::blockdata::locktime::relative::LockTime
 pub fn bitcoin::blockdata::locktime::relative::LockTime::arbitrary_cmp(&self, other: &Self) -> core::cmp::Ordering
-impl serde::ser::Serialize for bitcoin::blockdata::locktime::relative::LockTime
-pub fn bitcoin::blockdata::locktime::relative::LockTime::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
-impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::locktime::relative::LockTime
-pub fn bitcoin::blockdata::locktime::relative::LockTime::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl serde_core::ser::Serialize for bitcoin::blockdata::locktime::relative::LockTime
+pub fn bitcoin::blockdata::locktime::relative::LockTime::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::blockdata::locktime::relative::LockTime
+pub fn bitcoin::blockdata::locktime::relative::LockTime::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin::blockdata::locktime::relative::LockTime
 impl core::marker::Send for bitcoin::blockdata::locktime::relative::LockTime
 impl core::marker::Sync for bitcoin::blockdata::locktime::relative::LockTime
@@ -3519,6 +3679,8 @@ impl core::marker::Unpin for bitcoin::blockdata::locktime::relative::LockTime
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::locktime::relative::LockTime
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::relative::LockTime
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::relative::LockTime
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::locktime::relative::LockTime where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::locktime::relative::LockTime where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::locktime::relative::LockTime where U: core::convert::From<T>
 pub fn bitcoin::blockdata::locktime::relative::LockTime::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::locktime::relative::LockTime where U: core::convert::Into<T>
@@ -3543,7 +3705,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::locktime::relative::L
 pub unsafe fn bitcoin::blockdata::locktime::relative::LockTime::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::locktime::relative::LockTime
 pub fn bitcoin::blockdata::locktime::relative::LockTime::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::blockdata::locktime::relative::LockTime where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::blockdata::locktime::relative::LockTime where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::locktime::relative::LockTime where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::locktime::relative::LockTime where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::locktime::relative::LockTime::vzip(self) -> V
 pub struct bitcoin::blockdata::locktime::relative::DisabledLockTimeError(_)
@@ -3566,6 +3729,8 @@ impl core::marker::Unpin for bitcoin::blockdata::locktime::relative::DisabledLoc
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::locktime::relative::DisabledLockTimeError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::relative::DisabledLockTimeError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::relative::DisabledLockTimeError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::locktime::relative::DisabledLockTimeError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::locktime::relative::DisabledLockTimeError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::locktime::relative::DisabledLockTimeError where U: core::convert::From<T>
 pub fn bitcoin::blockdata::locktime::relative::DisabledLockTimeError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::locktime::relative::DisabledLockTimeError where U: core::convert::Into<T>
@@ -3590,6 +3755,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::locktime::relative::D
 pub unsafe fn bitcoin::blockdata::locktime::relative::DisabledLockTimeError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::locktime::relative::DisabledLockTimeError
 pub fn bitcoin::blockdata::locktime::relative::DisabledLockTimeError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::locktime::relative::DisabledLockTimeError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::locktime::relative::DisabledLockTimeError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::locktime::relative::DisabledLockTimeError::vzip(self) -> V
 #[non_exhaustive] pub struct bitcoin::blockdata::locktime::relative::IncompatibleHeightError
@@ -3612,6 +3778,8 @@ impl core::marker::Unpin for bitcoin::blockdata::locktime::relative::Incompatibl
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::locktime::relative::IncompatibleHeightError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::relative::IncompatibleHeightError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::relative::IncompatibleHeightError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::locktime::relative::IncompatibleHeightError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::locktime::relative::IncompatibleHeightError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::locktime::relative::IncompatibleHeightError where U: core::convert::From<T>
 pub fn bitcoin::blockdata::locktime::relative::IncompatibleHeightError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::locktime::relative::IncompatibleHeightError where U: core::convert::Into<T>
@@ -3636,6 +3804,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::locktime::relative::I
 pub unsafe fn bitcoin::blockdata::locktime::relative::IncompatibleHeightError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::locktime::relative::IncompatibleHeightError
 pub fn bitcoin::blockdata::locktime::relative::IncompatibleHeightError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::locktime::relative::IncompatibleHeightError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::locktime::relative::IncompatibleHeightError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::locktime::relative::IncompatibleHeightError::vzip(self) -> V
 #[non_exhaustive] pub struct bitcoin::blockdata::locktime::relative::IncompatibleTimeError
@@ -3658,6 +3827,8 @@ impl core::marker::Unpin for bitcoin::blockdata::locktime::relative::Incompatibl
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::locktime::relative::IncompatibleTimeError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::locktime::relative::IncompatibleTimeError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::locktime::relative::IncompatibleTimeError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::locktime::relative::IncompatibleTimeError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::locktime::relative::IncompatibleTimeError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::locktime::relative::IncompatibleTimeError where U: core::convert::From<T>
 pub fn bitcoin::blockdata::locktime::relative::IncompatibleTimeError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::locktime::relative::IncompatibleTimeError where U: core::convert::Into<T>
@@ -3682,6 +3853,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::locktime::relative::I
 pub unsafe fn bitcoin::blockdata::locktime::relative::IncompatibleTimeError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::locktime::relative::IncompatibleTimeError
 pub fn bitcoin::blockdata::locktime::relative::IncompatibleTimeError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::locktime::relative::IncompatibleTimeError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::locktime::relative::IncompatibleTimeError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::locktime::relative::IncompatibleTimeError::vzip(self) -> V
 pub mod bitcoin::blockdata::opcodes
@@ -3966,6 +4138,8 @@ impl core::marker::Unpin for bitcoin::blockdata::opcodes::Class
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::opcodes::Class
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::opcodes::Class
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::opcodes::Class
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::opcodes::Class where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::opcodes::Class where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::opcodes::Class where U: core::convert::From<T>
 pub fn bitcoin::blockdata::opcodes::Class::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::opcodes::Class where U: core::convert::Into<T>
@@ -3988,6 +4162,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::opcodes::Class where 
 pub unsafe fn bitcoin::blockdata::opcodes::Class::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::opcodes::Class
 pub fn bitcoin::blockdata::opcodes::Class::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::opcodes::Class where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::opcodes::Class where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::opcodes::Class::vzip(self) -> V
 pub enum bitcoin::blockdata::opcodes::ClassifyContext
@@ -4015,6 +4190,8 @@ impl core::marker::Unpin for bitcoin::blockdata::opcodes::ClassifyContext
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::opcodes::ClassifyContext
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::opcodes::ClassifyContext
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::opcodes::ClassifyContext
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::opcodes::ClassifyContext where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::opcodes::ClassifyContext where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::opcodes::ClassifyContext where U: core::convert::From<T>
 pub fn bitcoin::blockdata::opcodes::ClassifyContext::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::opcodes::ClassifyContext where U: core::convert::Into<T>
@@ -4037,6 +4214,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::opcodes::ClassifyCont
 pub unsafe fn bitcoin::blockdata::opcodes::ClassifyContext::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::opcodes::ClassifyContext
 pub fn bitcoin::blockdata::opcodes::ClassifyContext::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::opcodes::ClassifyContext where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::opcodes::ClassifyContext where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::opcodes::ClassifyContext::vzip(self) -> V
 pub struct bitcoin::blockdata::opcodes::Opcode
@@ -4061,8 +4239,8 @@ impl core::fmt::Display for bitcoin::blockdata::opcodes::Opcode
 pub fn bitcoin::blockdata::opcodes::Opcode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for bitcoin::blockdata::opcodes::Opcode
 impl core::marker::StructuralPartialEq for bitcoin::blockdata::opcodes::Opcode
-impl serde::ser::Serialize for bitcoin::blockdata::opcodes::Opcode
-pub fn bitcoin::blockdata::opcodes::Opcode::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+impl serde_core::ser::Serialize for bitcoin::blockdata::opcodes::Opcode
+pub fn bitcoin::blockdata::opcodes::Opcode::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error> where S: serde_core::ser::Serializer
 impl core::marker::Freeze for bitcoin::blockdata::opcodes::Opcode
 impl core::marker::Send for bitcoin::blockdata::opcodes::Opcode
 impl core::marker::Sync for bitcoin::blockdata::opcodes::Opcode
@@ -4070,6 +4248,8 @@ impl core::marker::Unpin for bitcoin::blockdata::opcodes::Opcode
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::opcodes::Opcode
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::opcodes::Opcode
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::opcodes::Opcode
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::opcodes::Opcode where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::opcodes::Opcode where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::opcodes::Opcode where U: core::convert::From<T>
 pub fn bitcoin::blockdata::opcodes::Opcode::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::opcodes::Opcode where U: core::convert::Into<T>
@@ -4094,6 +4274,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::opcodes::Opcode where
 pub unsafe fn bitcoin::blockdata::opcodes::Opcode::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::opcodes::Opcode
 pub fn bitcoin::blockdata::opcodes::Opcode::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::opcodes::Opcode where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::opcodes::Opcode where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::opcodes::Opcode::vzip(self) -> V
 pub static bitcoin::blockdata::opcodes::OP_0: bitcoin::blockdata::opcodes::Opcode
@@ -4126,6 +4307,8 @@ impl core::marker::Unpin for bitcoin::blockdata::script::witness_program::Error
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::script::witness_program::Error
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::witness_program::Error
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::witness_program::Error
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::script::witness_program::Error where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::script::witness_program::Error where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::script::witness_program::Error where U: core::convert::From<T>
 pub fn bitcoin::blockdata::script::witness_program::Error::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::script::witness_program::Error where U: core::convert::Into<T>
@@ -4150,6 +4333,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::script::witness_progr
 pub unsafe fn bitcoin::blockdata::script::witness_program::Error::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::script::witness_program::Error
 pub fn bitcoin::blockdata::script::witness_program::Error::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::script::witness_program::Error where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::script::witness_program::Error where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::script::witness_program::Error::vzip(self) -> V
 pub struct bitcoin::blockdata::script::witness_program::WitnessProgram
@@ -4188,6 +4372,8 @@ impl core::marker::Unpin for bitcoin::blockdata::script::witness_program::Witnes
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::script::witness_program::WitnessProgram
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::witness_program::WitnessProgram
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::witness_program::WitnessProgram
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::script::witness_program::WitnessProgram where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::script::witness_program::WitnessProgram where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::script::witness_program::WitnessProgram where U: core::convert::From<T>
 pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::script::witness_program::WitnessProgram where U: core::convert::Into<T>
@@ -4210,6 +4396,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::script::witness_progr
 pub unsafe fn bitcoin::blockdata::script::witness_program::WitnessProgram::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::script::witness_program::WitnessProgram
 pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::script::witness_program::WitnessProgram where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::script::witness_program::WitnessProgram where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::script::witness_program::WitnessProgram::vzip(self) -> V
 pub const bitcoin::blockdata::script::witness_program::MAX_SIZE: usize
@@ -4242,6 +4429,8 @@ impl core::marker::Unpin for bitcoin::blockdata::script::witness_version::FromSt
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::script::witness_version::FromStrError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::witness_version::FromStrError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::witness_version::FromStrError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::script::witness_version::FromStrError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::script::witness_version::FromStrError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::script::witness_version::FromStrError where U: core::convert::From<T>
 pub fn bitcoin::blockdata::script::witness_version::FromStrError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::script::witness_version::FromStrError where U: core::convert::Into<T>
@@ -4266,6 +4455,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::script::witness_versi
 pub unsafe fn bitcoin::blockdata::script::witness_version::FromStrError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::script::witness_version::FromStrError
 pub fn bitcoin::blockdata::script::witness_version::FromStrError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::script::witness_version::FromStrError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::script::witness_version::FromStrError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::script::witness_version::FromStrError::vzip(self) -> V
 #[non_exhaustive] pub enum bitcoin::blockdata::script::witness_version::TryFromInstructionError
@@ -4293,6 +4483,8 @@ impl core::marker::Unpin for bitcoin::blockdata::script::witness_version::TryFro
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::script::witness_version::TryFromInstructionError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::witness_version::TryFromInstructionError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::witness_version::TryFromInstructionError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::script::witness_version::TryFromInstructionError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::script::witness_version::TryFromInstructionError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::script::witness_version::TryFromInstructionError where U: core::convert::From<T>
 pub fn bitcoin::blockdata::script::witness_version::TryFromInstructionError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::script::witness_version::TryFromInstructionError where U: core::convert::Into<T>
@@ -4317,6 +4509,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::script::witness_versi
 pub unsafe fn bitcoin::blockdata::script::witness_version::TryFromInstructionError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::script::witness_version::TryFromInstructionError
 pub fn bitcoin::blockdata::script::witness_version::TryFromInstructionError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::script::witness_version::TryFromInstructionError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::script::witness_version::TryFromInstructionError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::script::witness_version::TryFromInstructionError::vzip(self) -> V
 #[repr(u8)] pub enum bitcoin::blockdata::script::witness_version::WitnessVersion
@@ -4375,6 +4568,8 @@ impl core::marker::Unpin for bitcoin::blockdata::script::witness_version::Witnes
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::script::witness_version::WitnessVersion
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::witness_version::WitnessVersion
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::witness_version::WitnessVersion
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::script::witness_version::WitnessVersion where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::script::witness_version::WitnessVersion where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::script::witness_version::WitnessVersion where U: core::convert::From<T>
 pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::script::witness_version::WitnessVersion where U: core::convert::Into<T>
@@ -4399,6 +4594,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::script::witness_versi
 pub unsafe fn bitcoin::blockdata::script::witness_version::WitnessVersion::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::script::witness_version::WitnessVersion
 pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::script::witness_version::WitnessVersion where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::script::witness_version::WitnessVersion where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::script::witness_version::WitnessVersion::vzip(self) -> V
 pub struct bitcoin::blockdata::script::witness_version::TryFromError
@@ -4421,6 +4617,8 @@ impl core::marker::Unpin for bitcoin::blockdata::script::witness_version::TryFro
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::script::witness_version::TryFromError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::witness_version::TryFromError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::witness_version::TryFromError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::script::witness_version::TryFromError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::script::witness_version::TryFromError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::script::witness_version::TryFromError where U: core::convert::From<T>
 pub fn bitcoin::blockdata::script::witness_version::TryFromError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::script::witness_version::TryFromError where U: core::convert::Into<T>
@@ -4445,6 +4643,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::script::witness_versi
 pub unsafe fn bitcoin::blockdata::script::witness_version::TryFromError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::script::witness_version::TryFromError
 pub fn bitcoin::blockdata::script::witness_version::TryFromError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::script::witness_version::TryFromError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::script::witness_version::TryFromError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::script::witness_version::TryFromError::vzip(self) -> V
 #[non_exhaustive] pub enum bitcoin::blockdata::script::Error
@@ -4473,6 +4672,8 @@ impl core::marker::Unpin for bitcoin::blockdata::script::Error
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::script::Error
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::Error
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::Error
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::script::Error where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::script::Error where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::script::Error where U: core::convert::From<T>
 pub fn bitcoin::blockdata::script::Error::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::script::Error where U: core::convert::Into<T>
@@ -4497,6 +4698,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::script::Error where T
 pub unsafe fn bitcoin::blockdata::script::Error::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::script::Error
 pub fn bitcoin::blockdata::script::Error::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::script::Error where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::script::Error where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::script::Error::vzip(self) -> V
 pub enum bitcoin::blockdata::script::Instruction<'a>
@@ -4526,6 +4728,8 @@ impl<'a> core::marker::Unpin for bitcoin::blockdata::script::Instruction<'a>
 impl<'a> core::marker::UnsafeUnpin for bitcoin::blockdata::script::Instruction<'a>
 impl<'a> core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::Instruction<'a>
 impl<'a> core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::Instruction<'a>
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::script::Instruction<'a> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::script::Instruction<'a> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::script::Instruction<'a> where U: core::convert::From<T>
 pub fn bitcoin::blockdata::script::Instruction<'a>::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::script::Instruction<'a> where U: core::convert::Into<T>
@@ -4548,6 +4752,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::script::Instruction<'
 pub unsafe fn bitcoin::blockdata::script::Instruction<'a>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::script::Instruction<'a>
 pub fn bitcoin::blockdata::script::Instruction<'a>::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::script::Instruction<'a> where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::script::Instruction<'a> where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::script::Instruction<'a>::vzip(self) -> V
 pub struct bitcoin::blockdata::script::Builder(_, _)
@@ -4588,6 +4793,8 @@ impl core::marker::Unpin for bitcoin::blockdata::script::Builder
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::script::Builder
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::Builder
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::Builder
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::script::Builder where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::script::Builder where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::script::Builder where U: core::convert::From<T>
 pub fn bitcoin::blockdata::script::Builder::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::script::Builder where U: core::convert::Into<T>
@@ -4612,6 +4819,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::script::Builder where
 pub unsafe fn bitcoin::blockdata::script::Builder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::script::Builder
 pub fn bitcoin::blockdata::script::Builder::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::script::Builder where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::script::Builder where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::script::Builder::vzip(self) -> V
 pub struct bitcoin::blockdata::script::Bytes<'a>(_)
@@ -4638,6 +4846,8 @@ pub type bitcoin::blockdata::script::Bytes<'a>::IntoIter = I
 pub type bitcoin::blockdata::script::Bytes<'a>::Item = <I as core::iter::traits::iterator::Iterator>::Item
 pub fn bitcoin::blockdata::script::Bytes<'a>::into_iter(self) -> I
 impl<I> rand::seq::IteratorRandom for bitcoin::blockdata::script::Bytes<'a> where I: core::iter::traits::iterator::Iterator
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::script::Bytes<'a> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::script::Bytes<'a> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::script::Bytes<'a> where U: core::convert::From<T>
 pub fn bitcoin::blockdata::script::Bytes<'a>::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::script::Bytes<'a> where U: core::convert::Into<T>
@@ -4654,6 +4864,7 @@ impl<T> core::borrow::BorrowMut<T> for bitcoin::blockdata::script::Bytes<'a> whe
 pub fn bitcoin::blockdata::script::Bytes<'a>::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for bitcoin::blockdata::script::Bytes<'a>
 pub fn bitcoin::blockdata::script::Bytes<'a>::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::script::Bytes<'a> where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::script::Bytes<'a> where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::script::Bytes<'a>::vzip(self) -> V
 pub struct bitcoin::blockdata::script::InstructionIndices<'a>
@@ -4681,6 +4892,8 @@ pub type bitcoin::blockdata::script::InstructionIndices<'a>::IntoIter = I
 pub type bitcoin::blockdata::script::InstructionIndices<'a>::Item = <I as core::iter::traits::iterator::Iterator>::Item
 pub fn bitcoin::blockdata::script::InstructionIndices<'a>::into_iter(self) -> I
 impl<I> rand::seq::IteratorRandom for bitcoin::blockdata::script::InstructionIndices<'a> where I: core::iter::traits::iterator::Iterator
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::script::InstructionIndices<'a> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::script::InstructionIndices<'a> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::script::InstructionIndices<'a> where U: core::convert::From<T>
 pub fn bitcoin::blockdata::script::InstructionIndices<'a>::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::script::InstructionIndices<'a> where U: core::convert::Into<T>
@@ -4703,6 +4916,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::script::InstructionIn
 pub unsafe fn bitcoin::blockdata::script::InstructionIndices<'a>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::script::InstructionIndices<'a>
 pub fn bitcoin::blockdata::script::InstructionIndices<'a>::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::script::InstructionIndices<'a> where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::script::InstructionIndices<'a> where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::script::InstructionIndices<'a>::vzip(self) -> V
 pub struct bitcoin::blockdata::script::Instructions<'a>
@@ -4729,6 +4943,8 @@ pub type bitcoin::blockdata::script::Instructions<'a>::IntoIter = I
 pub type bitcoin::blockdata::script::Instructions<'a>::Item = <I as core::iter::traits::iterator::Iterator>::Item
 pub fn bitcoin::blockdata::script::Instructions<'a>::into_iter(self) -> I
 impl<I> rand::seq::IteratorRandom for bitcoin::blockdata::script::Instructions<'a> where I: core::iter::traits::iterator::Iterator
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::script::Instructions<'a> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::script::Instructions<'a> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::script::Instructions<'a> where U: core::convert::From<T>
 pub fn bitcoin::blockdata::script::Instructions<'a>::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::script::Instructions<'a> where U: core::convert::Into<T>
@@ -4751,6 +4967,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::script::Instructions<
 pub unsafe fn bitcoin::blockdata::script::Instructions<'a>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::script::Instructions<'a>
 pub fn bitcoin::blockdata::script::Instructions<'a>::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::script::Instructions<'a> where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::script::Instructions<'a> where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::script::Instructions<'a>::vzip(self) -> V
 #[repr(transparent)] pub struct bitcoin::blockdata::script::PushBytes(_)
@@ -5449,12 +5666,15 @@ impl core::marker::Unpin for bitcoin::blockdata::script::PushBytes
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::script::PushBytes
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::PushBytes
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::PushBytes
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::script::PushBytes where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::script::PushBytes where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T> core::any::Any for bitcoin::blockdata::script::PushBytes where T: 'static + ?core::marker::Sized
 pub fn bitcoin::blockdata::script::PushBytes::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin::blockdata::script::PushBytes where T: ?core::marker::Sized
 pub fn bitcoin::blockdata::script::PushBytes::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin::blockdata::script::PushBytes where T: ?core::marker::Sized
 pub fn bitcoin::blockdata::script::PushBytes::borrow_mut(&mut self) -> &mut T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::script::PushBytes where T: ?core::marker::Sized
 pub struct bitcoin::blockdata::script::PushBytesBuf(_)
 impl bitcoin::blockdata::script::PushBytesBuf
 pub fn bitcoin::blockdata::script::PushBytesBuf::as_mut_push_bytes(&mut self) -> &mut bitcoin::blockdata::script::PushBytes
@@ -5822,6 +6042,8 @@ impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::Pus
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::PushBytesBuf
 impl<P, T> core::ops::deref::Receiver for bitcoin::blockdata::script::PushBytesBuf where P: core::ops::deref::Deref<Target = T> + ?core::marker::Sized, T: ?core::marker::Sized
 pub type bitcoin::blockdata::script::PushBytesBuf::Target = T
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::script::PushBytesBuf where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::script::PushBytesBuf where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::script::PushBytesBuf where U: core::convert::From<T>
 pub fn bitcoin::blockdata::script::PushBytesBuf::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::script::PushBytesBuf where U: core::convert::Into<T>
@@ -5844,6 +6066,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::script::PushBytesBuf 
 pub unsafe fn bitcoin::blockdata::script::PushBytesBuf::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::script::PushBytesBuf
 pub fn bitcoin::blockdata::script::PushBytesBuf::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::script::PushBytesBuf where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::script::PushBytesBuf where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::script::PushBytesBuf::vzip(self) -> V
 pub struct bitcoin::blockdata::script::PushBytesError
@@ -5868,6 +6091,8 @@ impl core::marker::Unpin for bitcoin::blockdata::script::PushBytesError
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::script::PushBytesError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::PushBytesError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::PushBytesError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::script::PushBytesError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::script::PushBytesError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::script::PushBytesError where U: core::convert::From<T>
 pub fn bitcoin::blockdata::script::PushBytesError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::script::PushBytesError where U: core::convert::Into<T>
@@ -5892,6 +6117,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::script::PushBytesErro
 pub unsafe fn bitcoin::blockdata::script::PushBytesError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::script::PushBytesError
 pub fn bitcoin::blockdata::script::PushBytesError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::script::PushBytesError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::script::PushBytesError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::script::PushBytesError::vzip(self) -> V
 #[repr(transparent)] pub struct bitcoin::blockdata::script::Script(_)
@@ -6008,8 +6234,8 @@ impl core::ops::index::Index<core::ops::range::RangeTo<usize>> for bitcoin::bloc
 pub fn bitcoin::blockdata::script::Script::index(&self, index: core::ops::range::RangeTo<usize>) -> &Self::Output
 impl core::ops::index::Index<core::ops::range::RangeToInclusive<usize>> for bitcoin::blockdata::script::Script
 pub fn bitcoin::blockdata::script::Script::index(&self, index: core::ops::range::RangeToInclusive<usize>) -> &Self::Output
-impl serde::ser::Serialize for bitcoin::blockdata::script::Script
-pub fn bitcoin::blockdata::script::Script::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+impl serde_core::ser::Serialize for bitcoin::blockdata::script::Script
+pub fn bitcoin::blockdata::script::Script::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error> where S: serde_core::ser::Serializer
 impl<'a> core::convert::From<&'a bitcoin::blockdata::script::Script> for alloc::borrow::Cow<'a, bitcoin::blockdata::script::Script>
 pub fn alloc::borrow::Cow<'a, bitcoin::blockdata::script::Script>::from(value: &'a bitcoin::blockdata::script::Script) -> Self
 impl<'a> core::convert::From<&'a bitcoin::blockdata::script::Script> for alloc::boxed::Box<bitcoin::blockdata::script::Script>
@@ -6022,8 +6248,8 @@ impl<'a> core::convert::From<&'a bitcoin::blockdata::script::Script> for bitcoin
 pub fn bitcoin::blockdata::script::ScriptBuf::from(value: &'a bitcoin::blockdata::script::Script) -> Self
 impl<'a> core::convert::From<alloc::borrow::Cow<'a, bitcoin::blockdata::script::Script>> for alloc::boxed::Box<bitcoin::blockdata::script::Script>
 pub fn alloc::boxed::Box<bitcoin::blockdata::script::Script>::from(value: alloc::borrow::Cow<'a, bitcoin::blockdata::script::Script>) -> Self
-impl<'de> serde::de::Deserialize<'de> for &'de bitcoin::blockdata::script::Script
-pub fn &'de bitcoin::blockdata::script::Script::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+impl<'de> serde_core::de::Deserialize<'de> for &'de bitcoin::blockdata::script::Script
+pub fn &'de bitcoin::blockdata::script::Script::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde_core::de::Deserializer>::Error> where D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin::blockdata::script::Script
 impl core::marker::Send for bitcoin::blockdata::script::Script
 impl !core::marker::Sized for bitcoin::blockdata::script::Script
@@ -6032,6 +6258,8 @@ impl core::marker::Unpin for bitcoin::blockdata::script::Script
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::script::Script
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::Script
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::Script
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::script::Script where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::script::Script where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T> alloc::string::ToString for bitcoin::blockdata::script::Script where T: core::fmt::Display + ?core::marker::Sized
 pub fn bitcoin::blockdata::script::Script::to_string(&self) -> alloc::string::String
 impl<T> core::any::Any for bitcoin::blockdata::script::Script where T: 'static + ?core::marker::Sized
@@ -6040,6 +6268,7 @@ impl<T> core::borrow::Borrow<T> for bitcoin::blockdata::script::Script where T: 
 pub fn bitcoin::blockdata::script::Script::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin::blockdata::script::Script where T: ?core::marker::Sized
 pub fn bitcoin::blockdata::script::Script::borrow_mut(&mut self) -> &mut T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::script::Script where T: ?core::marker::Sized
 pub struct bitcoin::blockdata::script::ScriptBuf(_)
 impl bitcoin::blockdata::script::ScriptBuf
 pub fn bitcoin::blockdata::script::ScriptBuf::as_mut_script(&mut self) -> &mut bitcoin::blockdata::script::Script
@@ -6115,14 +6344,14 @@ pub type bitcoin::blockdata::script::ScriptBuf::Target = bitcoin::blockdata::scr
 pub fn bitcoin::blockdata::script::ScriptBuf::deref(&self) -> &Self::Target
 impl core::ops::deref::DerefMut for bitcoin::blockdata::script::ScriptBuf
 pub fn bitcoin::blockdata::script::ScriptBuf::deref_mut(&mut self) -> &mut Self::Target
-impl serde::ser::Serialize for bitcoin::blockdata::script::ScriptBuf
-pub fn bitcoin::blockdata::script::ScriptBuf::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+impl serde_core::ser::Serialize for bitcoin::blockdata::script::ScriptBuf
+pub fn bitcoin::blockdata::script::ScriptBuf::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error> where S: serde_core::ser::Serializer
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin::blockdata::script::ScriptBuf
 pub fn bitcoin::blockdata::script::ScriptBuf::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
 impl<'a> core::convert::From<alloc::borrow::Cow<'a, bitcoin::blockdata::script::Script>> for bitcoin::blockdata::script::ScriptBuf
 pub fn bitcoin::blockdata::script::ScriptBuf::from(value: alloc::borrow::Cow<'a, bitcoin::blockdata::script::Script>) -> Self
-impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::script::ScriptBuf
-pub fn bitcoin::blockdata::script::ScriptBuf::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::blockdata::script::ScriptBuf
+pub fn bitcoin::blockdata::script::ScriptBuf::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde_core::de::Deserializer>::Error> where D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin::blockdata::script::ScriptBuf
 impl core::marker::Send for bitcoin::blockdata::script::ScriptBuf
 impl core::marker::Sync for bitcoin::blockdata::script::ScriptBuf
@@ -6132,6 +6361,8 @@ impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::Scr
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::ScriptBuf
 impl<P, T> core::ops::deref::Receiver for bitcoin::blockdata::script::ScriptBuf where P: core::ops::deref::Deref<Target = T> + ?core::marker::Sized, T: ?core::marker::Sized
 pub type bitcoin::blockdata::script::ScriptBuf::Target = T
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::script::ScriptBuf where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::script::ScriptBuf where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::script::ScriptBuf where U: core::convert::From<T>
 pub fn bitcoin::blockdata::script::ScriptBuf::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::script::ScriptBuf where U: core::convert::Into<T>
@@ -6156,7 +6387,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::script::ScriptBuf whe
 pub unsafe fn bitcoin::blockdata::script::ScriptBuf::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::script::ScriptBuf
 pub fn bitcoin::blockdata::script::ScriptBuf::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::blockdata::script::ScriptBuf where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::blockdata::script::ScriptBuf where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::script::ScriptBuf where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::script::ScriptBuf where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::script::ScriptBuf::vzip(self) -> V
 pub struct bitcoin::blockdata::script::ScriptHash(_)
@@ -6210,10 +6442,10 @@ impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::ScriptHas
 impl core::str::traits::FromStr for bitcoin::blockdata::script::ScriptHash
 pub type bitcoin::blockdata::script::ScriptHash::Err = hex_conservative::error::HexToArrayError
 pub fn bitcoin::blockdata::script::ScriptHash::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::script::ScriptHash, Self::Err>
-impl serde::ser::Serialize for bitcoin::blockdata::script::ScriptHash
-pub fn bitcoin::blockdata::script::ScriptHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::script::ScriptHash
-pub fn bitcoin::blockdata::script::ScriptHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::blockdata::script::ScriptHash, <D as serde::de::Deserializer>::Error>
+impl serde_core::ser::Serialize for bitcoin::blockdata::script::ScriptHash
+pub fn bitcoin::blockdata::script::ScriptHash::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::blockdata::script::ScriptHash
+pub fn bitcoin::blockdata::script::ScriptHash::deserialize<D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::blockdata::script::ScriptHash, <D as serde_core::de::Deserializer>::Error>
 impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::blockdata::script::ScriptHash
 pub type bitcoin::blockdata::script::ScriptHash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
 pub fn bitcoin::blockdata::script::ScriptHash::index(&self, index: I) -> &Self::Output
@@ -6224,6 +6456,8 @@ impl core::marker::Unpin for bitcoin::blockdata::script::ScriptHash
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::script::ScriptHash
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::ScriptHash
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::ScriptHash
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::script::ScriptHash where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::script::ScriptHash where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::script::ScriptHash where U: core::convert::From<T>
 pub fn bitcoin::blockdata::script::ScriptHash::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::script::ScriptHash where U: core::convert::Into<T>
@@ -6248,7 +6482,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::script::ScriptHash wh
 pub unsafe fn bitcoin::blockdata::script::ScriptHash::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::script::ScriptHash
 pub fn bitcoin::blockdata::script::ScriptHash::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::blockdata::script::ScriptHash where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::blockdata::script::ScriptHash where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::script::ScriptHash where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::script::ScriptHash where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::script::ScriptHash::vzip(self) -> V
 pub struct bitcoin::blockdata::script::WScriptHash(_)
@@ -6302,10 +6537,10 @@ impl core::marker::StructuralPartialEq for bitcoin::blockdata::script::WScriptHa
 impl core::str::traits::FromStr for bitcoin::blockdata::script::WScriptHash
 pub type bitcoin::blockdata::script::WScriptHash::Err = hex_conservative::error::HexToArrayError
 pub fn bitcoin::blockdata::script::WScriptHash::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::script::WScriptHash, Self::Err>
-impl serde::ser::Serialize for bitcoin::blockdata::script::WScriptHash
-pub fn bitcoin::blockdata::script::WScriptHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::script::WScriptHash
-pub fn bitcoin::blockdata::script::WScriptHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::blockdata::script::WScriptHash, <D as serde::de::Deserializer>::Error>
+impl serde_core::ser::Serialize for bitcoin::blockdata::script::WScriptHash
+pub fn bitcoin::blockdata::script::WScriptHash::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::blockdata::script::WScriptHash
+pub fn bitcoin::blockdata::script::WScriptHash::deserialize<D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::blockdata::script::WScriptHash, <D as serde_core::de::Deserializer>::Error>
 impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::blockdata::script::WScriptHash
 pub type bitcoin::blockdata::script::WScriptHash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
 pub fn bitcoin::blockdata::script::WScriptHash::index(&self, index: I) -> &Self::Output
@@ -6316,6 +6551,8 @@ impl core::marker::Unpin for bitcoin::blockdata::script::WScriptHash
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::script::WScriptHash
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::script::WScriptHash
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::script::WScriptHash
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::script::WScriptHash where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::script::WScriptHash where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::script::WScriptHash where U: core::convert::From<T>
 pub fn bitcoin::blockdata::script::WScriptHash::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::script::WScriptHash where U: core::convert::Into<T>
@@ -6340,7 +6577,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::script::WScriptHash w
 pub unsafe fn bitcoin::blockdata::script::WScriptHash::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::script::WScriptHash
 pub fn bitcoin::blockdata::script::WScriptHash::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::blockdata::script::WScriptHash where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::blockdata::script::WScriptHash where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::script::WScriptHash where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::script::WScriptHash where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::script::WScriptHash::vzip(self) -> V
 pub trait bitcoin::blockdata::script::PushBytesErrorReport
@@ -6378,6 +6616,8 @@ impl core::marker::Unpin for bitcoin::blockdata::transaction::ParseOutPointError
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::transaction::ParseOutPointError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::ParseOutPointError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::ParseOutPointError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::transaction::ParseOutPointError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::transaction::ParseOutPointError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::transaction::ParseOutPointError where U: core::convert::From<T>
 pub fn bitcoin::blockdata::transaction::ParseOutPointError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::transaction::ParseOutPointError where U: core::convert::Into<T>
@@ -6402,6 +6642,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::transaction::ParseOut
 pub unsafe fn bitcoin::blockdata::transaction::ParseOutPointError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::transaction::ParseOutPointError
 pub fn bitcoin::blockdata::transaction::ParseOutPointError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::transaction::ParseOutPointError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::transaction::ParseOutPointError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::transaction::ParseOutPointError::vzip(self) -> V
 #[non_exhaustive] pub enum bitcoin::blockdata::transaction::TxVerifyError
@@ -6429,6 +6670,8 @@ impl core::marker::Unpin for bitcoin::consensus::validation::TxVerifyError
 impl core::marker::UnsafeUnpin for bitcoin::consensus::validation::TxVerifyError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::consensus::validation::TxVerifyError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::consensus::validation::TxVerifyError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::consensus::validation::TxVerifyError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::consensus::validation::TxVerifyError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::consensus::validation::TxVerifyError where U: core::convert::From<T>
 pub fn bitcoin::consensus::validation::TxVerifyError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::consensus::validation::TxVerifyError where U: core::convert::Into<T>
@@ -6453,6 +6696,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::consensus::validation::TxVerifyE
 pub unsafe fn bitcoin::consensus::validation::TxVerifyError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::consensus::validation::TxVerifyError
 pub fn bitcoin::consensus::validation::TxVerifyError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::consensus::validation::TxVerifyError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::consensus::validation::TxVerifyError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::consensus::validation::TxVerifyError::vzip(self) -> V
 #[non_exhaustive] pub struct bitcoin::blockdata::transaction::IndexOutOfBoundsError
@@ -6480,6 +6724,8 @@ impl core::marker::Unpin for bitcoin::blockdata::transaction::IndexOutOfBoundsEr
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::transaction::IndexOutOfBoundsError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::IndexOutOfBoundsError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::IndexOutOfBoundsError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::transaction::IndexOutOfBoundsError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::transaction::IndexOutOfBoundsError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::transaction::IndexOutOfBoundsError where U: core::convert::From<T>
 pub fn bitcoin::blockdata::transaction::IndexOutOfBoundsError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::transaction::IndexOutOfBoundsError where U: core::convert::Into<T>
@@ -6504,6 +6750,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::transaction::IndexOut
 pub unsafe fn bitcoin::blockdata::transaction::IndexOutOfBoundsError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::transaction::IndexOutOfBoundsError
 pub fn bitcoin::blockdata::transaction::IndexOutOfBoundsError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::transaction::IndexOutOfBoundsError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::transaction::IndexOutOfBoundsError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::transaction::IndexOutOfBoundsError::vzip(self) -> V
 pub struct bitcoin::blockdata::transaction::InputWeightPrediction
@@ -6532,6 +6779,8 @@ impl core::marker::Unpin for bitcoin::blockdata::transaction::InputWeightPredict
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::transaction::InputWeightPrediction
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::InputWeightPrediction
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::InputWeightPrediction
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::transaction::InputWeightPrediction where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::transaction::InputWeightPrediction where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::transaction::InputWeightPrediction where U: core::convert::From<T>
 pub fn bitcoin::blockdata::transaction::InputWeightPrediction::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::transaction::InputWeightPrediction where U: core::convert::Into<T>
@@ -6554,6 +6803,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::transaction::InputWei
 pub unsafe fn bitcoin::blockdata::transaction::InputWeightPrediction::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::transaction::InputWeightPrediction
 pub fn bitcoin::blockdata::transaction::InputWeightPrediction::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::transaction::InputWeightPrediction where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::transaction::InputWeightPrediction where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::transaction::InputWeightPrediction::vzip(self) -> V
 pub struct bitcoin::blockdata::transaction::InputsIndexError(pub bitcoin::blockdata::transaction::IndexOutOfBoundsError)
@@ -6579,6 +6829,8 @@ impl core::marker::Unpin for bitcoin::blockdata::transaction::InputsIndexError
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::transaction::InputsIndexError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::InputsIndexError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::InputsIndexError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::transaction::InputsIndexError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::transaction::InputsIndexError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::transaction::InputsIndexError where U: core::convert::From<T>
 pub fn bitcoin::blockdata::transaction::InputsIndexError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::transaction::InputsIndexError where U: core::convert::Into<T>
@@ -6603,6 +6855,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::transaction::InputsIn
 pub unsafe fn bitcoin::blockdata::transaction::InputsIndexError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::transaction::InputsIndexError
 pub fn bitcoin::blockdata::transaction::InputsIndexError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::transaction::InputsIndexError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::transaction::InputsIndexError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::transaction::InputsIndexError::vzip(self) -> V
 pub struct bitcoin::blockdata::transaction::OutPoint
@@ -6637,12 +6890,12 @@ impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::OutP
 impl core::str::traits::FromStr for bitcoin::blockdata::transaction::OutPoint
 pub type bitcoin::blockdata::transaction::OutPoint::Err = bitcoin::blockdata::transaction::ParseOutPointError
 pub fn bitcoin::blockdata::transaction::OutPoint::from_str(s: &str) -> core::result::Result<Self, Self::Err>
-impl serde::ser::Serialize for bitcoin::blockdata::transaction::OutPoint
-pub fn bitcoin::blockdata::transaction::OutPoint::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+impl serde_core::ser::Serialize for bitcoin::blockdata::transaction::OutPoint
+pub fn bitcoin::blockdata::transaction::OutPoint::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error> where S: serde_core::ser::Serializer
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin::blockdata::transaction::OutPoint
 pub fn bitcoin::blockdata::transaction::OutPoint::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::transaction::OutPoint
-pub fn bitcoin::blockdata::transaction::OutPoint::deserialize<D>(deserializer: D) -> core::result::Result<bitcoin::blockdata::transaction::OutPoint, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::blockdata::transaction::OutPoint
+pub fn bitcoin::blockdata::transaction::OutPoint::deserialize<D>(deserializer: D) -> core::result::Result<bitcoin::blockdata::transaction::OutPoint, <D as serde_core::de::Deserializer>::Error> where D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin::blockdata::transaction::OutPoint
 impl core::marker::Send for bitcoin::blockdata::transaction::OutPoint
 impl core::marker::Sync for bitcoin::blockdata::transaction::OutPoint
@@ -6650,6 +6903,8 @@ impl core::marker::Unpin for bitcoin::blockdata::transaction::OutPoint
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::transaction::OutPoint
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::OutPoint
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::OutPoint
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::transaction::OutPoint where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::transaction::OutPoint where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::transaction::OutPoint where U: core::convert::From<T>
 pub fn bitcoin::blockdata::transaction::OutPoint::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::transaction::OutPoint where U: core::convert::Into<T>
@@ -6674,7 +6929,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::transaction::OutPoint
 pub unsafe fn bitcoin::blockdata::transaction::OutPoint::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::transaction::OutPoint
 pub fn bitcoin::blockdata::transaction::OutPoint::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::blockdata::transaction::OutPoint where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::blockdata::transaction::OutPoint where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::transaction::OutPoint where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::transaction::OutPoint where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::transaction::OutPoint::vzip(self) -> V
 pub struct bitcoin::blockdata::transaction::OutputsIndexError(pub bitcoin::blockdata::transaction::IndexOutOfBoundsError)
@@ -6696,6 +6952,8 @@ impl core::marker::Unpin for bitcoin::blockdata::transaction::OutputsIndexError
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::transaction::OutputsIndexError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::OutputsIndexError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::OutputsIndexError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::transaction::OutputsIndexError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::transaction::OutputsIndexError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::transaction::OutputsIndexError where U: core::convert::From<T>
 pub fn bitcoin::blockdata::transaction::OutputsIndexError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::transaction::OutputsIndexError where U: core::convert::Into<T>
@@ -6720,6 +6978,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::transaction::OutputsI
 pub unsafe fn bitcoin::blockdata::transaction::OutputsIndexError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::transaction::OutputsIndexError
 pub fn bitcoin::blockdata::transaction::OutputsIndexError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::transaction::OutputsIndexError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::transaction::OutputsIndexError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::transaction::OutputsIndexError::vzip(self) -> V
 pub struct bitcoin::blockdata::transaction::Sequence(pub u32)
@@ -6779,12 +7038,12 @@ impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::Sequ
 impl core::str::traits::FromStr for bitcoin::blockdata::transaction::Sequence
 pub type bitcoin::blockdata::transaction::Sequence::Err = bitcoin_units::parse::ParseIntError
 pub fn bitcoin::blockdata::transaction::Sequence::from_str(s: &str) -> core::result::Result<Self, Self::Err>
-impl serde::ser::Serialize for bitcoin::blockdata::transaction::Sequence
-pub fn bitcoin::blockdata::transaction::Sequence::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl serde_core::ser::Serialize for bitcoin::blockdata::transaction::Sequence
+pub fn bitcoin::blockdata::transaction::Sequence::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin::blockdata::transaction::Sequence
 pub fn bitcoin::blockdata::transaction::Sequence::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::transaction::Sequence
-pub fn bitcoin::blockdata::transaction::Sequence::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::blockdata::transaction::Sequence
+pub fn bitcoin::blockdata::transaction::Sequence::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin::blockdata::transaction::Sequence
 impl core::marker::Send for bitcoin::blockdata::transaction::Sequence
 impl core::marker::Sync for bitcoin::blockdata::transaction::Sequence
@@ -6792,6 +7051,8 @@ impl core::marker::Unpin for bitcoin::blockdata::transaction::Sequence
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::transaction::Sequence
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::Sequence
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::Sequence
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::transaction::Sequence where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::transaction::Sequence where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::transaction::Sequence where U: core::convert::From<T>
 pub fn bitcoin::blockdata::transaction::Sequence::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::transaction::Sequence where U: core::convert::Into<T>
@@ -6816,7 +7077,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::transaction::Sequence
 pub unsafe fn bitcoin::blockdata::transaction::Sequence::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::transaction::Sequence
 pub fn bitcoin::blockdata::transaction::Sequence::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::blockdata::transaction::Sequence where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::blockdata::transaction::Sequence where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::transaction::Sequence where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::transaction::Sequence where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::transaction::Sequence::vzip(self) -> V
 pub struct bitcoin::blockdata::transaction::Transaction
@@ -6872,12 +7134,12 @@ pub fn bitcoin::blockdata::transaction::Transaction::fmt(&self, f: &mut core::fm
 impl core::hash::Hash for bitcoin::blockdata::transaction::Transaction
 pub fn bitcoin::blockdata::transaction::Transaction::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::Transaction
-impl serde::ser::Serialize for bitcoin::blockdata::transaction::Transaction
-pub fn bitcoin::blockdata::transaction::Transaction::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl serde_core::ser::Serialize for bitcoin::blockdata::transaction::Transaction
+pub fn bitcoin::blockdata::transaction::Transaction::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin::blockdata::transaction::Transaction
 pub fn bitcoin::blockdata::transaction::Transaction::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::transaction::Transaction
-pub fn bitcoin::blockdata::transaction::Transaction::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::blockdata::transaction::Transaction
+pub fn bitcoin::blockdata::transaction::Transaction::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin::blockdata::transaction::Transaction
 impl core::marker::Send for bitcoin::blockdata::transaction::Transaction
 impl core::marker::Sync for bitcoin::blockdata::transaction::Transaction
@@ -6885,6 +7147,8 @@ impl core::marker::Unpin for bitcoin::blockdata::transaction::Transaction
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::transaction::Transaction
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::Transaction
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::Transaction
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::transaction::Transaction where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::transaction::Transaction where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::transaction::Transaction where U: core::convert::From<T>
 pub fn bitcoin::blockdata::transaction::Transaction::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::transaction::Transaction where U: core::convert::Into<T>
@@ -6907,7 +7171,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::transaction::Transact
 pub unsafe fn bitcoin::blockdata::transaction::Transaction::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::transaction::Transaction
 pub fn bitcoin::blockdata::transaction::Transaction::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::blockdata::transaction::Transaction where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::blockdata::transaction::Transaction where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::transaction::Transaction where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::transaction::Transaction where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::transaction::Transaction::vzip(self) -> V
 pub struct bitcoin::blockdata::transaction::TxIn
@@ -6941,12 +7206,12 @@ pub fn bitcoin::blockdata::transaction::TxIn::fmt(&self, f: &mut core::fmt::Form
 impl core::hash::Hash for bitcoin::blockdata::transaction::TxIn
 pub fn bitcoin::blockdata::transaction::TxIn::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::TxIn
-impl serde::ser::Serialize for bitcoin::blockdata::transaction::TxIn
-pub fn bitcoin::blockdata::transaction::TxIn::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl serde_core::ser::Serialize for bitcoin::blockdata::transaction::TxIn
+pub fn bitcoin::blockdata::transaction::TxIn::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin::blockdata::transaction::TxIn
 pub fn bitcoin::blockdata::transaction::TxIn::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::transaction::TxIn
-pub fn bitcoin::blockdata::transaction::TxIn::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::blockdata::transaction::TxIn
+pub fn bitcoin::blockdata::transaction::TxIn::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin::blockdata::transaction::TxIn
 impl core::marker::Send for bitcoin::blockdata::transaction::TxIn
 impl core::marker::Sync for bitcoin::blockdata::transaction::TxIn
@@ -6954,6 +7219,8 @@ impl core::marker::Unpin for bitcoin::blockdata::transaction::TxIn
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::transaction::TxIn
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::TxIn
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::TxIn
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::transaction::TxIn where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::transaction::TxIn where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::transaction::TxIn where U: core::convert::From<T>
 pub fn bitcoin::blockdata::transaction::TxIn::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::transaction::TxIn where U: core::convert::Into<T>
@@ -6976,7 +7243,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::transaction::TxIn whe
 pub unsafe fn bitcoin::blockdata::transaction::TxIn::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::transaction::TxIn
 pub fn bitcoin::blockdata::transaction::TxIn::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::blockdata::transaction::TxIn where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::blockdata::transaction::TxIn where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::transaction::TxIn where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::transaction::TxIn where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::transaction::TxIn::vzip(self) -> V
 pub struct bitcoin::blockdata::transaction::TxOut
@@ -7007,12 +7275,12 @@ pub fn bitcoin::blockdata::transaction::TxOut::fmt(&self, f: &mut core::fmt::For
 impl core::hash::Hash for bitcoin::blockdata::transaction::TxOut
 pub fn bitcoin::blockdata::transaction::TxOut::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::TxOut
-impl serde::ser::Serialize for bitcoin::blockdata::transaction::TxOut
-pub fn bitcoin::blockdata::transaction::TxOut::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl serde_core::ser::Serialize for bitcoin::blockdata::transaction::TxOut
+pub fn bitcoin::blockdata::transaction::TxOut::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin::blockdata::transaction::TxOut
 pub fn bitcoin::blockdata::transaction::TxOut::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::transaction::TxOut
-pub fn bitcoin::blockdata::transaction::TxOut::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::blockdata::transaction::TxOut
+pub fn bitcoin::blockdata::transaction::TxOut::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin::blockdata::transaction::TxOut
 impl core::marker::Send for bitcoin::blockdata::transaction::TxOut
 impl core::marker::Sync for bitcoin::blockdata::transaction::TxOut
@@ -7020,6 +7288,8 @@ impl core::marker::Unpin for bitcoin::blockdata::transaction::TxOut
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::transaction::TxOut
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::TxOut
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::TxOut
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::transaction::TxOut where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::transaction::TxOut where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::transaction::TxOut where U: core::convert::From<T>
 pub fn bitcoin::blockdata::transaction::TxOut::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::transaction::TxOut where U: core::convert::Into<T>
@@ -7042,7 +7312,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::transaction::TxOut wh
 pub unsafe fn bitcoin::blockdata::transaction::TxOut::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::transaction::TxOut
 pub fn bitcoin::blockdata::transaction::TxOut::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::blockdata::transaction::TxOut where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::blockdata::transaction::TxOut where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::transaction::TxOut where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::transaction::TxOut where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::transaction::TxOut::vzip(self) -> V
 pub struct bitcoin::blockdata::transaction::Txid(_)
@@ -7100,12 +7371,12 @@ impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::Txid
 impl core::str::traits::FromStr for bitcoin::blockdata::transaction::Txid
 pub type bitcoin::blockdata::transaction::Txid::Err = hex_conservative::error::HexToArrayError
 pub fn bitcoin::blockdata::transaction::Txid::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::transaction::Txid, Self::Err>
-impl serde::ser::Serialize for bitcoin::blockdata::transaction::Txid
-pub fn bitcoin::blockdata::transaction::Txid::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+impl serde_core::ser::Serialize for bitcoin::blockdata::transaction::Txid
+pub fn bitcoin::blockdata::transaction::Txid::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin::blockdata::transaction::Txid
 pub fn bitcoin::blockdata::transaction::Txid::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::transaction::Txid
-pub fn bitcoin::blockdata::transaction::Txid::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::blockdata::transaction::Txid, <D as serde::de::Deserializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::blockdata::transaction::Txid
+pub fn bitcoin::blockdata::transaction::Txid::deserialize<D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::blockdata::transaction::Txid, <D as serde_core::de::Deserializer>::Error>
 impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::blockdata::transaction::Txid
 pub type bitcoin::blockdata::transaction::Txid::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
 pub fn bitcoin::blockdata::transaction::Txid::index(&self, index: I) -> &Self::Output
@@ -7116,6 +7387,8 @@ impl core::marker::Unpin for bitcoin::blockdata::transaction::Txid
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::transaction::Txid
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::Txid
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::Txid
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::transaction::Txid where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::transaction::Txid where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::transaction::Txid where U: core::convert::From<T>
 pub fn bitcoin::blockdata::transaction::Txid::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::transaction::Txid where U: core::convert::Into<T>
@@ -7140,7 +7413,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::transaction::Txid whe
 pub unsafe fn bitcoin::blockdata::transaction::Txid::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::transaction::Txid
 pub fn bitcoin::blockdata::transaction::Txid::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::blockdata::transaction::Txid where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::blockdata::transaction::Txid where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::transaction::Txid where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::transaction::Txid where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::transaction::Txid::vzip(self) -> V
 pub struct bitcoin::blockdata::transaction::Version(pub i32)
@@ -7169,12 +7443,12 @@ impl core::hash::Hash for bitcoin::blockdata::transaction::Version
 pub fn bitcoin::blockdata::transaction::Version::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for bitcoin::blockdata::transaction::Version
 impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::Version
-impl serde::ser::Serialize for bitcoin::blockdata::transaction::Version
-pub fn bitcoin::blockdata::transaction::Version::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl serde_core::ser::Serialize for bitcoin::blockdata::transaction::Version
+pub fn bitcoin::blockdata::transaction::Version::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin::blockdata::transaction::Version
 pub fn bitcoin::blockdata::transaction::Version::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::transaction::Version
-pub fn bitcoin::blockdata::transaction::Version::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::blockdata::transaction::Version
+pub fn bitcoin::blockdata::transaction::Version::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin::blockdata::transaction::Version
 impl core::marker::Send for bitcoin::blockdata::transaction::Version
 impl core::marker::Sync for bitcoin::blockdata::transaction::Version
@@ -7182,6 +7456,8 @@ impl core::marker::Unpin for bitcoin::blockdata::transaction::Version
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::transaction::Version
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::Version
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::Version
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::transaction::Version where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::transaction::Version where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::transaction::Version where U: core::convert::From<T>
 pub fn bitcoin::blockdata::transaction::Version::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::transaction::Version where U: core::convert::Into<T>
@@ -7206,7 +7482,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::transaction::Version 
 pub unsafe fn bitcoin::blockdata::transaction::Version::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::transaction::Version
 pub fn bitcoin::blockdata::transaction::Version::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::blockdata::transaction::Version where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::blockdata::transaction::Version where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::transaction::Version where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::transaction::Version where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::transaction::Version::vzip(self) -> V
 pub struct bitcoin::blockdata::transaction::Wtxid(_)
@@ -7264,12 +7541,12 @@ impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::Wtxi
 impl core::str::traits::FromStr for bitcoin::blockdata::transaction::Wtxid
 pub type bitcoin::blockdata::transaction::Wtxid::Err = hex_conservative::error::HexToArrayError
 pub fn bitcoin::blockdata::transaction::Wtxid::from_str(s: &str) -> core::result::Result<bitcoin::blockdata::transaction::Wtxid, Self::Err>
-impl serde::ser::Serialize for bitcoin::blockdata::transaction::Wtxid
-pub fn bitcoin::blockdata::transaction::Wtxid::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+impl serde_core::ser::Serialize for bitcoin::blockdata::transaction::Wtxid
+pub fn bitcoin::blockdata::transaction::Wtxid::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin::blockdata::transaction::Wtxid
 pub fn bitcoin::blockdata::transaction::Wtxid::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::transaction::Wtxid
-pub fn bitcoin::blockdata::transaction::Wtxid::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::blockdata::transaction::Wtxid, <D as serde::de::Deserializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::blockdata::transaction::Wtxid
+pub fn bitcoin::blockdata::transaction::Wtxid::deserialize<D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::blockdata::transaction::Wtxid, <D as serde_core::de::Deserializer>::Error>
 impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::blockdata::transaction::Wtxid
 pub type bitcoin::blockdata::transaction::Wtxid::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
 pub fn bitcoin::blockdata::transaction::Wtxid::index(&self, index: I) -> &Self::Output
@@ -7280,6 +7557,8 @@ impl core::marker::Unpin for bitcoin::blockdata::transaction::Wtxid
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::transaction::Wtxid
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::Wtxid
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::Wtxid
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::transaction::Wtxid where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::transaction::Wtxid where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::transaction::Wtxid where U: core::convert::From<T>
 pub fn bitcoin::blockdata::transaction::Wtxid::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::transaction::Wtxid where U: core::convert::Into<T>
@@ -7304,7 +7583,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::transaction::Wtxid wh
 pub unsafe fn bitcoin::blockdata::transaction::Wtxid::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::transaction::Wtxid
 pub fn bitcoin::blockdata::transaction::Wtxid::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::blockdata::transaction::Wtxid where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::blockdata::transaction::Wtxid where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::transaction::Wtxid where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::transaction::Wtxid where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::transaction::Wtxid::vzip(self) -> V
 pub fn bitcoin::blockdata::transaction::effective_value(fee_rate: bitcoin_units::fee_rate::FeeRate, satisfaction_weight: bitcoin_units::weight::Weight, value: bitcoin_units::amount::Amount) -> core::option::Option<bitcoin_units::amount::SignedAmount>
@@ -7331,6 +7611,8 @@ pub type bitcoin::blockdata::witness::Iter<'a>::IntoIter = I
 pub type bitcoin::blockdata::witness::Iter<'a>::Item = <I as core::iter::traits::iterator::Iterator>::Item
 pub fn bitcoin::blockdata::witness::Iter<'a>::into_iter(self) -> I
 impl<I> rand::seq::IteratorRandom for bitcoin::blockdata::witness::Iter<'a> where I: core::iter::traits::iterator::Iterator
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::witness::Iter<'a> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::witness::Iter<'a> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::witness::Iter<'a> where U: core::convert::From<T>
 pub fn bitcoin::blockdata::witness::Iter<'a>::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::witness::Iter<'a> where U: core::convert::Into<T>
@@ -7347,6 +7629,7 @@ impl<T> core::borrow::BorrowMut<T> for bitcoin::blockdata::witness::Iter<'a> whe
 pub fn bitcoin::blockdata::witness::Iter<'a>::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for bitcoin::blockdata::witness::Iter<'a>
 pub fn bitcoin::blockdata::witness::Iter<'a>::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::witness::Iter<'a> where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::witness::Iter<'a> where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::witness::Iter<'a>::vzip(self) -> V
 pub struct bitcoin::blockdata::witness::Witness
@@ -7403,16 +7686,16 @@ impl core::marker::StructuralPartialEq for bitcoin::blockdata::witness::Witness
 impl core::ops::index::Index<usize> for bitcoin::blockdata::witness::Witness
 pub type bitcoin::blockdata::witness::Witness::Output = [u8]
 pub fn bitcoin::blockdata::witness::Witness::index(&self, index: usize) -> &Self::Output
-impl serde::ser::Serialize for bitcoin::blockdata::witness::Witness
-pub fn bitcoin::blockdata::witness::Witness::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+impl serde_core::ser::Serialize for bitcoin::blockdata::witness::Witness
+pub fn bitcoin::blockdata::witness::Witness::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error> where S: serde_core::ser::Serializer
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin::blockdata::witness::Witness
 pub fn bitcoin::blockdata::witness::Witness::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
 impl<'a> core::iter::traits::collect::IntoIterator for &'a bitcoin::blockdata::witness::Witness
 pub type &'a bitcoin::blockdata::witness::Witness::IntoIter = bitcoin::blockdata::witness::Iter<'a>
 pub type &'a bitcoin::blockdata::witness::Witness::Item = &'a [u8]
 pub fn &'a bitcoin::blockdata::witness::Witness::into_iter(self) -> Self::IntoIter
-impl<'de> serde::de::Deserialize<'de> for bitcoin::blockdata::witness::Witness
-pub fn bitcoin::blockdata::witness::Witness::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::blockdata::witness::Witness
+pub fn bitcoin::blockdata::witness::Witness::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde_core::de::Deserializer>::Error> where D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin::blockdata::witness::Witness
 impl core::marker::Send for bitcoin::blockdata::witness::Witness
 impl core::marker::Sync for bitcoin::blockdata::witness::Witness
@@ -7420,6 +7703,8 @@ impl core::marker::Unpin for bitcoin::blockdata::witness::Witness
 impl core::marker::UnsafeUnpin for bitcoin::blockdata::witness::Witness
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::witness::Witness
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::witness::Witness
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::witness::Witness where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::witness::Witness where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::blockdata::witness::Witness where U: core::convert::From<T>
 pub fn bitcoin::blockdata::witness::Witness::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::witness::Witness where U: core::convert::Into<T>
@@ -7442,7 +7727,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::blockdata::witness::Witness wher
 pub unsafe fn bitcoin::blockdata::witness::Witness::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::blockdata::witness::Witness
 pub fn bitcoin::blockdata::witness::Witness::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::blockdata::witness::Witness where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::blockdata::witness::Witness where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::witness::Witness where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::witness::Witness where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::witness::Witness::vzip(self) -> V
 pub mod bitcoin::consensus
@@ -7477,6 +7763,8 @@ impl core::marker::Unpin for bitcoin::consensus::encode::Error
 impl core::marker::UnsafeUnpin for bitcoin::consensus::encode::Error
 impl !core::panic::unwind_safe::RefUnwindSafe for bitcoin::consensus::encode::Error
 impl !core::panic::unwind_safe::UnwindSafe for bitcoin::consensus::encode::Error
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::consensus::encode::Error where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::consensus::encode::Error where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::consensus::encode::Error where U: core::convert::From<T>
 pub fn bitcoin::consensus::encode::Error::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::consensus::encode::Error where U: core::convert::Into<T>
@@ -7495,6 +7783,7 @@ impl<T> core::borrow::BorrowMut<T> for bitcoin::consensus::encode::Error where T
 pub fn bitcoin::consensus::encode::Error::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for bitcoin::consensus::encode::Error
 pub fn bitcoin::consensus::encode::Error::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::consensus::encode::Error where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::consensus::encode::Error where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::consensus::encode::Error::vzip(self) -> V
 pub enum bitcoin::consensus::encode::FromHexError
@@ -7514,6 +7803,8 @@ impl core::marker::Unpin for bitcoin::consensus::encode::FromHexError
 impl core::marker::UnsafeUnpin for bitcoin::consensus::encode::FromHexError
 impl !core::panic::unwind_safe::RefUnwindSafe for bitcoin::consensus::encode::FromHexError
 impl !core::panic::unwind_safe::UnwindSafe for bitcoin::consensus::encode::FromHexError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::consensus::encode::FromHexError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::consensus::encode::FromHexError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::consensus::encode::FromHexError where U: core::convert::From<T>
 pub fn bitcoin::consensus::encode::FromHexError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::consensus::encode::FromHexError where U: core::convert::Into<T>
@@ -7532,6 +7823,7 @@ impl<T> core::borrow::BorrowMut<T> for bitcoin::consensus::encode::FromHexError 
 pub fn bitcoin::consensus::encode::FromHexError::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for bitcoin::consensus::encode::FromHexError
 pub fn bitcoin::consensus::encode::FromHexError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::consensus::encode::FromHexError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::consensus::encode::FromHexError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::consensus::encode::FromHexError::vzip(self) -> V
 pub struct bitcoin::consensus::encode::CheckedData
@@ -7559,6 +7851,8 @@ impl core::marker::Unpin for bitcoin::consensus::encode::CheckedData
 impl core::marker::UnsafeUnpin for bitcoin::consensus::encode::CheckedData
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::consensus::encode::CheckedData
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::consensus::encode::CheckedData
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::consensus::encode::CheckedData where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::consensus::encode::CheckedData where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::consensus::encode::CheckedData where U: core::convert::From<T>
 pub fn bitcoin::consensus::encode::CheckedData::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::consensus::encode::CheckedData where U: core::convert::Into<T>
@@ -7581,6 +7875,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::consensus::encode::CheckedData w
 pub unsafe fn bitcoin::consensus::encode::CheckedData::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::consensus::encode::CheckedData
 pub fn bitcoin::consensus::encode::CheckedData::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::consensus::encode::CheckedData where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::consensus::encode::CheckedData where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::consensus::encode::CheckedData::vzip(self) -> V
 pub struct bitcoin::consensus::encode::VarInt(pub u64)
@@ -7619,6 +7914,8 @@ impl core::marker::Unpin for bitcoin::consensus::encode::VarInt
 impl core::marker::UnsafeUnpin for bitcoin::consensus::encode::VarInt
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::consensus::encode::VarInt
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::consensus::encode::VarInt
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::consensus::encode::VarInt where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::consensus::encode::VarInt where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::consensus::encode::VarInt where U: core::convert::From<T>
 pub fn bitcoin::consensus::encode::VarInt::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::consensus::encode::VarInt where U: core::convert::Into<T>
@@ -7641,6 +7938,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::consensus::encode::VarInt where 
 pub unsafe fn bitcoin::consensus::encode::VarInt::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::consensus::encode::VarInt
 pub fn bitcoin::consensus::encode::VarInt::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::consensus::encode::VarInt where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::consensus::encode::VarInt where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::consensus::encode::VarInt::vzip(self) -> V
 pub const bitcoin::consensus::encode::MAX_COMPACT_SIZE: usize
@@ -8100,6 +8398,8 @@ impl core::marker::Unpin for bitcoin::consensus::params::Params
 impl core::marker::UnsafeUnpin for bitcoin::consensus::params::Params
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::consensus::params::Params
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::consensus::params::Params
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::consensus::params::Params where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::consensus::params::Params where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::consensus::params::Params where U: core::convert::From<T>
 pub fn bitcoin::consensus::params::Params::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::consensus::params::Params where U: core::convert::Into<T>
@@ -8122,6 +8422,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::consensus::params::Params where 
 pub unsafe fn bitcoin::consensus::params::Params::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::consensus::params::Params
 pub fn bitcoin::consensus::params::Params::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::consensus::params::Params where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::consensus::params::Params where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::consensus::params::Params::vzip(self) -> V
 pub static bitcoin::consensus::params::MAINNET: bitcoin::consensus::params::Params
@@ -8140,6 +8441,8 @@ impl core::marker::Unpin for bitcoin::consensus::serde::hex::Lower
 impl core::marker::UnsafeUnpin for bitcoin::consensus::serde::hex::Lower
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::consensus::serde::hex::Lower
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::consensus::serde::hex::Lower
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::consensus::serde::hex::Lower where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::consensus::serde::hex::Lower where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::consensus::serde::hex::Lower where U: core::convert::From<T>
 pub fn bitcoin::consensus::serde::hex::Lower::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::consensus::serde::hex::Lower where U: core::convert::Into<T>
@@ -8157,6 +8460,7 @@ impl<T> core::borrow::BorrowMut<T> for bitcoin::consensus::serde::hex::Lower whe
 pub fn bitcoin::consensus::serde::hex::Lower::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for bitcoin::consensus::serde::hex::Lower
 pub fn bitcoin::consensus::serde::hex::Lower::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::consensus::serde::hex::Lower where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::consensus::serde::hex::Lower where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::consensus::serde::hex::Lower::vzip(self) -> V
 pub enum bitcoin::consensus::serde::hex::Upper
@@ -8167,6 +8471,8 @@ impl core::marker::Unpin for bitcoin::consensus::serde::hex::Upper
 impl core::marker::UnsafeUnpin for bitcoin::consensus::serde::hex::Upper
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::consensus::serde::hex::Upper
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::consensus::serde::hex::Upper
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::consensus::serde::hex::Upper where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::consensus::serde::hex::Upper where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::consensus::serde::hex::Upper where U: core::convert::From<T>
 pub fn bitcoin::consensus::serde::hex::Upper::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::consensus::serde::hex::Upper where U: core::convert::Into<T>
@@ -8184,11 +8490,12 @@ impl<T> core::borrow::BorrowMut<T> for bitcoin::consensus::serde::hex::Upper whe
 pub fn bitcoin::consensus::serde::hex::Upper::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for bitcoin::consensus::serde::hex::Upper
 pub fn bitcoin::consensus::serde::hex::Upper::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::consensus::serde::hex::Upper where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::consensus::serde::hex::Upper where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::consensus::serde::hex::Upper::vzip(self) -> V
 pub struct bitcoin::consensus::serde::hex::DecodeError(_)
 impl bitcoin::consensus::serde::IntoDeError for bitcoin::consensus::serde::hex::DecodeError
-pub fn bitcoin::consensus::serde::hex::DecodeError::into_de_error<E: serde::de::Error>(self) -> E
+pub fn bitcoin::consensus::serde::hex::DecodeError::into_de_error<E: serde_core::de::Error>(self) -> E
 impl core::clone::Clone for bitcoin::consensus::serde::hex::DecodeError
 pub fn bitcoin::consensus::serde::hex::DecodeError::clone(&self) -> bitcoin::consensus::serde::hex::DecodeError
 impl core::cmp::Eq for bitcoin::consensus::serde::hex::DecodeError
@@ -8204,6 +8511,8 @@ impl core::marker::Unpin for bitcoin::consensus::serde::hex::DecodeError
 impl core::marker::UnsafeUnpin for bitcoin::consensus::serde::hex::DecodeError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::consensus::serde::hex::DecodeError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::consensus::serde::hex::DecodeError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::consensus::serde::hex::DecodeError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::consensus::serde::hex::DecodeError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::consensus::serde::hex::DecodeError where U: core::convert::From<T>
 pub fn bitcoin::consensus::serde::hex::DecodeError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::consensus::serde::hex::DecodeError where U: core::convert::Into<T>
@@ -8226,11 +8535,12 @@ impl<T> core::clone::CloneToUninit for bitcoin::consensus::serde::hex::DecodeErr
 pub unsafe fn bitcoin::consensus::serde::hex::DecodeError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::consensus::serde::hex::DecodeError
 pub fn bitcoin::consensus::serde::hex::DecodeError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::consensus::serde::hex::DecodeError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::consensus::serde::hex::DecodeError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::consensus::serde::hex::DecodeError::vzip(self) -> V
 pub struct bitcoin::consensus::serde::hex::DecodeInitError(_)
 impl bitcoin::consensus::serde::IntoDeError for bitcoin::consensus::serde::hex::DecodeInitError
-pub fn bitcoin::consensus::serde::hex::DecodeInitError::into_de_error<E: serde::de::Error>(self) -> E
+pub fn bitcoin::consensus::serde::hex::DecodeInitError::into_de_error<E: serde_core::de::Error>(self) -> E
 impl core::clone::Clone for bitcoin::consensus::serde::hex::DecodeInitError
 pub fn bitcoin::consensus::serde::hex::DecodeInitError::clone(&self) -> bitcoin::consensus::serde::hex::DecodeInitError
 impl core::cmp::Eq for bitcoin::consensus::serde::hex::DecodeInitError
@@ -8246,6 +8556,8 @@ impl core::marker::Unpin for bitcoin::consensus::serde::hex::DecodeInitError
 impl core::marker::UnsafeUnpin for bitcoin::consensus::serde::hex::DecodeInitError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::consensus::serde::hex::DecodeInitError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::consensus::serde::hex::DecodeInitError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::consensus::serde::hex::DecodeInitError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::consensus::serde::hex::DecodeInitError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::consensus::serde::hex::DecodeInitError where U: core::convert::From<T>
 pub fn bitcoin::consensus::serde::hex::DecodeInitError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::consensus::serde::hex::DecodeInitError where U: core::convert::Into<T>
@@ -8268,6 +8580,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::consensus::serde::hex::DecodeIni
 pub unsafe fn bitcoin::consensus::serde::hex::DecodeInitError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::consensus::serde::hex::DecodeInitError
 pub fn bitcoin::consensus::serde::hex::DecodeInitError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::consensus::serde::hex::DecodeInitError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::consensus::serde::hex::DecodeInitError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::consensus::serde::hex::DecodeInitError::vzip(self) -> V
 pub struct bitcoin::consensus::serde::hex::Decoder<'a>(_)
@@ -8286,6 +8599,8 @@ pub type bitcoin::consensus::serde::hex::Decoder<'a>::IntoIter = I
 pub type bitcoin::consensus::serde::hex::Decoder<'a>::Item = <I as core::iter::traits::iterator::Iterator>::Item
 pub fn bitcoin::consensus::serde::hex::Decoder<'a>::into_iter(self) -> I
 impl<I> rand::seq::IteratorRandom for bitcoin::consensus::serde::hex::Decoder<'a> where I: core::iter::traits::iterator::Iterator
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::consensus::serde::hex::Decoder<'a> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::consensus::serde::hex::Decoder<'a> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::consensus::serde::hex::Decoder<'a> where U: core::convert::From<T>
 pub fn bitcoin::consensus::serde::hex::Decoder<'a>::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::consensus::serde::hex::Decoder<'a> where U: core::convert::Into<T>
@@ -8302,6 +8617,7 @@ impl<T> core::borrow::BorrowMut<T> for bitcoin::consensus::serde::hex::Decoder<'
 pub fn bitcoin::consensus::serde::hex::Decoder<'a>::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for bitcoin::consensus::serde::hex::Decoder<'a>
 pub fn bitcoin::consensus::serde::hex::Decoder<'a>::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::consensus::serde::hex::Decoder<'a> where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::consensus::serde::hex::Decoder<'a> where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::consensus::serde::hex::Decoder<'a>::vzip(self) -> V
 pub struct bitcoin::consensus::serde::hex::Encoder<C: bitcoin::consensus::serde::hex::Case>(_, _)
@@ -8317,6 +8633,8 @@ impl<C> core::marker::Unpin for bitcoin::consensus::serde::hex::Encoder<C> where
 impl<C> core::marker::UnsafeUnpin for bitcoin::consensus::serde::hex::Encoder<C>
 impl<C> core::panic::unwind_safe::RefUnwindSafe for bitcoin::consensus::serde::hex::Encoder<C> where C: core::panic::unwind_safe::RefUnwindSafe
 impl<C> core::panic::unwind_safe::UnwindSafe for bitcoin::consensus::serde::hex::Encoder<C> where C: core::panic::unwind_safe::UnwindSafe
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::consensus::serde::hex::Encoder<C> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::consensus::serde::hex::Encoder<C> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::consensus::serde::hex::Encoder<C> where U: core::convert::From<T>
 pub fn bitcoin::consensus::serde::hex::Encoder<C>::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::consensus::serde::hex::Encoder<C> where U: core::convert::Into<T>
@@ -8333,6 +8651,7 @@ impl<T> core::borrow::BorrowMut<T> for bitcoin::consensus::serde::hex::Encoder<C
 pub fn bitcoin::consensus::serde::hex::Encoder<C>::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for bitcoin::consensus::serde::hex::Encoder<C>
 pub fn bitcoin::consensus::serde::hex::Encoder<C>::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::consensus::serde::hex::Encoder<C> where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::consensus::serde::hex::Encoder<C> where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::consensus::serde::hex::Encoder<C>::vzip(self) -> V
 pub trait bitcoin::consensus::serde::hex::Case: bitcoin::consensus::serde::hex::sealed::Case
@@ -8354,6 +8673,8 @@ impl<Case> core::marker::Unpin for bitcoin::consensus::serde::Hex<Case> where Ca
 impl<Case> core::marker::UnsafeUnpin for bitcoin::consensus::serde::Hex<Case>
 impl<Case> core::panic::unwind_safe::RefUnwindSafe for bitcoin::consensus::serde::Hex<Case> where Case: core::panic::unwind_safe::RefUnwindSafe
 impl<Case> core::panic::unwind_safe::UnwindSafe for bitcoin::consensus::serde::Hex<Case> where Case: core::panic::unwind_safe::UnwindSafe
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::consensus::serde::Hex<Case> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::consensus::serde::Hex<Case> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::consensus::serde::Hex<Case> where U: core::convert::From<T>
 pub fn bitcoin::consensus::serde::Hex<Case>::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::consensus::serde::Hex<Case> where U: core::convert::Into<T>
@@ -8370,12 +8691,13 @@ impl<T> core::borrow::BorrowMut<T> for bitcoin::consensus::serde::Hex<Case> wher
 pub fn bitcoin::consensus::serde::Hex<Case>::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for bitcoin::consensus::serde::Hex<Case>
 pub fn bitcoin::consensus::serde::Hex<Case>::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::consensus::serde::Hex<Case> where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::consensus::serde::Hex<Case> where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::consensus::serde::Hex<Case>::vzip(self) -> V
 pub struct bitcoin::consensus::serde::With<E>(_)
 impl<E> bitcoin::consensus::serde::With<E>
-pub fn bitcoin::consensus::serde::With<E>::deserialize<'d, T: bitcoin::consensus::encode::Decodable, D: serde::de::Deserializer<'d>>(deserializer: D) -> core::result::Result<T, <D as serde::de::Deserializer>::Error> where for<'a> E: bitcoin::consensus::serde::ByteDecoder<'a>
-pub fn bitcoin::consensus::serde::With<E>::serialize<T: bitcoin::consensus::encode::Encodable, S: serde::ser::Serializer>(value: &T, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where E: bitcoin::consensus::serde::ByteEncoder
+pub fn bitcoin::consensus::serde::With<E>::deserialize<'d, T: bitcoin::consensus::encode::Decodable, D: serde_core::de::Deserializer<'d>>(deserializer: D) -> core::result::Result<T, <D as serde_core::de::Deserializer>::Error> where for<'a> E: bitcoin::consensus::serde::ByteDecoder<'a>
+pub fn bitcoin::consensus::serde::With<E>::serialize<T: bitcoin::consensus::encode::Encodable, S: serde_core::ser::Serializer>(value: &T, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error> where E: bitcoin::consensus::serde::ByteEncoder
 impl<E> core::marker::Freeze for bitcoin::consensus::serde::With<E>
 impl<E> core::marker::Send for bitcoin::consensus::serde::With<E> where E: core::marker::Send
 impl<E> core::marker::Sync for bitcoin::consensus::serde::With<E> where E: core::marker::Sync
@@ -8383,6 +8705,8 @@ impl<E> core::marker::Unpin for bitcoin::consensus::serde::With<E> where E: core
 impl<E> core::marker::UnsafeUnpin for bitcoin::consensus::serde::With<E>
 impl<E> core::panic::unwind_safe::RefUnwindSafe for bitcoin::consensus::serde::With<E> where E: core::panic::unwind_safe::RefUnwindSafe
 impl<E> core::panic::unwind_safe::UnwindSafe for bitcoin::consensus::serde::With<E> where E: core::panic::unwind_safe::UnwindSafe
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::consensus::serde::With<E> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::consensus::serde::With<E> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::consensus::serde::With<E> where U: core::convert::From<T>
 pub fn bitcoin::consensus::serde::With<E>::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::consensus::serde::With<E> where U: core::convert::Into<T>
@@ -8399,6 +8723,7 @@ impl<T> core::borrow::BorrowMut<T> for bitcoin::consensus::serde::With<E> where 
 pub fn bitcoin::consensus::serde::With<E>::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for bitcoin::consensus::serde::With<E>
 pub fn bitcoin::consensus::serde::With<E>::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::consensus::serde::With<E> where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::consensus::serde::With<E> where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::consensus::serde::With<E>::vzip(self) -> V
 pub trait bitcoin::consensus::serde::ByteDecoder<'a>
@@ -8412,9 +8737,9 @@ pub trait bitcoin::consensus::serde::EncodeBytes
 pub fn bitcoin::consensus::serde::EncodeBytes::encode_chunk<W: core::fmt::Write>(&mut self, writer: &mut W, bytes: &[u8]) -> core::fmt::Result
 pub fn bitcoin::consensus::serde::EncodeBytes::flush<W: core::fmt::Write>(&mut self, writer: &mut W) -> core::fmt::Result
 pub trait bitcoin::consensus::serde::IntoDeError
-pub fn bitcoin::consensus::serde::IntoDeError::into_de_error<E: serde::de::Error>(self) -> E
+pub fn bitcoin::consensus::serde::IntoDeError::into_de_error<E: serde_core::de::Error>(self) -> E
 impl<E> bitcoin::consensus::serde::IntoDeError for bitcoin::consensus::DecodeError<E> where E: bitcoin::consensus::serde::IntoDeError
-pub fn bitcoin::consensus::DecodeError<E>::into_de_error<DE: serde::de::Error>(self) -> DE
+pub fn bitcoin::consensus::DecodeError<E>::into_de_error<DE: serde_core::de::Error>(self) -> DE
 pub mod bitcoin::consensus::validation
 #[non_exhaustive] pub enum bitcoin::consensus::validation::TxVerifyError
 pub bitcoin::consensus::validation::TxVerifyError::ScriptVerification(bitcoin::consensus::validation::BitcoinconsensusError)
@@ -8438,6 +8763,8 @@ impl core::marker::Unpin for bitcoin::consensus::validation::BitcoinconsensusErr
 impl core::marker::UnsafeUnpin for bitcoin::consensus::validation::BitcoinconsensusError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::consensus::validation::BitcoinconsensusError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::consensus::validation::BitcoinconsensusError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::consensus::validation::BitcoinconsensusError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::consensus::validation::BitcoinconsensusError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::consensus::validation::BitcoinconsensusError where U: core::convert::From<T>
 pub fn bitcoin::consensus::validation::BitcoinconsensusError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::consensus::validation::BitcoinconsensusError where U: core::convert::Into<T>
@@ -8462,6 +8789,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::consensus::validation::Bitcoinco
 pub unsafe fn bitcoin::consensus::validation::BitcoinconsensusError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::consensus::validation::BitcoinconsensusError
 pub fn bitcoin::consensus::validation::BitcoinconsensusError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::consensus::validation::BitcoinconsensusError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::consensus::validation::BitcoinconsensusError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::consensus::validation::BitcoinconsensusError::vzip(self) -> V
 pub fn bitcoin::consensus::validation::verify_script(script: &bitcoin::blockdata::script::Script, index: usize, amount: bitcoin_units::amount::Amount, spending_tx: &[u8]) -> core::result::Result<(), bitcoin::consensus::validation::BitcoinconsensusError>
@@ -8486,6 +8814,8 @@ impl<E> core::marker::Unpin for bitcoin::consensus::DecodeError<E> where E: core
 impl<E> core::marker::UnsafeUnpin for bitcoin::consensus::DecodeError<E> where E: core::marker::UnsafeUnpin
 impl<E> !core::panic::unwind_safe::RefUnwindSafe for bitcoin::consensus::DecodeError<E>
 impl<E> !core::panic::unwind_safe::UnwindSafe for bitcoin::consensus::DecodeError<E>
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::consensus::DecodeError<E> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::consensus::DecodeError<E> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::consensus::DecodeError<E> where U: core::convert::From<T>
 pub fn bitcoin::consensus::DecodeError<E>::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::consensus::DecodeError<E> where U: core::convert::Into<T>
@@ -8504,6 +8834,7 @@ impl<T> core::borrow::BorrowMut<T> for bitcoin::consensus::DecodeError<E> where 
 pub fn bitcoin::consensus::DecodeError<E>::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for bitcoin::consensus::DecodeError<E>
 pub fn bitcoin::consensus::DecodeError<E>::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::consensus::DecodeError<E> where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::consensus::DecodeError<E> where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::consensus::DecodeError<E>::vzip(self) -> V
 #[non_exhaustive] pub struct bitcoin::consensus::Params
@@ -8602,6 +8933,8 @@ impl core::marker::Unpin for bitcoin::ecdsa::Error
 impl core::marker::UnsafeUnpin for bitcoin::ecdsa::Error
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::ecdsa::Error
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::ecdsa::Error
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::ecdsa::Error where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::ecdsa::Error where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::ecdsa::Error where U: core::convert::From<T>
 pub fn bitcoin::ecdsa::Error::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::ecdsa::Error where U: core::convert::Into<T>
@@ -8626,6 +8959,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::ecdsa::Error where T: core::clon
 pub unsafe fn bitcoin::ecdsa::Error::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::ecdsa::Error
 pub fn bitcoin::ecdsa::Error::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::ecdsa::Error where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::ecdsa::Error where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::ecdsa::Error::vzip(self) -> V
 pub struct bitcoin::ecdsa::SerializedSignature
@@ -8671,6 +9005,8 @@ impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::ecdsa::SerializedSigna
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::ecdsa::SerializedSignature
 impl<P, T> core::ops::deref::Receiver for bitcoin::ecdsa::SerializedSignature where P: core::ops::deref::Deref<Target = T> + ?core::marker::Sized, T: ?core::marker::Sized
 pub type bitcoin::ecdsa::SerializedSignature::Target = T
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::ecdsa::SerializedSignature where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::ecdsa::SerializedSignature where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::ecdsa::SerializedSignature where U: core::convert::From<T>
 pub fn bitcoin::ecdsa::SerializedSignature::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::ecdsa::SerializedSignature where U: core::convert::Into<T>
@@ -8695,6 +9031,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::ecdsa::SerializedSignature where
 pub unsafe fn bitcoin::ecdsa::SerializedSignature::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::ecdsa::SerializedSignature
 pub fn bitcoin::ecdsa::SerializedSignature::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::ecdsa::SerializedSignature where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::ecdsa::SerializedSignature where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::ecdsa::SerializedSignature::vzip(self) -> V
 pub struct bitcoin::ecdsa::Signature
@@ -8721,12 +9058,12 @@ impl core::marker::StructuralPartialEq for bitcoin::ecdsa::Signature
 impl core::str::traits::FromStr for bitcoin::ecdsa::Signature
 pub type bitcoin::ecdsa::Signature::Err = bitcoin::ecdsa::Error
 pub fn bitcoin::ecdsa::Signature::from_str(s: &str) -> core::result::Result<Self, Self::Err>
-impl serde::ser::Serialize for bitcoin::ecdsa::Signature
-pub fn bitcoin::ecdsa::Signature::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl serde_core::ser::Serialize for bitcoin::ecdsa::Signature
+pub fn bitcoin::ecdsa::Signature::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin::ecdsa::Signature
 pub fn bitcoin::ecdsa::Signature::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::ecdsa::Signature
-pub fn bitcoin::ecdsa::Signature::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::ecdsa::Signature
+pub fn bitcoin::ecdsa::Signature::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin::ecdsa::Signature
 impl core::marker::Send for bitcoin::ecdsa::Signature
 impl core::marker::Sync for bitcoin::ecdsa::Signature
@@ -8734,6 +9071,8 @@ impl core::marker::Unpin for bitcoin::ecdsa::Signature
 impl core::marker::UnsafeUnpin for bitcoin::ecdsa::Signature
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::ecdsa::Signature
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::ecdsa::Signature
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::ecdsa::Signature where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::ecdsa::Signature where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::ecdsa::Signature where U: core::convert::From<T>
 pub fn bitcoin::ecdsa::Signature::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::ecdsa::Signature where U: core::convert::Into<T>
@@ -8758,7 +9097,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::ecdsa::Signature where T: core::
 pub unsafe fn bitcoin::ecdsa::Signature::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::ecdsa::Signature
 pub fn bitcoin::ecdsa::Signature::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::ecdsa::Signature where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::ecdsa::Signature where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::ecdsa::Signature where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::ecdsa::Signature where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::ecdsa::Signature::vzip(self) -> V
 pub mod bitcoin::error
@@ -8788,6 +9128,8 @@ impl core::marker::Unpin for bitcoin::error::PrefixedHexError
 impl core::marker::UnsafeUnpin for bitcoin::error::PrefixedHexError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::error::PrefixedHexError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::error::PrefixedHexError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::error::PrefixedHexError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::error::PrefixedHexError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::error::PrefixedHexError where U: core::convert::From<T>
 pub fn bitcoin::error::PrefixedHexError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::error::PrefixedHexError where U: core::convert::Into<T>
@@ -8812,6 +9154,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::error::PrefixedHexError where T:
 pub unsafe fn bitcoin::error::PrefixedHexError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::error::PrefixedHexError
 pub fn bitcoin::error::PrefixedHexError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::error::PrefixedHexError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::error::PrefixedHexError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::error::PrefixedHexError::vzip(self) -> V
 pub enum bitcoin::error::UnprefixedHexError
@@ -8839,6 +9182,8 @@ impl core::marker::Unpin for bitcoin::error::UnprefixedHexError
 impl core::marker::UnsafeUnpin for bitcoin::error::UnprefixedHexError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::error::UnprefixedHexError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::error::UnprefixedHexError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::error::UnprefixedHexError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::error::UnprefixedHexError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::error::UnprefixedHexError where U: core::convert::From<T>
 pub fn bitcoin::error::UnprefixedHexError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::error::UnprefixedHexError where U: core::convert::Into<T>
@@ -8863,6 +9208,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::error::UnprefixedHexError where 
 pub unsafe fn bitcoin::error::UnprefixedHexError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::error::UnprefixedHexError
 pub fn bitcoin::error::UnprefixedHexError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::error::UnprefixedHexError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::error::UnprefixedHexError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::error::UnprefixedHexError::vzip(self) -> V
 pub struct bitcoin::error::ContainsPrefixError
@@ -8883,6 +9229,8 @@ impl core::marker::Unpin for bitcoin::error::ContainsPrefixError
 impl core::marker::UnsafeUnpin for bitcoin::error::ContainsPrefixError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::error::ContainsPrefixError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::error::ContainsPrefixError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::error::ContainsPrefixError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::error::ContainsPrefixError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::error::ContainsPrefixError where U: core::convert::From<T>
 pub fn bitcoin::error::ContainsPrefixError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::error::ContainsPrefixError where U: core::convert::Into<T>
@@ -8907,6 +9255,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::error::ContainsPrefixError where
 pub unsafe fn bitcoin::error::ContainsPrefixError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::error::ContainsPrefixError
 pub fn bitcoin::error::ContainsPrefixError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::error::ContainsPrefixError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::error::ContainsPrefixError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::error::ContainsPrefixError::vzip(self) -> V
 pub struct bitcoin::error::MissingPrefixError
@@ -8927,6 +9276,8 @@ impl core::marker::Unpin for bitcoin::error::MissingPrefixError
 impl core::marker::UnsafeUnpin for bitcoin::error::MissingPrefixError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::error::MissingPrefixError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::error::MissingPrefixError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::error::MissingPrefixError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::error::MissingPrefixError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::error::MissingPrefixError where U: core::convert::From<T>
 pub fn bitcoin::error::MissingPrefixError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::error::MissingPrefixError where U: core::convert::Into<T>
@@ -8951,6 +9302,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::error::MissingPrefixError where 
 pub unsafe fn bitcoin::error::MissingPrefixError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::error::MissingPrefixError
 pub fn bitcoin::error::MissingPrefixError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::error::MissingPrefixError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::error::MissingPrefixError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::error::MissingPrefixError::vzip(self) -> V
 pub mod bitcoin::hash_types
@@ -8998,6 +9350,8 @@ impl core::marker::Unpin for bitcoin::key::FromSliceError
 impl core::marker::UnsafeUnpin for bitcoin::key::FromSliceError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::key::FromSliceError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::key::FromSliceError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::key::FromSliceError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::key::FromSliceError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::key::FromSliceError where U: core::convert::From<T>
 pub fn bitcoin::key::FromSliceError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::key::FromSliceError where U: core::convert::Into<T>
@@ -9022,6 +9376,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::key::FromSliceError where T: cor
 pub unsafe fn bitcoin::key::FromSliceError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::key::FromSliceError
 pub fn bitcoin::key::FromSliceError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::key::FromSliceError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::key::FromSliceError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::key::FromSliceError::vzip(self) -> V
 #[non_exhaustive] pub enum bitcoin::key::FromWifError
@@ -9057,6 +9412,8 @@ impl core::marker::Unpin for bitcoin::key::FromWifError
 impl core::marker::UnsafeUnpin for bitcoin::key::FromWifError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::key::FromWifError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::key::FromWifError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::key::FromWifError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::key::FromWifError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::key::FromWifError where U: core::convert::From<T>
 pub fn bitcoin::key::FromWifError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::key::FromWifError where U: core::convert::Into<T>
@@ -9081,6 +9438,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::key::FromWifError where T: core:
 pub unsafe fn bitcoin::key::FromWifError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::key::FromWifError
 pub fn bitcoin::key::FromWifError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::key::FromWifError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::key::FromWifError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::key::FromWifError::vzip(self) -> V
 pub enum bitcoin::key::ParseCompressedPublicKeyError
@@ -9110,6 +9468,8 @@ impl core::marker::Unpin for bitcoin::key::ParseCompressedPublicKeyError
 impl core::marker::UnsafeUnpin for bitcoin::key::ParseCompressedPublicKeyError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::key::ParseCompressedPublicKeyError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::key::ParseCompressedPublicKeyError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::key::ParseCompressedPublicKeyError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::key::ParseCompressedPublicKeyError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::key::ParseCompressedPublicKeyError where U: core::convert::From<T>
 pub fn bitcoin::key::ParseCompressedPublicKeyError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::key::ParseCompressedPublicKeyError where U: core::convert::Into<T>
@@ -9134,6 +9494,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::key::ParseCompressedPublicKeyErr
 pub unsafe fn bitcoin::key::ParseCompressedPublicKeyError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::key::ParseCompressedPublicKeyError
 pub fn bitcoin::key::ParseCompressedPublicKeyError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::key::ParseCompressedPublicKeyError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::key::ParseCompressedPublicKeyError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::key::ParseCompressedPublicKeyError::vzip(self) -> V
 pub enum bitcoin::key::ParsePublicKeyError
@@ -9160,6 +9521,8 @@ impl core::marker::Unpin for bitcoin::key::ParsePublicKeyError
 impl core::marker::UnsafeUnpin for bitcoin::key::ParsePublicKeyError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::key::ParsePublicKeyError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::key::ParsePublicKeyError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::key::ParsePublicKeyError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::key::ParsePublicKeyError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::key::ParsePublicKeyError where U: core::convert::From<T>
 pub fn bitcoin::key::ParsePublicKeyError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::key::ParsePublicKeyError where U: core::convert::Into<T>
@@ -9184,6 +9547,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::key::ParsePublicKeyError where T
 pub unsafe fn bitcoin::key::ParsePublicKeyError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::key::ParsePublicKeyError
 pub fn bitcoin::key::ParsePublicKeyError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::key::ParsePublicKeyError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::key::ParsePublicKeyError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::key::ParsePublicKeyError::vzip(self) -> V
 pub struct bitcoin::key::CompressedPublicKey(pub secp256k1::key::PublicKey)
@@ -9231,10 +9595,10 @@ impl core::marker::StructuralPartialEq for bitcoin::CompressedPublicKey
 impl core::str::traits::FromStr for bitcoin::CompressedPublicKey
 pub type bitcoin::CompressedPublicKey::Err = bitcoin::key::ParseCompressedPublicKeyError
 pub fn bitcoin::CompressedPublicKey::from_str(s: &str) -> core::result::Result<Self, Self::Err>
-impl serde::ser::Serialize for bitcoin::CompressedPublicKey
-pub fn bitcoin::CompressedPublicKey::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::CompressedPublicKey
-pub fn bitcoin::CompressedPublicKey::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
+impl serde_core::ser::Serialize for bitcoin::CompressedPublicKey
+pub fn bitcoin::CompressedPublicKey::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::CompressedPublicKey
+pub fn bitcoin::CompressedPublicKey::deserialize<D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<Self, <D as serde_core::de::Deserializer>::Error>
 impl core::marker::Freeze for bitcoin::CompressedPublicKey
 impl core::marker::Send for bitcoin::CompressedPublicKey
 impl core::marker::Sync for bitcoin::CompressedPublicKey
@@ -9242,6 +9606,8 @@ impl core::marker::Unpin for bitcoin::CompressedPublicKey
 impl core::marker::UnsafeUnpin for bitcoin::CompressedPublicKey
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::CompressedPublicKey
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::CompressedPublicKey
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::CompressedPublicKey where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::CompressedPublicKey where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::CompressedPublicKey where U: core::convert::From<T>
 pub fn bitcoin::CompressedPublicKey::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::CompressedPublicKey where U: core::convert::Into<T>
@@ -9266,7 +9632,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::CompressedPublicKey where T: cor
 pub unsafe fn bitcoin::CompressedPublicKey::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::CompressedPublicKey
 pub fn bitcoin::CompressedPublicKey::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::CompressedPublicKey where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::CompressedPublicKey where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::CompressedPublicKey where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::CompressedPublicKey where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::CompressedPublicKey::vzip(self) -> V
 pub struct bitcoin::key::InvalidAddressVersionError
@@ -9289,6 +9656,8 @@ impl core::marker::Unpin for bitcoin::key::InvalidAddressVersionError
 impl core::marker::UnsafeUnpin for bitcoin::key::InvalidAddressVersionError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::key::InvalidAddressVersionError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::key::InvalidAddressVersionError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::key::InvalidAddressVersionError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::key::InvalidAddressVersionError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::key::InvalidAddressVersionError where U: core::convert::From<T>
 pub fn bitcoin::key::InvalidAddressVersionError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::key::InvalidAddressVersionError where U: core::convert::Into<T>
@@ -9313,6 +9682,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::key::InvalidAddressVersionError 
 pub unsafe fn bitcoin::key::InvalidAddressVersionError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::key::InvalidAddressVersionError
 pub fn bitcoin::key::InvalidAddressVersionError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::key::InvalidAddressVersionError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::key::InvalidAddressVersionError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::key::InvalidAddressVersionError::vzip(self) -> V
 pub struct bitcoin::key::InvalidBase58PayloadLengthError
@@ -9335,6 +9705,8 @@ impl core::marker::Unpin for bitcoin::key::InvalidBase58PayloadLengthError
 impl core::marker::UnsafeUnpin for bitcoin::key::InvalidBase58PayloadLengthError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::key::InvalidBase58PayloadLengthError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::key::InvalidBase58PayloadLengthError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::key::InvalidBase58PayloadLengthError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::key::InvalidBase58PayloadLengthError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::key::InvalidBase58PayloadLengthError where U: core::convert::From<T>
 pub fn bitcoin::key::InvalidBase58PayloadLengthError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::key::InvalidBase58PayloadLengthError where U: core::convert::Into<T>
@@ -9359,6 +9731,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::key::InvalidBase58PayloadLengthE
 pub unsafe fn bitcoin::key::InvalidBase58PayloadLengthError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::key::InvalidBase58PayloadLengthError
 pub fn bitcoin::key::InvalidBase58PayloadLengthError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::key::InvalidBase58PayloadLengthError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::key::InvalidBase58PayloadLengthError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::key::InvalidBase58PayloadLengthError::vzip(self) -> V
 pub struct bitcoin::key::PrivateKey
@@ -9392,10 +9765,10 @@ pub fn bitcoin::PrivateKey::index(&self, _: core::ops::range::RangeFull) -> &[u8
 impl core::str::traits::FromStr for bitcoin::PrivateKey
 pub type bitcoin::PrivateKey::Err = bitcoin::key::FromWifError
 pub fn bitcoin::PrivateKey::from_str(s: &str) -> core::result::Result<bitcoin::PrivateKey, bitcoin::key::FromWifError>
-impl serde::ser::Serialize for bitcoin::PrivateKey
-pub fn bitcoin::PrivateKey::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::PrivateKey
-pub fn bitcoin::PrivateKey::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::PrivateKey, <D as serde::de::Deserializer>::Error>
+impl serde_core::ser::Serialize for bitcoin::PrivateKey
+pub fn bitcoin::PrivateKey::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::PrivateKey
+pub fn bitcoin::PrivateKey::deserialize<D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::PrivateKey, <D as serde_core::de::Deserializer>::Error>
 impl core::marker::Freeze for bitcoin::PrivateKey
 impl core::marker::Send for bitcoin::PrivateKey
 impl core::marker::Sync for bitcoin::PrivateKey
@@ -9403,6 +9776,8 @@ impl core::marker::Unpin for bitcoin::PrivateKey
 impl core::marker::UnsafeUnpin for bitcoin::PrivateKey
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::PrivateKey
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::PrivateKey
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::PrivateKey where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::PrivateKey where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::PrivateKey where U: core::convert::From<T>
 pub fn bitcoin::PrivateKey::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::PrivateKey where U: core::convert::Into<T>
@@ -9427,7 +9802,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::PrivateKey where T: core::clone:
 pub unsafe fn bitcoin::PrivateKey::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::PrivateKey
 pub fn bitcoin::PrivateKey::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::PrivateKey where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::PrivateKey where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::PrivateKey where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::PrivateKey where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::PrivateKey::vzip(self) -> V
 pub struct bitcoin::key::PubkeyHash(_)
@@ -9485,10 +9861,10 @@ impl core::marker::StructuralPartialEq for bitcoin::PubkeyHash
 impl core::str::traits::FromStr for bitcoin::PubkeyHash
 pub type bitcoin::PubkeyHash::Err = hex_conservative::error::HexToArrayError
 pub fn bitcoin::PubkeyHash::from_str(s: &str) -> core::result::Result<bitcoin::PubkeyHash, Self::Err>
-impl serde::ser::Serialize for bitcoin::PubkeyHash
-pub fn bitcoin::PubkeyHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::PubkeyHash
-pub fn bitcoin::PubkeyHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::PubkeyHash, <D as serde::de::Deserializer>::Error>
+impl serde_core::ser::Serialize for bitcoin::PubkeyHash
+pub fn bitcoin::PubkeyHash::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::PubkeyHash
+pub fn bitcoin::PubkeyHash::deserialize<D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::PubkeyHash, <D as serde_core::de::Deserializer>::Error>
 impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::PubkeyHash
 pub type bitcoin::PubkeyHash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
 pub fn bitcoin::PubkeyHash::index(&self, index: I) -> &Self::Output
@@ -9499,6 +9875,8 @@ impl core::marker::Unpin for bitcoin::PubkeyHash
 impl core::marker::UnsafeUnpin for bitcoin::PubkeyHash
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::PubkeyHash
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::PubkeyHash
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::PubkeyHash where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::PubkeyHash where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::PubkeyHash where U: core::convert::From<T>
 pub fn bitcoin::PubkeyHash::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::PubkeyHash where U: core::convert::Into<T>
@@ -9523,7 +9901,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::PubkeyHash where T: core::clone:
 pub unsafe fn bitcoin::PubkeyHash::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::PubkeyHash
 pub fn bitcoin::PubkeyHash::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::PubkeyHash where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::PubkeyHash where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::PubkeyHash where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::PubkeyHash where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::PubkeyHash::vzip(self) -> V
 pub struct bitcoin::key::PublicKey
@@ -9565,10 +9944,10 @@ impl core::marker::StructuralPartialEq for bitcoin::PublicKey
 impl core::str::traits::FromStr for bitcoin::PublicKey
 pub type bitcoin::PublicKey::Err = bitcoin::key::ParsePublicKeyError
 pub fn bitcoin::PublicKey::from_str(s: &str) -> core::result::Result<bitcoin::PublicKey, bitcoin::key::ParsePublicKeyError>
-impl serde::ser::Serialize for bitcoin::PublicKey
-pub fn bitcoin::PublicKey::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::PublicKey
-pub fn bitcoin::PublicKey::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::PublicKey, <D as serde::de::Deserializer>::Error>
+impl serde_core::ser::Serialize for bitcoin::PublicKey
+pub fn bitcoin::PublicKey::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::PublicKey
+pub fn bitcoin::PublicKey::deserialize<D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::PublicKey, <D as serde_core::de::Deserializer>::Error>
 impl core::marker::Freeze for bitcoin::PublicKey
 impl core::marker::Send for bitcoin::PublicKey
 impl core::marker::Sync for bitcoin::PublicKey
@@ -9576,6 +9955,8 @@ impl core::marker::Unpin for bitcoin::PublicKey
 impl core::marker::UnsafeUnpin for bitcoin::PublicKey
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::PublicKey
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::PublicKey
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::PublicKey where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::PublicKey where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::PublicKey where U: core::convert::From<T>
 pub fn bitcoin::PublicKey::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::PublicKey where U: core::convert::Into<T>
@@ -9600,7 +9981,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::PublicKey where T: core::clone::
 pub unsafe fn bitcoin::PublicKey::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::PublicKey
 pub fn bitcoin::PublicKey::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::PublicKey where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::PublicKey where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::PublicKey where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::PublicKey where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::PublicKey::vzip(self) -> V
 pub struct bitcoin::key::SortKey(_)
@@ -9626,6 +10008,8 @@ impl core::marker::Unpin for bitcoin::key::SortKey
 impl core::marker::UnsafeUnpin for bitcoin::key::SortKey
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::key::SortKey
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::key::SortKey
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::key::SortKey where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::key::SortKey where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::key::SortKey where U: core::convert::From<T>
 pub fn bitcoin::key::SortKey::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::key::SortKey where U: core::convert::Into<T>
@@ -9648,6 +10032,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::key::SortKey where T: core::clon
 pub unsafe fn bitcoin::key::SortKey::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::key::SortKey
 pub fn bitcoin::key::SortKey::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::key::SortKey where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::key::SortKey where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::key::SortKey::vzip(self) -> V
 pub struct bitcoin::key::TweakedKeypair(_)
@@ -9675,10 +10060,10 @@ impl core::hash::Hash for bitcoin::key::TweakedKeypair
 pub fn bitcoin::key::TweakedKeypair::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for bitcoin::key::TweakedKeypair
 impl core::marker::StructuralPartialEq for bitcoin::key::TweakedKeypair
-impl serde::ser::Serialize for bitcoin::key::TweakedKeypair
-pub fn bitcoin::key::TweakedKeypair::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
-impl<'de> serde::de::Deserialize<'de> for bitcoin::key::TweakedKeypair
-pub fn bitcoin::key::TweakedKeypair::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl serde_core::ser::Serialize for bitcoin::key::TweakedKeypair
+pub fn bitcoin::key::TweakedKeypair::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::key::TweakedKeypair
+pub fn bitcoin::key::TweakedKeypair::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin::key::TweakedKeypair
 impl core::marker::Send for bitcoin::key::TweakedKeypair
 impl core::marker::Sync for bitcoin::key::TweakedKeypair
@@ -9686,6 +10071,8 @@ impl core::marker::Unpin for bitcoin::key::TweakedKeypair
 impl core::marker::UnsafeUnpin for bitcoin::key::TweakedKeypair
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::key::TweakedKeypair
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::key::TweakedKeypair
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::key::TweakedKeypair where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::key::TweakedKeypair where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::key::TweakedKeypair where U: core::convert::From<T>
 pub fn bitcoin::key::TweakedKeypair::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::key::TweakedKeypair where U: core::convert::Into<T>
@@ -9708,7 +10095,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::key::TweakedKeypair where T: cor
 pub unsafe fn bitcoin::key::TweakedKeypair::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::key::TweakedKeypair
 pub fn bitcoin::key::TweakedKeypair::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::key::TweakedKeypair where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::key::TweakedKeypair where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::key::TweakedKeypair where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::key::TweakedKeypair where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::key::TweakedKeypair::vzip(self) -> V
 pub struct bitcoin::key::TweakedPublicKey(_)
@@ -9737,10 +10125,10 @@ impl core::hash::Hash for bitcoin::key::TweakedPublicKey
 pub fn bitcoin::key::TweakedPublicKey::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for bitcoin::key::TweakedPublicKey
 impl core::marker::StructuralPartialEq for bitcoin::key::TweakedPublicKey
-impl serde::ser::Serialize for bitcoin::key::TweakedPublicKey
-pub fn bitcoin::key::TweakedPublicKey::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
-impl<'de> serde::de::Deserialize<'de> for bitcoin::key::TweakedPublicKey
-pub fn bitcoin::key::TweakedPublicKey::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl serde_core::ser::Serialize for bitcoin::key::TweakedPublicKey
+pub fn bitcoin::key::TweakedPublicKey::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::key::TweakedPublicKey
+pub fn bitcoin::key::TweakedPublicKey::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin::key::TweakedPublicKey
 impl core::marker::Send for bitcoin::key::TweakedPublicKey
 impl core::marker::Sync for bitcoin::key::TweakedPublicKey
@@ -9748,6 +10136,8 @@ impl core::marker::Unpin for bitcoin::key::TweakedPublicKey
 impl core::marker::UnsafeUnpin for bitcoin::key::TweakedPublicKey
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::key::TweakedPublicKey
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::key::TweakedPublicKey
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::key::TweakedPublicKey where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::key::TweakedPublicKey where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::key::TweakedPublicKey where U: core::convert::From<T>
 pub fn bitcoin::key::TweakedPublicKey::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::key::TweakedPublicKey where U: core::convert::Into<T>
@@ -9772,7 +10162,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::key::TweakedPublicKey where T: c
 pub unsafe fn bitcoin::key::TweakedPublicKey::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::key::TweakedPublicKey
 pub fn bitcoin::key::TweakedPublicKey::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::key::TweakedPublicKey where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::key::TweakedPublicKey where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::key::TweakedPublicKey where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::key::TweakedPublicKey where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::key::TweakedPublicKey::vzip(self) -> V
 #[non_exhaustive] pub struct bitcoin::key::UncompressedPublicKeyError
@@ -9794,6 +10185,8 @@ impl core::marker::Unpin for bitcoin::key::UncompressedPublicKeyError
 impl core::marker::UnsafeUnpin for bitcoin::key::UncompressedPublicKeyError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::key::UncompressedPublicKeyError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::key::UncompressedPublicKeyError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::key::UncompressedPublicKeyError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::key::UncompressedPublicKeyError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::key::UncompressedPublicKeyError where U: core::convert::From<T>
 pub fn bitcoin::key::UncompressedPublicKeyError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::key::UncompressedPublicKeyError where U: core::convert::Into<T>
@@ -9818,6 +10211,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::key::UncompressedPublicKeyError 
 pub unsafe fn bitcoin::key::UncompressedPublicKeyError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::key::UncompressedPublicKeyError
 pub fn bitcoin::key::UncompressedPublicKeyError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::key::UncompressedPublicKeyError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::key::UncompressedPublicKeyError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::key::UncompressedPublicKeyError::vzip(self) -> V
 pub struct bitcoin::key::WPubkeyHash(_)
@@ -9871,10 +10265,10 @@ impl core::marker::StructuralPartialEq for bitcoin::WPubkeyHash
 impl core::str::traits::FromStr for bitcoin::WPubkeyHash
 pub type bitcoin::WPubkeyHash::Err = hex_conservative::error::HexToArrayError
 pub fn bitcoin::WPubkeyHash::from_str(s: &str) -> core::result::Result<bitcoin::WPubkeyHash, Self::Err>
-impl serde::ser::Serialize for bitcoin::WPubkeyHash
-pub fn bitcoin::WPubkeyHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::WPubkeyHash
-pub fn bitcoin::WPubkeyHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::WPubkeyHash, <D as serde::de::Deserializer>::Error>
+impl serde_core::ser::Serialize for bitcoin::WPubkeyHash
+pub fn bitcoin::WPubkeyHash::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::WPubkeyHash
+pub fn bitcoin::WPubkeyHash::deserialize<D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::WPubkeyHash, <D as serde_core::de::Deserializer>::Error>
 impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::WPubkeyHash
 pub type bitcoin::WPubkeyHash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
 pub fn bitcoin::WPubkeyHash::index(&self, index: I) -> &Self::Output
@@ -9885,6 +10279,8 @@ impl core::marker::Unpin for bitcoin::WPubkeyHash
 impl core::marker::UnsafeUnpin for bitcoin::WPubkeyHash
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::WPubkeyHash
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::WPubkeyHash
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::WPubkeyHash where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::WPubkeyHash where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::WPubkeyHash where U: core::convert::From<T>
 pub fn bitcoin::WPubkeyHash::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::WPubkeyHash where U: core::convert::Into<T>
@@ -9909,7 +10305,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::WPubkeyHash where T: core::clone
 pub unsafe fn bitcoin::WPubkeyHash::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::WPubkeyHash
 pub fn bitcoin::WPubkeyHash::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::WPubkeyHash where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::WPubkeyHash where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::WPubkeyHash where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::WPubkeyHash where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::WPubkeyHash::vzip(self) -> V
 pub trait bitcoin::key::TapTweak
@@ -9986,6 +10383,8 @@ impl core::marker::Unpin for bitcoin::merkle_tree::MerkleBlockError
 impl core::marker::UnsafeUnpin for bitcoin::merkle_tree::MerkleBlockError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::merkle_tree::MerkleBlockError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::merkle_tree::MerkleBlockError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::merkle_tree::MerkleBlockError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::merkle_tree::MerkleBlockError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::merkle_tree::MerkleBlockError where U: core::convert::From<T>
 pub fn bitcoin::merkle_tree::MerkleBlockError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::merkle_tree::MerkleBlockError where U: core::convert::Into<T>
@@ -10010,6 +10409,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::merkle_tree::MerkleBlockError wh
 pub unsafe fn bitcoin::merkle_tree::MerkleBlockError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::merkle_tree::MerkleBlockError
 pub fn bitcoin::merkle_tree::MerkleBlockError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::merkle_tree::MerkleBlockError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::merkle_tree::MerkleBlockError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::merkle_tree::MerkleBlockError::vzip(self) -> V
 pub struct bitcoin::merkle_tree::MerkleBlock
@@ -10036,6 +10436,8 @@ impl core::marker::Unpin for bitcoin::MerkleBlock
 impl core::marker::UnsafeUnpin for bitcoin::MerkleBlock
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::MerkleBlock
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::MerkleBlock
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::MerkleBlock where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::MerkleBlock where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::MerkleBlock where U: core::convert::From<T>
 pub fn bitcoin::MerkleBlock::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::MerkleBlock where U: core::convert::Into<T>
@@ -10058,6 +10460,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::MerkleBlock where T: core::clone
 pub unsafe fn bitcoin::MerkleBlock::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::MerkleBlock
 pub fn bitcoin::MerkleBlock::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::MerkleBlock where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::MerkleBlock where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::MerkleBlock::vzip(self) -> V
 pub struct bitcoin::merkle_tree::PartialMerkleTree
@@ -10084,6 +10487,8 @@ impl core::marker::Unpin for bitcoin::merkle_tree::PartialMerkleTree
 impl core::marker::UnsafeUnpin for bitcoin::merkle_tree::PartialMerkleTree
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::merkle_tree::PartialMerkleTree
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::merkle_tree::PartialMerkleTree
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::merkle_tree::PartialMerkleTree where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::merkle_tree::PartialMerkleTree where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::merkle_tree::PartialMerkleTree where U: core::convert::From<T>
 pub fn bitcoin::merkle_tree::PartialMerkleTree::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::merkle_tree::PartialMerkleTree where U: core::convert::Into<T>
@@ -10106,14 +10511,15 @@ impl<T> core::clone::CloneToUninit for bitcoin::merkle_tree::PartialMerkleTree w
 pub unsafe fn bitcoin::merkle_tree::PartialMerkleTree::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::merkle_tree::PartialMerkleTree
 pub fn bitcoin::merkle_tree::PartialMerkleTree::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::merkle_tree::PartialMerkleTree where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::merkle_tree::PartialMerkleTree where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::merkle_tree::PartialMerkleTree::vzip(self) -> V
 pub fn bitcoin::merkle_tree::calculate_root<T, I>(hashes: I) -> core::option::Option<T> where T: bitcoin_hashes::Hash + bitcoin::consensus::encode::Encodable, <T as bitcoin_hashes::Hash>::Engine: bitcoin_io::Write, I: core::iter::traits::iterator::Iterator<Item = T>
 pub fn bitcoin::merkle_tree::calculate_root_inline<T>(hashes: &mut [T]) -> core::option::Option<T> where T: bitcoin_hashes::Hash + bitcoin::consensus::encode::Encodable, <T as bitcoin_hashes::Hash>::Engine: bitcoin_io::Write
 pub mod bitcoin::network
 pub mod bitcoin::network::as_core_arg
-pub fn bitcoin::network::as_core_arg::deserialize<'de, D>(deserializer: D) -> core::result::Result<bitcoin::network::Network, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
-pub fn bitcoin::network::as_core_arg::serialize<S>(network: &bitcoin::network::Network, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+pub fn bitcoin::network::as_core_arg::deserialize<'de, D>(deserializer: D) -> core::result::Result<bitcoin::network::Network, <D as serde_core::de::Deserializer>::Error> where D: serde_core::de::Deserializer<'de>
+pub fn bitcoin::network::as_core_arg::serialize<S>(network: &bitcoin::network::Network, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error> where S: serde_core::ser::Serializer
 pub enum bitcoin::network::Network
 pub bitcoin::network::Network::Bitcoin
 pub bitcoin::network::Network::Regtest
@@ -10154,10 +10560,10 @@ impl core::marker::StructuralPartialEq for bitcoin::network::Network
 impl core::str::traits::FromStr for bitcoin::network::Network
 pub type bitcoin::network::Network::Err = bitcoin::network::ParseNetworkError
 pub fn bitcoin::network::Network::from_str(s: &str) -> core::result::Result<Self, Self::Err>
-impl serde::ser::Serialize for bitcoin::network::Network
-pub fn bitcoin::network::Network::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
-impl<'de> serde::de::Deserialize<'de> for bitcoin::network::Network
-pub fn bitcoin::network::Network::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl serde_core::ser::Serialize for bitcoin::network::Network
+pub fn bitcoin::network::Network::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::network::Network
+pub fn bitcoin::network::Network::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin::network::Network
 impl core::marker::Send for bitcoin::network::Network
 impl core::marker::Sync for bitcoin::network::Network
@@ -10165,6 +10571,8 @@ impl core::marker::Unpin for bitcoin::network::Network
 impl core::marker::UnsafeUnpin for bitcoin::network::Network
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::network::Network
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::network::Network
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::network::Network where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::network::Network where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::network::Network where U: core::convert::From<T>
 pub fn bitcoin::network::Network::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::network::Network where U: core::convert::Into<T>
@@ -10189,7 +10597,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::network::Network where T: core::
 pub unsafe fn bitcoin::network::Network::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::network::Network
 pub fn bitcoin::network::Network::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::network::Network where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::network::Network where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::network::Network where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::network::Network where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::network::Network::vzip(self) -> V
 pub enum bitcoin::network::NetworkKind
@@ -10219,6 +10628,8 @@ impl core::marker::Unpin for bitcoin::network::NetworkKind
 impl core::marker::UnsafeUnpin for bitcoin::network::NetworkKind
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::network::NetworkKind
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::network::NetworkKind
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::network::NetworkKind where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::network::NetworkKind where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::network::NetworkKind where U: core::convert::From<T>
 pub fn bitcoin::network::NetworkKind::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::network::NetworkKind where U: core::convert::Into<T>
@@ -10241,6 +10652,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::network::NetworkKind where T: co
 pub unsafe fn bitcoin::network::NetworkKind::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::network::NetworkKind
 pub fn bitcoin::network::NetworkKind::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::network::NetworkKind where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::network::NetworkKind where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::network::NetworkKind::vzip(self) -> V
 #[non_exhaustive] pub struct bitcoin::network::ParseNetworkError(_)
@@ -10263,6 +10675,8 @@ impl core::marker::Unpin for bitcoin::network::ParseNetworkError
 impl core::marker::UnsafeUnpin for bitcoin::network::ParseNetworkError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::network::ParseNetworkError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::network::ParseNetworkError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::network::ParseNetworkError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::network::ParseNetworkError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::network::ParseNetworkError where U: core::convert::From<T>
 pub fn bitcoin::network::ParseNetworkError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::network::ParseNetworkError where U: core::convert::Into<T>
@@ -10287,6 +10701,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::network::ParseNetworkError where
 pub unsafe fn bitcoin::network::ParseNetworkError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::network::ParseNetworkError
 pub fn bitcoin::network::ParseNetworkError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::network::ParseNetworkError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::network::ParseNetworkError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::network::ParseNetworkError::vzip(self) -> V
 #[non_exhaustive] pub struct bitcoin::network::UnknownChainHashError(_)
@@ -10308,6 +10723,8 @@ impl core::marker::Unpin for bitcoin::network::UnknownChainHashError
 impl core::marker::UnsafeUnpin for bitcoin::network::UnknownChainHashError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::network::UnknownChainHashError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::network::UnknownChainHashError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::network::UnknownChainHashError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::network::UnknownChainHashError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::network::UnknownChainHashError where U: core::convert::From<T>
 pub fn bitcoin::network::UnknownChainHashError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::network::UnknownChainHashError where U: core::convert::Into<T>
@@ -10332,6 +10749,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::network::UnknownChainHashError w
 pub unsafe fn bitcoin::network::UnknownChainHashError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::network::UnknownChainHashError
 pub fn bitcoin::network::UnknownChainHashError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::network::UnknownChainHashError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::network::UnknownChainHashError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::network::UnknownChainHashError::vzip(self) -> V
 pub mod bitcoin::opcodes
@@ -10636,6 +11054,8 @@ impl core::marker::Unpin for bitcoin::p2p::address::AddrV2
 impl core::marker::UnsafeUnpin for bitcoin::p2p::address::AddrV2
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::address::AddrV2
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::address::AddrV2
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::p2p::address::AddrV2 where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::p2p::address::AddrV2 where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::p2p::address::AddrV2 where U: core::convert::From<T>
 pub fn bitcoin::p2p::address::AddrV2::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::p2p::address::AddrV2 where U: core::convert::Into<T>
@@ -10658,6 +11078,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::p2p::address::AddrV2 where T: co
 pub unsafe fn bitcoin::p2p::address::AddrV2::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::p2p::address::AddrV2
 pub fn bitcoin::p2p::address::AddrV2::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::p2p::address::AddrV2 where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::p2p::address::AddrV2 where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::p2p::address::AddrV2::vzip(self) -> V
 pub struct bitcoin::p2p::address::AddrV2Message
@@ -10687,6 +11108,8 @@ impl core::marker::Unpin for bitcoin::p2p::address::AddrV2Message
 impl core::marker::UnsafeUnpin for bitcoin::p2p::address::AddrV2Message
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::address::AddrV2Message
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::address::AddrV2Message
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::p2p::address::AddrV2Message where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::p2p::address::AddrV2Message where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::p2p::address::AddrV2Message where U: core::convert::From<T>
 pub fn bitcoin::p2p::address::AddrV2Message::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::p2p::address::AddrV2Message where U: core::convert::Into<T>
@@ -10709,6 +11132,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::p2p::address::AddrV2Message wher
 pub unsafe fn bitcoin::p2p::address::AddrV2Message::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::p2p::address::AddrV2Message
 pub fn bitcoin::p2p::address::AddrV2Message::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::p2p::address::AddrV2Message where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::p2p::address::AddrV2Message where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::p2p::address::AddrV2Message::vzip(self) -> V
 pub struct bitcoin::p2p::address::Address
@@ -10738,6 +11162,8 @@ impl core::marker::Unpin for bitcoin::p2p::address::Address
 impl core::marker::UnsafeUnpin for bitcoin::p2p::address::Address
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::address::Address
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::address::Address
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::p2p::address::Address where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::p2p::address::Address where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::p2p::address::Address where U: core::convert::From<T>
 pub fn bitcoin::p2p::address::Address::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::p2p::address::Address where U: core::convert::Into<T>
@@ -10760,6 +11186,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::p2p::address::Address where T: c
 pub unsafe fn bitcoin::p2p::address::Address::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::p2p::address::Address
 pub fn bitcoin::p2p::address::Address::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::p2p::address::Address where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::p2p::address::Address where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::p2p::address::Address::vzip(self) -> V
 pub mod bitcoin::p2p::message
@@ -10821,6 +11248,8 @@ impl core::marker::Unpin for bitcoin::p2p::message::NetworkMessage
 impl core::marker::UnsafeUnpin for bitcoin::p2p::message::NetworkMessage
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message::NetworkMessage
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message::NetworkMessage
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::p2p::message::NetworkMessage where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::p2p::message::NetworkMessage where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::p2p::message::NetworkMessage where U: core::convert::From<T>
 pub fn bitcoin::p2p::message::NetworkMessage::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::p2p::message::NetworkMessage where U: core::convert::Into<T>
@@ -10843,6 +11272,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::p2p::message::NetworkMessage whe
 pub unsafe fn bitcoin::p2p::message::NetworkMessage::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::p2p::message::NetworkMessage
 pub fn bitcoin::p2p::message::NetworkMessage::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::p2p::message::NetworkMessage where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::p2p::message::NetworkMessage where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::p2p::message::NetworkMessage::vzip(self) -> V
 pub struct bitcoin::p2p::message::CommandString(_)
@@ -10876,6 +11306,8 @@ impl core::marker::Unpin for bitcoin::p2p::message::CommandString
 impl core::marker::UnsafeUnpin for bitcoin::p2p::message::CommandString
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message::CommandString
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message::CommandString
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::p2p::message::CommandString where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::p2p::message::CommandString where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::p2p::message::CommandString where U: core::convert::From<T>
 pub fn bitcoin::p2p::message::CommandString::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::p2p::message::CommandString where U: core::convert::Into<T>
@@ -10900,6 +11332,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::p2p::message::CommandString wher
 pub unsafe fn bitcoin::p2p::message::CommandString::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::p2p::message::CommandString
 pub fn bitcoin::p2p::message::CommandString::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::p2p::message::CommandString where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::p2p::message::CommandString where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::p2p::message::CommandString::vzip(self) -> V
 #[non_exhaustive] pub struct bitcoin::p2p::message::CommandStringError
@@ -10921,6 +11354,8 @@ impl core::marker::Unpin for bitcoin::p2p::message::CommandStringError
 impl core::marker::UnsafeUnpin for bitcoin::p2p::message::CommandStringError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message::CommandStringError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message::CommandStringError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::p2p::message::CommandStringError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::p2p::message::CommandStringError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::p2p::message::CommandStringError where U: core::convert::From<T>
 pub fn bitcoin::p2p::message::CommandStringError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::p2p::message::CommandStringError where U: core::convert::Into<T>
@@ -10945,6 +11380,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::p2p::message::CommandStringError
 pub unsafe fn bitcoin::p2p::message::CommandStringError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::p2p::message::CommandStringError
 pub fn bitcoin::p2p::message::CommandStringError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::p2p::message::CommandStringError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::p2p::message::CommandStringError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::p2p::message::CommandStringError::vzip(self) -> V
 pub struct bitcoin::p2p::message::RawNetworkMessage
@@ -10970,6 +11406,8 @@ impl core::marker::Unpin for bitcoin::p2p::message::RawNetworkMessage
 impl core::marker::UnsafeUnpin for bitcoin::p2p::message::RawNetworkMessage
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message::RawNetworkMessage
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message::RawNetworkMessage
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::p2p::message::RawNetworkMessage where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::p2p::message::RawNetworkMessage where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::p2p::message::RawNetworkMessage where U: core::convert::From<T>
 pub fn bitcoin::p2p::message::RawNetworkMessage::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::p2p::message::RawNetworkMessage where U: core::convert::Into<T>
@@ -10992,6 +11430,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::p2p::message::RawNetworkMessage 
 pub unsafe fn bitcoin::p2p::message::RawNetworkMessage::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::p2p::message::RawNetworkMessage
 pub fn bitcoin::p2p::message::RawNetworkMessage::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::p2p::message::RawNetworkMessage where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::p2p::message::RawNetworkMessage where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::p2p::message::RawNetworkMessage::vzip(self) -> V
 pub const bitcoin::p2p::message::MAX_INV_SIZE: usize
@@ -11033,6 +11472,8 @@ impl core::marker::Unpin for bitcoin::p2p::message_blockdata::Inventory
 impl core::marker::UnsafeUnpin for bitcoin::p2p::message_blockdata::Inventory
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_blockdata::Inventory
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_blockdata::Inventory
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::p2p::message_blockdata::Inventory where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::p2p::message_blockdata::Inventory where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::p2p::message_blockdata::Inventory where U: core::convert::From<T>
 pub fn bitcoin::p2p::message_blockdata::Inventory::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::p2p::message_blockdata::Inventory where U: core::convert::Into<T>
@@ -11055,6 +11496,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::p2p::message_blockdata::Inventor
 pub unsafe fn bitcoin::p2p::message_blockdata::Inventory::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::p2p::message_blockdata::Inventory
 pub fn bitcoin::p2p::message_blockdata::Inventory::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::p2p::message_blockdata::Inventory where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::p2p::message_blockdata::Inventory where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::p2p::message_blockdata::Inventory::vzip(self) -> V
 pub struct bitcoin::p2p::message_blockdata::GetBlocksMessage
@@ -11078,6 +11520,8 @@ impl core::marker::Unpin for bitcoin::p2p::message_blockdata::GetBlocksMessage
 impl core::marker::UnsafeUnpin for bitcoin::p2p::message_blockdata::GetBlocksMessage
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_blockdata::GetBlocksMessage
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_blockdata::GetBlocksMessage
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::p2p::message_blockdata::GetBlocksMessage where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::p2p::message_blockdata::GetBlocksMessage where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::p2p::message_blockdata::GetBlocksMessage where U: core::convert::From<T>
 pub fn bitcoin::p2p::message_blockdata::GetBlocksMessage::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::p2p::message_blockdata::GetBlocksMessage where U: core::convert::Into<T>
@@ -11100,6 +11544,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::p2p::message_blockdata::GetBlock
 pub unsafe fn bitcoin::p2p::message_blockdata::GetBlocksMessage::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::p2p::message_blockdata::GetBlocksMessage
 pub fn bitcoin::p2p::message_blockdata::GetBlocksMessage::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::p2p::message_blockdata::GetBlocksMessage where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::p2p::message_blockdata::GetBlocksMessage where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::p2p::message_blockdata::GetBlocksMessage::vzip(self) -> V
 pub struct bitcoin::p2p::message_blockdata::GetHeadersMessage
@@ -11123,6 +11568,8 @@ impl core::marker::Unpin for bitcoin::p2p::message_blockdata::GetHeadersMessage
 impl core::marker::UnsafeUnpin for bitcoin::p2p::message_blockdata::GetHeadersMessage
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_blockdata::GetHeadersMessage
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_blockdata::GetHeadersMessage
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::p2p::message_blockdata::GetHeadersMessage where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::p2p::message_blockdata::GetHeadersMessage where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::p2p::message_blockdata::GetHeadersMessage where U: core::convert::From<T>
 pub fn bitcoin::p2p::message_blockdata::GetHeadersMessage::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::p2p::message_blockdata::GetHeadersMessage where U: core::convert::Into<T>
@@ -11145,6 +11592,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::p2p::message_blockdata::GetHeade
 pub unsafe fn bitcoin::p2p::message_blockdata::GetHeadersMessage::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::p2p::message_blockdata::GetHeadersMessage
 pub fn bitcoin::p2p::message_blockdata::GetHeadersMessage::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::p2p::message_blockdata::GetHeadersMessage where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::p2p::message_blockdata::GetHeadersMessage where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::p2p::message_blockdata::GetHeadersMessage::vzip(self) -> V
 pub mod bitcoin::p2p::message_bloom
@@ -11168,6 +11616,8 @@ impl core::marker::Unpin for bitcoin::p2p::message_bloom::BloomFlags
 impl core::marker::UnsafeUnpin for bitcoin::p2p::message_bloom::BloomFlags
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_bloom::BloomFlags
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_bloom::BloomFlags
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::p2p::message_bloom::BloomFlags where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::p2p::message_bloom::BloomFlags where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::p2p::message_bloom::BloomFlags where U: core::convert::From<T>
 pub fn bitcoin::p2p::message_bloom::BloomFlags::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::p2p::message_bloom::BloomFlags where U: core::convert::Into<T>
@@ -11190,6 +11640,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::p2p::message_bloom::BloomFlags w
 pub unsafe fn bitcoin::p2p::message_bloom::BloomFlags::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::p2p::message_bloom::BloomFlags
 pub fn bitcoin::p2p::message_bloom::BloomFlags::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::p2p::message_bloom::BloomFlags where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::p2p::message_bloom::BloomFlags where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::p2p::message_bloom::BloomFlags::vzip(self) -> V
 pub struct bitcoin::p2p::message_bloom::FilterAdd
@@ -11209,6 +11660,8 @@ impl core::marker::Unpin for bitcoin::p2p::message_bloom::FilterAdd
 impl core::marker::UnsafeUnpin for bitcoin::p2p::message_bloom::FilterAdd
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_bloom::FilterAdd
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_bloom::FilterAdd
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::p2p::message_bloom::FilterAdd where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::p2p::message_bloom::FilterAdd where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::p2p::message_bloom::FilterAdd where U: core::convert::From<T>
 pub fn bitcoin::p2p::message_bloom::FilterAdd::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::p2p::message_bloom::FilterAdd where U: core::convert::Into<T>
@@ -11231,6 +11684,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::p2p::message_bloom::FilterAdd wh
 pub unsafe fn bitcoin::p2p::message_bloom::FilterAdd::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::p2p::message_bloom::FilterAdd
 pub fn bitcoin::p2p::message_bloom::FilterAdd::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::p2p::message_bloom::FilterAdd where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::p2p::message_bloom::FilterAdd where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::p2p::message_bloom::FilterAdd::vzip(self) -> V
 pub struct bitcoin::p2p::message_bloom::FilterLoad
@@ -11253,6 +11707,8 @@ impl core::marker::Unpin for bitcoin::p2p::message_bloom::FilterLoad
 impl core::marker::UnsafeUnpin for bitcoin::p2p::message_bloom::FilterLoad
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_bloom::FilterLoad
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_bloom::FilterLoad
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::p2p::message_bloom::FilterLoad where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::p2p::message_bloom::FilterLoad where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::p2p::message_bloom::FilterLoad where U: core::convert::From<T>
 pub fn bitcoin::p2p::message_bloom::FilterLoad::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::p2p::message_bloom::FilterLoad where U: core::convert::Into<T>
@@ -11275,6 +11731,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::p2p::message_bloom::FilterLoad w
 pub unsafe fn bitcoin::p2p::message_bloom::FilterLoad::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::p2p::message_bloom::FilterLoad
 pub fn bitcoin::p2p::message_bloom::FilterLoad::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::p2p::message_bloom::FilterLoad where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::p2p::message_bloom::FilterLoad where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::p2p::message_bloom::FilterLoad::vzip(self) -> V
 pub mod bitcoin::p2p::message_compact_blocks
@@ -11301,6 +11758,8 @@ impl core::marker::Unpin for bitcoin::p2p::message_compact_blocks::BlockTxn
 impl core::marker::UnsafeUnpin for bitcoin::p2p::message_compact_blocks::BlockTxn
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_compact_blocks::BlockTxn
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_compact_blocks::BlockTxn
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::p2p::message_compact_blocks::BlockTxn where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::p2p::message_compact_blocks::BlockTxn where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::p2p::message_compact_blocks::BlockTxn where U: core::convert::From<T>
 pub fn bitcoin::p2p::message_compact_blocks::BlockTxn::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::p2p::message_compact_blocks::BlockTxn where U: core::convert::Into<T>
@@ -11323,6 +11782,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::p2p::message_compact_blocks::Blo
 pub unsafe fn bitcoin::p2p::message_compact_blocks::BlockTxn::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::p2p::message_compact_blocks::BlockTxn
 pub fn bitcoin::p2p::message_compact_blocks::BlockTxn::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::p2p::message_compact_blocks::BlockTxn where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::p2p::message_compact_blocks::BlockTxn where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::p2p::message_compact_blocks::BlockTxn::vzip(self) -> V
 pub struct bitcoin::p2p::message_compact_blocks::CmpctBlock
@@ -11348,6 +11808,8 @@ impl core::marker::Unpin for bitcoin::p2p::message_compact_blocks::CmpctBlock
 impl core::marker::UnsafeUnpin for bitcoin::p2p::message_compact_blocks::CmpctBlock
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_compact_blocks::CmpctBlock
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_compact_blocks::CmpctBlock
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::p2p::message_compact_blocks::CmpctBlock where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::p2p::message_compact_blocks::CmpctBlock where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::p2p::message_compact_blocks::CmpctBlock where U: core::convert::From<T>
 pub fn bitcoin::p2p::message_compact_blocks::CmpctBlock::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::p2p::message_compact_blocks::CmpctBlock where U: core::convert::Into<T>
@@ -11370,6 +11832,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::p2p::message_compact_blocks::Cmp
 pub unsafe fn bitcoin::p2p::message_compact_blocks::CmpctBlock::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::p2p::message_compact_blocks::CmpctBlock
 pub fn bitcoin::p2p::message_compact_blocks::CmpctBlock::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::p2p::message_compact_blocks::CmpctBlock where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::p2p::message_compact_blocks::CmpctBlock where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::p2p::message_compact_blocks::CmpctBlock::vzip(self) -> V
 pub struct bitcoin::p2p::message_compact_blocks::GetBlockTxn
@@ -11395,6 +11858,8 @@ impl core::marker::Unpin for bitcoin::p2p::message_compact_blocks::GetBlockTxn
 impl core::marker::UnsafeUnpin for bitcoin::p2p::message_compact_blocks::GetBlockTxn
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_compact_blocks::GetBlockTxn
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_compact_blocks::GetBlockTxn
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::p2p::message_compact_blocks::GetBlockTxn where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::p2p::message_compact_blocks::GetBlockTxn where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::p2p::message_compact_blocks::GetBlockTxn where U: core::convert::From<T>
 pub fn bitcoin::p2p::message_compact_blocks::GetBlockTxn::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::p2p::message_compact_blocks::GetBlockTxn where U: core::convert::Into<T>
@@ -11417,6 +11882,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::p2p::message_compact_blocks::Get
 pub unsafe fn bitcoin::p2p::message_compact_blocks::GetBlockTxn::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::p2p::message_compact_blocks::GetBlockTxn
 pub fn bitcoin::p2p::message_compact_blocks::GetBlockTxn::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::p2p::message_compact_blocks::GetBlockTxn where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::p2p::message_compact_blocks::GetBlockTxn where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::p2p::message_compact_blocks::GetBlockTxn::vzip(self) -> V
 pub struct bitcoin::p2p::message_compact_blocks::SendCmpct
@@ -11444,6 +11910,8 @@ impl core::marker::Unpin for bitcoin::p2p::message_compact_blocks::SendCmpct
 impl core::marker::UnsafeUnpin for bitcoin::p2p::message_compact_blocks::SendCmpct
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_compact_blocks::SendCmpct
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_compact_blocks::SendCmpct
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::p2p::message_compact_blocks::SendCmpct where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::p2p::message_compact_blocks::SendCmpct where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::p2p::message_compact_blocks::SendCmpct where U: core::convert::From<T>
 pub fn bitcoin::p2p::message_compact_blocks::SendCmpct::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::p2p::message_compact_blocks::SendCmpct where U: core::convert::Into<T>
@@ -11466,6 +11934,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::p2p::message_compact_blocks::Sen
 pub unsafe fn bitcoin::p2p::message_compact_blocks::SendCmpct::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::p2p::message_compact_blocks::SendCmpct
 pub fn bitcoin::p2p::message_compact_blocks::SendCmpct::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::p2p::message_compact_blocks::SendCmpct where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::p2p::message_compact_blocks::SendCmpct where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::p2p::message_compact_blocks::SendCmpct::vzip(self) -> V
 pub mod bitcoin::p2p::message_filter
@@ -11488,6 +11957,8 @@ impl core::marker::Unpin for bitcoin::p2p::message_filter::CFCheckpt
 impl core::marker::UnsafeUnpin for bitcoin::p2p::message_filter::CFCheckpt
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_filter::CFCheckpt
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_filter::CFCheckpt
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::p2p::message_filter::CFCheckpt where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::p2p::message_filter::CFCheckpt where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::p2p::message_filter::CFCheckpt where U: core::convert::From<T>
 pub fn bitcoin::p2p::message_filter::CFCheckpt::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::p2p::message_filter::CFCheckpt where U: core::convert::Into<T>
@@ -11510,6 +11981,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::p2p::message_filter::CFCheckpt w
 pub unsafe fn bitcoin::p2p::message_filter::CFCheckpt::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::p2p::message_filter::CFCheckpt
 pub fn bitcoin::p2p::message_filter::CFCheckpt::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::p2p::message_filter::CFCheckpt where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::p2p::message_filter::CFCheckpt where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::p2p::message_filter::CFCheckpt::vzip(self) -> V
 pub struct bitcoin::p2p::message_filter::CFHeaders
@@ -11532,6 +12004,8 @@ impl core::marker::Unpin for bitcoin::p2p::message_filter::CFHeaders
 impl core::marker::UnsafeUnpin for bitcoin::p2p::message_filter::CFHeaders
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_filter::CFHeaders
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_filter::CFHeaders
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::p2p::message_filter::CFHeaders where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::p2p::message_filter::CFHeaders where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::p2p::message_filter::CFHeaders where U: core::convert::From<T>
 pub fn bitcoin::p2p::message_filter::CFHeaders::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::p2p::message_filter::CFHeaders where U: core::convert::Into<T>
@@ -11554,6 +12028,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::p2p::message_filter::CFHeaders w
 pub unsafe fn bitcoin::p2p::message_filter::CFHeaders::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::p2p::message_filter::CFHeaders
 pub fn bitcoin::p2p::message_filter::CFHeaders::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::p2p::message_filter::CFHeaders where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::p2p::message_filter::CFHeaders where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::p2p::message_filter::CFHeaders::vzip(self) -> V
 pub struct bitcoin::p2p::message_filter::CFilter
@@ -11575,6 +12050,8 @@ impl core::marker::Unpin for bitcoin::p2p::message_filter::CFilter
 impl core::marker::UnsafeUnpin for bitcoin::p2p::message_filter::CFilter
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_filter::CFilter
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_filter::CFilter
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::p2p::message_filter::CFilter where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::p2p::message_filter::CFilter where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::p2p::message_filter::CFilter where U: core::convert::From<T>
 pub fn bitcoin::p2p::message_filter::CFilter::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::p2p::message_filter::CFilter where U: core::convert::Into<T>
@@ -11597,6 +12074,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::p2p::message_filter::CFilter whe
 pub unsafe fn bitcoin::p2p::message_filter::CFilter::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::p2p::message_filter::CFilter
 pub fn bitcoin::p2p::message_filter::CFilter::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::p2p::message_filter::CFilter where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::p2p::message_filter::CFilter where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::p2p::message_filter::CFilter::vzip(self) -> V
 pub struct bitcoin::p2p::message_filter::GetCFCheckpt
@@ -11617,6 +12095,8 @@ impl core::marker::Unpin for bitcoin::p2p::message_filter::GetCFCheckpt
 impl core::marker::UnsafeUnpin for bitcoin::p2p::message_filter::GetCFCheckpt
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_filter::GetCFCheckpt
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_filter::GetCFCheckpt
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::p2p::message_filter::GetCFCheckpt where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::p2p::message_filter::GetCFCheckpt where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::p2p::message_filter::GetCFCheckpt where U: core::convert::From<T>
 pub fn bitcoin::p2p::message_filter::GetCFCheckpt::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::p2p::message_filter::GetCFCheckpt where U: core::convert::Into<T>
@@ -11639,6 +12119,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::p2p::message_filter::GetCFCheckp
 pub unsafe fn bitcoin::p2p::message_filter::GetCFCheckpt::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::p2p::message_filter::GetCFCheckpt
 pub fn bitcoin::p2p::message_filter::GetCFCheckpt::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::p2p::message_filter::GetCFCheckpt where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::p2p::message_filter::GetCFCheckpt where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::p2p::message_filter::GetCFCheckpt::vzip(self) -> V
 pub struct bitcoin::p2p::message_filter::GetCFHeaders
@@ -11660,6 +12141,8 @@ impl core::marker::Unpin for bitcoin::p2p::message_filter::GetCFHeaders
 impl core::marker::UnsafeUnpin for bitcoin::p2p::message_filter::GetCFHeaders
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_filter::GetCFHeaders
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_filter::GetCFHeaders
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::p2p::message_filter::GetCFHeaders where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::p2p::message_filter::GetCFHeaders where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::p2p::message_filter::GetCFHeaders where U: core::convert::From<T>
 pub fn bitcoin::p2p::message_filter::GetCFHeaders::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::p2p::message_filter::GetCFHeaders where U: core::convert::Into<T>
@@ -11682,6 +12165,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::p2p::message_filter::GetCFHeader
 pub unsafe fn bitcoin::p2p::message_filter::GetCFHeaders::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::p2p::message_filter::GetCFHeaders
 pub fn bitcoin::p2p::message_filter::GetCFHeaders::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::p2p::message_filter::GetCFHeaders where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::p2p::message_filter::GetCFHeaders where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::p2p::message_filter::GetCFHeaders::vzip(self) -> V
 pub struct bitcoin::p2p::message_filter::GetCFilters
@@ -11703,6 +12187,8 @@ impl core::marker::Unpin for bitcoin::p2p::message_filter::GetCFilters
 impl core::marker::UnsafeUnpin for bitcoin::p2p::message_filter::GetCFilters
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_filter::GetCFilters
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_filter::GetCFilters
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::p2p::message_filter::GetCFilters where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::p2p::message_filter::GetCFilters where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::p2p::message_filter::GetCFilters where U: core::convert::From<T>
 pub fn bitcoin::p2p::message_filter::GetCFilters::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::p2p::message_filter::GetCFilters where U: core::convert::Into<T>
@@ -11725,6 +12211,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::p2p::message_filter::GetCFilters
 pub unsafe fn bitcoin::p2p::message_filter::GetCFilters::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::p2p::message_filter::GetCFilters
 pub fn bitcoin::p2p::message_filter::GetCFilters::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::p2p::message_filter::GetCFilters where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::p2p::message_filter::GetCFilters where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::p2p::message_filter::GetCFilters::vzip(self) -> V
 pub mod bitcoin::p2p::message_network
@@ -11753,6 +12240,8 @@ impl core::marker::Unpin for bitcoin::p2p::message_network::RejectReason
 impl core::marker::UnsafeUnpin for bitcoin::p2p::message_network::RejectReason
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_network::RejectReason
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_network::RejectReason
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::p2p::message_network::RejectReason where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::p2p::message_network::RejectReason where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::p2p::message_network::RejectReason where U: core::convert::From<T>
 pub fn bitcoin::p2p::message_network::RejectReason::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::p2p::message_network::RejectReason where U: core::convert::Into<T>
@@ -11775,6 +12264,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::p2p::message_network::RejectReas
 pub unsafe fn bitcoin::p2p::message_network::RejectReason::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::p2p::message_network::RejectReason
 pub fn bitcoin::p2p::message_network::RejectReason::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::p2p::message_network::RejectReason where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::p2p::message_network::RejectReason where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::p2p::message_network::RejectReason::vzip(self) -> V
 pub struct bitcoin::p2p::message_network::Reject
@@ -11797,6 +12287,8 @@ impl core::marker::Unpin for bitcoin::p2p::message_network::Reject
 impl core::marker::UnsafeUnpin for bitcoin::p2p::message_network::Reject
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_network::Reject
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_network::Reject
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::p2p::message_network::Reject where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::p2p::message_network::Reject where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::p2p::message_network::Reject where U: core::convert::From<T>
 pub fn bitcoin::p2p::message_network::Reject::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::p2p::message_network::Reject where U: core::convert::Into<T>
@@ -11819,6 +12311,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::p2p::message_network::Reject whe
 pub unsafe fn bitcoin::p2p::message_network::Reject::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::p2p::message_network::Reject
 pub fn bitcoin::p2p::message_network::Reject::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::p2p::message_network::Reject where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::p2p::message_network::Reject where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::p2p::message_network::Reject::vzip(self) -> V
 pub struct bitcoin::p2p::message_network::VersionMessage
@@ -11848,6 +12341,8 @@ impl core::marker::Unpin for bitcoin::p2p::message_network::VersionMessage
 impl core::marker::UnsafeUnpin for bitcoin::p2p::message_network::VersionMessage
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::message_network::VersionMessage
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::message_network::VersionMessage
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::p2p::message_network::VersionMessage where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::p2p::message_network::VersionMessage where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::p2p::message_network::VersionMessage where U: core::convert::From<T>
 pub fn bitcoin::p2p::message_network::VersionMessage::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::p2p::message_network::VersionMessage where U: core::convert::Into<T>
@@ -11870,6 +12365,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::p2p::message_network::VersionMes
 pub unsafe fn bitcoin::p2p::message_network::VersionMessage::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::p2p::message_network::VersionMessage
 pub fn bitcoin::p2p::message_network::VersionMessage::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::p2p::message_network::VersionMessage where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::p2p::message_network::VersionMessage where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::p2p::message_network::VersionMessage::vzip(self) -> V
 pub struct bitcoin::p2p::Address
@@ -11931,6 +12427,8 @@ impl core::marker::Unpin for bitcoin::p2p::Magic
 impl core::marker::UnsafeUnpin for bitcoin::p2p::Magic
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::Magic
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::Magic
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::p2p::Magic where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::p2p::Magic where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::p2p::Magic where U: core::convert::From<T>
 pub fn bitcoin::p2p::Magic::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::p2p::Magic where U: core::convert::Into<T>
@@ -11955,6 +12453,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::p2p::Magic where T: core::clone:
 pub unsafe fn bitcoin::p2p::Magic::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::p2p::Magic
 pub fn bitcoin::p2p::Magic::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::p2p::Magic where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::p2p::Magic where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::p2p::Magic::vzip(self) -> V
 #[non_exhaustive] pub struct bitcoin::p2p::ParseMagicError
@@ -11977,6 +12476,8 @@ impl core::marker::Unpin for bitcoin::p2p::ParseMagicError
 impl core::marker::UnsafeUnpin for bitcoin::p2p::ParseMagicError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::ParseMagicError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::ParseMagicError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::p2p::ParseMagicError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::p2p::ParseMagicError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::p2p::ParseMagicError where U: core::convert::From<T>
 pub fn bitcoin::p2p::ParseMagicError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::p2p::ParseMagicError where U: core::convert::Into<T>
@@ -12001,6 +12502,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::p2p::ParseMagicError where T: co
 pub unsafe fn bitcoin::p2p::ParseMagicError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::p2p::ParseMagicError
 pub fn bitcoin::p2p::ParseMagicError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::p2p::ParseMagicError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::p2p::ParseMagicError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::p2p::ParseMagicError::vzip(self) -> V
 pub struct bitcoin::p2p::ServiceFlags(_)
@@ -12057,6 +12559,8 @@ impl core::marker::Unpin for bitcoin::p2p::ServiceFlags
 impl core::marker::UnsafeUnpin for bitcoin::p2p::ServiceFlags
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::ServiceFlags
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::ServiceFlags
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::p2p::ServiceFlags where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::p2p::ServiceFlags where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::p2p::ServiceFlags where U: core::convert::From<T>
 pub fn bitcoin::p2p::ServiceFlags::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::p2p::ServiceFlags where U: core::convert::Into<T>
@@ -12081,6 +12585,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::p2p::ServiceFlags where T: core:
 pub unsafe fn bitcoin::p2p::ServiceFlags::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::p2p::ServiceFlags
 pub fn bitcoin::p2p::ServiceFlags::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::p2p::ServiceFlags where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::p2p::ServiceFlags where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::p2p::ServiceFlags::vzip(self) -> V
 #[non_exhaustive] pub struct bitcoin::p2p::UnknownMagicError(_)
@@ -12103,6 +12608,8 @@ impl core::marker::Unpin for bitcoin::p2p::UnknownMagicError
 impl core::marker::UnsafeUnpin for bitcoin::p2p::UnknownMagicError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::p2p::UnknownMagicError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::p2p::UnknownMagicError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::p2p::UnknownMagicError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::p2p::UnknownMagicError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::p2p::UnknownMagicError where U: core::convert::From<T>
 pub fn bitcoin::p2p::UnknownMagicError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::p2p::UnknownMagicError where U: core::convert::Into<T>
@@ -12127,6 +12634,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::p2p::UnknownMagicError where T: 
 pub unsafe fn bitcoin::p2p::UnknownMagicError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::p2p::UnknownMagicError
 pub fn bitcoin::p2p::UnknownMagicError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::p2p::UnknownMagicError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::p2p::UnknownMagicError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::p2p::UnknownMagicError::vzip(self) -> V
 pub const bitcoin::p2p::PROTOCOL_VERSION: u32
@@ -12193,10 +12701,10 @@ impl core::hash::Hash for bitcoin::pow::CompactTarget
 pub fn bitcoin::pow::CompactTarget::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for bitcoin::pow::CompactTarget
 impl core::marker::StructuralPartialEq for bitcoin::pow::CompactTarget
-impl serde::ser::Serialize for bitcoin::pow::CompactTarget
-pub fn bitcoin::pow::CompactTarget::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
-impl<'de> serde::de::Deserialize<'de> for bitcoin::pow::CompactTarget
-pub fn bitcoin::pow::CompactTarget::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl serde_core::ser::Serialize for bitcoin::pow::CompactTarget
+pub fn bitcoin::pow::CompactTarget::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::pow::CompactTarget
+pub fn bitcoin::pow::CompactTarget::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin::pow::CompactTarget
 impl core::marker::Send for bitcoin::pow::CompactTarget
 impl core::marker::Sync for bitcoin::pow::CompactTarget
@@ -12204,6 +12712,8 @@ impl core::marker::Unpin for bitcoin::pow::CompactTarget
 impl core::marker::UnsafeUnpin for bitcoin::pow::CompactTarget
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::pow::CompactTarget
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::pow::CompactTarget
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::pow::CompactTarget where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::pow::CompactTarget where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::pow::CompactTarget where U: core::convert::From<T>
 pub fn bitcoin::pow::CompactTarget::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::pow::CompactTarget where U: core::convert::Into<T>
@@ -12226,7 +12736,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::pow::CompactTarget where T: core
 pub unsafe fn bitcoin::pow::CompactTarget::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::pow::CompactTarget
 pub fn bitcoin::pow::CompactTarget::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::pow::CompactTarget where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::pow::CompactTarget where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::pow::CompactTarget where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::pow::CompactTarget where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::pow::CompactTarget::vzip(self) -> V
 pub struct bitcoin::pow::Target(_)
@@ -12272,10 +12783,10 @@ impl core::hash::Hash for bitcoin::pow::Target
 pub fn bitcoin::pow::Target::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for bitcoin::pow::Target
 impl core::marker::StructuralPartialEq for bitcoin::pow::Target
-impl serde::ser::Serialize for bitcoin::pow::Target
-pub fn bitcoin::pow::Target::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
-impl<'de> serde::de::Deserialize<'de> for bitcoin::pow::Target
-pub fn bitcoin::pow::Target::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl serde_core::ser::Serialize for bitcoin::pow::Target
+pub fn bitcoin::pow::Target::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::pow::Target
+pub fn bitcoin::pow::Target::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin::pow::Target
 impl core::marker::Send for bitcoin::pow::Target
 impl core::marker::Sync for bitcoin::pow::Target
@@ -12283,6 +12794,8 @@ impl core::marker::Unpin for bitcoin::pow::Target
 impl core::marker::UnsafeUnpin for bitcoin::pow::Target
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::pow::Target
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::pow::Target
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::pow::Target where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::pow::Target where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::pow::Target where U: core::convert::From<T>
 pub fn bitcoin::pow::Target::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::pow::Target where U: core::convert::Into<T>
@@ -12307,7 +12820,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::pow::Target where T: core::clone
 pub unsafe fn bitcoin::pow::Target::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::pow::Target
 pub fn bitcoin::pow::Target::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::pow::Target where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::pow::Target where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::pow::Target where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::pow::Target where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::pow::Target::vzip(self) -> V
 pub struct bitcoin::pow::Work(_)
@@ -12343,10 +12857,10 @@ pub type bitcoin::pow::Work::Output = bitcoin::pow::Work
 pub fn bitcoin::pow::Work::add(self, rhs: Self) -> Self
 impl core::ops::arith::Sub for bitcoin::pow::Work
 pub fn bitcoin::pow::Work::sub(self, rhs: Self) -> Self
-impl serde::ser::Serialize for bitcoin::pow::Work
-pub fn bitcoin::pow::Work::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
-impl<'de> serde::de::Deserialize<'de> for bitcoin::pow::Work
-pub fn bitcoin::pow::Work::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl serde_core::ser::Serialize for bitcoin::pow::Work
+pub fn bitcoin::pow::Work::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::pow::Work
+pub fn bitcoin::pow::Work::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin::pow::Work
 impl core::marker::Send for bitcoin::pow::Work
 impl core::marker::Sync for bitcoin::pow::Work
@@ -12354,6 +12868,8 @@ impl core::marker::Unpin for bitcoin::pow::Work
 impl core::marker::UnsafeUnpin for bitcoin::pow::Work
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::pow::Work
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::pow::Work
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::pow::Work where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::pow::Work where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::pow::Work where U: core::convert::From<T>
 pub fn bitcoin::pow::Work::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::pow::Work where U: core::convert::Into<T>
@@ -12378,7 +12894,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::pow::Work where T: core::clone::
 pub unsafe fn bitcoin::pow::Work::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::pow::Work
 pub fn bitcoin::pow::Work::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::pow::Work where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::pow::Work where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::pow::Work where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::pow::Work where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::pow::Work::vzip(self) -> V
 pub mod bitcoin::psbt
@@ -12401,12 +12918,12 @@ impl core::fmt::Display for bitcoin::psbt::raw::Key
 impl core::hash::Hash for bitcoin::psbt::raw::Key
 pub fn bitcoin::psbt::raw::Key::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for bitcoin::psbt::raw::Key
-impl serde::ser::Serialize for bitcoin::psbt::raw::Key
-pub fn bitcoin::psbt::raw::Key::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl serde_core::ser::Serialize for bitcoin::psbt::raw::Key
+pub fn bitcoin::psbt::raw::Key::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin::psbt::raw::Key
 pub fn bitcoin::psbt::raw::Key::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::psbt::raw::Key
-pub fn bitcoin::psbt::raw::Key::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::psbt::raw::Key
+pub fn bitcoin::psbt::raw::Key::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 impl<Subtype> core::convert::TryFrom<bitcoin::psbt::raw::Key> for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8>
 pub type bitcoin::psbt::raw::ProprietaryKey<Subtype>::Error = bitcoin::psbt::Error
 pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::try_from(key: bitcoin::psbt::raw::Key) -> core::result::Result<Self, Self::Error>
@@ -12417,6 +12934,8 @@ impl core::marker::Unpin for bitcoin::psbt::raw::Key
 impl core::marker::UnsafeUnpin for bitcoin::psbt::raw::Key
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::raw::Key
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::raw::Key
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::psbt::raw::Key where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::psbt::raw::Key where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::psbt::raw::Key where U: core::convert::From<T>
 pub fn bitcoin::psbt::raw::Key::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::psbt::raw::Key where U: core::convert::Into<T>
@@ -12441,7 +12960,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::psbt::raw::Key where T: core::cl
 pub unsafe fn bitcoin::psbt::raw::Key::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::psbt::raw::Key
 pub fn bitcoin::psbt::raw::Key::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::psbt::raw::Key where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::psbt::raw::Key where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::psbt::raw::Key where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::psbt::raw::Key where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::psbt::raw::Key::vzip(self) -> V
 pub struct bitcoin::psbt::raw::Pair
@@ -12453,10 +12973,10 @@ pub fn bitcoin::psbt::raw::Pair::eq(&self, other: &bitcoin::psbt::raw::Pair) -> 
 impl core::fmt::Debug for bitcoin::psbt::raw::Pair
 pub fn bitcoin::psbt::raw::Pair::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for bitcoin::psbt::raw::Pair
-impl serde::ser::Serialize for bitcoin::psbt::raw::Pair
-pub fn bitcoin::psbt::raw::Pair::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
-impl<'de> serde::de::Deserialize<'de> for bitcoin::psbt::raw::Pair
-pub fn bitcoin::psbt::raw::Pair::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl serde_core::ser::Serialize for bitcoin::psbt::raw::Pair
+pub fn bitcoin::psbt::raw::Pair::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::psbt::raw::Pair
+pub fn bitcoin::psbt::raw::Pair::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin::psbt::raw::Pair
 impl core::marker::Send for bitcoin::psbt::raw::Pair
 impl core::marker::Sync for bitcoin::psbt::raw::Pair
@@ -12464,6 +12984,8 @@ impl core::marker::Unpin for bitcoin::psbt::raw::Pair
 impl core::marker::UnsafeUnpin for bitcoin::psbt::raw::Pair
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::raw::Pair
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::raw::Pair
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::psbt::raw::Pair where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::psbt::raw::Pair where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::psbt::raw::Pair where U: core::convert::From<T>
 pub fn bitcoin::psbt::raw::Pair::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::psbt::raw::Pair where U: core::convert::Into<T>
@@ -12480,7 +13002,8 @@ impl<T> core::borrow::BorrowMut<T> for bitcoin::psbt::raw::Pair where T: ?core::
 pub fn bitcoin::psbt::raw::Pair::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for bitcoin::psbt::raw::Pair
 pub fn bitcoin::psbt::raw::Pair::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::psbt::raw::Pair where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::psbt::raw::Pair where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::psbt::raw::Pair where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::psbt::raw::Pair where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::psbt::raw::Pair::vzip(self) -> V
 pub struct bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8>
@@ -12491,8 +13014,8 @@ impl<Subtype> bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::m
 pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::to_key(&self) -> bitcoin::psbt::raw::Key
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin::psbt::raw::ProprietaryKey
 pub fn bitcoin::psbt::raw::ProprietaryKey::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
-impl<'de, Subtype> serde::de::Deserialize<'de> for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8> + serde::de::Deserialize<'de>
-pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl<'de, Subtype> serde_core::de::Deserialize<'de> for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8> + serde_core::de::Deserialize<'de>
+pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 impl<Subtype> core::clone::Clone for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8> + core::clone::Clone
 pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::clone(&self) -> bitcoin::psbt::raw::ProprietaryKey<Subtype>
 impl<Subtype> core::cmp::Eq for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8> + core::cmp::Eq
@@ -12507,8 +13030,8 @@ pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::fmt(&self, f: &mut core::fmt
 impl<Subtype> core::hash::Hash for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8> + core::hash::Hash
 pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl<Subtype> core::marker::StructuralPartialEq for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8>
-impl<Subtype> serde::ser::Serialize for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8> + serde::ser::Serialize
-pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl<Subtype> serde_core::ser::Serialize for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8> + serde_core::ser::Serialize
+pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<Subtype> core::marker::Freeze for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Freeze
 impl<Subtype> core::marker::Send for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Send
 impl<Subtype> core::marker::Sync for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Sync
@@ -12516,6 +13039,8 @@ impl<Subtype> core::marker::Unpin for bitcoin::psbt::raw::ProprietaryKey<Subtype
 impl<Subtype> core::marker::UnsafeUnpin for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::UnsafeUnpin
 impl<Subtype> core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::panic::unwind_safe::RefUnwindSafe
 impl<Subtype> core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::panic::unwind_safe::UnwindSafe
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::psbt::raw::ProprietaryKey<Subtype> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::psbt::raw::ProprietaryKey<Subtype> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::psbt::raw::ProprietaryKey<Subtype> where U: core::convert::From<T>
 pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::psbt::raw::ProprietaryKey<Subtype> where U: core::convert::Into<T>
@@ -12538,7 +13063,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::psbt::raw::ProprietaryKey<Subtyp
 pub unsafe fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::psbt::raw::ProprietaryKey<Subtype>
 pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::psbt::raw::ProprietaryKey<Subtype> where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::psbt::raw::ProprietaryKey<Subtype> where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::psbt::raw::ProprietaryKey<Subtype> where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::psbt::raw::ProprietaryKey<Subtype> where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::vzip(self) -> V
 pub type bitcoin::psbt::raw::ProprietaryType = u8
@@ -12599,6 +13125,8 @@ impl core::marker::Unpin for bitcoin::psbt::Error
 impl core::marker::UnsafeUnpin for bitcoin::psbt::Error
 impl !core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::Error
 impl !core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::Error
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::psbt::Error where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::psbt::Error where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::psbt::Error where U: core::convert::From<T>
 pub fn bitcoin::psbt::Error::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::psbt::Error where U: core::convert::Into<T>
@@ -12617,6 +13145,7 @@ impl<T> core::borrow::BorrowMut<T> for bitcoin::psbt::Error where T: ?core::mark
 pub fn bitcoin::psbt::Error::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for bitcoin::psbt::Error
 pub fn bitcoin::psbt::Error::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::psbt::Error where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::psbt::Error where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::psbt::Error::vzip(self) -> V
 #[non_exhaustive] pub enum bitcoin::psbt::ExtractTxError
@@ -12647,6 +13176,8 @@ impl core::marker::Unpin for bitcoin::psbt::ExtractTxError
 impl core::marker::UnsafeUnpin for bitcoin::psbt::ExtractTxError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::ExtractTxError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::ExtractTxError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::psbt::ExtractTxError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::psbt::ExtractTxError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::psbt::ExtractTxError where U: core::convert::From<T>
 pub fn bitcoin::psbt::ExtractTxError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::psbt::ExtractTxError where U: core::convert::Into<T>
@@ -12671,6 +13202,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::psbt::ExtractTxError where T: co
 pub unsafe fn bitcoin::psbt::ExtractTxError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::psbt::ExtractTxError
 pub fn bitcoin::psbt::ExtractTxError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::psbt::ExtractTxError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::psbt::ExtractTxError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::psbt::ExtractTxError::vzip(self) -> V
 #[non_exhaustive] pub enum bitcoin::psbt::GetKeyError
@@ -12696,6 +13228,8 @@ impl core::marker::Unpin for bitcoin::psbt::GetKeyError
 impl core::marker::UnsafeUnpin for bitcoin::psbt::GetKeyError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::GetKeyError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::GetKeyError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::psbt::GetKeyError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::psbt::GetKeyError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::psbt::GetKeyError where U: core::convert::From<T>
 pub fn bitcoin::psbt::GetKeyError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::psbt::GetKeyError where U: core::convert::Into<T>
@@ -12720,6 +13254,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::psbt::GetKeyError where T: core:
 pub unsafe fn bitcoin::psbt::GetKeyError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::psbt::GetKeyError
 pub fn bitcoin::psbt::GetKeyError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::psbt::GetKeyError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::psbt::GetKeyError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::psbt::GetKeyError::vzip(self) -> V
 #[non_exhaustive] pub enum bitcoin::psbt::IndexOutOfBoundsError
@@ -12751,6 +13286,8 @@ impl core::marker::Unpin for bitcoin::psbt::IndexOutOfBoundsError
 impl core::marker::UnsafeUnpin for bitcoin::psbt::IndexOutOfBoundsError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::IndexOutOfBoundsError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::IndexOutOfBoundsError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::psbt::IndexOutOfBoundsError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::psbt::IndexOutOfBoundsError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::psbt::IndexOutOfBoundsError where U: core::convert::From<T>
 pub fn bitcoin::psbt::IndexOutOfBoundsError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::psbt::IndexOutOfBoundsError where U: core::convert::Into<T>
@@ -12775,6 +13312,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::psbt::IndexOutOfBoundsError wher
 pub unsafe fn bitcoin::psbt::IndexOutOfBoundsError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::psbt::IndexOutOfBoundsError
 pub fn bitcoin::psbt::IndexOutOfBoundsError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::psbt::IndexOutOfBoundsError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::psbt::IndexOutOfBoundsError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::psbt::IndexOutOfBoundsError::vzip(self) -> V
 #[non_exhaustive] pub enum bitcoin::psbt::KeyRequest
@@ -12796,6 +13334,8 @@ impl core::marker::Unpin for bitcoin::psbt::KeyRequest
 impl core::marker::UnsafeUnpin for bitcoin::psbt::KeyRequest
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::KeyRequest
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::KeyRequest
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::psbt::KeyRequest where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::psbt::KeyRequest where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::psbt::KeyRequest where U: core::convert::From<T>
 pub fn bitcoin::psbt::KeyRequest::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::psbt::KeyRequest where U: core::convert::Into<T>
@@ -12818,6 +13358,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::psbt::KeyRequest where T: core::
 pub unsafe fn bitcoin::psbt::KeyRequest::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::psbt::KeyRequest
 pub fn bitcoin::psbt::KeyRequest::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::psbt::KeyRequest where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::psbt::KeyRequest where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::psbt::KeyRequest::vzip(self) -> V
 #[non_exhaustive] pub enum bitcoin::psbt::OutputType
@@ -12852,6 +13393,8 @@ impl core::marker::Unpin for bitcoin::psbt::OutputType
 impl core::marker::UnsafeUnpin for bitcoin::psbt::OutputType
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::OutputType
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::OutputType
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::psbt::OutputType where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::psbt::OutputType where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::psbt::OutputType where U: core::convert::From<T>
 pub fn bitcoin::psbt::OutputType::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::psbt::OutputType where U: core::convert::Into<T>
@@ -12874,6 +13417,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::psbt::OutputType where T: core::
 pub unsafe fn bitcoin::psbt::OutputType::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::psbt::OutputType
 pub fn bitcoin::psbt::OutputType::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::psbt::OutputType where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::psbt::OutputType where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::psbt::OutputType::vzip(self) -> V
 #[non_exhaustive] pub enum bitcoin::psbt::PsbtParseError
@@ -12893,6 +13437,8 @@ impl core::marker::Unpin for bitcoin::psbt::PsbtParseError
 impl core::marker::UnsafeUnpin for bitcoin::psbt::PsbtParseError
 impl !core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::PsbtParseError
 impl !core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::PsbtParseError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::psbt::PsbtParseError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::psbt::PsbtParseError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::psbt::PsbtParseError where U: core::convert::From<T>
 pub fn bitcoin::psbt::PsbtParseError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::psbt::PsbtParseError where U: core::convert::Into<T>
@@ -12911,6 +13457,7 @@ impl<T> core::borrow::BorrowMut<T> for bitcoin::psbt::PsbtParseError where T: ?c
 pub fn bitcoin::psbt::PsbtParseError::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for bitcoin::psbt::PsbtParseError
 pub fn bitcoin::psbt::PsbtParseError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::psbt::PsbtParseError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::psbt::PsbtParseError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::psbt::PsbtParseError::vzip(self) -> V
 #[non_exhaustive] pub enum bitcoin::psbt::SignError
@@ -12954,6 +13501,8 @@ impl core::marker::Unpin for bitcoin::psbt::SignError
 impl core::marker::UnsafeUnpin for bitcoin::psbt::SignError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::SignError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::SignError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::psbt::SignError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::psbt::SignError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::psbt::SignError where U: core::convert::From<T>
 pub fn bitcoin::psbt::SignError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::psbt::SignError where U: core::convert::Into<T>
@@ -12978,6 +13527,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::psbt::SignError where T: core::c
 pub unsafe fn bitcoin::psbt::SignError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::psbt::SignError
 pub fn bitcoin::psbt::SignError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::psbt::SignError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::psbt::SignError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::psbt::SignError::vzip(self) -> V
 pub enum bitcoin::psbt::SigningAlgorithm
@@ -13005,6 +13555,8 @@ impl core::marker::Unpin for bitcoin::psbt::SigningAlgorithm
 impl core::marker::UnsafeUnpin for bitcoin::psbt::SigningAlgorithm
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::SigningAlgorithm
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::SigningAlgorithm
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::psbt::SigningAlgorithm where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::psbt::SigningAlgorithm where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::psbt::SigningAlgorithm where U: core::convert::From<T>
 pub fn bitcoin::psbt::SigningAlgorithm::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::psbt::SigningAlgorithm where U: core::convert::Into<T>
@@ -13027,6 +13579,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::psbt::SigningAlgorithm where T: 
 pub unsafe fn bitcoin::psbt::SigningAlgorithm::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::psbt::SigningAlgorithm
 pub fn bitcoin::psbt::SigningAlgorithm::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::psbt::SigningAlgorithm where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::psbt::SigningAlgorithm where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::psbt::SigningAlgorithm::vzip(self) -> V
 pub enum bitcoin::psbt::SigningKeys
@@ -13051,6 +13604,8 @@ impl core::marker::Unpin for bitcoin::psbt::SigningKeys
 impl core::marker::UnsafeUnpin for bitcoin::psbt::SigningKeys
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::SigningKeys
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::SigningKeys
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::psbt::SigningKeys where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::psbt::SigningKeys where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::psbt::SigningKeys where U: core::convert::From<T>
 pub fn bitcoin::psbt::SigningKeys::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::psbt::SigningKeys where U: core::convert::Into<T>
@@ -13073,6 +13628,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::psbt::SigningKeys where T: core:
 pub unsafe fn bitcoin::psbt::SigningKeys::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::psbt::SigningKeys
 pub fn bitcoin::psbt::SigningKeys::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::psbt::SigningKeys where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::psbt::SigningKeys where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::psbt::SigningKeys::vzip(self) -> V
 pub struct bitcoin::psbt::Input
@@ -13113,10 +13669,10 @@ pub fn bitcoin::psbt::Input::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> cor
 impl core::hash::Hash for bitcoin::psbt::Input
 pub fn bitcoin::psbt::Input::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for bitcoin::psbt::Input
-impl serde::ser::Serialize for bitcoin::psbt::Input
-pub fn bitcoin::psbt::Input::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
-impl<'de> serde::de::Deserialize<'de> for bitcoin::psbt::Input
-pub fn bitcoin::psbt::Input::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl serde_core::ser::Serialize for bitcoin::psbt::Input
+pub fn bitcoin::psbt::Input::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::psbt::Input
+pub fn bitcoin::psbt::Input::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin::psbt::Input
 impl core::marker::Send for bitcoin::psbt::Input
 impl core::marker::Sync for bitcoin::psbt::Input
@@ -13124,6 +13680,8 @@ impl core::marker::Unpin for bitcoin::psbt::Input
 impl core::marker::UnsafeUnpin for bitcoin::psbt::Input
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::Input
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::Input
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::psbt::Input where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::psbt::Input where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::psbt::Input where U: core::convert::From<T>
 pub fn bitcoin::psbt::Input::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::psbt::Input where U: core::convert::Into<T>
@@ -13146,7 +13704,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::psbt::Input where T: core::clone
 pub unsafe fn bitcoin::psbt::Input::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::psbt::Input
 pub fn bitcoin::psbt::Input::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::psbt::Input where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::psbt::Input where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::psbt::Input where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::psbt::Input where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::psbt::Input::vzip(self) -> V
 pub struct bitcoin::psbt::Output
@@ -13172,10 +13731,10 @@ pub fn bitcoin::psbt::Output::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> co
 impl core::hash::Hash for bitcoin::psbt::Output
 pub fn bitcoin::psbt::Output::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for bitcoin::psbt::Output
-impl serde::ser::Serialize for bitcoin::psbt::Output
-pub fn bitcoin::psbt::Output::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
-impl<'de> serde::de::Deserialize<'de> for bitcoin::psbt::Output
-pub fn bitcoin::psbt::Output::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl serde_core::ser::Serialize for bitcoin::psbt::Output
+pub fn bitcoin::psbt::Output::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::psbt::Output
+pub fn bitcoin::psbt::Output::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin::psbt::Output
 impl core::marker::Send for bitcoin::psbt::Output
 impl core::marker::Sync for bitcoin::psbt::Output
@@ -13183,6 +13742,8 @@ impl core::marker::Unpin for bitcoin::psbt::Output
 impl core::marker::UnsafeUnpin for bitcoin::psbt::Output
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::Output
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::Output
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::psbt::Output where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::psbt::Output where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::psbt::Output where U: core::convert::From<T>
 pub fn bitcoin::psbt::Output::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::psbt::Output where U: core::convert::Into<T>
@@ -13205,7 +13766,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::psbt::Output where T: core::clon
 pub unsafe fn bitcoin::psbt::Output::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::psbt::Output
 pub fn bitcoin::psbt::Output::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::psbt::Output where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::psbt::Output where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::psbt::Output where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::psbt::Output where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::psbt::Output::vzip(self) -> V
 pub struct bitcoin::psbt::Psbt
@@ -13248,10 +13810,10 @@ impl core::marker::StructuralPartialEq for bitcoin::psbt::Psbt
 impl core::str::traits::FromStr for bitcoin::psbt::Psbt
 pub type bitcoin::psbt::Psbt::Err = bitcoin::psbt::PsbtParseError
 pub fn bitcoin::psbt::Psbt::from_str(s: &str) -> core::result::Result<Self, Self::Err>
-impl serde::ser::Serialize for bitcoin::psbt::Psbt
-pub fn bitcoin::psbt::Psbt::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
-impl<'de> serde::de::Deserialize<'de> for bitcoin::psbt::Psbt
-pub fn bitcoin::psbt::Psbt::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl serde_core::ser::Serialize for bitcoin::psbt::Psbt
+pub fn bitcoin::psbt::Psbt::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::psbt::Psbt
+pub fn bitcoin::psbt::Psbt::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin::psbt::Psbt
 impl core::marker::Send for bitcoin::psbt::Psbt
 impl core::marker::Sync for bitcoin::psbt::Psbt
@@ -13259,6 +13821,8 @@ impl core::marker::Unpin for bitcoin::psbt::Psbt
 impl core::marker::UnsafeUnpin for bitcoin::psbt::Psbt
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::Psbt
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::Psbt
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::psbt::Psbt where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::psbt::Psbt where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::psbt::Psbt where U: core::convert::From<T>
 pub fn bitcoin::psbt::Psbt::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::psbt::Psbt where U: core::convert::Into<T>
@@ -13283,7 +13847,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::psbt::Psbt where T: core::clone:
 pub unsafe fn bitcoin::psbt::Psbt::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::psbt::Psbt
 pub fn bitcoin::psbt::Psbt::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::psbt::Psbt where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::psbt::Psbt where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::psbt::Psbt where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::psbt::Psbt where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::psbt::Psbt::vzip(self) -> V
 pub struct bitcoin::psbt::PsbtSighashType
@@ -13315,10 +13880,10 @@ impl core::marker::StructuralPartialEq for bitcoin::psbt::PsbtSighashType
 impl core::str::traits::FromStr for bitcoin::psbt::PsbtSighashType
 pub type bitcoin::psbt::PsbtSighashType::Err = bitcoin::sighash::SighashTypeParseError
 pub fn bitcoin::psbt::PsbtSighashType::from_str(s: &str) -> core::result::Result<Self, Self::Err>
-impl serde::ser::Serialize for bitcoin::psbt::PsbtSighashType
-pub fn bitcoin::psbt::PsbtSighashType::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
-impl<'de> serde::de::Deserialize<'de> for bitcoin::psbt::PsbtSighashType
-pub fn bitcoin::psbt::PsbtSighashType::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl serde_core::ser::Serialize for bitcoin::psbt::PsbtSighashType
+pub fn bitcoin::psbt::PsbtSighashType::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::psbt::PsbtSighashType
+pub fn bitcoin::psbt::PsbtSighashType::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin::psbt::PsbtSighashType
 impl core::marker::Send for bitcoin::psbt::PsbtSighashType
 impl core::marker::Sync for bitcoin::psbt::PsbtSighashType
@@ -13326,6 +13891,8 @@ impl core::marker::Unpin for bitcoin::psbt::PsbtSighashType
 impl core::marker::UnsafeUnpin for bitcoin::psbt::PsbtSighashType
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::psbt::PsbtSighashType
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::psbt::PsbtSighashType
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::psbt::PsbtSighashType where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::psbt::PsbtSighashType where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::psbt::PsbtSighashType where U: core::convert::From<T>
 pub fn bitcoin::psbt::PsbtSighashType::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::psbt::PsbtSighashType where U: core::convert::Into<T>
@@ -13350,7 +13917,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::psbt::PsbtSighashType where T: c
 pub unsafe fn bitcoin::psbt::PsbtSighashType::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::psbt::PsbtSighashType
 pub fn bitcoin::psbt::PsbtSighashType::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::psbt::PsbtSighashType where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::psbt::PsbtSighashType where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::psbt::PsbtSighashType where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::psbt::PsbtSighashType where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::psbt::PsbtSighashType::vzip(self) -> V
 pub trait bitcoin::psbt::GetKey
@@ -13474,6 +14042,8 @@ impl core::marker::Unpin for bitcoin::sighash::AnnexError
 impl core::marker::UnsafeUnpin for bitcoin::sighash::AnnexError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::AnnexError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::AnnexError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::sighash::AnnexError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::sighash::AnnexError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::sighash::AnnexError where U: core::convert::From<T>
 pub fn bitcoin::sighash::AnnexError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::sighash::AnnexError where U: core::convert::Into<T>
@@ -13498,6 +14068,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::sighash::AnnexError where T: cor
 pub unsafe fn bitcoin::sighash::AnnexError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::sighash::AnnexError
 pub fn bitcoin::sighash::AnnexError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::sighash::AnnexError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::sighash::AnnexError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::sighash::AnnexError::vzip(self) -> V
 pub enum bitcoin::sighash::EcdsaSighashType
@@ -13529,12 +14100,12 @@ impl core::marker::StructuralPartialEq for bitcoin::EcdsaSighashType
 impl core::str::traits::FromStr for bitcoin::EcdsaSighashType
 pub type bitcoin::EcdsaSighashType::Err = bitcoin::sighash::SighashTypeParseError
 pub fn bitcoin::EcdsaSighashType::from_str(s: &str) -> core::result::Result<Self, Self::Err>
-impl serde::ser::Serialize for bitcoin::EcdsaSighashType
-pub fn bitcoin::EcdsaSighashType::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+impl serde_core::ser::Serialize for bitcoin::EcdsaSighashType
+pub fn bitcoin::EcdsaSighashType::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error> where S: serde_core::ser::Serializer
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin::EcdsaSighashType
 pub fn bitcoin::EcdsaSighashType::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::EcdsaSighashType
-pub fn bitcoin::EcdsaSighashType::deserialize<D>(deserializer: D) -> core::result::Result<bitcoin::EcdsaSighashType, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::EcdsaSighashType
+pub fn bitcoin::EcdsaSighashType::deserialize<D>(deserializer: D) -> core::result::Result<bitcoin::EcdsaSighashType, <D as serde_core::de::Deserializer>::Error> where D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin::EcdsaSighashType
 impl core::marker::Send for bitcoin::EcdsaSighashType
 impl core::marker::Sync for bitcoin::EcdsaSighashType
@@ -13542,6 +14113,8 @@ impl core::marker::Unpin for bitcoin::EcdsaSighashType
 impl core::marker::UnsafeUnpin for bitcoin::EcdsaSighashType
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::EcdsaSighashType
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::EcdsaSighashType
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::EcdsaSighashType where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::EcdsaSighashType where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::EcdsaSighashType where U: core::convert::From<T>
 pub fn bitcoin::EcdsaSighashType::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::EcdsaSighashType where U: core::convert::Into<T>
@@ -13566,7 +14139,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::EcdsaSighashType where T: core::
 pub unsafe fn bitcoin::EcdsaSighashType::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::EcdsaSighashType
 pub fn bitcoin::EcdsaSighashType::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::EcdsaSighashType where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::EcdsaSighashType where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::EcdsaSighashType where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::EcdsaSighashType where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::EcdsaSighashType::vzip(self) -> V
 pub enum bitcoin::sighash::EncodeSigningDataResult<E>
@@ -13582,6 +14156,8 @@ impl<E> core::marker::Unpin for bitcoin::sighash::EncodeSigningDataResult<E> whe
 impl<E> core::marker::UnsafeUnpin for bitcoin::sighash::EncodeSigningDataResult<E> where E: core::marker::UnsafeUnpin
 impl<E> core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::EncodeSigningDataResult<E> where E: core::panic::unwind_safe::RefUnwindSafe
 impl<E> core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::EncodeSigningDataResult<E> where E: core::panic::unwind_safe::UnwindSafe
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::sighash::EncodeSigningDataResult<E> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::sighash::EncodeSigningDataResult<E> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::sighash::EncodeSigningDataResult<E> where U: core::convert::From<T>
 pub fn bitcoin::sighash::EncodeSigningDataResult<E>::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::sighash::EncodeSigningDataResult<E> where U: core::convert::Into<T>
@@ -13598,6 +14174,7 @@ impl<T> core::borrow::BorrowMut<T> for bitcoin::sighash::EncodeSigningDataResult
 pub fn bitcoin::sighash::EncodeSigningDataResult<E>::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for bitcoin::sighash::EncodeSigningDataResult<E>
 pub fn bitcoin::sighash::EncodeSigningDataResult<E>::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::sighash::EncodeSigningDataResult<E> where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::sighash::EncodeSigningDataResult<E> where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::sighash::EncodeSigningDataResult<E>::vzip(self) -> V
 #[non_exhaustive] pub enum bitcoin::sighash::P2wpkhError
@@ -13623,6 +14200,8 @@ impl core::marker::Unpin for bitcoin::sighash::P2wpkhError
 impl core::marker::UnsafeUnpin for bitcoin::sighash::P2wpkhError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::P2wpkhError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::P2wpkhError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::sighash::P2wpkhError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::sighash::P2wpkhError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::sighash::P2wpkhError where U: core::convert::From<T>
 pub fn bitcoin::sighash::P2wpkhError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::sighash::P2wpkhError where U: core::convert::Into<T>
@@ -13647,6 +14226,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::sighash::P2wpkhError where T: co
 pub unsafe fn bitcoin::sighash::P2wpkhError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::sighash::P2wpkhError
 pub fn bitcoin::sighash::P2wpkhError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::sighash::P2wpkhError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::sighash::P2wpkhError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::sighash::P2wpkhError::vzip(self) -> V
 pub enum bitcoin::sighash::Prevouts<'u, T> where T: 'u + core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut>
@@ -13673,6 +14253,8 @@ impl<'u, T> core::marker::Unpin for bitcoin::sighash::Prevouts<'u, T> where T: c
 impl<'u, T> core::marker::UnsafeUnpin for bitcoin::sighash::Prevouts<'u, T> where T: core::marker::UnsafeUnpin
 impl<'u, T> core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::Prevouts<'u, T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<'u, T> core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::Prevouts<'u, T> where T: core::panic::unwind_safe::UnwindSafe + core::panic::unwind_safe::RefUnwindSafe
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::sighash::Prevouts<'u, T> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::sighash::Prevouts<'u, T> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::sighash::Prevouts<'u, T> where U: core::convert::From<T>
 pub fn bitcoin::sighash::Prevouts<'u, T>::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::sighash::Prevouts<'u, T> where U: core::convert::Into<T>
@@ -13695,6 +14277,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::sighash::Prevouts<'u, T> where T
 pub unsafe fn bitcoin::sighash::Prevouts<'u, T>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::sighash::Prevouts<'u, T>
 pub fn bitcoin::sighash::Prevouts<'u, T>::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::sighash::Prevouts<'u, T> where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::sighash::Prevouts<'u, T> where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::sighash::Prevouts<'u, T>::vzip(self) -> V
 #[non_exhaustive] pub enum bitcoin::sighash::PrevoutsIndexError
@@ -13722,6 +14305,8 @@ impl core::marker::Unpin for bitcoin::sighash::PrevoutsIndexError
 impl core::marker::UnsafeUnpin for bitcoin::sighash::PrevoutsIndexError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::PrevoutsIndexError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::PrevoutsIndexError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::sighash::PrevoutsIndexError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::sighash::PrevoutsIndexError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::sighash::PrevoutsIndexError where U: core::convert::From<T>
 pub fn bitcoin::sighash::PrevoutsIndexError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::sighash::PrevoutsIndexError where U: core::convert::Into<T>
@@ -13746,6 +14331,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::sighash::PrevoutsIndexError wher
 pub unsafe fn bitcoin::sighash::PrevoutsIndexError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::sighash::PrevoutsIndexError
 pub fn bitcoin::sighash::PrevoutsIndexError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::sighash::PrevoutsIndexError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::sighash::PrevoutsIndexError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::sighash::PrevoutsIndexError::vzip(self) -> V
 pub enum bitcoin::sighash::SigningDataError<E>
@@ -13767,6 +14353,8 @@ impl<E> core::marker::Unpin for bitcoin::sighash::SigningDataError<E> where E: c
 impl<E> core::marker::UnsafeUnpin for bitcoin::sighash::SigningDataError<E> where E: core::marker::UnsafeUnpin
 impl<E> !core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::SigningDataError<E>
 impl<E> !core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::SigningDataError<E>
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::sighash::SigningDataError<E> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::sighash::SigningDataError<E> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::sighash::SigningDataError<E> where U: core::convert::From<T>
 pub fn bitcoin::sighash::SigningDataError<E>::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::sighash::SigningDataError<E> where U: core::convert::Into<T>
@@ -13785,6 +14373,7 @@ impl<T> core::borrow::BorrowMut<T> for bitcoin::sighash::SigningDataError<E> whe
 pub fn bitcoin::sighash::SigningDataError<E>::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for bitcoin::sighash::SigningDataError<E>
 pub fn bitcoin::sighash::SigningDataError<E>::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::sighash::SigningDataError<E> where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::sighash::SigningDataError<E> where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::sighash::SigningDataError<E>::vzip(self) -> V
 pub enum bitcoin::sighash::TapSighashType
@@ -13816,12 +14405,12 @@ impl core::marker::StructuralPartialEq for bitcoin::TapSighashType
 impl core::str::traits::FromStr for bitcoin::TapSighashType
 pub type bitcoin::TapSighashType::Err = bitcoin::sighash::SighashTypeParseError
 pub fn bitcoin::TapSighashType::from_str(s: &str) -> core::result::Result<Self, Self::Err>
-impl serde::ser::Serialize for bitcoin::TapSighashType
-pub fn bitcoin::TapSighashType::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+impl serde_core::ser::Serialize for bitcoin::TapSighashType
+pub fn bitcoin::TapSighashType::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error> where S: serde_core::ser::Serializer
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin::TapSighashType
 pub fn bitcoin::TapSighashType::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::TapSighashType
-pub fn bitcoin::TapSighashType::deserialize<D>(deserializer: D) -> core::result::Result<bitcoin::TapSighashType, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::TapSighashType
+pub fn bitcoin::TapSighashType::deserialize<D>(deserializer: D) -> core::result::Result<bitcoin::TapSighashType, <D as serde_core::de::Deserializer>::Error> where D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin::TapSighashType
 impl core::marker::Send for bitcoin::TapSighashType
 impl core::marker::Sync for bitcoin::TapSighashType
@@ -13829,6 +14418,8 @@ impl core::marker::Unpin for bitcoin::TapSighashType
 impl core::marker::UnsafeUnpin for bitcoin::TapSighashType
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::TapSighashType
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::TapSighashType
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::TapSighashType where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::TapSighashType where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::TapSighashType where U: core::convert::From<T>
 pub fn bitcoin::TapSighashType::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::TapSighashType where U: core::convert::Into<T>
@@ -13853,7 +14444,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::TapSighashType where T: core::cl
 pub unsafe fn bitcoin::TapSighashType::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::TapSighashType
 pub fn bitcoin::TapSighashType::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::TapSighashType where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::TapSighashType where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::TapSighashType where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::TapSighashType where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::TapSighashType::vzip(self) -> V
 #[non_exhaustive] pub enum bitcoin::sighash::TaprootError
@@ -13887,6 +14479,8 @@ impl core::marker::Unpin for bitcoin::sighash::TaprootError
 impl core::marker::UnsafeUnpin for bitcoin::sighash::TaprootError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::TaprootError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::TaprootError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::sighash::TaprootError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::sighash::TaprootError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::sighash::TaprootError where U: core::convert::From<T>
 pub fn bitcoin::sighash::TaprootError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::sighash::TaprootError where U: core::convert::Into<T>
@@ -13911,6 +14505,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::sighash::TaprootError where T: c
 pub unsafe fn bitcoin::sighash::TaprootError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::sighash::TaprootError
 pub fn bitcoin::sighash::TaprootError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::sighash::TaprootError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::sighash::TaprootError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::sighash::TaprootError::vzip(self) -> V
 pub struct bitcoin::sighash::Annex<'a>(_)
@@ -13934,6 +14529,8 @@ impl<'a> core::marker::Unpin for bitcoin::sighash::Annex<'a>
 impl<'a> core::marker::UnsafeUnpin for bitcoin::sighash::Annex<'a>
 impl<'a> core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::Annex<'a>
 impl<'a> core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::Annex<'a>
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::sighash::Annex<'a> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::sighash::Annex<'a> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::sighash::Annex<'a> where U: core::convert::From<T>
 pub fn bitcoin::sighash::Annex<'a>::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::sighash::Annex<'a> where U: core::convert::Into<T>
@@ -13956,6 +14553,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::sighash::Annex<'a> where T: core
 pub unsafe fn bitcoin::sighash::Annex<'a>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::sighash::Annex<'a>
 pub fn bitcoin::sighash::Annex<'a>::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::sighash::Annex<'a> where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::sighash::Annex<'a> where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::sighash::Annex<'a>::vzip(self) -> V
 pub struct bitcoin::sighash::InvalidSighashTypeError(pub u32)
@@ -13979,6 +14577,8 @@ impl core::marker::Unpin for bitcoin::sighash::InvalidSighashTypeError
 impl core::marker::UnsafeUnpin for bitcoin::sighash::InvalidSighashTypeError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::InvalidSighashTypeError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::InvalidSighashTypeError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::sighash::InvalidSighashTypeError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::sighash::InvalidSighashTypeError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::sighash::InvalidSighashTypeError where U: core::convert::From<T>
 pub fn bitcoin::sighash::InvalidSighashTypeError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::sighash::InvalidSighashTypeError where U: core::convert::Into<T>
@@ -14003,6 +14603,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::sighash::InvalidSighashTypeError
 pub unsafe fn bitcoin::sighash::InvalidSighashTypeError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::sighash::InvalidSighashTypeError
 pub fn bitcoin::sighash::InvalidSighashTypeError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::sighash::InvalidSighashTypeError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::sighash::InvalidSighashTypeError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::sighash::InvalidSighashTypeError::vzip(self) -> V
 pub struct bitcoin::sighash::LegacySighash(_)
@@ -14058,10 +14659,10 @@ impl core::marker::StructuralPartialEq for bitcoin::LegacySighash
 impl core::str::traits::FromStr for bitcoin::LegacySighash
 pub type bitcoin::LegacySighash::Err = hex_conservative::error::HexToArrayError
 pub fn bitcoin::LegacySighash::from_str(s: &str) -> core::result::Result<bitcoin::LegacySighash, Self::Err>
-impl serde::ser::Serialize for bitcoin::LegacySighash
-pub fn bitcoin::LegacySighash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::LegacySighash
-pub fn bitcoin::LegacySighash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::LegacySighash, <D as serde::de::Deserializer>::Error>
+impl serde_core::ser::Serialize for bitcoin::LegacySighash
+pub fn bitcoin::LegacySighash::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::LegacySighash
+pub fn bitcoin::LegacySighash::deserialize<D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::LegacySighash, <D as serde_core::de::Deserializer>::Error>
 impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::LegacySighash
 pub type bitcoin::LegacySighash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
 pub fn bitcoin::LegacySighash::index(&self, index: I) -> &Self::Output
@@ -14072,6 +14673,8 @@ impl core::marker::Unpin for bitcoin::LegacySighash
 impl core::marker::UnsafeUnpin for bitcoin::LegacySighash
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::LegacySighash
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::LegacySighash
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::LegacySighash where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::LegacySighash where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::LegacySighash where U: core::convert::From<T>
 pub fn bitcoin::LegacySighash::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::LegacySighash where U: core::convert::Into<T>
@@ -14096,7 +14699,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::LegacySighash where T: core::clo
 pub unsafe fn bitcoin::LegacySighash::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::LegacySighash
 pub fn bitcoin::LegacySighash::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::LegacySighash where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::LegacySighash where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::LegacySighash where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::LegacySighash where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::LegacySighash::vzip(self) -> V
 pub struct bitcoin::sighash::NonStandardSighashTypeError(pub u32)
@@ -14118,6 +14722,8 @@ impl core::marker::Unpin for bitcoin::sighash::NonStandardSighashTypeError
 impl core::marker::UnsafeUnpin for bitcoin::sighash::NonStandardSighashTypeError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::NonStandardSighashTypeError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::NonStandardSighashTypeError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::sighash::NonStandardSighashTypeError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::sighash::NonStandardSighashTypeError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::sighash::NonStandardSighashTypeError where U: core::convert::From<T>
 pub fn bitcoin::sighash::NonStandardSighashTypeError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::sighash::NonStandardSighashTypeError where U: core::convert::Into<T>
@@ -14142,6 +14748,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::sighash::NonStandardSighashTypeE
 pub unsafe fn bitcoin::sighash::NonStandardSighashTypeError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::sighash::NonStandardSighashTypeError
 pub fn bitcoin::sighash::NonStandardSighashTypeError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::sighash::NonStandardSighashTypeError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::sighash::NonStandardSighashTypeError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::sighash::NonStandardSighashTypeError::vzip(self) -> V
 #[non_exhaustive] pub struct bitcoin::sighash::PrevoutsKindError
@@ -14163,6 +14770,8 @@ impl core::marker::Unpin for bitcoin::sighash::PrevoutsKindError
 impl core::marker::UnsafeUnpin for bitcoin::sighash::PrevoutsKindError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::PrevoutsKindError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::PrevoutsKindError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::sighash::PrevoutsKindError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::sighash::PrevoutsKindError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::sighash::PrevoutsKindError where U: core::convert::From<T>
 pub fn bitcoin::sighash::PrevoutsKindError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::sighash::PrevoutsKindError where U: core::convert::Into<T>
@@ -14187,6 +14796,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::sighash::PrevoutsKindError where
 pub unsafe fn bitcoin::sighash::PrevoutsKindError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::sighash::PrevoutsKindError
 pub fn bitcoin::sighash::PrevoutsKindError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::sighash::PrevoutsKindError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::sighash::PrevoutsKindError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::sighash::PrevoutsKindError::vzip(self) -> V
 #[non_exhaustive] pub struct bitcoin::sighash::PrevoutsSizeError
@@ -14208,6 +14818,8 @@ impl core::marker::Unpin for bitcoin::sighash::PrevoutsSizeError
 impl core::marker::UnsafeUnpin for bitcoin::sighash::PrevoutsSizeError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::PrevoutsSizeError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::PrevoutsSizeError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::sighash::PrevoutsSizeError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::sighash::PrevoutsSizeError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::sighash::PrevoutsSizeError where U: core::convert::From<T>
 pub fn bitcoin::sighash::PrevoutsSizeError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::sighash::PrevoutsSizeError where U: core::convert::Into<T>
@@ -14232,6 +14844,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::sighash::PrevoutsSizeError where
 pub unsafe fn bitcoin::sighash::PrevoutsSizeError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::sighash::PrevoutsSizeError
 pub fn bitcoin::sighash::PrevoutsSizeError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::sighash::PrevoutsSizeError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::sighash::PrevoutsSizeError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::sighash::PrevoutsSizeError::vzip(self) -> V
 pub struct bitcoin::sighash::ScriptPath<'s>
@@ -14262,6 +14875,8 @@ impl<'s> core::marker::Unpin for bitcoin::sighash::ScriptPath<'s>
 impl<'s> core::marker::UnsafeUnpin for bitcoin::sighash::ScriptPath<'s>
 impl<'s> core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::ScriptPath<'s>
 impl<'s> core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::ScriptPath<'s>
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::sighash::ScriptPath<'s> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::sighash::ScriptPath<'s> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::sighash::ScriptPath<'s> where U: core::convert::From<T>
 pub fn bitcoin::sighash::ScriptPath<'s>::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::sighash::ScriptPath<'s> where U: core::convert::Into<T>
@@ -14284,6 +14899,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::sighash::ScriptPath<'s> where T:
 pub unsafe fn bitcoin::sighash::ScriptPath<'s>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::sighash::ScriptPath<'s>
 pub fn bitcoin::sighash::ScriptPath<'s>::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::sighash::ScriptPath<'s> where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::sighash::ScriptPath<'s> where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::sighash::ScriptPath<'s>::vzip(self) -> V
 pub struct bitcoin::sighash::SegwitV0Sighash(_)
@@ -14339,10 +14955,10 @@ impl core::marker::StructuralPartialEq for bitcoin::SegwitV0Sighash
 impl core::str::traits::FromStr for bitcoin::SegwitV0Sighash
 pub type bitcoin::SegwitV0Sighash::Err = hex_conservative::error::HexToArrayError
 pub fn bitcoin::SegwitV0Sighash::from_str(s: &str) -> core::result::Result<bitcoin::SegwitV0Sighash, Self::Err>
-impl serde::ser::Serialize for bitcoin::SegwitV0Sighash
-pub fn bitcoin::SegwitV0Sighash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::SegwitV0Sighash
-pub fn bitcoin::SegwitV0Sighash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::SegwitV0Sighash, <D as serde::de::Deserializer>::Error>
+impl serde_core::ser::Serialize for bitcoin::SegwitV0Sighash
+pub fn bitcoin::SegwitV0Sighash::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::SegwitV0Sighash
+pub fn bitcoin::SegwitV0Sighash::deserialize<D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::SegwitV0Sighash, <D as serde_core::de::Deserializer>::Error>
 impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::SegwitV0Sighash
 pub type bitcoin::SegwitV0Sighash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
 pub fn bitcoin::SegwitV0Sighash::index(&self, index: I) -> &Self::Output
@@ -14353,6 +14969,8 @@ impl core::marker::Unpin for bitcoin::SegwitV0Sighash
 impl core::marker::UnsafeUnpin for bitcoin::SegwitV0Sighash
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::SegwitV0Sighash
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::SegwitV0Sighash
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::SegwitV0Sighash where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::SegwitV0Sighash where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::SegwitV0Sighash where U: core::convert::From<T>
 pub fn bitcoin::SegwitV0Sighash::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::SegwitV0Sighash where U: core::convert::Into<T>
@@ -14377,7 +14995,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::SegwitV0Sighash where T: core::c
 pub unsafe fn bitcoin::SegwitV0Sighash::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::SegwitV0Sighash
 pub fn bitcoin::SegwitV0Sighash::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::SegwitV0Sighash where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::SegwitV0Sighash where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::SegwitV0Sighash where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::SegwitV0Sighash where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::SegwitV0Sighash::vzip(self) -> V
 pub struct bitcoin::sighash::SighashCache<T: core::borrow::Borrow<bitcoin::blockdata::transaction::Transaction>>
@@ -14405,6 +15024,8 @@ impl<T> core::marker::Unpin for bitcoin::sighash::SighashCache<T> where T: core:
 impl<T> core::marker::UnsafeUnpin for bitcoin::sighash::SighashCache<T> where T: core::marker::UnsafeUnpin
 impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::SighashCache<T> where T: core::panic::unwind_safe::RefUnwindSafe
 impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::SighashCache<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::sighash::SighashCache<T> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::sighash::SighashCache<T> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::sighash::SighashCache<T> where U: core::convert::From<T>
 pub fn bitcoin::sighash::SighashCache<T>::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::sighash::SighashCache<T> where U: core::convert::Into<T>
@@ -14421,6 +15042,7 @@ impl<T> core::borrow::BorrowMut<T> for bitcoin::sighash::SighashCache<T> where T
 pub fn bitcoin::sighash::SighashCache<T>::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for bitcoin::sighash::SighashCache<T>
 pub fn bitcoin::sighash::SighashCache<T>::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::sighash::SighashCache<T> where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::sighash::SighashCache<T> where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::sighash::SighashCache<T>::vzip(self) -> V
 #[non_exhaustive] pub struct bitcoin::sighash::SighashTypeParseError
@@ -14443,6 +15065,8 @@ impl core::marker::Unpin for bitcoin::sighash::SighashTypeParseError
 impl core::marker::UnsafeUnpin for bitcoin::sighash::SighashTypeParseError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::SighashTypeParseError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::SighashTypeParseError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::sighash::SighashTypeParseError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::sighash::SighashTypeParseError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::sighash::SighashTypeParseError where U: core::convert::From<T>
 pub fn bitcoin::sighash::SighashTypeParseError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::sighash::SighashTypeParseError where U: core::convert::Into<T>
@@ -14467,6 +15091,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::sighash::SighashTypeParseError w
 pub unsafe fn bitcoin::sighash::SighashTypeParseError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::sighash::SighashTypeParseError
 pub fn bitcoin::sighash::SighashTypeParseError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::sighash::SighashTypeParseError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::sighash::SighashTypeParseError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::sighash::SighashTypeParseError::vzip(self) -> V
 #[non_exhaustive] pub struct bitcoin::sighash::SingleMissingOutputError
@@ -14490,6 +15115,8 @@ impl core::marker::Unpin for bitcoin::sighash::SingleMissingOutputError
 impl core::marker::UnsafeUnpin for bitcoin::sighash::SingleMissingOutputError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sighash::SingleMissingOutputError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::sighash::SingleMissingOutputError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::sighash::SingleMissingOutputError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::sighash::SingleMissingOutputError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::sighash::SingleMissingOutputError where U: core::convert::From<T>
 pub fn bitcoin::sighash::SingleMissingOutputError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::sighash::SingleMissingOutputError where U: core::convert::Into<T>
@@ -14514,6 +15141,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::sighash::SingleMissingOutputErro
 pub unsafe fn bitcoin::sighash::SingleMissingOutputError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::sighash::SingleMissingOutputError
 pub fn bitcoin::sighash::SingleMissingOutputError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::sighash::SingleMissingOutputError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::sighash::SingleMissingOutputError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::sighash::SingleMissingOutputError::vzip(self) -> V
 pub struct bitcoin::sighash::TapSighash(_)
@@ -14569,10 +15197,10 @@ impl core::marker::StructuralPartialEq for bitcoin::TapSighash
 impl core::str::traits::FromStr for bitcoin::TapSighash
 pub type bitcoin::TapSighash::Err = hex_conservative::error::HexToArrayError
 pub fn bitcoin::TapSighash::from_str(s: &str) -> core::result::Result<bitcoin::TapSighash, Self::Err>
-impl serde::ser::Serialize for bitcoin::TapSighash
-pub fn bitcoin::TapSighash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::TapSighash
-pub fn bitcoin::TapSighash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::TapSighash, <D as serde::de::Deserializer>::Error>
+impl serde_core::ser::Serialize for bitcoin::TapSighash
+pub fn bitcoin::TapSighash::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::TapSighash
+pub fn bitcoin::TapSighash::deserialize<D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::TapSighash, <D as serde_core::de::Deserializer>::Error>
 impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::TapSighash
 pub type bitcoin::TapSighash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
 pub fn bitcoin::TapSighash::index(&self, index: I) -> &Self::Output
@@ -14583,6 +15211,8 @@ impl core::marker::Unpin for bitcoin::TapSighash
 impl core::marker::UnsafeUnpin for bitcoin::TapSighash
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::TapSighash
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::TapSighash
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::TapSighash where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::TapSighash where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::TapSighash where U: core::convert::From<T>
 pub fn bitcoin::TapSighash::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::TapSighash where U: core::convert::Into<T>
@@ -14607,7 +15237,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::TapSighash where T: core::clone:
 pub unsafe fn bitcoin::TapSighash::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::TapSighash
 pub fn bitcoin::TapSighash::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::TapSighash where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::TapSighash where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::TapSighash where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::TapSighash where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::TapSighash::vzip(self) -> V
 pub struct bitcoin::sighash::TapSighashTag
@@ -14635,6 +15266,8 @@ impl core::marker::Unpin for bitcoin::TapSighashTag
 impl core::marker::UnsafeUnpin for bitcoin::TapSighashTag
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::TapSighashTag
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::TapSighashTag
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::TapSighashTag where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::TapSighashTag where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::TapSighashTag where U: core::convert::From<T>
 pub fn bitcoin::TapSighashTag::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::TapSighashTag where U: core::convert::Into<T>
@@ -14657,6 +15290,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::TapSighashTag where T: core::clo
 pub unsafe fn bitcoin::TapSighashTag::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::TapSighashTag
 pub fn bitcoin::TapSighashTag::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::TapSighashTag where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::TapSighashTag where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::TapSighashTag::vzip(self) -> V
 pub mod bitcoin::sign_message
@@ -14687,6 +15321,8 @@ impl core::marker::Unpin for bitcoin::sign_message::MessageSignatureError
 impl core::marker::UnsafeUnpin for bitcoin::sign_message::MessageSignatureError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sign_message::MessageSignatureError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::sign_message::MessageSignatureError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::sign_message::MessageSignatureError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::sign_message::MessageSignatureError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::sign_message::MessageSignatureError where U: core::convert::From<T>
 pub fn bitcoin::sign_message::MessageSignatureError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::sign_message::MessageSignatureError where U: core::convert::Into<T>
@@ -14711,6 +15347,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::sign_message::MessageSignatureEr
 pub unsafe fn bitcoin::sign_message::MessageSignatureError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::sign_message::MessageSignatureError
 pub fn bitcoin::sign_message::MessageSignatureError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::sign_message::MessageSignatureError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::sign_message::MessageSignatureError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::sign_message::MessageSignatureError::vzip(self) -> V
 pub struct bitcoin::sign_message::MessageSignature
@@ -14744,6 +15381,8 @@ impl core::marker::Unpin for bitcoin::sign_message::MessageSignature
 impl core::marker::UnsafeUnpin for bitcoin::sign_message::MessageSignature
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::sign_message::MessageSignature
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::sign_message::MessageSignature
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::sign_message::MessageSignature where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::sign_message::MessageSignature where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::sign_message::MessageSignature where U: core::convert::From<T>
 pub fn bitcoin::sign_message::MessageSignature::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::sign_message::MessageSignature where U: core::convert::Into<T>
@@ -14768,6 +15407,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::sign_message::MessageSignature w
 pub unsafe fn bitcoin::sign_message::MessageSignature::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::sign_message::MessageSignature
 pub fn bitcoin::sign_message::MessageSignature::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::sign_message::MessageSignature where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::sign_message::MessageSignature where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::sign_message::MessageSignature::vzip(self) -> V
 pub const bitcoin::sign_message::BITCOIN_SIGNED_MSG_PREFIX: &[u8]
@@ -14806,6 +15446,8 @@ pub type bitcoin::taproot::merkle_branch::IntoIter::IntoIter = I
 pub type bitcoin::taproot::merkle_branch::IntoIter::Item = <I as core::iter::traits::iterator::Iterator>::Item
 pub fn bitcoin::taproot::merkle_branch::IntoIter::into_iter(self) -> I
 impl<I> rand::seq::IteratorRandom for bitcoin::taproot::merkle_branch::IntoIter where I: core::iter::traits::iterator::Iterator
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::taproot::merkle_branch::IntoIter where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::taproot::merkle_branch::IntoIter where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::taproot::merkle_branch::IntoIter where U: core::convert::From<T>
 pub fn bitcoin::taproot::merkle_branch::IntoIter::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::taproot::merkle_branch::IntoIter where U: core::convert::Into<T>
@@ -14828,6 +15470,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::taproot::merkle_branch::IntoIter
 pub unsafe fn bitcoin::taproot::merkle_branch::IntoIter::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::taproot::merkle_branch::IntoIter
 pub fn bitcoin::taproot::merkle_branch::IntoIter::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::taproot::merkle_branch::IntoIter where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::taproot::merkle_branch::IntoIter where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::taproot::merkle_branch::IntoIter::vzip(self) -> V
 pub struct bitcoin::taproot::merkle_branch::TaprootMerkleBranch(_)
@@ -15141,8 +15784,8 @@ pub type bitcoin::taproot::merkle_branch::TaprootMerkleBranch::Target = [bitcoin
 pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::deref(&self) -> &Self::Target
 impl core::ops::deref::DerefMut for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
 pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::deref_mut(&mut self) -> &mut Self::Target
-impl serde::ser::Serialize for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
-pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl serde_core::ser::Serialize for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'a> core::iter::traits::collect::IntoIterator for &'a bitcoin::taproot::merkle_branch::TaprootMerkleBranch
 pub type &'a bitcoin::taproot::merkle_branch::TaprootMerkleBranch::IntoIter = core::slice::iter::Iter<'a, bitcoin::taproot::TapNodeHash>
 pub type &'a bitcoin::taproot::merkle_branch::TaprootMerkleBranch::Item = &'a bitcoin::taproot::TapNodeHash
@@ -15151,8 +15794,8 @@ impl<'a> core::iter::traits::collect::IntoIterator for &'a mut bitcoin::taproot:
 pub type &'a mut bitcoin::taproot::merkle_branch::TaprootMerkleBranch::IntoIter = core::slice::iter::IterMut<'a, bitcoin::taproot::TapNodeHash>
 pub type &'a mut bitcoin::taproot::merkle_branch::TaprootMerkleBranch::Item = &'a mut bitcoin::taproot::TapNodeHash
 pub fn &'a mut bitcoin::taproot::merkle_branch::TaprootMerkleBranch::into_iter(self) -> Self::IntoIter
-impl<'de> serde::de::Deserialize<'de> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
-pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
+pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
 impl core::marker::Send for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
 impl core::marker::Sync for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
@@ -15162,6 +15805,8 @@ impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::merkle_branch
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
 impl<P, T> core::ops::deref::Receiver for bitcoin::taproot::merkle_branch::TaprootMerkleBranch where P: core::ops::deref::Deref<Target = T> + ?core::marker::Sized, T: ?core::marker::Sized
 pub type bitcoin::taproot::merkle_branch::TaprootMerkleBranch::Target = T
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch where U: core::convert::From<T>
 pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch where U: core::convert::Into<T>
@@ -15184,7 +15829,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::taproot::merkle_branch::TaprootM
 pub unsafe fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch
 pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::taproot::merkle_branch::TaprootMerkleBranch where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::taproot::merkle_branch::TaprootMerkleBranch where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::taproot::merkle_branch::TaprootMerkleBranch where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::taproot::merkle_branch::TaprootMerkleBranch::vzip(self) -> V
 pub mod bitcoin::taproot::serialized_signature
@@ -15217,6 +15863,8 @@ pub type bitcoin::taproot::serialized_signature::IntoIter::IntoIter = I
 pub type bitcoin::taproot::serialized_signature::IntoIter::Item = <I as core::iter::traits::iterator::Iterator>::Item
 pub fn bitcoin::taproot::serialized_signature::IntoIter::into_iter(self) -> I
 impl<I> rand::seq::IteratorRandom for bitcoin::taproot::serialized_signature::IntoIter where I: core::iter::traits::iterator::Iterator
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::taproot::serialized_signature::IntoIter where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::taproot::serialized_signature::IntoIter where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::taproot::serialized_signature::IntoIter where U: core::convert::From<T>
 pub fn bitcoin::taproot::serialized_signature::IntoIter::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::taproot::serialized_signature::IntoIter where U: core::convert::Into<T>
@@ -15239,6 +15887,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::taproot::serialized_signature::I
 pub unsafe fn bitcoin::taproot::serialized_signature::IntoIter::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::taproot::serialized_signature::IntoIter
 pub fn bitcoin::taproot::serialized_signature::IntoIter::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::taproot::serialized_signature::IntoIter where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::taproot::serialized_signature::IntoIter where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::taproot::serialized_signature::IntoIter::vzip(self) -> V
 pub struct bitcoin::taproot::serialized_signature::SerializedSignature
@@ -15303,6 +15952,8 @@ impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::serialized_si
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::serialized_signature::SerializedSignature
 impl<P, T> core::ops::deref::Receiver for bitcoin::taproot::serialized_signature::SerializedSignature where P: core::ops::deref::Deref<Target = T> + ?core::marker::Sized, T: ?core::marker::Sized
 pub type bitcoin::taproot::serialized_signature::SerializedSignature::Target = T
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::taproot::serialized_signature::SerializedSignature where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::taproot::serialized_signature::SerializedSignature where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::taproot::serialized_signature::SerializedSignature where U: core::convert::From<T>
 pub fn bitcoin::taproot::serialized_signature::SerializedSignature::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::taproot::serialized_signature::SerializedSignature where U: core::convert::Into<T>
@@ -15327,6 +15978,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::taproot::serialized_signature::S
 pub unsafe fn bitcoin::taproot::serialized_signature::SerializedSignature::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::taproot::serialized_signature::SerializedSignature
 pub fn bitcoin::taproot::serialized_signature::SerializedSignature::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::taproot::serialized_signature::SerializedSignature where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::taproot::serialized_signature::SerializedSignature where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::taproot::serialized_signature::SerializedSignature::vzip(self) -> V
 #[non_exhaustive] pub enum bitcoin::taproot::HiddenNodesError
@@ -15353,6 +16005,8 @@ impl core::marker::Unpin for bitcoin::taproot::HiddenNodesError
 impl core::marker::UnsafeUnpin for bitcoin::taproot::HiddenNodesError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::HiddenNodesError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::HiddenNodesError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::taproot::HiddenNodesError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::taproot::HiddenNodesError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::taproot::HiddenNodesError where U: core::convert::From<T>
 pub fn bitcoin::taproot::HiddenNodesError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::taproot::HiddenNodesError where U: core::convert::Into<T>
@@ -15377,6 +16031,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::taproot::HiddenNodesError where 
 pub unsafe fn bitcoin::taproot::HiddenNodesError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::taproot::HiddenNodesError
 pub fn bitcoin::taproot::HiddenNodesError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::taproot::HiddenNodesError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::taproot::HiddenNodesError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::taproot::HiddenNodesError::vzip(self) -> V
 #[non_exhaustive] pub enum bitcoin::taproot::IncompleteBuilderError
@@ -15404,6 +16059,8 @@ impl core::marker::Unpin for bitcoin::taproot::IncompleteBuilderError
 impl core::marker::UnsafeUnpin for bitcoin::taproot::IncompleteBuilderError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::IncompleteBuilderError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::IncompleteBuilderError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::taproot::IncompleteBuilderError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::taproot::IncompleteBuilderError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::taproot::IncompleteBuilderError where U: core::convert::From<T>
 pub fn bitcoin::taproot::IncompleteBuilderError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::taproot::IncompleteBuilderError where U: core::convert::Into<T>
@@ -15428,6 +16085,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::taproot::IncompleteBuilderError 
 pub unsafe fn bitcoin::taproot::IncompleteBuilderError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::taproot::IncompleteBuilderError
 pub fn bitcoin::taproot::IncompleteBuilderError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::taproot::IncompleteBuilderError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::taproot::IncompleteBuilderError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::taproot::IncompleteBuilderError::vzip(self) -> V
 pub enum bitcoin::taproot::LeafVersion
@@ -15454,10 +16112,10 @@ impl core::hash::Hash for bitcoin::taproot::LeafVersion
 pub fn bitcoin::taproot::LeafVersion::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for bitcoin::taproot::LeafVersion
 impl core::marker::StructuralPartialEq for bitcoin::taproot::LeafVersion
-impl serde::ser::Serialize for bitcoin::taproot::LeafVersion
-pub fn bitcoin::taproot::LeafVersion::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
-impl<'de> serde::de::Deserialize<'de> for bitcoin::taproot::LeafVersion
-pub fn bitcoin::taproot::LeafVersion::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+impl serde_core::ser::Serialize for bitcoin::taproot::LeafVersion
+pub fn bitcoin::taproot::LeafVersion::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error> where S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::taproot::LeafVersion
+pub fn bitcoin::taproot::LeafVersion::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde_core::de::Deserializer>::Error> where D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin::taproot::LeafVersion
 impl core::marker::Send for bitcoin::taproot::LeafVersion
 impl core::marker::Sync for bitcoin::taproot::LeafVersion
@@ -15465,6 +16123,8 @@ impl core::marker::Unpin for bitcoin::taproot::LeafVersion
 impl core::marker::UnsafeUnpin for bitcoin::taproot::LeafVersion
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::LeafVersion
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::LeafVersion
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::taproot::LeafVersion where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::taproot::LeafVersion where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::taproot::LeafVersion where U: core::convert::From<T>
 pub fn bitcoin::taproot::LeafVersion::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::taproot::LeafVersion where U: core::convert::Into<T>
@@ -15489,7 +16149,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::taproot::LeafVersion where T: co
 pub unsafe fn bitcoin::taproot::LeafVersion::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::taproot::LeafVersion
 pub fn bitcoin::taproot::LeafVersion::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::taproot::LeafVersion where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::taproot::LeafVersion where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::taproot::LeafVersion where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::taproot::LeafVersion where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::taproot::LeafVersion::vzip(self) -> V
 #[non_exhaustive] pub enum bitcoin::taproot::SigFromSliceError
@@ -15518,6 +16179,8 @@ impl core::marker::Unpin for bitcoin::taproot::SigFromSliceError
 impl core::marker::UnsafeUnpin for bitcoin::taproot::SigFromSliceError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::SigFromSliceError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::SigFromSliceError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::taproot::SigFromSliceError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::taproot::SigFromSliceError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::taproot::SigFromSliceError where U: core::convert::From<T>
 pub fn bitcoin::taproot::SigFromSliceError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::taproot::SigFromSliceError where U: core::convert::Into<T>
@@ -15542,6 +16205,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::taproot::SigFromSliceError where
 pub unsafe fn bitcoin::taproot::SigFromSliceError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::taproot::SigFromSliceError
 pub fn bitcoin::taproot::SigFromSliceError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::taproot::SigFromSliceError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::taproot::SigFromSliceError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::taproot::SigFromSliceError::vzip(self) -> V
 pub enum bitcoin::taproot::TapLeaf
@@ -15564,10 +16228,10 @@ pub fn bitcoin::taproot::TapLeaf::fmt(&self, f: &mut core::fmt::Formatter<'_>) -
 impl core::hash::Hash for bitcoin::taproot::TapLeaf
 pub fn bitcoin::taproot::TapLeaf::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for bitcoin::taproot::TapLeaf
-impl serde::ser::Serialize for bitcoin::taproot::TapLeaf
-pub fn bitcoin::taproot::TapLeaf::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
-impl<'de> serde::de::Deserialize<'de> for bitcoin::taproot::TapLeaf
-pub fn bitcoin::taproot::TapLeaf::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl serde_core::ser::Serialize for bitcoin::taproot::TapLeaf
+pub fn bitcoin::taproot::TapLeaf::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::taproot::TapLeaf
+pub fn bitcoin::taproot::TapLeaf::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin::taproot::TapLeaf
 impl core::marker::Send for bitcoin::taproot::TapLeaf
 impl core::marker::Sync for bitcoin::taproot::TapLeaf
@@ -15575,6 +16239,8 @@ impl core::marker::Unpin for bitcoin::taproot::TapLeaf
 impl core::marker::UnsafeUnpin for bitcoin::taproot::TapLeaf
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TapLeaf
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TapLeaf
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::taproot::TapLeaf where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::taproot::TapLeaf where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::taproot::TapLeaf where U: core::convert::From<T>
 pub fn bitcoin::taproot::TapLeaf::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::taproot::TapLeaf where U: core::convert::Into<T>
@@ -15597,7 +16263,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::taproot::TapLeaf where T: core::
 pub unsafe fn bitcoin::taproot::TapLeaf::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::taproot::TapLeaf
 pub fn bitcoin::taproot::TapLeaf::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::taproot::TapLeaf where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::taproot::TapLeaf where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::taproot::TapLeaf where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::taproot::TapLeaf where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::taproot::TapLeaf::vzip(self) -> V
 #[non_exhaustive] pub enum bitcoin::taproot::TaprootBuilderError
@@ -15626,6 +16293,8 @@ impl core::marker::Unpin for bitcoin::taproot::TaprootBuilderError
 impl core::marker::UnsafeUnpin for bitcoin::taproot::TaprootBuilderError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TaprootBuilderError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TaprootBuilderError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::taproot::TaprootBuilderError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::taproot::TaprootBuilderError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::taproot::TaprootBuilderError where U: core::convert::From<T>
 pub fn bitcoin::taproot::TaprootBuilderError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::taproot::TaprootBuilderError where U: core::convert::Into<T>
@@ -15650,6 +16319,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::taproot::TaprootBuilderError whe
 pub unsafe fn bitcoin::taproot::TaprootBuilderError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::taproot::TaprootBuilderError
 pub fn bitcoin::taproot::TaprootBuilderError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::taproot::TaprootBuilderError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::taproot::TaprootBuilderError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::taproot::TaprootBuilderError::vzip(self) -> V
 #[non_exhaustive] pub enum bitcoin::taproot::TaprootError
@@ -15679,6 +16349,8 @@ impl core::marker::Unpin for bitcoin::taproot::TaprootError
 impl core::marker::UnsafeUnpin for bitcoin::taproot::TaprootError
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TaprootError
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TaprootError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::taproot::TaprootError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::taproot::TaprootError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::taproot::TaprootError where U: core::convert::From<T>
 pub fn bitcoin::taproot::TaprootError::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::taproot::TaprootError where U: core::convert::Into<T>
@@ -15703,6 +16375,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::taproot::TaprootError where T: c
 pub unsafe fn bitcoin::taproot::TaprootError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::taproot::TaprootError
 pub fn bitcoin::taproot::TaprootError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::taproot::TaprootError where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::taproot::TaprootError where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::taproot::TaprootError::vzip(self) -> V
 pub struct bitcoin::taproot::ControlBlock
@@ -15730,10 +16403,10 @@ pub fn bitcoin::taproot::ControlBlock::fmt(&self, f: &mut core::fmt::Formatter<'
 impl core::hash::Hash for bitcoin::taproot::ControlBlock
 pub fn bitcoin::taproot::ControlBlock::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for bitcoin::taproot::ControlBlock
-impl serde::ser::Serialize for bitcoin::taproot::ControlBlock
-pub fn bitcoin::taproot::ControlBlock::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
-impl<'de> serde::de::Deserialize<'de> for bitcoin::taproot::ControlBlock
-pub fn bitcoin::taproot::ControlBlock::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl serde_core::ser::Serialize for bitcoin::taproot::ControlBlock
+pub fn bitcoin::taproot::ControlBlock::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::taproot::ControlBlock
+pub fn bitcoin::taproot::ControlBlock::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin::taproot::ControlBlock
 impl core::marker::Send for bitcoin::taproot::ControlBlock
 impl core::marker::Sync for bitcoin::taproot::ControlBlock
@@ -15741,6 +16414,8 @@ impl core::marker::Unpin for bitcoin::taproot::ControlBlock
 impl core::marker::UnsafeUnpin for bitcoin::taproot::ControlBlock
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::ControlBlock
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::ControlBlock
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::taproot::ControlBlock where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::taproot::ControlBlock where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::taproot::ControlBlock where U: core::convert::From<T>
 pub fn bitcoin::taproot::ControlBlock::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::taproot::ControlBlock where U: core::convert::Into<T>
@@ -15763,7 +16438,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::taproot::ControlBlock where T: c
 pub unsafe fn bitcoin::taproot::ControlBlock::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::taproot::ControlBlock
 pub fn bitcoin::taproot::ControlBlock::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::taproot::ControlBlock where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::taproot::ControlBlock where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::taproot::ControlBlock where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::taproot::ControlBlock where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::taproot::ControlBlock::vzip(self) -> V
 pub struct bitcoin::taproot::FutureLeafVersion(_)
@@ -15794,6 +16470,8 @@ impl core::marker::Unpin for bitcoin::taproot::FutureLeafVersion
 impl core::marker::UnsafeUnpin for bitcoin::taproot::FutureLeafVersion
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::FutureLeafVersion
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::FutureLeafVersion
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::taproot::FutureLeafVersion where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::taproot::FutureLeafVersion where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::taproot::FutureLeafVersion where U: core::convert::From<T>
 pub fn bitcoin::taproot::FutureLeafVersion::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::taproot::FutureLeafVersion where U: core::convert::Into<T>
@@ -15818,6 +16496,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::taproot::FutureLeafVersion where
 pub unsafe fn bitcoin::taproot::FutureLeafVersion::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::taproot::FutureLeafVersion
 pub fn bitcoin::taproot::FutureLeafVersion::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::taproot::FutureLeafVersion where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::taproot::FutureLeafVersion where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::taproot::FutureLeafVersion::vzip(self) -> V
 pub struct bitcoin::taproot::LeafNode
@@ -15856,6 +16535,8 @@ impl core::marker::Unpin for bitcoin::taproot::LeafNode
 impl core::marker::UnsafeUnpin for bitcoin::taproot::LeafNode
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::LeafNode
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::LeafNode
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::taproot::LeafNode where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::taproot::LeafNode where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::taproot::LeafNode where U: core::convert::From<T>
 pub fn bitcoin::taproot::LeafNode::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::taproot::LeafNode where U: core::convert::Into<T>
@@ -15878,6 +16559,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::taproot::LeafNode where T: core:
 pub unsafe fn bitcoin::taproot::LeafNode::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::taproot::LeafNode
 pub fn bitcoin::taproot::LeafNode::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::taproot::LeafNode where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::taproot::LeafNode where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::taproot::LeafNode::vzip(self) -> V
 pub struct bitcoin::taproot::LeafNodes<'a>
@@ -15901,6 +16583,8 @@ pub type bitcoin::taproot::LeafNodes<'a>::IntoIter = I
 pub type bitcoin::taproot::LeafNodes<'a>::Item = <I as core::iter::traits::iterator::Iterator>::Item
 pub fn bitcoin::taproot::LeafNodes<'a>::into_iter(self) -> I
 impl<I> rand::seq::IteratorRandom for bitcoin::taproot::LeafNodes<'a> where I: core::iter::traits::iterator::Iterator
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::taproot::LeafNodes<'a> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::taproot::LeafNodes<'a> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::taproot::LeafNodes<'a> where U: core::convert::From<T>
 pub fn bitcoin::taproot::LeafNodes<'a>::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::taproot::LeafNodes<'a> where U: core::convert::Into<T>
@@ -15917,6 +16601,7 @@ impl<T> core::borrow::BorrowMut<T> for bitcoin::taproot::LeafNodes<'a> where T: 
 pub fn bitcoin::taproot::LeafNodes<'a>::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for bitcoin::taproot::LeafNodes<'a>
 pub fn bitcoin::taproot::LeafNodes<'a>::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::taproot::LeafNodes<'a> where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::taproot::LeafNodes<'a> where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::taproot::LeafNodes<'a>::vzip(self) -> V
 pub struct bitcoin::taproot::LeafScript<S>
@@ -15940,6 +16625,8 @@ impl<S> core::marker::Unpin for bitcoin::taproot::LeafScript<S> where S: core::m
 impl<S> core::marker::UnsafeUnpin for bitcoin::taproot::LeafScript<S> where S: core::marker::UnsafeUnpin
 impl<S> core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::LeafScript<S> where S: core::panic::unwind_safe::RefUnwindSafe
 impl<S> core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::LeafScript<S> where S: core::panic::unwind_safe::UnwindSafe
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::taproot::LeafScript<S> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::taproot::LeafScript<S> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::taproot::LeafScript<S> where U: core::convert::From<T>
 pub fn bitcoin::taproot::LeafScript<S>::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::taproot::LeafScript<S> where U: core::convert::Into<T>
@@ -15962,6 +16649,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::taproot::LeafScript<S> where T: 
 pub unsafe fn bitcoin::taproot::LeafScript<S>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::taproot::LeafScript<S>
 pub fn bitcoin::taproot::LeafScript<S>::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::taproot::LeafScript<S> where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::taproot::LeafScript<S> where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::taproot::LeafScript<S>::vzip(self) -> V
 pub struct bitcoin::taproot::NodeInfo
@@ -15992,10 +16680,10 @@ impl core::fmt::Debug for bitcoin::taproot::NodeInfo
 pub fn bitcoin::taproot::NodeInfo::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for bitcoin::taproot::NodeInfo
 pub fn bitcoin::taproot::NodeInfo::hash<H: core::hash::Hasher>(&self, state: &mut H)
-impl serde::ser::Serialize for bitcoin::taproot::NodeInfo
-pub fn bitcoin::taproot::NodeInfo::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
-impl<'de> serde::de::Deserialize<'de> for bitcoin::taproot::NodeInfo
-pub fn bitcoin::taproot::NodeInfo::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+impl serde_core::ser::Serialize for bitcoin::taproot::NodeInfo
+pub fn bitcoin::taproot::NodeInfo::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error> where S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::taproot::NodeInfo
+pub fn bitcoin::taproot::NodeInfo::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde_core::de::Deserializer>::Error> where D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin::taproot::NodeInfo
 impl core::marker::Send for bitcoin::taproot::NodeInfo
 impl core::marker::Sync for bitcoin::taproot::NodeInfo
@@ -16003,6 +16691,8 @@ impl core::marker::Unpin for bitcoin::taproot::NodeInfo
 impl core::marker::UnsafeUnpin for bitcoin::taproot::NodeInfo
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::NodeInfo
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::NodeInfo
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::taproot::NodeInfo where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::taproot::NodeInfo where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::taproot::NodeInfo where U: core::convert::From<T>
 pub fn bitcoin::taproot::NodeInfo::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::taproot::NodeInfo where U: core::convert::Into<T>
@@ -16025,7 +16715,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::taproot::NodeInfo where T: core:
 pub unsafe fn bitcoin::taproot::NodeInfo::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::taproot::NodeInfo
 pub fn bitcoin::taproot::NodeInfo::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::taproot::NodeInfo where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::taproot::NodeInfo where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::taproot::NodeInfo where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::taproot::NodeInfo where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::taproot::NodeInfo::vzip(self) -> V
 pub struct bitcoin::taproot::ScriptLeaf<'leaf>
@@ -16055,6 +16746,8 @@ impl<'leaf> core::marker::Unpin for bitcoin::taproot::ScriptLeaf<'leaf>
 impl<'leaf> core::marker::UnsafeUnpin for bitcoin::taproot::ScriptLeaf<'leaf>
 impl<'leaf> core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::ScriptLeaf<'leaf>
 impl<'leaf> core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::ScriptLeaf<'leaf>
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::taproot::ScriptLeaf<'leaf> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::taproot::ScriptLeaf<'leaf> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::taproot::ScriptLeaf<'leaf> where U: core::convert::From<T>
 pub fn bitcoin::taproot::ScriptLeaf<'leaf>::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::taproot::ScriptLeaf<'leaf> where U: core::convert::Into<T>
@@ -16077,6 +16770,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::taproot::ScriptLeaf<'leaf> where
 pub unsafe fn bitcoin::taproot::ScriptLeaf<'leaf>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::taproot::ScriptLeaf<'leaf>
 pub fn bitcoin::taproot::ScriptLeaf<'leaf>::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::taproot::ScriptLeaf<'leaf> where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::taproot::ScriptLeaf<'leaf> where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::taproot::ScriptLeaf<'leaf>::vzip(self) -> V
 pub struct bitcoin::taproot::ScriptLeaves<'tree>
@@ -16100,6 +16794,8 @@ pub type bitcoin::taproot::ScriptLeaves<'tree>::IntoIter = I
 pub type bitcoin::taproot::ScriptLeaves<'tree>::Item = <I as core::iter::traits::iterator::Iterator>::Item
 pub fn bitcoin::taproot::ScriptLeaves<'tree>::into_iter(self) -> I
 impl<I> rand::seq::IteratorRandom for bitcoin::taproot::ScriptLeaves<'tree> where I: core::iter::traits::iterator::Iterator
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::taproot::ScriptLeaves<'tree> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::taproot::ScriptLeaves<'tree> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::taproot::ScriptLeaves<'tree> where U: core::convert::From<T>
 pub fn bitcoin::taproot::ScriptLeaves<'tree>::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::taproot::ScriptLeaves<'tree> where U: core::convert::Into<T>
@@ -16116,6 +16812,7 @@ impl<T> core::borrow::BorrowMut<T> for bitcoin::taproot::ScriptLeaves<'tree> whe
 pub fn bitcoin::taproot::ScriptLeaves<'tree>::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for bitcoin::taproot::ScriptLeaves<'tree>
 pub fn bitcoin::taproot::ScriptLeaves<'tree>::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::taproot::ScriptLeaves<'tree> where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::taproot::ScriptLeaves<'tree> where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::taproot::ScriptLeaves<'tree>::vzip(self) -> V
 pub struct bitcoin::taproot::Signature
@@ -16141,12 +16838,12 @@ impl core::hash::Hash for bitcoin::taproot::Signature
 pub fn bitcoin::taproot::Signature::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::Copy for bitcoin::taproot::Signature
 impl core::marker::StructuralPartialEq for bitcoin::taproot::Signature
-impl serde::ser::Serialize for bitcoin::taproot::Signature
-pub fn bitcoin::taproot::Signature::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl serde_core::ser::Serialize for bitcoin::taproot::Signature
+pub fn bitcoin::taproot::Signature::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin::taproot::Signature
 pub fn bitcoin::taproot::Signature::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::taproot::Signature
-pub fn bitcoin::taproot::Signature::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::taproot::Signature
+pub fn bitcoin::taproot::Signature::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin::taproot::Signature
 impl core::marker::Send for bitcoin::taproot::Signature
 impl core::marker::Sync for bitcoin::taproot::Signature
@@ -16154,6 +16851,8 @@ impl core::marker::Unpin for bitcoin::taproot::Signature
 impl core::marker::UnsafeUnpin for bitcoin::taproot::Signature
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::Signature
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::Signature
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::taproot::Signature where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::taproot::Signature where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::taproot::Signature where U: core::convert::From<T>
 pub fn bitcoin::taproot::Signature::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::taproot::Signature where U: core::convert::Into<T>
@@ -16176,7 +16875,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::taproot::Signature where T: core
 pub unsafe fn bitcoin::taproot::Signature::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::taproot::Signature
 pub fn bitcoin::taproot::Signature::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::taproot::Signature where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::taproot::Signature where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::taproot::Signature where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::taproot::Signature where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::taproot::Signature::vzip(self) -> V
 pub struct bitcoin::taproot::TapBranchTag
@@ -16204,6 +16904,8 @@ impl core::marker::Unpin for bitcoin::taproot::TapBranchTag
 impl core::marker::UnsafeUnpin for bitcoin::taproot::TapBranchTag
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TapBranchTag
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TapBranchTag
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::taproot::TapBranchTag where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::taproot::TapBranchTag where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::taproot::TapBranchTag where U: core::convert::From<T>
 pub fn bitcoin::taproot::TapBranchTag::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::taproot::TapBranchTag where U: core::convert::Into<T>
@@ -16226,6 +16928,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::taproot::TapBranchTag where T: c
 pub unsafe fn bitcoin::taproot::TapBranchTag::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::taproot::TapBranchTag
 pub fn bitcoin::taproot::TapBranchTag::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::taproot::TapBranchTag where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::taproot::TapBranchTag where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::taproot::TapBranchTag::vzip(self) -> V
 pub struct bitcoin::taproot::TapLeafHash(_)
@@ -16282,10 +16985,10 @@ impl core::marker::StructuralPartialEq for bitcoin::taproot::TapLeafHash
 impl core::str::traits::FromStr for bitcoin::taproot::TapLeafHash
 pub type bitcoin::taproot::TapLeafHash::Err = hex_conservative::error::HexToArrayError
 pub fn bitcoin::taproot::TapLeafHash::from_str(s: &str) -> core::result::Result<bitcoin::taproot::TapLeafHash, Self::Err>
-impl serde::ser::Serialize for bitcoin::taproot::TapLeafHash
-pub fn bitcoin::taproot::TapLeafHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::taproot::TapLeafHash
-pub fn bitcoin::taproot::TapLeafHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::taproot::TapLeafHash, <D as serde::de::Deserializer>::Error>
+impl serde_core::ser::Serialize for bitcoin::taproot::TapLeafHash
+pub fn bitcoin::taproot::TapLeafHash::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::taproot::TapLeafHash
+pub fn bitcoin::taproot::TapLeafHash::deserialize<D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::taproot::TapLeafHash, <D as serde_core::de::Deserializer>::Error>
 impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::taproot::TapLeafHash
 pub type bitcoin::taproot::TapLeafHash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
 pub fn bitcoin::taproot::TapLeafHash::index(&self, index: I) -> &Self::Output
@@ -16296,6 +16999,8 @@ impl core::marker::Unpin for bitcoin::taproot::TapLeafHash
 impl core::marker::UnsafeUnpin for bitcoin::taproot::TapLeafHash
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TapLeafHash
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TapLeafHash
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::taproot::TapLeafHash where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::taproot::TapLeafHash where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::taproot::TapLeafHash where U: core::convert::From<T>
 pub fn bitcoin::taproot::TapLeafHash::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::taproot::TapLeafHash where U: core::convert::Into<T>
@@ -16320,7 +17025,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::taproot::TapLeafHash where T: co
 pub unsafe fn bitcoin::taproot::TapLeafHash::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::taproot::TapLeafHash
 pub fn bitcoin::taproot::TapLeafHash::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::taproot::TapLeafHash where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::taproot::TapLeafHash where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::taproot::TapLeafHash where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::taproot::TapLeafHash where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::taproot::TapLeafHash::vzip(self) -> V
 pub struct bitcoin::taproot::TapLeafTag
@@ -16348,6 +17054,8 @@ impl core::marker::Unpin for bitcoin::taproot::TapLeafTag
 impl core::marker::UnsafeUnpin for bitcoin::taproot::TapLeafTag
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TapLeafTag
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TapLeafTag
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::taproot::TapLeafTag where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::taproot::TapLeafTag where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::taproot::TapLeafTag where U: core::convert::From<T>
 pub fn bitcoin::taproot::TapLeafTag::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::taproot::TapLeafTag where U: core::convert::Into<T>
@@ -16370,6 +17078,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::taproot::TapLeafTag where T: cor
 pub unsafe fn bitcoin::taproot::TapLeafTag::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::taproot::TapLeafTag
 pub fn bitcoin::taproot::TapLeafTag::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::taproot::TapLeafTag where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::taproot::TapLeafTag where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::taproot::TapLeafTag::vzip(self) -> V
 pub struct bitcoin::taproot::TapNodeHash(_)
@@ -16426,10 +17135,10 @@ impl core::marker::StructuralPartialEq for bitcoin::taproot::TapNodeHash
 impl core::str::traits::FromStr for bitcoin::taproot::TapNodeHash
 pub type bitcoin::taproot::TapNodeHash::Err = hex_conservative::error::HexToArrayError
 pub fn bitcoin::taproot::TapNodeHash::from_str(s: &str) -> core::result::Result<bitcoin::taproot::TapNodeHash, Self::Err>
-impl serde::ser::Serialize for bitcoin::taproot::TapNodeHash
-pub fn bitcoin::taproot::TapNodeHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::taproot::TapNodeHash
-pub fn bitcoin::taproot::TapNodeHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::taproot::TapNodeHash, <D as serde::de::Deserializer>::Error>
+impl serde_core::ser::Serialize for bitcoin::taproot::TapNodeHash
+pub fn bitcoin::taproot::TapNodeHash::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::taproot::TapNodeHash
+pub fn bitcoin::taproot::TapNodeHash::deserialize<D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::taproot::TapNodeHash, <D as serde_core::de::Deserializer>::Error>
 impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::taproot::TapNodeHash
 pub type bitcoin::taproot::TapNodeHash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
 pub fn bitcoin::taproot::TapNodeHash::index(&self, index: I) -> &Self::Output
@@ -16440,6 +17149,8 @@ impl core::marker::Unpin for bitcoin::taproot::TapNodeHash
 impl core::marker::UnsafeUnpin for bitcoin::taproot::TapNodeHash
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TapNodeHash
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TapNodeHash
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::taproot::TapNodeHash where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::taproot::TapNodeHash where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::taproot::TapNodeHash where U: core::convert::From<T>
 pub fn bitcoin::taproot::TapNodeHash::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::taproot::TapNodeHash where U: core::convert::Into<T>
@@ -16464,7 +17175,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::taproot::TapNodeHash where T: co
 pub unsafe fn bitcoin::taproot::TapNodeHash::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::taproot::TapNodeHash
 pub fn bitcoin::taproot::TapNodeHash::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::taproot::TapNodeHash where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::taproot::TapNodeHash where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::taproot::TapNodeHash where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::taproot::TapNodeHash where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::taproot::TapNodeHash::vzip(self) -> V
 pub struct bitcoin::taproot::TapTree(_)
@@ -16486,10 +17198,10 @@ pub fn bitcoin::taproot::TapTree::fmt(&self, f: &mut core::fmt::Formatter<'_>) -
 impl core::hash::Hash for bitcoin::taproot::TapTree
 pub fn bitcoin::taproot::TapTree::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 impl core::marker::StructuralPartialEq for bitcoin::taproot::TapTree
-impl serde::ser::Serialize for bitcoin::taproot::TapTree
-pub fn bitcoin::taproot::TapTree::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
-impl<'de> serde::de::Deserialize<'de> for bitcoin::taproot::TapTree
-pub fn bitcoin::taproot::TapTree::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl serde_core::ser::Serialize for bitcoin::taproot::TapTree
+pub fn bitcoin::taproot::TapTree::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::taproot::TapTree
+pub fn bitcoin::taproot::TapTree::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin::taproot::TapTree
 impl core::marker::Send for bitcoin::taproot::TapTree
 impl core::marker::Sync for bitcoin::taproot::TapTree
@@ -16497,6 +17209,8 @@ impl core::marker::Unpin for bitcoin::taproot::TapTree
 impl core::marker::UnsafeUnpin for bitcoin::taproot::TapTree
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TapTree
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TapTree
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::taproot::TapTree where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::taproot::TapTree where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::taproot::TapTree where U: core::convert::From<T>
 pub fn bitcoin::taproot::TapTree::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::taproot::TapTree where U: core::convert::Into<T>
@@ -16519,7 +17233,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::taproot::TapTree where T: core::
 pub unsafe fn bitcoin::taproot::TapTree::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::taproot::TapTree
 pub fn bitcoin::taproot::TapTree::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::taproot::TapTree where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::taproot::TapTree where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::taproot::TapTree where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::taproot::TapTree where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::taproot::TapTree::vzip(self) -> V
 pub struct bitcoin::taproot::TapTweakHash(_)
@@ -16579,10 +17294,10 @@ impl core::marker::StructuralPartialEq for bitcoin::taproot::TapTweakHash
 impl core::str::traits::FromStr for bitcoin::taproot::TapTweakHash
 pub type bitcoin::taproot::TapTweakHash::Err = hex_conservative::error::HexToArrayError
 pub fn bitcoin::taproot::TapTweakHash::from_str(s: &str) -> core::result::Result<bitcoin::taproot::TapTweakHash, Self::Err>
-impl serde::ser::Serialize for bitcoin::taproot::TapTweakHash
-pub fn bitcoin::taproot::TapTweakHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-impl<'de> serde::de::Deserialize<'de> for bitcoin::taproot::TapTweakHash
-pub fn bitcoin::taproot::TapTweakHash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::taproot::TapTweakHash, <D as serde::de::Deserializer>::Error>
+impl serde_core::ser::Serialize for bitcoin::taproot::TapTweakHash
+pub fn bitcoin::taproot::TapTweakHash::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin::taproot::TapTweakHash
+pub fn bitcoin::taproot::TapTweakHash::deserialize<D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin::taproot::TapTweakHash, <D as serde_core::de::Deserializer>::Error>
 impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin::taproot::TapTweakHash
 pub type bitcoin::taproot::TapTweakHash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
 pub fn bitcoin::taproot::TapTweakHash::index(&self, index: I) -> &Self::Output
@@ -16593,6 +17308,8 @@ impl core::marker::Unpin for bitcoin::taproot::TapTweakHash
 impl core::marker::UnsafeUnpin for bitcoin::taproot::TapTweakHash
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TapTweakHash
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TapTweakHash
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::taproot::TapTweakHash where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::taproot::TapTweakHash where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::taproot::TapTweakHash where U: core::convert::From<T>
 pub fn bitcoin::taproot::TapTweakHash::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::taproot::TapTweakHash where U: core::convert::Into<T>
@@ -16617,7 +17334,8 @@ impl<T> core::clone::CloneToUninit for bitcoin::taproot::TapTweakHash where T: c
 pub unsafe fn bitcoin::taproot::TapTweakHash::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::taproot::TapTweakHash
 pub fn bitcoin::taproot::TapTweakHash::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin::taproot::TapTweakHash where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin::taproot::TapTweakHash where T: for<'de> serde_core::de::Deserialize<'de>
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::taproot::TapTweakHash where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::taproot::TapTweakHash where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::taproot::TapTweakHash::vzip(self) -> V
 pub struct bitcoin::taproot::TapTweakTag
@@ -16645,6 +17363,8 @@ impl core::marker::Unpin for bitcoin::taproot::TapTweakTag
 impl core::marker::UnsafeUnpin for bitcoin::taproot::TapTweakTag
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TapTweakTag
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TapTweakTag
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::taproot::TapTweakTag where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::taproot::TapTweakTag where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::taproot::TapTweakTag where U: core::convert::From<T>
 pub fn bitcoin::taproot::TapTweakTag::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::taproot::TapTweakTag where U: core::convert::Into<T>
@@ -16667,6 +17387,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::taproot::TapTweakTag where T: co
 pub unsafe fn bitcoin::taproot::TapTweakTag::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::taproot::TapTweakTag
 pub fn bitcoin::taproot::TapTweakTag::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::taproot::TapTweakTag where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::taproot::TapTweakTag where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::taproot::TapTweakTag::vzip(self) -> V
 pub struct bitcoin::taproot::TaprootBuilder
@@ -16705,6 +17426,8 @@ impl core::marker::Unpin for bitcoin::taproot::TaprootBuilder
 impl core::marker::UnsafeUnpin for bitcoin::taproot::TaprootBuilder
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TaprootBuilder
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TaprootBuilder
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::taproot::TaprootBuilder where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::taproot::TaprootBuilder where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::taproot::TaprootBuilder where U: core::convert::From<T>
 pub fn bitcoin::taproot::TaprootBuilder::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::taproot::TaprootBuilder where U: core::convert::Into<T>
@@ -16727,6 +17450,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::taproot::TaprootBuilder where T:
 pub unsafe fn bitcoin::taproot::TaprootBuilder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::taproot::TaprootBuilder
 pub fn bitcoin::taproot::TaprootBuilder::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::taproot::TaprootBuilder where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::taproot::TaprootBuilder where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::taproot::TaprootBuilder::vzip(self) -> V
 pub struct bitcoin::taproot::TaprootMerkleBranch(_)
@@ -16763,6 +17487,8 @@ impl core::marker::Unpin for bitcoin::taproot::TaprootSpendInfo
 impl core::marker::UnsafeUnpin for bitcoin::taproot::TaprootSpendInfo
 impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::taproot::TaprootSpendInfo
 impl core::panic::unwind_safe::UnwindSafe for bitcoin::taproot::TaprootSpendInfo
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::taproot::TaprootSpendInfo where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::taproot::TaprootSpendInfo where ST: ?core::marker::Sized, DT: ?core::marker::Sized
 impl<T, U> core::convert::Into<U> for bitcoin::taproot::TaprootSpendInfo where U: core::convert::From<T>
 pub fn bitcoin::taproot::TaprootSpendInfo::into(self) -> U
 impl<T, U> core::convert::TryFrom<U> for bitcoin::taproot::TaprootSpendInfo where U: core::convert::Into<T>
@@ -16785,6 +17511,7 @@ impl<T> core::clone::CloneToUninit for bitcoin::taproot::TaprootSpendInfo where 
 pub unsafe fn bitcoin::taproot::TaprootSpendInfo::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin::taproot::TaprootSpendInfo
 pub fn bitcoin::taproot::TaprootSpendInfo::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::taproot::TaprootSpendInfo where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::taproot::TaprootSpendInfo where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::taproot::TaprootSpendInfo::vzip(self) -> V
 pub const bitcoin::taproot::TAPROOT_ANNEX_PREFIX: u8

--- a/bitcoin/api/all-features.txt
+++ b/bitcoin/api/all-features.txt
@@ -12828,6 +12828,11 @@ pub fn bitcoin::pow::CompactTarget::from_hex(s: &str) -> core::result::Result<Se
 pub fn bitcoin::pow::CompactTarget::from_next_work_required(last: bitcoin::pow::CompactTarget, timespan: u64, params: impl core::convert::AsRef<bitcoin::consensus::params::Params>) -> bitcoin::pow::CompactTarget
 pub fn bitcoin::pow::CompactTarget::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin::error::UnprefixedHexError>
 pub fn bitcoin::pow::CompactTarget::to_consensus(self) -> u32
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin::pow::CompactTarget
+pub type bitcoin::pow::CompactTarget::Decoder = bitcoin::pow::CompactTargetDecoder
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin::pow::CompactTarget
+pub type bitcoin::pow::CompactTarget::Encoder<'e> = bitcoin::pow::CompactTargetEncoder<'e>
+pub fn bitcoin::pow::CompactTarget::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin::pow::CompactTarget
 pub fn bitcoin::pow::CompactTarget::clone(&self) -> bitcoin::pow::CompactTarget
 impl core::cmp::Eq for bitcoin::pow::CompactTarget
@@ -12888,6 +12893,149 @@ impl<T> serde_core::de::DeserializeOwned for bitcoin::pow::CompactTarget where T
 impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::pow::CompactTarget where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::pow::CompactTarget where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::pow::CompactTarget::vzip(self) -> V
+pub struct bitcoin::pow::CompactTargetDecoder(_)
+impl bitcoin::pow::CompactTargetDecoder
+pub const fn bitcoin::pow::CompactTargetDecoder::new() -> Self
+impl bitcoin_consensus_encoding::decode::Decoder for bitcoin::pow::CompactTargetDecoder
+pub type bitcoin::pow::CompactTargetDecoder::Error = bitcoin::pow::CompactTargetDecoderError
+pub type bitcoin::pow::CompactTargetDecoder::Output = bitcoin::pow::CompactTarget
+pub fn bitcoin::pow::CompactTargetDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
+pub fn bitcoin::pow::CompactTargetDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
+pub fn bitcoin::pow::CompactTargetDecoder::read_limit(&self) -> usize
+impl core::clone::Clone for bitcoin::pow::CompactTargetDecoder
+pub fn bitcoin::pow::CompactTargetDecoder::clone(&self) -> bitcoin::pow::CompactTargetDecoder
+impl core::default::Default for bitcoin::pow::CompactTargetDecoder
+pub fn bitcoin::pow::CompactTargetDecoder::default() -> Self
+impl core::fmt::Debug for bitcoin::pow::CompactTargetDecoder
+pub fn bitcoin::pow::CompactTargetDecoder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitcoin::pow::CompactTargetDecoder
+impl core::marker::Send for bitcoin::pow::CompactTargetDecoder
+impl core::marker::Sync for bitcoin::pow::CompactTargetDecoder
+impl core::marker::Unpin for bitcoin::pow::CompactTargetDecoder
+impl core::marker::UnsafeUnpin for bitcoin::pow::CompactTargetDecoder
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::pow::CompactTargetDecoder
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::pow::CompactTargetDecoder
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::pow::CompactTargetDecoder where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::pow::CompactTargetDecoder where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<T, U> core::convert::Into<U> for bitcoin::pow::CompactTargetDecoder where U: core::convert::From<T>
+pub fn bitcoin::pow::CompactTargetDecoder::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin::pow::CompactTargetDecoder where U: core::convert::Into<T>
+pub type bitcoin::pow::CompactTargetDecoder::Error = core::convert::Infallible
+pub fn bitcoin::pow::CompactTargetDecoder::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin::pow::CompactTargetDecoder where U: core::convert::TryFrom<T>
+pub type bitcoin::pow::CompactTargetDecoder::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin::pow::CompactTargetDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin::pow::CompactTargetDecoder where T: core::clone::Clone
+pub type bitcoin::pow::CompactTargetDecoder::Owned = T
+pub fn bitcoin::pow::CompactTargetDecoder::clone_into(&self, target: &mut T)
+pub fn bitcoin::pow::CompactTargetDecoder::to_owned(&self) -> T
+impl<T> core::any::Any for bitcoin::pow::CompactTargetDecoder where T: 'static + ?core::marker::Sized
+pub fn bitcoin::pow::CompactTargetDecoder::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin::pow::CompactTargetDecoder where T: ?core::marker::Sized
+pub fn bitcoin::pow::CompactTargetDecoder::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin::pow::CompactTargetDecoder where T: ?core::marker::Sized
+pub fn bitcoin::pow::CompactTargetDecoder::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin::pow::CompactTargetDecoder where T: core::clone::Clone
+pub unsafe fn bitcoin::pow::CompactTargetDecoder::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin::pow::CompactTargetDecoder
+pub fn bitcoin::pow::CompactTargetDecoder::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::pow::CompactTargetDecoder where T: ?core::marker::Sized
+impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::pow::CompactTargetDecoder where V: ppv_lite86::types::MultiLane<T>
+pub fn bitcoin::pow::CompactTargetDecoder::vzip(self) -> V
+pub struct bitcoin::pow::CompactTargetDecoderError(_)
+impl core::clone::Clone for bitcoin::pow::CompactTargetDecoderError
+pub fn bitcoin::pow::CompactTargetDecoderError::clone(&self) -> bitcoin::pow::CompactTargetDecoderError
+impl core::cmp::Eq for bitcoin::pow::CompactTargetDecoderError
+impl core::cmp::PartialEq for bitcoin::pow::CompactTargetDecoderError
+pub fn bitcoin::pow::CompactTargetDecoderError::eq(&self, other: &bitcoin::pow::CompactTargetDecoderError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin::pow::CompactTargetDecoderError
+pub fn bitcoin::pow::CompactTargetDecoderError::from(never: core::convert::Infallible) -> Self
+impl core::error::Error for bitcoin::pow::CompactTargetDecoderError
+pub fn bitcoin::pow::CompactTargetDecoderError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl core::fmt::Debug for bitcoin::pow::CompactTargetDecoderError
+pub fn bitcoin::pow::CompactTargetDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin::pow::CompactTargetDecoderError
+impl core::marker::StructuralPartialEq for bitcoin::pow::CompactTargetDecoderError
+impl core::marker::Freeze for bitcoin::pow::CompactTargetDecoderError
+impl core::marker::Send for bitcoin::pow::CompactTargetDecoderError
+impl core::marker::Sync for bitcoin::pow::CompactTargetDecoderError
+impl core::marker::Unpin for bitcoin::pow::CompactTargetDecoderError
+impl core::marker::UnsafeUnpin for bitcoin::pow::CompactTargetDecoderError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::pow::CompactTargetDecoderError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::pow::CompactTargetDecoderError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::pow::CompactTargetDecoderError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::pow::CompactTargetDecoderError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<T, U> core::convert::Into<U> for bitcoin::pow::CompactTargetDecoderError where U: core::convert::From<T>
+pub fn bitcoin::pow::CompactTargetDecoderError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin::pow::CompactTargetDecoderError where U: core::convert::Into<T>
+pub type bitcoin::pow::CompactTargetDecoderError::Error = core::convert::Infallible
+pub fn bitcoin::pow::CompactTargetDecoderError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin::pow::CompactTargetDecoderError where U: core::convert::TryFrom<T>
+pub type bitcoin::pow::CompactTargetDecoderError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin::pow::CompactTargetDecoderError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin::pow::CompactTargetDecoderError where T: core::clone::Clone
+pub type bitcoin::pow::CompactTargetDecoderError::Owned = T
+pub fn bitcoin::pow::CompactTargetDecoderError::clone_into(&self, target: &mut T)
+pub fn bitcoin::pow::CompactTargetDecoderError::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin::pow::CompactTargetDecoderError where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin::pow::CompactTargetDecoderError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin::pow::CompactTargetDecoderError where T: 'static + ?core::marker::Sized
+pub fn bitcoin::pow::CompactTargetDecoderError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin::pow::CompactTargetDecoderError where T: ?core::marker::Sized
+pub fn bitcoin::pow::CompactTargetDecoderError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin::pow::CompactTargetDecoderError where T: ?core::marker::Sized
+pub fn bitcoin::pow::CompactTargetDecoderError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin::pow::CompactTargetDecoderError where T: core::clone::Clone
+pub unsafe fn bitcoin::pow::CompactTargetDecoderError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin::pow::CompactTargetDecoderError
+pub fn bitcoin::pow::CompactTargetDecoderError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::pow::CompactTargetDecoderError where T: ?core::marker::Sized
+impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::pow::CompactTargetDecoderError where V: ppv_lite86::types::MultiLane<T>
+pub fn bitcoin::pow::CompactTargetDecoderError::vzip(self) -> V
+pub struct bitcoin::pow::CompactTargetEncoder<'e>(_, _)
+impl<'e> bitcoin_consensus_encoding::encode::Encoder for bitcoin::pow::CompactTargetEncoder<'e>
+pub fn bitcoin::pow::CompactTargetEncoder<'e>::advance(&mut self) -> bitcoin_consensus_encoding::encode::EncoderStatus
+pub fn bitcoin::pow::CompactTargetEncoder<'e>::current_chunk(&self) -> &[u8]
+impl<'e> bitcoin_consensus_encoding::encode::ExactSizeEncoder for bitcoin::pow::CompactTargetEncoder<'e>
+pub fn bitcoin::pow::CompactTargetEncoder<'e>::len(&self) -> usize
+impl<'e> core::clone::Clone for bitcoin::pow::CompactTargetEncoder<'e>
+pub fn bitcoin::pow::CompactTargetEncoder<'e>::clone(&self) -> bitcoin::pow::CompactTargetEncoder<'e>
+impl<'e> core::fmt::Debug for bitcoin::pow::CompactTargetEncoder<'e>
+pub fn bitcoin::pow::CompactTargetEncoder<'e>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<'e> core::marker::Freeze for bitcoin::pow::CompactTargetEncoder<'e>
+impl<'e> core::marker::Send for bitcoin::pow::CompactTargetEncoder<'e>
+impl<'e> core::marker::Sync for bitcoin::pow::CompactTargetEncoder<'e>
+impl<'e> core::marker::Unpin for bitcoin::pow::CompactTargetEncoder<'e>
+impl<'e> core::marker::UnsafeUnpin for bitcoin::pow::CompactTargetEncoder<'e>
+impl<'e> core::panic::unwind_safe::RefUnwindSafe for bitcoin::pow::CompactTargetEncoder<'e>
+impl<'e> core::panic::unwind_safe::UnwindSafe for bitcoin::pow::CompactTargetEncoder<'e>
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::pow::CompactTargetEncoder<'e> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::pow::CompactTargetEncoder<'e> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<T, U> core::convert::Into<U> for bitcoin::pow::CompactTargetEncoder<'e> where U: core::convert::From<T>
+pub fn bitcoin::pow::CompactTargetEncoder<'e>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin::pow::CompactTargetEncoder<'e> where U: core::convert::Into<T>
+pub type bitcoin::pow::CompactTargetEncoder<'e>::Error = core::convert::Infallible
+pub fn bitcoin::pow::CompactTargetEncoder<'e>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin::pow::CompactTargetEncoder<'e> where U: core::convert::TryFrom<T>
+pub type bitcoin::pow::CompactTargetEncoder<'e>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin::pow::CompactTargetEncoder<'e>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin::pow::CompactTargetEncoder<'e> where T: core::clone::Clone
+pub type bitcoin::pow::CompactTargetEncoder<'e>::Owned = T
+pub fn bitcoin::pow::CompactTargetEncoder<'e>::clone_into(&self, target: &mut T)
+pub fn bitcoin::pow::CompactTargetEncoder<'e>::to_owned(&self) -> T
+impl<T> core::any::Any for bitcoin::pow::CompactTargetEncoder<'e> where T: 'static + ?core::marker::Sized
+pub fn bitcoin::pow::CompactTargetEncoder<'e>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin::pow::CompactTargetEncoder<'e> where T: ?core::marker::Sized
+pub fn bitcoin::pow::CompactTargetEncoder<'e>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin::pow::CompactTargetEncoder<'e> where T: ?core::marker::Sized
+pub fn bitcoin::pow::CompactTargetEncoder<'e>::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin::pow::CompactTargetEncoder<'e> where T: core::clone::Clone
+pub unsafe fn bitcoin::pow::CompactTargetEncoder<'e>::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin::pow::CompactTargetEncoder<'e>
+pub fn bitcoin::pow::CompactTargetEncoder<'e>::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::pow::CompactTargetEncoder<'e> where T: ?core::marker::Sized
+impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::pow::CompactTargetEncoder<'e> where V: ppv_lite86::types::MultiLane<T>
+pub fn bitcoin::pow::CompactTargetEncoder<'e>::vzip(self) -> V
 pub struct bitcoin::pow::Target(_)
 impl bitcoin::pow::Target
 pub const bitcoin::pow::Target::MAX: Self

--- a/bitcoin/api/all-features.txt
+++ b/bitcoin/api/all-features.txt
@@ -7006,6 +7006,11 @@ impl bitcoin::consensus::encode::Decodable for bitcoin::blockdata::transaction::
 pub fn bitcoin::blockdata::transaction::Sequence::consensus_decode<R: bitcoin_io::Read + ?core::marker::Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error>
 impl bitcoin::consensus::encode::Encodable for bitcoin::blockdata::transaction::Sequence
 pub fn bitcoin::blockdata::transaction::Sequence::consensus_encode<W: bitcoin_io::Write + ?core::marker::Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin_io::error::Error>
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin::blockdata::transaction::Sequence
+pub type bitcoin::blockdata::transaction::Sequence::Decoder = bitcoin::blockdata::transaction::SequenceDecoder
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin::blockdata::transaction::Sequence
+pub type bitcoin::blockdata::transaction::Sequence::Encoder<'e> = bitcoin::blockdata::transaction::SequenceEncoder<'e>
+pub fn bitcoin::blockdata::transaction::Sequence::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin::blockdata::transaction::Sequence
 pub fn bitcoin::blockdata::transaction::Sequence::clone(&self) -> bitcoin::blockdata::transaction::Sequence
 impl core::cmp::Eq for bitcoin::blockdata::transaction::Sequence
@@ -7081,6 +7086,149 @@ impl<T> serde_core::de::DeserializeOwned for bitcoin::blockdata::transaction::Se
 impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::transaction::Sequence where T: ?core::marker::Sized
 impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::transaction::Sequence where V: ppv_lite86::types::MultiLane<T>
 pub fn bitcoin::blockdata::transaction::Sequence::vzip(self) -> V
+pub struct bitcoin::blockdata::transaction::SequenceDecoder(_)
+impl bitcoin::blockdata::transaction::SequenceDecoder
+pub const fn bitcoin::blockdata::transaction::SequenceDecoder::new() -> Self
+impl bitcoin_consensus_encoding::decode::Decoder for bitcoin::blockdata::transaction::SequenceDecoder
+pub type bitcoin::blockdata::transaction::SequenceDecoder::Error = bitcoin::blockdata::transaction::SequenceDecoderError
+pub type bitcoin::blockdata::transaction::SequenceDecoder::Output = bitcoin::blockdata::transaction::Sequence
+pub fn bitcoin::blockdata::transaction::SequenceDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
+pub fn bitcoin::blockdata::transaction::SequenceDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
+pub fn bitcoin::blockdata::transaction::SequenceDecoder::read_limit(&self) -> usize
+impl core::clone::Clone for bitcoin::blockdata::transaction::SequenceDecoder
+pub fn bitcoin::blockdata::transaction::SequenceDecoder::clone(&self) -> bitcoin::blockdata::transaction::SequenceDecoder
+impl core::default::Default for bitcoin::blockdata::transaction::SequenceDecoder
+pub fn bitcoin::blockdata::transaction::SequenceDecoder::default() -> Self
+impl core::fmt::Debug for bitcoin::blockdata::transaction::SequenceDecoder
+pub fn bitcoin::blockdata::transaction::SequenceDecoder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitcoin::blockdata::transaction::SequenceDecoder
+impl core::marker::Send for bitcoin::blockdata::transaction::SequenceDecoder
+impl core::marker::Sync for bitcoin::blockdata::transaction::SequenceDecoder
+impl core::marker::Unpin for bitcoin::blockdata::transaction::SequenceDecoder
+impl core::marker::UnsafeUnpin for bitcoin::blockdata::transaction::SequenceDecoder
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::SequenceDecoder
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::SequenceDecoder
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::transaction::SequenceDecoder where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::transaction::SequenceDecoder where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<T, U> core::convert::Into<U> for bitcoin::blockdata::transaction::SequenceDecoder where U: core::convert::From<T>
+pub fn bitcoin::blockdata::transaction::SequenceDecoder::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::transaction::SequenceDecoder where U: core::convert::Into<T>
+pub type bitcoin::blockdata::transaction::SequenceDecoder::Error = core::convert::Infallible
+pub fn bitcoin::blockdata::transaction::SequenceDecoder::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin::blockdata::transaction::SequenceDecoder where U: core::convert::TryFrom<T>
+pub type bitcoin::blockdata::transaction::SequenceDecoder::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin::blockdata::transaction::SequenceDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin::blockdata::transaction::SequenceDecoder where T: core::clone::Clone
+pub type bitcoin::blockdata::transaction::SequenceDecoder::Owned = T
+pub fn bitcoin::blockdata::transaction::SequenceDecoder::clone_into(&self, target: &mut T)
+pub fn bitcoin::blockdata::transaction::SequenceDecoder::to_owned(&self) -> T
+impl<T> core::any::Any for bitcoin::blockdata::transaction::SequenceDecoder where T: 'static + ?core::marker::Sized
+pub fn bitcoin::blockdata::transaction::SequenceDecoder::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin::blockdata::transaction::SequenceDecoder where T: ?core::marker::Sized
+pub fn bitcoin::blockdata::transaction::SequenceDecoder::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin::blockdata::transaction::SequenceDecoder where T: ?core::marker::Sized
+pub fn bitcoin::blockdata::transaction::SequenceDecoder::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin::blockdata::transaction::SequenceDecoder where T: core::clone::Clone
+pub unsafe fn bitcoin::blockdata::transaction::SequenceDecoder::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin::blockdata::transaction::SequenceDecoder
+pub fn bitcoin::blockdata::transaction::SequenceDecoder::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::transaction::SequenceDecoder where T: ?core::marker::Sized
+impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::transaction::SequenceDecoder where V: ppv_lite86::types::MultiLane<T>
+pub fn bitcoin::blockdata::transaction::SequenceDecoder::vzip(self) -> V
+pub struct bitcoin::blockdata::transaction::SequenceDecoderError(_)
+impl core::clone::Clone for bitcoin::blockdata::transaction::SequenceDecoderError
+pub fn bitcoin::blockdata::transaction::SequenceDecoderError::clone(&self) -> bitcoin::blockdata::transaction::SequenceDecoderError
+impl core::cmp::Eq for bitcoin::blockdata::transaction::SequenceDecoderError
+impl core::cmp::PartialEq for bitcoin::blockdata::transaction::SequenceDecoderError
+pub fn bitcoin::blockdata::transaction::SequenceDecoderError::eq(&self, other: &bitcoin::blockdata::transaction::SequenceDecoderError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin::blockdata::transaction::SequenceDecoderError
+pub fn bitcoin::blockdata::transaction::SequenceDecoderError::from(never: core::convert::Infallible) -> Self
+impl core::error::Error for bitcoin::blockdata::transaction::SequenceDecoderError
+pub fn bitcoin::blockdata::transaction::SequenceDecoderError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl core::fmt::Debug for bitcoin::blockdata::transaction::SequenceDecoderError
+pub fn bitcoin::blockdata::transaction::SequenceDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin::blockdata::transaction::SequenceDecoderError
+impl core::marker::StructuralPartialEq for bitcoin::blockdata::transaction::SequenceDecoderError
+impl core::marker::Freeze for bitcoin::blockdata::transaction::SequenceDecoderError
+impl core::marker::Send for bitcoin::blockdata::transaction::SequenceDecoderError
+impl core::marker::Sync for bitcoin::blockdata::transaction::SequenceDecoderError
+impl core::marker::Unpin for bitcoin::blockdata::transaction::SequenceDecoderError
+impl core::marker::UnsafeUnpin for bitcoin::blockdata::transaction::SequenceDecoderError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::SequenceDecoderError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::SequenceDecoderError
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::transaction::SequenceDecoderError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::transaction::SequenceDecoderError where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<T, U> core::convert::Into<U> for bitcoin::blockdata::transaction::SequenceDecoderError where U: core::convert::From<T>
+pub fn bitcoin::blockdata::transaction::SequenceDecoderError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::transaction::SequenceDecoderError where U: core::convert::Into<T>
+pub type bitcoin::blockdata::transaction::SequenceDecoderError::Error = core::convert::Infallible
+pub fn bitcoin::blockdata::transaction::SequenceDecoderError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin::blockdata::transaction::SequenceDecoderError where U: core::convert::TryFrom<T>
+pub type bitcoin::blockdata::transaction::SequenceDecoderError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin::blockdata::transaction::SequenceDecoderError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin::blockdata::transaction::SequenceDecoderError where T: core::clone::Clone
+pub type bitcoin::blockdata::transaction::SequenceDecoderError::Owned = T
+pub fn bitcoin::blockdata::transaction::SequenceDecoderError::clone_into(&self, target: &mut T)
+pub fn bitcoin::blockdata::transaction::SequenceDecoderError::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin::blockdata::transaction::SequenceDecoderError where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin::blockdata::transaction::SequenceDecoderError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin::blockdata::transaction::SequenceDecoderError where T: 'static + ?core::marker::Sized
+pub fn bitcoin::blockdata::transaction::SequenceDecoderError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin::blockdata::transaction::SequenceDecoderError where T: ?core::marker::Sized
+pub fn bitcoin::blockdata::transaction::SequenceDecoderError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin::blockdata::transaction::SequenceDecoderError where T: ?core::marker::Sized
+pub fn bitcoin::blockdata::transaction::SequenceDecoderError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin::blockdata::transaction::SequenceDecoderError where T: core::clone::Clone
+pub unsafe fn bitcoin::blockdata::transaction::SequenceDecoderError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin::blockdata::transaction::SequenceDecoderError
+pub fn bitcoin::blockdata::transaction::SequenceDecoderError::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::transaction::SequenceDecoderError where T: ?core::marker::Sized
+impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::transaction::SequenceDecoderError where V: ppv_lite86::types::MultiLane<T>
+pub fn bitcoin::blockdata::transaction::SequenceDecoderError::vzip(self) -> V
+pub struct bitcoin::blockdata::transaction::SequenceEncoder<'e>(_, _)
+impl<'e> bitcoin_consensus_encoding::encode::Encoder for bitcoin::blockdata::transaction::SequenceEncoder<'e>
+pub fn bitcoin::blockdata::transaction::SequenceEncoder<'e>::advance(&mut self) -> bitcoin_consensus_encoding::encode::EncoderStatus
+pub fn bitcoin::blockdata::transaction::SequenceEncoder<'e>::current_chunk(&self) -> &[u8]
+impl<'e> bitcoin_consensus_encoding::encode::ExactSizeEncoder for bitcoin::blockdata::transaction::SequenceEncoder<'e>
+pub fn bitcoin::blockdata::transaction::SequenceEncoder<'e>::len(&self) -> usize
+impl<'e> core::clone::Clone for bitcoin::blockdata::transaction::SequenceEncoder<'e>
+pub fn bitcoin::blockdata::transaction::SequenceEncoder<'e>::clone(&self) -> bitcoin::blockdata::transaction::SequenceEncoder<'e>
+impl<'e> core::fmt::Debug for bitcoin::blockdata::transaction::SequenceEncoder<'e>
+pub fn bitcoin::blockdata::transaction::SequenceEncoder<'e>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<'e> core::marker::Freeze for bitcoin::blockdata::transaction::SequenceEncoder<'e>
+impl<'e> core::marker::Send for bitcoin::blockdata::transaction::SequenceEncoder<'e>
+impl<'e> core::marker::Sync for bitcoin::blockdata::transaction::SequenceEncoder<'e>
+impl<'e> core::marker::Unpin for bitcoin::blockdata::transaction::SequenceEncoder<'e>
+impl<'e> core::marker::UnsafeUnpin for bitcoin::blockdata::transaction::SequenceEncoder<'e>
+impl<'e> core::panic::unwind_safe::RefUnwindSafe for bitcoin::blockdata::transaction::SequenceEncoder<'e>
+impl<'e> core::panic::unwind_safe::UnwindSafe for bitcoin::blockdata::transaction::SequenceEncoder<'e>
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Initialized, zerocopy::pointer::invariant::Initialized> for bitcoin::blockdata::transaction::SequenceEncoder<'e> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<ST, DT> zerocopy::pointer::invariant::CastableFrom<ST, zerocopy::pointer::invariant::Uninit, zerocopy::pointer::invariant::Uninit> for bitcoin::blockdata::transaction::SequenceEncoder<'e> where ST: ?core::marker::Sized, DT: ?core::marker::Sized
+impl<T, U> core::convert::Into<U> for bitcoin::blockdata::transaction::SequenceEncoder<'e> where U: core::convert::From<T>
+pub fn bitcoin::blockdata::transaction::SequenceEncoder<'e>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin::blockdata::transaction::SequenceEncoder<'e> where U: core::convert::Into<T>
+pub type bitcoin::blockdata::transaction::SequenceEncoder<'e>::Error = core::convert::Infallible
+pub fn bitcoin::blockdata::transaction::SequenceEncoder<'e>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin::blockdata::transaction::SequenceEncoder<'e> where U: core::convert::TryFrom<T>
+pub type bitcoin::blockdata::transaction::SequenceEncoder<'e>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin::blockdata::transaction::SequenceEncoder<'e>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin::blockdata::transaction::SequenceEncoder<'e> where T: core::clone::Clone
+pub type bitcoin::blockdata::transaction::SequenceEncoder<'e>::Owned = T
+pub fn bitcoin::blockdata::transaction::SequenceEncoder<'e>::clone_into(&self, target: &mut T)
+pub fn bitcoin::blockdata::transaction::SequenceEncoder<'e>::to_owned(&self) -> T
+impl<T> core::any::Any for bitcoin::blockdata::transaction::SequenceEncoder<'e> where T: 'static + ?core::marker::Sized
+pub fn bitcoin::blockdata::transaction::SequenceEncoder<'e>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin::blockdata::transaction::SequenceEncoder<'e> where T: ?core::marker::Sized
+pub fn bitcoin::blockdata::transaction::SequenceEncoder<'e>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin::blockdata::transaction::SequenceEncoder<'e> where T: ?core::marker::Sized
+pub fn bitcoin::blockdata::transaction::SequenceEncoder<'e>::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin::blockdata::transaction::SequenceEncoder<'e> where T: core::clone::Clone
+pub unsafe fn bitcoin::blockdata::transaction::SequenceEncoder<'e>::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin::blockdata::transaction::SequenceEncoder<'e>
+pub fn bitcoin::blockdata::transaction::SequenceEncoder<'e>::from(t: T) -> T
+impl<T> zerocopy::pointer::invariant::Read<zerocopy::pointer::invariant::Exclusive, zerocopy::pointer::invariant::BecauseExclusive> for bitcoin::blockdata::transaction::SequenceEncoder<'e> where T: ?core::marker::Sized
+impl<V, T> ppv_lite86::types::VZip<V> for bitcoin::blockdata::transaction::SequenceEncoder<'e> where V: ppv_lite86::types::MultiLane<T>
+pub fn bitcoin::blockdata::transaction::SequenceEncoder<'e>::vzip(self) -> V
 pub struct bitcoin::blockdata::transaction::Transaction
 pub bitcoin::blockdata::transaction::Transaction::input: alloc::vec::Vec<bitcoin::blockdata::transaction::TxIn>
 pub bitcoin::blockdata::transaction::Transaction::lock_time: bitcoin::blockdata::locktime::absolute::LockTime
@@ -17541,6 +17689,9 @@ pub bitcoin::transaction::OutPoint::txid: bitcoin::blockdata::transaction::Txid
 pub bitcoin::transaction::OutPoint::vout: u32
 pub struct bitcoin::transaction::OutputsIndexError(pub bitcoin::blockdata::transaction::IndexOutOfBoundsError)
 pub struct bitcoin::transaction::Sequence(pub u32)
+pub struct bitcoin::transaction::SequenceDecoder(_)
+pub struct bitcoin::transaction::SequenceDecoderError(_)
+pub struct bitcoin::transaction::SequenceEncoder<'e>(_, _)
 pub struct bitcoin::transaction::Transaction
 pub bitcoin::transaction::Transaction::input: alloc::vec::Vec<bitcoin::blockdata::transaction::TxIn>
 pub bitcoin::transaction::Transaction::lock_time: bitcoin::blockdata::locktime::absolute::LockTime

--- a/bitcoin/include/decoder_newtype.rs
+++ b/bitcoin/include/decoder_newtype.rs
@@ -1,0 +1,1 @@
+../../include/decoder_newtype.rs

--- a/bitcoin/src/blockdata/locktime/absolute.rs
+++ b/bitcoin/src/blockdata/locktime/absolute.rs
@@ -7,6 +7,8 @@
 //!
 
 use core::cmp::Ordering;
+#[cfg(feature = "encoding")]
+use core::convert::Infallible;
 use core::fmt;
 use core::str::FromStr;
 
@@ -19,6 +21,8 @@ use units::parse::{self, ParseIntError};
 use crate::absolute;
 use crate::consensus::encode::{self, Decodable, Encodable};
 use crate::error::{ContainsPrefixError, MissingPrefixError, PrefixedHexError, UnprefixedHexError};
+#[cfg(feature = "encoding")]
+use crate::internal_macros::write_err;
 use crate::prelude::{Box, String};
 
 #[rustfmt::skip]                // Keep public re-exports separate.
@@ -377,6 +381,69 @@ impl Decodable for LockTime {
     fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
         u32::consensus_decode(r).map(LockTime::from_consensus)
     }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for LockTime {
+    type Encoder<'e> = LockTimeEncoder<'e>;
+    #[inline]
+    fn encoder(&self) -> Self::Encoder<'_> {
+        LockTimeEncoder::new(encoding::ArrayEncoder::without_length_prefix(
+            self.to_consensus_u32().to_le_bytes(),
+        ))
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for LockTime {
+    type Decoder = LockTimeDecoder;
+}
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// The encoder for the [`LockTime`] type.
+    #[derive(Debug, Clone)]
+    pub struct LockTimeEncoder<'e>(encoding::ArrayEncoder<4>);
+}
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// The decoder for the [`LockTime`] type.
+    #[derive(Debug, Clone)]
+    pub struct LockTimeDecoder(encoding::ArrayDecoder<4>);
+
+    /// Constructs a new [`LockTime`] decoder.
+    pub const fn new() -> Self { Self(encoding::ArrayDecoder::new()) }
+
+    fn end(result: Result<[u8; 4], encoding::UnexpectedEofError>) -> Result<LockTime, LockTimeDecoderError> {
+        let value = result.map_err(LockTimeDecoderError)?;
+        let n = u32::from_le_bytes(value);
+        Ok(LockTime::from_consensus(n))
+    }
+}
+
+/// An error consensus decoding a [`LockTime`].
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LockTimeDecoderError(pub(super) encoding::UnexpectedEofError);
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for LockTimeDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl fmt::Display for LockTimeDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write_err!(f, "lock time decoder error"; self.0)
+    }
+}
+
+#[cfg(feature = "std")]
+#[cfg(feature = "encoding")]
+impl std::error::Error for LockTimeDecoderError {
+    #[inline]
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
 }
 
 #[cfg(feature = "serde")]

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -559,6 +559,68 @@ impl TryFrom<Box<str>> for Sequence {
     fn try_from(s: Box<str>) -> Result<Self, Self::Error> { Sequence::from_str(&s) }
 }
 
+#[cfg(feature = "encoding")]
+impl encoding::Encode for Sequence {
+    type Encoder<'e> = SequenceEncoder<'e>;
+    #[inline]
+    fn encoder(&self) -> Self::Encoder<'_> {
+        SequenceEncoder::new(encoding::ArrayEncoder::without_length_prefix(
+            self.to_consensus_u32().to_le_bytes(),
+        ))
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for Sequence {
+    type Decoder = SequenceDecoder;
+}
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// The encoder for the [`Sequence`] type.
+    #[derive(Debug, Clone)]
+    pub struct SequenceEncoder<'e>(encoding::ArrayEncoder<4>);
+}
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// The decoder for the [`Sequence`] type.
+    #[derive(Debug, Clone)]
+    pub struct SequenceDecoder(encoding::ArrayDecoder<4>);
+
+    /// Constructs a new [`Sequence`] decoder.
+    pub const fn new() -> Self { Self(encoding::ArrayDecoder::new()) }
+
+    fn end(result: Result<[u8; 4], encoding::UnexpectedEofError>) -> Result<Sequence, SequenceDecoderError> {
+        let value = result.map_err(SequenceDecoderError)?;
+        let n = u32::from_le_bytes(value);
+        Ok(Sequence::from_consensus(n))
+    }
+}
+
+/// An error consensus decoding an `Sequence`.
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SequenceDecoderError(pub(super) encoding::UnexpectedEofError);
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for SequenceDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl fmt::Display for SequenceDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write_err!(f, "sequence decoder error"; self.0)
+    }
+}
+
+#[cfg(all(feature = "std", feature = "encoding"))]
+impl std::error::Error for SequenceDecoderError {
+    #[inline]
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
+}
+
 /// Bitcoin transaction output.
 ///
 /// Defines new coins to be created as a result of the transaction,

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -21,6 +21,7 @@
 //! * `rand` - (dependency), makes it more convenient to generate random values.
 //! * `serde` - (dependency), implements `serde`-based serialization and
 //!   deserialization.
+//! * `encoding` - enables consensus encoding support.
 //! * `secp-lowmemory` - optimizations for low-memory devices.
 //! * `bitcoinconsensus-std` - enables `std` in `bitcoinconsensus` and communicates it to this
 //!   crate so it knows how to implement `std::error::Error`. At this time there's a hack to
@@ -73,6 +74,9 @@ pub extern crate hex;
 
 /// Re-export the `bitcoin-io` crate.
 pub extern crate io;
+
+#[cfg(feature = "encoding")]
+pub extern crate encoding;
 
 /// Re-export the `ordered` crate.
 #[cfg(feature = "ordered")]
@@ -168,6 +172,10 @@ mod prelude {
 
     pub use hex::DisplayHex;
 }
+
+// decoder_newtype! macro
+#[cfg(feature = "encoding")]
+include!("../include/decoder_newtype.rs");
 
 pub mod amount {
     //! Bitcoin amounts.

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -7,6 +7,8 @@
 //!
 
 use core::cmp;
+#[cfg(feature = "encoding")]
+use core::convert::Infallible;
 use core::fmt::{self, LowerHex, UpperHex};
 use core::ops::{Add, Div, Mul, Not, Rem, Shl, Shr, Sub};
 
@@ -20,6 +22,8 @@ use crate::consensus::Params;
 use crate::error::{
     ContainsPrefixError, MissingPrefixError, ParseIntError, PrefixedHexError, UnprefixedHexError,
 };
+#[cfg(feature = "encoding")]
+use crate::internal_macros::write_err;
 
 /// Implement traits and methods shared by `Target` and `Work`.
 macro_rules! do_impl {
@@ -471,6 +475,68 @@ impl LowerHex for CompactTarget {
 impl UpperHex for CompactTarget {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { UpperHex::fmt(&self.0, f) }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for CompactTarget {
+    type Encoder<'e> = CompactTargetEncoder<'e>;
+    #[inline]
+    fn encoder(&self) -> Self::Encoder<'_> {
+        CompactTargetEncoder::new(encoding::ArrayEncoder::without_length_prefix(
+            self.to_consensus().to_le_bytes(),
+        ))
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for CompactTarget {
+    type Decoder = CompactTargetDecoder;
+}
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// The encoder for the [`CompactTarget`] type.
+    #[derive(Debug, Clone)]
+    pub struct CompactTargetEncoder<'e>(encoding::ArrayEncoder<4>);
+}
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// The decoder for the [`CompactTarget`] type.
+    #[derive(Debug, Clone)]
+    pub struct CompactTargetDecoder(encoding::ArrayDecoder<4>);
+
+    /// Constructs a new [`CompactTarget`] decoder.
+    pub const fn new() -> Self { Self(encoding::ArrayDecoder::new()) }
+
+    fn end(result: Result<[u8; 4], encoding::UnexpectedEofError>) -> Result<CompactTarget, CompactTargetDecoderError> {
+        let value = result.map_err(CompactTargetDecoderError)?;
+        let n = u32::from_le_bytes(value);
+        Ok(CompactTarget::from_consensus(n))
+    }
+}
+
+/// An error consensus decoding a `CompactTarget`.
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompactTargetDecoderError(pub(super) encoding::UnexpectedEofError);
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for CompactTargetDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl fmt::Display for CompactTargetDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write_err!(f, "compact target decoder error"; self.0)
+    }
+}
+
+#[cfg(all(feature = "std", feature = "encoding"))]
+impl std::error::Error for CompactTargetDecoderError {
+    #[inline]
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
 }
 
 /// Big-endian 256 bit integer type.

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,7 +11,7 @@ cargo-fuzz = true
 
 [dependencies]
 honggfuzz = { version = "0.5.55", default-features = false }
-bitcoin = { path = "../bitcoin", features = [ "serde" ] }
+bitcoin = { path = "../bitcoin", features = [ "serde", "encoding" ] }
 
 serde = { version = "1.0.130", features = [ "derive" ] }
 serde_json = "1.0.68"
@@ -56,6 +56,10 @@ path = "fuzz_targets/bitcoin/outpoint_string.rs"
 [[bin]]
 name = "bitcoin_script_bytes_to_asm_fmt"
 path = "fuzz_targets/bitcoin/script_bytes_to_asm_fmt.rs"
+
+[[bin]]
+name = "bitcoin_compare_consensus_encoding"
+path = "fuzz_targets/bitcoin/compare_consensus_encoding.rs"
 
 [[bin]]
 name = "hashes_cbor"

--- a/fuzz/fuzz_targets/bitcoin/compare_consensus_encoding.rs
+++ b/fuzz/fuzz_targets/bitcoin/compare_consensus_encoding.rs
@@ -1,0 +1,61 @@
+use bitcoin::absolute;
+use bitcoin::consensus::encode::deserialize_partial;
+use bitcoin::consensus::serialize;
+use bitcoin::encoding::{self, decode_from_slice_unbounded};
+use honggfuzz::fuzz;
+
+macro_rules! compare_encoding {
+    ($data:expr, $ty:ident) => {
+        compare_encoding!($data, bitcoin::$ty);
+    };
+
+    ($data:expr, $ty:ty) => {{
+        // Use partial/unbounded decoding so the fuzzer can exercise the actual parsing
+        // logic even when the input is longer than the encoded type. Using strict
+        // deserialize() would reject any input with trailing bytes, reducing coverage.
+        let old_result = deserialize_partial::<$ty>($data);
+        let mut rem = &*$data;
+        let new_result: Result<$ty, _> = decode_from_slice_unbounded(&mut rem);
+
+        match (old_result, new_result) {
+            (Ok((old_obj, old_consumed)), Ok(new_obj)) => {
+                assert_eq!(old_obj, new_obj);
+                let new_consumed = $data.len() - rem.len();
+                assert_eq!(
+                    old_consumed, new_consumed,
+                    "decoders consumed different number of bytes: legacy={old_consumed}, new={new_consumed}"
+                );
+                let old_encoded = serialize(&old_obj);
+                let new_encoded = encoding::encode_to_vec(&new_obj);
+                assert_eq!(old_encoded, new_encoded);
+            }
+            (Err(_), Err(_)) => {}
+            (Ok((old_obj, _)), Err(err)) => {
+                panic!("legacy decoder accepted {old_obj:?}, new decoder failed: {err:?}");
+            }
+            (Err(err), Ok(new_obj)) => {
+                panic!("new decoder accepted {new_obj:?}, legacy decoder failed: {err:?}");
+            }
+        }
+    }};
+}
+
+fn do_test(data: &[u8]) {
+    // Split data evenly so the fuzzer can independently explore each type's input space.
+    // Each type gets its own non-overlapping sub-slice; `Amount` needs 8 bytes (u64 LE),
+    // the rest need 4 bytes (u32 LE). Trailing bytes in each slice are tolerated by the
+    // partial/unbounded decoders used in `compare_encoding!`.
+    let n = data.len() / 4;
+    compare_encoding!(&data[..n], Amount);
+    compare_encoding!(&data[n..2 * n], Sequence);
+    compare_encoding!(&data[2 * n..3 * n], CompactTarget);
+    compare_encoding!(&data[3 * n..4 * n], absolute::LockTime);
+}
+
+fn main() {
+    loop {
+        fuzz!(|data| {
+            do_test(data);
+        });
+    }
+}

--- a/fuzz/generate-files.sh
+++ b/fuzz/generate-files.sh
@@ -22,7 +22,7 @@ cargo-fuzz = true
 
 [dependencies]
 honggfuzz = { version = "0.5.55", default-features = false }
-bitcoin = { path = "../bitcoin", features = [ "serde" ] }
+bitcoin = { path = "../bitcoin", features = [ "serde", "encoding" ] }
 
 serde = { version = "1.0.130", features = [ "derive" ] }
 serde_json = "1.0.68"

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -33,7 +33,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 hex = { package = "hex-conservative", version = "0.2.2", default-features = false }
 
-bitcoin-io = { version = "0.1.1", default-features = false, optional = true }
+bitcoin-io = { version = "0.1.100", default-features = false, optional = true }
 # Do NOT use this as a feature! Use the `schemars` feature instead.
 actual-schemars = { package = "schemars", version = "0.8.3", default-features = false, optional = true }
 serde = { version = "1.0.130", default-features = false, optional = true }

--- a/hashes/api/all-features.txt
+++ b/hashes/api/all-features.txt
@@ -53,10 +53,10 @@ pub fn bitcoin_hashes::hash160::Hash::from_str(s: &str) -> core::result::Result<
 impl schemars::JsonSchema for bitcoin_hashes::hash160::Hash
 pub fn bitcoin_hashes::hash160::Hash::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
 pub fn bitcoin_hashes::hash160::Hash::schema_name() -> alloc::string::String
-impl serde::ser::Serialize for bitcoin_hashes::hash160::Hash
-pub fn bitcoin_hashes::hash160::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::hash160::Hash
-pub fn bitcoin_hashes::hash160::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::hash160::Hash, <D as serde::de::Deserializer>::Error>
+impl serde_core::ser::Serialize for bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::hash160::Hash::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin_hashes::hash160::Hash
+pub fn bitcoin_hashes::hash160::Hash::deserialize<D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::hash160::Hash, <D as serde_core::de::Deserializer>::Error>
 impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::hash160::Hash
 pub type bitcoin_hashes::hash160::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
 pub fn bitcoin_hashes::hash160::Hash::index(&self, index: I) -> &Self::Output
@@ -93,11 +93,11 @@ impl<T> core::convert::From<T> for bitcoin_hashes::hash160::Hash
 pub fn bitcoin_hashes::hash160::Hash::from(t: T) -> T
 impl<T> dyn_clone::DynClone for bitcoin_hashes::hash160::Hash where T: core::clone::Clone
 pub fn bitcoin_hashes::hash160::Hash::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
-impl<T> serde::de::DeserializeOwned for bitcoin_hashes::hash160::Hash where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin_hashes::hash160::Hash where T: for<'de> serde_core::de::Deserialize<'de>
 pub mod bitcoin_hashes::hmac
 #[repr(transparent)] pub struct bitcoin_hashes::hmac::Hmac<T: bitcoin_hashes::Hash>(_)
-impl<'de, T: bitcoin_hashes::Hash + serde::de::Deserialize<'de>> serde::de::Deserialize<'de> for bitcoin_hashes::hmac::Hmac<T>
-pub fn bitcoin_hashes::hmac::Hmac<T>::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::hmac::Hmac<T>, <D as serde::de::Deserializer>::Error>
+impl<'de, T: bitcoin_hashes::Hash + serde_core::de::Deserialize<'de>> serde_core::de::Deserialize<'de> for bitcoin_hashes::hmac::Hmac<T>
+pub fn bitcoin_hashes::hmac::Hmac<T>::deserialize<D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::hmac::Hmac<T>, <D as serde_core::de::Deserializer>::Error>
 impl<T: bitcoin_hashes::Hash + core::str::traits::FromStr> core::str::traits::FromStr for bitcoin_hashes::hmac::Hmac<T>
 pub type bitcoin_hashes::hmac::Hmac<T>::Err = <T as core::str::traits::FromStr>::Err
 pub fn bitcoin_hashes::hmac::Hmac<T>::from_str(s: &str) -> core::result::Result<Self, Self::Err>
@@ -105,8 +105,8 @@ impl<T: bitcoin_hashes::Hash + schemars::JsonSchema> schemars::JsonSchema for bi
 pub fn bitcoin_hashes::hmac::Hmac<T>::is_referenceable() -> bool
 pub fn bitcoin_hashes::hmac::Hmac<T>::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
 pub fn bitcoin_hashes::hmac::Hmac<T>::schema_name() -> alloc::string::String
-impl<T: bitcoin_hashes::Hash + serde::ser::Serialize> serde::ser::Serialize for bitcoin_hashes::hmac::Hmac<T>
-pub fn bitcoin_hashes::hmac::Hmac<T>::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+impl<T: bitcoin_hashes::Hash + serde_core::ser::Serialize> serde_core::ser::Serialize for bitcoin_hashes::hmac::Hmac<T>
+pub fn bitcoin_hashes::hmac::Hmac<T>::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 impl<T: bitcoin_hashes::Hash> bitcoin_hashes::Hash for bitcoin_hashes::hmac::Hmac<T>
 pub type bitcoin_hashes::hmac::Hmac<T>::Bytes = <T as bitcoin_hashes::Hash>::Bytes
 pub type bitcoin_hashes::hmac::Hmac<T>::Engine = bitcoin_hashes::hmac::HmacEngine<T>
@@ -181,7 +181,7 @@ impl<T> core::convert::From<T> for bitcoin_hashes::hmac::Hmac<T>
 pub fn bitcoin_hashes::hmac::Hmac<T>::from(t: T) -> T
 impl<T> dyn_clone::DynClone for bitcoin_hashes::hmac::Hmac<T> where T: core::clone::Clone
 pub fn bitcoin_hashes::hmac::Hmac<T>::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
-impl<T> serde::de::DeserializeOwned for bitcoin_hashes::hmac::Hmac<T> where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin_hashes::hmac::Hmac<T> where T: for<'de> serde_core::de::Deserialize<'de>
 pub struct bitcoin_hashes::hmac::HmacEngine<T: bitcoin_hashes::Hash>
 impl<T: bitcoin_hashes::Hash> bitcoin_hashes::hmac::HmacEngine<T>
 pub fn bitcoin_hashes::hmac::HmacEngine<T>::from_inner_engines(iengine: <T as bitcoin_hashes::Hash>::Engine, oengine: <T as bitcoin_hashes::Hash>::Engine) -> bitcoin_hashes::hmac::HmacEngine<T>
@@ -309,10 +309,10 @@ pub fn bitcoin_hashes::ripemd160::Hash::from_str(s: &str) -> core::result::Resul
 impl schemars::JsonSchema for bitcoin_hashes::ripemd160::Hash
 pub fn bitcoin_hashes::ripemd160::Hash::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
 pub fn bitcoin_hashes::ripemd160::Hash::schema_name() -> alloc::string::String
-impl serde::ser::Serialize for bitcoin_hashes::ripemd160::Hash
-pub fn bitcoin_hashes::ripemd160::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::ripemd160::Hash
-pub fn bitcoin_hashes::ripemd160::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::ripemd160::Hash, <D as serde::de::Deserializer>::Error>
+impl serde_core::ser::Serialize for bitcoin_hashes::ripemd160::Hash
+pub fn bitcoin_hashes::ripemd160::Hash::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin_hashes::ripemd160::Hash
+pub fn bitcoin_hashes::ripemd160::Hash::deserialize<D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::ripemd160::Hash, <D as serde_core::de::Deserializer>::Error>
 impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::ripemd160::Hash
 pub type bitcoin_hashes::ripemd160::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
 pub fn bitcoin_hashes::ripemd160::Hash::index(&self, index: I) -> &Self::Output
@@ -349,7 +349,7 @@ impl<T> core::convert::From<T> for bitcoin_hashes::ripemd160::Hash
 pub fn bitcoin_hashes::ripemd160::Hash::from(t: T) -> T
 impl<T> dyn_clone::DynClone for bitcoin_hashes::ripemd160::Hash where T: core::clone::Clone
 pub fn bitcoin_hashes::ripemd160::Hash::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
-impl<T> serde::de::DeserializeOwned for bitcoin_hashes::ripemd160::Hash where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin_hashes::ripemd160::Hash where T: for<'de> serde_core::de::Deserialize<'de>
 pub struct bitcoin_hashes::ripemd160::HashEngine
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::ripemd160::HashEngine
 pub type bitcoin_hashes::ripemd160::HashEngine::MidState = [u8; 20]
@@ -402,9 +402,9 @@ pub mod bitcoin_hashes::serde_macros
 pub mod bitcoin_hashes::serde_macros::serde_details
 pub trait bitcoin_hashes::serde_macros::serde_details::SerdeHash where Self: core::marker::Sized + core::str::traits::FromStr + core::fmt::Display + core::ops::index::Index<usize, Output = u8> + core::ops::index::Index<core::ops::range::RangeFull, Output = [u8]>, <Self as core::str::traits::FromStr>::Err: core::fmt::Display
 pub const bitcoin_hashes::serde_macros::serde_details::SerdeHash::N: usize
-pub fn bitcoin_hashes::serde_macros::serde_details::SerdeHash::deserialize<'de, D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
+pub fn bitcoin_hashes::serde_macros::serde_details::SerdeHash::deserialize<'de, D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<Self, <D as serde_core::de::Deserializer>::Error>
 pub fn bitcoin_hashes::serde_macros::serde_details::SerdeHash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
-pub fn bitcoin_hashes::serde_macros::serde_details::SerdeHash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_hashes::serde_macros::serde_details::SerdeHash::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 impl bitcoin_hashes::serde_macros::serde_details::SerdeHash for bitcoin_hashes::sha1::Hash
 pub const bitcoin_hashes::sha1::Hash::N: usize
 pub fn bitcoin_hashes::sha1::Hash::from_slice_delegated(sl: &[u8]) -> core::result::Result<Self, bitcoin_hashes::FromSliceError>
@@ -479,10 +479,10 @@ pub fn bitcoin_hashes::sha1::Hash::from_str(s: &str) -> core::result::Result<Sel
 impl schemars::JsonSchema for bitcoin_hashes::sha1::Hash
 pub fn bitcoin_hashes::sha1::Hash::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
 pub fn bitcoin_hashes::sha1::Hash::schema_name() -> alloc::string::String
-impl serde::ser::Serialize for bitcoin_hashes::sha1::Hash
-pub fn bitcoin_hashes::sha1::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::sha1::Hash
-pub fn bitcoin_hashes::sha1::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha1::Hash, <D as serde::de::Deserializer>::Error>
+impl serde_core::ser::Serialize for bitcoin_hashes::sha1::Hash
+pub fn bitcoin_hashes::sha1::Hash::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin_hashes::sha1::Hash
+pub fn bitcoin_hashes::sha1::Hash::deserialize<D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha1::Hash, <D as serde_core::de::Deserializer>::Error>
 impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha1::Hash
 pub type bitcoin_hashes::sha1::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
 pub fn bitcoin_hashes::sha1::Hash::index(&self, index: I) -> &Self::Output
@@ -519,7 +519,7 @@ impl<T> core::convert::From<T> for bitcoin_hashes::sha1::Hash
 pub fn bitcoin_hashes::sha1::Hash::from(t: T) -> T
 impl<T> dyn_clone::DynClone for bitcoin_hashes::sha1::Hash where T: core::clone::Clone
 pub fn bitcoin_hashes::sha1::Hash::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
-impl<T> serde::de::DeserializeOwned for bitcoin_hashes::sha1::Hash where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin_hashes::sha1::Hash where T: for<'de> serde_core::de::Deserialize<'de>
 pub struct bitcoin_hashes::sha1::HashEngine
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha1::HashEngine
 pub type bitcoin_hashes::sha1::HashEngine::MidState = [u8; 20]
@@ -617,10 +617,10 @@ pub fn bitcoin_hashes::sha256::Hash::from_str(s: &str) -> core::result::Result<S
 impl schemars::JsonSchema for bitcoin_hashes::sha256::Hash
 pub fn bitcoin_hashes::sha256::Hash::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
 pub fn bitcoin_hashes::sha256::Hash::schema_name() -> alloc::string::String
-impl serde::ser::Serialize for bitcoin_hashes::sha256::Hash
-pub fn bitcoin_hashes::sha256::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::sha256::Hash
-pub fn bitcoin_hashes::sha256::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha256::Hash, <D as serde::de::Deserializer>::Error>
+impl serde_core::ser::Serialize for bitcoin_hashes::sha256::Hash
+pub fn bitcoin_hashes::sha256::Hash::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin_hashes::sha256::Hash
+pub fn bitcoin_hashes::sha256::Hash::deserialize<D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha256::Hash, <D as serde_core::de::Deserializer>::Error>
 impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha256::Hash
 pub type bitcoin_hashes::sha256::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
 pub fn bitcoin_hashes::sha256::Hash::index(&self, index: I) -> &Self::Output
@@ -657,7 +657,7 @@ impl<T> core::convert::From<T> for bitcoin_hashes::sha256::Hash
 pub fn bitcoin_hashes::sha256::Hash::from(t: T) -> T
 impl<T> dyn_clone::DynClone for bitcoin_hashes::sha256::Hash where T: core::clone::Clone
 pub fn bitcoin_hashes::sha256::Hash::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
-impl<T> serde::de::DeserializeOwned for bitcoin_hashes::sha256::Hash where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin_hashes::sha256::Hash where T: for<'de> serde_core::de::Deserialize<'de>
 pub struct bitcoin_hashes::sha256::HashEngine
 impl bitcoin_hashes::sha256::HashEngine
 pub fn bitcoin_hashes::sha256::HashEngine::from_midstate(midstate: bitcoin_hashes::sha256::Midstate, length: usize) -> bitcoin_hashes::sha256::HashEngine
@@ -744,10 +744,10 @@ pub fn bitcoin_hashes::sha256::Midstate::from_str(s: &str) -> core::result::Resu
 impl hex_conservative::parse::FromHex for bitcoin_hashes::sha256::Midstate
 pub type bitcoin_hashes::sha256::Midstate::Error = hex_conservative::error::HexToArrayError
 pub fn bitcoin_hashes::sha256::Midstate::from_hex(s: &str) -> core::result::Result<Self, Self::Error>
-impl serde::ser::Serialize for bitcoin_hashes::sha256::Midstate
-pub fn bitcoin_hashes::sha256::Midstate::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::sha256::Midstate
-pub fn bitcoin_hashes::sha256::Midstate::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha256::Midstate, <D as serde::de::Deserializer>::Error>
+impl serde_core::ser::Serialize for bitcoin_hashes::sha256::Midstate
+pub fn bitcoin_hashes::sha256::Midstate::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin_hashes::sha256::Midstate
+pub fn bitcoin_hashes::sha256::Midstate::deserialize<D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha256::Midstate, <D as serde_core::de::Deserializer>::Error>
 impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha256::Midstate
 pub type bitcoin_hashes::sha256::Midstate::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
 pub fn bitcoin_hashes::sha256::Midstate::index(&self, index: I) -> &Self::Output
@@ -784,7 +784,7 @@ impl<T> core::convert::From<T> for bitcoin_hashes::sha256::Midstate
 pub fn bitcoin_hashes::sha256::Midstate::from(t: T) -> T
 impl<T> dyn_clone::DynClone for bitcoin_hashes::sha256::Midstate where T: core::clone::Clone
 pub fn bitcoin_hashes::sha256::Midstate::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
-impl<T> serde::de::DeserializeOwned for bitcoin_hashes::sha256::Midstate where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin_hashes::sha256::Midstate where T: for<'de> serde_core::de::Deserialize<'de>
 pub mod bitcoin_hashes::sha256d
 #[repr(transparent)] pub struct bitcoin_hashes::sha256d::Hash(_)
 impl bitcoin_hashes::sha256d::Hash
@@ -832,10 +832,10 @@ pub fn bitcoin_hashes::sha256d::Hash::from_str(s: &str) -> core::result::Result<
 impl schemars::JsonSchema for bitcoin_hashes::sha256d::Hash
 pub fn bitcoin_hashes::sha256d::Hash::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
 pub fn bitcoin_hashes::sha256d::Hash::schema_name() -> alloc::string::String
-impl serde::ser::Serialize for bitcoin_hashes::sha256d::Hash
-pub fn bitcoin_hashes::sha256d::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::sha256d::Hash
-pub fn bitcoin_hashes::sha256d::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha256d::Hash, <D as serde::de::Deserializer>::Error>
+impl serde_core::ser::Serialize for bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin_hashes::sha256d::Hash
+pub fn bitcoin_hashes::sha256d::Hash::deserialize<D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha256d::Hash, <D as serde_core::de::Deserializer>::Error>
 impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha256d::Hash
 pub type bitcoin_hashes::sha256d::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
 pub fn bitcoin_hashes::sha256d::Hash::index(&self, index: I) -> &Self::Output
@@ -872,14 +872,14 @@ impl<T> core::convert::From<T> for bitcoin_hashes::sha256d::Hash
 pub fn bitcoin_hashes::sha256d::Hash::from(t: T) -> T
 impl<T> dyn_clone::DynClone for bitcoin_hashes::sha256d::Hash where T: core::clone::Clone
 pub fn bitcoin_hashes::sha256d::Hash::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
-impl<T> serde::de::DeserializeOwned for bitcoin_hashes::sha256d::Hash where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin_hashes::sha256d::Hash where T: for<'de> serde_core::de::Deserialize<'de>
 pub mod bitcoin_hashes::sha256t
 #[repr(transparent)] pub struct bitcoin_hashes::sha256t::Hash<T: bitcoin_hashes::sha256t::Tag>(_, _)
 impl<T: bitcoin_hashes::sha256t::Tag> bitcoin_hashes::sha256t::Hash<T>
 pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
 pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_ref(bytes: &[u8; 32]) -> &Self
-impl<'de, T: bitcoin_hashes::sha256t::Tag> serde::de::Deserialize<'de> for bitcoin_hashes::sha256t::Hash<T>
-pub fn bitcoin_hashes::sha256t::Hash<T>::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha256t::Hash<T>, <D as serde::de::Deserializer>::Error>
+impl<'de, T: bitcoin_hashes::sha256t::Tag> serde_core::de::Deserialize<'de> for bitcoin_hashes::sha256t::Hash<T>
+pub fn bitcoin_hashes::sha256t::Hash<T>::deserialize<D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha256t::Hash<T>, <D as serde_core::de::Deserializer>::Error>
 impl<I: core::slice::index::SliceIndex<[u8]>, T: bitcoin_hashes::sha256t::Tag> core::ops::index::Index<I> for bitcoin_hashes::sha256t::Hash<T>
 pub type bitcoin_hashes::sha256t::Hash<T>::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
 pub fn bitcoin_hashes::sha256t::Hash<T>::index(&self, index: I) -> &Self::Output
@@ -926,8 +926,8 @@ pub fn bitcoin_hashes::sha256t::Hash<T>::from_str(s: &str) -> core::result::Resu
 impl<T: bitcoin_hashes::sha256t::Tag> schemars::JsonSchema for bitcoin_hashes::sha256t::Hash<T>
 pub fn bitcoin_hashes::sha256t::Hash<T>::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
 pub fn bitcoin_hashes::sha256t::Hash<T>::schema_name() -> alloc::string::String
-impl<T: bitcoin_hashes::sha256t::Tag> serde::ser::Serialize for bitcoin_hashes::sha256t::Hash<T>
-pub fn bitcoin_hashes::sha256t::Hash<T>::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+impl<T: bitcoin_hashes::sha256t::Tag> serde_core::ser::Serialize for bitcoin_hashes::sha256t::Hash<T>
+pub fn bitcoin_hashes::sha256t::Hash<T>::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 impl<T> core::marker::Freeze for bitcoin_hashes::sha256t::Hash<T>
 impl<T> core::marker::Send for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Send
 impl<T> core::marker::Sync for bitcoin_hashes::sha256t::Hash<T> where T: core::marker::Sync
@@ -961,7 +961,7 @@ impl<T> core::convert::From<T> for bitcoin_hashes::sha256t::Hash<T>
 pub fn bitcoin_hashes::sha256t::Hash<T>::from(t: T) -> T
 impl<T> dyn_clone::DynClone for bitcoin_hashes::sha256t::Hash<T> where T: core::clone::Clone
 pub fn bitcoin_hashes::sha256t::Hash<T>::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
-impl<T> serde::de::DeserializeOwned for bitcoin_hashes::sha256t::Hash<T> where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin_hashes::sha256t::Hash<T> where T: for<'de> serde_core::de::Deserialize<'de>
 pub trait bitcoin_hashes::sha256t::Tag
 pub fn bitcoin_hashes::sha256t::Tag::engine() -> bitcoin_hashes::sha256::HashEngine
 pub mod bitcoin_hashes::sha384
@@ -1011,10 +1011,10 @@ pub fn bitcoin_hashes::sha384::Hash::from_str(s: &str) -> core::result::Result<S
 impl schemars::JsonSchema for bitcoin_hashes::sha384::Hash
 pub fn bitcoin_hashes::sha384::Hash::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
 pub fn bitcoin_hashes::sha384::Hash::schema_name() -> alloc::string::String
-impl serde::ser::Serialize for bitcoin_hashes::sha384::Hash
-pub fn bitcoin_hashes::sha384::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::sha384::Hash
-pub fn bitcoin_hashes::sha384::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha384::Hash, <D as serde::de::Deserializer>::Error>
+impl serde_core::ser::Serialize for bitcoin_hashes::sha384::Hash
+pub fn bitcoin_hashes::sha384::Hash::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin_hashes::sha384::Hash
+pub fn bitcoin_hashes::sha384::Hash::deserialize<D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha384::Hash, <D as serde_core::de::Deserializer>::Error>
 impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha384::Hash
 pub type bitcoin_hashes::sha384::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
 pub fn bitcoin_hashes::sha384::Hash::index(&self, index: I) -> &Self::Output
@@ -1051,7 +1051,7 @@ impl<T> core::convert::From<T> for bitcoin_hashes::sha384::Hash
 pub fn bitcoin_hashes::sha384::Hash::from(t: T) -> T
 impl<T> dyn_clone::DynClone for bitcoin_hashes::sha384::Hash where T: core::clone::Clone
 pub fn bitcoin_hashes::sha384::Hash::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
-impl<T> serde::de::DeserializeOwned for bitcoin_hashes::sha384::Hash where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin_hashes::sha384::Hash where T: for<'de> serde_core::de::Deserialize<'de>
 pub struct bitcoin_hashes::sha384::HashEngine(_)
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha384::HashEngine
 pub type bitcoin_hashes::sha384::HashEngine::MidState = [u8; 64]
@@ -1141,10 +1141,10 @@ pub fn bitcoin_hashes::sha512::Hash::from_str(s: &str) -> core::result::Result<S
 impl schemars::JsonSchema for bitcoin_hashes::sha512::Hash
 pub fn bitcoin_hashes::sha512::Hash::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
 pub fn bitcoin_hashes::sha512::Hash::schema_name() -> alloc::string::String
-impl serde::ser::Serialize for bitcoin_hashes::sha512::Hash
-pub fn bitcoin_hashes::sha512::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::sha512::Hash
-pub fn bitcoin_hashes::sha512::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha512::Hash, <D as serde::de::Deserializer>::Error>
+impl serde_core::ser::Serialize for bitcoin_hashes::sha512::Hash
+pub fn bitcoin_hashes::sha512::Hash::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin_hashes::sha512::Hash
+pub fn bitcoin_hashes::sha512::Hash::deserialize<D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha512::Hash, <D as serde_core::de::Deserializer>::Error>
 impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha512::Hash
 pub type bitcoin_hashes::sha512::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
 pub fn bitcoin_hashes::sha512::Hash::index(&self, index: I) -> &Self::Output
@@ -1181,7 +1181,7 @@ impl<T> core::convert::From<T> for bitcoin_hashes::sha512::Hash
 pub fn bitcoin_hashes::sha512::Hash::from(t: T) -> T
 impl<T> dyn_clone::DynClone for bitcoin_hashes::sha512::Hash where T: core::clone::Clone
 pub fn bitcoin_hashes::sha512::Hash::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
-impl<T> serde::de::DeserializeOwned for bitcoin_hashes::sha512::Hash where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin_hashes::sha512::Hash where T: for<'de> serde_core::de::Deserialize<'de>
 pub struct bitcoin_hashes::sha512::HashEngine
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512::HashEngine
 pub type bitcoin_hashes::sha512::HashEngine::MidState = [u8; 64]
@@ -1277,10 +1277,10 @@ pub fn bitcoin_hashes::sha512_256::Hash::from_str(s: &str) -> core::result::Resu
 impl schemars::JsonSchema for bitcoin_hashes::sha512_256::Hash
 pub fn bitcoin_hashes::sha512_256::Hash::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
 pub fn bitcoin_hashes::sha512_256::Hash::schema_name() -> alloc::string::String
-impl serde::ser::Serialize for bitcoin_hashes::sha512_256::Hash
-pub fn bitcoin_hashes::sha512_256::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::sha512_256::Hash
-pub fn bitcoin_hashes::sha512_256::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha512_256::Hash, <D as serde::de::Deserializer>::Error>
+impl serde_core::ser::Serialize for bitcoin_hashes::sha512_256::Hash
+pub fn bitcoin_hashes::sha512_256::Hash::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin_hashes::sha512_256::Hash
+pub fn bitcoin_hashes::sha512_256::Hash::deserialize<D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha512_256::Hash, <D as serde_core::de::Deserializer>::Error>
 impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::sha512_256::Hash
 pub type bitcoin_hashes::sha512_256::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
 pub fn bitcoin_hashes::sha512_256::Hash::index(&self, index: I) -> &Self::Output
@@ -1317,7 +1317,7 @@ impl<T> core::convert::From<T> for bitcoin_hashes::sha512_256::Hash
 pub fn bitcoin_hashes::sha512_256::Hash::from(t: T) -> T
 impl<T> dyn_clone::DynClone for bitcoin_hashes::sha512_256::Hash where T: core::clone::Clone
 pub fn bitcoin_hashes::sha512_256::Hash::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
-impl<T> serde::de::DeserializeOwned for bitcoin_hashes::sha512_256::Hash where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin_hashes::sha512_256::Hash where T: for<'de> serde_core::de::Deserialize<'de>
 pub struct bitcoin_hashes::sha512_256::HashEngine(_)
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512_256::HashEngine
 pub type bitcoin_hashes::sha512_256::HashEngine::MidState = [u8; 64]
@@ -1412,10 +1412,10 @@ pub fn bitcoin_hashes::siphash24::Hash::from_str(s: &str) -> core::result::Resul
 impl schemars::JsonSchema for bitcoin_hashes::siphash24::Hash
 pub fn bitcoin_hashes::siphash24::Hash::json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema
 pub fn bitcoin_hashes::siphash24::Hash::schema_name() -> alloc::string::String
-impl serde::ser::Serialize for bitcoin_hashes::siphash24::Hash
-pub fn bitcoin_hashes::siphash24::Hash::serialize<S: serde::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-impl<'de> serde::de::Deserialize<'de> for bitcoin_hashes::siphash24::Hash
-pub fn bitcoin_hashes::siphash24::Hash::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::siphash24::Hash, <D as serde::de::Deserializer>::Error>
+impl serde_core::ser::Serialize for bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::serialize<S: serde_core::ser::Serializer>(&self, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin_hashes::siphash24::Hash
+pub fn bitcoin_hashes::siphash24::Hash::deserialize<D: serde_core::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::siphash24::Hash, <D as serde_core::de::Deserializer>::Error>
 impl<I: core::slice::index::SliceIndex<[u8]>> core::ops::index::Index<I> for bitcoin_hashes::siphash24::Hash
 pub type bitcoin_hashes::siphash24::Hash::Output = <I as core::slice::index::SliceIndex<[u8]>>::Output
 pub fn bitcoin_hashes::siphash24::Hash::index(&self, index: I) -> &Self::Output
@@ -1452,7 +1452,7 @@ impl<T> core::convert::From<T> for bitcoin_hashes::siphash24::Hash
 pub fn bitcoin_hashes::siphash24::Hash::from(t: T) -> T
 impl<T> dyn_clone::DynClone for bitcoin_hashes::siphash24::Hash where T: core::clone::Clone
 pub fn bitcoin_hashes::siphash24::Hash::__clone_box(&self, _: dyn_clone::sealed::Private) -> *mut ()
-impl<T> serde::de::DeserializeOwned for bitcoin_hashes::siphash24::Hash where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin_hashes::siphash24::Hash where T: for<'de> serde_core::de::Deserialize<'de>
 pub struct bitcoin_hashes::siphash24::HashEngine
 impl bitcoin_hashes::siphash24::HashEngine
 pub fn bitcoin_hashes::siphash24::HashEngine::keys(&self) -> (u64, u64)

--- a/include/decoder_newtype.rs
+++ b/include/decoder_newtype.rs
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: CC0-1.0
+
+/// Constructs a newtype wrapper around an inner [`encoding::Decoder`] type.
+///
+/// The generated struct wraps an inner decoder and implements [`encoding::Decoder`] by delegating
+/// `push_bytes` and `read_limit` to the inner decoder, then transforming the result in `end`.
+///
+/// ## Required items
+///
+/// * **Struct definition** - declares the newtype with its inner decoder type.
+/// * `fn end` - receives the `Result` returned by the inner decoder's `end` method (i.e.
+///   `Result<InnerOutput, InnerError>`) and must return a `Result<Output, Error>` for the
+///   newtype decoder.
+///
+/// ## Optional items
+///
+/// * `fn new` - a custom constructor. If provided, this macro also generates a [`Default`]
+///   impl that calls through to `new()`. You may specify any visibility and/or make the function
+///   const. If omitted, the resulting type will not have a new function or a [`Default`] impl.
+/// * `fn map_push_bytes_err` - a custom error mapping function to tranform any error from the inner
+///   decoder's `push_bytes` to the wrapper decoder's error type. If omitted, the macro assumes
+///   the error type is a single value newtype that directly wraps the inner error.
+///
+/// Both `fn new` and `fn map_push_bytes_err` are independently optional, giving four possible forms.
+/// Due to limitations in macros, the order must be `new`, `push_bytes_err`, then `end`.
+///
+/// ## Attributes
+///
+/// You can add arbitrary doc comments or attributes to the struct definition and the new function.
+/// Note that the new function always has #[inline].
+///
+/// # Examples
+///
+/// Minimal form (no `new`, no `push_bytes_err`):
+///
+/// ```ignore
+/// decoder_newtype! {
+///     /// The decoder for the [`Block`] type.
+///     pub struct BlockDecoder(BlockInnerDecoder);
+///
+///     fn end(
+///         result: Result<(Header, Vec<Transaction>), <BlockInnerDecoder as Decoder>::Error>
+///     ) -> Result<Block, BlockDecoderError> {
+///         let (header, transactions) = result.map_err(BlockDecoderError)?;
+///         Ok(Block::new_unchecked(header, transactions))
+///     }
+/// }
+/// ```
+///
+/// With a custom constructor:
+///
+/// ```ignore
+/// decoder_newtype! {
+///     /// The decoder for the [`BlockHeight`] type.
+///     pub struct BlockHeightDecoder(encoding::ArrayDecoder<4>);
+///
+///     /// Constructs a new [`BlockHeight`] decoder.
+///     pub const fn new() -> Self { Self(encoding::ArrayDecoder::new()) }
+///
+///     fn end(result: Result<[u8; 4], encoding::UnexpectedEofError>) -> Result<BlockHeight, BlockHeightDecoderError> {
+///         let value = result.map_err(BlockHeightDecoderError)?;
+///         let n = u32::from_le_bytes(value);
+///         Ok(BlockHeight::from_u32(n))
+///     }
+/// }
+/// ```
+///
+/// With a custom `push_bytes` error mapping:
+///
+/// ```ignore
+/// decoder_newtype! {
+///     /// The decoder for the [`Header`] type.
+///     pub struct HeaderDecoder(HeaderInnerDecoder);
+///
+///     fn map_push_bytes_err(err: <HeaderInnerDecoder as Decoder>::Error) -> HeaderDecoderError {
+///         Self::from_inner(err)
+///     }
+///
+///     fn end(
+///         result: Result<<HeaderInnerDecoder as Decoder>::Output, <HeaderInnerDecoder as Decoder>::Error>
+///     ) -> Result<Header, HeaderDecoderError> {
+///         let (version, prev_blockhash, merkle_root, time, bits, nonce) = result.map_err(Self::from_inner)?;
+///         let nonce = u32::from_le_bytes(nonce);
+///         Ok(Header { version, prev_blockhash, merkle_root, time, bits, nonce })
+///     }
+/// }
+/// ```
+macro_rules! decoder_newtype {
+    // Arm 1: without new, without push_bytes_err
+    (
+        $(#[$($struct_attr:tt)*])*
+        $vis:vis struct $name:ident($decoder:ty);
+
+        fn end($result_name:ident: $result_ty:ty) -> Result<$output:ty, $err:ident> $end_impl:block
+    ) => {
+        crate::_decoder_newtype_internal! {
+            $(#[$($struct_attr)*])*
+            $vis struct $name($decoder);
+
+            (err: <$decoder as encoding::Decoder>::Error) -> $err { $err(err) }
+            ($result_name: $result_ty) -> Result<$output, $err> $end_impl
+        }
+    };
+    // Arm 2: with new, without push_bytes_err
+    (
+        $(#[$($struct_attr:tt)*])*
+        $vis:vis struct $name:ident($decoder:ty);
+
+        $(#[$($new_attr:tt)*])*
+        $new_vis:vis $(const $($const:block)?)? fn new() -> Self $new_impl:block
+
+        fn end($result_name:ident: $result_ty:ty) -> Result<$output:ty, $err:ident> $end_impl:block
+    ) => {
+        crate::_decoder_newtype_internal! {
+            $(#[$($struct_attr)*])*
+            $vis struct $name($decoder);
+
+            (err: <$decoder as encoding::Decoder>::Error) -> $err { $err(err) }
+            ($result_name: $result_ty) -> Result<$output, $err> $end_impl
+
+            $(#[$($new_attr)*])*
+            $new_vis $(const $($const)?)? fn new() -> Self $new_impl
+        }
+    };
+    // Arm 3: without new, with push_bytes_err
+    (
+        $(#[$($struct_attr:tt)*])*
+        $vis:vis struct $name:ident($decoder:ty);
+
+        fn map_push_bytes_err($err_var:ident: $inner_err:ty) -> $err_name:ident $on_err_impl:block
+        fn end($result_name:ident: $result_ty:ty) -> Result<$output:ty, $err:ident> $end_impl:block
+    ) => {
+        crate::_decoder_newtype_internal! {
+            $(#[$($struct_attr)*])*
+            $vis struct $name($decoder);
+
+            ($err_var: $inner_err) -> $err_name $on_err_impl
+            ($result_name: $result_ty) -> Result<$output, $err> $end_impl
+        }
+    };
+    // Arm 4: with new, with push_bytes_err
+    (
+        $(#[$($struct_attr:tt)*])*
+        $vis:vis struct $name:ident($decoder:ty);
+
+        $(#[$($new_attr:tt)*])*
+        $new_vis:vis $(const $($const:block)?)? fn new() -> Self $new_impl:block
+
+        fn map_push_bytes_err($err_var:ident: $inner_err:ty) -> $err_name:ident $on_err_impl:block
+        fn end($result_name:ident: $result_ty:ty) -> Result<$output:ty, $err:ident> $end_impl:block
+    ) => {
+        crate::_decoder_newtype_internal! {
+            $(#[$($struct_attr)*])*
+            $vis struct $name($decoder);
+
+            ($err_var: $inner_err) -> $err_name $on_err_impl
+            ($result_name: $result_ty) -> Result<$output, $err> $end_impl
+
+            $(#[$($new_attr)*])*
+            $new_vis $(const $($const)?)? fn new() -> Self $new_impl
+        }
+    };
+}
+pub(crate) use decoder_newtype;
+
+// Due to macro ambiguity, the new needs to go at the end.
+macro_rules! _decoder_newtype_internal {
+    (
+        $(#[$($struct_attr:tt)*])*
+        $vis:vis struct $name:ident($decoder:ty);
+
+        ($err_var:ident: $inner_err:ty) -> $err_name:ident $on_err_impl:block
+        ($result_name:ident: $result_ty:ty) -> Result<$output:ty, $err:ident> $end_impl:block
+
+        $(
+            $(#[$($new_attr:tt)*])*
+            $new_vis:vis $(const $($const:block)?)? fn new() -> Self $new_impl:block
+        )?
+    ) => {
+        $(#[$($struct_attr)*])*
+        $vis struct $name($decoder);
+
+        $(
+            impl Default for $name {
+                #[inline]
+                fn default() -> Self { Self::new() }
+            }
+
+            impl $name {
+                $(#[$($new_attr)*])*
+                #[inline]
+                $new_vis $(const $($const)?)? fn new() -> Self $new_impl
+            }
+        )?
+
+        impl $name {
+            /// INTERNAL ONLY: Converts an inner decoder error into the correct error type.
+            /// Needed because we don't want to have a From impl in the public API just for this.
+            /// Only used by the `push_bytes` method.
+            #[inline]
+            fn push_bytes_map_err($err_var: $inner_err) -> $err $on_err_impl
+        }
+
+        impl encoding::Decoder for $name {
+            type Output = $output;
+            type Error = $err;
+
+            #[inline]
+            fn push_bytes(&mut self, bytes: &mut &[u8]) -> Result<encoding::DecoderStatus, Self::Error> {
+                self.0.push_bytes(bytes).map_err(Self::push_bytes_map_err)
+            }
+
+            #[inline]
+            fn end(self) -> Result<Self::Output, Self::Error> {
+                let end = |$result_name: $result_ty| $end_impl;
+                end(self.0.end())
+            }
+
+            #[inline]
+            fn read_limit(&self) -> usize { self.0.read_limit() }
+        }
+    };
+}
+pub(crate) use _decoder_newtype_internal;

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -17,8 +17,8 @@ exclude = ["api", "tests", "contrib"]
 
 [features]
 default = ["std"]
-std = ["alloc"]
-alloc = []
+std = ["alloc", "encoding?/std"]
+alloc = ["encoding?/alloc"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -26,6 +26,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 arbitrary = { version = "1.0.1", optional = true }
+encoding = { package = "bitcoin-consensus-encoding", version = "1.0", default-features = false, optional = true }
 serde = { version = "1.0.130", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/units/api/all-features.txt
+++ b/units/api/all-features.txt
@@ -305,6 +305,11 @@ pub fn bitcoin_units::amount::Amount::to_string_in(self, denom: bitcoin_units::a
 pub fn bitcoin_units::amount::Amount::to_string_with_denomination(self, denom: bitcoin_units::amount::Denomination) -> alloc::string::String
 pub fn bitcoin_units::amount::Amount::unchecked_add(self, rhs: bitcoin_units::amount::Amount) -> bitcoin_units::amount::Amount
 pub fn bitcoin_units::amount::Amount::unchecked_sub(self, rhs: bitcoin_units::amount::Amount) -> bitcoin_units::amount::Amount
+impl bitcoin_consensus_encoding::decode::Decode for bitcoin_units::amount::Amount
+pub type bitcoin_units::amount::Amount::Decoder = bitcoin_units::amount::AmountDecoder
+impl bitcoin_consensus_encoding::encode::Encode for bitcoin_units::amount::Amount
+pub type bitcoin_units::amount::Amount::Encoder<'e> = bitcoin_units::amount::AmountEncoder<'e>
+pub fn bitcoin_units::amount::Amount::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_units::amount::Amount
 pub fn bitcoin_units::amount::Amount::clone(&self) -> bitcoin_units::amount::Amount
 impl core::cmp::Eq for bitcoin_units::amount::Amount
@@ -398,6 +403,134 @@ pub unsafe fn bitcoin_units::amount::Amount::clone_to_uninit(&self, dest: *mut u
 impl<T> core::convert::From<T> for bitcoin_units::amount::Amount
 pub fn bitcoin_units::amount::Amount::from(t: T) -> T
 impl<T> serde_core::de::DeserializeOwned for bitcoin_units::amount::Amount where T: for<'de> serde_core::de::Deserialize<'de>
+pub struct bitcoin_units::amount::AmountDecoder(_)
+impl bitcoin_units::amount::AmountDecoder
+pub const fn bitcoin_units::amount::AmountDecoder::new() -> Self
+impl bitcoin_consensus_encoding::decode::Decoder for bitcoin_units::amount::AmountDecoder
+pub type bitcoin_units::amount::AmountDecoder::Error = bitcoin_units::amount::AmountDecoderError
+pub type bitcoin_units::amount::AmountDecoder::Output = bitcoin_units::amount::Amount
+pub fn bitcoin_units::amount::AmountDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
+pub fn bitcoin_units::amount::AmountDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
+pub fn bitcoin_units::amount::AmountDecoder::read_limit(&self) -> usize
+impl core::clone::Clone for bitcoin_units::amount::AmountDecoder
+pub fn bitcoin_units::amount::AmountDecoder::clone(&self) -> bitcoin_units::amount::AmountDecoder
+impl core::default::Default for bitcoin_units::amount::AmountDecoder
+pub fn bitcoin_units::amount::AmountDecoder::default() -> Self
+impl core::fmt::Debug for bitcoin_units::amount::AmountDecoder
+pub fn bitcoin_units::amount::AmountDecoder::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitcoin_units::amount::AmountDecoder
+impl core::marker::Send for bitcoin_units::amount::AmountDecoder
+impl core::marker::Sync for bitcoin_units::amount::AmountDecoder
+impl core::marker::Unpin for bitcoin_units::amount::AmountDecoder
+impl core::marker::UnsafeUnpin for bitcoin_units::amount::AmountDecoder
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::AmountDecoder
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::AmountDecoder
+impl<T, U> core::convert::Into<U> for bitcoin_units::amount::AmountDecoder where U: core::convert::From<T>
+pub fn bitcoin_units::amount::AmountDecoder::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::amount::AmountDecoder where U: core::convert::Into<T>
+pub type bitcoin_units::amount::AmountDecoder::Error = core::convert::Infallible
+pub fn bitcoin_units::amount::AmountDecoder::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::amount::AmountDecoder where U: core::convert::TryFrom<T>
+pub type bitcoin_units::amount::AmountDecoder::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::amount::AmountDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_units::amount::AmountDecoder where T: core::clone::Clone
+pub type bitcoin_units::amount::AmountDecoder::Owned = T
+pub fn bitcoin_units::amount::AmountDecoder::clone_into(&self, target: &mut T)
+pub fn bitcoin_units::amount::AmountDecoder::to_owned(&self) -> T
+impl<T> core::any::Any for bitcoin_units::amount::AmountDecoder where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::amount::AmountDecoder::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::amount::AmountDecoder where T: ?core::marker::Sized
+pub fn bitcoin_units::amount::AmountDecoder::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::amount::AmountDecoder where T: ?core::marker::Sized
+pub fn bitcoin_units::amount::AmountDecoder::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::amount::AmountDecoder where T: core::clone::Clone
+pub unsafe fn bitcoin_units::amount::AmountDecoder::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::amount::AmountDecoder
+pub fn bitcoin_units::amount::AmountDecoder::from(t: T) -> T
+pub struct bitcoin_units::amount::AmountDecoderError(_)
+impl core::clone::Clone for bitcoin_units::amount::AmountDecoderError
+pub fn bitcoin_units::amount::AmountDecoderError::clone(&self) -> bitcoin_units::amount::AmountDecoderError
+impl core::cmp::Eq for bitcoin_units::amount::AmountDecoderError
+impl core::cmp::PartialEq for bitcoin_units::amount::AmountDecoderError
+pub fn bitcoin_units::amount::AmountDecoderError::eq(&self, other: &bitcoin_units::amount::AmountDecoderError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::amount::AmountDecoderError
+pub fn bitcoin_units::amount::AmountDecoderError::from(never: core::convert::Infallible) -> Self
+impl core::error::Error for bitcoin_units::amount::AmountDecoderError
+pub fn bitcoin_units::amount::AmountDecoderError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl core::fmt::Debug for bitcoin_units::amount::AmountDecoderError
+pub fn bitcoin_units::amount::AmountDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_units::amount::AmountDecoderError
+impl core::marker::StructuralPartialEq for bitcoin_units::amount::AmountDecoderError
+impl core::marker::Freeze for bitcoin_units::amount::AmountDecoderError
+impl core::marker::Send for bitcoin_units::amount::AmountDecoderError
+impl core::marker::Sync for bitcoin_units::amount::AmountDecoderError
+impl core::marker::Unpin for bitcoin_units::amount::AmountDecoderError
+impl core::marker::UnsafeUnpin for bitcoin_units::amount::AmountDecoderError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::AmountDecoderError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::AmountDecoderError
+impl<T, U> core::convert::Into<U> for bitcoin_units::amount::AmountDecoderError where U: core::convert::From<T>
+pub fn bitcoin_units::amount::AmountDecoderError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::amount::AmountDecoderError where U: core::convert::Into<T>
+pub type bitcoin_units::amount::AmountDecoderError::Error = core::convert::Infallible
+pub fn bitcoin_units::amount::AmountDecoderError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::amount::AmountDecoderError where U: core::convert::TryFrom<T>
+pub type bitcoin_units::amount::AmountDecoderError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::amount::AmountDecoderError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_units::amount::AmountDecoderError where T: core::clone::Clone
+pub type bitcoin_units::amount::AmountDecoderError::Owned = T
+pub fn bitcoin_units::amount::AmountDecoderError::clone_into(&self, target: &mut T)
+pub fn bitcoin_units::amount::AmountDecoderError::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin_units::amount::AmountDecoderError where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_units::amount::AmountDecoderError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin_units::amount::AmountDecoderError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::amount::AmountDecoderError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::amount::AmountDecoderError where T: ?core::marker::Sized
+pub fn bitcoin_units::amount::AmountDecoderError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::amount::AmountDecoderError where T: ?core::marker::Sized
+pub fn bitcoin_units::amount::AmountDecoderError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::amount::AmountDecoderError where T: core::clone::Clone
+pub unsafe fn bitcoin_units::amount::AmountDecoderError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::amount::AmountDecoderError
+pub fn bitcoin_units::amount::AmountDecoderError::from(t: T) -> T
+pub struct bitcoin_units::amount::AmountEncoder<'e>(_, _)
+impl<'e> bitcoin_consensus_encoding::encode::Encoder for bitcoin_units::amount::AmountEncoder<'e>
+pub fn bitcoin_units::amount::AmountEncoder<'e>::advance(&mut self) -> bitcoin_consensus_encoding::encode::EncoderStatus
+pub fn bitcoin_units::amount::AmountEncoder<'e>::current_chunk(&self) -> &[u8]
+impl<'e> bitcoin_consensus_encoding::encode::ExactSizeEncoder for bitcoin_units::amount::AmountEncoder<'e>
+pub fn bitcoin_units::amount::AmountEncoder<'e>::len(&self) -> usize
+impl<'e> core::clone::Clone for bitcoin_units::amount::AmountEncoder<'e>
+pub fn bitcoin_units::amount::AmountEncoder<'e>::clone(&self) -> bitcoin_units::amount::AmountEncoder<'e>
+impl<'e> core::fmt::Debug for bitcoin_units::amount::AmountEncoder<'e>
+pub fn bitcoin_units::amount::AmountEncoder<'e>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<'e> core::marker::Freeze for bitcoin_units::amount::AmountEncoder<'e>
+impl<'e> core::marker::Send for bitcoin_units::amount::AmountEncoder<'e>
+impl<'e> core::marker::Sync for bitcoin_units::amount::AmountEncoder<'e>
+impl<'e> core::marker::Unpin for bitcoin_units::amount::AmountEncoder<'e>
+impl<'e> core::marker::UnsafeUnpin for bitcoin_units::amount::AmountEncoder<'e>
+impl<'e> core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::amount::AmountEncoder<'e>
+impl<'e> core::panic::unwind_safe::UnwindSafe for bitcoin_units::amount::AmountEncoder<'e>
+impl<T, U> core::convert::Into<U> for bitcoin_units::amount::AmountEncoder<'e> where U: core::convert::From<T>
+pub fn bitcoin_units::amount::AmountEncoder<'e>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::amount::AmountEncoder<'e> where U: core::convert::Into<T>
+pub type bitcoin_units::amount::AmountEncoder<'e>::Error = core::convert::Infallible
+pub fn bitcoin_units::amount::AmountEncoder<'e>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::amount::AmountEncoder<'e> where U: core::convert::TryFrom<T>
+pub type bitcoin_units::amount::AmountEncoder<'e>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_units::amount::AmountEncoder<'e>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_units::amount::AmountEncoder<'e> where T: core::clone::Clone
+pub type bitcoin_units::amount::AmountEncoder<'e>::Owned = T
+pub fn bitcoin_units::amount::AmountEncoder<'e>::clone_into(&self, target: &mut T)
+pub fn bitcoin_units::amount::AmountEncoder<'e>::to_owned(&self) -> T
+impl<T> core::any::Any for bitcoin_units::amount::AmountEncoder<'e> where T: 'static + ?core::marker::Sized
+pub fn bitcoin_units::amount::AmountEncoder<'e>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_units::amount::AmountEncoder<'e> where T: ?core::marker::Sized
+pub fn bitcoin_units::amount::AmountEncoder<'e>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::amount::AmountEncoder<'e> where T: ?core::marker::Sized
+pub fn bitcoin_units::amount::AmountEncoder<'e>::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_units::amount::AmountEncoder<'e> where T: core::clone::Clone
+pub unsafe fn bitcoin_units::amount::AmountEncoder<'e>::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_units::amount::AmountEncoder<'e>
+pub fn bitcoin_units::amount::AmountEncoder<'e>::from(t: T) -> T
 pub struct bitcoin_units::amount::Display
 impl bitcoin_units::amount::Display
 pub fn bitcoin_units::amount::Display::show_denomination(self) -> Self

--- a/units/api/all-features.txt
+++ b/units/api/all-features.txt
@@ -1,45 +1,46 @@
 pub mod bitcoin_units
+pub extern crate bitcoin_units::encoding
 pub extern crate bitcoin_units::serde
 pub mod bitcoin_units::amount
 pub mod bitcoin_units::amount::serde
 pub mod bitcoin_units::amount::serde::as_btc
 pub mod bitcoin_units::amount::serde::as_btc::opt
-pub fn bitcoin_units::amount::serde::as_btc::opt::deserialize<'d, A: bitcoin_units::amount::serde::SerdeAmountForOpt, D: serde::de::Deserializer<'d>>(d: D) -> core::result::Result<core::option::Option<A>, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin_units::amount::serde::as_btc::opt::serialize<A: bitcoin_units::amount::serde::SerdeAmountForOpt, S: serde::ser::Serializer>(a: &core::option::Option<A>, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-pub fn bitcoin_units::amount::serde::as_btc::deserialize<'d, A: bitcoin_units::amount::serde::SerdeAmount, D: serde::de::Deserializer<'d>>(d: D) -> core::result::Result<A, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin_units::amount::serde::as_btc::serialize<A: bitcoin_units::amount::serde::SerdeAmount, S: serde::ser::Serializer>(a: &A, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::serde::as_btc::opt::deserialize<'d, A: bitcoin_units::amount::serde::SerdeAmountForOpt, D: serde_core::de::Deserializer<'d>>(d: D) -> core::result::Result<core::option::Option<A>, <D as serde_core::de::Deserializer>::Error>
+pub fn bitcoin_units::amount::serde::as_btc::opt::serialize<A: bitcoin_units::amount::serde::SerdeAmountForOpt, S: serde_core::ser::Serializer>(a: &core::option::Option<A>, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::serde::as_btc::deserialize<'d, A: bitcoin_units::amount::serde::SerdeAmount, D: serde_core::de::Deserializer<'d>>(d: D) -> core::result::Result<A, <D as serde_core::de::Deserializer>::Error>
+pub fn bitcoin_units::amount::serde::as_btc::serialize<A: bitcoin_units::amount::serde::SerdeAmount, S: serde_core::ser::Serializer>(a: &A, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub mod bitcoin_units::amount::serde::as_sat
 pub mod bitcoin_units::amount::serde::as_sat::opt
-pub fn bitcoin_units::amount::serde::as_sat::opt::deserialize<'d, A: bitcoin_units::amount::serde::SerdeAmountForOpt, D: serde::de::Deserializer<'d>>(d: D) -> core::result::Result<core::option::Option<A>, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin_units::amount::serde::as_sat::opt::serialize<A: bitcoin_units::amount::serde::SerdeAmountForOpt, S: serde::ser::Serializer>(a: &core::option::Option<A>, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-pub fn bitcoin_units::amount::serde::as_sat::deserialize<'d, A: bitcoin_units::amount::serde::SerdeAmount, D: serde::de::Deserializer<'d>>(d: D) -> core::result::Result<A, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin_units::amount::serde::as_sat::serialize<A: bitcoin_units::amount::serde::SerdeAmount, S: serde::ser::Serializer>(a: &A, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::serde::as_sat::opt::deserialize<'d, A: bitcoin_units::amount::serde::SerdeAmountForOpt, D: serde_core::de::Deserializer<'d>>(d: D) -> core::result::Result<core::option::Option<A>, <D as serde_core::de::Deserializer>::Error>
+pub fn bitcoin_units::amount::serde::as_sat::opt::serialize<A: bitcoin_units::amount::serde::SerdeAmountForOpt, S: serde_core::ser::Serializer>(a: &core::option::Option<A>, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::serde::as_sat::deserialize<'d, A: bitcoin_units::amount::serde::SerdeAmount, D: serde_core::de::Deserializer<'d>>(d: D) -> core::result::Result<A, <D as serde_core::de::Deserializer>::Error>
+pub fn bitcoin_units::amount::serde::as_sat::serialize<A: bitcoin_units::amount::serde::SerdeAmount, S: serde_core::ser::Serializer>(a: &A, s: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub trait bitcoin_units::amount::serde::SerdeAmount: core::marker::Copy + core::marker::Sized
-pub fn bitcoin_units::amount::serde::SerdeAmount::des_btc<'d, D: serde::de::Deserializer<'d>>(d: D, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin_units::amount::serde::SerdeAmount::des_sat<'d, D: serde::de::Deserializer<'d>>(d: D, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin_units::amount::serde::SerdeAmount::ser_btc<S: serde::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-pub fn bitcoin_units::amount::serde::SerdeAmount::ser_sat<S: serde::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::serde::SerdeAmount::des_btc<'d, D: serde_core::de::Deserializer<'d>>(d: D, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<Self, <D as serde_core::de::Deserializer>::Error>
+pub fn bitcoin_units::amount::serde::SerdeAmount::des_sat<'d, D: serde_core::de::Deserializer<'d>>(d: D, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<Self, <D as serde_core::de::Deserializer>::Error>
+pub fn bitcoin_units::amount::serde::SerdeAmount::ser_btc<S: serde_core::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::serde::SerdeAmount::ser_sat<S: serde_core::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 impl bitcoin_units::amount::serde::SerdeAmount for bitcoin_units::amount::Amount
-pub fn bitcoin_units::amount::Amount::des_btc<'d, D: serde::de::Deserializer<'d>>(d: D, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin_units::amount::Amount::des_sat<'d, D: serde::de::Deserializer<'d>>(d: D, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin_units::amount::Amount::ser_btc<S: serde::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-pub fn bitcoin_units::amount::Amount::ser_sat<S: serde::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::Amount::des_btc<'d, D: serde_core::de::Deserializer<'d>>(d: D, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<Self, <D as serde_core::de::Deserializer>::Error>
+pub fn bitcoin_units::amount::Amount::des_sat<'d, D: serde_core::de::Deserializer<'d>>(d: D, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<Self, <D as serde_core::de::Deserializer>::Error>
+pub fn bitcoin_units::amount::Amount::ser_btc<S: serde_core::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::Amount::ser_sat<S: serde_core::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 impl bitcoin_units::amount::serde::SerdeAmount for bitcoin_units::amount::SignedAmount
-pub fn bitcoin_units::amount::SignedAmount::des_btc<'d, D: serde::de::Deserializer<'d>>(d: D, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin_units::amount::SignedAmount::des_sat<'d, D: serde::de::Deserializer<'d>>(d: D, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error>
-pub fn bitcoin_units::amount::SignedAmount::ser_btc<S: serde::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-pub fn bitcoin_units::amount::SignedAmount::ser_sat<S: serde::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::SignedAmount::des_btc<'d, D: serde_core::de::Deserializer<'d>>(d: D, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<Self, <D as serde_core::de::Deserializer>::Error>
+pub fn bitcoin_units::amount::SignedAmount::des_sat<'d, D: serde_core::de::Deserializer<'d>>(d: D, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<Self, <D as serde_core::de::Deserializer>::Error>
+pub fn bitcoin_units::amount::SignedAmount::ser_btc<S: serde_core::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::SignedAmount::ser_sat<S: serde_core::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub trait bitcoin_units::amount::serde::SerdeAmountForOpt: core::marker::Copy + core::marker::Sized + bitcoin_units::amount::serde::SerdeAmount
-pub fn bitcoin_units::amount::serde::SerdeAmountForOpt::ser_btc_opt<S: serde::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-pub fn bitcoin_units::amount::serde::SerdeAmountForOpt::ser_sat_opt<S: serde::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::serde::SerdeAmountForOpt::ser_btc_opt<S: serde_core::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::serde::SerdeAmountForOpt::ser_sat_opt<S: serde_core::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub fn bitcoin_units::amount::serde::SerdeAmountForOpt::type_prefix(_: bitcoin_units::amount::serde::private::Token) -> &'static str
 impl bitcoin_units::amount::serde::SerdeAmountForOpt for bitcoin_units::amount::Amount
-pub fn bitcoin_units::amount::Amount::ser_btc_opt<S: serde::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-pub fn bitcoin_units::amount::Amount::ser_sat_opt<S: serde::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::Amount::ser_btc_opt<S: serde_core::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::Amount::ser_sat_opt<S: serde_core::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub fn bitcoin_units::amount::Amount::type_prefix(_: bitcoin_units::amount::serde::private::Token) -> &'static str
 impl bitcoin_units::amount::serde::SerdeAmountForOpt for bitcoin_units::amount::SignedAmount
-pub fn bitcoin_units::amount::SignedAmount::ser_btc_opt<S: serde::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
-pub fn bitcoin_units::amount::SignedAmount::ser_sat_opt<S: serde::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::SignedAmount::ser_btc_opt<S: serde_core::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+pub fn bitcoin_units::amount::SignedAmount::ser_sat_opt<S: serde_core::ser::Serializer>(self, s: S, _: bitcoin_units::amount::serde::private::Token) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub fn bitcoin_units::amount::SignedAmount::type_prefix(_: bitcoin_units::amount::serde::private::Token) -> &'static str
 #[non_exhaustive] pub enum bitcoin_units::amount::Denomination
 pub bitcoin_units::amount::Denomination::Bit
@@ -357,12 +358,12 @@ pub fn bitcoin_units::amount::Amount::sub_assign(&mut self, other: bitcoin_units
 impl core::str::traits::FromStr for bitcoin_units::amount::Amount
 pub type bitcoin_units::amount::Amount::Err = bitcoin_units::amount::ParseError
 pub fn bitcoin_units::amount::Amount::from_str(s: &str) -> core::result::Result<Self, Self::Err>
-impl serde::ser::Serialize for bitcoin_units::amount::Amount
-pub fn bitcoin_units::amount::Amount::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl serde_core::ser::Serialize for bitcoin_units::amount::Amount
+pub fn bitcoin_units::amount::Amount::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::amount::Amount
 pub fn bitcoin_units::amount::Amount::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
-impl<'de> serde::de::Deserialize<'de> for bitcoin_units::amount::Amount
-pub fn bitcoin_units::amount::Amount::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin_units::amount::Amount
+pub fn bitcoin_units::amount::Amount::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 impl<T> bitcoin_units::amount::CheckedSum<bitcoin_units::amount::Amount> for T where T: core::iter::traits::iterator::Iterator<Item = bitcoin_units::amount::Amount>
 pub fn T::checked_sum(self) -> core::option::Option<bitcoin_units::amount::Amount>
 impl core::marker::Freeze for bitcoin_units::amount::Amount
@@ -396,7 +397,7 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::amount::Amount where T: co
 pub unsafe fn bitcoin_units::amount::Amount::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_units::amount::Amount
 pub fn bitcoin_units::amount::Amount::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin_units::amount::Amount where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin_units::amount::Amount where T: for<'de> serde_core::de::Deserialize<'de>
 pub struct bitcoin_units::amount::Display
 impl bitcoin_units::amount::Display
 pub fn bitcoin_units::amount::Display::show_denomination(self) -> Self
@@ -948,12 +949,12 @@ pub fn bitcoin_units::fee_rate::FeeRate::mul(self, rhs: bitcoin_units::weight::W
 impl core::str::traits::FromStr for bitcoin_units::fee_rate::FeeRate
 pub type bitcoin_units::fee_rate::FeeRate::Err = bitcoin_units::parse::ParseIntError
 pub fn bitcoin_units::fee_rate::FeeRate::from_str(s: &str) -> core::result::Result<Self, Self::Err>
-impl serde::ser::Serialize for bitcoin_units::fee_rate::FeeRate
-pub fn bitcoin_units::fee_rate::FeeRate::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl serde_core::ser::Serialize for bitcoin_units::fee_rate::FeeRate
+pub fn bitcoin_units::fee_rate::FeeRate::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::fee_rate::FeeRate
 pub fn bitcoin_units::fee_rate::FeeRate::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
-impl<'de> serde::de::Deserialize<'de> for bitcoin_units::fee_rate::FeeRate
-pub fn bitcoin_units::fee_rate::FeeRate::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin_units::fee_rate::FeeRate
+pub fn bitcoin_units::fee_rate::FeeRate::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin_units::fee_rate::FeeRate
 impl core::marker::Send for bitcoin_units::fee_rate::FeeRate
 impl core::marker::Sync for bitcoin_units::fee_rate::FeeRate
@@ -985,7 +986,7 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::fee_rate::FeeRate where T:
 pub unsafe fn bitcoin_units::fee_rate::FeeRate::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_units::fee_rate::FeeRate
 pub fn bitcoin_units::fee_rate::FeeRate::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin_units::fee_rate::FeeRate where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin_units::fee_rate::FeeRate where T: for<'de> serde_core::de::Deserialize<'de>
 pub mod bitcoin_units::locktime
 pub mod bitcoin_units::locktime::absolute
 #[non_exhaustive] pub struct bitcoin_units::locktime::absolute::ConversionError
@@ -1065,12 +1066,12 @@ impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::He
 impl core::str::traits::FromStr for bitcoin_units::locktime::absolute::Height
 pub type bitcoin_units::locktime::absolute::Height::Err = bitcoin_units::locktime::absolute::ParseHeightError
 pub fn bitcoin_units::locktime::absolute::Height::from_str(s: &str) -> core::result::Result<Self, Self::Err>
-impl serde::ser::Serialize for bitcoin_units::locktime::absolute::Height
-pub fn bitcoin_units::locktime::absolute::Height::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+impl serde_core::ser::Serialize for bitcoin_units::locktime::absolute::Height
+pub fn bitcoin_units::locktime::absolute::Height::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error> where S: serde_core::ser::Serializer
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::locktime::absolute::Height
 pub fn bitcoin_units::locktime::absolute::Height::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
-impl<'de> serde::de::Deserialize<'de> for bitcoin_units::locktime::absolute::Height
-pub fn bitcoin_units::locktime::absolute::Height::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin_units::locktime::absolute::Height
+pub fn bitcoin_units::locktime::absolute::Height::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde_core::de::Deserializer>::Error> where D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin_units::locktime::absolute::Height
 impl core::marker::Send for bitcoin_units::locktime::absolute::Height
 impl core::marker::Sync for bitcoin_units::locktime::absolute::Height
@@ -1102,7 +1103,7 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::absolute::Height
 pub unsafe fn bitcoin_units::locktime::absolute::Height::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_units::locktime::absolute::Height
 pub fn bitcoin_units::locktime::absolute::Height::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin_units::locktime::absolute::Height where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin_units::locktime::absolute::Height where T: for<'de> serde_core::de::Deserialize<'de>
 pub struct bitcoin_units::locktime::absolute::ParseHeightError(_)
 impl core::clone::Clone for bitcoin_units::locktime::absolute::ParseHeightError
 pub fn bitcoin_units::locktime::absolute::ParseHeightError::clone(&self) -> bitcoin_units::locktime::absolute::ParseHeightError
@@ -1222,12 +1223,12 @@ impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::Ti
 impl core::str::traits::FromStr for bitcoin_units::locktime::absolute::Time
 pub type bitcoin_units::locktime::absolute::Time::Err = bitcoin_units::locktime::absolute::ParseTimeError
 pub fn bitcoin_units::locktime::absolute::Time::from_str(s: &str) -> core::result::Result<Self, Self::Err>
-impl serde::ser::Serialize for bitcoin_units::locktime::absolute::Time
-pub fn bitcoin_units::locktime::absolute::Time::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+impl serde_core::ser::Serialize for bitcoin_units::locktime::absolute::Time
+pub fn bitcoin_units::locktime::absolute::Time::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error> where S: serde_core::ser::Serializer
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::locktime::absolute::Time
 pub fn bitcoin_units::locktime::absolute::Time::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
-impl<'de> serde::de::Deserialize<'de> for bitcoin_units::locktime::absolute::Time
-pub fn bitcoin_units::locktime::absolute::Time::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin_units::locktime::absolute::Time
+pub fn bitcoin_units::locktime::absolute::Time::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde_core::de::Deserializer>::Error> where D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin_units::locktime::absolute::Time
 impl core::marker::Send for bitcoin_units::locktime::absolute::Time
 impl core::marker::Sync for bitcoin_units::locktime::absolute::Time
@@ -1259,7 +1260,7 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::absolute::Time w
 pub unsafe fn bitcoin_units::locktime::absolute::Time::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_units::locktime::absolute::Time
 pub fn bitcoin_units::locktime::absolute::Time::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin_units::locktime::absolute::Time where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin_units::locktime::absolute::Time where T: for<'de> serde_core::de::Deserialize<'de>
 pub const bitcoin_units::locktime::absolute::LOCK_TIME_THRESHOLD: u32
 pub fn bitcoin_units::locktime::absolute::is_block_height(n: u32) -> bool
 pub fn bitcoin_units::locktime::absolute::is_block_time(n: u32) -> bool
@@ -1302,12 +1303,12 @@ impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::He
 impl core::str::traits::FromStr for bitcoin_units::locktime::relative::Height
 pub type bitcoin_units::locktime::relative::Height::Err = bitcoin_units::parse::ParseIntError
 pub fn bitcoin_units::locktime::relative::Height::from_str(s: &str) -> core::result::Result<Self, Self::Err>
-impl serde::ser::Serialize for bitcoin_units::locktime::relative::Height
-pub fn bitcoin_units::locktime::relative::Height::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl serde_core::ser::Serialize for bitcoin_units::locktime::relative::Height
+pub fn bitcoin_units::locktime::relative::Height::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::locktime::relative::Height
 pub fn bitcoin_units::locktime::relative::Height::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
-impl<'de> serde::de::Deserialize<'de> for bitcoin_units::locktime::relative::Height
-pub fn bitcoin_units::locktime::relative::Height::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin_units::locktime::relative::Height
+pub fn bitcoin_units::locktime::relative::Height::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin_units::locktime::relative::Height
 impl core::marker::Send for bitcoin_units::locktime::relative::Height
 impl core::marker::Sync for bitcoin_units::locktime::relative::Height
@@ -1339,7 +1340,7 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::Height
 pub unsafe fn bitcoin_units::locktime::relative::Height::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::Height
 pub fn bitcoin_units::locktime::relative::Height::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin_units::locktime::relative::Height where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin_units::locktime::relative::Height where T: for<'de> serde_core::de::Deserialize<'de>
 pub struct bitcoin_units::locktime::relative::Time(_)
 impl bitcoin_units::locktime::relative::Time
 pub const bitcoin_units::locktime::relative::Time::MAX: Self
@@ -1378,12 +1379,12 @@ impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::Ti
 impl core::str::traits::FromStr for bitcoin_units::locktime::relative::Time
 pub type bitcoin_units::locktime::relative::Time::Err = bitcoin_units::parse::ParseIntError
 pub fn bitcoin_units::locktime::relative::Time::from_str(s: &str) -> core::result::Result<Self, Self::Err>
-impl serde::ser::Serialize for bitcoin_units::locktime::relative::Time
-pub fn bitcoin_units::locktime::relative::Time::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl serde_core::ser::Serialize for bitcoin_units::locktime::relative::Time
+pub fn bitcoin_units::locktime::relative::Time::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::locktime::relative::Time
 pub fn bitcoin_units::locktime::relative::Time::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
-impl<'de> serde::de::Deserialize<'de> for bitcoin_units::locktime::relative::Time
-pub fn bitcoin_units::locktime::relative::Time::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin_units::locktime::relative::Time
+pub fn bitcoin_units::locktime::relative::Time::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin_units::locktime::relative::Time
 impl core::marker::Send for bitcoin_units::locktime::relative::Time
 impl core::marker::Sync for bitcoin_units::locktime::relative::Time
@@ -1415,7 +1416,7 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::Time w
 pub unsafe fn bitcoin_units::locktime::relative::Time::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::Time
 pub fn bitcoin_units::locktime::relative::Time::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin_units::locktime::relative::Time where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin_units::locktime::relative::Time where T: for<'de> serde_core::de::Deserialize<'de>
 pub struct bitcoin_units::locktime::relative::TimeOverflowError
 impl bitcoin_units::locktime::relative::TimeOverflowError
 pub fn bitcoin_units::locktime::relative::TimeOverflowError::new(seconds: u32) -> Self
@@ -1603,14 +1604,14 @@ pub fn bitcoin_units::weight::Weight::sub_assign(&mut self, rhs: Self)
 impl core::str::traits::FromStr for bitcoin_units::weight::Weight
 pub type bitcoin_units::weight::Weight::Err = bitcoin_units::parse::ParseIntError
 pub fn bitcoin_units::weight::Weight::from_str(s: &str) -> core::result::Result<Self, Self::Err>
-impl serde::ser::Serialize for bitcoin_units::weight::Weight
-pub fn bitcoin_units::weight::Weight::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl serde_core::ser::Serialize for bitcoin_units::weight::Weight
+pub fn bitcoin_units::weight::Weight::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::weight::Weight
 pub fn bitcoin_units::weight::Weight::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self>
 impl<'a> core::iter::traits::accum::Sum<&'a bitcoin_units::weight::Weight> for bitcoin_units::weight::Weight
 pub fn bitcoin_units::weight::Weight::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = &'a bitcoin_units::weight::Weight>
-impl<'de> serde::de::Deserialize<'de> for bitcoin_units::weight::Weight
-pub fn bitcoin_units::weight::Weight::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl<'de> serde_core::de::Deserialize<'de> for bitcoin_units::weight::Weight
+pub fn bitcoin_units::weight::Weight::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 impl core::marker::Freeze for bitcoin_units::weight::Weight
 impl core::marker::Send for bitcoin_units::weight::Weight
 impl core::marker::Sync for bitcoin_units::weight::Weight
@@ -1642,7 +1643,7 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::weight::Weight where T: co
 pub unsafe fn bitcoin_units::weight::Weight::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_units::weight::Weight
 pub fn bitcoin_units::weight::Weight::from(t: T) -> T
-impl<T> serde::de::DeserializeOwned for bitcoin_units::weight::Weight where T: for<'de> serde::de::Deserialize<'de>
+impl<T> serde_core::de::DeserializeOwned for bitcoin_units::weight::Weight where T: for<'de> serde_core::de::Deserialize<'de>
 pub const bitcoin_units::weight::WITNESS_SCALE_FACTOR: usize
 pub macro bitcoin_units::impl_parse_str!
 pub macro bitcoin_units::impl_parse_str_from_int_infallible!

--- a/units/include/decoder_newtype.rs
+++ b/units/include/decoder_newtype.rs
@@ -1,0 +1,1 @@
+../../include/decoder_newtype.rs

--- a/units/src/amount.rs
+++ b/units/src/amount.rs
@@ -1207,6 +1207,69 @@ impl core::iter::Sum for Amount {
     }
 }
 
+#[cfg(feature = "encoding")]
+impl encoding::Encode for Amount {
+    type Encoder<'e> = AmountEncoder<'e>;
+
+    #[inline]
+    fn encoder(&self) -> Self::Encoder<'_> {
+        AmountEncoder::new(encoding::ArrayEncoder::without_length_prefix(
+            self.to_sat().to_le_bytes(),
+        ))
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for Amount {
+    type Decoder = AmountDecoder;
+}
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// The encoder for the [`Amount`] type.
+    #[derive(Debug, Clone)]
+    pub struct AmountEncoder<'e>(encoding::ArrayEncoder<8>);
+}
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// The decoder for the [`Amount`] type.
+    #[derive(Debug, Clone)]
+    pub struct AmountDecoder(encoding::ArrayDecoder<8>);
+
+    /// Constructs a new [`Amount`] decoder.
+    pub const fn new() -> Self { Self(encoding::ArrayDecoder::new()) }
+
+    fn end(result: Result<[u8; 8], encoding::UnexpectedEofError>) -> Result<Amount, AmountDecoderError> {
+        let value = result.map_err(AmountDecoderError)?;
+        let a = u64::from_le_bytes(value);
+        Ok(Amount::from_sat(a))
+    }
+}
+
+/// An error consensus decoding an [`Amount`].
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AmountDecoderError(pub(super) encoding::UnexpectedEofError);
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for AmountDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl fmt::Display for AmountDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write_err!(f, "amount decoder error"; self.0)
+    }
+}
+
+#[cfg(all(feature = "std", feature = "encoding"))]
+impl std::error::Error for AmountDecoderError {
+    #[inline]
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
+}
+
 /// A helper/builder that displays amount with specified settings.
 ///
 /// This provides richer interface than `fmt::Formatter`:

--- a/units/src/lib.rs
+++ b/units/src/lib.rs
@@ -25,6 +25,9 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+#[cfg(feature = "encoding")]
+pub extern crate encoding;
+
 /// A generic serialization/deserialization framework.
 #[cfg(feature = "serde")]
 pub extern crate serde;
@@ -63,3 +66,7 @@ mod prelude {
     #[cfg(feature = "std")]
     pub use std::{string::{String, ToString}, vec::Vec, boxed::Box, borrow::{Borrow, BorrowMut, Cow, ToOwned}, rc};
 }
+
+// decoder_newtype! macro
+#[cfg(feature = "encoding")]
+include!("../include/decoder_newtype.rs");


### PR DESCRIPTION
As a first step in implementing `consensus_encoding` in `0.32.x` add impl for types that are in `units` `1.0` and in `0.32.x`.

- Add `consensus_encoding` dependency to `units` and `bitcoin` (some units 1.0 types are still in bitcoin in v0.32).
- Add `consensus_encoding` to `Amount`, `Sequence`, `CompactTarget` and `absolute::LockTime`.
  - These are a copy and paste from master with minimal changes required, described in the commit logs.
- Bump the `base58ck` dependence in `bitcoin` to `0.1.100`. Required to remove the dependence of `0.1.0` on `internals`.
- Add fuzzing of the new vs old impl. The slices are trimmed to the length required by the decoder since the new encoding logic reads what it needs and ignores the rest, but the legacy fails if there are trailing bytes.
