### PR TITLE
hashes: Add compat layer

### DIFF
--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -18,13 +18,15 @@ exclude = ["api", "tests", "contrib"]
 
 [features]
 default = ["std"]
-std = ["alloc", "hex/std", "bitcoin-io/std"]
-alloc = ["hex/alloc"]
+std = ["alloc", "hex/std", "bitcoin-io/std", "bitcoin-hashes-stable?/std"]
+alloc = ["hex/alloc", "bitcoin-hashes-stable?/alloc"]
 schemars = ["actual-schemars", "alloc"]
 # If you want I/O you must enable either "std" or "io".
 io = ["bitcoin-io"]
 # Smaller (but slower) implementation of sha256, sha512 and ripemd160
 small-hash = []
+# Enable compatability layer between this version and `bitcoin_hashes v1.0.0`.
+compat = ["bitcoin-hashes-stable"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -37,6 +39,9 @@ bitcoin-io = { version = "0.1.1", default-features = false, optional = true }
 # Do NOT use this as a feature! Use the `schemars` feature instead.
 actual-schemars = { package = "schemars", version = "0.8.3", default-features = false, optional = true }
 serde = { version = "1.0.130", default-features = false, optional = true }
+# Do not use this feature, use `compat` instead.
+# Release tracking PR: https://github.com/rust-bitcoin/rust-bitcoin/pull/6229
+bitcoin-hashes-stable = { package = "bitcoin_hashes", git = "https://github.com/tcharding/rust-bitcoin", branch = "push-ypqsqskuysov", default-features = false, optional = true }
 
 [dev-dependencies]
 serde_test = "1.0.19"
@@ -58,4 +63,9 @@ exact_features = [
     ["std", "small-hash"],
     ["alloc", "serde", "small-hash"],
     ["std", "serde", "small-hash"],
+]
+
+[package.metadata.rbmt.lint]
+allowed_duplicates = [
+    "bitcoin_hashes",
 ]

--- a/hashes/api/all-features.txt
+++ b/hashes/api/all-features.txt
@@ -8,6 +8,8 @@ pub mod bitcoin_hashes::hash160
 impl bitcoin_hashes::hash160::Hash
 pub fn bitcoin_hashes::hash160::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
 pub fn bitcoin_hashes::hash160::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub fn bitcoin_hashes::hash160::Hash::from_stable(stable: bitcoin_hashes::hash160::Hash) -> Self
+pub fn bitcoin_hashes::hash160::Hash::to_stable(self) -> bitcoin_hashes::hash160::Hash
 impl bitcoin_hashes::Hash for bitcoin_hashes::hash160::Hash
 pub type bitcoin_hashes::hash160::Hash::Bytes = [u8; 20]
 pub type bitcoin_hashes::hash160::Hash::Engine = bitcoin_hashes::sha256::HashEngine
@@ -96,6 +98,9 @@ pub fn bitcoin_hashes::hash160::Hash::__clone_box(&self, _: dyn_clone::sealed::P
 impl<T> serde::de::DeserializeOwned for bitcoin_hashes::hash160::Hash where T: for<'de> serde::de::Deserialize<'de>
 pub mod bitcoin_hashes::hmac
 #[repr(transparent)] pub struct bitcoin_hashes::hmac::Hmac<T: bitcoin_hashes::Hash>(_)
+impl<T: bitcoin_hashes::Hash> bitcoin_hashes::hmac::Hmac<T>
+pub fn bitcoin_hashes::hmac::Hmac<T>::from_stable<S>(stable_hmac: bitcoin_hashes::hmac::Hmac<S>) -> Self where S: bitcoin_hashes::Hash<Bytes = <T as bitcoin_hashes::Hash>::Bytes>
+pub fn bitcoin_hashes::hmac::Hmac<T>::to_stable<S>(self) -> bitcoin_hashes::hmac::Hmac<S> where S: bitcoin_hashes::Hash<Bytes = <T as bitcoin_hashes::Hash>::Bytes>
 impl<'de, T: bitcoin_hashes::Hash + serde::de::Deserialize<'de>> serde::de::Deserialize<'de> for bitcoin_hashes::hmac::Hmac<T>
 pub fn bitcoin_hashes::hmac::Hmac<T>::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::hmac::Hmac<T>, <D as serde::de::Deserializer>::Error>
 impl<T: bitcoin_hashes::Hash + core::str::traits::FromStr> core::str::traits::FromStr for bitcoin_hashes::hmac::Hmac<T>
@@ -264,6 +269,8 @@ pub mod bitcoin_hashes::ripemd160
 impl bitcoin_hashes::ripemd160::Hash
 pub fn bitcoin_hashes::ripemd160::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
 pub fn bitcoin_hashes::ripemd160::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub fn bitcoin_hashes::ripemd160::Hash::from_stable(stable: bitcoin_hashes::ripemd160::Hash) -> Self
+pub fn bitcoin_hashes::ripemd160::Hash::to_stable(self) -> bitcoin_hashes::ripemd160::Hash
 impl bitcoin_hashes::Hash for bitcoin_hashes::ripemd160::Hash
 pub type bitcoin_hashes::ripemd160::Hash::Bytes = [u8; 20]
 pub type bitcoin_hashes::ripemd160::Hash::Engine = bitcoin_hashes::ripemd160::HashEngine
@@ -437,6 +444,8 @@ pub mod bitcoin_hashes::sha1
 impl bitcoin_hashes::sha1::Hash
 pub fn bitcoin_hashes::sha1::Hash::from_bytes_mut(bytes: &mut [u8; 20]) -> &mut Self
 pub fn bitcoin_hashes::sha1::Hash::from_bytes_ref(bytes: &[u8; 20]) -> &Self
+pub fn bitcoin_hashes::sha1::Hash::from_stable(stable: bitcoin_hashes::sha1::Hash) -> Self
+pub fn bitcoin_hashes::sha1::Hash::to_stable(self) -> bitcoin_hashes::sha1::Hash
 impl bitcoin_hashes::Hash for bitcoin_hashes::sha1::Hash
 pub type bitcoin_hashes::sha1::Hash::Bytes = [u8; 20]
 pub type bitcoin_hashes::sha1::Hash::Engine = bitcoin_hashes::sha1::HashEngine
@@ -575,6 +584,8 @@ pub const fn bitcoin_hashes::sha256::Hash::const_hash(bytes: &[u8]) -> Self
 pub fn bitcoin_hashes::sha256::Hash::hash_again(&self) -> bitcoin_hashes::sha256d::Hash
 pub fn bitcoin_hashes::sha256::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
 pub fn bitcoin_hashes::sha256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha256::Hash::from_stable(stable: bitcoin_hashes::sha256::Hash) -> Self
+pub fn bitcoin_hashes::sha256::Hash::to_stable(self) -> bitcoin_hashes::sha256::Hash
 impl bitcoin_hashes::Hash for bitcoin_hashes::sha256::Hash
 pub type bitcoin_hashes::sha256::Hash::Bytes = [u8; 32]
 pub type bitcoin_hashes::sha256::Hash::Engine = bitcoin_hashes::sha256::HashEngine
@@ -661,6 +672,8 @@ impl<T> serde::de::DeserializeOwned for bitcoin_hashes::sha256::Hash where T: fo
 pub struct bitcoin_hashes::sha256::HashEngine
 impl bitcoin_hashes::sha256::HashEngine
 pub fn bitcoin_hashes::sha256::HashEngine::from_midstate(midstate: bitcoin_hashes::sha256::Midstate, length: usize) -> bitcoin_hashes::sha256::HashEngine
+pub fn bitcoin_hashes::sha256::HashEngine::from_stable(stable_engine: bitcoin_hashes::sha256::HashEngine) -> Self
+pub fn bitcoin_hashes::sha256::HashEngine::to_stable(self) -> bitcoin_hashes::sha256::HashEngine
 impl bitcoin_hashes::HashEngine for bitcoin_hashes::sha256::HashEngine
 pub type bitcoin_hashes::sha256::HashEngine::MidState = bitcoin_hashes::sha256::Midstate
 pub const bitcoin_hashes::sha256::HashEngine::BLOCK_SIZE: usize
@@ -714,6 +727,8 @@ pub const fn bitcoin_hashes::sha256::Midstate::from_byte_array(inner: [u8; 32]) 
 pub fn bitcoin_hashes::sha256::Midstate::from_slice(sl: &[u8]) -> core::result::Result<bitcoin_hashes::sha256::Midstate, bitcoin_hashes::FromSliceError>
 pub const fn bitcoin_hashes::sha256::Midstate::hash_tag(tag: &[u8]) -> Self
 pub fn bitcoin_hashes::sha256::Midstate::to_byte_array(self) -> [u8; 32]
+pub fn bitcoin_hashes::sha256::Midstate::from_stable(stable: bitcoin_hashes::sha256::Midstate) -> Self
+pub fn bitcoin_hashes::sha256::Midstate::to_stable(self, bytes_hashed: u64) -> bitcoin_hashes::sha256::Midstate
 impl core::borrow::Borrow<[u8]> for bitcoin_hashes::sha256::Midstate
 pub fn bitcoin_hashes::sha256::Midstate::borrow(&self) -> &[u8]
 impl core::clone::Clone for bitcoin_hashes::sha256::Midstate
@@ -790,6 +805,8 @@ pub mod bitcoin_hashes::sha256d
 impl bitcoin_hashes::sha256d::Hash
 pub fn bitcoin_hashes::sha256d::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
 pub fn bitcoin_hashes::sha256d::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha256d::Hash::from_stable(stable: bitcoin_hashes::sha256d::Hash) -> Self
+pub fn bitcoin_hashes::sha256d::Hash::to_stable(self) -> bitcoin_hashes::sha256d::Hash
 impl bitcoin_hashes::Hash for bitcoin_hashes::sha256d::Hash
 pub type bitcoin_hashes::sha256d::Hash::Bytes = [u8; 32]
 pub type bitcoin_hashes::sha256d::Hash::Engine = bitcoin_hashes::sha256::HashEngine
@@ -878,6 +895,8 @@ pub mod bitcoin_hashes::sha256t
 impl<T: bitcoin_hashes::sha256t::Tag> bitcoin_hashes::sha256t::Hash<T>
 pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
 pub fn bitcoin_hashes::sha256t::Hash<T>::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha256t::Hash<T>::from_stable<S>(stable: bitcoin_hashes::sha256t::Hash<S>) -> Self where S: bitcoin_hashes::sha256t::Tag
+pub fn bitcoin_hashes::sha256t::Hash<T>::to_stable<S>(self) -> bitcoin_hashes::sha256t::Hash<S> where S: bitcoin_hashes::sha256t::Tag
 impl<'de, T: bitcoin_hashes::sha256t::Tag> serde::de::Deserialize<'de> for bitcoin_hashes::sha256t::Hash<T>
 pub fn bitcoin_hashes::sha256t::Hash<T>::deserialize<D: serde::de::Deserializer<'de>>(d: D) -> core::result::Result<bitcoin_hashes::sha256t::Hash<T>, <D as serde::de::Deserializer>::Error>
 impl<I: core::slice::index::SliceIndex<[u8]>, T: bitcoin_hashes::sha256t::Tag> core::ops::index::Index<I> for bitcoin_hashes::sha256t::Hash<T>
@@ -969,6 +988,8 @@ pub mod bitcoin_hashes::sha384
 impl bitcoin_hashes::sha384::Hash
 pub fn bitcoin_hashes::sha384::Hash::from_bytes_mut(bytes: &mut [u8; 48]) -> &mut Self
 pub fn bitcoin_hashes::sha384::Hash::from_bytes_ref(bytes: &[u8; 48]) -> &Self
+pub fn bitcoin_hashes::sha384::Hash::from_stable(stable: bitcoin_hashes::sha384::Hash) -> Self
+pub fn bitcoin_hashes::sha384::Hash::to_stable(self) -> bitcoin_hashes::sha384::Hash
 impl bitcoin_hashes::Hash for bitcoin_hashes::sha384::Hash
 pub type bitcoin_hashes::sha384::Hash::Bytes = [u8; 48]
 pub type bitcoin_hashes::sha384::Hash::Engine = bitcoin_hashes::sha384::HashEngine
@@ -1099,6 +1120,8 @@ pub mod bitcoin_hashes::sha512
 impl bitcoin_hashes::sha512::Hash
 pub fn bitcoin_hashes::sha512::Hash::from_bytes_mut(bytes: &mut [u8; 64]) -> &mut Self
 pub fn bitcoin_hashes::sha512::Hash::from_bytes_ref(bytes: &[u8; 64]) -> &Self
+pub fn bitcoin_hashes::sha512::Hash::from_stable(stable: bitcoin_hashes::sha512::Hash) -> Self
+pub fn bitcoin_hashes::sha512::Hash::to_stable(self) -> bitcoin_hashes::sha512::Hash
 impl bitcoin_hashes::Hash for bitcoin_hashes::sha512::Hash
 pub type bitcoin_hashes::sha512::Hash::Bytes = [u8; 64]
 pub type bitcoin_hashes::sha512::Hash::Engine = bitcoin_hashes::sha512::HashEngine
@@ -1235,6 +1258,8 @@ pub mod bitcoin_hashes::sha512_256
 impl bitcoin_hashes::sha512_256::Hash
 pub fn bitcoin_hashes::sha512_256::Hash::from_bytes_mut(bytes: &mut [u8; 32]) -> &mut Self
 pub fn bitcoin_hashes::sha512_256::Hash::from_bytes_ref(bytes: &[u8; 32]) -> &Self
+pub fn bitcoin_hashes::sha512_256::Hash::from_stable(stable: bitcoin_hashes::sha512_256::Hash) -> Self
+pub fn bitcoin_hashes::sha512_256::Hash::to_stable(self) -> bitcoin_hashes::sha512_256::Hash
 impl bitcoin_hashes::Hash for bitcoin_hashes::sha512_256::Hash
 pub type bitcoin_hashes::sha512_256::Hash::Bytes = [u8; 32]
 pub type bitcoin_hashes::sha512_256::Hash::Engine = bitcoin_hashes::sha512_256::HashEngine
@@ -1370,6 +1395,8 @@ pub fn bitcoin_hashes::siphash24::Hash::hash_to_u64_with_keys(k0: u64, k1: u64, 
 pub fn bitcoin_hashes::siphash24::Hash::hash_with_keys(k0: u64, k1: u64, data: &[u8]) -> bitcoin_hashes::siphash24::Hash
 pub fn bitcoin_hashes::siphash24::Hash::from_bytes_mut(bytes: &mut [u8; 8]) -> &mut Self
 pub fn bitcoin_hashes::siphash24::Hash::from_bytes_ref(bytes: &[u8; 8]) -> &Self
+pub fn bitcoin_hashes::siphash24::Hash::from_stable(stable: bitcoin_hashes::siphash24::Hash) -> Self
+pub fn bitcoin_hashes::siphash24::Hash::to_stable(self) -> bitcoin_hashes::siphash24::Hash
 impl bitcoin_hashes::Hash for bitcoin_hashes::siphash24::Hash
 pub type bitcoin_hashes::siphash24::Hash::Bytes = [u8; 8]
 pub type bitcoin_hashes::siphash24::Hash::Engine = bitcoin_hashes::siphash24::HashEngine

--- a/hashes/src/compat.rs
+++ b/hashes/src/compat.rs
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Comparability layer
+//!
+//! For converting pre-1.0 types into their 1.0 (stable) equivalent.
+//!
+//! ## Naming convention
+//!
+//! We are aiming for an ergonomic API that is in line with the Rust API naming conventions. Since
+//! some types here are `Copy` and some are not we have two choices:
+//!
+//! 1. Use `into_foo()` for non-`Copy` type coupled with `to_foo()` for `Copy` types.
+//! 2. Use `to_foo()` for both with `Copy` types consuming `self` and non-`Copy` types taking borrowing `self`.
+//!
+//! We elected to do (2).
+//!
+//! ref: https://rust-lang.github.io/api-guidelines/naming.html#ad-hoc-conversions-follow-as_-to_-into_-conventions-c-conv
+
+// Where possible we use getters and setters instead of accessing private fields.
+
+use bitcoin_hashes_stable as stable;
+
+mod hash160 {
+    use super::stable;
+    use crate::hash160::Hash;
+    use crate::Hash as _;
+
+    impl Hash {
+        /// Converts pre-1.0 type to a stable type.
+        pub fn to_stable(self) -> stable::hash160::Hash {
+            stable::hash160::Hash::from_byte_array(self.to_byte_array())
+        }
+
+        /// Converts a stable type to a pre-1.0 type.
+        pub fn from_stable(stable: stable::hash160::Hash) -> Self {
+            Self::from_byte_array(stable.to_byte_array())
+        }
+    }
+}
+
+mod hmac {
+    use super::stable;
+    use crate::{Hmac, Hash as _};
+
+    // (Tobin) I'm not exactly sure why we need this. Something to do with the trait bound I'd say.
+    use stable::Hash as _;
+
+    impl<T: crate::Hash> Hmac<T> {
+        /// Converts pre-1.0 type to a stable type.
+        ///
+        /// The type parameter `S` is the stable inner hash type and must have the same byte
+        /// representation as `T` (i.e. `S::Bytes = T::Bytes`).
+        pub fn to_stable<S>(self) -> stable::Hmac<S>
+        where
+            S: stable::Hash<Bytes = T::Bytes>,
+        {
+            stable::Hmac::<S>::from_byte_array(self.to_byte_array())
+        }
+
+        /// Converts a stable type to a pre-1.0 type.
+        ///
+        /// The type parameter `S` is the stable inner hash type and must have the same byte
+        /// representation as `T` (i.e. `S::Bytes = T::Bytes`).
+        pub fn from_stable<S>(stable_hmac: stable::Hmac<S>) -> Self
+        where
+            S: stable::Hash<Bytes = T::Bytes>,
+        {
+            Self::from_byte_array(stable_hmac.to_byte_array())
+        }
+    }
+}
+
+mod ripemd160 {
+    use super::stable;
+    use crate::ripemd160::Hash;
+    use crate::Hash as _;
+
+    impl Hash {
+        /// Converts pre-1.0 type to a stable type.
+        pub fn to_stable(self) -> stable::ripemd160::Hash {
+            stable::ripemd160::Hash::from_byte_array(self.to_byte_array())
+        }
+
+        /// Converts a stable type to a pre-1.0 type.
+        pub fn from_stable(stable: stable::ripemd160::Hash) -> Self {
+            Self::from_byte_array(stable.to_byte_array())
+        }
+    }
+}
+
+mod sha1 {
+    use super::stable;
+    use crate::sha1::Hash;
+    use crate::Hash as _;
+
+    impl Hash {
+        /// Converts pre-1.0 type to a stable type.
+        pub fn to_stable(self) -> stable::sha1::Hash {
+            stable::sha1::Hash::from_byte_array(self.to_byte_array())
+        }
+
+        /// Converts a stable type to a pre-1.0 type.
+        pub fn from_stable(stable: stable::sha1::Hash) -> Self {
+            Self::from_byte_array(stable.to_byte_array())
+        }
+    }
+}
+
+mod sha256 {
+    use super::stable;
+    use crate::sha256::Hash;
+    use crate::Hash as _;
+
+    impl Hash {
+        /// Converts pre-1.0 type to a stable type.
+        pub fn to_stable(self) -> stable::sha256::Hash {
+            stable::sha256::Hash::from_byte_array(self.to_byte_array())
+        }
+
+        /// Converts a stable type to a pre-1.0 type.
+        pub fn from_stable(stable: stable::sha256::Hash) -> Self {
+            Self::from_byte_array(stable.to_byte_array())
+        }
+    }
+}
+
+mod sha256d {
+    use super::stable;
+    use crate::sha256d::Hash;
+    use crate::Hash as _;
+
+    impl Hash {
+        /// Converts pre-1.0 type to a stable type.
+        pub fn to_stable(self) -> stable::sha256d::Hash {
+            stable::sha256d::Hash::from_byte_array(self.to_byte_array())
+        }
+
+        /// Converts a stable type to a pre-1.0 type.
+        pub fn from_stable(stable: stable::sha256d::Hash) -> Self {
+            Self::from_byte_array(stable.to_byte_array())
+        }
+    }
+}
+
+mod sha256t {
+    use super::stable;
+    use crate::sha256t::{Hash, Tag};
+    use crate::Hash as _;
+
+    impl<T: Tag> Hash<T> {
+        /// Converts pre-1.0 type to a stable type.
+        pub fn to_stable<S>(self) -> stable::sha256t::Hash<S>
+        where
+            S: stable::sha256t::Tag,
+        {
+            stable::sha256t::Hash::<S>::from_byte_array(self.to_byte_array())
+        }
+
+        /// Converts a stable type to a pre-1.0 type.
+        pub fn from_stable<S>(stable: stable::sha256t::Hash<S>) -> Self
+        where
+            S: stable::sha256t::Tag,
+        {
+            Self::from_byte_array(stable.to_byte_array())
+        }
+    }
+}
+
+mod sha384 {
+    use super::stable;
+    use crate::sha384::Hash;
+    use crate::Hash as _;
+
+    impl Hash {
+        /// Converts pre-1.0 type to a stable type.
+        pub fn to_stable(self) -> stable::sha384::Hash {
+            stable::sha384::Hash::from_byte_array(self.to_byte_array())
+        }
+
+        /// Converts a stable type to a pre-1.0 type.
+        pub fn from_stable(stable: stable::sha384::Hash) -> Self {
+            Self::from_byte_array(stable.to_byte_array())
+        }
+    }
+}
+
+mod sha512 {
+    use super::stable;
+    use crate::sha512::Hash;
+    use crate::Hash as _;
+
+    impl Hash {
+        /// Converts pre-1.0 type to a stable type.
+        pub fn to_stable(self) -> stable::sha512::Hash {
+            stable::sha512::Hash::from_byte_array(self.to_byte_array())
+        }
+
+        /// Converts a stable type to a pre-1.0 type.
+        pub fn from_stable(stable: stable::sha512::Hash) -> Self {
+            Self::from_byte_array(stable.to_byte_array())
+        }
+    }
+}
+
+mod sha512_256 {
+    use super::stable;
+    use crate::sha512_256::Hash;
+    use crate::Hash as _;
+
+    impl Hash {
+        /// Converts pre-1.0 type to a stable type.
+        pub fn to_stable(self) -> stable::sha512_256::Hash {
+            stable::sha512_256::Hash::from_byte_array(self.to_byte_array())
+        }
+
+        /// Converts a stable type to a pre-1.0 type.
+        pub fn from_stable(stable: stable::sha512_256::Hash) -> Self {
+            Self::from_byte_array(stable.to_byte_array())
+        }
+    }
+}
+
+mod siphash24 {
+    use super::stable;
+    use crate::siphash24::Hash;
+    use crate::Hash as _;
+
+    impl Hash {
+        /// Converts pre-1.0 type to a stable type.
+        pub fn to_stable(self) -> stable::siphash24::Hash {
+            stable::siphash24::Hash::from_byte_array(self.to_byte_array())
+        }
+
+        /// Converts a stable type to a pre-1.0 type.
+        pub fn from_stable(stable: stable::siphash24::Hash) -> Self {
+            Self::from_byte_array(stable.to_byte_array())
+        }
+    }
+}

--- a/hashes/src/compat.rs
+++ b/hashes/src/compat.rs
@@ -108,7 +108,7 @@ mod sha1 {
 
 mod sha256 {
     use super::stable;
-    use crate::sha256::Hash;
+    use crate::sha256::{Hash, HashEngine, Midstate};
     use crate::Hash as _;
 
     impl Hash {
@@ -120,6 +120,62 @@ mod sha256 {
         /// Converts a stable type to a pre-1.0 type.
         pub fn from_stable(stable: stable::sha256::Hash) -> Self {
             Self::from_byte_array(stable.to_byte_array())
+        }
+    }
+
+    impl Midstate {
+        /// Converts pre-1.0 type to a stable type.
+        ///
+        /// The stable [`sha256::Midstate`] includes the number of bytes hashed alongside the
+        /// midstate bytes but the pre-1.0 type does not — callers must supply this value.
+        pub fn to_stable(self, bytes_hashed: u64) -> stable::sha256::Midstate {
+            stable::sha256::Midstate::new(self.to_byte_array(), bytes_hashed)
+        }
+
+        /// Converts a stable type to a pre-1.0 type.
+        ///
+        /// Note: the number of bytes hashed is discarded during this conversion.
+        pub fn from_stable(stable: stable::sha256::Midstate) -> Self {
+            let (bytes, _) = stable.to_parts();
+            Self::from_byte_array(bytes)
+        }
+    }
+
+    impl HashEngine {
+        /// Converts pre-1.0 type to a stable type.
+        ///
+        /// Only engines where the number of bytes hashed so far is a multiple of the block size
+        /// (64) can be converted, because the pre-1.0 midstate does not carry the partial block
+        /// buffer. This matches the constraint already imposed by the pre-1.0
+        /// [`HashEngine::from_midstate`].
+        ///
+        /// # Panics
+        ///
+        /// Panics if `self.n_bytes_hashed() % 64 != 0`.
+        pub fn to_stable(self) -> stable::sha256::HashEngine {
+            use crate::HashEngine as _;
+
+            let n = self.n_bytes_hashed();
+            assert!(n % 64 == 0, "cannot convert sha256::HashEngine: {n} bytes hashed is not a multiple of 64");
+            let stable_midstate = self.midstate().to_stable(n as u64);
+            stable::sha256::HashEngine::from_midstate(stable_midstate)
+        }
+
+        /// Converts a stable type to a pre-1.0 type.
+        ///
+        /// Only engines where the number of bytes hashed so far is a multiple of the block size
+        /// (64) can be converted.
+        ///
+        /// # Panics
+        ///
+        /// Panics if the stable engine's bytes hashed is not a multiple of 64.
+        pub fn from_stable(stable_engine: stable::sha256::HashEngine) -> Self {
+            let stable_midstate = stable_engine
+                .midstate()
+                .expect("cannot convert sha256::HashEngine: bytes hashed is not a multiple of 64");
+            let (bytes, bytes_hashed) = stable_midstate.to_parts();
+            let midstate = Midstate::from_byte_array(bytes);
+            Self::from_midstate(midstate, bytes_hashed as usize)
         }
     }
 }

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -105,6 +105,8 @@ pub mod _export {
 #[cfg(feature = "schemars")]
 extern crate actual_schemars as schemars;
 
+#[cfg(feature = "compat")]
+mod compat;
 mod internal_macros;
 #[macro_use]
 mod util;


### PR DESCRIPTION
Currently we have a problem, the ecosystem is on `rust-bitcoin 0.32` and master is so far ahead that there is no palatable upgrade path.
    
This is a demonstration of one idea to help solve this problem. Demonstrated for `hashes` because the 1.0 is about to drop, a more realistic candidate would be `units v1.0.0.`.
    
The idea is that some users can start using stable crates and when they need to interoperate with libraries that are yet to do so they can use the provided compat layer to convert types. Furthermore if a library started to use stable types in their API applications that did not want to upgrade could use the compat layer instead.
    
Done only for `sha256::Hash`, each type in the crate would need doing also obviously.

This won't build in CI because uses https://github.com/rust-bitcoin/rust-bitcoin/pull/6229 as the branch to pull down `hashes 1.0.0`.