### PR TITLE
Hard fail semver breaks for 1.0 crates

### DIFF
--- a/contrib/check-semver-pr.sh
+++ b/contrib/check-semver-pr.sh
@@ -16,6 +16,9 @@ set -euo pipefail
 # under the hood to invoke rustdoc.
 RUSTDOCFLAGS="-Z unstable-options --document-private-items --document-hidden-items --output-format=json --cap-lints=allow"
 
+# Crates that have reached 1.0 must not introduce semver-breaking API changes.
+SEMVER_HARD_FAIL_CRATES=("bitcoin-consensus-encoding")
+
 # These will be set to the commit SHA from the PR's target branch
 # GitHub Actions CI.
 # NOTE: if running locally this will be set to master.
@@ -50,6 +53,11 @@ main() {
     generate_json_files_no_default_features "bitcoin-io" "current"
     generate_json_files_features_alloc "bitcoin-io" "current"
 
+    # 6. bitcoin-consensus-encoding: all-features, no-default-features and alloc feature.
+    generate_json_files_all_features "bitcoin-consensus-encoding" "current"
+    generate_json_files_no_default_features "bitcoin-consensus-encoding" "current"
+    generate_json_files_features_alloc "bitcoin-consensus-encoding" "current"
+
 
     # Switch to target commit.
     echo "Checking out target commit at $TARGET_COMMIT"
@@ -79,6 +87,11 @@ main() {
     generate_json_files_no_default_features "bitcoin-io" "master"
     generate_json_files_features_alloc "bitcoin-io" "master"
 
+    # 6. bitcoin-consensus-encoding: all-features, no-default-features and alloc feature.
+    generate_json_files_all_features "bitcoin-consensus-encoding" "master"
+    generate_json_files_no_default_features "bitcoin-consensus-encoding" "master"
+    generate_json_files_features_alloc "bitcoin-consensus-encoding" "master"
+
     # Check for API semver breaks on all the generated JSON files above.
     run_cargo_semver_check "bitcoin" "all-features"
     run_cargo_semver_check "bitcoin" "no-default-features"
@@ -93,6 +106,9 @@ main() {
     run_cargo_semver_check "bitcoin-io" "all-features"
     run_cargo_semver_check "bitcoin-io" "no-default-features"
     run_cargo_semver_check "bitcoin-io" "alloc"
+    run_cargo_semver_check "bitcoin-consensus-encoding" "all-features"
+    run_cargo_semver_check "bitcoin-consensus-encoding" "no-default-features"
+    run_cargo_semver_check "bitcoin-consensus-encoding" "alloc"
 
     # Invoke cargo semver-checks to check for breaking changes
     # in all generated files.
@@ -179,10 +195,20 @@ check_for_breaking_changes() {
             # flag it as a breaking change
             # Handle the case where FAIL is found
             touch semver-break
+
+            for crate in "${SEMVER_HARD_FAIL_CRATES[@]}"; do
+                if [[ "$file" == "$crate"-* ]]; then
+                    touch semver-hard-fail
+                fi
+            done
         fi
     done
     if ! [ -f semver-break ]; then
        echo "No breaking changes found"
+    fi
+    if [ -f semver-hard-fail ]; then
+        echo "Semver break detected in a 1.0 crate; failing CI"
+        exit 1
     fi
 }
 


### PR DESCRIPTION
Summary
- include bitcoin-consensus-encoding in the PR semver-checks coverage
- mark semver breaks in 1.0 crates as a hard CI failure while preserving the existing semver-break artifact for softer reports

Why
Issue #6230 asks for the cargo-semver-checks job to fail when a 1.0 crate has a breaking API change. bitcoin-consensus-encoding is currently a 1.0 crate, so this adds it to the checked crate set and exits non-zero if cargo-semver-checks reports a FAIL for it.

Testing
- bash -n contrib/check-semver-pr.sh

Notes
- shellcheck was not available in my local environment

Closes #6230.