### PR TITLE
Explicitly don't support ficticious architectures

### DIFF
--- a/consensus_encoding/src/compact_size.rs
+++ b/consensus_encoding/src/compact_size.rs
@@ -47,14 +47,16 @@ impl CompactSizeEncoder {
     /// dominant use case for compact size encoding in the Bitcoin protocol. Prefer this constructor
     /// whenever you are encoding the length of a collection or a byte slice.
     ///
-    /// Compact size encodings are defined only over the `u64` range. On exotic platforms where
-    /// `usize` is wider than 64 bits the value will be saturated to [`u64::MAX`], but in practice
-    /// any in-memory length that could actually be passed here is well within the `u64` range.
+    /// Compact size encodings are defined only over the `u64` range. Hypothetical future platforms
+    /// that have `usize` greater than 64 bits are currently not supported.
     ///
     /// If you need to encode an arbitrary `u64` integer that is not a length prefix, use
     /// [`Self::new_u64`] instead.
     pub fn new(value: usize) -> Self {
-        Self { buf: Self::encode(u64::try_from(value).unwrap_or(u64::MAX)) }
+        const _WE_ONLY_SUPPORT_ARCHITECTURES_WITH_UP_TO_64_BIT_USIZE: () = {
+            assert!(core::mem::size_of::<usize>() <= 8);
+        };
+        Self { buf: Self::encode(value as u64) }
     }
 
     /// Constructs a new `CompactSizeEncoder` for an arbitrary `u64` integer.


### PR DESCRIPTION
Currently, no architecture with `usize` exists in stable or unstable Rust or anywhere in the world that I (or ChatGPT) know of. Notably, CHERI has 128 bit **pointers**, but **not** `usize`, which is still 64 bits.

Rather then producing garbage on such platforms it is much cleaner to flat out not support them. This makes reviews easier to reason about and removes the WTF factor. And while this appears breaking, it really isn't becuase since no such platforms exist, nobody could've realied on this behavior.

If such platforms ever arrive, this crate will be most likely EOL for millenia but even then there exists upgrade path:

1. release 2.0 which has the `new` method behind a feature flag, off by default
2. semver-trick the entire 2.0 with `*` import and the feature forced on
3. add `try_new` method that returns `Result`

Then downstream crates that want to support crazy-wide architecture will just upgrade to 2.0 with the feature deactivated and use the new method.