### PR TITLE
witness: Allocate in reserve_batch if capacity < MIN_VECTOR_ALLOCATE

### DIFF
--- a/primitives/src/witness.rs
+++ b/primitives/src/witness.rs
@@ -354,7 +354,7 @@ impl WitnessDecoder {
         let bytes_needed = required_len - self.content.len();
         let available_capacity = self.content.capacity() - self.content.len();
 
-        if available_capacity == 0 {
+        if available_capacity < MIN_VECTOR_ALLOCATE {
             let batch_size = bytes_needed.clamp(MIN_VECTOR_ALLOCATE, MAX_VECTOR_ALLOCATE);
             self.content.reserve_exact(batch_size);
         }


### PR DESCRIPTION
Following #6198, the reserve_batch call now allocates a minimum size of 1000 bytes. Since the allocation only updates beyond capacity when capacity - len == 0, reserve_batch may not always allocate up to the given required_len.
In WitnessDecoder::push_bytes, reserve_batch is used in such a way that assumes self.content will have the required_len. This causes a panic when writing a compact size to the witness content if it does not.

Replace capacity == 0 check with capacity < MIN_VECTOR_ALLOCATE, ensuring reserve_batch always allocates at least MIN_VECTOR_ALLOCATE empty content space.

Closes #6239