### PR TITLE
primitives: add minimum allocation size

### DIFF
--- a/primitives/src/witness.rs
+++ b/primitives/src/witness.rs
@@ -33,6 +33,10 @@ use self::error::WitnessDecoderErrorInner;
 #[cfg(feature = "alloc")]
 const MAX_VECTOR_ALLOCATE: usize = 1_000_000;
 
+/// Minimum amount of memory (in bytes) to allocate at once when deserializing vectors.
+#[cfg(feature = "alloc")]
+const MIN_VECTOR_ALLOCATE: usize = 1_000;
+
 /// Maximum number of items in a witness stack.
 ///
 /// This is an anti-DoS limit based on Bitcoin's 4MB block weight limit.
@@ -350,7 +354,7 @@ impl WitnessDecoder {
         let available_capacity = self.content.capacity() - self.content.len();
 
         if available_capacity == 0 {
-            let batch_size = bytes_needed.min(MAX_VECTOR_ALLOCATE);
+            let batch_size = bytes_needed.clamp(MIN_VECTOR_ALLOCATE, MAX_VECTOR_ALLOCATE);
             self.content.reserve_exact(batch_size);
         }
 


### PR DESCRIPTION
It's possible to construct witnesses that force our current logic to repeatedly allocate a single byte, many thousands of times. This is inefficient, and on some targets (notably: x86 with fuzzer instrumentation) it is slow to the point of being a DoS vector.

I was not able to construct a unit test which meaningfully demonstrates this behavior (or even runs slowly enough to notice), but with this patch, a fuzzer input which previously took several seconds now takes only milliseconds.