### PR TITLE
internals: Implement try_push for ArrayVec

### DIFF
--- a/internals/api/all-features.txt
+++ b/internals/api/all-features.txt
@@ -15,6 +15,53 @@ pub type [T; N]::Item = T
 pub fn [T; N]::split_array<const LEFT: usize, const RIGHT: usize>(&self) -> (&[Self::Item; LEFT], &[Self::Item; RIGHT])
 pub fn [T; N]::sub_array<const OFFSET: usize, const LEN: usize>(&self) -> &[Self::Item; LEN]
 pub mod bitcoin_internals::array_vec
+pub mod bitcoin_internals::array_vec::error
+pub enum bitcoin_internals::array_vec::error::Error
+pub bitcoin_internals::array_vec::error::Error::CapacityExceeded(usize)
+impl core::clone::Clone for bitcoin_internals::array_vec::error::Error
+pub fn bitcoin_internals::array_vec::error::Error::clone(&self) -> bitcoin_internals::array_vec::error::Error
+impl core::cmp::Eq for bitcoin_internals::array_vec::error::Error
+impl core::cmp::PartialEq for bitcoin_internals::array_vec::error::Error
+pub fn bitcoin_internals::array_vec::error::Error::eq(&self, other: &bitcoin_internals::array_vec::error::Error) -> bool
+impl core::error::Error for bitcoin_internals::array_vec::error::Error
+pub fn bitcoin_internals::array_vec::error::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl core::fmt::Debug for bitcoin_internals::array_vec::error::Error
+pub fn bitcoin_internals::array_vec::error::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_internals::array_vec::error::Error
+pub fn bitcoin_internals::array_vec::error::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitcoin_internals::array_vec::error::Error
+impl core::marker::StructuralPartialEq for bitcoin_internals::array_vec::error::Error
+impl core::marker::Freeze for bitcoin_internals::array_vec::error::Error
+impl core::marker::Send for bitcoin_internals::array_vec::error::Error
+impl core::marker::Sync for bitcoin_internals::array_vec::error::Error
+impl core::marker::Unpin for bitcoin_internals::array_vec::error::Error
+impl core::marker::UnsafeUnpin for bitcoin_internals::array_vec::error::Error
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_internals::array_vec::error::Error
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_internals::array_vec::error::Error
+impl<T, U> core::convert::Into<U> for bitcoin_internals::array_vec::error::Error where U: core::convert::From<T>
+pub fn bitcoin_internals::array_vec::error::Error::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_internals::array_vec::error::Error where U: core::convert::Into<T>
+pub type bitcoin_internals::array_vec::error::Error::Error = core::convert::Infallible
+pub fn bitcoin_internals::array_vec::error::Error::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_internals::array_vec::error::Error where U: core::convert::TryFrom<T>
+pub type bitcoin_internals::array_vec::error::Error::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_internals::array_vec::error::Error::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_internals::array_vec::error::Error where T: core::clone::Clone
+pub type bitcoin_internals::array_vec::error::Error::Owned = T
+pub fn bitcoin_internals::array_vec::error::Error::clone_into(&self, target: &mut T)
+pub fn bitcoin_internals::array_vec::error::Error::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin_internals::array_vec::error::Error where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_internals::array_vec::error::Error::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin_internals::array_vec::error::Error where T: 'static + ?core::marker::Sized
+pub fn bitcoin_internals::array_vec::error::Error::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_internals::array_vec::error::Error where T: ?core::marker::Sized
+pub fn bitcoin_internals::array_vec::error::Error::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_internals::array_vec::error::Error where T: ?core::marker::Sized
+pub fn bitcoin_internals::array_vec::error::Error::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_internals::array_vec::error::Error where T: core::clone::Clone
+pub unsafe fn bitcoin_internals::array_vec::error::Error::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_internals::array_vec::error::Error
+pub fn bitcoin_internals::array_vec::error::Error::from(t: T) -> T
 pub struct bitcoin_internals::array_vec::ArrayVec<T: core::marker::Copy, const CAP: usize>
 impl<T: core::marker::Copy, const CAP: usize> bitcoin_internals::array_vec::ArrayVec<T, CAP>
 pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::as_mut_slice(&mut self) -> &mut [T]
