### PR TITLE
hashes: Promote BLOCK_SIZE assertion to hard assert

### DIFF
--- a/hashes/src/hmac/mod.rs
+++ b/hashes/src/hmac/mod.rs
@@ -99,7 +99,7 @@ impl<T: HashEngine> HmacEngine<T> {
     where
         T: Default,
     {
-        debug_assert!(T::BLOCK_SIZE <= 128);
+        assert!(T::BLOCK_SIZE <= 128);
 
         let mut ipad = [0x36u8; 128];
         let mut opad = [0x5cu8; 128];


### PR DESCRIPTION
The debug_assert only fires in debug builds; a downstream HashEngine implementation with BLOCK_SIZE > 128 would silently produce wrong outputs in release builds by indexing into fixed-size 128-byte ipad/opad buffers beyond their length.

Change to assert! so the check is unconditional.

Assisted-by: claude-sonnet-4.6