### PR TITLE
Fix fuzz cache key to use fuzz target

### DIFF
--- a/.github/workflows/cron-daily-fuzz.yml
+++ b/.github/workflows/cron-daily-fuzz.yml
@@ -133,7 +133,7 @@ jobs:
             ~/.cargo/bin
             fuzz/target
             target
-          key: cache-${{ matrix.target }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+          key: cache-${{ matrix.fuzz_target }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
       - uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6 # stable
         with:
           toolchain: '1.74.0'

--- a/fuzz/generate-files.sh
+++ b/fuzz/generate-files.sh
@@ -113,7 +113,7 @@ $(for name in $(cargo fuzz list); do echo "          $name,"; done)
             ~/.cargo/bin
             fuzz/target
             target
-          key: cache-\${{ matrix.target }}-\${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+          key: cache-\${{ matrix.fuzz_target }}-\${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
       - uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6 # stable
         with:
           toolchain: '1.74.0'
@@ -147,4 +147,3 @@ $(for name in $(cargo fuzz list); do echo "          $name,"; done)
       - run: find executed_* -type f -exec cat {} + | sort > executed
       - run: cargo fuzz list | sort | diff - executed
 EOF
-


### PR DESCRIPTION
Fixes #6234.

The fuzz workflow matrix defines `fuzz_target`, but the cache key used `matrix.target`. That leaves the target-specific part empty instead of using the current fuzz target name.

Update both the generated workflow and `fuzz/generate-files.sh` so future regeneration keeps the fix.

Tested:
- `bash -n fuzz/generate-files.sh`
- `git diff --check`
