### PR TITLE
bip158: reject malformed filter counts

### DIFF
--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -698,6 +698,37 @@ mod test {
     }
 
     #[test]
+    fn malformed_filter_count_errors() {
+        use crate::consensus::Error::Parse as ConsensusParse;
+        use crate::consensus::ParseError::{MissingData, NonMinimalCompactSize};
+
+        let query = [hex!("000000")];
+        let reader = GcsFilterReader::new(0, 0, M, P);
+
+        let mut bytes = &[0xfd][..];
+        let result = reader.match_any(&mut bytes, query.iter().map(|v| v.as_slice()));
+        assert!(matches!(result, Err(Error::InvalidCompactSize(ConsensusParse(MissingData)))));
+
+        let mut bytes = &[0xfd][..];
+        let result = reader.match_all(&mut bytes, query.iter().map(|v| v.as_slice()));
+        assert!(matches!(result, Err(Error::InvalidCompactSize(ConsensusParse(MissingData)))));
+
+        let mut bytes = &[0xfd, 0xfc, 0x00][..];
+        let result = reader.match_any(&mut bytes, query.iter().map(|v| v.as_slice()));
+        assert!(matches!(
+            result,
+            Err(Error::InvalidCompactSize(ConsensusParse(NonMinimalCompactSize)))
+        ));
+
+        let mut bytes = &[0xfd, 0xfc, 0x00][..];
+        let result = reader.match_all(&mut bytes, query.iter().map(|v| v.as_slice()));
+        assert!(matches!(
+            result,
+            Err(Error::InvalidCompactSize(ConsensusParse(NonMinimalCompactSize)))
+        ));
+    }
+
+    #[test]
     fn bit_stream() {
         let mut out = Vec::new();
         {

--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -222,7 +222,7 @@ impl GcsFilterReader {
         I::Item: Borrow<[u8]>,
         R: BufRead + ?Sized,
     {
-        let n_elements = reader.read_compact_size().unwrap_or(0);
+        let n_elements = reader.read_compact_size().map_err(Error::InvalidCompactSize)?;
         // map hashes to [0, n_elements << grp]
         let nm = n_elements * self.m;
         let mut mapped =
@@ -265,7 +265,7 @@ impl GcsFilterReader {
         I::Item: Borrow<[u8]>,
         R: BufRead + ?Sized,
     {
-        let n_elements = reader.read_compact_size().unwrap_or(0);
+        let n_elements = reader.read_compact_size().map_err(Error::InvalidCompactSize)?;
         // map hashes to [0, n_elements << grp]
         let nm = n_elements * self.m;
         let mut mapped =

--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -503,6 +503,7 @@ pub mod error {
 
     use internals::write_err;
 
+    use crate::consensus;
     use crate::transaction::OutPoint;
 
     /// Errors for blockfilter.
@@ -511,6 +512,8 @@ pub mod error {
     pub enum Error {
         /// Missing UTXO, cannot calculate script filter.
         UtxoMissing(OutPoint),
+        /// Invalid CompactSize encoded element count in the filter.
+        InvalidCompactSize(consensus::Error),
         /// I/O error reading or writing binary serialization of the filter.
         Io(io::Error),
     }
@@ -523,6 +526,7 @@ pub mod error {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             match self {
                 Self::UtxoMissing(ref coin) => write!(f, "unresolved UTXO {}", coin),
+                Self::InvalidCompactSize(ref e) => write_err!(f, "invalid CompactSize"; e),
                 Self::Io(ref e) => write_err!(f, "I/O error"; e),
             }
         }
@@ -533,6 +537,7 @@ pub mod error {
         fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
             match self {
                 Self::UtxoMissing(_) => None,
+                Self::InvalidCompactSize(ref e) => Some(e),
                 Self::Io(ref e) => Some(e),
             }
         }


### PR DESCRIPTION
I found a small discrepancy of bip158.rs from BIP-158.

[BIP-158](https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki) says:

> Since the value N is required to decode a GCS, a serialized GCS includes it as a prefix, written as a CompactSize. Thus, the complete serialization of a filter is:
>   - N, encoded as a CompactSize
>   - The bytes of the compressed filter itself
>
> A zero element filter MUST be written as one byte containing zeroes. 

If the node serving filters sends a malformed N, the current version of the code interprets it as N = 0. If N is really 0, it must send a single zero byte. So N = 0 is a legitimate value, but it should be encoded as 0x00, not as malformed data.

The bug has no security impact, since the remote node may just send 0x00 to get the same outcome. But it is still worth fixing, so the client can classify the outcome as an error rather than as missing data. If the client has a single peer, it may misclassify a broken peer as missing data, resulting in false negatives.

I had to add InvalidCompactSize variant to enum Error for it to work. Also added a test covering both affected functions and both types of malformed input.

🤖 Assisted-by: OpenAI GPT-5

I know that first-time contributors are discouraged from using AI, but there is a bug here worth fixing, so I'll give it a try.