### PR TITLE
CI probe: intentionally break consensus_encoding API

### DIFF
--- a/consensus_encoding/src/lib.rs
+++ b/consensus_encoding/src/lib.rs
@@ -71,7 +71,7 @@ mod encode;
 pub mod error;
 
 #[doc(inline)]
-pub use self::compact_size::{CompactSizeDecoder, CompactSizeEncoder, CompactSizeU64Decoder};
+pub use self::compact_size::{CompactSizeDecoder, CompactSizeEncoder};
 #[doc(inline)]
 pub use self::decode::decoders::{ArrayDecoder, Decoder2, Decoder3, Decoder4, Decoder6};
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
## Summary

This is an intentional CI probe requested in #6240. It removes the root-level re-export of `CompactSizeU64Decoder` from `bitcoin-consensus-encoding` to introduce a clear public API break in a 1.0 crate.

## Intent

This PR is **not intended to be merged**. Its purpose is only to verify that the new semver hard-fail path catches a breaking API change in `bitcoin-consensus-encoding` and reports the expected CI failure.

Expected result:

- `cargo-semver-checks` should report a semver failure for `bitcoin-consensus-encoding`
- the semver job should fail hard rather than only uploading the report artifact

## Testing

- `bash -n contrib/check-semver-pr.sh`

Notes:

- I intentionally did not try to make this PR pass CI.
- The code change is deliberately minimal so the semver signal is easy to inspect.