### PR TITLE
Move Miri CI to a daily cron job

### DIFF
--- a/.github/workflows/ci-failure-issues.yml
+++ b/.github/workflows/ci-failure-issues.yml
@@ -5,6 +5,7 @@ on:
     workflows:
       - Fuzz
       - Kani CI
+      - Miri
     types:
       - completed
     branches:
@@ -32,6 +33,7 @@ jobs:
             const workflowFiles = {
               "Fuzz": "cron-daily-fuzz.yml",
               "Kani CI": "cron-daily-kani.yml",
+              "Miri": "cron-daily-miri.yml",
             };
 
             const formatTs = iso => {

--- a/.github/workflows/cron-daily-miri.yml
+++ b/.github/workflows/cron-daily-miri.yml
@@ -1,12 +1,11 @@
----   # rust-bitcoin CI: If you edit this file please update README.md
-on:   # yamllint disable-line rule:truthy
-  push:
-    branches:
-      - master
-      - 'test-ci/**'
-  pull_request:
-
 name: Miri
+on:   # yamllint disable-line rule:truthy
+  schedule:
+    # 10am every day UTC, this correlates to:
+    # - 3am PDT
+    # - 11am CET
+    # - 9pm AEDT
+    - cron: '00 10 * * *'
 
 permissions: {}
 


### PR DESCRIPTION
Miri takes hours and rarely completes on a PR, cancelled ones give a red x on the PR the same as a CI failure.

Run it instead on a daily schedule like fuzz and kani.

Use the same tool as used for fuzz and kani to produce an issue when it fails.

Closes #5883