### PR TITLE
hashes: Remove Bytes and LEN from HashEngine

### DIFF
--- a/hashes/api/all-features.txt
+++ b/hashes/api/all-features.txt
@@ -99,7 +99,6 @@ pub struct bitcoin_hashes::hash160::HashEngine(_)
 impl bitcoin_hashes::hash160::HashEngine
 pub const fn bitcoin_hashes::hash160::HashEngine::new() -> Self
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::hash160::HashEngine
-pub type bitcoin_hashes::hash160::HashEngine::Bytes = [u8; 20]
 pub type bitcoin_hashes::hash160::HashEngine::Hash = bitcoin_hashes::hash160::Hash
 pub const bitcoin_hashes::hash160::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::hash160::HashEngine::finalize(self) -> Self::Hash
@@ -351,7 +350,6 @@ pub fn bitcoin_hashes::hmac::HmacEngine<T>::from_inner_engines(iengine: T, oengi
 pub fn bitcoin_hashes::hmac::HmacEngine<T>::new(key: &[u8]) -> Self where T: core::default::Default
 pub fn bitcoin_hashes::hmac::HmacEngine<T>::non_secure_erase(&mut self)
 impl<T: bitcoin_hashes::HashEngine> bitcoin_hashes::HashEngine for bitcoin_hashes::hmac::HmacEngine<T>
-pub type bitcoin_hashes::hmac::HmacEngine<T>::Bytes = <T as bitcoin_hashes::HashEngine>::Bytes
 pub type bitcoin_hashes::hmac::HmacEngine<T>::Hash = bitcoin_hashes::hmac::Hmac<<T as bitcoin_hashes::HashEngine>::Hash>
 pub const bitcoin_hashes::hmac::HmacEngine<T>::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::hmac::HmacEngine<T>::finalize(self) -> Self::Hash
@@ -572,7 +570,6 @@ pub struct bitcoin_hashes::ripemd160::HashEngine
 impl bitcoin_hashes::ripemd160::HashEngine
 pub const fn bitcoin_hashes::ripemd160::HashEngine::new() -> Self
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::ripemd160::HashEngine
-pub type bitcoin_hashes::ripemd160::HashEngine::Bytes = [u8; 20]
 pub type bitcoin_hashes::ripemd160::HashEngine::Hash = bitcoin_hashes::ripemd160::Hash
 pub const bitcoin_hashes::ripemd160::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::ripemd160::HashEngine::finalize(self) -> Self::Hash
@@ -713,7 +710,6 @@ pub struct bitcoin_hashes::sha1::HashEngine
 impl bitcoin_hashes::sha1::HashEngine
 pub const fn bitcoin_hashes::sha1::HashEngine::new() -> Self
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha1::HashEngine
-pub type bitcoin_hashes::sha1::HashEngine::Bytes = [u8; 20]
 pub type bitcoin_hashes::sha1::HashEngine::Hash = bitcoin_hashes::sha1::Hash
 pub const bitcoin_hashes::sha1::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha1::HashEngine::finalize(self) -> Self::Hash
@@ -907,7 +903,6 @@ pub fn bitcoin_hashes::sha256::HashEngine::from_midstate(midstate: bitcoin_hashe
 pub fn bitcoin_hashes::sha256::HashEngine::midstate(&self) -> core::result::Result<bitcoin_hashes::sha256::Midstate, bitcoin_hashes::sha256::error::MidstateError>
 pub const fn bitcoin_hashes::sha256::HashEngine::new() -> Self
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha256::HashEngine
-pub type bitcoin_hashes::sha256::HashEngine::Bytes = [u8; 32]
 pub type bitcoin_hashes::sha256::HashEngine::Hash = bitcoin_hashes::sha256::Hash
 pub const bitcoin_hashes::sha256::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha256::HashEngine::finalize(self) -> Self::Hash
@@ -1151,7 +1146,6 @@ pub struct bitcoin_hashes::sha256d::HashEngine(_)
 impl bitcoin_hashes::sha256d::HashEngine
 pub const fn bitcoin_hashes::sha256d::HashEngine::new() -> Self
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha256d::HashEngine
-pub type bitcoin_hashes::sha256d::HashEngine::Bytes = [u8; 32]
 pub type bitcoin_hashes::sha256d::HashEngine::Hash = bitcoin_hashes::sha256d::Hash
 pub const bitcoin_hashes::sha256d::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha256d::HashEngine::finalize(self) -> Self::Hash
@@ -1285,7 +1279,6 @@ pub fn bitcoin_hashes::sha256t::Hash<T>::from(t: T) -> T
 impl<T> serde::de::DeserializeOwned for bitcoin_hashes::sha256t::Hash<T> where T: for<'de> serde::de::Deserialize<'de>
 pub struct bitcoin_hashes::sha256t::HashEngine<T>(_, _)
 impl<T: bitcoin_hashes::sha256t::Tag> bitcoin_hashes::HashEngine for bitcoin_hashes::sha256t::HashEngine<T>
-pub type bitcoin_hashes::sha256t::HashEngine<T>::Bytes = [u8; 32]
 pub type bitcoin_hashes::sha256t::HashEngine<T>::Hash = bitcoin_hashes::sha256t::Hash<T>
 pub const bitcoin_hashes::sha256t::HashEngine<T>::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha256t::HashEngine<T>::finalize(self) -> Self::Hash
@@ -1428,7 +1421,6 @@ pub struct bitcoin_hashes::sha384::HashEngine(_)
 impl bitcoin_hashes::sha384::HashEngine
 pub const fn bitcoin_hashes::sha384::HashEngine::new() -> Self
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha384::HashEngine
-pub type bitcoin_hashes::sha384::HashEngine::Bytes = [u8; 48]
 pub type bitcoin_hashes::sha384::HashEngine::Hash = bitcoin_hashes::sha384::Hash
 pub const bitcoin_hashes::sha384::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha384::HashEngine::finalize(self) -> Self::Hash
@@ -1567,7 +1559,6 @@ pub struct bitcoin_hashes::sha3_256::HashEngine
 impl bitcoin_hashes::sha3_256::HashEngine
 pub const fn bitcoin_hashes::sha3_256::HashEngine::new() -> Self
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha3_256::HashEngine
-pub type bitcoin_hashes::sha3_256::HashEngine::Bytes = [u8; 32]
 pub type bitcoin_hashes::sha3_256::HashEngine::Hash = bitcoin_hashes::sha3_256::Hash
 pub const bitcoin_hashes::sha3_256::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha3_256::HashEngine::finalize(self) -> Self::Hash
@@ -1708,7 +1699,6 @@ pub struct bitcoin_hashes::sha512::HashEngine
 impl bitcoin_hashes::sha512::HashEngine
 pub const fn bitcoin_hashes::sha512::HashEngine::new() -> Self
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512::HashEngine
-pub type bitcoin_hashes::sha512::HashEngine::Bytes = [u8; 64]
 pub type bitcoin_hashes::sha512::HashEngine::Hash = bitcoin_hashes::sha512::Hash
 pub const bitcoin_hashes::sha512::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha512::HashEngine::finalize(self) -> Self::Hash
@@ -1849,7 +1839,6 @@ pub struct bitcoin_hashes::sha512_256::HashEngine(_)
 impl bitcoin_hashes::sha512_256::HashEngine
 pub const fn bitcoin_hashes::sha512_256::HashEngine::new() -> Self
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512_256::HashEngine
-pub type bitcoin_hashes::sha512_256::HashEngine::Bytes = [u8; 64]
 pub type bitcoin_hashes::sha512_256::HashEngine::Hash = bitcoin_hashes::sha512_256::Hash
 pub const bitcoin_hashes::sha512_256::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha512_256::HashEngine::finalize(self) -> Self::Hash
@@ -1991,7 +1980,6 @@ impl bitcoin_hashes::siphash24::HashEngine
 pub fn bitcoin_hashes::siphash24::HashEngine::keys(&self) -> (u64, u64)
 pub const fn bitcoin_hashes::siphash24::HashEngine::with_keys(k0: u64, k1: u64) -> Self
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::siphash24::HashEngine
-pub type bitcoin_hashes::siphash24::HashEngine::Bytes = [u8; 8]
 pub type bitcoin_hashes::siphash24::HashEngine::Hash = bitcoin_hashes::siphash24::Hash
 pub const bitcoin_hashes::siphash24::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::siphash24::HashEngine::finalize(self) -> Self::Hash
@@ -2241,7 +2229,6 @@ pub fn bitcoin_hashes::hmac::HmacEngine<T>::from_inner_engines(iengine: T, oengi
 pub fn bitcoin_hashes::hmac::HmacEngine<T>::new(key: &[u8]) -> Self where T: core::default::Default
 pub fn bitcoin_hashes::hmac::HmacEngine<T>::non_secure_erase(&mut self)
 impl<T: bitcoin_hashes::HashEngine> bitcoin_hashes::HashEngine for bitcoin_hashes::hmac::HmacEngine<T>
-pub type bitcoin_hashes::hmac::HmacEngine<T>::Bytes = <T as bitcoin_hashes::HashEngine>::Bytes
 pub type bitcoin_hashes::hmac::HmacEngine<T>::Hash = bitcoin_hashes::hmac::Hmac<<T as bitcoin_hashes::HashEngine>::Hash>
 pub const bitcoin_hashes::hmac::HmacEngine<T>::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::hmac::HmacEngine<T>::finalize(self) -> Self::Hash
@@ -3261,92 +3248,78 @@ pub fn bitcoin_hashes::sha256t::Hash<T>::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin_hashes::sha256t::Hash<T>::from_byte_array(bytes: Self::Bytes) -> Self
 pub fn bitcoin_hashes::sha256t::Hash<T>::to_byte_array(self) -> Self::Bytes
 pub trait bitcoin_hashes::HashEngine: core::clone::Clone
-pub type bitcoin_hashes::HashEngine::Bytes: core::marker::Copy + bitcoin_hashes::IsByteArray
 pub type bitcoin_hashes::HashEngine::Hash: bitcoin_hashes::Hash
 pub const bitcoin_hashes::HashEngine::BLOCK_SIZE: usize
-pub const bitcoin_hashes::HashEngine::LEN: usize
 pub fn bitcoin_hashes::HashEngine::finalize(self) -> Self::Hash
 pub fn bitcoin_hashes::HashEngine::input(&mut self, data: &[u8])
 pub fn bitcoin_hashes::HashEngine::n_bytes_hashed(&self) -> u64
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::hash160::HashEngine
-pub type bitcoin_hashes::hash160::HashEngine::Bytes = [u8; 20]
 pub type bitcoin_hashes::hash160::HashEngine::Hash = bitcoin_hashes::hash160::Hash
 pub const bitcoin_hashes::hash160::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::hash160::HashEngine::finalize(self) -> Self::Hash
 pub fn bitcoin_hashes::hash160::HashEngine::input(&mut self, data: &[u8])
 pub fn bitcoin_hashes::hash160::HashEngine::n_bytes_hashed(&self) -> u64
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::ripemd160::HashEngine
-pub type bitcoin_hashes::ripemd160::HashEngine::Bytes = [u8; 20]
 pub type bitcoin_hashes::ripemd160::HashEngine::Hash = bitcoin_hashes::ripemd160::Hash
 pub const bitcoin_hashes::ripemd160::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::ripemd160::HashEngine::finalize(self) -> Self::Hash
 pub fn bitcoin_hashes::ripemd160::HashEngine::input(&mut self, inp: &[u8])
 pub fn bitcoin_hashes::ripemd160::HashEngine::n_bytes_hashed(&self) -> u64
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha1::HashEngine
-pub type bitcoin_hashes::sha1::HashEngine::Bytes = [u8; 20]
 pub type bitcoin_hashes::sha1::HashEngine::Hash = bitcoin_hashes::sha1::Hash
 pub const bitcoin_hashes::sha1::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha1::HashEngine::finalize(self) -> Self::Hash
 pub fn bitcoin_hashes::sha1::HashEngine::input(&mut self, inp: &[u8])
 pub fn bitcoin_hashes::sha1::HashEngine::n_bytes_hashed(&self) -> u64
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha256::HashEngine
-pub type bitcoin_hashes::sha256::HashEngine::Bytes = [u8; 32]
 pub type bitcoin_hashes::sha256::HashEngine::Hash = bitcoin_hashes::sha256::Hash
 pub const bitcoin_hashes::sha256::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha256::HashEngine::finalize(self) -> Self::Hash
 pub fn bitcoin_hashes::sha256::HashEngine::input(&mut self, inp: &[u8])
 pub fn bitcoin_hashes::sha256::HashEngine::n_bytes_hashed(&self) -> u64
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha256d::HashEngine
-pub type bitcoin_hashes::sha256d::HashEngine::Bytes = [u8; 32]
 pub type bitcoin_hashes::sha256d::HashEngine::Hash = bitcoin_hashes::sha256d::Hash
 pub const bitcoin_hashes::sha256d::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha256d::HashEngine::finalize(self) -> Self::Hash
 pub fn bitcoin_hashes::sha256d::HashEngine::input(&mut self, data: &[u8])
 pub fn bitcoin_hashes::sha256d::HashEngine::n_bytes_hashed(&self) -> u64
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha384::HashEngine
-pub type bitcoin_hashes::sha384::HashEngine::Bytes = [u8; 48]
 pub type bitcoin_hashes::sha384::HashEngine::Hash = bitcoin_hashes::sha384::Hash
 pub const bitcoin_hashes::sha384::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha384::HashEngine::finalize(self) -> Self::Hash
 pub fn bitcoin_hashes::sha384::HashEngine::input(&mut self, inp: &[u8])
 pub fn bitcoin_hashes::sha384::HashEngine::n_bytes_hashed(&self) -> u64
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha3_256::HashEngine
-pub type bitcoin_hashes::sha3_256::HashEngine::Bytes = [u8; 32]
 pub type bitcoin_hashes::sha3_256::HashEngine::Hash = bitcoin_hashes::sha3_256::Hash
 pub const bitcoin_hashes::sha3_256::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha3_256::HashEngine::finalize(self) -> Self::Hash
 pub fn bitcoin_hashes::sha3_256::HashEngine::input(&mut self, inp: &[u8])
 pub fn bitcoin_hashes::sha3_256::HashEngine::n_bytes_hashed(&self) -> u64
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512::HashEngine
-pub type bitcoin_hashes::sha512::HashEngine::Bytes = [u8; 64]
 pub type bitcoin_hashes::sha512::HashEngine::Hash = bitcoin_hashes::sha512::Hash
 pub const bitcoin_hashes::sha512::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha512::HashEngine::finalize(self) -> Self::Hash
 pub fn bitcoin_hashes::sha512::HashEngine::input(&mut self, inp: &[u8])
 pub fn bitcoin_hashes::sha512::HashEngine::n_bytes_hashed(&self) -> u64
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512_256::HashEngine
-pub type bitcoin_hashes::sha512_256::HashEngine::Bytes = [u8; 64]
 pub type bitcoin_hashes::sha512_256::HashEngine::Hash = bitcoin_hashes::sha512_256::Hash
 pub const bitcoin_hashes::sha512_256::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha512_256::HashEngine::finalize(self) -> Self::Hash
 pub fn bitcoin_hashes::sha512_256::HashEngine::input(&mut self, inp: &[u8])
 pub fn bitcoin_hashes::sha512_256::HashEngine::n_bytes_hashed(&self) -> u64
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::siphash24::HashEngine
-pub type bitcoin_hashes::siphash24::HashEngine::Bytes = [u8; 8]
 pub type bitcoin_hashes::siphash24::HashEngine::Hash = bitcoin_hashes::siphash24::Hash
 pub const bitcoin_hashes::siphash24::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::siphash24::HashEngine::finalize(self) -> Self::Hash
 pub fn bitcoin_hashes::siphash24::HashEngine::input(&mut self, msg: &[u8])
 pub fn bitcoin_hashes::siphash24::HashEngine::n_bytes_hashed(&self) -> u64
 impl<T: bitcoin_hashes::HashEngine> bitcoin_hashes::HashEngine for bitcoin_hashes::hmac::HmacEngine<T>
-pub type bitcoin_hashes::hmac::HmacEngine<T>::Bytes = <T as bitcoin_hashes::HashEngine>::Bytes
 pub type bitcoin_hashes::hmac::HmacEngine<T>::Hash = bitcoin_hashes::hmac::Hmac<<T as bitcoin_hashes::HashEngine>::Hash>
 pub const bitcoin_hashes::hmac::HmacEngine<T>::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::hmac::HmacEngine<T>::finalize(self) -> Self::Hash
 pub fn bitcoin_hashes::hmac::HmacEngine<T>::input(&mut self, buf: &[u8])
 pub fn bitcoin_hashes::hmac::HmacEngine<T>::n_bytes_hashed(&self) -> u64
 impl<T: bitcoin_hashes::sha256t::Tag> bitcoin_hashes::HashEngine for bitcoin_hashes::sha256t::HashEngine<T>
-pub type bitcoin_hashes::sha256t::HashEngine<T>::Bytes = [u8; 32]
 pub type bitcoin_hashes::sha256t::HashEngine<T>::Hash = bitcoin_hashes::sha256t::Hash<T>
 pub const bitcoin_hashes::sha256t::HashEngine<T>::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha256t::HashEngine<T>::finalize(self) -> Self::Hash

--- a/hashes/api/alloc-only.txt
+++ b/hashes/api/alloc-only.txt
@@ -79,7 +79,6 @@ pub struct bitcoin_hashes::hash160::HashEngine(_)
 impl bitcoin_hashes::hash160::HashEngine
 pub const fn bitcoin_hashes::hash160::HashEngine::new() -> Self
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::hash160::HashEngine
-pub type bitcoin_hashes::hash160::HashEngine::Bytes = [u8; 20]
 pub type bitcoin_hashes::hash160::HashEngine::Hash = bitcoin_hashes::hash160::Hash
 pub const bitcoin_hashes::hash160::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::hash160::HashEngine::finalize(self) -> Self::Hash
@@ -319,7 +318,6 @@ pub fn bitcoin_hashes::hmac::HmacEngine<T>::from_inner_engines(iengine: T, oengi
 pub fn bitcoin_hashes::hmac::HmacEngine<T>::new(key: &[u8]) -> Self where T: core::default::Default
 pub fn bitcoin_hashes::hmac::HmacEngine<T>::non_secure_erase(&mut self)
 impl<T: bitcoin_hashes::HashEngine> bitcoin_hashes::HashEngine for bitcoin_hashes::hmac::HmacEngine<T>
-pub type bitcoin_hashes::hmac::HmacEngine<T>::Bytes = <T as bitcoin_hashes::HashEngine>::Bytes
 pub type bitcoin_hashes::hmac::HmacEngine<T>::Hash = bitcoin_hashes::hmac::Hmac<<T as bitcoin_hashes::HashEngine>::Hash>
 pub const bitcoin_hashes::hmac::HmacEngine<T>::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::hmac::HmacEngine<T>::finalize(self) -> Self::Hash
@@ -503,7 +501,6 @@ pub struct bitcoin_hashes::ripemd160::HashEngine
 impl bitcoin_hashes::ripemd160::HashEngine
 pub const fn bitcoin_hashes::ripemd160::HashEngine::new() -> Self
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::ripemd160::HashEngine
-pub type bitcoin_hashes::ripemd160::HashEngine::Bytes = [u8; 20]
 pub type bitcoin_hashes::ripemd160::HashEngine::Hash = bitcoin_hashes::ripemd160::Hash
 pub const bitcoin_hashes::ripemd160::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::ripemd160::HashEngine::finalize(self) -> Self::Hash
@@ -623,7 +620,6 @@ pub struct bitcoin_hashes::sha1::HashEngine
 impl bitcoin_hashes::sha1::HashEngine
 pub const fn bitcoin_hashes::sha1::HashEngine::new() -> Self
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha1::HashEngine
-pub type bitcoin_hashes::sha1::HashEngine::Bytes = [u8; 20]
 pub type bitcoin_hashes::sha1::HashEngine::Hash = bitcoin_hashes::sha1::Hash
 pub const bitcoin_hashes::sha1::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha1::HashEngine::finalize(self) -> Self::Hash
@@ -794,7 +790,6 @@ pub fn bitcoin_hashes::sha256::HashEngine::from_midstate(midstate: bitcoin_hashe
 pub fn bitcoin_hashes::sha256::HashEngine::midstate(&self) -> core::result::Result<bitcoin_hashes::sha256::Midstate, bitcoin_hashes::sha256::error::MidstateError>
 pub const fn bitcoin_hashes::sha256::HashEngine::new() -> Self
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha256::HashEngine
-pub type bitcoin_hashes::sha256::HashEngine::Bytes = [u8; 32]
 pub type bitcoin_hashes::sha256::HashEngine::Hash = bitcoin_hashes::sha256::Hash
 pub const bitcoin_hashes::sha256::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha256::HashEngine::finalize(self) -> Self::Hash
@@ -1015,7 +1010,6 @@ pub struct bitcoin_hashes::sha256d::HashEngine(_)
 impl bitcoin_hashes::sha256d::HashEngine
 pub const fn bitcoin_hashes::sha256d::HashEngine::new() -> Self
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha256d::HashEngine
-pub type bitcoin_hashes::sha256d::HashEngine::Bytes = [u8; 32]
 pub type bitcoin_hashes::sha256d::HashEngine::Hash = bitcoin_hashes::sha256d::Hash
 pub const bitcoin_hashes::sha256d::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha256d::HashEngine::finalize(self) -> Self::Hash
@@ -1130,7 +1124,6 @@ impl<T> core::convert::From<T> for bitcoin_hashes::sha256t::Hash<T>
 pub fn bitcoin_hashes::sha256t::Hash<T>::from(t: T) -> T
 pub struct bitcoin_hashes::sha256t::HashEngine<T>(_, _)
 impl<T: bitcoin_hashes::sha256t::Tag> bitcoin_hashes::HashEngine for bitcoin_hashes::sha256t::HashEngine<T>
-pub type bitcoin_hashes::sha256t::HashEngine<T>::Bytes = [u8; 32]
 pub type bitcoin_hashes::sha256t::HashEngine<T>::Hash = bitcoin_hashes::sha256t::Hash<T>
 pub const bitcoin_hashes::sha256t::HashEngine<T>::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha256t::HashEngine<T>::finalize(self) -> Self::Hash
@@ -1252,7 +1245,6 @@ pub struct bitcoin_hashes::sha384::HashEngine(_)
 impl bitcoin_hashes::sha384::HashEngine
 pub const fn bitcoin_hashes::sha384::HashEngine::new() -> Self
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha384::HashEngine
-pub type bitcoin_hashes::sha384::HashEngine::Bytes = [u8; 48]
 pub type bitcoin_hashes::sha384::HashEngine::Hash = bitcoin_hashes::sha384::Hash
 pub const bitcoin_hashes::sha384::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha384::HashEngine::finalize(self) -> Self::Hash
@@ -1370,7 +1362,6 @@ pub struct bitcoin_hashes::sha3_256::HashEngine
 impl bitcoin_hashes::sha3_256::HashEngine
 pub const fn bitcoin_hashes::sha3_256::HashEngine::new() -> Self
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha3_256::HashEngine
-pub type bitcoin_hashes::sha3_256::HashEngine::Bytes = [u8; 32]
 pub type bitcoin_hashes::sha3_256::HashEngine::Hash = bitcoin_hashes::sha3_256::Hash
 pub const bitcoin_hashes::sha3_256::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha3_256::HashEngine::finalize(self) -> Self::Hash
@@ -1490,7 +1481,6 @@ pub struct bitcoin_hashes::sha512::HashEngine
 impl bitcoin_hashes::sha512::HashEngine
 pub const fn bitcoin_hashes::sha512::HashEngine::new() -> Self
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512::HashEngine
-pub type bitcoin_hashes::sha512::HashEngine::Bytes = [u8; 64]
 pub type bitcoin_hashes::sha512::HashEngine::Hash = bitcoin_hashes::sha512::Hash
 pub const bitcoin_hashes::sha512::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha512::HashEngine::finalize(self) -> Self::Hash
@@ -1610,7 +1600,6 @@ pub struct bitcoin_hashes::sha512_256::HashEngine(_)
 impl bitcoin_hashes::sha512_256::HashEngine
 pub const fn bitcoin_hashes::sha512_256::HashEngine::new() -> Self
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512_256::HashEngine
-pub type bitcoin_hashes::sha512_256::HashEngine::Bytes = [u8; 64]
 pub type bitcoin_hashes::sha512_256::HashEngine::Hash = bitcoin_hashes::sha512_256::Hash
 pub const bitcoin_hashes::sha512_256::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha512_256::HashEngine::finalize(self) -> Self::Hash
@@ -1733,7 +1722,6 @@ impl bitcoin_hashes::siphash24::HashEngine
 pub fn bitcoin_hashes::siphash24::HashEngine::keys(&self) -> (u64, u64)
 pub const fn bitcoin_hashes::siphash24::HashEngine::with_keys(k0: u64, k1: u64) -> Self
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::siphash24::HashEngine
-pub type bitcoin_hashes::siphash24::HashEngine::Bytes = [u8; 8]
 pub type bitcoin_hashes::siphash24::HashEngine::Hash = bitcoin_hashes::siphash24::Hash
 pub const bitcoin_hashes::siphash24::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::siphash24::HashEngine::finalize(self) -> Self::Hash
@@ -1955,7 +1943,6 @@ pub fn bitcoin_hashes::hmac::HmacEngine<T>::from_inner_engines(iengine: T, oengi
 pub fn bitcoin_hashes::hmac::HmacEngine<T>::new(key: &[u8]) -> Self where T: core::default::Default
 pub fn bitcoin_hashes::hmac::HmacEngine<T>::non_secure_erase(&mut self)
 impl<T: bitcoin_hashes::HashEngine> bitcoin_hashes::HashEngine for bitcoin_hashes::hmac::HmacEngine<T>
-pub type bitcoin_hashes::hmac::HmacEngine<T>::Bytes = <T as bitcoin_hashes::HashEngine>::Bytes
 pub type bitcoin_hashes::hmac::HmacEngine<T>::Hash = bitcoin_hashes::hmac::Hmac<<T as bitcoin_hashes::HashEngine>::Hash>
 pub const bitcoin_hashes::hmac::HmacEngine<T>::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::hmac::HmacEngine<T>::finalize(self) -> Self::Hash
@@ -2796,92 +2783,78 @@ pub fn bitcoin_hashes::sha256t::Hash<T>::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin_hashes::sha256t::Hash<T>::from_byte_array(bytes: Self::Bytes) -> Self
 pub fn bitcoin_hashes::sha256t::Hash<T>::to_byte_array(self) -> Self::Bytes
 pub trait bitcoin_hashes::HashEngine: core::clone::Clone
-pub type bitcoin_hashes::HashEngine::Bytes: core::marker::Copy + bitcoin_hashes::IsByteArray
 pub type bitcoin_hashes::HashEngine::Hash: bitcoin_hashes::Hash
 pub const bitcoin_hashes::HashEngine::BLOCK_SIZE: usize
-pub const bitcoin_hashes::HashEngine::LEN: usize
 pub fn bitcoin_hashes::HashEngine::finalize(self) -> Self::Hash
 pub fn bitcoin_hashes::HashEngine::input(&mut self, data: &[u8])
 pub fn bitcoin_hashes::HashEngine::n_bytes_hashed(&self) -> u64
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::hash160::HashEngine
-pub type bitcoin_hashes::hash160::HashEngine::Bytes = [u8; 20]
 pub type bitcoin_hashes::hash160::HashEngine::Hash = bitcoin_hashes::hash160::Hash
 pub const bitcoin_hashes::hash160::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::hash160::HashEngine::finalize(self) -> Self::Hash
 pub fn bitcoin_hashes::hash160::HashEngine::input(&mut self, data: &[u8])
 pub fn bitcoin_hashes::hash160::HashEngine::n_bytes_hashed(&self) -> u64
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::ripemd160::HashEngine
-pub type bitcoin_hashes::ripemd160::HashEngine::Bytes = [u8; 20]
 pub type bitcoin_hashes::ripemd160::HashEngine::Hash = bitcoin_hashes::ripemd160::Hash
 pub const bitcoin_hashes::ripemd160::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::ripemd160::HashEngine::finalize(self) -> Self::Hash
 pub fn bitcoin_hashes::ripemd160::HashEngine::input(&mut self, inp: &[u8])
 pub fn bitcoin_hashes::ripemd160::HashEngine::n_bytes_hashed(&self) -> u64
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha1::HashEngine
-pub type bitcoin_hashes::sha1::HashEngine::Bytes = [u8; 20]
 pub type bitcoin_hashes::sha1::HashEngine::Hash = bitcoin_hashes::sha1::Hash
 pub const bitcoin_hashes::sha1::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha1::HashEngine::finalize(self) -> Self::Hash
 pub fn bitcoin_hashes::sha1::HashEngine::input(&mut self, inp: &[u8])
 pub fn bitcoin_hashes::sha1::HashEngine::n_bytes_hashed(&self) -> u64
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha256::HashEngine
-pub type bitcoin_hashes::sha256::HashEngine::Bytes = [u8; 32]
 pub type bitcoin_hashes::sha256::HashEngine::Hash = bitcoin_hashes::sha256::Hash
 pub const bitcoin_hashes::sha256::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha256::HashEngine::finalize(self) -> Self::Hash
 pub fn bitcoin_hashes::sha256::HashEngine::input(&mut self, inp: &[u8])
 pub fn bitcoin_hashes::sha256::HashEngine::n_bytes_hashed(&self) -> u64
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha256d::HashEngine
-pub type bitcoin_hashes::sha256d::HashEngine::Bytes = [u8; 32]
 pub type bitcoin_hashes::sha256d::HashEngine::Hash = bitcoin_hashes::sha256d::Hash
 pub const bitcoin_hashes::sha256d::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha256d::HashEngine::finalize(self) -> Self::Hash
 pub fn bitcoin_hashes::sha256d::HashEngine::input(&mut self, data: &[u8])
 pub fn bitcoin_hashes::sha256d::HashEngine::n_bytes_hashed(&self) -> u64
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha384::HashEngine
-pub type bitcoin_hashes::sha384::HashEngine::Bytes = [u8; 48]
 pub type bitcoin_hashes::sha384::HashEngine::Hash = bitcoin_hashes::sha384::Hash
 pub const bitcoin_hashes::sha384::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha384::HashEngine::finalize(self) -> Self::Hash
 pub fn bitcoin_hashes::sha384::HashEngine::input(&mut self, inp: &[u8])
 pub fn bitcoin_hashes::sha384::HashEngine::n_bytes_hashed(&self) -> u64
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha3_256::HashEngine
-pub type bitcoin_hashes::sha3_256::HashEngine::Bytes = [u8; 32]
 pub type bitcoin_hashes::sha3_256::HashEngine::Hash = bitcoin_hashes::sha3_256::Hash
 pub const bitcoin_hashes::sha3_256::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha3_256::HashEngine::finalize(self) -> Self::Hash
 pub fn bitcoin_hashes::sha3_256::HashEngine::input(&mut self, inp: &[u8])
 pub fn bitcoin_hashes::sha3_256::HashEngine::n_bytes_hashed(&self) -> u64
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512::HashEngine
-pub type bitcoin_hashes::sha512::HashEngine::Bytes = [u8; 64]
 pub type bitcoin_hashes::sha512::HashEngine::Hash = bitcoin_hashes::sha512::Hash
 pub const bitcoin_hashes::sha512::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha512::HashEngine::finalize(self) -> Self::Hash
 pub fn bitcoin_hashes::sha512::HashEngine::input(&mut self, inp: &[u8])
 pub fn bitcoin_hashes::sha512::HashEngine::n_bytes_hashed(&self) -> u64
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512_256::HashEngine
-pub type bitcoin_hashes::sha512_256::HashEngine::Bytes = [u8; 64]
 pub type bitcoin_hashes::sha512_256::HashEngine::Hash = bitcoin_hashes::sha512_256::Hash
 pub const bitcoin_hashes::sha512_256::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha512_256::HashEngine::finalize(self) -> Self::Hash
 pub fn bitcoin_hashes::sha512_256::HashEngine::input(&mut self, inp: &[u8])
 pub fn bitcoin_hashes::sha512_256::HashEngine::n_bytes_hashed(&self) -> u64
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::siphash24::HashEngine
-pub type bitcoin_hashes::siphash24::HashEngine::Bytes = [u8; 8]
 pub type bitcoin_hashes::siphash24::HashEngine::Hash = bitcoin_hashes::siphash24::Hash
 pub const bitcoin_hashes::siphash24::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::siphash24::HashEngine::finalize(self) -> Self::Hash
 pub fn bitcoin_hashes::siphash24::HashEngine::input(&mut self, msg: &[u8])
 pub fn bitcoin_hashes::siphash24::HashEngine::n_bytes_hashed(&self) -> u64
 impl<T: bitcoin_hashes::HashEngine> bitcoin_hashes::HashEngine for bitcoin_hashes::hmac::HmacEngine<T>
-pub type bitcoin_hashes::hmac::HmacEngine<T>::Bytes = <T as bitcoin_hashes::HashEngine>::Bytes
 pub type bitcoin_hashes::hmac::HmacEngine<T>::Hash = bitcoin_hashes::hmac::Hmac<<T as bitcoin_hashes::HashEngine>::Hash>
 pub const bitcoin_hashes::hmac::HmacEngine<T>::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::hmac::HmacEngine<T>::finalize(self) -> Self::Hash
 pub fn bitcoin_hashes::hmac::HmacEngine<T>::input(&mut self, buf: &[u8])
 pub fn bitcoin_hashes::hmac::HmacEngine<T>::n_bytes_hashed(&self) -> u64
 impl<T: bitcoin_hashes::sha256t::Tag> bitcoin_hashes::HashEngine for bitcoin_hashes::sha256t::HashEngine<T>
-pub type bitcoin_hashes::sha256t::HashEngine<T>::Bytes = [u8; 32]
 pub type bitcoin_hashes::sha256t::HashEngine<T>::Hash = bitcoin_hashes::sha256t::Hash<T>
 pub const bitcoin_hashes::sha256t::HashEngine<T>::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha256t::HashEngine<T>::finalize(self) -> Self::Hash

--- a/hashes/api/no-features.txt
+++ b/hashes/api/no-features.txt
@@ -75,7 +75,6 @@ pub struct bitcoin_hashes::hash160::HashEngine(_)
 impl bitcoin_hashes::hash160::HashEngine
 pub const fn bitcoin_hashes::hash160::HashEngine::new() -> Self
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::hash160::HashEngine
-pub type bitcoin_hashes::hash160::HashEngine::Bytes = [u8; 20]
 pub type bitcoin_hashes::hash160::HashEngine::Hash = bitcoin_hashes::hash160::Hash
 pub const bitcoin_hashes::hash160::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::hash160::HashEngine::finalize(self) -> Self::Hash
@@ -288,7 +287,6 @@ pub fn bitcoin_hashes::hmac::HmacEngine<T>::from_inner_engines(iengine: T, oengi
 pub fn bitcoin_hashes::hmac::HmacEngine<T>::new(key: &[u8]) -> Self where T: core::default::Default
 pub fn bitcoin_hashes::hmac::HmacEngine<T>::non_secure_erase(&mut self)
 impl<T: bitcoin_hashes::HashEngine> bitcoin_hashes::HashEngine for bitcoin_hashes::hmac::HmacEngine<T>
-pub type bitcoin_hashes::hmac::HmacEngine<T>::Bytes = <T as bitcoin_hashes::HashEngine>::Bytes
 pub type bitcoin_hashes::hmac::HmacEngine<T>::Hash = bitcoin_hashes::hmac::Hmac<<T as bitcoin_hashes::HashEngine>::Hash>
 pub const bitcoin_hashes::hmac::HmacEngine<T>::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::hmac::HmacEngine<T>::finalize(self) -> Self::Hash
@@ -460,7 +458,6 @@ pub struct bitcoin_hashes::ripemd160::HashEngine
 impl bitcoin_hashes::ripemd160::HashEngine
 pub const fn bitcoin_hashes::ripemd160::HashEngine::new() -> Self
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::ripemd160::HashEngine
-pub type bitcoin_hashes::ripemd160::HashEngine::Bytes = [u8; 20]
 pub type bitcoin_hashes::ripemd160::HashEngine::Hash = bitcoin_hashes::ripemd160::Hash
 pub const bitcoin_hashes::ripemd160::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::ripemd160::HashEngine::finalize(self) -> Self::Hash
@@ -572,7 +569,6 @@ pub struct bitcoin_hashes::sha1::HashEngine
 impl bitcoin_hashes::sha1::HashEngine
 pub const fn bitcoin_hashes::sha1::HashEngine::new() -> Self
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha1::HashEngine
-pub type bitcoin_hashes::sha1::HashEngine::Bytes = [u8; 20]
 pub type bitcoin_hashes::sha1::HashEngine::Hash = bitcoin_hashes::sha1::Hash
 pub const bitcoin_hashes::sha1::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha1::HashEngine::finalize(self) -> Self::Hash
@@ -729,7 +725,6 @@ pub fn bitcoin_hashes::sha256::HashEngine::from_midstate(midstate: bitcoin_hashe
 pub fn bitcoin_hashes::sha256::HashEngine::midstate(&self) -> core::result::Result<bitcoin_hashes::sha256::Midstate, bitcoin_hashes::sha256::error::MidstateError>
 pub const fn bitcoin_hashes::sha256::HashEngine::new() -> Self
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha256::HashEngine
-pub type bitcoin_hashes::sha256::HashEngine::Bytes = [u8; 32]
 pub type bitcoin_hashes::sha256::HashEngine::Hash = bitcoin_hashes::sha256::Hash
 pub const bitcoin_hashes::sha256::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha256::HashEngine::finalize(self) -> Self::Hash
@@ -932,7 +927,6 @@ pub struct bitcoin_hashes::sha256d::HashEngine(_)
 impl bitcoin_hashes::sha256d::HashEngine
 pub const fn bitcoin_hashes::sha256d::HashEngine::new() -> Self
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha256d::HashEngine
-pub type bitcoin_hashes::sha256d::HashEngine::Bytes = [u8; 32]
 pub type bitcoin_hashes::sha256d::HashEngine::Hash = bitcoin_hashes::sha256d::Hash
 pub const bitcoin_hashes::sha256d::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha256d::HashEngine::finalize(self) -> Self::Hash
@@ -1039,7 +1033,6 @@ impl<T> core::convert::From<T> for bitcoin_hashes::sha256t::Hash<T>
 pub fn bitcoin_hashes::sha256t::Hash<T>::from(t: T) -> T
 pub struct bitcoin_hashes::sha256t::HashEngine<T>(_, _)
 impl<T: bitcoin_hashes::sha256t::Tag> bitcoin_hashes::HashEngine for bitcoin_hashes::sha256t::HashEngine<T>
-pub type bitcoin_hashes::sha256t::HashEngine<T>::Bytes = [u8; 32]
 pub type bitcoin_hashes::sha256t::HashEngine<T>::Hash = bitcoin_hashes::sha256t::Hash<T>
 pub const bitcoin_hashes::sha256t::HashEngine<T>::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha256t::HashEngine<T>::finalize(self) -> Self::Hash
@@ -1153,7 +1146,6 @@ pub struct bitcoin_hashes::sha384::HashEngine(_)
 impl bitcoin_hashes::sha384::HashEngine
 pub const fn bitcoin_hashes::sha384::HashEngine::new() -> Self
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha384::HashEngine
-pub type bitcoin_hashes::sha384::HashEngine::Bytes = [u8; 48]
 pub type bitcoin_hashes::sha384::HashEngine::Hash = bitcoin_hashes::sha384::Hash
 pub const bitcoin_hashes::sha384::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha384::HashEngine::finalize(self) -> Self::Hash
@@ -1263,7 +1255,6 @@ pub struct bitcoin_hashes::sha3_256::HashEngine
 impl bitcoin_hashes::sha3_256::HashEngine
 pub const fn bitcoin_hashes::sha3_256::HashEngine::new() -> Self
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha3_256::HashEngine
-pub type bitcoin_hashes::sha3_256::HashEngine::Bytes = [u8; 32]
 pub type bitcoin_hashes::sha3_256::HashEngine::Hash = bitcoin_hashes::sha3_256::Hash
 pub const bitcoin_hashes::sha3_256::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha3_256::HashEngine::finalize(self) -> Self::Hash
@@ -1375,7 +1366,6 @@ pub struct bitcoin_hashes::sha512::HashEngine
 impl bitcoin_hashes::sha512::HashEngine
 pub const fn bitcoin_hashes::sha512::HashEngine::new() -> Self
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512::HashEngine
-pub type bitcoin_hashes::sha512::HashEngine::Bytes = [u8; 64]
 pub type bitcoin_hashes::sha512::HashEngine::Hash = bitcoin_hashes::sha512::Hash
 pub const bitcoin_hashes::sha512::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha512::HashEngine::finalize(self) -> Self::Hash
@@ -1487,7 +1477,6 @@ pub struct bitcoin_hashes::sha512_256::HashEngine(_)
 impl bitcoin_hashes::sha512_256::HashEngine
 pub const fn bitcoin_hashes::sha512_256::HashEngine::new() -> Self
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512_256::HashEngine
-pub type bitcoin_hashes::sha512_256::HashEngine::Bytes = [u8; 64]
 pub type bitcoin_hashes::sha512_256::HashEngine::Hash = bitcoin_hashes::sha512_256::Hash
 pub const bitcoin_hashes::sha512_256::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha512_256::HashEngine::finalize(self) -> Self::Hash
@@ -1602,7 +1591,6 @@ impl bitcoin_hashes::siphash24::HashEngine
 pub fn bitcoin_hashes::siphash24::HashEngine::keys(&self) -> (u64, u64)
 pub const fn bitcoin_hashes::siphash24::HashEngine::with_keys(k0: u64, k1: u64) -> Self
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::siphash24::HashEngine
-pub type bitcoin_hashes::siphash24::HashEngine::Bytes = [u8; 8]
 pub type bitcoin_hashes::siphash24::HashEngine::Hash = bitcoin_hashes::siphash24::Hash
 pub const bitcoin_hashes::siphash24::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::siphash24::HashEngine::finalize(self) -> Self::Hash
@@ -1805,7 +1793,6 @@ pub fn bitcoin_hashes::hmac::HmacEngine<T>::from_inner_engines(iengine: T, oengi
 pub fn bitcoin_hashes::hmac::HmacEngine<T>::new(key: &[u8]) -> Self where T: core::default::Default
 pub fn bitcoin_hashes::hmac::HmacEngine<T>::non_secure_erase(&mut self)
 impl<T: bitcoin_hashes::HashEngine> bitcoin_hashes::HashEngine for bitcoin_hashes::hmac::HmacEngine<T>
-pub type bitcoin_hashes::hmac::HmacEngine<T>::Bytes = <T as bitcoin_hashes::HashEngine>::Bytes
 pub type bitcoin_hashes::hmac::HmacEngine<T>::Hash = bitcoin_hashes::hmac::Hmac<<T as bitcoin_hashes::HashEngine>::Hash>
 pub const bitcoin_hashes::hmac::HmacEngine<T>::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::hmac::HmacEngine<T>::finalize(self) -> Self::Hash
@@ -2602,92 +2589,78 @@ pub fn bitcoin_hashes::sha256t::Hash<T>::as_byte_array(&self) -> &Self::Bytes
 pub fn bitcoin_hashes::sha256t::Hash<T>::from_byte_array(bytes: Self::Bytes) -> Self
 pub fn bitcoin_hashes::sha256t::Hash<T>::to_byte_array(self) -> Self::Bytes
 pub trait bitcoin_hashes::HashEngine: core::clone::Clone
-pub type bitcoin_hashes::HashEngine::Bytes: core::marker::Copy + bitcoin_hashes::IsByteArray
 pub type bitcoin_hashes::HashEngine::Hash: bitcoin_hashes::Hash
 pub const bitcoin_hashes::HashEngine::BLOCK_SIZE: usize
-pub const bitcoin_hashes::HashEngine::LEN: usize
 pub fn bitcoin_hashes::HashEngine::finalize(self) -> Self::Hash
 pub fn bitcoin_hashes::HashEngine::input(&mut self, data: &[u8])
 pub fn bitcoin_hashes::HashEngine::n_bytes_hashed(&self) -> u64
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::hash160::HashEngine
-pub type bitcoin_hashes::hash160::HashEngine::Bytes = [u8; 20]
 pub type bitcoin_hashes::hash160::HashEngine::Hash = bitcoin_hashes::hash160::Hash
 pub const bitcoin_hashes::hash160::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::hash160::HashEngine::finalize(self) -> Self::Hash
 pub fn bitcoin_hashes::hash160::HashEngine::input(&mut self, data: &[u8])
 pub fn bitcoin_hashes::hash160::HashEngine::n_bytes_hashed(&self) -> u64
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::ripemd160::HashEngine
-pub type bitcoin_hashes::ripemd160::HashEngine::Bytes = [u8; 20]
 pub type bitcoin_hashes::ripemd160::HashEngine::Hash = bitcoin_hashes::ripemd160::Hash
 pub const bitcoin_hashes::ripemd160::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::ripemd160::HashEngine::finalize(self) -> Self::Hash
 pub fn bitcoin_hashes::ripemd160::HashEngine::input(&mut self, inp: &[u8])
 pub fn bitcoin_hashes::ripemd160::HashEngine::n_bytes_hashed(&self) -> u64
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha1::HashEngine
-pub type bitcoin_hashes::sha1::HashEngine::Bytes = [u8; 20]
 pub type bitcoin_hashes::sha1::HashEngine::Hash = bitcoin_hashes::sha1::Hash
 pub const bitcoin_hashes::sha1::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha1::HashEngine::finalize(self) -> Self::Hash
 pub fn bitcoin_hashes::sha1::HashEngine::input(&mut self, inp: &[u8])
 pub fn bitcoin_hashes::sha1::HashEngine::n_bytes_hashed(&self) -> u64
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha256::HashEngine
-pub type bitcoin_hashes::sha256::HashEngine::Bytes = [u8; 32]
 pub type bitcoin_hashes::sha256::HashEngine::Hash = bitcoin_hashes::sha256::Hash
 pub const bitcoin_hashes::sha256::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha256::HashEngine::finalize(self) -> Self::Hash
 pub fn bitcoin_hashes::sha256::HashEngine::input(&mut self, inp: &[u8])
 pub fn bitcoin_hashes::sha256::HashEngine::n_bytes_hashed(&self) -> u64
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha256d::HashEngine
-pub type bitcoin_hashes::sha256d::HashEngine::Bytes = [u8; 32]
 pub type bitcoin_hashes::sha256d::HashEngine::Hash = bitcoin_hashes::sha256d::Hash
 pub const bitcoin_hashes::sha256d::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha256d::HashEngine::finalize(self) -> Self::Hash
 pub fn bitcoin_hashes::sha256d::HashEngine::input(&mut self, data: &[u8])
 pub fn bitcoin_hashes::sha256d::HashEngine::n_bytes_hashed(&self) -> u64
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha384::HashEngine
-pub type bitcoin_hashes::sha384::HashEngine::Bytes = [u8; 48]
 pub type bitcoin_hashes::sha384::HashEngine::Hash = bitcoin_hashes::sha384::Hash
 pub const bitcoin_hashes::sha384::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha384::HashEngine::finalize(self) -> Self::Hash
 pub fn bitcoin_hashes::sha384::HashEngine::input(&mut self, inp: &[u8])
 pub fn bitcoin_hashes::sha384::HashEngine::n_bytes_hashed(&self) -> u64
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha3_256::HashEngine
-pub type bitcoin_hashes::sha3_256::HashEngine::Bytes = [u8; 32]
 pub type bitcoin_hashes::sha3_256::HashEngine::Hash = bitcoin_hashes::sha3_256::Hash
 pub const bitcoin_hashes::sha3_256::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha3_256::HashEngine::finalize(self) -> Self::Hash
 pub fn bitcoin_hashes::sha3_256::HashEngine::input(&mut self, inp: &[u8])
 pub fn bitcoin_hashes::sha3_256::HashEngine::n_bytes_hashed(&self) -> u64
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512::HashEngine
-pub type bitcoin_hashes::sha512::HashEngine::Bytes = [u8; 64]
 pub type bitcoin_hashes::sha512::HashEngine::Hash = bitcoin_hashes::sha512::Hash
 pub const bitcoin_hashes::sha512::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha512::HashEngine::finalize(self) -> Self::Hash
 pub fn bitcoin_hashes::sha512::HashEngine::input(&mut self, inp: &[u8])
 pub fn bitcoin_hashes::sha512::HashEngine::n_bytes_hashed(&self) -> u64
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha512_256::HashEngine
-pub type bitcoin_hashes::sha512_256::HashEngine::Bytes = [u8; 64]
 pub type bitcoin_hashes::sha512_256::HashEngine::Hash = bitcoin_hashes::sha512_256::Hash
 pub const bitcoin_hashes::sha512_256::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha512_256::HashEngine::finalize(self) -> Self::Hash
 pub fn bitcoin_hashes::sha512_256::HashEngine::input(&mut self, inp: &[u8])
 pub fn bitcoin_hashes::sha512_256::HashEngine::n_bytes_hashed(&self) -> u64
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::siphash24::HashEngine
-pub type bitcoin_hashes::siphash24::HashEngine::Bytes = [u8; 8]
 pub type bitcoin_hashes::siphash24::HashEngine::Hash = bitcoin_hashes::siphash24::Hash
 pub const bitcoin_hashes::siphash24::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::siphash24::HashEngine::finalize(self) -> Self::Hash
 pub fn bitcoin_hashes::siphash24::HashEngine::input(&mut self, msg: &[u8])
 pub fn bitcoin_hashes::siphash24::HashEngine::n_bytes_hashed(&self) -> u64
 impl<T: bitcoin_hashes::HashEngine> bitcoin_hashes::HashEngine for bitcoin_hashes::hmac::HmacEngine<T>
-pub type bitcoin_hashes::hmac::HmacEngine<T>::Bytes = <T as bitcoin_hashes::HashEngine>::Bytes
 pub type bitcoin_hashes::hmac::HmacEngine<T>::Hash = bitcoin_hashes::hmac::Hmac<<T as bitcoin_hashes::HashEngine>::Hash>
 pub const bitcoin_hashes::hmac::HmacEngine<T>::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::hmac::HmacEngine<T>::finalize(self) -> Self::Hash
 pub fn bitcoin_hashes::hmac::HmacEngine<T>::input(&mut self, buf: &[u8])
 pub fn bitcoin_hashes::hmac::HmacEngine<T>::n_bytes_hashed(&self) -> u64
 impl<T: bitcoin_hashes::sha256t::Tag> bitcoin_hashes::HashEngine for bitcoin_hashes::sha256t::HashEngine<T>
-pub type bitcoin_hashes::sha256t::HashEngine<T>::Bytes = [u8; 32]
 pub type bitcoin_hashes::sha256t::HashEngine<T>::Hash = bitcoin_hashes::sha256t::Hash<T>
 pub const bitcoin_hashes::sha256t::HashEngine<T>::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::sha256t::HashEngine<T>::finalize(self) -> Self::Hash

--- a/hashes/src/hash160/mod.rs
+++ b/hashes/src/hash160/mod.rs
@@ -43,7 +43,6 @@ impl Default for HashEngine {
 
 impl crate::HashEngine for HashEngine {
     type Hash = Hash;
-    type Bytes = [u8; 20];
     const BLOCK_SIZE: usize = 64; // Same as sha256::HashEngine::BLOCK_SIZE;
 
     fn input(&mut self, data: &[u8]) { self.0.input(data) }

--- a/hashes/src/hkdf/mod.rs
+++ b/hashes/src/hkdf/mod.rs
@@ -10,7 +10,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 use core::fmt;
 
-use crate::{HashEngine, Hmac, HmacEngine, IsByteArray};
+use crate::{Hash, HashEngine, Hmac, HmacEngine};
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(no_inline)]
@@ -67,14 +67,14 @@ where
     /// (255 * hash output length).
     pub fn expand(&self, info: &[u8], okm: &mut [u8]) -> Result<(), MaxLengthError> {
         // Length of output keying material in bytes must be less than 255 * hash length.
-        if okm.len() > (MAX_OUTPUT_BLOCKS * T::Bytes::LEN) {
-            return Err(MaxLengthError { max: MAX_OUTPUT_BLOCKS * T::Bytes::LEN });
+        if okm.len() > (MAX_OUTPUT_BLOCKS * T::Hash::LEN) {
+            return Err(MaxLengthError { max: MAX_OUTPUT_BLOCKS * T::Hash::LEN });
         }
 
         // Counter starts at "1" based on RFC5869 spec and is committed to in the hash.
         let mut counter = 1u8;
         // Ceiling calculation for the total number of blocks (iterations) required for the expand.
-        let total_blocks = okm.len().div_ceil(T::Bytes::LEN);
+        let total_blocks = okm.len().div_ceil(T::Hash::LEN);
 
         while counter <= total_blocks as u8 {
             let mut engine: HmacEngine<T> = HmacEngine::new(self.prk.as_ref());
@@ -82,20 +82,20 @@ where
             // First block does not have a previous block,
             // all other blocks include last block in the HMAC input.
             if counter != 1u8 {
-                let previous_start_index = (counter as usize - 2) * T::Bytes::LEN;
-                let previous_end_index = (counter as usize - 1) * T::Bytes::LEN;
+                let previous_start_index = (counter as usize - 2) * T::Hash::LEN;
+                let previous_end_index = (counter as usize - 1) * T::Hash::LEN;
                 engine.input(&okm[previous_start_index..previous_end_index]);
             }
             engine.input(info);
             engine.input(&[counter]);
 
             let t = engine.finalize();
-            let start_index = (counter as usize - 1) * T::Bytes::LEN;
+            let start_index = (counter as usize - 1) * T::Hash::LEN;
             // Last block might not take full hash length.
             let end_index = if counter == (total_blocks as u8) {
                 okm.len()
             } else {
-                counter as usize * T::Bytes::LEN
+                counter as usize * T::Hash::LEN
             };
 
             okm[start_index..end_index].copy_from_slice(&t.as_ref()[0..(end_index - start_index)]);

--- a/hashes/src/hmac/mod.rs
+++ b/hashes/src/hmac/mod.rs
@@ -145,7 +145,6 @@ impl<T: HashEngine> HmacEngine<T> {
 
 impl<T: HashEngine> HashEngine for HmacEngine<T> {
     type Hash = Hmac<T::Hash>;
-    type Bytes = T::Bytes;
     const BLOCK_SIZE: usize = T::BLOCK_SIZE;
 
     fn n_bytes_hashed(&self) -> u64 { self.iengine.n_bytes_hashed() }

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -175,12 +175,6 @@ pub trait HashEngine: Clone {
     /// The `Hash` type returned when finalizing this engine.
     type Hash: Hash;
 
-    /// The byte array that is used internally in [`HashEngine::finalize`].
-    type Bytes: Copy + IsByteArray;
-
-    /// Length of the hash, in bytes.
-    const LEN: usize = Self::Bytes::LEN;
-
     /// Length of the hash's internal block size, in bytes.
     const BLOCK_SIZE: usize;
 

--- a/hashes/src/ripemd160/mod.rs
+++ b/hashes/src/ripemd160/mod.rs
@@ -91,7 +91,6 @@ impl Default for HashEngine {
 
 impl crate::HashEngine for HashEngine {
     type Hash = Hash;
-    type Bytes = [u8; 20];
     const BLOCK_SIZE: usize = 64;
 
     fn n_bytes_hashed(&self) -> u64 { self.bytes_hashed }

--- a/hashes/src/sha1/mod.rs
+++ b/hashes/src/sha1/mod.rs
@@ -82,7 +82,6 @@ impl Default for HashEngine {
 
 impl crate::HashEngine for HashEngine {
     type Hash = Hash;
-    type Bytes = [u8; 20];
     const BLOCK_SIZE: usize = 64;
 
     fn n_bytes_hashed(&self) -> u64 { self.bytes_hashed }

--- a/hashes/src/sha256/mod.rs
+++ b/hashes/src/sha256/mod.rs
@@ -166,7 +166,6 @@ impl Default for HashEngine {
 
 impl crate::HashEngine for HashEngine {
     type Hash = Hash;
-    type Bytes = [u8; 32];
     const BLOCK_SIZE: usize = 64;
 
     fn n_bytes_hashed(&self) -> u64 { self.bytes_hashed }

--- a/hashes/src/sha256d/mod.rs
+++ b/hashes/src/sha256d/mod.rs
@@ -47,7 +47,6 @@ impl Default for HashEngine {
 
 impl crate::HashEngine for HashEngine {
     type Hash = Hash;
-    type Bytes = [u8; 32];
     const BLOCK_SIZE: usize = 64; // Same as sha256::HashEngine::BLOCK_SIZE;
 
     fn input(&mut self, data: &[u8]) { self.0.input(data) }

--- a/hashes/src/sha256t/mod.rs
+++ b/hashes/src/sha256t/mod.rs
@@ -145,7 +145,6 @@ impl<T: Tag> Clone for HashEngine<T> {
 
 impl<T: Tag> crate::HashEngine for HashEngine<T> {
     type Hash = Hash<T>;
-    type Bytes = [u8; 32];
     const BLOCK_SIZE: usize = 64; // Same as sha256::HashEngine::BLOCK_SIZE;
 
     fn input(&mut self, data: &[u8]) { self.0.input(data) }

--- a/hashes/src/sha384/mod.rs
+++ b/hashes/src/sha384/mod.rs
@@ -35,7 +35,6 @@ impl Default for HashEngine {
 
 impl crate::HashEngine for HashEngine {
     type Hash = Hash;
-    type Bytes = [u8; 48];
     const BLOCK_SIZE: usize = sha512::BLOCK_SIZE;
 
     fn n_bytes_hashed(&self) -> u64 { self.0.n_bytes_hashed() }

--- a/hashes/src/sha3_256/mod.rs
+++ b/hashes/src/sha3_256/mod.rs
@@ -212,7 +212,6 @@ impl HashEngine {
 
 impl crate::HashEngine for HashEngine {
     type Hash = Hash;
-    type Bytes = [u8; 32];
     const BLOCK_SIZE: usize = RATE;
 
     crate::internal_macros::engine_input_impl!();

--- a/hashes/src/sha512/mod.rs
+++ b/hashes/src/sha512/mod.rs
@@ -124,7 +124,6 @@ impl HashEngine {
 
 impl crate::HashEngine for HashEngine {
     type Hash = Hash;
-    type Bytes = [u8; 64];
     const BLOCK_SIZE: usize = 128;
 
     fn n_bytes_hashed(&self) -> u64 { self.bytes_hashed }

--- a/hashes/src/sha512_256/mod.rs
+++ b/hashes/src/sha512_256/mod.rs
@@ -48,7 +48,6 @@ impl Default for HashEngine {
 
 impl crate::HashEngine for HashEngine {
     type Hash = Hash;
-    type Bytes = [u8; 64];
     const BLOCK_SIZE: usize = sha512::BLOCK_SIZE;
 
     fn n_bytes_hashed(&self) -> u64 { self.0.n_bytes_hashed() }

--- a/hashes/src/siphash24/mod.rs
+++ b/hashes/src/siphash24/mod.rs
@@ -168,7 +168,6 @@ impl HashEngine {
 
 impl crate::HashEngine for HashEngine {
     type Hash = Hash;
-    type Bytes = [u8; 8];
     const BLOCK_SIZE: usize = 8;
 
     #[inline]


### PR DESCRIPTION
Simplify the API by removing Bytes and LEN from HashEngine. Callers can still use `HashEngine::Hash::LEN` and `HashEngine::Hash::Bytes` to access those values.

This will automatically solve the inconsistency between HashEngine and Hash we found for sha512_256 output size.