### PR TITLE
p2p: Add `sendtxrcncl`

### DIFF
--- a/contrib/check-encodable-coverage.sh
+++ b/contrib/check-encodable-coverage.sh
@@ -18,7 +18,8 @@ TRAIT_IMPL_JS="$REPO_DIR/target/doc/trait.impl/bitcoin_consensus_encoding/encode
 # - HeadersMessage has no type in 0.32 bitcoin. Vec<(Header, u8)> is not Decodable.
 # - InventoryPayload has no type in 0.32 bitcoin. Vec<Inventory> fails special case consideration.
 # - FeeFilter is a FeeRate newtype. FeeRate has no old Encodable/Decodable and is just a u64 le encoding in FeeFilter.
-EXCLUSIONS="CommandString HeadersMessage InventoryPayload FeeFilter NetworkMessage Script Validation V2NetworkMessage V1MessageHeader"
+# - SendTxRcnCl is a new type that does not have a comparison.
+EXCLUSIONS="CommandString HeadersMessage InventoryPayload FeeFilter NetworkMessage Script Validation V2NetworkMessage V1MessageHeader SendTxRcnCl"
 
 main() {
     check_required_commands

--- a/fuzz/generate-encoding-roundtrip.sh
+++ b/fuzz/generate-encoding-roundtrip.sh
@@ -79,6 +79,7 @@ ROUNDTRIP_TYPES=(
     "p2p::message_network::RejectReason"
     "p2p::message_network::UserAgent"
     "p2p::message_network::VersionMessage"
+    "p2p::message_erlay::SendTxRcnCl"
 )
 
 # Types tested with check_script_roundtrip (Buf types that Deref to their Encodable target).

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -20,6 +20,7 @@ pub mod message;
 pub mod message_blockdata;
 pub mod message_bloom;
 pub mod message_compact_blocks;
+pub mod message_erlay;
 pub mod message_filter;
 #[cfg(feature = "std")]
 pub mod message_network;

--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -25,6 +25,7 @@ use units::{Amount, FeeRate};
 use self::error::V1NetworkMessageDecoderErrorInner;
 use crate::address::{AddrV1Message, AddrV2Message};
 use crate::merkle_tree::MerkleBlock;
+use crate::message_erlay::{SendTxRcnCl, SendTxRcnClDecoder};
 use crate::{
     bip152, message_blockdata, message_bloom, message_compact_blocks, message_filter,
     message_network, Magic,
@@ -748,7 +749,8 @@ pub enum NetworkMessage {
     AddrV2(AddrV2Payload),
     /// `sendaddrv2`
     SendAddrV2,
-
+    /// `sendtxrcncl`
+    SendTxRcnCl(SendTxRcnCl),
     /// Any other message.
     Unknown {
         /// The command of this message.
@@ -802,6 +804,7 @@ impl NetworkMessage {
             Self::WtxidRelay => "wtxidrelay",
             Self::AddrV2(_) => "addrv2",
             Self::SendAddrV2 => "sendaddrv2",
+            Self::SendTxRcnCl(_) => "sendtxrcncl",
             Self::Unknown { .. } => "unknown",
         }
     }
@@ -940,6 +943,8 @@ pub enum NetworkMessageEncoder<'e> {
     FeeFilter(<FeeFilter as encoding::Encode>::Encoder<'e>),
     /// Encodes [`NetworkMessage::AddrV2`]
     AddrV2(<AddrV2Payload as encoding::Encode>::Encoder<'e>),
+    /// Encodes [`NetworkMessage::SendTxRcnCl`].
+    SendTxRcnCl(<SendTxRcnCl as encoding::Encode>::Encoder<'e>),
     /// Encodes zero-payload messages: verack, mempool, sendheaders, getaddr, wtxidrelay,
     /// filterclear, sendaddrv2.
     Empty,
@@ -980,6 +985,7 @@ impl<'e> NetworkMessageEncoder<'e> {
             NetworkMessage::Reject(dat) => Self::Reject(dat.encoder()),
             NetworkMessage::FeeFilter(dat) => Self::FeeFilter(dat.encoder()),
             NetworkMessage::AddrV2(dat) => Self::AddrV2(dat.encoder()),
+            NetworkMessage::SendTxRcnCl(dat) => Self::SendTxRcnCl(dat.encoder()),
             NetworkMessage::Verack
             | NetworkMessage::SendHeaders
             | NetworkMessage::MemPool
@@ -1024,6 +1030,7 @@ impl encoding::Encoder for NetworkMessageEncoder<'_> {
             Self::Reject(e) => e.current_chunk(),
             Self::FeeFilter(e) => e.current_chunk(),
             Self::AddrV2(e) => e.current_chunk(),
+            Self::SendTxRcnCl(e) => e.current_chunk(),
             Self::Empty => &[],
             Self::Unknown(e) => e.current_chunk(),
         }
@@ -1058,6 +1065,7 @@ impl encoding::Encoder for NetworkMessageEncoder<'_> {
             Self::Reject(e) => e.advance(),
             Self::FeeFilter(e) => e.advance(),
             Self::AddrV2(e) => e.advance(),
+            Self::SendTxRcnCl(e) => e.advance(),
             Self::Empty => false,
             Self::Unknown(e) => e.advance(),
         }
@@ -1127,6 +1135,7 @@ enum NetworkMessageDecoderInner {
     Reject(message_network::RejectDecoder),
     FeeFilter(FeeFilterDecoder),
     AddrV2(AddrV2PayloadDecoder),
+    SendTxRcnCl(SendTxRcnClDecoder),
     /// Zero-payload messages: verack, mempool, sendheaders, getaddr, wtxidrelay,
     /// filterclear, sendaddrv2.
     Empty(CommandString),
@@ -1172,6 +1181,7 @@ impl NetworkMessageDecoderInner {
             "alert" => Self::Alert(message_network::Alert::decoder()),
             "reject" => Self::Reject(message_network::Reject::decoder()),
             "feefilter" => Self::FeeFilter(FeeFilter::decoder()),
+            "sendtxrcncl" => Self::SendTxRcnCl(SendTxRcnCl::decoder()),
             "addrv2" => Self::AddrV2(AddrV2Payload::decoder()),
             _ => Self::Unknown {
                 command,
@@ -1218,6 +1228,7 @@ impl encoding::Decoder for NetworkMessageDecoderInner {
             Self::Reject(d) => d.push_bytes(bytes).map_err(|_| err),
             Self::FeeFilter(d) => d.push_bytes(bytes).map_err(|_| err),
             Self::AddrV2(d) => d.push_bytes(bytes).map_err(|_| err),
+            Self::SendTxRcnCl(d) => d.push_bytes(bytes).map_err(|_| err),
             Self::Empty(_) => Ok(false),
             Self::Unknown { remaining, buffer, .. } => {
                 let copy_len = bytes.len().min(*remaining);
@@ -1263,6 +1274,7 @@ impl encoding::Decoder for NetworkMessageDecoderInner {
             Self::Reject(d) => Ok(NetworkMessage::Reject(d.end().map_err(|_| err)?)),
             Self::FeeFilter(d) => Ok(NetworkMessage::FeeFilter(d.end().map_err(|_| err)?)),
             Self::AddrV2(d) => Ok(NetworkMessage::AddrV2(d.end().map_err(|_| err)?)),
+            Self::SendTxRcnCl(d) => Ok(NetworkMessage::SendTxRcnCl(d.end().map_err(|_| err)?)),
             Self::Empty(cmd) => match cmd.as_ref() {
                 "verack" => Ok(NetworkMessage::Verack),
                 "mempool" => Ok(NetworkMessage::MemPool),
@@ -1312,6 +1324,7 @@ impl encoding::Decoder for NetworkMessageDecoderInner {
             Self::Reject(d) => d.read_limit(),
             Self::FeeFilter(d) => d.read_limit(),
             Self::AddrV2(d) => d.read_limit(),
+            Self::SendTxRcnCl(d) => d.read_limit(),
             Self::Empty(_) => 0,
             Self::Unknown { remaining, .. } => *remaining,
         }
@@ -1584,6 +1597,7 @@ fn v2_command_byte(payload: &NetworkMessage) -> (u8, Option<CommandString>) {
         | NetworkMessage::SendAddrV2
         | NetworkMessage::Alert(_)
         | NetworkMessage::Reject(_)
+        | NetworkMessage::SendTxRcnCl(_)
         | NetworkMessage::Unknown { .. } => (0u8, Some(payload.command())),
     }
 }
@@ -1800,6 +1814,7 @@ impl V2NetworkMessageDecoder {
             "verack" | "sendheaders" | "getaddr" | "wtxidrelay" | "sendaddrv2" => E::Empty(command),
             "alert" => E::Alert(message_network::Alert::decoder()),
             "reject" => E::Reject(message_network::Reject::decoder()),
+            "sendtxrcncl" => E::SendTxRcnCl(SendTxRcnCl::decoder()),
             _ => E::Unknown {
                 command,
                 remaining: 0, // no payload length, buffer all bytes until end().
@@ -2559,6 +2574,7 @@ mod test {
             )),
             NetworkMessage::BlockTxn(blocktxn),
             NetworkMessage::SendCmpct(SendCmpct { send_compact: true, version: 8333 }),
+            NetworkMessage::SendTxRcnCl(SendTxRcnCl::from_salt(224)),
         ];
 
         for msg in &msgs {

--- a/p2p/src/message_erlay.rs
+++ b/p2p/src/message_erlay.rs
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Messages related to [Erlay transaction announcements](https://github.com/bitcoin/bips/blob/master/bip-0330.mediawiki#user-content-sendtxrcncl).
+
+use encoding::{ArrayDecoder, ArrayEncoder, Decoder2, Encoder2};
+
+use crate::message_erlay::error::SendTxRcnClDecoderError;
+
+/// Announce support for the transaction reconciliation protocol.
+///
+/// Note that this message should be [sent before
+/// verack](https://github.com/bitcoin/bips/blob/master/bip-0330.mediawiki#sendtxrcncl).
+#[derive(PartialEq, Eq, Clone, Debug, Copy, Hash, PartialOrd, Ord)]
+pub struct SendTxRcnCl {
+    // Transaction reconciliation protocol version.
+    version: u32,
+    /// Salt used in short ID computation.
+    pub salt: u64,
+}
+
+impl SendTxRcnCl {
+    /// Version one of the protocol.
+    pub const VERSION_ONE: u32 = 1;
+
+    /// Build a new announcement for erlay with salt.
+    pub fn from_salt(salt: u64) -> Self {
+        Self { version: Self::VERSION_ONE, salt }
+    }
+
+    /// Get the transaction reconciliation protocol version.
+    pub fn version(&self) -> u32 {
+        self.version
+    }
+}
+
+encoding::encoder_newtype_exact! {
+    /// The encoder for a [`SendTxRcnCl`] message.
+    #[derive(Debug, Clone)]
+    pub struct SendTxRcnClEncoder<'e>(Encoder2<ArrayEncoder<4>, ArrayEncoder<8>>);
+}
+
+impl encoding::Encode for SendTxRcnCl {
+    type Encoder<'e>
+        = SendTxRcnClEncoder<'e>
+    where
+        Self: 'e;
+
+    fn encoder(&self) -> Self::Encoder<'_> {
+        SendTxRcnClEncoder::new(Encoder2::new(
+            ArrayEncoder::without_length_prefix(self.version.to_le_bytes()),
+            ArrayEncoder::without_length_prefix(self.salt.to_le_bytes()),
+        ))
+    }
+}
+
+type SendTxRcnClInnerDecoder = Decoder2<ArrayDecoder<4>, ArrayDecoder<8>>;
+
+/// The decoder for a [`SendTxRcnCl`] message.
+#[derive(Debug, Default, Clone)]
+pub struct SendTxRcnClDecoder(SendTxRcnClInnerDecoder);
+
+impl encoding::Decoder for SendTxRcnClDecoder {
+    type Output = SendTxRcnCl;
+    type Error = SendTxRcnClDecoderError;
+
+    #[inline]
+    fn push_bytes(&mut self, bytes: &mut &[u8]) -> Result<bool, Self::Error> {
+        self.0.push_bytes(bytes).map_err(SendTxRcnClDecoderError)
+    }
+
+    #[inline]
+    fn end(self) -> Result<Self::Output, Self::Error> {
+        let (version, salt) = self.0.end().map_err(SendTxRcnClDecoderError)?;
+        Ok(SendTxRcnCl { version: u32::from_le_bytes(version), salt: u64::from_le_bytes(salt) })
+    }
+
+    #[inline]
+    fn read_limit(&self) -> usize {
+        self.0.read_limit()
+    }
+}
+
+impl encoding::Decode for SendTxRcnCl {
+    type Decoder = SendTxRcnClDecoder;
+}
+
+/// Error types for erlay messages.
+pub mod error {
+    use core::convert::Infallible;
+    use core::fmt;
+    use internals::write_err;
+
+    /// An error occurring when decoding a [`SendTxRcnCl`](super) message.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct SendTxRcnClDecoderError(
+        pub(super) <super::SendTxRcnClInnerDecoder as encoding::Decoder>::Error,
+    );
+
+    impl From<Infallible> for SendTxRcnClDecoderError {
+        fn from(never: Infallible) -> Self {
+            match never {}
+        }
+    }
+
+    impl fmt::Display for SendTxRcnClDecoderError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write_err!(f, "sendtxrcncl error"; self.0)
+        }
+    }
+
+    #[cfg(feature = "std")]
+    impl std::error::Error for SendTxRcnClDecoderError {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            Some(&self.0)
+        }
+    }
+}


### PR DESCRIPTION
From first commit: Although full erlay support has not been implemented, Bitcoin Core nodes can still advertise support for erlay as a configuration option. We should support decoding this message. Replaces #5242 

ref: https://github.com/bitcoin/bitcoin/blob/master/src/net_processing.cpp#L3736
ref: https://github.com/bitcoin/bitcoin/blob/master/src/net.cpp#L920