@@ -24,6 +71,7 @@ pub const fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::from_slice(slice: &
 pub const fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::new() -> Self
 pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::pop(&mut self) -> core::option::Option<T>
 pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::push(&mut self, element: T)
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::try_push(&mut self, element: T) -> core::result::Result<(), bitcoin_internals::array_vec::error::Error>
 impl<'de, T, const CAP: usize> serde::de::Deserialize<'de> for bitcoin_internals::array_vec::ArrayVec<T, CAP> where T: core::marker::Copy + serde::de::Deserialize<'de>
 pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
 impl<T: core::marker::Copy + core::cmp::Eq, const CAP: usize> core::cmp::Eq for bitcoin_internals::array_vec::ArrayVec<T, CAP>

--- a/internals/api/alloc-only.txt
+++ b/internals/api/alloc-only.txt
@@ -13,6 +13,51 @@ pub type [T; N]::Item = T
 pub fn [T; N]::split_array<const LEFT: usize, const RIGHT: usize>(&self) -> (&[Self::Item; LEFT], &[Self::Item; RIGHT])
 pub fn [T; N]::sub_array<const OFFSET: usize, const LEN: usize>(&self) -> &[Self::Item; LEN]
 pub mod bitcoin_internals::array_vec
+pub mod bitcoin_internals::array_vec::error
+pub enum bitcoin_internals::array_vec::error::Error
+pub bitcoin_internals::array_vec::error::Error::CapacityExceeded(usize)
+impl core::clone::Clone for bitcoin_internals::array_vec::error::Error
+pub fn bitcoin_internals::array_vec::error::Error::clone(&self) -> bitcoin_internals::array_vec::error::Error
+impl core::cmp::Eq for bitcoin_internals::array_vec::error::Error
+impl core::cmp::PartialEq for bitcoin_internals::array_vec::error::Error
+pub fn bitcoin_internals::array_vec::error::Error::eq(&self, other: &bitcoin_internals::array_vec::error::Error) -> bool
+impl core::fmt::Debug for bitcoin_internals::array_vec::error::Error
+pub fn bitcoin_internals::array_vec::error::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_internals::array_vec::error::Error
+pub fn bitcoin_internals::array_vec::error::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitcoin_internals::array_vec::error::Error
+impl core::marker::StructuralPartialEq for bitcoin_internals::array_vec::error::Error
+impl core::marker::Freeze for bitcoin_internals::array_vec::error::Error
+impl core::marker::Send for bitcoin_internals::array_vec::error::Error
+impl core::marker::Sync for bitcoin_internals::array_vec::error::Error
+impl core::marker::Unpin for bitcoin_internals::array_vec::error::Error
+impl core::marker::UnsafeUnpin for bitcoin_internals::array_vec::error::Error
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_internals::array_vec::error::Error
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_internals::array_vec::error::Error
+impl<T, U> core::convert::Into<U> for bitcoin_internals::array_vec::error::Error where U: core::convert::From<T>
+pub fn bitcoin_internals::array_vec::error::Error::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_internals::array_vec::error::Error where U: core::convert::Into<T>
+pub type bitcoin_internals::array_vec::error::Error::Error = core::convert::Infallible
+pub fn bitcoin_internals::array_vec::error::Error::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_internals::array_vec::error::Error where U: core::convert::TryFrom<T>
+pub type bitcoin_internals::array_vec::error::Error::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_internals::array_vec::error::Error::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_internals::array_vec::error::Error where T: core::clone::Clone
+pub type bitcoin_internals::array_vec::error::Error::Owned = T
+pub fn bitcoin_internals::array_vec::error::Error::clone_into(&self, target: &mut T)
+pub fn bitcoin_internals::array_vec::error::Error::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin_internals::array_vec::error::Error where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_internals::array_vec::error::Error::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin_internals::array_vec::error::Error where T: 'static + ?core::marker::Sized
+pub fn bitcoin_internals::array_vec::error::Error::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_internals::array_vec::error::Error where T: ?core::marker::Sized
+pub fn bitcoin_internals::array_vec::error::Error::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_internals::array_vec::error::Error where T: ?core::marker::Sized
+pub fn bitcoin_internals::array_vec::error::Error::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_internals::array_vec::error::Error where T: core::clone::Clone
+pub unsafe fn bitcoin_internals::array_vec::error::Error::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_internals::array_vec::error::Error
+pub fn bitcoin_internals::array_vec::error::Error::from(t: T) -> T
 pub struct bitcoin_internals::array_vec::ArrayVec<T: core::marker::Copy, const CAP: usize>
 impl<T: core::marker::Copy, const CAP: usize> bitcoin_internals::array_vec::ArrayVec<T, CAP>
 pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::as_mut_slice(&mut self) -> &mut [T]
@@ -22,6 +67,7 @@ pub const fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::from_slice(slice: &
 pub const fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::new() -> Self
 pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::pop(&mut self) -> core::option::Option<T>
 pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::push(&mut self, element: T)
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::try_push(&mut self, element: T) -> core::result::Result<(), bitcoin_internals::array_vec::error::Error>
 impl<T: core::marker::Copy + core::cmp::Eq, const CAP: usize> core::cmp::Eq for bitcoin_internals::array_vec::ArrayVec<T, CAP>
 impl<T: core::marker::Copy + core::cmp::Ord, const CAP: usize> core::cmp::Ord for bitcoin_internals::array_vec::ArrayVec<T, CAP>
 pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::cmp(&self, other: &Self) -> core::cmp::Ordering

--- a/internals/api/no-features.txt
+++ b/internals/api/no-features.txt
@@ -13,6 +13,45 @@ pub type [T; N]::Item = T
 pub fn [T; N]::split_array<const LEFT: usize, const RIGHT: usize>(&self) -> (&[Self::Item; LEFT], &[Self::Item; RIGHT])
 pub fn [T; N]::sub_array<const OFFSET: usize, const LEN: usize>(&self) -> &[Self::Item; LEN]
 pub mod bitcoin_internals::array_vec
+pub mod bitcoin_internals::array_vec::error
+pub enum bitcoin_internals::array_vec::error::Error
+pub bitcoin_internals::array_vec::error::Error::CapacityExceeded(usize)
+impl core::clone::Clone for bitcoin_internals::array_vec::error::Error
+pub fn bitcoin_internals::array_vec::error::Error::clone(&self) -> bitcoin_internals::array_vec::error::Error
+impl core::cmp::Eq for bitcoin_internals::array_vec::error::Error
+impl core::cmp::PartialEq for bitcoin_internals::array_vec::error::Error
+pub fn bitcoin_internals::array_vec::error::Error::eq(&self, other: &bitcoin_internals::array_vec::error::Error) -> bool
+impl core::fmt::Debug for bitcoin_internals::array_vec::error::Error
+pub fn bitcoin_internals::array_vec::error::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_internals::array_vec::error::Error
+pub fn bitcoin_internals::array_vec::error::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitcoin_internals::array_vec::error::Error
+impl core::marker::StructuralPartialEq for bitcoin_internals::array_vec::error::Error
+impl core::marker::Freeze for bitcoin_internals::array_vec::error::Error
+impl core::marker::Send for bitcoin_internals::array_vec::error::Error
+impl core::marker::Sync for bitcoin_internals::array_vec::error::Error
+impl core::marker::Unpin for bitcoin_internals::array_vec::error::Error
+impl core::marker::UnsafeUnpin for bitcoin_internals::array_vec::error::Error
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_internals::array_vec::error::Error
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_internals::array_vec::error::Error
+impl<T, U> core::convert::Into<U> for bitcoin_internals::array_vec::error::Error where U: core::convert::From<T>
+pub fn bitcoin_internals::array_vec::error::Error::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_internals::array_vec::error::Error where U: core::convert::Into<T>
+pub type bitcoin_internals::array_vec::error::Error::Error = core::convert::Infallible
+pub fn bitcoin_internals::array_vec::error::Error::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_internals::array_vec::error::Error where U: core::convert::TryFrom<T>
+pub type bitcoin_internals::array_vec::error::Error::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_internals::array_vec::error::Error::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for bitcoin_internals::array_vec::error::Error where T: 'static + ?core::marker::Sized
+pub fn bitcoin_internals::array_vec::error::Error::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_internals::array_vec::error::Error where T: ?core::marker::Sized
+pub fn bitcoin_internals::array_vec::error::Error::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_internals::array_vec::error::Error where T: ?core::marker::Sized
+pub fn bitcoin_internals::array_vec::error::Error::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_internals::array_vec::error::Error where T: core::clone::Clone
+pub unsafe fn bitcoin_internals::array_vec::error::Error::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_internals::array_vec::error::Error
+pub fn bitcoin_internals::array_vec::error::Error::from(t: T) -> T
 pub struct bitcoin_internals::array_vec::ArrayVec<T: core::marker::Copy, const CAP: usize>
 impl<T: core::marker::Copy, const CAP: usize> bitcoin_internals::array_vec::ArrayVec<T, CAP>
 pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::as_mut_slice(&mut self) -> &mut [T]
@@ -22,6 +61,7 @@ pub const fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::from_slice(slice: &
 pub const fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::new() -> Self
 pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::pop(&mut self) -> core::option::Option<T>
 pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::push(&mut self, element: T)
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::try_push(&mut self, element: T) -> core::result::Result<(), bitcoin_internals::array_vec::error::Error>
 impl<T: core::marker::Copy + core::cmp::Eq, const CAP: usize> core::cmp::Eq for bitcoin_internals::array_vec::ArrayVec<T, CAP>
 impl<T: core::marker::Copy + core::cmp::Ord, const CAP: usize> core::cmp::Ord for bitcoin_internals::array_vec::ArrayVec<T, CAP>
 pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::cmp(&self, other: &Self) -> core::cmp::Ordering

--- a/internals/src/array_vec.rs
+++ b/internals/src/array_vec.rs
@@ -12,6 +12,8 @@ pub use safety_boundary::ArrayVec;
 mod safety_boundary {
     use core::mem::MaybeUninit;
 
+    use crate::array_vec::error::Error;
+
     /// A growable contiguous collection backed by array.
     #[derive(Copy)]
     pub struct ArrayVec<T: Copy, const CAP: usize> {
@@ -68,6 +70,20 @@ mod safety_boundary {
             assert!(self.len < CAP);
             self.data[self.len] = MaybeUninit::new(element);
             self.len += 1;
+        }
+
+        /// Adds an element into `self`.
+        ///
+        /// # Errors
+        ///
+        /// Returns `CAPSizeExceeded` if the `ArrayVec` is full.
+        pub fn try_push(&mut self, element: T) -> Result<(), Error> {
+            if self.len >= CAP {
+                return Err(Error::CapacityExceeded(CAP));
+            }
+            self.data[self.len] = MaybeUninit::new(element);
+            self.len += 1;
+            Ok(())
         }
 
         /// Removes the last element, returning it.
@@ -176,6 +192,35 @@ impl<T: Copy + fmt::Debug, const CAP: usize> fmt::Debug for ArrayVec<T, CAP> {
 
 impl<T: Copy + core::hash::Hash, const CAP: usize> core::hash::Hash for ArrayVec<T, CAP> {
     fn hash<H: core::hash::Hasher>(&self, state: &mut H) { core::hash::Hash::hash(&**self, state); }
+}
+
+/// Error types for `ArrayVec`.
+pub mod error {
+    use core::fmt;
+
+    /// Errors encountered when inserting or removing elements from an `ArrayVec`.
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+    pub enum Error {
+        /// Attempting to push additional element beyond the `ArrayVec`'s capacity.
+        CapacityExceeded(usize),
+    }
+
+    impl fmt::Display for Error {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            match self {
+                Self::CapacityExceeded(cap) => write!(f, "Capacity exceeded: {}", cap),
+            }
+        }
+    }
+
+    #[cfg(feature = "std")]
+    impl std::error::Error for Error {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            match self {
+                Self::CapacityExceeded(_) => None,
+            }
+        }
+    }
 }
 
 #[cfg(feature = "serde")]

--- a/internals/src/array_vec.rs
+++ b/internals/src/array_vec.rs
@@ -274,11 +274,7 @@ where
 
                 let mut out = ArrayVec::<T, CAP>::new();
                 while let Some(elem) = seq.next_element::<T>()? {
-                    // The `push()` call below panics if array is full but we want to error.
-                    if out.len() >= CAP {
-                        return Err(Error::invalid_length(out.len() + 1, &self));
-                    }
-                    out.push(elem);
+                    out.try_push(elem).map_err(|_| Error::invalid_length(out.len() + 1, &self))?;
                 }
                 Ok(out)
             }


### PR DESCRIPTION
> Abeeujah I meant to call `try_push` here instead and convert the error as invalid length.

*Comment by Kixunil https://github.com/rust-bitcoin/rust-bitcoin/pull/6099#discussion_r3244648444*

`ArrayVec::push` panics when inserting beyond the `ArrayVec`'s capacity. During deserialization, we generally want to return a proper error instead of panicking.

`ArrayVec::try_push` returns a `Result<(), Error>` with the variant `CapacityExceeded(usize)` when the capacity is exceeded, allowing us to map the failure to Serde's `invalid_length` error during deserialization.