### PR TITLE
Fix bug in `LeafVerison::Future`'s `Display` output

### DIFF
--- a/taproot-primitives/src/lib.rs
+++ b/taproot-primitives/src/lib.rs
@@ -339,3 +339,15 @@ impl<'a> Arbitrary<'a> for LeafVersion {
         }
     }
 }
+
+#[cfg(test)]
+#[cfg(feature = "alloc")]
+mod test {
+    use super::*;
+
+    #[test]
+    fn leaf_version_future_fmt() {
+        let v = LeafVersion::Future(FutureLeafVersion(1));
+        assert_eq!(alloc::format!("{:#}", v), "future_script_0x01");
+    }
+}

--- a/taproot-primitives/src/lib.rs
+++ b/taproot-primitives/src/lib.rs
@@ -165,7 +165,7 @@ impl fmt::Display for LeafVersion {
         match (self, f.alternate()) {
             (Self::TapScript, true) => f.write_str("tapscript"),
             (Self::TapScript, false) => fmt::Display::fmt(&TAPROOT_LEAF_TAPSCRIPT, f),
-            (Self::Future(version), true) => write!(f, "future_script_{:#02x}", version.0),
+            (Self::Future(version), true) => write!(f, "future_script_{:#04x}", version.0),
             (Self::Future(version), false) => fmt::Display::fmt(version, f),
         }
     }


### PR DESCRIPTION
This is a _forward port_ of #6208. I.e. I found the bug in `0.32.x` and fixed it there without checking on master at the time - face palm.

On this branch the fix is in `taproot-primitives` and I put the test there too even though all other Taproot tests were left in `bitcoin::taproot` still. This one needs access to a private field. 