### PR TITLE
bitcoin: Implement Serde for WitnessVersion and WitnessProgram

### DIFF
--- a/bitcoin/src/blockdata/script/witness_program.rs
+++ b/bitcoin/src/blockdata/script/witness_program.rs
@@ -142,6 +142,149 @@ impl WitnessProgram {
     }
 }
 
+#[cfg(feature = "serde")]
+impl serde::Serialize for WitnessProgram {
+    /// Serializes a [`WitnessProgram`].
+    ///
+    /// Depending on the data format, the underlying `program` bytes are serialized differently:
+    /// - **Human-readable formats** (e.g., JSON): The `program` bytes are serialized as a hex string.
+    /// - **Binary formats** (e.g., Bincode): The `program` bytes are serialized directly as raw bytes.
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use internals::serde::SerializeBytesAsHex;
+        use serde::ser::SerializeStruct;
+
+        let human_readable = serializer.is_human_readable();
+        let mut state = serializer.serialize_struct("WitnessProgram", 2)?;
+        state.serialize_field("version", &self.version)?;
+        if human_readable {
+            state.serialize_field("program", &SerializeBytesAsHex(self.program.as_slice()))?;
+        } else {
+            state.serialize_field("program", &self.program)?;
+        }
+        state.end()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for WitnessProgram {
+    /// Deserializes a [`WitnessProgram`].
+    ///
+    /// ### Errors
+    /// Returns a deserialization error if:
+    /// - Mandatory fields (`version` or `program`) are missing or duplicated.
+    /// - The hex string in a human-readable format is malformed or invalidly sized.
+    /// - The combination of `version` and `program` fails validation in `WitnessProgram::new`.
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use core::fmt;
+
+        use serde::de;
+
+        struct Program(ArrayVec<u8, MAX_SIZE>);
+
+        impl<'de> serde::Deserialize<'de> for Program {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                if deserializer.is_human_readable() {
+                    struct HexVisitor;
+
+                    impl de::Visitor<'_> for HexVisitor {
+                        type Value = Program;
+
+                        fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                            write!(f, "a hex string encoding {} to {} bytes", MIN_SIZE, MAX_SIZE)
+                        }
+
+                        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+                        where
+                            E: de::Error,
+                        {
+                            let bytes = hex::decode_to_vec(v).map_err(E::custom)?;
+                            if bytes.len() > MAX_SIZE {
+                                return Err(E::invalid_length(bytes.len(), &self));
+                            }
+                            Ok(Program(ArrayVec::from_slice(&bytes)))
+                        }
+                    }
+
+                    deserializer.deserialize_str(HexVisitor)
+                } else {
+                    let av = ArrayVec::<u8, MAX_SIZE>::deserialize(deserializer)?;
+                    Ok(Self(av))
+                }
+            }
+        }
+
+        #[derive(Deserialize)]
+        #[serde(field_identifier, rename_all = "lowercase")]
+        enum Field {
+            Version,
+            Program,
+        }
+
+        struct Visitor;
+
+        impl<'de> de::Visitor<'de> for Visitor {
+            type Value = WitnessProgram;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a WitnessProgram struct with 'version' and 'program' fields")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let version: WitnessVersion =
+                    seq.next_element()?.ok_or_else(|| de::Error::invalid_length(0, &self))?;
+                let program: Program =
+                    seq.next_element()?.ok_or_else(|| de::Error::invalid_length(1, &self))?;
+                WitnessProgram::new(version, &program.0).map_err(de::Error::custom)
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                let mut version: Option<WitnessVersion> = None;
+                let mut program: Option<Program> = None;
+
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Field::Version => {
+                            if version.is_some() {
+                                return Err(de::Error::duplicate_field("version"));
+                            }
+                            version = Some(map.next_value()?);
+                        }
+                        Field::Program => {
+                            if program.is_some() {
+                                return Err(de::Error::duplicate_field("program"));
+                            }
+                            program = Some(map.next_value::<Program>()?);
+                        }
+                    }
+                }
+
+                let version = version.ok_or_else(|| de::Error::missing_field("version"))?;
+                let program = program.ok_or_else(|| de::Error::missing_field("program"))?;
+
+                WitnessProgram::new(version, &program.0).map_err(de::Error::custom)
+            }
+        }
+
+        const FIELDS: &[&str] = &["version", "program"];
+        deserializer.deserialize_struct("WitnessProgram", FIELDS, Visitor)
+    }
+}
+
 /// Error types for witness programs.
 pub mod error {
     use core::convert::Infallible;
@@ -228,5 +371,103 @@ mod tests {
         assert!(WitnessProgram::new(WitnessVersion::V1, &p2a_bytes)
             .expect("valid witness program")
             .is_p2a());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn roundtrip_v0_p2wpkh() {
+        let want = WitnessProgram::new(WitnessVersion::V0, &[0xAB; 20]).unwrap();
+        let json = serde_json::to_string(&want).expect("serialize");
+        let got: WitnessProgram = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(got, want);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn roundtrip_v1_p2tr() {
+        let want = WitnessProgram::new(WitnessVersion::V1, &[0xCD; 32]).unwrap();
+        let json = serde_json::to_string(&want).expect("serialize");
+        let got: WitnessProgram = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(want, got);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn deserialize_seq_format() {
+        let want = WitnessProgram::new(WitnessVersion::V0, &[0xAB; 20]).unwrap();
+        let encoded = bincode::serialize(&want).expect("serialize");
+        let got: WitnessProgram = bincode::deserialize(&encoded).expect("deserialize");
+        assert_eq!(got, want);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn deserialize_duplicate_version_field_is_err() {
+        let prog = "00".repeat(20);
+        let json = format!(r#"{{"version":0,"version":0,"program":"{prog}"}}"#);
+        assert!(serde_json::from_str::<WitnessProgram>(&json).is_err());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn deserialize_duplicate_program_field_is_err() {
+        let prog = "00".repeat(20);
+        let json = format!(r#"{{"version":0,"program":"{prog}","program":"{prog}"}}"#);
+        assert!(serde_json::from_str::<WitnessProgram>(&json).is_err());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn deserialize_missing_version_field_is_err() {
+        let prog = "00".repeat(20);
+        let json = format!(r#"{{"program":"{prog}"}}"#);
+        assert!(serde_json::from_str::<WitnessProgram>(&json).is_err());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn deserialize_missing_program_field_is_err() {
+        let json = r#"{"version":0}"#;
+        assert!(serde_json::from_str::<WitnessProgram>(json).is_err());
+    }
+
+    // WitnessProgram::new validation is still enforced after deserialization.
+    // A V0 program of length 21 is structurally valid JSON but semantically invalid.
+    #[cfg(feature = "serde")]
+    #[test]
+    fn deserialize_invalid_v0_program_length_is_err() {
+        let prog = "aa".repeat(21);
+        let json = format!(r#"{{"version":0,"program":"{prog}"}}"#);
+        assert!(serde_json::from_str::<WitnessProgram>(&json).is_err());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serialize_human_readable_uses_hex_for_program() {
+        let original = WitnessProgram::new(WitnessVersion::V0, &[0xAB; 20]).unwrap();
+        let got = serde_json::to_string(&original).expect("serialize");
+        let want = format!(r#"{{"version":0,"program":"{}"}}"#, "ab".repeat(20));
+        assert_eq!(got, want);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn deserialize_human_readable_hex_program() {
+        let json = format!(r#"{{"version":1,"program":"{}"}}"#, "cd".repeat(32));
+        let got: WitnessProgram = serde_json::from_str(&json).expect("deserialize");
+        let want = WitnessProgram::new(WitnessVersion::V1, &[0xCD; 32]).unwrap();
+        assert_eq!(got, want);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn deserialize_invalid_hex_program_is_err() {
+        // Odd-length hex string.
+        let json = r#"{"version":0,"program":"abc"}"#;
+        assert!(serde_json::from_str::<WitnessProgram>(json).is_err());
+
+        // Non-hex character.
+        let json = r#"{"version":0,"program":"zz"}"#;
+        assert!(serde_json::from_str::<WitnessProgram>(json).is_err());
     }
 }

--- a/bitcoin/src/blockdata/script/witness_version.rs
+++ b/bitcoin/src/blockdata/script/witness_version.rs
@@ -151,6 +151,57 @@ impl From<WitnessVersion> for Opcode {
     }
 }
 
+/// Serializes [`WitnessVersion`] as a `u8`.
+#[cfg(feature = "serde")]
+impl serde::Serialize for WitnessVersion {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_u8(self.to_num())
+    }
+}
+
+/// Deserializes ['WitnessVersion`] as a `u8`.
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for WitnessVersion {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de;
+
+        struct Visitor;
+
+        impl de::Visitor<'_> for Visitor {
+            type Value = WitnessVersion;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a valid Bitcoin witness version (0-16)")
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                let value = u8::try_from(v)
+                    .map_err(|_| E::invalid_value(de::Unexpected::Unsigned(v), &self))?;
+                self.visit_u8(value)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                WitnessVersion::try_from(v)
+                    .map_err(|_| E::invalid_value(de::Unexpected::Unsigned(v as u64), &self))
+            }
+        }
+
+        deserializer.deserialize_u8(Visitor)
+    }
+}
+
 /// Error types for the segwit version number.
 pub mod error {
     use core::convert::Infallible;
@@ -267,5 +318,42 @@ pub mod error {
     #[cfg(feature = "std")]
     impl std::error::Error for TryFromError {
         fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests {
+    use crate::WitnessVersion;
+
+    #[test]
+    fn test_serde_roundtrip_json() {
+        for version in [0, 1, 15, 16] {
+            let want = WitnessVersion::try_from(version).unwrap();
+
+            let serialized = serde_json::to_string(&want).unwrap();
+            let got: WitnessVersion = serde_json::from_str(&serialized).unwrap();
+
+            assert_eq!(got, want);
+        }
+    }
+
+    #[test]
+    fn test_serde_roundtrip_bincode() {
+        for version in [0, 1, 15, 16] {
+            let want = WitnessVersion::try_from(version).unwrap();
+
+            let serialized = bincode::serialize(&want).unwrap();
+            let got: WitnessVersion = bincode::deserialize(&serialized).unwrap();
+
+            assert_eq!(got, want);
+        }
+    }
+
+    #[test]
+    fn test_serde_invalid_version() {
+        let invalid_version = "17";
+        let result: Result<WitnessVersion, _> = serde_json::from_str(invalid_version);
+
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
> However if we had actual WitnessProgram then I think bytes/hex conditioned on the format being human-readable makes most sense.

*Comment by @Kixunil [6099](https://github.com/rust-bitcoin/rust-bitcoin/pull/6099#discussion_r3244670231)*

WitnessVersion serializes via `serialize_u8`, leveraging the `WitnessVersion::to_num` method which converts a WitnessVersion to a `u8`, and then deserializes as a `u8`, implementing `visit_u64` for formats e.g. JSON that prefers to parse unsigned ints as u64 and `visit_u8` for binary deserializers that call `visit_u8` when hinted.

WitnessProgram serializes and deserializes the program as hex if human readable format is preferred and delegates to ArrayVec's serde impls if not.

closes #3513 