### PR TITLE
consensus_encoding: mark ArrayDecoder struct as Copy

### DIFF
--- a/consensus_encoding/src/decode/decoders.rs
+++ b/consensus_encoding/src/decode/decoders.rs
@@ -314,7 +314,7 @@ impl<T: Decode> Decoder for VecDecoder<T> {
 }
 
 /// A decoder that expects exactly N bytes and returns them as an array.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct ArrayDecoder<const N: usize> {
     buffer: [u8; N],
     bytes_written: usize,


### PR DESCRIPTION
Pre-req for marking p2p structs such as `CommandString` as `Copy`