### PR TITLE
backport: Fix bug in `LeafVerison::Future`'s `Display` output

### DIFF
--- a/bitcoin/src/taproot.rs
+++ b/bitcoin/src/taproot.rs
@@ -1978,4 +1978,10 @@ mod test {
         let json_str = include_str!("../tests/data/bip341_tests.json");
         serde_json::from_str(json_str).expect("JSON was not well-formatted")
     }
+
+    #[test]
+    fn leaf_version_future_fmt() {
+        let v = LeafVersion::Future(FutureLeafVersion(1));
+        assert_eq!(format!("{:#}", v), "future_script_0x01");
+    }
 }

--- a/bitcoin/src/taproot.rs
+++ b/bitcoin/src/taproot.rs
@@ -1366,7 +1366,7 @@ impl fmt::Display for LeafVersion {
         match (self, f.alternate()) {
             (LeafVersion::TapScript, true) => f.write_str("tapscript"),
             (LeafVersion::TapScript, false) => fmt::Display::fmt(&TAPROOT_LEAF_TAPSCRIPT, f),
-            (LeafVersion::Future(version), true) => write!(f, "future_script_{:#02x}", version.0),
+            (LeafVersion::Future(version), true) => write!(f, "future_script_{:#04x}", version.0),
             (LeafVersion::Future(version), false) => fmt::Display::fmt(version, f),
         }
     }


### PR DESCRIPTION
Backport #6208 to `0.31.x` - fix the width specifier in `Display` impl.