### PR TITLE
Remove Clone implementations on decoders

### DIFF
--- a/consensus_encoding/api/all-features.txt
+++ b/consensus_encoding/api/all-features.txt
@@ -925,8 +925,6 @@ pub type bitcoin_consensus_encoding::ArrayDecoder<N>::Output = [u8; N]
 pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error>
 pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::read_limit(&self) -> usize
-impl<const N: usize> core::clone::Clone for bitcoin_consensus_encoding::ArrayDecoder<N>
-pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::clone(&self) -> bitcoin_consensus_encoding::ArrayDecoder<N>
 impl<const N: usize> core::default::Default for bitcoin_consensus_encoding::ArrayDecoder<N>
 pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::default() -> Self
 impl<const N: usize> core::fmt::Debug for bitcoin_consensus_encoding::ArrayDecoder<N>
@@ -946,18 +944,12 @@ pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::try_from(value: U) -> core::
 impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::ArrayDecoder<N> where U: core::convert::TryFrom<T>
 pub type bitcoin_consensus_encoding::ArrayDecoder<N>::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::ArrayDecoder<N> where T: core::clone::Clone
-pub type bitcoin_consensus_encoding::ArrayDecoder<N>::Owned = T
-pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::clone_into(&self, target: &mut T)
-pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_consensus_encoding::ArrayDecoder<N> where T: 'static + ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::ArrayDecoder<N> where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::ArrayDecoder<N> where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::ArrayDecoder<N> where T: core::clone::Clone
-pub unsafe fn bitcoin_consensus_encoding::ArrayDecoder<N>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::ArrayDecoder<N>
 pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::from(t: T) -> T
 pub struct bitcoin_consensus_encoding::ArrayEncoder<const N: usize>
@@ -1052,8 +1044,6 @@ pub type bitcoin_consensus_encoding::ByteVecDecoder::Output = alloc::vec::Vec<u8
 pub fn bitcoin_consensus_encoding::ByteVecDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_consensus_encoding::ByteVecDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error>
 pub fn bitcoin_consensus_encoding::ByteVecDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_consensus_encoding::ByteVecDecoder
-pub fn bitcoin_consensus_encoding::ByteVecDecoder::clone(&self) -> bitcoin_consensus_encoding::ByteVecDecoder
 impl core::default::Default for bitcoin_consensus_encoding::ByteVecDecoder
 pub fn bitcoin_consensus_encoding::ByteVecDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_consensus_encoding::ByteVecDecoder
@@ -1073,18 +1063,12 @@ pub fn bitcoin_consensus_encoding::ByteVecDecoder::try_from(value: U) -> core::r
 impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::ByteVecDecoder where U: core::convert::TryFrom<T>
 pub type bitcoin_consensus_encoding::ByteVecDecoder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_consensus_encoding::ByteVecDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::ByteVecDecoder where T: core::clone::Clone
-pub type bitcoin_consensus_encoding::ByteVecDecoder::Owned = T
-pub fn bitcoin_consensus_encoding::ByteVecDecoder::clone_into(&self, target: &mut T)
-pub fn bitcoin_consensus_encoding::ByteVecDecoder::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_consensus_encoding::ByteVecDecoder where T: 'static + ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::ByteVecDecoder::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::ByteVecDecoder where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::ByteVecDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::ByteVecDecoder where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::ByteVecDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::ByteVecDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_consensus_encoding::ByteVecDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::ByteVecDecoder
 pub fn bitcoin_consensus_encoding::ByteVecDecoder::from(t: T) -> T
 pub struct bitcoin_consensus_encoding::ByteVecDecoderError(_)
@@ -1184,8 +1168,6 @@ pub type bitcoin_consensus_encoding::CompactSizeDecoder::Output = usize
 pub fn bitcoin_consensus_encoding::CompactSizeDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_consensus_encoding::CompactSizeDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error>
 pub fn bitcoin_consensus_encoding::CompactSizeDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_consensus_encoding::CompactSizeDecoder
-pub fn bitcoin_consensus_encoding::CompactSizeDecoder::clone(&self) -> bitcoin_consensus_encoding::CompactSizeDecoder
 impl core::default::Default for bitcoin_consensus_encoding::CompactSizeDecoder
 pub fn bitcoin_consensus_encoding::CompactSizeDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_consensus_encoding::CompactSizeDecoder
@@ -1205,18 +1187,12 @@ pub fn bitcoin_consensus_encoding::CompactSizeDecoder::try_from(value: U) -> cor
 impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::CompactSizeDecoder where U: core::convert::TryFrom<T>
 pub type bitcoin_consensus_encoding::CompactSizeDecoder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_consensus_encoding::CompactSizeDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::CompactSizeDecoder where T: core::clone::Clone
-pub type bitcoin_consensus_encoding::CompactSizeDecoder::Owned = T
-pub fn bitcoin_consensus_encoding::CompactSizeDecoder::clone_into(&self, target: &mut T)
-pub fn bitcoin_consensus_encoding::CompactSizeDecoder::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_consensus_encoding::CompactSizeDecoder where T: 'static + ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::CompactSizeDecoder::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::CompactSizeDecoder where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::CompactSizeDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::CompactSizeDecoder where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::CompactSizeDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::CompactSizeDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_consensus_encoding::CompactSizeDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::CompactSizeDecoder
 pub fn bitcoin_consensus_encoding::CompactSizeDecoder::from(t: T) -> T
 pub struct bitcoin_consensus_encoding::CompactSizeDecoderError(_)
@@ -1317,8 +1293,6 @@ pub type bitcoin_consensus_encoding::CompactSizeU64Decoder::Output = u64
 pub fn bitcoin_consensus_encoding::CompactSizeU64Decoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_consensus_encoding::CompactSizeU64Decoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error>
 pub fn bitcoin_consensus_encoding::CompactSizeU64Decoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_consensus_encoding::CompactSizeU64Decoder
-pub fn bitcoin_consensus_encoding::CompactSizeU64Decoder::clone(&self) -> bitcoin_consensus_encoding::CompactSizeU64Decoder
 impl core::default::Default for bitcoin_consensus_encoding::CompactSizeU64Decoder
 pub fn bitcoin_consensus_encoding::CompactSizeU64Decoder::default() -> Self
 impl core::fmt::Debug for bitcoin_consensus_encoding::CompactSizeU64Decoder
@@ -1338,18 +1312,12 @@ pub fn bitcoin_consensus_encoding::CompactSizeU64Decoder::try_from(value: U) -> 
 impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::CompactSizeU64Decoder where U: core::convert::TryFrom<T>
 pub type bitcoin_consensus_encoding::CompactSizeU64Decoder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_consensus_encoding::CompactSizeU64Decoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::CompactSizeU64Decoder where T: core::clone::Clone
-pub type bitcoin_consensus_encoding::CompactSizeU64Decoder::Owned = T
-pub fn bitcoin_consensus_encoding::CompactSizeU64Decoder::clone_into(&self, target: &mut T)
-pub fn bitcoin_consensus_encoding::CompactSizeU64Decoder::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_consensus_encoding::CompactSizeU64Decoder where T: 'static + ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::CompactSizeU64Decoder::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::CompactSizeU64Decoder where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::CompactSizeU64Decoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::CompactSizeU64Decoder where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::CompactSizeU64Decoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::CompactSizeU64Decoder where T: core::clone::Clone
-pub unsafe fn bitcoin_consensus_encoding::CompactSizeU64Decoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::CompactSizeU64Decoder
 pub fn bitcoin_consensus_encoding::CompactSizeU64Decoder::from(t: T) -> T
 pub struct bitcoin_consensus_encoding::Decoder2<A, B> where A: bitcoin_consensus_encoding::Decoder, B: bitcoin_consensus_encoding::Decoder
