### PR TITLE
p2p: refactor: use `take()` in place of `replace()`

### DIFF
--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -1357,19 +1357,8 @@ impl encoding::Decoder for V1NetworkMessageDecoder {
                 })?;
 
                 if status.is_ready() {
-                    // Header complete, extract values and transition to payload state.
-                    let old_state = core::mem::replace(
-                        &mut self.state,
-                        DecoderState::ReadingHeader {
-                            header_decoder: <V1MessageHeader as encoding::Decode>::decoder(),
-                        },
-                    );
-
-                    let DecoderState::ReadingHeader { header_decoder } = old_state else {
-                        unreachable!("we are in ReadingHeader state")
-                    };
-
-                    let header = header_decoder.end().map_err(|e| {
+                    let decoder = core::mem::take(header_decoder);
+                    let header = decoder.end().map_err(|e| {
                         V1NetworkMessageDecoderError(V1NetworkMessageDecoderErrorInner::Header(e))
                     })?;
                     let payload_len = usize::try_from(header.length)


### PR DESCRIPTION
The `end()` method consumes the decoder, requiring the `DecoderState` enum to give up ownership. `mem::replace()` is used to copy the state thus releasing ownership by `DecoderState`.  However, since the header has been fully read at this point (decoder is ready), the state is transitioned to `ReadingPayload` and therefore, the header decoder state does not need to be stored as it will not be returned to.

Furthermore, it's possible to remove `clone()` also if `header_decoder`implemented the Copy trait.  Although, there has not been agreement that implementing the `Copy` trait for decoders is desirable.

To validate this refactor, ran local tests and also tested change with the p2p examples in the examples directory.