### PR TITLE
Exclude `ExactSizeEncoder::is_empty` in `mutants.toml`

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -78,4 +78,5 @@ exclude_re = [
     "consensus_encoding/.* DecoderStatus::is_ready", # Replacing with true causes an infinite loop
     "consensus_encoding/.* delete ! in drain_to_vec", # Causes an infinite loop.
     "consensus_encoding/.* delete ! in drain_to_writer", # Causes an infinite loop.
+    "consensus_encoding/.* ExactSizeEncoder::is_empty", # Too trivial to test.
 ]


### PR DESCRIPTION
Encoder tests has been updated to test the outcome of encoders, and not the internal details of the encoder, `is_empty` is a default method which is too trivial to test.

closes #6227