@@ -1361,8 +1329,6 @@ pub type bitcoin_consensus_encoding::Decoder2<A, B>::Output = (<A as bitcoin_con
 pub fn bitcoin_consensus_encoding::Decoder2<A, B>::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_consensus_encoding::Decoder2<A, B>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error>
 pub fn bitcoin_consensus_encoding::Decoder2<A, B>::read_limit(&self) -> usize
-impl<A, B> core::clone::Clone for bitcoin_consensus_encoding::Decoder2<A, B> where A: bitcoin_consensus_encoding::Decoder + core::clone::Clone, B: bitcoin_consensus_encoding::Decoder + core::clone::Clone, <A as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone
-pub fn bitcoin_consensus_encoding::Decoder2<A, B>::clone(&self) -> Self
 impl<A, B> core::default::Default for bitcoin_consensus_encoding::Decoder2<A, B> where A: bitcoin_consensus_encoding::Decoder + core::default::Default, B: bitcoin_consensus_encoding::Decoder + core::default::Default
 pub fn bitcoin_consensus_encoding::Decoder2<A, B>::default() -> bitcoin_consensus_encoding::Decoder2<A, B>
 impl<A, B> core::fmt::Debug for bitcoin_consensus_encoding::Decoder2<A, B> where A: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, B: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, <A as bitcoin_consensus_encoding::Decoder>::Output: core::fmt::Debug
@@ -1382,18 +1348,12 @@ pub fn bitcoin_consensus_encoding::Decoder2<A, B>::try_from(value: U) -> core::r
 impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::Decoder2<A, B> where U: core::convert::TryFrom<T>
 pub type bitcoin_consensus_encoding::Decoder2<A, B>::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_consensus_encoding::Decoder2<A, B>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::Decoder2<A, B> where T: core::clone::Clone
-pub type bitcoin_consensus_encoding::Decoder2<A, B>::Owned = T
-pub fn bitcoin_consensus_encoding::Decoder2<A, B>::clone_into(&self, target: &mut T)
-pub fn bitcoin_consensus_encoding::Decoder2<A, B>::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_consensus_encoding::Decoder2<A, B> where T: 'static + ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::Decoder2<A, B>::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::Decoder2<A, B> where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::Decoder2<A, B>::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::Decoder2<A, B> where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::Decoder2<A, B>::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::Decoder2<A, B> where T: core::clone::Clone
-pub unsafe fn bitcoin_consensus_encoding::Decoder2<A, B>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::Decoder2<A, B>
 pub fn bitcoin_consensus_encoding::Decoder2<A, B>::from(t: T) -> T
 pub struct bitcoin_consensus_encoding::Decoder3<A, B, C> where A: bitcoin_consensus_encoding::Decoder, B: bitcoin_consensus_encoding::Decoder, C: bitcoin_consensus_encoding::Decoder
@@ -1405,8 +1365,6 @@ pub type bitcoin_consensus_encoding::Decoder3<A, B, C>::Output = (<A as bitcoin_
 pub fn bitcoin_consensus_encoding::Decoder3<A, B, C>::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_consensus_encoding::Decoder3<A, B, C>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error>
 pub fn bitcoin_consensus_encoding::Decoder3<A, B, C>::read_limit(&self) -> usize
-impl<A, B, C> core::clone::Clone for bitcoin_consensus_encoding::Decoder3<A, B, C> where A: bitcoin_consensus_encoding::Decoder + core::clone::Clone, B: bitcoin_consensus_encoding::Decoder + core::clone::Clone, C: bitcoin_consensus_encoding::Decoder + core::clone::Clone, <A as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone, <B as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone
-pub fn bitcoin_consensus_encoding::Decoder3<A, B, C>::clone(&self) -> Self
 impl<A, B, C> core::default::Default for bitcoin_consensus_encoding::Decoder3<A, B, C> where A: bitcoin_consensus_encoding::Decoder + core::default::Default, B: bitcoin_consensus_encoding::Decoder + core::default::Default, C: bitcoin_consensus_encoding::Decoder + core::default::Default
 pub fn bitcoin_consensus_encoding::Decoder3<A, B, C>::default() -> bitcoin_consensus_encoding::Decoder3<A, B, C>
 impl<A, B, C> core::fmt::Debug for bitcoin_consensus_encoding::Decoder3<A, B, C> where A: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, B: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, C: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, <A as bitcoin_consensus_encoding::Decoder>::Output: core::fmt::Debug, <B as bitcoin_consensus_encoding::Decoder>::Output: core::fmt::Debug
@@ -1426,18 +1384,12 @@ pub fn bitcoin_consensus_encoding::Decoder3<A, B, C>::try_from(value: U) -> core
 impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::Decoder3<A, B, C> where U: core::convert::TryFrom<T>
 pub type bitcoin_consensus_encoding::Decoder3<A, B, C>::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_consensus_encoding::Decoder3<A, B, C>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::Decoder3<A, B, C> where T: core::clone::Clone
-pub type bitcoin_consensus_encoding::Decoder3<A, B, C>::Owned = T
-pub fn bitcoin_consensus_encoding::Decoder3<A, B, C>::clone_into(&self, target: &mut T)
-pub fn bitcoin_consensus_encoding::Decoder3<A, B, C>::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_consensus_encoding::Decoder3<A, B, C> where T: 'static + ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::Decoder3<A, B, C>::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::Decoder3<A, B, C> where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::Decoder3<A, B, C>::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::Decoder3<A, B, C> where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::Decoder3<A, B, C>::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::Decoder3<A, B, C> where T: core::clone::Clone
-pub unsafe fn bitcoin_consensus_encoding::Decoder3<A, B, C>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::Decoder3<A, B, C>
 pub fn bitcoin_consensus_encoding::Decoder3<A, B, C>::from(t: T) -> T
 pub struct bitcoin_consensus_encoding::Decoder4<A, B, C, D> where A: bitcoin_consensus_encoding::Decoder, B: bitcoin_consensus_encoding::Decoder, C: bitcoin_consensus_encoding::Decoder, D: bitcoin_consensus_encoding::Decoder
@@ -1449,8 +1401,6 @@ pub type bitcoin_consensus_encoding::Decoder4<A, B, C, D>::Output = (<A as bitco
 pub fn bitcoin_consensus_encoding::Decoder4<A, B, C, D>::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_consensus_encoding::Decoder4<A, B, C, D>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error>
 pub fn bitcoin_consensus_encoding::Decoder4<A, B, C, D>::read_limit(&self) -> usize
-impl<A, B, C, D> core::clone::Clone for bitcoin_consensus_encoding::Decoder4<A, B, C, D> where A: bitcoin_consensus_encoding::Decoder + core::clone::Clone, B: bitcoin_consensus_encoding::Decoder + core::clone::Clone, C: bitcoin_consensus_encoding::Decoder + core::clone::Clone, D: bitcoin_consensus_encoding::Decoder + core::clone::Clone, <A as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone, <B as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone, <C as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone
-pub fn bitcoin_consensus_encoding::Decoder4<A, B, C, D>::clone(&self) -> Self
 impl<A, B, C, D> core::default::Default for bitcoin_consensus_encoding::Decoder4<A, B, C, D> where A: bitcoin_consensus_encoding::Decoder + core::default::Default, B: bitcoin_consensus_encoding::Decoder + core::default::Default, C: bitcoin_consensus_encoding::Decoder + core::default::Default, D: bitcoin_consensus_encoding::Decoder + core::default::Default
 pub fn bitcoin_consensus_encoding::Decoder4<A, B, C, D>::default() -> bitcoin_consensus_encoding::Decoder4<A, B, C, D>
 impl<A, B, C, D> core::fmt::Debug for bitcoin_consensus_encoding::Decoder4<A, B, C, D> where A: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, B: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, C: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, D: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, <A as bitcoin_consensus_encoding::Decoder>::Output: core::fmt::Debug, <B as bitcoin_consensus_encoding::Decoder>::Output: core::fmt::Debug, <C as bitcoin_consensus_encoding::Decoder>::Output: core::fmt::Debug
@@ -1470,18 +1420,12 @@ pub fn bitcoin_consensus_encoding::Decoder4<A, B, C, D>::try_from(value: U) -> c
 impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::Decoder4<A, B, C, D> where U: core::convert::TryFrom<T>
 pub type bitcoin_consensus_encoding::Decoder4<A, B, C, D>::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_consensus_encoding::Decoder4<A, B, C, D>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::Decoder4<A, B, C, D> where T: core::clone::Clone
-pub type bitcoin_consensus_encoding::Decoder4<A, B, C, D>::Owned = T
-pub fn bitcoin_consensus_encoding::Decoder4<A, B, C, D>::clone_into(&self, target: &mut T)
-pub fn bitcoin_consensus_encoding::Decoder4<A, B, C, D>::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_consensus_encoding::Decoder4<A, B, C, D> where T: 'static + ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::Decoder4<A, B, C, D>::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::Decoder4<A, B, C, D> where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::Decoder4<A, B, C, D>::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::Decoder4<A, B, C, D> where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::Decoder4<A, B, C, D>::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::Decoder4<A, B, C, D> where T: core::clone::Clone
-pub unsafe fn bitcoin_consensus_encoding::Decoder4<A, B, C, D>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::Decoder4<A, B, C, D>
 pub fn bitcoin_consensus_encoding::Decoder4<A, B, C, D>::from(t: T) -> T
 pub struct bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F> where A: bitcoin_consensus_encoding::Decoder, B: bitcoin_consensus_encoding::Decoder, C: bitcoin_consensus_encoding::Decoder, D: bitcoin_consensus_encoding::Decoder, E: bitcoin_consensus_encoding::Decoder, F: bitcoin_consensus_encoding::Decoder
@@ -1493,8 +1437,6 @@ pub type bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::Output = (<A as
 pub fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error>
 pub fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::read_limit(&self) -> usize
-impl<A, B, C, D, E, F> core::clone::Clone for bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F> where A: bitcoin_consensus_encoding::Decoder + core::clone::Clone, B: bitcoin_consensus_encoding::Decoder + core::clone::Clone, C: bitcoin_consensus_encoding::Decoder + core::clone::Clone, D: bitcoin_consensus_encoding::Decoder + core::clone::Clone, E: bitcoin_consensus_encoding::Decoder + core::clone::Clone, F: bitcoin_consensus_encoding::Decoder + core::clone::Clone, <A as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone, <B as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone, <C as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone, <D as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone, <E as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone
-pub fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::clone(&self) -> Self
 impl<A, B, C, D, E, F> core::default::Default for bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F> where A: bitcoin_consensus_encoding::Decoder + core::default::Default, B: bitcoin_consensus_encoding::Decoder + core::default::Default, C: bitcoin_consensus_encoding::Decoder + core::default::Default, D: bitcoin_consensus_encoding::Decoder + core::default::Default, E: bitcoin_consensus_encoding::Decoder + core::default::Default, F: bitcoin_consensus_encoding::Decoder + core::default::Default
 pub fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::default() -> bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>
 impl<A, B, C, D, E, F> core::fmt::Debug for bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F> where A: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, B: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, C: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, D: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, E: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, F: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, <A as bitcoin_consensus_encoding::Decoder>::Output: core::fmt::Debug, <B as bitcoin_consensus_encoding::Decoder>::Output: core::fmt::Debug, <C as bitcoin_consensus_encoding::Decoder>::Output: core::fmt::Debug, <D as bitcoin_consensus_encoding::Decoder>::Output: core::fmt::Debug, <E as bitcoin_consensus_encoding::Decoder>::Output: core::fmt::Debug
@@ -1514,18 +1456,12 @@ pub fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::try_from(value: U
 impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F> where U: core::convert::TryFrom<T>
 pub type bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F> where T: core::clone::Clone
-pub type bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::Owned = T
-pub fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::clone_into(&self, target: &mut T)
-pub fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F> where T: 'static + ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F> where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F> where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F> where T: core::clone::Clone
-pub unsafe fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>
 pub fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::from(t: T) -> T
 pub struct bitcoin_consensus_encoding::Encoder2<A, B>
@@ -1930,8 +1866,6 @@ impl<T: bitcoin_consensus_encoding::Decode> core::default::Default for bitcoin_c
 pub fn bitcoin_consensus_encoding::VecDecoder<T>::default() -> Self
 impl<T: bitcoin_consensus_encoding::Decode> core::fmt::Debug for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decode>::Decoder: core::fmt::Debug
 pub fn bitcoin_consensus_encoding::VecDecoder<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl<T> core::clone::Clone for bitcoin_consensus_encoding::VecDecoder<T> where T: core::clone::Clone + bitcoin_consensus_encoding::Decode, <T as bitcoin_consensus_encoding::Decode>::Decoder: core::clone::Clone
-pub fn bitcoin_consensus_encoding::VecDecoder<T>::clone(&self) -> Self
 impl<T> core::marker::Freeze for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decode>::Decoder: core::marker::Freeze
 impl<T> core::marker::Send for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decode>::Decoder: core::marker::Send, T: core::marker::Send
 impl<T> core::marker::Sync for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decode>::Decoder: core::marker::Sync, T: core::marker::Sync
@@ -1947,18 +1881,12 @@ pub fn bitcoin_consensus_encoding::VecDecoder<T>::try_from(value: U) -> core::re
 impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::VecDecoder<T> where U: core::convert::TryFrom<T>
 pub type bitcoin_consensus_encoding::VecDecoder<T>::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_consensus_encoding::VecDecoder<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::VecDecoder<T> where T: core::clone::Clone
-pub type bitcoin_consensus_encoding::VecDecoder<T>::Owned = T
-pub fn bitcoin_consensus_encoding::VecDecoder<T>::clone_into(&self, target: &mut T)
-pub fn bitcoin_consensus_encoding::VecDecoder<T>::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_consensus_encoding::VecDecoder<T> where T: 'static + ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::VecDecoder<T>::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::VecDecoder<T> where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::VecDecoder<T>::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::VecDecoder<T> where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::VecDecoder<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::VecDecoder<T> where T: core::clone::Clone
-pub unsafe fn bitcoin_consensus_encoding::VecDecoder<T>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::VecDecoder<T>
 pub fn bitcoin_consensus_encoding::VecDecoder<T>::from(t: T) -> T
 pub struct bitcoin_consensus_encoding::VecDecoderError<Err>(_)

--- a/consensus_encoding/api/alloc-only.txt
+++ b/consensus_encoding/api/alloc-only.txt
@@ -821,8 +821,6 @@ pub type bitcoin_consensus_encoding::ArrayDecoder<N>::Output = [u8; N]
 pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error>
 pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::read_limit(&self) -> usize
-impl<const N: usize> core::clone::Clone for bitcoin_consensus_encoding::ArrayDecoder<N>
-pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::clone(&self) -> bitcoin_consensus_encoding::ArrayDecoder<N>
 impl<const N: usize> core::default::Default for bitcoin_consensus_encoding::ArrayDecoder<N>
 pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::default() -> Self
 impl<const N: usize> core::fmt::Debug for bitcoin_consensus_encoding::ArrayDecoder<N>
@@ -842,18 +840,12 @@ pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::try_from(value: U) -> core::
 impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::ArrayDecoder<N> where U: core::convert::TryFrom<T>
 pub type bitcoin_consensus_encoding::ArrayDecoder<N>::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::ArrayDecoder<N> where T: core::clone::Clone
-pub type bitcoin_consensus_encoding::ArrayDecoder<N>::Owned = T
-pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::clone_into(&self, target: &mut T)
-pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_consensus_encoding::ArrayDecoder<N> where T: 'static + ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::ArrayDecoder<N> where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::ArrayDecoder<N> where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::ArrayDecoder<N> where T: core::clone::Clone
-pub unsafe fn bitcoin_consensus_encoding::ArrayDecoder<N>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::ArrayDecoder<N>
 pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::from(t: T) -> T
 pub struct bitcoin_consensus_encoding::ArrayEncoder<const N: usize>
@@ -948,8 +940,6 @@ pub type bitcoin_consensus_encoding::ByteVecDecoder::Output = alloc::vec::Vec<u8
 pub fn bitcoin_consensus_encoding::ByteVecDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_consensus_encoding::ByteVecDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error>
 pub fn bitcoin_consensus_encoding::ByteVecDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_consensus_encoding::ByteVecDecoder
-pub fn bitcoin_consensus_encoding::ByteVecDecoder::clone(&self) -> bitcoin_consensus_encoding::ByteVecDecoder
 impl core::default::Default for bitcoin_consensus_encoding::ByteVecDecoder
 pub fn bitcoin_consensus_encoding::ByteVecDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_consensus_encoding::ByteVecDecoder
@@ -969,18 +959,12 @@ pub fn bitcoin_consensus_encoding::ByteVecDecoder::try_from(value: U) -> core::r
 impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::ByteVecDecoder where U: core::convert::TryFrom<T>
 pub type bitcoin_consensus_encoding::ByteVecDecoder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_consensus_encoding::ByteVecDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::ByteVecDecoder where T: core::clone::Clone
-pub type bitcoin_consensus_encoding::ByteVecDecoder::Owned = T
-pub fn bitcoin_consensus_encoding::ByteVecDecoder::clone_into(&self, target: &mut T)
-pub fn bitcoin_consensus_encoding::ByteVecDecoder::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_consensus_encoding::ByteVecDecoder where T: 'static + ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::ByteVecDecoder::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::ByteVecDecoder where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::ByteVecDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::ByteVecDecoder where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::ByteVecDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::ByteVecDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_consensus_encoding::ByteVecDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::ByteVecDecoder
 pub fn bitcoin_consensus_encoding::ByteVecDecoder::from(t: T) -> T
 pub struct bitcoin_consensus_encoding::ByteVecDecoderError(_)
@@ -1078,8 +1062,6 @@ pub type bitcoin_consensus_encoding::CompactSizeDecoder::Output = usize
 pub fn bitcoin_consensus_encoding::CompactSizeDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_consensus_encoding::CompactSizeDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error>
 pub fn bitcoin_consensus_encoding::CompactSizeDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_consensus_encoding::CompactSizeDecoder
-pub fn bitcoin_consensus_encoding::CompactSizeDecoder::clone(&self) -> bitcoin_consensus_encoding::CompactSizeDecoder
 impl core::default::Default for bitcoin_consensus_encoding::CompactSizeDecoder
 pub fn bitcoin_consensus_encoding::CompactSizeDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_consensus_encoding::CompactSizeDecoder
@@ -1099,18 +1081,12 @@ pub fn bitcoin_consensus_encoding::CompactSizeDecoder::try_from(value: U) -> cor
 impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::CompactSizeDecoder where U: core::convert::TryFrom<T>
 pub type bitcoin_consensus_encoding::CompactSizeDecoder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_consensus_encoding::CompactSizeDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::CompactSizeDecoder where T: core::clone::Clone
-pub type bitcoin_consensus_encoding::CompactSizeDecoder::Owned = T
-pub fn bitcoin_consensus_encoding::CompactSizeDecoder::clone_into(&self, target: &mut T)
-pub fn bitcoin_consensus_encoding::CompactSizeDecoder::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_consensus_encoding::CompactSizeDecoder where T: 'static + ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::CompactSizeDecoder::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::CompactSizeDecoder where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::CompactSizeDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::CompactSizeDecoder where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::CompactSizeDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::CompactSizeDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_consensus_encoding::CompactSizeDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::CompactSizeDecoder
 pub fn bitcoin_consensus_encoding::CompactSizeDecoder::from(t: T) -> T
 pub struct bitcoin_consensus_encoding::CompactSizeDecoderError(_)
@@ -1209,8 +1185,6 @@ pub type bitcoin_consensus_encoding::CompactSizeU64Decoder::Output = u64
 pub fn bitcoin_consensus_encoding::CompactSizeU64Decoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_consensus_encoding::CompactSizeU64Decoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error>
 pub fn bitcoin_consensus_encoding::CompactSizeU64Decoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_consensus_encoding::CompactSizeU64Decoder
-pub fn bitcoin_consensus_encoding::CompactSizeU64Decoder::clone(&self) -> bitcoin_consensus_encoding::CompactSizeU64Decoder
 impl core::default::Default for bitcoin_consensus_encoding::CompactSizeU64Decoder
 pub fn bitcoin_consensus_encoding::CompactSizeU64Decoder::default() -> Self
 impl core::fmt::Debug for bitcoin_consensus_encoding::CompactSizeU64Decoder
@@ -1230,18 +1204,12 @@ pub fn bitcoin_consensus_encoding::CompactSizeU64Decoder::try_from(value: U) -> 
 impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::CompactSizeU64Decoder where U: core::convert::TryFrom<T>
 pub type bitcoin_consensus_encoding::CompactSizeU64Decoder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_consensus_encoding::CompactSizeU64Decoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::CompactSizeU64Decoder where T: core::clone::Clone
-pub type bitcoin_consensus_encoding::CompactSizeU64Decoder::Owned = T
-pub fn bitcoin_consensus_encoding::CompactSizeU64Decoder::clone_into(&self, target: &mut T)
-pub fn bitcoin_consensus_encoding::CompactSizeU64Decoder::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_consensus_encoding::CompactSizeU64Decoder where T: 'static + ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::CompactSizeU64Decoder::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::CompactSizeU64Decoder where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::CompactSizeU64Decoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::CompactSizeU64Decoder where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::CompactSizeU64Decoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::CompactSizeU64Decoder where T: core::clone::Clone
-pub unsafe fn bitcoin_consensus_encoding::CompactSizeU64Decoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::CompactSizeU64Decoder
 pub fn bitcoin_consensus_encoding::CompactSizeU64Decoder::from(t: T) -> T
 pub struct bitcoin_consensus_encoding::Decoder2<A, B> where A: bitcoin_consensus_encoding::Decoder, B: bitcoin_consensus_encoding::Decoder
@@ -1253,8 +1221,6 @@ pub type bitcoin_consensus_encoding::Decoder2<A, B>::Output = (<A as bitcoin_con
 pub fn bitcoin_consensus_encoding::Decoder2<A, B>::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_consensus_encoding::Decoder2<A, B>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error>
 pub fn bitcoin_consensus_encoding::Decoder2<A, B>::read_limit(&self) -> usize
-impl<A, B> core::clone::Clone for bitcoin_consensus_encoding::Decoder2<A, B> where A: bitcoin_consensus_encoding::Decoder + core::clone::Clone, B: bitcoin_consensus_encoding::Decoder + core::clone::Clone, <A as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone
-pub fn bitcoin_consensus_encoding::Decoder2<A, B>::clone(&self) -> Self
 impl<A, B> core::default::Default for bitcoin_consensus_encoding::Decoder2<A, B> where A: bitcoin_consensus_encoding::Decoder + core::default::Default, B: bitcoin_consensus_encoding::Decoder + core::default::Default
 pub fn bitcoin_consensus_encoding::Decoder2<A, B>::default() -> bitcoin_consensus_encoding::Decoder2<A, B>
 impl<A, B> core::fmt::Debug for bitcoin_consensus_encoding::Decoder2<A, B> where A: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, B: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, <A as bitcoin_consensus_encoding::Decoder>::Output: core::fmt::Debug
@@ -1274,18 +1240,12 @@ pub fn bitcoin_consensus_encoding::Decoder2<A, B>::try_from(value: U) -> core::r
 impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::Decoder2<A, B> where U: core::convert::TryFrom<T>
 pub type bitcoin_consensus_encoding::Decoder2<A, B>::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_consensus_encoding::Decoder2<A, B>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::Decoder2<A, B> where T: core::clone::Clone
-pub type bitcoin_consensus_encoding::Decoder2<A, B>::Owned = T
-pub fn bitcoin_consensus_encoding::Decoder2<A, B>::clone_into(&self, target: &mut T)
-pub fn bitcoin_consensus_encoding::Decoder2<A, B>::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_consensus_encoding::Decoder2<A, B> where T: 'static + ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::Decoder2<A, B>::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::Decoder2<A, B> where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::Decoder2<A, B>::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::Decoder2<A, B> where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::Decoder2<A, B>::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::Decoder2<A, B> where T: core::clone::Clone
-pub unsafe fn bitcoin_consensus_encoding::Decoder2<A, B>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::Decoder2<A, B>
 pub fn bitcoin_consensus_encoding::Decoder2<A, B>::from(t: T) -> T
 pub struct bitcoin_consensus_encoding::Decoder3<A, B, C> where A: bitcoin_consensus_encoding::Decoder, B: bitcoin_consensus_encoding::Decoder, C: bitcoin_consensus_encoding::Decoder
@@ -1297,8 +1257,6 @@ pub type bitcoin_consensus_encoding::Decoder3<A, B, C>::Output = (<A as bitcoin_
 pub fn bitcoin_consensus_encoding::Decoder3<A, B, C>::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_consensus_encoding::Decoder3<A, B, C>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error>
 pub fn bitcoin_consensus_encoding::Decoder3<A, B, C>::read_limit(&self) -> usize
-impl<A, B, C> core::clone::Clone for bitcoin_consensus_encoding::Decoder3<A, B, C> where A: bitcoin_consensus_encoding::Decoder + core::clone::Clone, B: bitcoin_consensus_encoding::Decoder + core::clone::Clone, C: bitcoin_consensus_encoding::Decoder + core::clone::Clone, <A as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone, <B as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone
-pub fn bitcoin_consensus_encoding::Decoder3<A, B, C>::clone(&self) -> Self
 impl<A, B, C> core::default::Default for bitcoin_consensus_encoding::Decoder3<A, B, C> where A: bitcoin_consensus_encoding::Decoder + core::default::Default, B: bitcoin_consensus_encoding::Decoder + core::default::Default, C: bitcoin_consensus_encoding::Decoder + core::default::Default
 pub fn bitcoin_consensus_encoding::Decoder3<A, B, C>::default() -> bitcoin_consensus_encoding::Decoder3<A, B, C>
 impl<A, B, C> core::fmt::Debug for bitcoin_consensus_encoding::Decoder3<A, B, C> where A: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, B: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, C: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, <A as bitcoin_consensus_encoding::Decoder>::Output: core::fmt::Debug, <B as bitcoin_consensus_encoding::Decoder>::Output: core::fmt::Debug
@@ -1318,18 +1276,12 @@ pub fn bitcoin_consensus_encoding::Decoder3<A, B, C>::try_from(value: U) -> core
 impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::Decoder3<A, B, C> where U: core::convert::TryFrom<T>
 pub type bitcoin_consensus_encoding::Decoder3<A, B, C>::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_consensus_encoding::Decoder3<A, B, C>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::Decoder3<A, B, C> where T: core::clone::Clone
-pub type bitcoin_consensus_encoding::Decoder3<A, B, C>::Owned = T
-pub fn bitcoin_consensus_encoding::Decoder3<A, B, C>::clone_into(&self, target: &mut T)
-pub fn bitcoin_consensus_encoding::Decoder3<A, B, C>::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_consensus_encoding::Decoder3<A, B, C> where T: 'static + ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::Decoder3<A, B, C>::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::Decoder3<A, B, C> where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::Decoder3<A, B, C>::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::Decoder3<A, B, C> where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::Decoder3<A, B, C>::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::Decoder3<A, B, C> where T: core::clone::Clone
-pub unsafe fn bitcoin_consensus_encoding::Decoder3<A, B, C>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::Decoder3<A, B, C>
 pub fn bitcoin_consensus_encoding::Decoder3<A, B, C>::from(t: T) -> T
 pub struct bitcoin_consensus_encoding::Decoder4<A, B, C, D> where A: bitcoin_consensus_encoding::Decoder, B: bitcoin_consensus_encoding::Decoder, C: bitcoin_consensus_encoding::Decoder, D: bitcoin_consensus_encoding::Decoder
@@ -1341,8 +1293,6 @@ pub type bitcoin_consensus_encoding::Decoder4<A, B, C, D>::Output = (<A as bitco
 pub fn bitcoin_consensus_encoding::Decoder4<A, B, C, D>::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_consensus_encoding::Decoder4<A, B, C, D>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error>
 pub fn bitcoin_consensus_encoding::Decoder4<A, B, C, D>::read_limit(&self) -> usize
-impl<A, B, C, D> core::clone::Clone for bitcoin_consensus_encoding::Decoder4<A, B, C, D> where A: bitcoin_consensus_encoding::Decoder + core::clone::Clone, B: bitcoin_consensus_encoding::Decoder + core::clone::Clone, C: bitcoin_consensus_encoding::Decoder + core::clone::Clone, D: bitcoin_consensus_encoding::Decoder + core::clone::Clone, <A as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone, <B as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone, <C as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone
-pub fn bitcoin_consensus_encoding::Decoder4<A, B, C, D>::clone(&self) -> Self
 impl<A, B, C, D> core::default::Default for bitcoin_consensus_encoding::Decoder4<A, B, C, D> where A: bitcoin_consensus_encoding::Decoder + core::default::Default, B: bitcoin_consensus_encoding::Decoder + core::default::Default, C: bitcoin_consensus_encoding::Decoder + core::default::Default, D: bitcoin_consensus_encoding::Decoder + core::default::Default
 pub fn bitcoin_consensus_encoding::Decoder4<A, B, C, D>::default() -> bitcoin_consensus_encoding::Decoder4<A, B, C, D>
 impl<A, B, C, D> core::fmt::Debug for bitcoin_consensus_encoding::Decoder4<A, B, C, D> where A: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, B: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, C: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, D: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, <A as bitcoin_consensus_encoding::Decoder>::Output: core::fmt::Debug, <B as bitcoin_consensus_encoding::Decoder>::Output: core::fmt::Debug, <C as bitcoin_consensus_encoding::Decoder>::Output: core::fmt::Debug
@@ -1362,18 +1312,12 @@ pub fn bitcoin_consensus_encoding::Decoder4<A, B, C, D>::try_from(value: U) -> c
 impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::Decoder4<A, B, C, D> where U: core::convert::TryFrom<T>
 pub type bitcoin_consensus_encoding::Decoder4<A, B, C, D>::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_consensus_encoding::Decoder4<A, B, C, D>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::Decoder4<A, B, C, D> where T: core::clone::Clone
-pub type bitcoin_consensus_encoding::Decoder4<A, B, C, D>::Owned = T
-pub fn bitcoin_consensus_encoding::Decoder4<A, B, C, D>::clone_into(&self, target: &mut T)
-pub fn bitcoin_consensus_encoding::Decoder4<A, B, C, D>::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_consensus_encoding::Decoder4<A, B, C, D> where T: 'static + ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::Decoder4<A, B, C, D>::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::Decoder4<A, B, C, D> where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::Decoder4<A, B, C, D>::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::Decoder4<A, B, C, D> where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::Decoder4<A, B, C, D>::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::Decoder4<A, B, C, D> where T: core::clone::Clone
-pub unsafe fn bitcoin_consensus_encoding::Decoder4<A, B, C, D>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::Decoder4<A, B, C, D>
 pub fn bitcoin_consensus_encoding::Decoder4<A, B, C, D>::from(t: T) -> T
 pub struct bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F> where A: bitcoin_consensus_encoding::Decoder, B: bitcoin_consensus_encoding::Decoder, C: bitcoin_consensus_encoding::Decoder, D: bitcoin_consensus_encoding::Decoder, E: bitcoin_consensus_encoding::Decoder, F: bitcoin_consensus_encoding::Decoder
@@ -1385,8 +1329,6 @@ pub type bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::Output = (<A as
 pub fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error>
 pub fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::read_limit(&self) -> usize
-impl<A, B, C, D, E, F> core::clone::Clone for bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F> where A: bitcoin_consensus_encoding::Decoder + core::clone::Clone, B: bitcoin_consensus_encoding::Decoder + core::clone::Clone, C: bitcoin_consensus_encoding::Decoder + core::clone::Clone, D: bitcoin_consensus_encoding::Decoder + core::clone::Clone, E: bitcoin_consensus_encoding::Decoder + core::clone::Clone, F: bitcoin_consensus_encoding::Decoder + core::clone::Clone, <A as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone, <B as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone, <C as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone, <D as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone, <E as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone
-pub fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::clone(&self) -> Self
 impl<A, B, C, D, E, F> core::default::Default for bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F> where A: bitcoin_consensus_encoding::Decoder + core::default::Default, B: bitcoin_consensus_encoding::Decoder + core::default::Default, C: bitcoin_consensus_encoding::Decoder + core::default::Default, D: bitcoin_consensus_encoding::Decoder + core::default::Default, E: bitcoin_consensus_encoding::Decoder + core::default::Default, F: bitcoin_consensus_encoding::Decoder + core::default::Default
 pub fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::default() -> bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>
 impl<A, B, C, D, E, F> core::fmt::Debug for bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F> where A: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, B: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, C: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, D: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, E: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, F: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, <A as bitcoin_consensus_encoding::Decoder>::Output: core::fmt::Debug, <B as bitcoin_consensus_encoding::Decoder>::Output: core::fmt::Debug, <C as bitcoin_consensus_encoding::Decoder>::Output: core::fmt::Debug, <D as bitcoin_consensus_encoding::Decoder>::Output: core::fmt::Debug, <E as bitcoin_consensus_encoding::Decoder>::Output: core::fmt::Debug
@@ -1406,18 +1348,12 @@ pub fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::try_from(value: U
 impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F> where U: core::convert::TryFrom<T>
 pub type bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F> where T: core::clone::Clone
-pub type bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::Owned = T
-pub fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::clone_into(&self, target: &mut T)
-pub fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F> where T: 'static + ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F> where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F> where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F> where T: core::clone::Clone
-pub unsafe fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>
 pub fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::from(t: T) -> T
 pub struct bitcoin_consensus_encoding::Encoder2<A, B>
@@ -1816,8 +1752,6 @@ impl<T: bitcoin_consensus_encoding::Decode> core::default::Default for bitcoin_c
 pub fn bitcoin_consensus_encoding::VecDecoder<T>::default() -> Self
 impl<T: bitcoin_consensus_encoding::Decode> core::fmt::Debug for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decode>::Decoder: core::fmt::Debug
 pub fn bitcoin_consensus_encoding::VecDecoder<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl<T> core::clone::Clone for bitcoin_consensus_encoding::VecDecoder<T> where T: core::clone::Clone + bitcoin_consensus_encoding::Decode, <T as bitcoin_consensus_encoding::Decode>::Decoder: core::clone::Clone
-pub fn bitcoin_consensus_encoding::VecDecoder<T>::clone(&self) -> Self
 impl<T> core::marker::Freeze for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decode>::Decoder: core::marker::Freeze
 impl<T> core::marker::Send for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decode>::Decoder: core::marker::Send, T: core::marker::Send
 impl<T> core::marker::Sync for bitcoin_consensus_encoding::VecDecoder<T> where <T as bitcoin_consensus_encoding::Decode>::Decoder: core::marker::Sync, T: core::marker::Sync
@@ -1833,18 +1767,12 @@ pub fn bitcoin_consensus_encoding::VecDecoder<T>::try_from(value: U) -> core::re
 impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::VecDecoder<T> where U: core::convert::TryFrom<T>
 pub type bitcoin_consensus_encoding::VecDecoder<T>::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_consensus_encoding::VecDecoder<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::VecDecoder<T> where T: core::clone::Clone
-pub type bitcoin_consensus_encoding::VecDecoder<T>::Owned = T
-pub fn bitcoin_consensus_encoding::VecDecoder<T>::clone_into(&self, target: &mut T)
-pub fn bitcoin_consensus_encoding::VecDecoder<T>::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_consensus_encoding::VecDecoder<T> where T: 'static + ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::VecDecoder<T>::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::VecDecoder<T> where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::VecDecoder<T>::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::VecDecoder<T> where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::VecDecoder<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::VecDecoder<T> where T: core::clone::Clone
-pub unsafe fn bitcoin_consensus_encoding::VecDecoder<T>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::VecDecoder<T>
 pub fn bitcoin_consensus_encoding::VecDecoder<T>::from(t: T) -> T
 pub struct bitcoin_consensus_encoding::VecDecoderError<Err>(_)

--- a/consensus_encoding/api/no-features.txt
+++ b/consensus_encoding/api/no-features.txt
@@ -641,8 +641,6 @@ pub type bitcoin_consensus_encoding::ArrayDecoder<N>::Output = [u8; N]
 pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error>
 pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::read_limit(&self) -> usize
-impl<const N: usize> core::clone::Clone for bitcoin_consensus_encoding::ArrayDecoder<N>
-pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::clone(&self) -> bitcoin_consensus_encoding::ArrayDecoder<N>
 impl<const N: usize> core::default::Default for bitcoin_consensus_encoding::ArrayDecoder<N>
 pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::default() -> Self
 impl<const N: usize> core::fmt::Debug for bitcoin_consensus_encoding::ArrayDecoder<N>
@@ -668,8 +666,6 @@ impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::ArrayDecoder<N> 
 pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::ArrayDecoder<N> where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::ArrayDecoder<N> where T: core::clone::Clone
-pub unsafe fn bitcoin_consensus_encoding::ArrayDecoder<N>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::ArrayDecoder<N>
 pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::from(t: T) -> T
 pub struct bitcoin_consensus_encoding::ArrayEncoder<const N: usize>
@@ -793,8 +789,6 @@ pub type bitcoin_consensus_encoding::CompactSizeDecoder::Output = usize
 pub fn bitcoin_consensus_encoding::CompactSizeDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_consensus_encoding::CompactSizeDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error>
 pub fn bitcoin_consensus_encoding::CompactSizeDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_consensus_encoding::CompactSizeDecoder
-pub fn bitcoin_consensus_encoding::CompactSizeDecoder::clone(&self) -> bitcoin_consensus_encoding::CompactSizeDecoder
 impl core::default::Default for bitcoin_consensus_encoding::CompactSizeDecoder
 pub fn bitcoin_consensus_encoding::CompactSizeDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_consensus_encoding::CompactSizeDecoder
@@ -820,8 +814,6 @@ impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::CompactSizeDecod
 pub fn bitcoin_consensus_encoding::CompactSizeDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::CompactSizeDecoder where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::CompactSizeDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::CompactSizeDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_consensus_encoding::CompactSizeDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::CompactSizeDecoder
 pub fn bitcoin_consensus_encoding::CompactSizeDecoder::from(t: T) -> T
 pub struct bitcoin_consensus_encoding::CompactSizeDecoderError(_)
@@ -910,8 +902,6 @@ pub type bitcoin_consensus_encoding::CompactSizeU64Decoder::Output = u64
 pub fn bitcoin_consensus_encoding::CompactSizeU64Decoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_consensus_encoding::CompactSizeU64Decoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error>
 pub fn bitcoin_consensus_encoding::CompactSizeU64Decoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_consensus_encoding::CompactSizeU64Decoder
-pub fn bitcoin_consensus_encoding::CompactSizeU64Decoder::clone(&self) -> bitcoin_consensus_encoding::CompactSizeU64Decoder
 impl core::default::Default for bitcoin_consensus_encoding::CompactSizeU64Decoder
 pub fn bitcoin_consensus_encoding::CompactSizeU64Decoder::default() -> Self
 impl core::fmt::Debug for bitcoin_consensus_encoding::CompactSizeU64Decoder
@@ -937,8 +927,6 @@ impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::CompactSizeU64De
 pub fn bitcoin_consensus_encoding::CompactSizeU64Decoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::CompactSizeU64Decoder where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::CompactSizeU64Decoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::CompactSizeU64Decoder where T: core::clone::Clone
-pub unsafe fn bitcoin_consensus_encoding::CompactSizeU64Decoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::CompactSizeU64Decoder
 pub fn bitcoin_consensus_encoding::CompactSizeU64Decoder::from(t: T) -> T
 pub struct bitcoin_consensus_encoding::Decoder2<A, B> where A: bitcoin_consensus_encoding::Decoder, B: bitcoin_consensus_encoding::Decoder
@@ -950,8 +938,6 @@ pub type bitcoin_consensus_encoding::Decoder2<A, B>::Output = (<A as bitcoin_con
 pub fn bitcoin_consensus_encoding::Decoder2<A, B>::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_consensus_encoding::Decoder2<A, B>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error>
 pub fn bitcoin_consensus_encoding::Decoder2<A, B>::read_limit(&self) -> usize
-impl<A, B> core::clone::Clone for bitcoin_consensus_encoding::Decoder2<A, B> where A: bitcoin_consensus_encoding::Decoder + core::clone::Clone, B: bitcoin_consensus_encoding::Decoder + core::clone::Clone, <A as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone
-pub fn bitcoin_consensus_encoding::Decoder2<A, B>::clone(&self) -> Self
 impl<A, B> core::default::Default for bitcoin_consensus_encoding::Decoder2<A, B> where A: bitcoin_consensus_encoding::Decoder + core::default::Default, B: bitcoin_consensus_encoding::Decoder + core::default::Default
 pub fn bitcoin_consensus_encoding::Decoder2<A, B>::default() -> bitcoin_consensus_encoding::Decoder2<A, B>
 impl<A, B> core::fmt::Debug for bitcoin_consensus_encoding::Decoder2<A, B> where A: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, B: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, <A as bitcoin_consensus_encoding::Decoder>::Output: core::fmt::Debug
@@ -977,8 +963,6 @@ impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::Decoder2<A, B> w
 pub fn bitcoin_consensus_encoding::Decoder2<A, B>::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::Decoder2<A, B> where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::Decoder2<A, B>::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::Decoder2<A, B> where T: core::clone::Clone
-pub unsafe fn bitcoin_consensus_encoding::Decoder2<A, B>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::Decoder2<A, B>
 pub fn bitcoin_consensus_encoding::Decoder2<A, B>::from(t: T) -> T
 pub struct bitcoin_consensus_encoding::Decoder3<A, B, C> where A: bitcoin_consensus_encoding::Decoder, B: bitcoin_consensus_encoding::Decoder, C: bitcoin_consensus_encoding::Decoder
@@ -990,8 +974,6 @@ pub type bitcoin_consensus_encoding::Decoder3<A, B, C>::Output = (<A as bitcoin_
 pub fn bitcoin_consensus_encoding::Decoder3<A, B, C>::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_consensus_encoding::Decoder3<A, B, C>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error>
 pub fn bitcoin_consensus_encoding::Decoder3<A, B, C>::read_limit(&self) -> usize
-impl<A, B, C> core::clone::Clone for bitcoin_consensus_encoding::Decoder3<A, B, C> where A: bitcoin_consensus_encoding::Decoder + core::clone::Clone, B: bitcoin_consensus_encoding::Decoder + core::clone::Clone, C: bitcoin_consensus_encoding::Decoder + core::clone::Clone, <A as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone, <B as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone
-pub fn bitcoin_consensus_encoding::Decoder3<A, B, C>::clone(&self) -> Self
 impl<A, B, C> core::default::Default for bitcoin_consensus_encoding::Decoder3<A, B, C> where A: bitcoin_consensus_encoding::Decoder + core::default::Default, B: bitcoin_consensus_encoding::Decoder + core::default::Default, C: bitcoin_consensus_encoding::Decoder + core::default::Default
 pub fn bitcoin_consensus_encoding::Decoder3<A, B, C>::default() -> bitcoin_consensus_encoding::Decoder3<A, B, C>
 impl<A, B, C> core::fmt::Debug for bitcoin_consensus_encoding::Decoder3<A, B, C> where A: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, B: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, C: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, <A as bitcoin_consensus_encoding::Decoder>::Output: core::fmt::Debug, <B as bitcoin_consensus_encoding::Decoder>::Output: core::fmt::Debug
@@ -1017,8 +999,6 @@ impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::Decoder3<A, B, C
 pub fn bitcoin_consensus_encoding::Decoder3<A, B, C>::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::Decoder3<A, B, C> where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::Decoder3<A, B, C>::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::Decoder3<A, B, C> where T: core::clone::Clone
-pub unsafe fn bitcoin_consensus_encoding::Decoder3<A, B, C>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::Decoder3<A, B, C>
 pub fn bitcoin_consensus_encoding::Decoder3<A, B, C>::from(t: T) -> T
 pub struct bitcoin_consensus_encoding::Decoder4<A, B, C, D> where A: bitcoin_consensus_encoding::Decoder, B: bitcoin_consensus_encoding::Decoder, C: bitcoin_consensus_encoding::Decoder, D: bitcoin_consensus_encoding::Decoder
@@ -1030,8 +1010,6 @@ pub type bitcoin_consensus_encoding::Decoder4<A, B, C, D>::Output = (<A as bitco
 pub fn bitcoin_consensus_encoding::Decoder4<A, B, C, D>::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_consensus_encoding::Decoder4<A, B, C, D>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error>
 pub fn bitcoin_consensus_encoding::Decoder4<A, B, C, D>::read_limit(&self) -> usize
-impl<A, B, C, D> core::clone::Clone for bitcoin_consensus_encoding::Decoder4<A, B, C, D> where A: bitcoin_consensus_encoding::Decoder + core::clone::Clone, B: bitcoin_consensus_encoding::Decoder + core::clone::Clone, C: bitcoin_consensus_encoding::Decoder + core::clone::Clone, D: bitcoin_consensus_encoding::Decoder + core::clone::Clone, <A as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone, <B as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone, <C as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone
-pub fn bitcoin_consensus_encoding::Decoder4<A, B, C, D>::clone(&self) -> Self
 impl<A, B, C, D> core::default::Default for bitcoin_consensus_encoding::Decoder4<A, B, C, D> where A: bitcoin_consensus_encoding::Decoder + core::default::Default, B: bitcoin_consensus_encoding::Decoder + core::default::Default, C: bitcoin_consensus_encoding::Decoder + core::default::Default, D: bitcoin_consensus_encoding::Decoder + core::default::Default
 pub fn bitcoin_consensus_encoding::Decoder4<A, B, C, D>::default() -> bitcoin_consensus_encoding::Decoder4<A, B, C, D>
 impl<A, B, C, D> core::fmt::Debug for bitcoin_consensus_encoding::Decoder4<A, B, C, D> where A: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, B: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, C: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, D: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, <A as bitcoin_consensus_encoding::Decoder>::Output: core::fmt::Debug, <B as bitcoin_consensus_encoding::Decoder>::Output: core::fmt::Debug, <C as bitcoin_consensus_encoding::Decoder>::Output: core::fmt::Debug
@@ -1057,8 +1035,6 @@ impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::Decoder4<A, B, C
 pub fn bitcoin_consensus_encoding::Decoder4<A, B, C, D>::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::Decoder4<A, B, C, D> where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::Decoder4<A, B, C, D>::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::Decoder4<A, B, C, D> where T: core::clone::Clone
-pub unsafe fn bitcoin_consensus_encoding::Decoder4<A, B, C, D>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::Decoder4<A, B, C, D>
 pub fn bitcoin_consensus_encoding::Decoder4<A, B, C, D>::from(t: T) -> T
 pub struct bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F> where A: bitcoin_consensus_encoding::Decoder, B: bitcoin_consensus_encoding::Decoder, C: bitcoin_consensus_encoding::Decoder, D: bitcoin_consensus_encoding::Decoder, E: bitcoin_consensus_encoding::Decoder, F: bitcoin_consensus_encoding::Decoder
@@ -1070,8 +1046,6 @@ pub type bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::Output = (<A as
 pub fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error>
 pub fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::read_limit(&self) -> usize
-impl<A, B, C, D, E, F> core::clone::Clone for bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F> where A: bitcoin_consensus_encoding::Decoder + core::clone::Clone, B: bitcoin_consensus_encoding::Decoder + core::clone::Clone, C: bitcoin_consensus_encoding::Decoder + core::clone::Clone, D: bitcoin_consensus_encoding::Decoder + core::clone::Clone, E: bitcoin_consensus_encoding::Decoder + core::clone::Clone, F: bitcoin_consensus_encoding::Decoder + core::clone::Clone, <A as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone, <B as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone, <C as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone, <D as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone, <E as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone
-pub fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::clone(&self) -> Self
 impl<A, B, C, D, E, F> core::default::Default for bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F> where A: bitcoin_consensus_encoding::Decoder + core::default::Default, B: bitcoin_consensus_encoding::Decoder + core::default::Default, C: bitcoin_consensus_encoding::Decoder + core::default::Default, D: bitcoin_consensus_encoding::Decoder + core::default::Default, E: bitcoin_consensus_encoding::Decoder + core::default::Default, F: bitcoin_consensus_encoding::Decoder + core::default::Default
 pub fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::default() -> bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>
 impl<A, B, C, D, E, F> core::fmt::Debug for bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F> where A: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, B: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, C: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, D: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, E: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, F: bitcoin_consensus_encoding::Decoder + core::fmt::Debug, <A as bitcoin_consensus_encoding::Decoder>::Output: core::fmt::Debug, <B as bitcoin_consensus_encoding::Decoder>::Output: core::fmt::Debug, <C as bitcoin_consensus_encoding::Decoder>::Output: core::fmt::Debug, <D as bitcoin_consensus_encoding::Decoder>::Output: core::fmt::Debug, <E as bitcoin_consensus_encoding::Decoder>::Output: core::fmt::Debug
@@ -1097,8 +1071,6 @@ impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::Decoder6<A, B, C
 pub fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F> where T: ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F> where T: core::clone::Clone
-pub unsafe fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>
 pub fn bitcoin_consensus_encoding::Decoder6<A, B, C, D, E, F>::from(t: T) -> T
 pub struct bitcoin_consensus_encoding::Encoder2<A, B>

--- a/consensus_encoding/src/compact_size.rs
+++ b/consensus_encoding/src/compact_size.rs
@@ -136,7 +136,7 @@ impl ExactSizeEncoder for CompactSizeEncoder {
 /// [`CompactSizeU64Decoder`] instead.
 ///
 /// For more information about decoders see the documentation of the [`Decoder`] trait.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct CompactSizeDecoder {
     buf: ArrayVec<u8, 9>,
     limit: usize,
@@ -210,7 +210,7 @@ impl Decoder for CompactSizeDecoder {
 /// configurable upper bound before returning the value.
 ///
 /// For more information about decoders see the documentation of the [`Decoder`] trait.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct CompactSizeU64Decoder {
     buf: ArrayVec<u8, 9>,
 }

--- a/consensus_encoding/src/decode/decoders.rs
+++ b/consensus_encoding/src/decode/decoders.rs
@@ -33,7 +33,7 @@ const MAX_VEC_SIZE: usize = 4_000_000;
 ///
 /// The encoding is expected to start with the number of encoded bytes (length prefix).
 #[cfg(feature = "alloc")]
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ByteVecDecoder {
     prefix_decoder: Option<CompactSizeDecoder>,
     buffer: Vec<u8>,
@@ -173,22 +173,6 @@ where
 }
 
 #[cfg(feature = "alloc")]
-impl<T: Decode> Clone for VecDecoder<T>
-where
-    T: Clone,
-    T::Decoder: Clone,
-{
-    fn clone(&self) -> Self {
-        Self {
-            prefix_decoder: self.prefix_decoder.clone(),
-            length: self.length,
-            buffer: self.buffer.clone(),
-            decoder: self.decoder.clone(),
-        }
-    }
-}
-
-#[cfg(feature = "alloc")]
 impl<T: Decode> VecDecoder<T> {
     /// Constructs a new typed vector decoder with the default limit of 4,000,000 elements.
     pub const fn new() -> Self { Self::new_with_limit(MAX_VEC_SIZE) }
@@ -314,7 +298,7 @@ impl<T: Decode> Decoder for VecDecoder<T> {
 }
 
 /// A decoder that expects exactly N bytes and returns them as an array.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ArrayDecoder<const N: usize> {
     buffer: [u8; N],
     bytes_written: usize,
@@ -412,22 +396,6 @@ where
             Decoder2State::Second(out, b) => f.debug_tuple("Second").field(out).field(b).finish(),
             Decoder2State::Errored => write!(f, "Errored"),
         }
-    }
-}
-
-impl<A, B> Clone for Decoder2<A, B>
-where
-    A: Decoder + Clone,
-    B: Decoder + Clone,
-    A::Output: Clone,
-{
-    fn clone(&self) -> Self {
-        let state = match &self.state {
-            Decoder2State::First(a, b) => Decoder2State::First(a.clone(), b.clone()),
-            Decoder2State::Second(out, b) => Decoder2State::Second(out.clone(), b.clone()),
-            Decoder2State::Errored => Decoder2State::Errored,
-        };
-        Self { state }
     }
 }
 
@@ -538,17 +506,6 @@ where
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { self.inner.fmt(f) }
 }
 
-impl<A, B, C> Clone for Decoder3<A, B, C>
-where
-    A: Decoder + Clone,
-    B: Decoder + Clone,
-    C: Decoder + Clone,
-    A::Output: Clone,
-    B::Output: Clone,
-{
-    fn clone(&self) -> Self { Self { inner: self.inner.clone() } }
-}
-
 impl<A, B, C> Decoder for Decoder3<A, B, C>
 where
     A: Decoder,
@@ -619,19 +576,6 @@ where
     C::Output: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { self.inner.fmt(f) }
-}
-
-impl<A, B, C, D> Clone for Decoder4<A, B, C, D>
-where
-    A: Decoder + Clone,
-    B: Decoder + Clone,
-    C: Decoder + Clone,
-    D: Decoder + Clone,
-    A::Output: Clone,
-    B::Output: Clone,
-    C::Output: Clone,
-{
-    fn clone(&self) -> Self { Self { inner: self.inner.clone() } }
 }
 
 impl<A, B, C, D> Decoder for Decoder4<A, B, C, D>
@@ -721,23 +665,6 @@ where
     E::Output: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { self.inner.fmt(f) }
-}
-
-impl<A, B, C, D, E, F> Clone for Decoder6<A, B, C, D, E, F>
-where
-    A: Decoder + Clone,
-    B: Decoder + Clone,
-    C: Decoder + Clone,
-    D: Decoder + Clone,
-    E: Decoder + Clone,
-    F: Decoder + Clone,
-    A::Output: Clone,
-    B::Output: Clone,
-    C::Output: Clone,
-    D::Output: Clone,
-    E::Output: Clone,
-{
-    fn clone(&self) -> Self { Self { inner: self.inner.clone() } }
 }
 
 impl<A, B, C, D, E, F> Decoder for Decoder6<A, B, C, D, E, F>
@@ -905,7 +832,7 @@ mod tests {
 
     /// The decoder for the [`Inner`] type.
     #[cfg(feature = "alloc")]
-    #[derive(Clone, Default)]
+    #[derive(Default)]
     pub struct InnerDecoder(ArrayDecoder<4>);
 
     #[cfg(feature = "alloc")]
@@ -936,7 +863,7 @@ mod tests {
 
     /// The decoder for the [`Test`] type.
     #[cfg(feature = "alloc")]
-    #[derive(Clone, Default)]
+    #[derive(Default)]
     pub struct TestDecoder(VecDecoder<Inner>);
 
     #[cfg(feature = "alloc")]

--- a/consensus_encoding/src/decode/mod.rs
+++ b/consensus_encoding/src/decode/mod.rs
@@ -50,6 +50,11 @@ pub trait Decode {
 }
 
 /// A push decoder for a consensus-decodable object.
+///
+/// Decoders are stateful machines that should not implement `Clone` or `Copy`. Duplicating a
+/// decoder copies its state, but what state that is depends entirely on what input has been fed
+/// to it, making it easy to accidentally duplicate at the wrong point in decoding. If you need to
+/// decode the same data multiple times, create new decoder instances instead.
 pub trait Decoder: Sized {
     /// The type that this decoder produces when decoding is complete.
     type Output;

--- a/consensus_encoding/tests/api.rs
+++ b/consensus_encoding/tests/api.rs
@@ -75,7 +75,7 @@ impl Encode for Foo {
     }
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 struct FooDecoder(ArrayDecoder<4>);
 
 impl Decoder for FooDecoder {
@@ -99,25 +99,23 @@ impl Decode for Foo {
 /// A struct that includes all types that implement `Clone`.
 #[derive(Clone)] // C-COMMON-TRAITS: `Clone`
 struct Clone {
-    a: ArrayDecoder<4>,
-    b: ArrayEncoder<4>,
-    c: ArrayRefEncoder<'static, 4>,
-    d: BytesEncoder<'static>,
-    #[cfg(feature = "alloc")]
-    e: ByteVecDecoder,
-    f: CompactSizeDecoder,
-    g: CompactSizeEncoder,
-    h: CompactSizeU64Decoder,
-    // We don't implement Clone for the composite decoders.
+    a: ArrayEncoder<4>,
+    b: ArrayRefEncoder<'static, 4>,
+    c: BytesEncoder<'static>,
+    d: CompactSizeEncoder,
+    // We don't implement Clone for decoders, they are state machines.
     //
+    // e: CompactSizeDecoder,
+    // f: CompactSizeU64Decoder,
+    // g: ArrayDecoder<4>,
+    // h: ByteVecDecoder,
     // i: Decoder2<D, D>,
     // j: Decoder3<D, D, D>,
     // k: Decoder4<D, D, D, D>,
     // l: Decoder6<D, D, D, D, D, D>,
-    m: EncoderByteIter<FooEncoder<'static>>,
-    n: SliceEncoder<'static, Foo>,
-    #[cfg(feature = "alloc")]
-    o: VecDecoder<Foo>,
+    // m: VecDecoder<Foo>,
+    n: EncoderByteIter<FooEncoder<'static>>,
+    o: SliceEncoder<'static, Foo>,
 }
 
 /// A struct that includes all types that implement `Default` (implies decoders).

--- a/consensus_encoding/tests/decode.rs
+++ b/consensus_encoding/tests/decode.rs
@@ -399,7 +399,7 @@ fn decode_from_read_unbuffered_extra_data() {
 struct Inner(u32);
 
 #[cfg(feature = "alloc")]
-#[derive(Clone, Default)]
+#[derive(Default)]
 struct InnerDecoder(ArrayDecoder<4>);
 
 #[cfg(feature = "alloc")]
@@ -432,7 +432,7 @@ impl Decode for Inner {
 struct Test(Vec<Inner>);
 
 #[cfg(feature = "alloc")]
-#[derive(Clone, Default)]
+#[derive(Default)]
 struct TestDecoder(VecDecoder<Inner>);
 
 #[cfg(feature = "alloc")]
@@ -560,30 +560,6 @@ fn vec_decoder_two_items() {
     let want = Test(vec![Inner(0xDEAD_BEEF), Inner(0xCAFE_BABE)]);
 
     assert_eq!(got, want);
-}
-
-#[test]
-#[cfg(feature = "alloc")]
-fn vec_decoder_clone_mid_decode() {
-    // Feed the length prefix and first item, clone, then feed the second item to both.
-    let prefix = vec![0x02, 0xEF, 0xBE, 0xAD, 0xDE]; // length=2, first item
-    let second = vec![0xBE, 0xBA, 0xFE, 0xCA]; // second item
-
-    let mut slice = prefix.as_slice();
-    let mut decoder = Test::decoder();
-    decoder.push_bytes(&mut slice).unwrap();
-
-    let mut clone = decoder.clone();
-
-    let mut slice = second.as_slice();
-    decoder.push_bytes(&mut slice).unwrap();
-    let got = decoder.end().unwrap();
-    assert_eq!(got, Test(vec![Inner(0xDEAD_BEEF), Inner(0xCAFE_BABE)]));
-
-    let mut slice = second.as_slice();
-    clone.push_bytes(&mut slice).unwrap();
-    let got = clone.end().unwrap();
-    assert_eq!(got, Test(vec![Inner(0xDEAD_BEEF), Inner(0xCAFE_BABE)]));
 }
 
 #[cfg(feature = "alloc")]

--- a/consensus_encoding/tests/iter.rs
+++ b/consensus_encoding/tests/iter.rs
@@ -76,7 +76,6 @@ fn hex_iter_cat_encoder() {
         assert_eq!(char::from(iter_chars[0]), hi);
         let lo = chars.next().unwrap();
         assert_eq!(char::from(iter_chars[1]), lo);
-
     }
     let none = iter.next();
     assert_eq!(none, None);

--- a/p2p/src/address.rs
+++ b/p2p/src/address.rs
@@ -120,7 +120,7 @@ impl ToSocketAddrs for Address {
 
 encoding::encoder_newtype_exact! {
     /// The encoder for the [`Address`] type.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct AddressEncoder<'e>(encoding::Encoder3<
         crate::ServiceFlagsEncoder<'e>,
         encoding::ArrayEncoder<16>,
@@ -159,7 +159,7 @@ type AddressInnerDecoder = encoding::Decoder3<
 >;
 
 /// The Decoder for [`Address`].
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct AddressDecoder(AddressInnerDecoder);
 
 impl encoding::Decoder for AddressDecoder {
@@ -197,7 +197,7 @@ pub struct AddrV1Message {
 
 encoding::encoder_newtype_exact! {
     /// The encoder for an [`AddrV1Message`].
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct AddrV1MessageEncoder<'e>(Encoder2<ArrayEncoder<4>, AddressEncoder<'e>>);
 }
 
@@ -215,7 +215,7 @@ impl encoding::Encode for AddrV1Message {
 type AddrV1MessageInnerDecoder = Decoder2<ArrayDecoder<4>, AddressDecoder>;
 
 /// The decoder for an [`AddrV1Message`].
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct AddrV1MessageDecoder(AddrV1MessageInnerDecoder);
 
 impl encoding::Decoder for AddrV1MessageDecoder {
@@ -322,7 +322,7 @@ impl From<Ipv6Addr> for AddrV2 {
 }
 
 /// The encoder type for [`AddrV2`].
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct AddrV2Encoder<'e> {
     network: Option<ArrayEncoder<1>>,
     size: Option<CompactSizeEncoder>,
@@ -480,7 +480,7 @@ impl encoding::Encode for AddrV2 {
 type AddrV2InnerDecoder = Decoder2<ArrayDecoder<1>, ByteVecDecoder>;
 
 /// The decoder type for an [`AddrV2`] type.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct AddrV2Decoder(AddrV2InnerDecoder);
 
 impl AddrV2Decoder {
@@ -627,7 +627,7 @@ impl ToSocketAddrs for AddrV2Message {
 
 encoding::encoder_newtype_exact! {
     /// The encoder type for an [`AddrV2Message`].
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct AddrV2MessageEncoder<'e>(Encoder4<ArrayEncoder<4>, CompactSizeEncoder, AddrV2Encoder<'e>, ArrayEncoder<2>>);
 }
 
@@ -648,7 +648,7 @@ type AddrV2MessageInnerDecoder =
     Decoder4<ArrayDecoder<4>, CompactSizeU64Decoder, AddrV2Decoder, ArrayDecoder<2>>;
 
 /// The decoder for an [`AddrV2Message`].
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct AddrV2MessageDecoder(AddrV2MessageInnerDecoder);
 
 impl encoding::Decoder for AddrV2MessageDecoder {
@@ -687,7 +687,7 @@ pub mod error {
     /// An error consensus decoding an [`Address`].
     ///
     /// [`Address`]: super::Address
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct AddressDecoderError(
         pub(super) <super::AddressInnerDecoder as encoding::Decoder>::Error,
     );
@@ -710,7 +710,7 @@ pub mod error {
     /// An error occuring when decoding a [`AddrV1Message`].
     ///
     /// [`AddrV1Message`]: super::AddrV1Message
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct AddrV1MessageDecoderError(
         pub(super) <super::AddrV1MessageInnerDecoder as encoding::Decoder>::Error,
     );
@@ -733,7 +733,7 @@ pub mod error {
     /// An error decoding a [`AddrV2`] message.
     ///
     /// [`AddrV2`]: super::AddrV2
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub enum AddrV2DecoderError {
         /// Inner decoder failure.
         Decoder(<super::AddrV2InnerDecoder as encoding::Decoder>::Error),
@@ -785,7 +785,7 @@ pub mod error {
     /// An error occuring when decoding a [`AddrV2Message`].
     ///
     /// [`AddrV2Message`]: super::AddrV2Message
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct AddrV2MessageDecoderError(
         pub(super) <super::AddrV2MessageInnerDecoder as encoding::Decoder>::Error,
     );

--- a/p2p/src/bip152.rs
+++ b/p2p/src/bip152.rs
@@ -54,7 +54,7 @@ impl convert::AsRef<Transaction> for PrefilledTransaction {
 
 encoding::encoder_newtype! {
     /// The encoder for a [`PrefilledTransaction`] message.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct PrefilledTransactionEncoder<'e>(Encoder2<CompactSizeEncoder, TransactionEncoder<'e>>);
 }
 
@@ -75,7 +75,7 @@ impl encoding::Encode for PrefilledTransaction {
 type PrefilledTransactionInnerDecoder = Decoder2<CompactSizeDecoder, TransactionDecoder>;
 
 /// The decoder for a [`PrefilledTransaction`] message.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct PrefilledTransactionDecoder(PrefilledTransactionInnerDecoder);
 
 impl PrefilledTransactionDecoder {
@@ -190,7 +190,7 @@ impl core::fmt::Debug for ShortId {
 
 encoding::encoder_newtype_exact! {
     /// Encoder type for a [`ShortId`].
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct ShortIdEncoder<'e>(ArrayEncoder<6>);
 }
 
@@ -205,7 +205,7 @@ impl encoding::Encode for ShortId {
 type ShortIdInnerDecoder = ArrayDecoder<6>;
 
 /// Decoder type for a [`ShortId`].
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct ShortIdDecoder(ShortIdInnerDecoder);
 
 impl encoding::Decoder for ShortIdDecoder {
@@ -259,7 +259,7 @@ type HeaderAndShortIdsInnerEncoder<'e> = Encoder4<
 
 encoding::encoder_newtype! {
     /// Encoder type for a [`HeaderAndShortIds`] message.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct HeaderAndShortIdsEncoder<'e>(
         HeaderAndShortIdsInnerEncoder<'e>
     );
@@ -291,7 +291,7 @@ type HeaderAndShortIdsInnerDecoder =
     Decoder4<HeaderDecoder, ArrayDecoder<8>, VecDecoder<ShortId>, VecDecoder<PrefilledTransaction>>;
 
 /// Decoder type for the [`HeaderAndShortIds`] message.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct HeaderAndShortIdsDecoder(HeaderAndShortIdsInnerDecoder);
 
 impl HeaderAndShortIdsDecoder {
@@ -427,7 +427,7 @@ impl encoding::Encode for Offset {
     fn encoder(&self) -> Self::Encoder<'_> { CompactSizeEncoder::new(self.0) }
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 struct OffsetDecoder(CompactSizeDecoder);
 
 impl encoding::Decoder for OffsetDecoder {
@@ -512,7 +512,7 @@ impl BlockTransactionsRequest {
 
 encoding::encoder_newtype! {
     /// The encoder for [`BlockTransactionsRequest`].
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct BlockTransactionsRequestEncoder<'e>(
         Encoder2<
             BlockHashEncoder<'e>,
@@ -538,7 +538,7 @@ impl encoding::Encode for BlockTransactionsRequest {
 type BlockTransactionsRequestInnerDecoder = Decoder2<BlockHashDecoder, VecDecoder<Offset>>;
 
 /// The encoder type for a [`BlockTransactionsRequest`].
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct BlockTransactionsRequestDecoder(BlockTransactionsRequestInnerDecoder);
 
 impl encoding::Decoder for BlockTransactionsRequestDecoder {
@@ -576,7 +576,7 @@ pub struct BlockTransactions {
 
 encoding::encoder_newtype! {
     /// Encoder type for [`BlockTransactions`].
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct BlockTransactionsEncoder<'e>(
         Encoder2<
             BlockHashEncoder<'e>,
@@ -605,7 +605,7 @@ impl encoding::Encode for BlockTransactions {
 type BlockTransactionsInnerDecoder = Decoder2<BlockHashDecoder, VecDecoder<Transaction>>;
 
 /// Decoder type for a [`BlockTransactions`] message.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct BlockTransactionsDecoder(BlockTransactionsInnerDecoder);
 
 impl encoding::Decoder for BlockTransactionsDecoder {
@@ -667,7 +667,7 @@ pub mod error {
     use internals::write_err;
 
     /// A BIP-0152 error.
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     #[non_exhaustive]
     pub enum Error {
         /// An unknown version number was used.
@@ -701,7 +701,7 @@ pub mod error {
     /// An error occuring when decoding a [`PrefilledTransaction`].
     ///
     /// [`PrefilledTransaction`]: super::PrefilledTransaction
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub enum PrefilledTransactionDecoderError {
         /// Inner decoder error.
         Decoder(<super::PrefilledTransactionInnerDecoder as encoding::Decoder>::Error),
@@ -735,7 +735,7 @@ pub mod error {
     /// An error decoding a [`ShortId`].
     ///
     /// [`ShortId`]: super::ShortId
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct ShortIdDecoderError(
         pub(super) <super::ShortIdInnerDecoder as encoding::Decoder>::Error,
     );
@@ -758,7 +758,7 @@ pub mod error {
     /// Errors occuring when decoding a [`HeaderAndShortIds`] message.
     ///
     /// [`HeaderAndShortIds`]: super::HeaderAndShortIds
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub enum HeaderAndShortIdsDecoderError {
         /// Inner decoder error.
         Decoder(<super::HeaderAndShortIdsInnerDecoder as encoding::Decoder>::Error),
@@ -792,7 +792,7 @@ pub mod error {
     /// An error decoding a [`BlockTransactionsRequest`] message.
     ///
     /// [`BlockTransactionsRequest`]: super::BlockTransactionsRequest
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct BlockTransactionsRequestDecoderError(
         pub(super) <super::BlockTransactionsRequestInnerDecoder as encoding::Decoder>::Error,
     );
@@ -813,7 +813,7 @@ pub mod error {
     }
 
     /// A transaction index is requested that is out of range from the corresponding block.
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     #[non_exhaustive]
     pub struct TxIndexOutOfRangeError(pub(super) u64);
 
@@ -836,7 +836,7 @@ pub mod error {
     /// An error occuring decoding a [`BlockTransactions`] message.
     ///
     /// [`BlockTransactions`]: super::BlockTransactions
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct BlockTransactionsDecoderError(
         pub(super) <super::BlockTransactionsInnerDecoder as encoding::Decoder>::Error,
     );

--- a/p2p/src/error.rs
+++ b/p2p/src/error.rs
@@ -14,7 +14,7 @@ use crate::Magic;
 /// An error consensus decoding a [`ProtocolVersion`].
 ///
 /// [`ProtocolVersion`]: crate::ProtocolVersion
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct ProtocolVersionDecoderError(
     pub(super) <encoding::ArrayDecoder<4> as encoding::Decoder>::Error,
 );
@@ -37,7 +37,7 @@ impl std::error::Error for ProtocolVersionDecoderError {
 /// An error consensus decoding a [`ServiceFlags`].
 ///
 /// [`ServiceFlags`]: crate::ServiceFlags
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct ServiceFlagsDecoderError(
     pub(super) <encoding::ArrayDecoder<8> as encoding::Decoder>::Error,
 );
@@ -58,7 +58,7 @@ impl std::error::Error for ServiceFlagsDecoderError {
 }
 
 /// Errors occuring when decoding a network [`Magic`].
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct MagicDecoderError(pub(super) <super::MagicInnerDecoder as encoding::Decoder>::Error);
 
 impl From<Infallible> for MagicDecoderError {
@@ -77,7 +77,7 @@ impl std::error::Error for MagicDecoderError {
 }
 
 /// An error in parsing magic bytes.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct ParseMagicError {
     /// The error that occurred when parsing the string.
@@ -98,7 +98,7 @@ impl std::error::Error for ParseMagicError {
 }
 
 /// Error in creating a Network from Magic bytes.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct UnknownMagicError(pub(super) Magic);
 
@@ -114,7 +114,7 @@ impl std::error::Error for UnknownMagicError {
 }
 
 /// Error in creating a Magic from a Network.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct UnknownNetworkError(pub(super) Network);
 

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -115,7 +115,7 @@ impl From<ProtocolVersion> for u32 {
 
 encoding::encoder_newtype_exact! {
     /// The encoder for the [`ProtocolVersion`] type.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct ProtocolVersionEncoder<'e>(encoding::ArrayEncoder<4>);
 }
 
@@ -129,7 +129,7 @@ impl encoding::Encode for ProtocolVersion {
 }
 
 /// The decoder for the [`ProtocolVersion`] type.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ProtocolVersionDecoder(encoding::ArrayDecoder<4>);
 
 impl ProtocolVersionDecoder {
@@ -309,7 +309,7 @@ impl ops::BitXorAssign for ServiceFlags {
 
 encoding::encoder_newtype_exact! {
     /// The encoder for the [`ServiceFlags`] type.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct ServiceFlagsEncoder<'e>(encoding::ArrayEncoder<8>);
 }
 
@@ -323,7 +323,7 @@ impl encoding::Encode for ServiceFlags {
 }
 
 /// The decoder for the [`ServiceFlags`] type.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ServiceFlagsDecoder(encoding::ArrayDecoder<8>);
 
 impl ServiceFlagsDecoder {
@@ -447,7 +447,7 @@ impl fmt::UpperHex for Magic {
 
 encoding::encoder_newtype_exact! {
     /// The encoder type for network [`Magic`].
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct MagicEncoder<'e>(ArrayEncoder<4>);
 }
 
@@ -462,7 +462,7 @@ impl encoding::Encode for Magic {
 type MagicInnerDecoder = ArrayDecoder<4>;
 
 /// The decoder type for a network [`Magic`].
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct MagicDecoder(MagicInnerDecoder);
 
 impl encoding::Decoder for MagicDecoder {

--- a/p2p/src/merkle_tree.rs
+++ b/p2p/src/merkle_tree.rs
@@ -129,7 +129,7 @@ impl MerkleBlock {
 
 encoding::encoder_newtype! {
     /// The encoder type for a [`MerkleBlock`].
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct MerkleBlockEncoder<'e>(Encoder2<HeaderEncoder<'e>, PartialMerkleTreeEncoder<'e>>);
 }
 
@@ -144,7 +144,7 @@ impl encoding::Encode for MerkleBlock {
 type MerkleBlockInnerDecoder = Decoder2<HeaderDecoder, PartialMerkleTreeDecoder>;
 
 /// The decoder for a [`MerkleBlock`].
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct MerkleBlockDecoder(MerkleBlockInnerDecoder);
 
 impl encoding::Decoder for MerkleBlockDecoder {
@@ -443,7 +443,7 @@ impl PartialMerkleTree {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 struct BitVecEncoder {
     buffer: Vec<u8>,
     exhausted: bool,
@@ -480,7 +480,7 @@ impl encoding::Encoder for BitVecEncoder {
 
 encoding::encoder_newtype! {
     /// The encoder for a [`PartialMerkleTree`].
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct PartialMerkleTreeEncoder<'e>(
         Encoder3<
             ArrayEncoder<4>,
@@ -512,7 +512,7 @@ type PartialMerkleTreeInnerDecoder =
     Decoder3<ArrayDecoder<4>, VecDecoder<TxMerkleNode>, ByteVecDecoder>;
 
 /// The decoder type for a [`PartialMerkleTree`].
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct PartialMerkleTreeDecoder(PartialMerkleTreeInnerDecoder);
 
 impl encoding::Decoder for PartialMerkleTreeDecoder {
@@ -556,7 +556,7 @@ pub mod error {
     /// An error occuring when decoding a [`MerkleBlock`].
     ///
     /// [`MerkleBlock`]: super::MerkleBlock
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct MerkleBlockDecoderError(
         pub(super) <super::MerkleBlockInnerDecoder as encoding::Decoder>::Error,
     );
@@ -579,7 +579,7 @@ pub mod error {
     /// An error occuring when decoding a [`PartialMerkleTree`].
     ///
     /// [`PartialMerkleTree`]: super::PartialMerkleTree
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct PartialMerkleTreeDecoderError(
         pub(super) <super::PartialMerkleTreeInnerDecoder as encoding::Decoder>::Error,
     );
@@ -600,7 +600,7 @@ pub mod error {
     }
 
     /// An error when verifying the Merkle block.
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     #[non_exhaustive]
     pub enum MerkleBlockError {
         /// Merkle root in the header doesn't match to the root calculated from partial Merkle tree.

--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -135,7 +135,7 @@ impl encoding::Decode for CommandString {
 /// Encoder for the [`CommandString`] type
 // We can't use the [`encoder_newtype!`] macro due to the lifetime conflicting
 // when constructing the encoder in `V1NetworkMessage`.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct CommandStringEncoder(encoding::ArrayEncoder<12>);
 
 impl CommandStringEncoder {
@@ -159,7 +159,7 @@ impl encoding::ExactSizeEncoder for CommandStringEncoder {
 }
 
 /// Decoder for [`CommandString`].
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct CommandStringDecoder {
     inner: encoding::ArrayDecoder<12>,
 }
@@ -252,7 +252,7 @@ impl encoding::Encode for V1MessageHeader {
 
 encoding::encoder_newtype_exact! {
     /// The encoder for the [`V1MessageHeader`] type.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct V1MessageHeaderEncoder<'e>(
         encoding::Encoder4<
             crate::MagicEncoder<'e>,
@@ -270,7 +270,7 @@ type V1MessageHeaderInnerDecoder = encoding::Decoder4<
 >;
 
 /// The Decoder for `V1MessageHeader`
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct V1MessageHeaderDecoder(V1MessageHeaderInnerDecoder);
 
 impl encoding::Decoder for V1MessageHeaderDecoder {
@@ -314,7 +314,7 @@ pub struct InventoryPayload(pub Vec<message_blockdata::Inventory>);
 
 encoding::encoder_newtype! {
     /// The encoder for an [`InventoryPayload`].
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct InventoryPayloadEncoder<'e>(Encoder2<CompactSizeEncoder, SliceEncoder<'e, message_blockdata::Inventory>>);
 }
 
@@ -335,7 +335,7 @@ impl encoding::Encode for InventoryPayload {
 type InventoryInnerDecoder = VecDecoder<message_blockdata::Inventory>;
 
 /// Decoder type for [`InventoryPayload`].
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct InventoryPayloadDecoder(InventoryInnerDecoder);
 
 impl encoding::Decoder for InventoryPayloadDecoder {
@@ -366,7 +366,7 @@ pub struct AddrPayload(pub Vec<AddrV1Message>);
 
 encoding::encoder_newtype! {
     /// The encoder for an [`AddrPayload`].
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct AddrPayloadEncoder<'e>(Encoder2<CompactSizeEncoder, SliceEncoder<'e, AddrV1Message>>);
 }
 
@@ -384,7 +384,7 @@ impl encoding::Encode for AddrPayload {
 type AddrPayloadInnerDecoder = VecDecoder<AddrV1Message>;
 
 /// Decoder type for [`AddrPayload`].
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct AddrPayloadDecoder(AddrPayloadInnerDecoder);
 
 impl encoding::Decoder for AddrPayloadDecoder {
@@ -415,7 +415,7 @@ pub struct AddrV2Payload(pub Vec<AddrV2Message>);
 
 encoding::encoder_newtype! {
     /// The encoder for an [`AddrV2Payload`].
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct AddrV2PayloadEncoder<'e>(Encoder2<CompactSizeEncoder, SliceEncoder<'e, AddrV2Message>>);
 }
 
@@ -436,7 +436,7 @@ impl encoding::Encode for AddrV2Payload {
 type AddrV2PayloadInnerDecoder = VecDecoder<AddrV2Message>;
 
 /// Decoder type for [`AddrV2Payload`].
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct AddrV2PayloadDecoder(AddrV2PayloadInnerDecoder);
 
 impl encoding::Decoder for AddrV2PayloadDecoder {
@@ -488,7 +488,7 @@ impl From<FeeFilter> for FeeRate {
 
 encoding::encoder_newtype_exact! {
     /// Encoder for [`FeeFilter`] type.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct FeeFilterEncoder<'e>(encoding::ArrayEncoder<8>);
 }
 
@@ -503,7 +503,7 @@ impl encoding::Encode for FeeFilter {
 }
 
 /// Decoder for [`FeeFilter`] type.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct FeeFilterDecoder(encoding::ArrayDecoder<8>);
 
 impl FeeFilterDecoder {
@@ -575,7 +575,7 @@ impl Ping {
 
 encoding::encoder_newtype_exact! {
     /// The encoder for the [`Ping`] type.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct PingEncoder<'e>(encoding::ArrayEncoder<8>);
 }
 
@@ -591,7 +591,7 @@ impl encoding::Encode for Ping {
 }
 
 /// The Decoder for [`Ping`]
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct PingDecoder(encoding::ArrayDecoder<8>);
 
 impl encoding::Decoder for PingDecoder {
@@ -631,7 +631,7 @@ impl Pong {
 
 encoding::encoder_newtype_exact! {
     /// The encoder for the [`Pong`] type.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct PongEncoder<'e>(encoding::ArrayEncoder<8>);
 }
 
@@ -647,7 +647,7 @@ impl encoding::Encode for Pong {
 }
 
 /// The Decoder for [`Pong`]
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct PongDecoder(encoding::ArrayDecoder<8>);
 
 impl encoding::Decoder for PongDecoder {
@@ -883,7 +883,7 @@ impl encoding::Encode for NetworkMessage {
 }
 
 /// Encoder for [`NetworkMessage`]
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum NetworkMessageEncoder<'e> {
     /// Encodes [`NetworkMessage::Version`]
     Version(<message_network::VersionMessage as encoding::Encode>::Encoder<'e>),
@@ -1074,7 +1074,7 @@ impl encoding::Encoder for NetworkMessageEncoder<'_> {
 
 encoding::encoder_newtype! {
     /// Encoder for [`V1NetworkMessage`].
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct V1NetworkMessageEncoder<'e>(
         encoding::Encoder2<
             encoding::Encoder4<
@@ -1104,7 +1104,7 @@ impl encoding::Encode for V1NetworkMessage {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 enum NetworkMessageDecoderInner {
     Version(message_network::VersionMessageDecoder),
     Addr(AddrPayloadDecoder),
@@ -1331,7 +1331,7 @@ impl encoding::Decoder for NetworkMessageDecoderInner {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 struct NetworkMessageDecoder {
     inner: NetworkMessageDecoderInner,
     payload_len: Option<usize>,
@@ -1389,7 +1389,7 @@ impl encoding::Decoder for NetworkMessageDecoder {
 }
 
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 enum DecoderState {
     ReadingHeader {
         header_decoder: V1MessageHeaderDecoder,
@@ -1415,7 +1415,7 @@ impl Default for DecoderState {
 /// This decoder implements a two-phase decoding process for Bitcoin V1 P2P messages.
 /// It first decodes the fixed-sized header. It then uses the payload length information
 /// to decode the dynamically sized network message.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct V1NetworkMessageDecoder {
     state: DecoderState,
 }
@@ -1530,7 +1530,7 @@ impl encoding::Decode for V1NetworkMessage {
 ///
 /// V2 messages encode a 1-byte short ID for optimized message types (IDs 1-28),
 /// or a 0-byte flag followed by a 12-byte command string for non-optimized types.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub enum V2NetworkMessageEncoder<'e> {
     /// Optimized message with a 1-byte short ID followed by the payload.
     ShortId(Encoder2<ArrayEncoder<1>, NetworkMessageEncoder<'e>>),
@@ -1622,7 +1622,7 @@ fn v2_command_byte(payload: &NetworkMessage) -> (u8, Option<CommandString>) {
 
 /// Network encoded [`Header`](primitives::block::Header) with associated byte for the length of
 /// transactions that follow, which is currently always zero.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct NetworkHeader {
     /// Block header.
     pub header: block::Header,
@@ -1637,7 +1637,7 @@ impl NetworkHeader {
 
 encoding::encoder_newtype_exact! {
     /// The encoder type for a [`NetworkHeader`].
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct NetworkHeaderEncoder<'e>(Encoder2<HeaderEncoder<'e>, ArrayEncoder<1>>);
 }
 
@@ -1655,7 +1655,7 @@ impl encoding::Encode for NetworkHeader {
 type NetworkHeaderInnerDecoder = Decoder2<HeaderDecoder, ArrayDecoder<1>>;
 
 /// The decoder type for a [`NetworkHeader`].
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct NetworkHeaderDecoder(NetworkHeaderInnerDecoder);
 
 impl encoding::Decoder for NetworkHeaderDecoder {
@@ -1682,7 +1682,7 @@ impl encoding::Decode for NetworkHeader {
 }
 
 /// A list of bitcoin block headers.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct HeadersMessage(pub Vec<NetworkHeader>);
 
 impl HeadersMessage {
@@ -1702,7 +1702,7 @@ impl HeadersMessage {
 
 encoding::encoder_newtype! {
     /// The encoder type for a [`HeadersMessage`].
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct HeadersMessageEncoder<'e>(Encoder2<CompactSizeEncoder, SliceEncoder<'e, NetworkHeader>>);
 }
 
@@ -1720,7 +1720,7 @@ impl encoding::Encode for HeadersMessage {
 type HeadersMessageInnerDecoder = VecDecoder<NetworkHeader>;
 
 /// The decoder type for a [`HeadersMessage`].
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct HeadersMessageDecoder(HeadersMessageInnerDecoder);
 
 impl encoding::Decoder for HeadersMessageDecoder {
@@ -1747,7 +1747,7 @@ impl encoding::Decode for HeadersMessage {
 }
 
 // State machine for decoding a [`V2NetworkMessage`].
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
 enum V2NetworkMessageDecoderState {
     // Decoding the short-id byte, with the command string and payload decoder
@@ -1969,7 +1969,7 @@ pub mod error {
     /// Error decoding a [`CommandString`].
     ///
     /// [`CommandString`]: super::CommandString
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     #[non_exhaustive]
     pub enum CommandStringDecoderError {
         /// Unexpected end of data.
@@ -2000,7 +2000,7 @@ pub mod error {
     /// Error returned when a command string is invalid.
     ///
     /// This is currently returned for command strings longer than 12.
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     #[non_exhaustive]
     pub struct CommandStringError {
         pub(super) cow: Cow<'static, str>,
@@ -2024,7 +2024,7 @@ pub mod error {
     /// An error consensus decoding a [`V1MessageHeader`].
     ///
     /// [`V1MessageHeader`]: super::V1MessageHeader
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct V1MessageHeaderDecoderError(
         pub(super) <super::V1MessageHeaderInnerDecoder as encoding::Decoder>::Error,
     );
@@ -2043,7 +2043,7 @@ pub mod error {
     /// An error decoding a [`InventoryPayload`].
     ///
     /// [`InventoryPayload`]: super::InventoryPayload
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct InventoryPayloadDecoderError(
         pub(super) <super::InventoryInnerDecoder as encoding::Decoder>::Error,
     );
@@ -2066,7 +2066,7 @@ pub mod error {
     /// An error decoding a [`AddrPayload`].
     ///
     /// [`AddrPayload`]: super::AddrPayload
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct AddrPayloadDecoderError(
         pub(super) <super::AddrPayloadInnerDecoder as encoding::Decoder>::Error,
     );
@@ -2089,7 +2089,7 @@ pub mod error {
     /// An error decoding a [`AddrV2Payload`].
     ///
     /// [`AddrV2Payload`]: super::AddrV2Payload
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct AddrV2PayloadDecoderError(
         pub(super) <super::AddrV2PayloadInnerDecoder as encoding::Decoder>::Error,
     );
@@ -2112,7 +2112,7 @@ pub mod error {
     /// An error consensus decoding a [`Ping`].
     ///
     /// [`Ping`]: super::Ping
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct PingDecoderError(pub(super) <encoding::ArrayDecoder<8> as encoding::Decoder>::Error);
 
     impl From<Infallible> for PingDecoderError {
@@ -2133,7 +2133,7 @@ pub mod error {
     /// An error consensus decoding a [`Pong`].
     ///
     /// [`Pong`]: super::Pong
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct PongDecoderError(pub(super) <encoding::ArrayDecoder<8> as encoding::Decoder>::Error);
 
     impl From<Infallible> for PongDecoderError {
@@ -2154,7 +2154,7 @@ pub mod error {
     /// An error consensus decoding a [`FeeFilter`].
     ///
     /// [`FeeFilter`]: super::FeeFilter
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     #[non_exhaustive]
     pub enum FeeFilterDecoderError {
         /// Unexpected end of data.
@@ -2192,10 +2192,10 @@ pub mod error {
     }
 
     /// Error decoding a raw network message.
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct V1NetworkMessageDecoderError(pub(super) V1NetworkMessageDecoderErrorInner);
 
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub(super) enum V1NetworkMessageDecoderErrorInner {
         /// Error decoding the message header.
         Header(V1MessageHeaderDecoderError),
@@ -2247,7 +2247,7 @@ pub mod error {
     }
 
     /// Error decoding a V2 network message.
-    #[derive(Clone, Debug, Eq, PartialEq)]
+    #[derive(Debug, Eq, PartialEq)]
     pub enum V2NetworkMessageDecoderError {
         /// Error decoding the short ID byte.
         ShortId,
@@ -2293,7 +2293,7 @@ pub mod error {
     /// An error decoding a [`NetworkHeader`] message.
     ///
     /// [`NetworkHeader`]: super::NetworkHeader
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct NetworkHeaderDecoderError(
         pub(super) <super::NetworkHeaderInnerDecoder as encoding::Decoder>::Error,
     );
@@ -2316,7 +2316,7 @@ pub mod error {
     /// An error decoding a [`HeadersMessage`] message.
     ///
     /// [`HeadersMessage`]: super::HeadersMessage
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct HeadersMessageDecoderError(
         pub(super) <super::HeadersMessageInnerDecoder as encoding::Decoder>::Error,
     );

--- a/p2p/src/message_blockdata.rs
+++ b/p2p/src/message_blockdata.rs
@@ -73,7 +73,7 @@ impl Inventory {
 
 encoding::encoder_newtype_exact! {
     /// The encoder for the [`Inventory`] type.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct InventoryEncoder<'e>(Encoder2<ArrayEncoder<4>, ArrayEncoder<32>>);
 }
 
@@ -101,7 +101,7 @@ impl encoding::Encode for Inventory {
 type InventoryInnerDecoder = Decoder2<ArrayDecoder<4>, ArrayDecoder<32>>;
 
 /// The decoder for the [`Inventory`] type.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct InventoryDecoder(InventoryInnerDecoder);
 
 impl encoding::Decoder for InventoryDecoder {
@@ -193,7 +193,7 @@ type BlockLocatorInnerEncoder<'e> = Encoder2<CompactSizeEncoder, SliceEncoder<'e
 
 encoding::encoder_newtype! {
     /// The encoder for [`BlockLocator`].
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct BlockLocatorEncoder<'e>(BlockLocatorInnerEncoder<'e>);
 }
 
@@ -211,7 +211,7 @@ impl encoding::Encode for BlockLocator {
 type BlockLocatorInnerDecoder = VecDecoder<BlockHash>;
 
 /// The decoder for the [`BlockLocator`] type.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct BlockLocatorDecoder(BlockLocatorInnerDecoder);
 
 impl BlockLocatorDecoder {
@@ -274,13 +274,13 @@ type GetBlocksOrHeadersInnerEncoder<'e> =
 
 encoding::encoder_newtype! {
     /// The encoder for [`GetBlocksMessage`].
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct GetBlocksEncoder<'e>(GetBlocksOrHeadersInnerEncoder<'e>);
 }
 
 encoding::encoder_newtype! {
     /// The encoder for [`GetHeadersMessage`].
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct GetHeadersEncoder<'e>(GetBlocksOrHeadersInnerEncoder<'e>);
 }
 
@@ -318,11 +318,11 @@ type GetBlocksOrHeadersInnerDecoder =
     Decoder3<ProtocolVersionDecoder, BlockLocatorDecoder, BlockHashDecoder>;
 
 /// Decoder type for [`GetBlocksMessage`].
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct GetBlocksMessageDecoder(GetBlocksOrHeadersInnerDecoder);
 
 /// Decoder type for [`GetHeadersMessage`].
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct GetHeadersMessageDecoder(GetBlocksOrHeadersInnerDecoder);
 
 impl encoding::Decoder for GetHeadersMessageDecoder {
@@ -383,7 +383,7 @@ pub mod error {
     /// An error consensus decoding an [`Inventory`].
     ///
     /// [`Inventory`]: super::Inventory
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct InventoryDecoderError(
         pub(super) <super::InventoryInnerDecoder as encoding::Decoder>::Error,
     );
@@ -406,7 +406,7 @@ pub mod error {
     /// An error consensus decoding a [`BlockLocator`].
     ///
     /// [`BlockLocator`]: super::BlockLocator
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct BlockLocatorDecoderError(
         pub(super) <super::BlockLocatorInnerDecoder as encoding::Decoder>::Error,
     );
@@ -429,7 +429,7 @@ pub mod error {
     /// An error consensus decoding a [`GetBlocksMessage`].
     ///
     /// [`GetBlocksMessage`]: super::GetBlocksMessage
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct GetBlocksMessageDecoderError(
         pub(super) <super::GetBlocksOrHeadersInnerDecoder as encoding::Decoder>::Error,
     );
@@ -452,7 +452,7 @@ pub mod error {
     /// An error consensus decoding a [`GetHeadersMessage`].
     ///
     /// [`GetHeadersMessage`]: super::GetHeadersMessage
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct GetHeadersMessageDecoderError(
         pub(super) <super::GetBlocksOrHeadersInnerDecoder as encoding::Decoder>::Error,
     );

--- a/p2p/src/message_bloom.rs
+++ b/p2p/src/message_bloom.rs
@@ -32,7 +32,7 @@ pub struct FilterLoad {
 
 encoding::encoder_newtype_exact! {
     /// The encoder for the [`FilterLoad`] message.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct FilterLoadEncoder<'e>(
         Encoder2<
             Encoder2<CompactSizeEncoder, BytesEncoder<'e>>,
@@ -67,7 +67,7 @@ type FilterLoadInnerDecoder =
     Decoder4<ByteVecDecoder, ArrayDecoder<4>, ArrayDecoder<4>, BloomFlagsDecoder>;
 
 /// The decoder for the [`FilterLoad`] message.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct FilterLoadDecoder(FilterLoadInnerDecoder);
 
 impl encoding::Decoder for FilterLoadDecoder {
@@ -111,7 +111,7 @@ pub enum BloomFlags {
 
 encoding::encoder_newtype_exact! {
     /// The encoder for [`BloomFlags`].
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct BloomFlagsEncoder<'e>(ArrayEncoder<1>);
 }
 
@@ -130,7 +130,7 @@ impl encoding::Encode for BloomFlags {
 type BloomFlagsInnerDecoder = ArrayDecoder<1>;
 
 /// The decoder for [`BloomFlags`].
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct BloomFlagsDecoder(BloomFlagsInnerDecoder);
 
 impl BloomFlagsDecoder {
@@ -179,7 +179,7 @@ pub struct FilterAdd {
 
 encoding::encoder_newtype_exact! {
     /// The encoder of the [`FilterAdd`] message.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct FilterAddEncoder<'e>(Encoder2<CompactSizeEncoder, BytesEncoder<'e>>);
 }
 
@@ -197,7 +197,7 @@ impl encoding::Encode for FilterAdd {
 type FilterAddInnerDecoder = ByteVecDecoder;
 
 /// The decoder for the [`FilterAdd`] message.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct FilterAddDecoder(FilterAddInnerDecoder);
 
 impl encoding::Decoder for FilterAddDecoder {
@@ -233,7 +233,7 @@ pub mod error {
     /// An error occuring when decoding a [`FilterLoad`] message.
     ///
     /// [`FilterLoad`]: super::FilterLoad
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct FilterLoadDecoderError(
         pub(super) <super::FilterLoadInnerDecoder as encoding::Decoder>::Error,
     );
@@ -256,7 +256,7 @@ pub mod error {
     /// An error occurring when decoding a [`BloomFlags`].
     ///
     /// [`BloomFlags`]: super::BloomFlags
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub enum BloomFlagsDecoderError {
         /// Inner decoder error.
         Decoder(<super::BloomFlagsInnerDecoder as encoding::Decoder>::Error),
@@ -290,7 +290,7 @@ pub mod error {
     /// An error decoding a [`FilterAdd`] message.
     ///
     /// [`FilterAdd`]: super::FilterAdd
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct FilterAddDecoderError(
         pub(super) <super::FilterAddInnerDecoder as encoding::Decoder>::Error,
     );

--- a/p2p/src/message_compact_blocks.rs
+++ b/p2p/src/message_compact_blocks.rs
@@ -22,7 +22,7 @@ pub struct SendCmpct {
 
 encoding::encoder_newtype_exact! {
     /// Encoder type for the [`SendCmpct`] message.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct SendCmpctEncoder<'e>(Encoder2<ArrayEncoder<1>, ArrayEncoder<8>>);
 }
 
@@ -40,7 +40,7 @@ impl encoding::Encode for SendCmpct {
 type SendCmpctInnerDecoder = Decoder2<ArrayDecoder<1>, ArrayDecoder<8>>;
 
 /// Decoder type for the [`SendCmpct`] message.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct SendCmpctDecoder(SendCmpctInnerDecoder);
 
 impl encoding::Decoder for SendCmpctDecoder {
@@ -77,7 +77,7 @@ pub mod error {
     /// Errors occuring when decoding a [`SendCmpct`] message.
     ///
     /// [`SendCmpct`]: super::SendCmpct
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct SendCmpctDecoderError(
         pub(super) <super::SendCmpctInnerDecoder as encoding::Decoder>::Error,
     );

--- a/p2p/src/message_erlay.rs
+++ b/p2p/src/message_erlay.rs
@@ -35,7 +35,7 @@ impl SendTxRcnCl {
 
 encoding::encoder_newtype_exact! {
     /// The encoder for a [`SendTxRcnCl`] message.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct SendTxRcnClEncoder<'e>(Encoder2<ArrayEncoder<4>, ArrayEncoder<8>>);
 }
 
@@ -56,7 +56,7 @@ impl encoding::Encode for SendTxRcnCl {
 type SendTxRcnClInnerDecoder = Decoder2<ArrayDecoder<4>, ArrayDecoder<8>>;
 
 /// The decoder for a [`SendTxRcnCl`] message.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct SendTxRcnClDecoder(SendTxRcnClInnerDecoder);
 
 impl encoding::Decoder for SendTxRcnClDecoder {
@@ -91,7 +91,7 @@ pub mod error {
     use internals::write_err;
 
     /// An error occurring when decoding a [`SendTxRcnCl`](super) message.
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct SendTxRcnClDecoderError(
         pub(super) <super::SendTxRcnClInnerDecoder as encoding::Decoder>::Error,
     );

--- a/p2p/src/message_filter.rs
+++ b/p2p/src/message_filter.rs
@@ -49,7 +49,7 @@ impl FilterHash {
 
 encoding::encoder_newtype_exact! {
     /// Encoder type for [`FilterHash`].
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct FilterHashEncoder<'e>(ArrayEncoder<32>);
 }
 
@@ -63,7 +63,7 @@ impl encoding::Encode for FilterHash {
 
 encoding::encoder_newtype_exact! {
     /// Encoder type for [`FilterHeader`].
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct FilterHeaderEncoder<'e>(ArrayEncoder<32>);
 }
 
@@ -78,7 +78,7 @@ impl encoding::Encode for FilterHeader {
 type HashInnerDecoder = ArrayDecoder<32>;
 
 /// Decoder for the [`FilterHash`] type.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct FilterHashDecoder(HashInnerDecoder);
 
 impl encoding::Decoder for FilterHashDecoder {
@@ -105,7 +105,7 @@ impl encoding::Decode for FilterHash {
 }
 
 /// Decoder for the [`FilterHeader`] type.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct FilterHeaderDecoder(HashInnerDecoder);
 
 impl encoding::Decoder for FilterHeaderDecoder {
@@ -158,7 +158,7 @@ pub struct GetCFilters {
 
 encoding::encoder_newtype_exact! {
     /// Encoder type for the [`GetCFilters`] message.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct GetCFiltersEncoder<'e>(Encoder3<ArrayEncoder<1>, BlockHeightEncoder<'e>, BlockHashEncoder<'e>>);
 }
 
@@ -177,7 +177,7 @@ impl encoding::Encode for GetCFilters {
 type GetCFiltersInnerDecoder = Decoder3<ArrayDecoder<1>, BlockHeightDecoder, BlockHashDecoder>;
 
 /// Decoder type for the [`GetCFilters`] message.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct GetCFiltersDecoder(GetCFiltersInnerDecoder);
 
 impl encoding::Decoder for GetCFiltersDecoder {
@@ -216,7 +216,7 @@ pub struct CFilter {
 
 encoding::encoder_newtype_exact! {
     /// Encoder type for a [`CFilter`] message.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct CFilterEncoder<'e>(
         Encoder3<
             ArrayEncoder<1>,
@@ -247,7 +247,7 @@ impl encoding::Encode for CFilter {
 type CFilterInnerDecoder = Decoder3<ArrayDecoder<1>, BlockHashDecoder, ByteVecDecoder>;
 
 /// Decoder type for a [`CFilter`] message.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct CFilterDecoder(CFilterInnerDecoder);
 
 impl encoding::Decoder for CFilterDecoder {
@@ -286,7 +286,7 @@ pub struct GetCFHeaders {
 
 encoding::encoder_newtype_exact! {
     /// Encoder type for the [`GetCFHeaders`] message.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct GetCFHeadersEncoder<'e>(Encoder3<ArrayEncoder<1>, BlockHeightEncoder<'e>, BlockHashEncoder<'e>>);
 }
 
@@ -305,7 +305,7 @@ impl encoding::Encode for GetCFHeaders {
 type GetCFHeadersInnerDecoder = Decoder3<ArrayDecoder<1>, BlockHeightDecoder, BlockHashDecoder>;
 
 /// Decoder type for the [`GetCFHeaders`] message.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct GetCFHeadersDecoder(GetCFHeadersInnerDecoder);
 
 impl encoding::Decoder for GetCFHeadersDecoder {
@@ -346,7 +346,7 @@ pub struct CFHeaders {
 
 encoding::encoder_newtype! {
     /// Encoder type for a [`CFHeaders`] message.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct CFHeadersEncoder<'e>(
         Encoder4<
             ArrayEncoder<1>,
@@ -377,7 +377,7 @@ type CFHeadersInnerDecoder =
     Decoder4<ArrayDecoder<1>, BlockHashDecoder, FilterHeaderDecoder, VecDecoder<FilterHash>>;
 
 /// Decoder type for a [`CFHeaders`] message.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct CFHeadersDecoder(CFHeadersInnerDecoder);
 
 impl encoding::Decoder for CFHeadersDecoder {
@@ -420,7 +420,7 @@ pub struct GetCFCheckpt {
 
 encoding::encoder_newtype_exact! {
     /// Encoder type for the [`GetCFCheckpt`] message.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct GetCFCheckptEncoder<'e>(Encoder2<ArrayEncoder<1>, BlockHashEncoder<'e>>);
 }
 
@@ -438,7 +438,7 @@ impl encoding::Encode for GetCFCheckpt {
 type GetCFCheckptInnerDecoder = Decoder2<ArrayDecoder<1>, BlockHashDecoder>;
 
 /// Decoder type for a [`GetCFCheckpt`] message.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct GetCFCheckptDecoder(GetCFCheckptInnerDecoder);
 
 impl encoding::Decoder for GetCFCheckptDecoder {
@@ -477,7 +477,7 @@ pub struct CFCheckpt {
 
 encoding::encoder_newtype! {
     /// Encoder type for a [`CFCheckpt`] message.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct CFCheckptEncoder<'e>(
         Encoder3<
             ArrayEncoder<1>,
@@ -508,7 +508,7 @@ impl encoding::Encode for CFCheckpt {
 type CFCheckptInnerDecoder = Decoder3<ArrayDecoder<1>, BlockHashDecoder, VecDecoder<FilterHeader>>;
 
 /// Decoder type for a [`CFCheckpt`] message.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct CFCheckptDecoder(CFCheckptInnerDecoder);
 
 impl encoding::Decoder for CFCheckptDecoder {
@@ -544,7 +544,7 @@ pub mod error {
     /// Errors occuring when decoding a [`FilterHash`] message.
     ///
     /// [`FilterHash`]: super::FilterHash
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct FilterHashDecoderError(
         pub(super) <super::HashInnerDecoder as encoding::Decoder>::Error,
     );
@@ -567,7 +567,7 @@ pub mod error {
     /// Errors occuring when decoding a [`FilterHeader`] message.
     ///
     /// [`FilterHeader`]: super::FilterHeader
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct FilterHeaderDecoderError(
         pub(super) <super::HashInnerDecoder as encoding::Decoder>::Error,
     );
@@ -590,7 +590,7 @@ pub mod error {
     /// Errors occuring when decoding a [`GetCFilters`] message.
     ///
     /// [`GetCFilters`]: super::GetCFilters
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct GetCFiltersDecoderError(
         pub(super) <super::GetCFiltersInnerDecoder as encoding::Decoder>::Error,
     );
@@ -613,7 +613,7 @@ pub mod error {
     /// Errors occuring when decoding a [`CFilter`] message.
     ///
     /// [`CFilter`]: super::CFilter
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct CFilterDecoderError(
         pub(super) <super::CFilterInnerDecoder as encoding::Decoder>::Error,
     );
@@ -636,7 +636,7 @@ pub mod error {
     /// Errors occuring when decoding a [`GetCFHeaders`] message.
     ///
     /// [`GetCFHeaders`]: super::GetCFHeaders
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct GetCFHeadersDecoderError(
         pub(super) <super::GetCFHeadersInnerDecoder as encoding::Decoder>::Error,
     );
@@ -659,7 +659,7 @@ pub mod error {
     /// Errors occuring when decoding a [`CFHeaders`] message.
     ///
     /// [`CFHeaders`]: super::CFHeaders
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct CFHeadersDecoderError(
         pub(super) <super::CFHeadersInnerDecoder as encoding::Decoder>::Error,
     );
@@ -682,7 +682,7 @@ pub mod error {
     /// Errors occuring when decoding a [`GetCFCheckpt`] message.
     ///
     /// [`GetCFCheckpt`]: super::GetCFCheckpt
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct GetCFCheckptDecoderError(
         pub(super) <super::GetCFCheckptInnerDecoder as encoding::Decoder>::Error,
     );
@@ -705,7 +705,7 @@ pub mod error {
     /// Errors occuring when decoding a [`CFCheckpt`] message.
     ///
     /// [`CFCheckpt`]: super::CFCheckpt
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct CFCheckptDecoderError(
         pub(super) <super::CFCheckptInnerDecoder as encoding::Decoder>::Error,
     );

--- a/p2p/src/message_network.rs
+++ b/p2p/src/message_network.rs
@@ -91,7 +91,7 @@ impl VersionMessage {
 
 encoding::encoder_newtype_exact! {
     /// The encoder for the [`VersionMessage`] type.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct VersionMessageEncoder<'e>(
         encoding::Encoder2<
             encoding::Encoder3<
@@ -191,7 +191,7 @@ type VersionMessageInnerDecoder = encoding::Decoder2<
 >;
 
 /// The Decoder for [`VersionMessage`].
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct VersionMessageDecoder(VersionMessageInnerDecoder);
 
 /// A bitcoin user agent defined by BIP-0014. The user agent is sent in the version message when a
@@ -199,14 +199,14 @@ pub struct VersionMessageDecoder(VersionMessageInnerDecoder);
 /// well-defined format.
 ///
 /// ref: <https://github.com/bitcoin/bips/blob/master/bip-0014.mediawiki>
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct UserAgent {
     user_agent: String,
 }
 
 encoding::encoder_newtype_exact! {
     /// The encoder for a [`UserAgent`] string.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct UserAgentEncoder<'e>(Encoder2<CompactSizeEncoder, BytesEncoder<'e>>);
 }
 
@@ -224,7 +224,7 @@ impl encoding::Encode for UserAgent {
 type UserAgentInnerDecoder = ByteVecDecoder;
 
 /// The decoder for the [`UserAgent`] message.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct UserAgentDecoder(UserAgentInnerDecoder);
 
 impl encoding::Decoder for UserAgentDecoder {
@@ -318,7 +318,7 @@ impl From<UserAgent> for String {
 }
 
 /// A software version field for inclusion in a user agent specified by BIP-0014.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct UserAgentVersion {
     version: ClientSoftwareVersion,
     comments: Option<String>,
@@ -420,7 +420,7 @@ pub enum RejectReason {
 
 encoding::encoder_newtype_exact! {
     /// The encoder type for a [`RejectReason`].
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct RejectReasonEncoder<'e>(ArrayEncoder<1>);
 }
 
@@ -433,7 +433,7 @@ impl encoding::Encode for RejectReason {
 }
 
 /// The decoder type for a [`RejectReason`].
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct RejectReasonDecoder(ArrayDecoder<1>);
 
 impl encoding::Decoder for RejectReasonDecoder {
@@ -487,7 +487,7 @@ pub struct Reject {
 
 encoding::encoder_newtype_exact! {
     /// The encoder type for a [`Reject`] message.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct RejectEncoder<'e>(
         Encoder4<
             Encoder2<CompactSizeEncoder, BytesEncoder<'e>>,
@@ -521,7 +521,7 @@ type RejectInnerDecoder =
     Decoder4<ByteVecDecoder, RejectReasonDecoder, ByteVecDecoder, ArrayDecoder<32>>;
 
 /// The decoder type for a [`Reject`] message.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct RejectDecoder(RejectInnerDecoder);
 
 impl encoding::Decoder for RejectDecoder {
@@ -566,7 +566,7 @@ impl encoding::Decode for Reject {
 /// A deprecated message type that was used to notify users of system changes. Due to a number of
 /// vulnerabilities, alerts are no longer used. A final alert was sent as of Bitcoin Core 0.14.0,
 /// and is sent to any node that is advertising a potentially vulnerable protocol version.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Alert(Vec<u8>);
 
 impl Alert {
@@ -588,7 +588,7 @@ impl Alert {
 
 encoding::encoder_newtype_exact! {
     /// The encoder type for an [`Alert`] message.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct AlertEncoder<'e>(Encoder2<CompactSizeEncoder, BytesEncoder<'e>>);
 }
 
@@ -606,7 +606,7 @@ impl encoding::Encode for Alert {
 type AlertInnerDecoder = ByteVecDecoder;
 
 /// The decoder for the [`Alert`] message.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct AlertDecoder(AlertInnerDecoder);
 
 impl encoding::Decoder for AlertDecoder {
@@ -643,7 +643,7 @@ pub mod error {
     /// An error consensus decoding a [`VersionMessage`].
     ///
     /// [`VersionMessage`]: super::VersionMessage
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct VersionMessageDecoderError(
         pub(super) <super::VersionMessageInnerDecoder as encoding::Decoder>::Error,
     );
@@ -666,7 +666,7 @@ pub mod error {
     /// An error decoding a [`UserAgent`] message.
     ///
     /// [`UserAgent`]: super::UserAgent
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub enum UserAgentDecoderError {
         /// Inner decoder error.
         Decoder(<super::UserAgentInnerDecoder as encoding::Decoder>::Error),
@@ -700,7 +700,7 @@ pub mod error {
     /// Errors occuring when decoding a [`RejectReason`].
     ///
     /// [`RejectReason`]: super::RejectReason
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub enum RejectReasonDecoderError {
         /// Inner decoder error.
         Decoder(<encoding::ArrayDecoder<1> as encoding::Decoder>::Error),
@@ -734,7 +734,7 @@ pub mod error {
     /// Errors occuring when decoding a [`Reject`].
     ///
     /// [`Reject`]: super::Reject
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub enum RejectDecoderError {
         /// Inner decoder error.
         Decoder(<super::RejectInnerDecoder as encoding::Decoder>::Error),
@@ -768,7 +768,7 @@ pub mod error {
     /// An error decoding an [`Alert`] message.
     ///
     /// [`Alert`]: super::Alert
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct AlertDecoderError(pub(super) <super::AlertInnerDecoder as encoding::Decoder>::Error);
 
     impl From<Infallible> for AlertDecoderError {

--- a/primitives/api/all-features.txt
+++ b/primitives/api/all-features.txt
@@ -235,8 +235,6 @@ pub unsafe fn bitcoin_primitives::block::BlockHashDecoderError::clone_to_uninit(
 impl<T> core::convert::From<T> for bitcoin_primitives::block::BlockHashDecoderError
 pub fn bitcoin_primitives::block::BlockHashDecoderError::from(t: T) -> T
 pub struct bitcoin_primitives::block::error::ParseBlockError(_)
-impl core::clone::Clone for bitcoin_primitives::block::error::ParseBlockError
-pub fn bitcoin_primitives::block::error::ParseBlockError::clone(&self) -> bitcoin_primitives::block::error::ParseBlockError
 impl core::cmp::Eq for bitcoin_primitives::block::error::ParseBlockError
 impl core::cmp::PartialEq for bitcoin_primitives::block::error::ParseBlockError
 pub fn bitcoin_primitives::block::error::ParseBlockError::eq(&self, other: &bitcoin_primitives::block::error::ParseBlockError) -> bool
@@ -264,10 +262,6 @@ pub fn bitcoin_primitives::block::error::ParseBlockError::try_from(value: U) -> 
 impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::block::error::ParseBlockError where U: core::convert::TryFrom<T>
 pub type bitcoin_primitives::block::error::ParseBlockError::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_primitives::block::error::ParseBlockError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::block::error::ParseBlockError where T: core::clone::Clone
-pub type bitcoin_primitives::block::error::ParseBlockError::Owned = T
-pub fn bitcoin_primitives::block::error::ParseBlockError::clone_into(&self, target: &mut T)
-pub fn bitcoin_primitives::block::error::ParseBlockError::to_owned(&self) -> T
 impl<T> alloc::string::ToString for bitcoin_primitives::block::error::ParseBlockError where T: core::fmt::Display + ?core::marker::Sized
 pub fn bitcoin_primitives::block::error::ParseBlockError::to_string(&self) -> alloc::string::String
 impl<T> core::any::Any for bitcoin_primitives::block::error::ParseBlockError where T: 'static + ?core::marker::Sized
@@ -276,13 +270,9 @@ impl<T> core::borrow::Borrow<T> for bitcoin_primitives::block::error::ParseBlock
 pub fn bitcoin_primitives::block::error::ParseBlockError::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::block::error::ParseBlockError where T: ?core::marker::Sized
 pub fn bitcoin_primitives::block::error::ParseBlockError::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::block::error::ParseBlockError where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::block::error::ParseBlockError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::block::error::ParseBlockError
 pub fn bitcoin_primitives::block::error::ParseBlockError::from(t: T) -> T
 pub struct bitcoin_primitives::block::error::ParseHeaderError(_)
-impl core::clone::Clone for bitcoin_primitives::block::error::ParseHeaderError
-pub fn bitcoin_primitives::block::error::ParseHeaderError::clone(&self) -> bitcoin_primitives::block::error::ParseHeaderError
 impl core::cmp::Eq for bitcoin_primitives::block::error::ParseHeaderError
 impl core::cmp::PartialEq for bitcoin_primitives::block::error::ParseHeaderError
 pub fn bitcoin_primitives::block::error::ParseHeaderError::eq(&self, other: &bitcoin_primitives::block::error::ParseHeaderError) -> bool
@@ -310,10 +300,6 @@ pub fn bitcoin_primitives::block::error::ParseHeaderError::try_from(value: U) ->
 impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::block::error::ParseHeaderError where U: core::convert::TryFrom<T>
 pub type bitcoin_primitives::block::error::ParseHeaderError::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_primitives::block::error::ParseHeaderError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::block::error::ParseHeaderError where T: core::clone::Clone
-pub type bitcoin_primitives::block::error::ParseHeaderError::Owned = T
-pub fn bitcoin_primitives::block::error::ParseHeaderError::clone_into(&self, target: &mut T)
-pub fn bitcoin_primitives::block::error::ParseHeaderError::to_owned(&self) -> T
 impl<T> alloc::string::ToString for bitcoin_primitives::block::error::ParseHeaderError where T: core::fmt::Display + ?core::marker::Sized
 pub fn bitcoin_primitives::block::error::ParseHeaderError::to_string(&self) -> alloc::string::String
 impl<T> core::any::Any for bitcoin_primitives::block::error::ParseHeaderError where T: 'static + ?core::marker::Sized
@@ -322,8 +308,6 @@ impl<T> core::borrow::Borrow<T> for bitcoin_primitives::block::error::ParseHeade
 pub fn bitcoin_primitives::block::error::ParseHeaderError::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::block::error::ParseHeaderError where T: ?core::marker::Sized
 pub fn bitcoin_primitives::block::error::ParseHeaderError::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::block::error::ParseHeaderError where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::block::error::ParseHeaderError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::block::error::ParseHeaderError
 pub fn bitcoin_primitives::block::error::ParseHeaderError::from(t: T) -> T
 pub struct bitcoin_primitives::block::error::VersionDecoderError(_)
@@ -650,8 +634,6 @@ pub type bitcoin_primitives::block::BlockDecoder::Output = bitcoin_primitives::b
 pub fn bitcoin_primitives::block::BlockDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_primitives::block::BlockDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
 pub fn bitcoin_primitives::block::BlockDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_primitives::block::BlockDecoder
-pub fn bitcoin_primitives::block::BlockDecoder::clone(&self) -> bitcoin_primitives::block::BlockDecoder
 impl core::default::Default for bitcoin_primitives::block::BlockDecoder
 pub fn bitcoin_primitives::block::BlockDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_primitives::block::BlockDecoder
@@ -671,18 +653,12 @@ pub fn bitcoin_primitives::block::BlockDecoder::try_from(value: U) -> core::resu
 impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::block::BlockDecoder where U: core::convert::TryFrom<T>
 pub type bitcoin_primitives::block::BlockDecoder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_primitives::block::BlockDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::block::BlockDecoder where T: core::clone::Clone
-pub type bitcoin_primitives::block::BlockDecoder::Owned = T
-pub fn bitcoin_primitives::block::BlockDecoder::clone_into(&self, target: &mut T)
-pub fn bitcoin_primitives::block::BlockDecoder::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_primitives::block::BlockDecoder where T: 'static + ?core::marker::Sized
 pub fn bitcoin_primitives::block::BlockDecoder::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_primitives::block::BlockDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::block::BlockDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::block::BlockDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::block::BlockDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::block::BlockDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::block::BlockDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::block::BlockDecoder
 pub fn bitcoin_primitives::block::BlockDecoder::from(t: T) -> T
 pub struct bitcoin_primitives::block::BlockDecoderError(_)
@@ -867,8 +843,6 @@ pub type bitcoin_primitives::block::BlockHashDecoder::Output = bitcoin_primitive
 pub fn bitcoin_primitives::block::BlockHashDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_primitives::block::BlockHashDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
 pub fn bitcoin_primitives::block::BlockHashDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_primitives::block::BlockHashDecoder
-pub fn bitcoin_primitives::block::BlockHashDecoder::clone(&self) -> bitcoin_primitives::block::BlockHashDecoder
 impl core::default::Default for bitcoin_primitives::block::BlockHashDecoder
 pub fn bitcoin_primitives::block::BlockHashDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_primitives::block::BlockHashDecoder
@@ -888,18 +862,12 @@ pub fn bitcoin_primitives::block::BlockHashDecoder::try_from(value: U) -> core::
 impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::block::BlockHashDecoder where U: core::convert::TryFrom<T>
 pub type bitcoin_primitives::block::BlockHashDecoder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_primitives::block::BlockHashDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::block::BlockHashDecoder where T: core::clone::Clone
-pub type bitcoin_primitives::block::BlockHashDecoder::Owned = T
-pub fn bitcoin_primitives::block::BlockHashDecoder::clone_into(&self, target: &mut T)
-pub fn bitcoin_primitives::block::BlockHashDecoder::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_primitives::block::BlockHashDecoder where T: 'static + ?core::marker::Sized
 pub fn bitcoin_primitives::block::BlockHashDecoder::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_primitives::block::BlockHashDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::block::BlockHashDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::block::BlockHashDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::block::BlockHashDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::block::BlockHashDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::block::BlockHashDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::block::BlockHashDecoder
 pub fn bitcoin_primitives::block::BlockHashDecoder::from(t: T) -> T
 pub struct bitcoin_primitives::block::BlockHashDecoderError(_)
@@ -1072,8 +1040,6 @@ pub type bitcoin_primitives::block::HeaderDecoder::Output = bitcoin_primitives::
 pub fn bitcoin_primitives::block::HeaderDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_primitives::block::HeaderDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
 pub fn bitcoin_primitives::block::HeaderDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_primitives::block::HeaderDecoder
-pub fn bitcoin_primitives::block::HeaderDecoder::clone(&self) -> bitcoin_primitives::block::HeaderDecoder
 impl core::default::Default for bitcoin_primitives::block::HeaderDecoder
 pub fn bitcoin_primitives::block::HeaderDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_primitives::block::HeaderDecoder
@@ -1093,18 +1059,12 @@ pub fn bitcoin_primitives::block::HeaderDecoder::try_from(value: U) -> core::res
 impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::block::HeaderDecoder where U: core::convert::TryFrom<T>
 pub type bitcoin_primitives::block::HeaderDecoder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_primitives::block::HeaderDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::block::HeaderDecoder where T: core::clone::Clone
-pub type bitcoin_primitives::block::HeaderDecoder::Owned = T
-pub fn bitcoin_primitives::block::HeaderDecoder::clone_into(&self, target: &mut T)
-pub fn bitcoin_primitives::block::HeaderDecoder::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_primitives::block::HeaderDecoder where T: 'static + ?core::marker::Sized
 pub fn bitcoin_primitives::block::HeaderDecoder::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_primitives::block::HeaderDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::block::HeaderDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::block::HeaderDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::block::HeaderDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::block::HeaderDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::block::HeaderDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::block::HeaderDecoder
 pub fn bitcoin_primitives::block::HeaderDecoder::from(t: T) -> T
 pub struct bitcoin_primitives::block::HeaderEncoder<'e>(_, _)
@@ -1147,8 +1107,6 @@ pub unsafe fn bitcoin_primitives::block::HeaderEncoder<'e>::clone_to_uninit(&sel
 impl<T> core::convert::From<T> for bitcoin_primitives::block::HeaderEncoder<'e>
 pub fn bitcoin_primitives::block::HeaderEncoder<'e>::from(t: T) -> T
 pub struct bitcoin_primitives::block::ParseBlockError(_)
-impl core::clone::Clone for bitcoin_primitives::block::error::ParseBlockError
-pub fn bitcoin_primitives::block::error::ParseBlockError::clone(&self) -> bitcoin_primitives::block::error::ParseBlockError
 impl core::cmp::Eq for bitcoin_primitives::block::error::ParseBlockError
 impl core::cmp::PartialEq for bitcoin_primitives::block::error::ParseBlockError
 pub fn bitcoin_primitives::block::error::ParseBlockError::eq(&self, other: &bitcoin_primitives::block::error::ParseBlockError) -> bool
@@ -1176,10 +1134,6 @@ pub fn bitcoin_primitives::block::error::ParseBlockError::try_from(value: U) -> 
 impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::block::error::ParseBlockError where U: core::convert::TryFrom<T>
 pub type bitcoin_primitives::block::error::ParseBlockError::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_primitives::block::error::ParseBlockError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::block::error::ParseBlockError where T: core::clone::Clone
-pub type bitcoin_primitives::block::error::ParseBlockError::Owned = T
-pub fn bitcoin_primitives::block::error::ParseBlockError::clone_into(&self, target: &mut T)
-pub fn bitcoin_primitives::block::error::ParseBlockError::to_owned(&self) -> T
 impl<T> alloc::string::ToString for bitcoin_primitives::block::error::ParseBlockError where T: core::fmt::Display + ?core::marker::Sized
 pub fn bitcoin_primitives::block::error::ParseBlockError::to_string(&self) -> alloc::string::String
 impl<T> core::any::Any for bitcoin_primitives::block::error::ParseBlockError where T: 'static + ?core::marker::Sized
@@ -1188,13 +1142,9 @@ impl<T> core::borrow::Borrow<T> for bitcoin_primitives::block::error::ParseBlock
 pub fn bitcoin_primitives::block::error::ParseBlockError::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::block::error::ParseBlockError where T: ?core::marker::Sized
 pub fn bitcoin_primitives::block::error::ParseBlockError::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::block::error::ParseBlockError where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::block::error::ParseBlockError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::block::error::ParseBlockError
 pub fn bitcoin_primitives::block::error::ParseBlockError::from(t: T) -> T
 pub struct bitcoin_primitives::block::ParseHeaderError(_)
-impl core::clone::Clone for bitcoin_primitives::block::error::ParseHeaderError
-pub fn bitcoin_primitives::block::error::ParseHeaderError::clone(&self) -> bitcoin_primitives::block::error::ParseHeaderError
 impl core::cmp::Eq for bitcoin_primitives::block::error::ParseHeaderError
 impl core::cmp::PartialEq for bitcoin_primitives::block::error::ParseHeaderError
 pub fn bitcoin_primitives::block::error::ParseHeaderError::eq(&self, other: &bitcoin_primitives::block::error::ParseHeaderError) -> bool
@@ -1222,10 +1172,6 @@ pub fn bitcoin_primitives::block::error::ParseHeaderError::try_from(value: U) ->
 impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::block::error::ParseHeaderError where U: core::convert::TryFrom<T>
 pub type bitcoin_primitives::block::error::ParseHeaderError::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_primitives::block::error::ParseHeaderError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::block::error::ParseHeaderError where T: core::clone::Clone
-pub type bitcoin_primitives::block::error::ParseHeaderError::Owned = T
-pub fn bitcoin_primitives::block::error::ParseHeaderError::clone_into(&self, target: &mut T)
-pub fn bitcoin_primitives::block::error::ParseHeaderError::to_owned(&self) -> T
 impl<T> alloc::string::ToString for bitcoin_primitives::block::error::ParseHeaderError where T: core::fmt::Display + ?core::marker::Sized
 pub fn bitcoin_primitives::block::error::ParseHeaderError::to_string(&self) -> alloc::string::String
 impl<T> core::any::Any for bitcoin_primitives::block::error::ParseHeaderError where T: 'static + ?core::marker::Sized
@@ -1234,8 +1180,6 @@ impl<T> core::borrow::Borrow<T> for bitcoin_primitives::block::error::ParseHeade
 pub fn bitcoin_primitives::block::error::ParseHeaderError::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::block::error::ParseHeaderError where T: ?core::marker::Sized
 pub fn bitcoin_primitives::block::error::ParseHeaderError::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::block::error::ParseHeaderError where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::block::error::ParseHeaderError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::block::error::ParseHeaderError
 pub fn bitcoin_primitives::block::error::ParseHeaderError::from(t: T) -> T
 pub struct bitcoin_primitives::block::Version(_)
@@ -1325,8 +1269,6 @@ pub type bitcoin_primitives::block::VersionDecoder::Output = bitcoin_primitives:
 pub fn bitcoin_primitives::block::VersionDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_primitives::block::VersionDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
 pub fn bitcoin_primitives::block::VersionDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_primitives::block::VersionDecoder
-pub fn bitcoin_primitives::block::VersionDecoder::clone(&self) -> bitcoin_primitives::block::VersionDecoder
 impl core::default::Default for bitcoin_primitives::block::VersionDecoder
 pub fn bitcoin_primitives::block::VersionDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_primitives::block::VersionDecoder
@@ -1346,18 +1288,12 @@ pub fn bitcoin_primitives::block::VersionDecoder::try_from(value: U) -> core::re
 impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::block::VersionDecoder where U: core::convert::TryFrom<T>
 pub type bitcoin_primitives::block::VersionDecoder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_primitives::block::VersionDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::block::VersionDecoder where T: core::clone::Clone
-pub type bitcoin_primitives::block::VersionDecoder::Owned = T
-pub fn bitcoin_primitives::block::VersionDecoder::clone_into(&self, target: &mut T)
-pub fn bitcoin_primitives::block::VersionDecoder::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_primitives::block::VersionDecoder where T: 'static + ?core::marker::Sized
 pub fn bitcoin_primitives::block::VersionDecoder::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_primitives::block::VersionDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::block::VersionDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::block::VersionDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::block::VersionDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::block::VersionDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::block::VersionDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::block::VersionDecoder
 pub fn bitcoin_primitives::block::VersionDecoder::from(t: T) -> T
 pub struct bitcoin_primitives::block::VersionDecoderError(_)
@@ -1624,8 +1560,6 @@ pub type bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::Output = bitcoin_
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder
-pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::clone(&self) -> bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder
 impl core::default::Default for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder
@@ -1645,18 +1579,12 @@ pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::try_from(value: U) 
 impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder where U: core::convert::TryFrom<T>
 pub type bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder where T: core::clone::Clone
-pub type bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::Owned = T
-pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::clone_into(&self, target: &mut T)
-pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder where T: 'static + ?core::marker::Sized
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::from(t: T) -> T
 pub struct bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError(_)
@@ -2658,8 +2586,6 @@ impl<T> serde::de::DeserializeOwned for bitcoin_primitives::script::ScriptBuf<T>
 pub struct bitcoin_primitives::script::ScriptBufDecoder<T>(_, _)
 impl<T> bitcoin_primitives::script::ScriptBufDecoder<T>
 pub const fn bitcoin_primitives::script::ScriptBufDecoder<T>::new() -> Self
-impl<T: core::clone::Clone> core::clone::Clone for bitcoin_primitives::script::ScriptBufDecoder<T>
-pub fn bitcoin_primitives::script::ScriptBufDecoder<T>::clone(&self) -> bitcoin_primitives::script::ScriptBufDecoder<T>
 impl<T: core::fmt::Debug> core::fmt::Debug for bitcoin_primitives::script::ScriptBufDecoder<T>
 pub fn bitcoin_primitives::script::ScriptBufDecoder<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<T> bitcoin_consensus_encoding::decode::Decoder for bitcoin_primitives::script::ScriptBufDecoder<T>
@@ -2685,18 +2611,12 @@ pub fn bitcoin_primitives::script::ScriptBufDecoder<T>::try_from(value: U) -> co
 impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::script::ScriptBufDecoder<T> where U: core::convert::TryFrom<T>
 pub type bitcoin_primitives::script::ScriptBufDecoder<T>::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_primitives::script::ScriptBufDecoder<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::script::ScriptBufDecoder<T> where T: core::clone::Clone
-pub type bitcoin_primitives::script::ScriptBufDecoder<T>::Owned = T
-pub fn bitcoin_primitives::script::ScriptBufDecoder<T>::clone_into(&self, target: &mut T)
-pub fn bitcoin_primitives::script::ScriptBufDecoder<T>::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_primitives::script::ScriptBufDecoder<T> where T: 'static + ?core::marker::Sized
 pub fn bitcoin_primitives::script::ScriptBufDecoder<T>::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_primitives::script::ScriptBufDecoder<T> where T: ?core::marker::Sized
 pub fn bitcoin_primitives::script::ScriptBufDecoder<T>::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::script::ScriptBufDecoder<T> where T: ?core::marker::Sized
 pub fn bitcoin_primitives::script::ScriptBufDecoder<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::script::ScriptBufDecoder<T> where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::script::ScriptBufDecoder<T>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::script::ScriptBufDecoder<T>
 pub fn bitcoin_primitives::script::ScriptBufDecoder<T>::from(t: T) -> T
 pub struct bitcoin_primitives::script::ScriptBufDecoderError(_)
@@ -3141,8 +3061,6 @@ pub unsafe fn bitcoin_primitives::transaction::error::OutPointDecoderError::clon
 impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::OutPointDecoderError
 pub fn bitcoin_primitives::transaction::error::OutPointDecoderError::from(t: T) -> T
 pub struct bitcoin_primitives::transaction::error::ParseTransactionError(_)
-impl core::clone::Clone for bitcoin_primitives::transaction::error::ParseTransactionError
-pub fn bitcoin_primitives::transaction::error::ParseTransactionError::clone(&self) -> bitcoin_primitives::transaction::error::ParseTransactionError
 impl core::cmp::Eq for bitcoin_primitives::transaction::error::ParseTransactionError
 impl core::cmp::PartialEq for bitcoin_primitives::transaction::error::ParseTransactionError
 pub fn bitcoin_primitives::transaction::error::ParseTransactionError::eq(&self, other: &bitcoin_primitives::transaction::error::ParseTransactionError) -> bool
@@ -3170,10 +3088,6 @@ pub fn bitcoin_primitives::transaction::error::ParseTransactionError::try_from(v
 impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::ParseTransactionError where U: core::convert::TryFrom<T>
 pub type bitcoin_primitives::transaction::error::ParseTransactionError::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_primitives::transaction::error::ParseTransactionError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::ParseTransactionError where T: core::clone::Clone
-pub type bitcoin_primitives::transaction::error::ParseTransactionError::Owned = T
-pub fn bitcoin_primitives::transaction::error::ParseTransactionError::clone_into(&self, target: &mut T)
-pub fn bitcoin_primitives::transaction::error::ParseTransactionError::to_owned(&self) -> T
 impl<T> alloc::string::ToString for bitcoin_primitives::transaction::error::ParseTransactionError where T: core::fmt::Display + ?core::marker::Sized
 pub fn bitcoin_primitives::transaction::error::ParseTransactionError::to_string(&self) -> alloc::string::String
 impl<T> core::any::Any for bitcoin_primitives::transaction::error::ParseTransactionError where T: 'static + ?core::marker::Sized
@@ -3182,8 +3096,6 @@ impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::error::Pars
 pub fn bitcoin_primitives::transaction::error::ParseTransactionError::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::error::ParseTransactionError where T: ?core::marker::Sized
 pub fn bitcoin_primitives::transaction::error::ParseTransactionError::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::ParseTransactionError where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::transaction::error::ParseTransactionError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::ParseTransactionError
 pub fn bitcoin_primitives::transaction::error::ParseTransactionError::from(t: T) -> T
 pub struct bitcoin_primitives::transaction::error::TransactionDecoderError(_)
@@ -3430,8 +3342,6 @@ pub type bitcoin_primitives::block::BlockHashDecoder::Output = bitcoin_primitive
 pub fn bitcoin_primitives::block::BlockHashDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_primitives::block::BlockHashDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
 pub fn bitcoin_primitives::block::BlockHashDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_primitives::block::BlockHashDecoder
-pub fn bitcoin_primitives::block::BlockHashDecoder::clone(&self) -> bitcoin_primitives::block::BlockHashDecoder
 impl core::default::Default for bitcoin_primitives::block::BlockHashDecoder
 pub fn bitcoin_primitives::block::BlockHashDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_primitives::block::BlockHashDecoder
@@ -3451,18 +3361,12 @@ pub fn bitcoin_primitives::block::BlockHashDecoder::try_from(value: U) -> core::
 impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::block::BlockHashDecoder where U: core::convert::TryFrom<T>
 pub type bitcoin_primitives::block::BlockHashDecoder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_primitives::block::BlockHashDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::block::BlockHashDecoder where T: core::clone::Clone
-pub type bitcoin_primitives::block::BlockHashDecoder::Owned = T
-pub fn bitcoin_primitives::block::BlockHashDecoder::clone_into(&self, target: &mut T)
-pub fn bitcoin_primitives::block::BlockHashDecoder::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_primitives::block::BlockHashDecoder where T: 'static + ?core::marker::Sized
 pub fn bitcoin_primitives::block::BlockHashDecoder::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_primitives::block::BlockHashDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::block::BlockHashDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::block::BlockHashDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::block::BlockHashDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::block::BlockHashDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::block::BlockHashDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::block::BlockHashDecoder
 pub fn bitcoin_primitives::block::BlockHashDecoder::from(t: T) -> T
 pub struct bitcoin_primitives::transaction::BlockHashDecoderError(_)
@@ -3664,8 +3568,6 @@ pub type bitcoin_primitives::transaction::OutPointDecoder::Output = bitcoin_prim
 pub fn bitcoin_primitives::transaction::OutPointDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_primitives::transaction::OutPointDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
 pub fn bitcoin_primitives::transaction::OutPointDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_primitives::transaction::OutPointDecoder
-pub fn bitcoin_primitives::transaction::OutPointDecoder::clone(&self) -> bitcoin_primitives::transaction::OutPointDecoder
 impl core::default::Default for bitcoin_primitives::transaction::OutPointDecoder
 pub fn bitcoin_primitives::transaction::OutPointDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_primitives::transaction::OutPointDecoder
@@ -3685,18 +3587,12 @@ pub fn bitcoin_primitives::transaction::OutPointDecoder::try_from(value: U) -> c
 impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::OutPointDecoder where U: core::convert::TryFrom<T>
 pub type bitcoin_primitives::transaction::OutPointDecoder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_primitives::transaction::OutPointDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::OutPointDecoder where T: core::clone::Clone
-pub type bitcoin_primitives::transaction::OutPointDecoder::Owned = T
-pub fn bitcoin_primitives::transaction::OutPointDecoder::clone_into(&self, target: &mut T)
-pub fn bitcoin_primitives::transaction::OutPointDecoder::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_primitives::transaction::OutPointDecoder where T: 'static + ?core::marker::Sized
 pub fn bitcoin_primitives::transaction::OutPointDecoder::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::OutPointDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::transaction::OutPointDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::OutPointDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::transaction::OutPointDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::OutPointDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::transaction::OutPointDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::transaction::OutPointDecoder
 pub fn bitcoin_primitives::transaction::OutPointDecoder::from(t: T) -> T
 pub struct bitcoin_primitives::transaction::OutPointDecoderError(_)
@@ -3785,8 +3681,6 @@ pub unsafe fn bitcoin_primitives::transaction::OutPointEncoder<'e>::clone_to_uni
 impl<T> core::convert::From<T> for bitcoin_primitives::transaction::OutPointEncoder<'e>
 pub fn bitcoin_primitives::transaction::OutPointEncoder<'e>::from(t: T) -> T
 pub struct bitcoin_primitives::transaction::ParseTransactionError(_)
-impl core::clone::Clone for bitcoin_primitives::transaction::error::ParseTransactionError
-pub fn bitcoin_primitives::transaction::error::ParseTransactionError::clone(&self) -> bitcoin_primitives::transaction::error::ParseTransactionError
 impl core::cmp::Eq for bitcoin_primitives::transaction::error::ParseTransactionError
 impl core::cmp::PartialEq for bitcoin_primitives::transaction::error::ParseTransactionError
 pub fn bitcoin_primitives::transaction::error::ParseTransactionError::eq(&self, other: &bitcoin_primitives::transaction::error::ParseTransactionError) -> bool
@@ -3814,10 +3708,6 @@ pub fn bitcoin_primitives::transaction::error::ParseTransactionError::try_from(v
 impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::ParseTransactionError where U: core::convert::TryFrom<T>
 pub type bitcoin_primitives::transaction::error::ParseTransactionError::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_primitives::transaction::error::ParseTransactionError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::ParseTransactionError where T: core::clone::Clone
-pub type bitcoin_primitives::transaction::error::ParseTransactionError::Owned = T
-pub fn bitcoin_primitives::transaction::error::ParseTransactionError::clone_into(&self, target: &mut T)
-pub fn bitcoin_primitives::transaction::error::ParseTransactionError::to_owned(&self) -> T
 impl<T> alloc::string::ToString for bitcoin_primitives::transaction::error::ParseTransactionError where T: core::fmt::Display + ?core::marker::Sized
 pub fn bitcoin_primitives::transaction::error::ParseTransactionError::to_string(&self) -> alloc::string::String
 impl<T> core::any::Any for bitcoin_primitives::transaction::error::ParseTransactionError where T: 'static + ?core::marker::Sized
@@ -3826,8 +3716,6 @@ impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::error::Pars
 pub fn bitcoin_primitives::transaction::error::ParseTransactionError::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::error::ParseTransactionError where T: ?core::marker::Sized
 pub fn bitcoin_primitives::transaction::error::ParseTransactionError::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::ParseTransactionError where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::transaction::error::ParseTransactionError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::ParseTransactionError
 pub fn bitcoin_primitives::transaction::error::ParseTransactionError::from(t: T) -> T
 pub struct bitcoin_primitives::transaction::Transaction
@@ -3919,8 +3807,6 @@ pub type bitcoin_primitives::transaction::TransactionDecoder::Output = bitcoin_p
 pub fn bitcoin_primitives::transaction::TransactionDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_primitives::transaction::TransactionDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
 pub fn bitcoin_primitives::transaction::TransactionDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_primitives::transaction::TransactionDecoder
-pub fn bitcoin_primitives::transaction::TransactionDecoder::clone(&self) -> bitcoin_primitives::transaction::TransactionDecoder
 impl core::default::Default for bitcoin_primitives::transaction::TransactionDecoder
 pub fn bitcoin_primitives::transaction::TransactionDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_primitives::transaction::TransactionDecoder
@@ -3940,18 +3826,12 @@ pub fn bitcoin_primitives::transaction::TransactionDecoder::try_from(value: U) -
 impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::TransactionDecoder where U: core::convert::TryFrom<T>
 pub type bitcoin_primitives::transaction::TransactionDecoder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_primitives::transaction::TransactionDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::TransactionDecoder where T: core::clone::Clone
-pub type bitcoin_primitives::transaction::TransactionDecoder::Owned = T
-pub fn bitcoin_primitives::transaction::TransactionDecoder::clone_into(&self, target: &mut T)
-pub fn bitcoin_primitives::transaction::TransactionDecoder::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_primitives::transaction::TransactionDecoder where T: 'static + ?core::marker::Sized
 pub fn bitcoin_primitives::transaction::TransactionDecoder::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::TransactionDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::transaction::TransactionDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::TransactionDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::transaction::TransactionDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::TransactionDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::transaction::TransactionDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::transaction::TransactionDecoder
 pub fn bitcoin_primitives::transaction::TransactionDecoder::from(t: T) -> T
 pub struct bitcoin_primitives::transaction::TransactionDecoderError(_)
@@ -4103,8 +3983,6 @@ pub type bitcoin_primitives::transaction::TxInDecoder::Output = bitcoin_primitiv
 pub fn bitcoin_primitives::transaction::TxInDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_primitives::transaction::TxInDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
 pub fn bitcoin_primitives::transaction::TxInDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_primitives::transaction::TxInDecoder
-pub fn bitcoin_primitives::transaction::TxInDecoder::clone(&self) -> bitcoin_primitives::transaction::TxInDecoder
 impl core::default::Default for bitcoin_primitives::transaction::TxInDecoder
 pub fn bitcoin_primitives::transaction::TxInDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_primitives::transaction::TxInDecoder
@@ -4124,18 +4002,12 @@ pub fn bitcoin_primitives::transaction::TxInDecoder::try_from(value: U) -> core:
 impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::TxInDecoder where U: core::convert::TryFrom<T>
 pub type bitcoin_primitives::transaction::TxInDecoder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_primitives::transaction::TxInDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::TxInDecoder where T: core::clone::Clone
-pub type bitcoin_primitives::transaction::TxInDecoder::Owned = T
-pub fn bitcoin_primitives::transaction::TxInDecoder::clone_into(&self, target: &mut T)
-pub fn bitcoin_primitives::transaction::TxInDecoder::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_primitives::transaction::TxInDecoder where T: 'static + ?core::marker::Sized
 pub fn bitcoin_primitives::transaction::TxInDecoder::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::TxInDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::transaction::TxInDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::TxInDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::transaction::TxInDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::TxInDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::transaction::TxInDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::transaction::TxInDecoder
 pub fn bitcoin_primitives::transaction::TxInDecoder::from(t: T) -> T
 pub struct bitcoin_primitives::transaction::TxInDecoderError(_)
@@ -4285,8 +4157,6 @@ pub type bitcoin_primitives::transaction::TxOutDecoder::Output = bitcoin_primiti
 pub fn bitcoin_primitives::transaction::TxOutDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_primitives::transaction::TxOutDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
 pub fn bitcoin_primitives::transaction::TxOutDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_primitives::transaction::TxOutDecoder
-pub fn bitcoin_primitives::transaction::TxOutDecoder::clone(&self) -> bitcoin_primitives::transaction::TxOutDecoder
 impl core::default::Default for bitcoin_primitives::transaction::TxOutDecoder
 pub fn bitcoin_primitives::transaction::TxOutDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_primitives::transaction::TxOutDecoder
@@ -4306,18 +4176,12 @@ pub fn bitcoin_primitives::transaction::TxOutDecoder::try_from(value: U) -> core
 impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::TxOutDecoder where U: core::convert::TryFrom<T>
 pub type bitcoin_primitives::transaction::TxOutDecoder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_primitives::transaction::TxOutDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::TxOutDecoder where T: core::clone::Clone
-pub type bitcoin_primitives::transaction::TxOutDecoder::Owned = T
-pub fn bitcoin_primitives::transaction::TxOutDecoder::clone_into(&self, target: &mut T)
-pub fn bitcoin_primitives::transaction::TxOutDecoder::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_primitives::transaction::TxOutDecoder where T: 'static + ?core::marker::Sized
 pub fn bitcoin_primitives::transaction::TxOutDecoder::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::TxOutDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::transaction::TxOutDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::TxOutDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::transaction::TxOutDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::TxOutDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::transaction::TxOutDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::transaction::TxOutDecoder
 pub fn bitcoin_primitives::transaction::TxOutDecoder::from(t: T) -> T
 pub struct bitcoin_primitives::transaction::TxOutDecoderError(_)
@@ -4573,8 +4437,6 @@ pub type bitcoin_primitives::transaction::VersionDecoder::Output = bitcoin_primi
 pub fn bitcoin_primitives::transaction::VersionDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_primitives::transaction::VersionDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
 pub fn bitcoin_primitives::transaction::VersionDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_primitives::transaction::VersionDecoder
-pub fn bitcoin_primitives::transaction::VersionDecoder::clone(&self) -> bitcoin_primitives::transaction::VersionDecoder
 impl core::default::Default for bitcoin_primitives::transaction::VersionDecoder
 pub fn bitcoin_primitives::transaction::VersionDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_primitives::transaction::VersionDecoder
@@ -4594,18 +4456,12 @@ pub fn bitcoin_primitives::transaction::VersionDecoder::try_from(value: U) -> co
 impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::VersionDecoder where U: core::convert::TryFrom<T>
 pub type bitcoin_primitives::transaction::VersionDecoder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_primitives::transaction::VersionDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::VersionDecoder where T: core::clone::Clone
-pub type bitcoin_primitives::transaction::VersionDecoder::Owned = T
-pub fn bitcoin_primitives::transaction::VersionDecoder::clone_into(&self, target: &mut T)
-pub fn bitcoin_primitives::transaction::VersionDecoder::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_primitives::transaction::VersionDecoder where T: 'static + ?core::marker::Sized
 pub fn bitcoin_primitives::transaction::VersionDecoder::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::VersionDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::transaction::VersionDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::VersionDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::transaction::VersionDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::VersionDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::transaction::VersionDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::transaction::VersionDecoder
 pub fn bitcoin_primitives::transaction::VersionDecoder::from(t: T) -> T
 pub struct bitcoin_primitives::transaction::VersionDecoderError(_)
@@ -5140,8 +4996,6 @@ pub type bitcoin_primitives::witness::WitnessDecoder::Output = bitcoin_primitive
 pub fn bitcoin_primitives::witness::WitnessDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_primitives::witness::WitnessDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
 pub fn bitcoin_primitives::witness::WitnessDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_primitives::witness::WitnessDecoder
-pub fn bitcoin_primitives::witness::WitnessDecoder::clone(&self) -> bitcoin_primitives::witness::WitnessDecoder
 impl core::default::Default for bitcoin_primitives::witness::WitnessDecoder
 pub fn bitcoin_primitives::witness::WitnessDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_primitives::witness::WitnessDecoder
@@ -5161,18 +5015,12 @@ pub fn bitcoin_primitives::witness::WitnessDecoder::try_from(value: U) -> core::
 impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness::WitnessDecoder where U: core::convert::TryFrom<T>
 pub type bitcoin_primitives::witness::WitnessDecoder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_primitives::witness::WitnessDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness::WitnessDecoder where T: core::clone::Clone
-pub type bitcoin_primitives::witness::WitnessDecoder::Owned = T
-pub fn bitcoin_primitives::witness::WitnessDecoder::clone_into(&self, target: &mut T)
-pub fn bitcoin_primitives::witness::WitnessDecoder::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_primitives::witness::WitnessDecoder where T: 'static + ?core::marker::Sized
 pub fn bitcoin_primitives::witness::WitnessDecoder::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness::WitnessDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::witness::WitnessDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness::WitnessDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::witness::WitnessDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness::WitnessDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::witness::WitnessDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::witness::WitnessDecoder
 pub fn bitcoin_primitives::witness::WitnessDecoder::from(t: T) -> T
 pub struct bitcoin_primitives::witness::WitnessDecoderError(_)

--- a/primitives/api/alloc-only.txt
+++ b/primitives/api/alloc-only.txt
@@ -528,8 +528,6 @@ pub type bitcoin_primitives::block::BlockDecoder::Output = bitcoin_primitives::b
 pub fn bitcoin_primitives::block::BlockDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_primitives::block::BlockDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
 pub fn bitcoin_primitives::block::BlockDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_primitives::block::BlockDecoder
-pub fn bitcoin_primitives::block::BlockDecoder::clone(&self) -> bitcoin_primitives::block::BlockDecoder
 impl core::default::Default for bitcoin_primitives::block::BlockDecoder
 pub fn bitcoin_primitives::block::BlockDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_primitives::block::BlockDecoder
@@ -549,18 +547,12 @@ pub fn bitcoin_primitives::block::BlockDecoder::try_from(value: U) -> core::resu
 impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::block::BlockDecoder where U: core::convert::TryFrom<T>
 pub type bitcoin_primitives::block::BlockDecoder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_primitives::block::BlockDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::block::BlockDecoder where T: core::clone::Clone
-pub type bitcoin_primitives::block::BlockDecoder::Owned = T
-pub fn bitcoin_primitives::block::BlockDecoder::clone_into(&self, target: &mut T)
-pub fn bitcoin_primitives::block::BlockDecoder::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_primitives::block::BlockDecoder where T: 'static + ?core::marker::Sized
 pub fn bitcoin_primitives::block::BlockDecoder::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_primitives::block::BlockDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::block::BlockDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::block::BlockDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::block::BlockDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::block::BlockDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::block::BlockDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::block::BlockDecoder
 pub fn bitcoin_primitives::block::BlockDecoder::from(t: T) -> T
 pub struct bitcoin_primitives::block::BlockDecoderError(_)
@@ -725,8 +717,6 @@ pub type bitcoin_primitives::block::BlockHashDecoder::Output = bitcoin_primitive
 pub fn bitcoin_primitives::block::BlockHashDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_primitives::block::BlockHashDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
 pub fn bitcoin_primitives::block::BlockHashDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_primitives::block::BlockHashDecoder
-pub fn bitcoin_primitives::block::BlockHashDecoder::clone(&self) -> bitcoin_primitives::block::BlockHashDecoder
 impl core::default::Default for bitcoin_primitives::block::BlockHashDecoder
 pub fn bitcoin_primitives::block::BlockHashDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_primitives::block::BlockHashDecoder
@@ -746,18 +736,12 @@ pub fn bitcoin_primitives::block::BlockHashDecoder::try_from(value: U) -> core::
 impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::block::BlockHashDecoder where U: core::convert::TryFrom<T>
 pub type bitcoin_primitives::block::BlockHashDecoder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_primitives::block::BlockHashDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::block::BlockHashDecoder where T: core::clone::Clone
-pub type bitcoin_primitives::block::BlockHashDecoder::Owned = T
-pub fn bitcoin_primitives::block::BlockHashDecoder::clone_into(&self, target: &mut T)
-pub fn bitcoin_primitives::block::BlockHashDecoder::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_primitives::block::BlockHashDecoder where T: 'static + ?core::marker::Sized
 pub fn bitcoin_primitives::block::BlockHashDecoder::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_primitives::block::BlockHashDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::block::BlockHashDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::block::BlockHashDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::block::BlockHashDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::block::BlockHashDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::block::BlockHashDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::block::BlockHashDecoder
 pub fn bitcoin_primitives::block::BlockHashDecoder::from(t: T) -> T
 pub struct bitcoin_primitives::block::BlockHashDecoderError(_)
@@ -915,8 +899,6 @@ pub type bitcoin_primitives::block::HeaderDecoder::Output = bitcoin_primitives::
 pub fn bitcoin_primitives::block::HeaderDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_primitives::block::HeaderDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
 pub fn bitcoin_primitives::block::HeaderDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_primitives::block::HeaderDecoder
-pub fn bitcoin_primitives::block::HeaderDecoder::clone(&self) -> bitcoin_primitives::block::HeaderDecoder
 impl core::default::Default for bitcoin_primitives::block::HeaderDecoder
 pub fn bitcoin_primitives::block::HeaderDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_primitives::block::HeaderDecoder
@@ -936,18 +918,12 @@ pub fn bitcoin_primitives::block::HeaderDecoder::try_from(value: U) -> core::res
 impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::block::HeaderDecoder where U: core::convert::TryFrom<T>
 pub type bitcoin_primitives::block::HeaderDecoder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_primitives::block::HeaderDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::block::HeaderDecoder where T: core::clone::Clone
-pub type bitcoin_primitives::block::HeaderDecoder::Owned = T
-pub fn bitcoin_primitives::block::HeaderDecoder::clone_into(&self, target: &mut T)
-pub fn bitcoin_primitives::block::HeaderDecoder::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_primitives::block::HeaderDecoder where T: 'static + ?core::marker::Sized
 pub fn bitcoin_primitives::block::HeaderDecoder::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_primitives::block::HeaderDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::block::HeaderDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::block::HeaderDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::block::HeaderDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::block::HeaderDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::block::HeaderDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::block::HeaderDecoder
 pub fn bitcoin_primitives::block::HeaderDecoder::from(t: T) -> T
 pub struct bitcoin_primitives::block::HeaderEncoder<'e>(_, _)
@@ -1069,8 +1045,6 @@ pub type bitcoin_primitives::block::VersionDecoder::Output = bitcoin_primitives:
 pub fn bitcoin_primitives::block::VersionDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_primitives::block::VersionDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
 pub fn bitcoin_primitives::block::VersionDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_primitives::block::VersionDecoder
-pub fn bitcoin_primitives::block::VersionDecoder::clone(&self) -> bitcoin_primitives::block::VersionDecoder
 impl core::default::Default for bitcoin_primitives::block::VersionDecoder
 pub fn bitcoin_primitives::block::VersionDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_primitives::block::VersionDecoder
@@ -1090,18 +1064,12 @@ pub fn bitcoin_primitives::block::VersionDecoder::try_from(value: U) -> core::re
 impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::block::VersionDecoder where U: core::convert::TryFrom<T>
 pub type bitcoin_primitives::block::VersionDecoder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_primitives::block::VersionDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::block::VersionDecoder where T: core::clone::Clone
-pub type bitcoin_primitives::block::VersionDecoder::Owned = T
-pub fn bitcoin_primitives::block::VersionDecoder::clone_into(&self, target: &mut T)
-pub fn bitcoin_primitives::block::VersionDecoder::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_primitives::block::VersionDecoder where T: 'static + ?core::marker::Sized
 pub fn bitcoin_primitives::block::VersionDecoder::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_primitives::block::VersionDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::block::VersionDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::block::VersionDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::block::VersionDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::block::VersionDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::block::VersionDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::block::VersionDecoder
 pub fn bitcoin_primitives::block::VersionDecoder::from(t: T) -> T
 pub struct bitcoin_primitives::block::VersionDecoderError(_)
@@ -1330,8 +1298,6 @@ pub type bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::Output = bitcoin_
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder
-pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::clone(&self) -> bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder
 impl core::default::Default for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder
@@ -1351,18 +1317,12 @@ pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::try_from(value: U) 
 impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder where U: core::convert::TryFrom<T>
 pub type bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder where T: core::clone::Clone
-pub type bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::Owned = T
-pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::clone_into(&self, target: &mut T)
-pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder where T: 'static + ?core::marker::Sized
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::from(t: T) -> T
 pub struct bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError(_)
@@ -2205,8 +2165,6 @@ pub fn bitcoin_primitives::script::ScriptBuf<T>::from(t: T) -> T
 pub struct bitcoin_primitives::script::ScriptBufDecoder<T>(_, _)
 impl<T> bitcoin_primitives::script::ScriptBufDecoder<T>
 pub const fn bitcoin_primitives::script::ScriptBufDecoder<T>::new() -> Self
-impl<T: core::clone::Clone> core::clone::Clone for bitcoin_primitives::script::ScriptBufDecoder<T>
-pub fn bitcoin_primitives::script::ScriptBufDecoder<T>::clone(&self) -> bitcoin_primitives::script::ScriptBufDecoder<T>
 impl<T: core::fmt::Debug> core::fmt::Debug for bitcoin_primitives::script::ScriptBufDecoder<T>
 pub fn bitcoin_primitives::script::ScriptBufDecoder<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<T> bitcoin_consensus_encoding::decode::Decoder for bitcoin_primitives::script::ScriptBufDecoder<T>
@@ -2232,18 +2190,12 @@ pub fn bitcoin_primitives::script::ScriptBufDecoder<T>::try_from(value: U) -> co
 impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::script::ScriptBufDecoder<T> where U: core::convert::TryFrom<T>
 pub type bitcoin_primitives::script::ScriptBufDecoder<T>::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_primitives::script::ScriptBufDecoder<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::script::ScriptBufDecoder<T> where T: core::clone::Clone
-pub type bitcoin_primitives::script::ScriptBufDecoder<T>::Owned = T
-pub fn bitcoin_primitives::script::ScriptBufDecoder<T>::clone_into(&self, target: &mut T)
-pub fn bitcoin_primitives::script::ScriptBufDecoder<T>::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_primitives::script::ScriptBufDecoder<T> where T: 'static + ?core::marker::Sized
 pub fn bitcoin_primitives::script::ScriptBufDecoder<T>::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_primitives::script::ScriptBufDecoder<T> where T: ?core::marker::Sized
 pub fn bitcoin_primitives::script::ScriptBufDecoder<T>::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::script::ScriptBufDecoder<T> where T: ?core::marker::Sized
 pub fn bitcoin_primitives::script::ScriptBufDecoder<T>::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::script::ScriptBufDecoder<T> where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::script::ScriptBufDecoder<T>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::script::ScriptBufDecoder<T>
 pub fn bitcoin_primitives::script::ScriptBufDecoder<T>::from(t: T) -> T
 pub struct bitcoin_primitives::script::ScriptBufDecoderError(_)
@@ -2770,8 +2722,6 @@ pub type bitcoin_primitives::block::BlockHashDecoder::Output = bitcoin_primitive
 pub fn bitcoin_primitives::block::BlockHashDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_primitives::block::BlockHashDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
 pub fn bitcoin_primitives::block::BlockHashDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_primitives::block::BlockHashDecoder
-pub fn bitcoin_primitives::block::BlockHashDecoder::clone(&self) -> bitcoin_primitives::block::BlockHashDecoder
 impl core::default::Default for bitcoin_primitives::block::BlockHashDecoder
 pub fn bitcoin_primitives::block::BlockHashDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_primitives::block::BlockHashDecoder
@@ -2791,18 +2741,12 @@ pub fn bitcoin_primitives::block::BlockHashDecoder::try_from(value: U) -> core::
 impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::block::BlockHashDecoder where U: core::convert::TryFrom<T>
 pub type bitcoin_primitives::block::BlockHashDecoder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_primitives::block::BlockHashDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::block::BlockHashDecoder where T: core::clone::Clone
-pub type bitcoin_primitives::block::BlockHashDecoder::Owned = T
-pub fn bitcoin_primitives::block::BlockHashDecoder::clone_into(&self, target: &mut T)
-pub fn bitcoin_primitives::block::BlockHashDecoder::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_primitives::block::BlockHashDecoder where T: 'static + ?core::marker::Sized
 pub fn bitcoin_primitives::block::BlockHashDecoder::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_primitives::block::BlockHashDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::block::BlockHashDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::block::BlockHashDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::block::BlockHashDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::block::BlockHashDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::block::BlockHashDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::block::BlockHashDecoder
 pub fn bitcoin_primitives::block::BlockHashDecoder::from(t: T) -> T
 pub struct bitcoin_primitives::transaction::BlockHashDecoderError(_)
@@ -2970,8 +2914,6 @@ pub type bitcoin_primitives::transaction::OutPointDecoder::Output = bitcoin_prim
 pub fn bitcoin_primitives::transaction::OutPointDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_primitives::transaction::OutPointDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
 pub fn bitcoin_primitives::transaction::OutPointDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_primitives::transaction::OutPointDecoder
-pub fn bitcoin_primitives::transaction::OutPointDecoder::clone(&self) -> bitcoin_primitives::transaction::OutPointDecoder
 impl core::default::Default for bitcoin_primitives::transaction::OutPointDecoder
 pub fn bitcoin_primitives::transaction::OutPointDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_primitives::transaction::OutPointDecoder
@@ -2991,18 +2933,12 @@ pub fn bitcoin_primitives::transaction::OutPointDecoder::try_from(value: U) -> c
 impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::OutPointDecoder where U: core::convert::TryFrom<T>
 pub type bitcoin_primitives::transaction::OutPointDecoder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_primitives::transaction::OutPointDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::OutPointDecoder where T: core::clone::Clone
-pub type bitcoin_primitives::transaction::OutPointDecoder::Owned = T
-pub fn bitcoin_primitives::transaction::OutPointDecoder::clone_into(&self, target: &mut T)
-pub fn bitcoin_primitives::transaction::OutPointDecoder::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_primitives::transaction::OutPointDecoder where T: 'static + ?core::marker::Sized
 pub fn bitcoin_primitives::transaction::OutPointDecoder::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::OutPointDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::transaction::OutPointDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::OutPointDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::transaction::OutPointDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::OutPointDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::transaction::OutPointDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::transaction::OutPointDecoder
 pub fn bitcoin_primitives::transaction::OutPointDecoder::from(t: T) -> T
 pub struct bitcoin_primitives::transaction::OutPointDecoderError(_)
@@ -3164,8 +3100,6 @@ pub type bitcoin_primitives::transaction::TransactionDecoder::Output = bitcoin_p
 pub fn bitcoin_primitives::transaction::TransactionDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_primitives::transaction::TransactionDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
 pub fn bitcoin_primitives::transaction::TransactionDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_primitives::transaction::TransactionDecoder
-pub fn bitcoin_primitives::transaction::TransactionDecoder::clone(&self) -> bitcoin_primitives::transaction::TransactionDecoder
 impl core::default::Default for bitcoin_primitives::transaction::TransactionDecoder
 pub fn bitcoin_primitives::transaction::TransactionDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_primitives::transaction::TransactionDecoder
@@ -3185,18 +3119,12 @@ pub fn bitcoin_primitives::transaction::TransactionDecoder::try_from(value: U) -
 impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::TransactionDecoder where U: core::convert::TryFrom<T>
 pub type bitcoin_primitives::transaction::TransactionDecoder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_primitives::transaction::TransactionDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::TransactionDecoder where T: core::clone::Clone
-pub type bitcoin_primitives::transaction::TransactionDecoder::Owned = T
-pub fn bitcoin_primitives::transaction::TransactionDecoder::clone_into(&self, target: &mut T)
-pub fn bitcoin_primitives::transaction::TransactionDecoder::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_primitives::transaction::TransactionDecoder where T: 'static + ?core::marker::Sized
 pub fn bitcoin_primitives::transaction::TransactionDecoder::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::TransactionDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::transaction::TransactionDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::TransactionDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::transaction::TransactionDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::TransactionDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::transaction::TransactionDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::transaction::TransactionDecoder
 pub fn bitcoin_primitives::transaction::TransactionDecoder::from(t: T) -> T
 pub struct bitcoin_primitives::transaction::TransactionDecoderError(_)
@@ -3344,8 +3272,6 @@ pub type bitcoin_primitives::transaction::TxInDecoder::Output = bitcoin_primitiv
 pub fn bitcoin_primitives::transaction::TxInDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_primitives::transaction::TxInDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
 pub fn bitcoin_primitives::transaction::TxInDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_primitives::transaction::TxInDecoder
-pub fn bitcoin_primitives::transaction::TxInDecoder::clone(&self) -> bitcoin_primitives::transaction::TxInDecoder
 impl core::default::Default for bitcoin_primitives::transaction::TxInDecoder
 pub fn bitcoin_primitives::transaction::TxInDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_primitives::transaction::TxInDecoder
@@ -3365,18 +3291,12 @@ pub fn bitcoin_primitives::transaction::TxInDecoder::try_from(value: U) -> core:
 impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::TxInDecoder where U: core::convert::TryFrom<T>
 pub type bitcoin_primitives::transaction::TxInDecoder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_primitives::transaction::TxInDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::TxInDecoder where T: core::clone::Clone
-pub type bitcoin_primitives::transaction::TxInDecoder::Owned = T
-pub fn bitcoin_primitives::transaction::TxInDecoder::clone_into(&self, target: &mut T)
-pub fn bitcoin_primitives::transaction::TxInDecoder::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_primitives::transaction::TxInDecoder where T: 'static + ?core::marker::Sized
 pub fn bitcoin_primitives::transaction::TxInDecoder::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::TxInDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::transaction::TxInDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::TxInDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::transaction::TxInDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::TxInDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::transaction::TxInDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::transaction::TxInDecoder
 pub fn bitcoin_primitives::transaction::TxInDecoder::from(t: T) -> T
 pub struct bitcoin_primitives::transaction::TxInDecoderError(_)
@@ -3522,8 +3442,6 @@ pub type bitcoin_primitives::transaction::TxOutDecoder::Output = bitcoin_primiti
 pub fn bitcoin_primitives::transaction::TxOutDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_primitives::transaction::TxOutDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
 pub fn bitcoin_primitives::transaction::TxOutDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_primitives::transaction::TxOutDecoder
-pub fn bitcoin_primitives::transaction::TxOutDecoder::clone(&self) -> bitcoin_primitives::transaction::TxOutDecoder
 impl core::default::Default for bitcoin_primitives::transaction::TxOutDecoder
 pub fn bitcoin_primitives::transaction::TxOutDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_primitives::transaction::TxOutDecoder
@@ -3543,18 +3461,12 @@ pub fn bitcoin_primitives::transaction::TxOutDecoder::try_from(value: U) -> core
 impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::TxOutDecoder where U: core::convert::TryFrom<T>
 pub type bitcoin_primitives::transaction::TxOutDecoder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_primitives::transaction::TxOutDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::TxOutDecoder where T: core::clone::Clone
-pub type bitcoin_primitives::transaction::TxOutDecoder::Owned = T
-pub fn bitcoin_primitives::transaction::TxOutDecoder::clone_into(&self, target: &mut T)
-pub fn bitcoin_primitives::transaction::TxOutDecoder::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_primitives::transaction::TxOutDecoder where T: 'static + ?core::marker::Sized
 pub fn bitcoin_primitives::transaction::TxOutDecoder::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::TxOutDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::transaction::TxOutDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::TxOutDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::transaction::TxOutDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::TxOutDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::transaction::TxOutDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::transaction::TxOutDecoder
 pub fn bitcoin_primitives::transaction::TxOutDecoder::from(t: T) -> T
 pub struct bitcoin_primitives::transaction::TxOutDecoderError(_)
@@ -3783,8 +3695,6 @@ pub type bitcoin_primitives::transaction::VersionDecoder::Output = bitcoin_primi
 pub fn bitcoin_primitives::transaction::VersionDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_primitives::transaction::VersionDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
 pub fn bitcoin_primitives::transaction::VersionDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_primitives::transaction::VersionDecoder
-pub fn bitcoin_primitives::transaction::VersionDecoder::clone(&self) -> bitcoin_primitives::transaction::VersionDecoder
 impl core::default::Default for bitcoin_primitives::transaction::VersionDecoder
 pub fn bitcoin_primitives::transaction::VersionDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_primitives::transaction::VersionDecoder
@@ -3804,18 +3714,12 @@ pub fn bitcoin_primitives::transaction::VersionDecoder::try_from(value: U) -> co
 impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::VersionDecoder where U: core::convert::TryFrom<T>
 pub type bitcoin_primitives::transaction::VersionDecoder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_primitives::transaction::VersionDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::VersionDecoder where T: core::clone::Clone
-pub type bitcoin_primitives::transaction::VersionDecoder::Owned = T
-pub fn bitcoin_primitives::transaction::VersionDecoder::clone_into(&self, target: &mut T)
-pub fn bitcoin_primitives::transaction::VersionDecoder::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_primitives::transaction::VersionDecoder where T: 'static + ?core::marker::Sized
 pub fn bitcoin_primitives::transaction::VersionDecoder::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::VersionDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::transaction::VersionDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::VersionDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::transaction::VersionDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::VersionDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::transaction::VersionDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::transaction::VersionDecoder
 pub fn bitcoin_primitives::transaction::VersionDecoder::from(t: T) -> T
 pub struct bitcoin_primitives::transaction::VersionDecoderError(_)
@@ -4316,8 +4220,6 @@ pub type bitcoin_primitives::witness::WitnessDecoder::Output = bitcoin_primitive
 pub fn bitcoin_primitives::witness::WitnessDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_primitives::witness::WitnessDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
 pub fn bitcoin_primitives::witness::WitnessDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_primitives::witness::WitnessDecoder
-pub fn bitcoin_primitives::witness::WitnessDecoder::clone(&self) -> bitcoin_primitives::witness::WitnessDecoder
 impl core::default::Default for bitcoin_primitives::witness::WitnessDecoder
 pub fn bitcoin_primitives::witness::WitnessDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_primitives::witness::WitnessDecoder
@@ -4337,18 +4239,12 @@ pub fn bitcoin_primitives::witness::WitnessDecoder::try_from(value: U) -> core::
 impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness::WitnessDecoder where U: core::convert::TryFrom<T>
 pub type bitcoin_primitives::witness::WitnessDecoder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_primitives::witness::WitnessDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness::WitnessDecoder where T: core::clone::Clone
-pub type bitcoin_primitives::witness::WitnessDecoder::Owned = T
-pub fn bitcoin_primitives::witness::WitnessDecoder::clone_into(&self, target: &mut T)
-pub fn bitcoin_primitives::witness::WitnessDecoder::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_primitives::witness::WitnessDecoder where T: 'static + ?core::marker::Sized
 pub fn bitcoin_primitives::witness::WitnessDecoder::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness::WitnessDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::witness::WitnessDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness::WitnessDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::witness::WitnessDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness::WitnessDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::witness::WitnessDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::witness::WitnessDecoder
 pub fn bitcoin_primitives::witness::WitnessDecoder::from(t: T) -> T
 pub struct bitcoin_primitives::witness::WitnessDecoderError(_)

--- a/primitives/api/no-features.txt
+++ b/primitives/api/no-features.txt
@@ -274,8 +274,6 @@ pub type bitcoin_primitives::block::BlockHashDecoder::Output = bitcoin_primitive
 pub fn bitcoin_primitives::block::BlockHashDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_primitives::block::BlockHashDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
 pub fn bitcoin_primitives::block::BlockHashDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_primitives::block::BlockHashDecoder
-pub fn bitcoin_primitives::block::BlockHashDecoder::clone(&self) -> bitcoin_primitives::block::BlockHashDecoder
 impl core::default::Default for bitcoin_primitives::block::BlockHashDecoder
 pub fn bitcoin_primitives::block::BlockHashDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_primitives::block::BlockHashDecoder
@@ -301,8 +299,6 @@ impl<T> core::borrow::Borrow<T> for bitcoin_primitives::block::BlockHashDecoder 
 pub fn bitcoin_primitives::block::BlockHashDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::block::BlockHashDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::block::BlockHashDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::block::BlockHashDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::block::BlockHashDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::block::BlockHashDecoder
 pub fn bitcoin_primitives::block::BlockHashDecoder::from(t: T) -> T
 pub struct bitcoin_primitives::block::BlockHashDecoderError(_)
@@ -446,8 +442,6 @@ pub type bitcoin_primitives::block::HeaderDecoder::Output = bitcoin_primitives::
 pub fn bitcoin_primitives::block::HeaderDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_primitives::block::HeaderDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
 pub fn bitcoin_primitives::block::HeaderDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_primitives::block::HeaderDecoder
-pub fn bitcoin_primitives::block::HeaderDecoder::clone(&self) -> bitcoin_primitives::block::HeaderDecoder
 impl core::default::Default for bitcoin_primitives::block::HeaderDecoder
 pub fn bitcoin_primitives::block::HeaderDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_primitives::block::HeaderDecoder
@@ -473,8 +467,6 @@ impl<T> core::borrow::Borrow<T> for bitcoin_primitives::block::HeaderDecoder whe
 pub fn bitcoin_primitives::block::HeaderDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::block::HeaderDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::block::HeaderDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::block::HeaderDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::block::HeaderDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::block::HeaderDecoder
 pub fn bitcoin_primitives::block::HeaderDecoder::from(t: T) -> T
 pub struct bitcoin_primitives::block::HeaderEncoder<'e>(_, _)
@@ -586,8 +578,6 @@ pub type bitcoin_primitives::block::VersionDecoder::Output = bitcoin_primitives:
 pub fn bitcoin_primitives::block::VersionDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_primitives::block::VersionDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
 pub fn bitcoin_primitives::block::VersionDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_primitives::block::VersionDecoder
-pub fn bitcoin_primitives::block::VersionDecoder::clone(&self) -> bitcoin_primitives::block::VersionDecoder
 impl core::default::Default for bitcoin_primitives::block::VersionDecoder
 pub fn bitcoin_primitives::block::VersionDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_primitives::block::VersionDecoder
@@ -613,8 +603,6 @@ impl<T> core::borrow::Borrow<T> for bitcoin_primitives::block::VersionDecoder wh
 pub fn bitcoin_primitives::block::VersionDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::block::VersionDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::block::VersionDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::block::VersionDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::block::VersionDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::block::VersionDecoder
 pub fn bitcoin_primitives::block::VersionDecoder::from(t: T) -> T
 pub struct bitcoin_primitives::block::VersionDecoderError(_)
@@ -817,8 +805,6 @@ pub type bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::Output = bitcoin_
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder
-pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::clone(&self) -> bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder
 impl core::default::Default for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder
@@ -844,8 +830,6 @@ impl<T> core::borrow::Borrow<T> for bitcoin_primitives::merkle_tree::TxMerkleNod
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoder::from(t: T) -> T
 pub struct bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError(_)
@@ -1070,8 +1054,6 @@ pub type bitcoin_primitives::block::BlockHashDecoder::Output = bitcoin_primitive
 pub fn bitcoin_primitives::block::BlockHashDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_primitives::block::BlockHashDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
 pub fn bitcoin_primitives::block::BlockHashDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_primitives::block::BlockHashDecoder
-pub fn bitcoin_primitives::block::BlockHashDecoder::clone(&self) -> bitcoin_primitives::block::BlockHashDecoder
 impl core::default::Default for bitcoin_primitives::block::BlockHashDecoder
 pub fn bitcoin_primitives::block::BlockHashDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_primitives::block::BlockHashDecoder
@@ -1097,8 +1079,6 @@ impl<T> core::borrow::Borrow<T> for bitcoin_primitives::block::BlockHashDecoder 
 pub fn bitcoin_primitives::block::BlockHashDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::block::BlockHashDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::block::BlockHashDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::block::BlockHashDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::block::BlockHashDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::block::BlockHashDecoder
 pub fn bitcoin_primitives::block::BlockHashDecoder::from(t: T) -> T
 pub struct bitcoin_primitives::transaction::BlockHashDecoderError(_)
@@ -1252,8 +1232,6 @@ pub type bitcoin_primitives::transaction::OutPointDecoder::Output = bitcoin_prim
 pub fn bitcoin_primitives::transaction::OutPointDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_primitives::transaction::OutPointDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
 pub fn bitcoin_primitives::transaction::OutPointDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_primitives::transaction::OutPointDecoder
-pub fn bitcoin_primitives::transaction::OutPointDecoder::clone(&self) -> bitcoin_primitives::transaction::OutPointDecoder
 impl core::default::Default for bitcoin_primitives::transaction::OutPointDecoder
 pub fn bitcoin_primitives::transaction::OutPointDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_primitives::transaction::OutPointDecoder
@@ -1279,8 +1257,6 @@ impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::OutPointDec
 pub fn bitcoin_primitives::transaction::OutPointDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::OutPointDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::transaction::OutPointDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::OutPointDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::transaction::OutPointDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::transaction::OutPointDecoder
 pub fn bitcoin_primitives::transaction::OutPointDecoder::from(t: T) -> T
 pub struct bitcoin_primitives::transaction::OutPointDecoderError(_)
@@ -1485,8 +1461,6 @@ pub type bitcoin_primitives::transaction::VersionDecoder::Output = bitcoin_primi
 pub fn bitcoin_primitives::transaction::VersionDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_primitives::transaction::VersionDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
 pub fn bitcoin_primitives::transaction::VersionDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_primitives::transaction::VersionDecoder
-pub fn bitcoin_primitives::transaction::VersionDecoder::clone(&self) -> bitcoin_primitives::transaction::VersionDecoder
 impl core::default::Default for bitcoin_primitives::transaction::VersionDecoder
 pub fn bitcoin_primitives::transaction::VersionDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_primitives::transaction::VersionDecoder
@@ -1512,8 +1486,6 @@ impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::VersionDeco
 pub fn bitcoin_primitives::transaction::VersionDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::VersionDecoder where T: ?core::marker::Sized
 pub fn bitcoin_primitives::transaction::VersionDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::VersionDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_primitives::transaction::VersionDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::transaction::VersionDecoder
 pub fn bitcoin_primitives::transaction::VersionDecoder::from(t: T) -> T
 pub struct bitcoin_primitives::transaction::VersionDecoderError(_)

--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -362,7 +362,7 @@ crate::decoder_newtype! {
     /// The decoder for the [`Block`] type.
     ///
     /// This decoder can only produce a `Block<Unchecked>`.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct BlockDecoder(BlockInnerDecoder);
 
     /// Constructs a new [`Block`] decoder.
@@ -564,7 +564,7 @@ type HeaderInnerDecoder = Decoder6<
 
 crate::decoder_newtype! {
     /// The decoder for the [`Header`] type.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct HeaderDecoder(HeaderInnerDecoder);
 
     /// Constructs a new [`Header`] decoder.
@@ -733,7 +733,7 @@ impl encoding::Encode for Version {
 
 crate::decoder_newtype! {
     /// The decoder for the [`Version`] type.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct VersionDecoder(encoding::ArrayDecoder<4>);
 
     /// Constructs a new [`Version`] decoder.
@@ -776,7 +776,7 @@ pub mod error {
     /// An error that occurs during parsing of a [`Block`] from a hex string.
     #[cfg(feature = "alloc")]
     #[cfg(feature = "hex")]
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct ParseBlockError(pub(super) ParsePrimitiveError<Block>);
 
     #[cfg(feature = "alloc")]
@@ -872,7 +872,7 @@ pub mod error {
 
     /// An error that occurs during parsing of a [`Header`] from a hex string.
     #[cfg(feature = "hex")]
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct ParseHeaderError(pub(super) ParsePrimitiveError<Header>);
 
     #[cfg(feature = "hex")]

--- a/primitives/src/hash_types/block_hash.rs
+++ b/primitives/src/hash_types/block_hash.rs
@@ -52,7 +52,7 @@ encoding::encoder_newtype_exact! {
 
 crate::decoder_newtype! {
     /// The decoder for the [`BlockHash`] type.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct BlockHashDecoder(encoding::ArrayDecoder<32>);
 
     /// Constructs a new [`BlockHash`] decoder.

--- a/primitives/src/hash_types/transaction_merkle_node.rs
+++ b/primitives/src/hash_types/transaction_merkle_node.rs
@@ -72,7 +72,7 @@ encoding::encoder_newtype_exact! {
 
 crate::decoder_newtype! {
     /// The decoder for the [`TxMerkleNode`] type.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct TxMerkleNodeDecoder(encoding::ArrayDecoder<32>);
 
     /// Constructs a new [`TxMerkleNode`] decoder.

--- a/primitives/src/hash_types/witness_merkle_node.rs
+++ b/primitives/src/hash_types/witness_merkle_node.rs
@@ -72,7 +72,7 @@ encoding::encoder_newtype_exact! {
 
 crate::decoder_newtype! {
     /// The decoder for the [`WitnessMerkleNode`] type.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct WitnessMerkleNodeDecoder(encoding::ArrayDecoder<32>);
 
     /// Constructs a new [`WitnessMerkleNode`] decoder.

--- a/primitives/src/script/owned.rs
+++ b/primitives/src/script/owned.rs
@@ -181,7 +181,7 @@ impl<T> DerefMut for ScriptBuf<T> {
 }
 
 /// The decoder for the [`ScriptBuf`] type.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ScriptBufDecoder<T>(ByteVecDecoder, PhantomData<T>);
 
 impl<T> ScriptBufDecoder<T> {

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -424,7 +424,7 @@ impl fmt::UpperHex for Transaction {
 
 /// The decoder for the [`Transaction`] type.
 #[cfg(feature = "alloc")]
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct TransactionDecoder {
     state: TransactionDecoderState,
 }
@@ -659,7 +659,7 @@ impl encoding::Decode for Transaction {
 
 /// The state of the transiting decoder.
 #[cfg(feature = "alloc")]
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 enum TransactionDecoderState {
     /// Decoding the transaction version.
     Version(VersionDecoder),
@@ -834,7 +834,7 @@ type TxInInnerDecoder = Decoder3<OutPointDecoder, ScriptSigBufDecoder, SequenceD
 #[cfg(feature = "alloc")]
 crate::decoder_newtype! {
     /// The decoder for the [`TxIn`] type.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct TxInDecoder(TxInInnerDecoder);
 
     /// Constructs a new [`TxIn`] decoder.
@@ -904,7 +904,7 @@ type TxOutInnerDecoder = Decoder2<AmountDecoder, ScriptPubKeyBufDecoder>;
 #[cfg(feature = "alloc")]
 crate::decoder_newtype! {
     /// The decoder for the [`TxOut`] type.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct TxOutDecoder(TxOutInnerDecoder);
 
     /// Constructs a new [`TxOut`] decoder.
@@ -1020,7 +1020,7 @@ fn parse_vout(s: &str) -> Result<u32, ParseOutPointError> {
 crate::decoder_newtype! {
     /// The decoder for the [`OutPoint`] type.
     // 32 for the txid + 4 for the vout
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct OutPointDecoder(encoding::ArrayDecoder<36>);
 
     /// Constructs a new [`OutPoint`] decoder.
@@ -1248,7 +1248,7 @@ impl encoding::Encode for Version {
 
 crate::decoder_newtype! {
     /// The decoder for the [`Version`] type.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct VersionDecoder(encoding::ArrayDecoder<4>);
 
     /// Constructs a new [`Version`] decoder.
@@ -1288,7 +1288,7 @@ pub mod error {
     /// An error that occurs during parsing of a [`Transaction`] from a hex string.
     #[cfg(feature = "alloc")]
     #[cfg(feature = "hex")]
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct ParseTransactionError(pub(super) ParsePrimitiveError<Transaction>);
 
     #[cfg(feature = "alloc")]

--- a/primitives/src/witness.rs
+++ b/primitives/src/witness.rs
@@ -304,7 +304,7 @@ impl encoding::Encoder for WitnessEncoder<'_> {
 
 /// The decoder for the [`Witness`] type.
 #[cfg(feature = "alloc")]
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct WitnessDecoder {
     /// The single buffer that will become the Witness content.
     /// The index entries are written at the beginning, then rotated in [`Self::end`].

--- a/units/api/all-features.txt
+++ b/units/api/all-features.txt
@@ -617,8 +617,6 @@ pub type bitcoin_units::locktime::absolute::LockTimeDecoder::Output = bitcoin_un
 pub fn bitcoin_units::locktime::absolute::LockTimeDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_units::locktime::absolute::LockTimeDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
 pub fn bitcoin_units::locktime::absolute::LockTimeDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_units::locktime::absolute::LockTimeDecoder
-pub fn bitcoin_units::locktime::absolute::LockTimeDecoder::clone(&self) -> bitcoin_units::locktime::absolute::LockTimeDecoder
 impl core::default::Default for bitcoin_units::locktime::absolute::LockTimeDecoder
 pub fn bitcoin_units::locktime::absolute::LockTimeDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_units::locktime::absolute::LockTimeDecoder
@@ -638,18 +636,12 @@ pub fn bitcoin_units::locktime::absolute::LockTimeDecoder::try_from(value: U) ->
 impl<T, U> core::convert::TryInto<U> for bitcoin_units::locktime::absolute::LockTimeDecoder where U: core::convert::TryFrom<T>
 pub type bitcoin_units::locktime::absolute::LockTimeDecoder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_units::locktime::absolute::LockTimeDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_units::locktime::absolute::LockTimeDecoder where T: core::clone::Clone
-pub type bitcoin_units::locktime::absolute::LockTimeDecoder::Owned = T
-pub fn bitcoin_units::locktime::absolute::LockTimeDecoder::clone_into(&self, target: &mut T)
-pub fn bitcoin_units::locktime::absolute::LockTimeDecoder::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_units::locktime::absolute::LockTimeDecoder where T: 'static + ?core::marker::Sized
 pub fn bitcoin_units::locktime::absolute::LockTimeDecoder::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_units::locktime::absolute::LockTimeDecoder where T: ?core::marker::Sized
 pub fn bitcoin_units::locktime::absolute::LockTimeDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_units::locktime::absolute::LockTimeDecoder where T: ?core::marker::Sized
 pub fn bitcoin_units::locktime::absolute::LockTimeDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::absolute::LockTimeDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_units::locktime::absolute::LockTimeDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_units::locktime::absolute::LockTimeDecoder
 pub fn bitcoin_units::locktime::absolute::LockTimeDecoder::from(t: T) -> T
 pub struct bitcoin_units::absolute::LockTimeDecoderError(_)
@@ -1958,8 +1950,6 @@ pub type bitcoin_units::amount::AmountDecoder::Output = bitcoin_units::Amount
 pub fn bitcoin_units::amount::AmountDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_units::amount::AmountDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
 pub fn bitcoin_units::amount::AmountDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_units::amount::AmountDecoder
-pub fn bitcoin_units::amount::AmountDecoder::clone(&self) -> bitcoin_units::amount::AmountDecoder
 impl core::default::Default for bitcoin_units::amount::AmountDecoder
 pub fn bitcoin_units::amount::AmountDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_units::amount::AmountDecoder
@@ -1979,18 +1969,12 @@ pub fn bitcoin_units::amount::AmountDecoder::try_from(value: U) -> core::result:
 impl<T, U> core::convert::TryInto<U> for bitcoin_units::amount::AmountDecoder where U: core::convert::TryFrom<T>
 pub type bitcoin_units::amount::AmountDecoder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_units::amount::AmountDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_units::amount::AmountDecoder where T: core::clone::Clone
-pub type bitcoin_units::amount::AmountDecoder::Owned = T
-pub fn bitcoin_units::amount::AmountDecoder::clone_into(&self, target: &mut T)
-pub fn bitcoin_units::amount::AmountDecoder::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_units::amount::AmountDecoder where T: 'static + ?core::marker::Sized
 pub fn bitcoin_units::amount::AmountDecoder::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_units::amount::AmountDecoder where T: ?core::marker::Sized
 pub fn bitcoin_units::amount::AmountDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_units::amount::AmountDecoder where T: ?core::marker::Sized
 pub fn bitcoin_units::amount::AmountDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_units::amount::AmountDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_units::amount::AmountDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_units::amount::AmountDecoder
 pub fn bitcoin_units::amount::AmountDecoder::from(t: T) -> T
 pub struct bitcoin_units::amount::AmountDecoderError(_)
@@ -3110,8 +3094,6 @@ pub type bitcoin_units::block::BlockHeightDecoder::Output = bitcoin_units::block
 pub fn bitcoin_units::block::BlockHeightDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_units::block::BlockHeightDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
 pub fn bitcoin_units::block::BlockHeightDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_units::block::BlockHeightDecoder
-pub fn bitcoin_units::block::BlockHeightDecoder::clone(&self) -> bitcoin_units::block::BlockHeightDecoder
 impl core::default::Default for bitcoin_units::block::BlockHeightDecoder
 pub fn bitcoin_units::block::BlockHeightDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_units::block::BlockHeightDecoder
@@ -3131,18 +3113,12 @@ pub fn bitcoin_units::block::BlockHeightDecoder::try_from(value: U) -> core::res
 impl<T, U> core::convert::TryInto<U> for bitcoin_units::block::BlockHeightDecoder where U: core::convert::TryFrom<T>
 pub type bitcoin_units::block::BlockHeightDecoder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_units::block::BlockHeightDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_units::block::BlockHeightDecoder where T: core::clone::Clone
-pub type bitcoin_units::block::BlockHeightDecoder::Owned = T
-pub fn bitcoin_units::block::BlockHeightDecoder::clone_into(&self, target: &mut T)
-pub fn bitcoin_units::block::BlockHeightDecoder::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_units::block::BlockHeightDecoder where T: 'static + ?core::marker::Sized
 pub fn bitcoin_units::block::BlockHeightDecoder::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_units::block::BlockHeightDecoder where T: ?core::marker::Sized
 pub fn bitcoin_units::block::BlockHeightDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_units::block::BlockHeightDecoder where T: ?core::marker::Sized
 pub fn bitcoin_units::block::BlockHeightDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_units::block::BlockHeightDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_units::block::BlockHeightDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_units::block::BlockHeightDecoder
 pub fn bitcoin_units::block::BlockHeightDecoder::from(t: T) -> T
 pub struct bitcoin_units::block::BlockHeightDecoderError(_)
@@ -4608,8 +4584,6 @@ pub type bitcoin_units::locktime::absolute::LockTimeDecoder::Output = bitcoin_un
 pub fn bitcoin_units::locktime::absolute::LockTimeDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_units::locktime::absolute::LockTimeDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
 pub fn bitcoin_units::locktime::absolute::LockTimeDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_units::locktime::absolute::LockTimeDecoder
-pub fn bitcoin_units::locktime::absolute::LockTimeDecoder::clone(&self) -> bitcoin_units::locktime::absolute::LockTimeDecoder
 impl core::default::Default for bitcoin_units::locktime::absolute::LockTimeDecoder
 pub fn bitcoin_units::locktime::absolute::LockTimeDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_units::locktime::absolute::LockTimeDecoder
@@ -4629,18 +4603,12 @@ pub fn bitcoin_units::locktime::absolute::LockTimeDecoder::try_from(value: U) ->
 impl<T, U> core::convert::TryInto<U> for bitcoin_units::locktime::absolute::LockTimeDecoder where U: core::convert::TryFrom<T>
 pub type bitcoin_units::locktime::absolute::LockTimeDecoder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_units::locktime::absolute::LockTimeDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_units::locktime::absolute::LockTimeDecoder where T: core::clone::Clone
-pub type bitcoin_units::locktime::absolute::LockTimeDecoder::Owned = T
-pub fn bitcoin_units::locktime::absolute::LockTimeDecoder::clone_into(&self, target: &mut T)
-pub fn bitcoin_units::locktime::absolute::LockTimeDecoder::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_units::locktime::absolute::LockTimeDecoder where T: 'static + ?core::marker::Sized
 pub fn bitcoin_units::locktime::absolute::LockTimeDecoder::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_units::locktime::absolute::LockTimeDecoder where T: ?core::marker::Sized
 pub fn bitcoin_units::locktime::absolute::LockTimeDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_units::locktime::absolute::LockTimeDecoder where T: ?core::marker::Sized
 pub fn bitcoin_units::locktime::absolute::LockTimeDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::absolute::LockTimeDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_units::locktime::absolute::LockTimeDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_units::locktime::absolute::LockTimeDecoder
 pub fn bitcoin_units::locktime::absolute::LockTimeDecoder::from(t: T) -> T
 pub struct bitcoin_units::locktime::absolute::LockTimeDecoderError(_)
@@ -6576,8 +6544,6 @@ pub type bitcoin_units::pow::CompactTargetDecoder::Output = bitcoin_units::pow::
 pub fn bitcoin_units::pow::CompactTargetDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_units::pow::CompactTargetDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
 pub fn bitcoin_units::pow::CompactTargetDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_units::pow::CompactTargetDecoder
-pub fn bitcoin_units::pow::CompactTargetDecoder::clone(&self) -> bitcoin_units::pow::CompactTargetDecoder
 impl core::default::Default for bitcoin_units::pow::CompactTargetDecoder
 pub fn bitcoin_units::pow::CompactTargetDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_units::pow::CompactTargetDecoder
@@ -6597,18 +6563,12 @@ pub fn bitcoin_units::pow::CompactTargetDecoder::try_from(value: U) -> core::res
 impl<T, U> core::convert::TryInto<U> for bitcoin_units::pow::CompactTargetDecoder where U: core::convert::TryFrom<T>
 pub type bitcoin_units::pow::CompactTargetDecoder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_units::pow::CompactTargetDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_units::pow::CompactTargetDecoder where T: core::clone::Clone
-pub type bitcoin_units::pow::CompactTargetDecoder::Owned = T
-pub fn bitcoin_units::pow::CompactTargetDecoder::clone_into(&self, target: &mut T)
-pub fn bitcoin_units::pow::CompactTargetDecoder::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_units::pow::CompactTargetDecoder where T: 'static + ?core::marker::Sized
 pub fn bitcoin_units::pow::CompactTargetDecoder::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_units::pow::CompactTargetDecoder where T: ?core::marker::Sized
 pub fn bitcoin_units::pow::CompactTargetDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_units::pow::CompactTargetDecoder where T: ?core::marker::Sized
 pub fn bitcoin_units::pow::CompactTargetDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_units::pow::CompactTargetDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_units::pow::CompactTargetDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_units::pow::CompactTargetDecoder
 pub fn bitcoin_units::pow::CompactTargetDecoder::from(t: T) -> T
 pub struct bitcoin_units::pow::CompactTargetDecoderError(_)
@@ -8843,8 +8803,6 @@ pub type bitcoin_units::sequence::SequenceDecoder::Output = bitcoin_units::seque
 pub fn bitcoin_units::sequence::SequenceDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_units::sequence::SequenceDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
 pub fn bitcoin_units::sequence::SequenceDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_units::sequence::SequenceDecoder
-pub fn bitcoin_units::sequence::SequenceDecoder::clone(&self) -> bitcoin_units::sequence::SequenceDecoder
 impl core::default::Default for bitcoin_units::sequence::SequenceDecoder
 pub fn bitcoin_units::sequence::SequenceDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_units::sequence::SequenceDecoder
@@ -8864,18 +8822,12 @@ pub fn bitcoin_units::sequence::SequenceDecoder::try_from(value: U) -> core::res
 impl<T, U> core::convert::TryInto<U> for bitcoin_units::sequence::SequenceDecoder where U: core::convert::TryFrom<T>
 pub type bitcoin_units::sequence::SequenceDecoder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_units::sequence::SequenceDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_units::sequence::SequenceDecoder where T: core::clone::Clone
-pub type bitcoin_units::sequence::SequenceDecoder::Owned = T
-pub fn bitcoin_units::sequence::SequenceDecoder::clone_into(&self, target: &mut T)
-pub fn bitcoin_units::sequence::SequenceDecoder::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_units::sequence::SequenceDecoder where T: 'static + ?core::marker::Sized
 pub fn bitcoin_units::sequence::SequenceDecoder::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_units::sequence::SequenceDecoder where T: ?core::marker::Sized
 pub fn bitcoin_units::sequence::SequenceDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_units::sequence::SequenceDecoder where T: ?core::marker::Sized
 pub fn bitcoin_units::sequence::SequenceDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_units::sequence::SequenceDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_units::sequence::SequenceDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_units::sequence::SequenceDecoder
 pub fn bitcoin_units::sequence::SequenceDecoder::from(t: T) -> T
 pub struct bitcoin_units::sequence::SequenceDecoderError(_)
@@ -9111,8 +9063,6 @@ pub type bitcoin_units::time::BlockTimeDecoder::Output = bitcoin_units::BlockTim
 pub fn bitcoin_units::time::BlockTimeDecoder::end(self) -> core::result::Result<Self::Output, Self::Error>
 pub fn bitcoin_units::time::BlockTimeDecoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::decode::DecoderStatus, Self::Error>
 pub fn bitcoin_units::time::BlockTimeDecoder::read_limit(&self) -> usize
-impl core::clone::Clone for bitcoin_units::time::BlockTimeDecoder
-pub fn bitcoin_units::time::BlockTimeDecoder::clone(&self) -> bitcoin_units::time::BlockTimeDecoder
 impl core::default::Default for bitcoin_units::time::BlockTimeDecoder
 pub fn bitcoin_units::time::BlockTimeDecoder::default() -> Self
 impl core::fmt::Debug for bitcoin_units::time::BlockTimeDecoder
@@ -9132,18 +9082,12 @@ pub fn bitcoin_units::time::BlockTimeDecoder::try_from(value: U) -> core::result
 impl<T, U> core::convert::TryInto<U> for bitcoin_units::time::BlockTimeDecoder where U: core::convert::TryFrom<T>
 pub type bitcoin_units::time::BlockTimeDecoder::Error = <U as core::convert::TryFrom<T>>::Error
 pub fn bitcoin_units::time::BlockTimeDecoder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_units::time::BlockTimeDecoder where T: core::clone::Clone
-pub type bitcoin_units::time::BlockTimeDecoder::Owned = T
-pub fn bitcoin_units::time::BlockTimeDecoder::clone_into(&self, target: &mut T)
-pub fn bitcoin_units::time::BlockTimeDecoder::to_owned(&self) -> T
 impl<T> core::any::Any for bitcoin_units::time::BlockTimeDecoder where T: 'static + ?core::marker::Sized
 pub fn bitcoin_units::time::BlockTimeDecoder::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for bitcoin_units::time::BlockTimeDecoder where T: ?core::marker::Sized
 pub fn bitcoin_units::time::BlockTimeDecoder::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_units::time::BlockTimeDecoder where T: ?core::marker::Sized
 pub fn bitcoin_units::time::BlockTimeDecoder::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_units::time::BlockTimeDecoder where T: core::clone::Clone
-pub unsafe fn bitcoin_units::time::BlockTimeDecoder::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_units::time::BlockTimeDecoder
 pub fn bitcoin_units::time::BlockTimeDecoder::from(t: T) -> T
 pub struct bitcoin_units::time::BlockTimeDecoderError(_)

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -638,7 +638,7 @@ encoding::encoder_newtype_exact! {
 #[cfg(feature = "encoding")]
 crate::decoder_newtype! {
     /// The decoder for the [`Amount`] type.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct AmountDecoder(encoding::ArrayDecoder<8>);
 
     /// Constructs a new [`Amount`] decoder.

--- a/units/src/block.rs
+++ b/units/src/block.rs
@@ -230,7 +230,7 @@ encoding::encoder_newtype_exact! {
 #[cfg(feature = "encoding")]
 crate::decoder_newtype! {
     /// The decoder for the [`BlockHeight`] type.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct BlockHeightDecoder(encoding::ArrayDecoder<4>);
 
     /// Constructs a new [`BlockHeight`] decoder.

--- a/units/src/locktime/absolute/mod.rs
+++ b/units/src/locktime/absolute/mod.rs
@@ -423,7 +423,7 @@ encoding::encoder_newtype_exact! {
 #[cfg(feature = "encoding")]
 crate::decoder_newtype! {
     /// The decoder for the [`LockTime`] type.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct LockTimeDecoder(encoding::ArrayDecoder<4>);
 
     /// Constructs a new [`LockTime`] decoder.

--- a/units/src/pow.rs
+++ b/units/src/pow.rs
@@ -328,7 +328,7 @@ encoding::encoder_newtype_exact! {
 #[cfg(feature = "encoding")]
 crate::decoder_newtype! {
     /// The decoder for the [`CompactTarget`] type.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct CompactTargetDecoder(encoding::ArrayDecoder<4>);
 
     /// Constructs a new [`CompactTarget`] decoder.

--- a/units/src/sequence.rs
+++ b/units/src/sequence.rs
@@ -284,7 +284,7 @@ encoding::encoder_newtype_exact! {
 #[cfg(feature = "encoding")]
 crate::decoder_newtype! {
     /// The decoder for the [`Sequence`] type.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct SequenceDecoder(encoding::ArrayDecoder<4>);
 
     /// Constructs a new [`Sequence`] decoder.

--- a/units/src/time.rs
+++ b/units/src/time.rs
@@ -143,7 +143,7 @@ encoding::encoder_newtype_exact! {
 #[cfg(feature = "encoding")]
 crate::decoder_newtype! {
     /// The decoder for the [`BlockTime`] type.
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct BlockTimeDecoder(encoding::ArrayDecoder<4>);
 
     /// Constructs a new [`BlockTime`] decoder.


### PR DESCRIPTION
@yancyribbens pointed out in https://github.com/rust-bitcoin/rust-bitcoin/pull/6210#issuecomment-4500633744 that it appears to be logically inconsistent for the decoders to implement `Clone` and not `Copy`. I couldn't remember any specific reason given for the `Clone` impls other that C-COMMON-TRAITS and at least requires the explicit `clone()` call?

Tossing this up at the 11th hour just to be sure we want to support `Clone`. Maybe just better docs on `Decoder` are required?