### PR TITLE
Ignore equivalent ExactSizeEncoder::is_empty mutant

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -74,6 +74,7 @@ exclude_re = [
     "consensus_encoding/.* decode_from_read", # Mutations cause an infinite loop
     "consensus_encoding/.* <impl Decoder for .*>::push_bytes", # Mutations cause an infinite loop
     "consensus_encoding/.* <impl Encoder for .*>::advance", # Replacing the return with true causes an infinite loop.
+    "consensus_encoding/.* ExactSizeEncoder::is_empty", # Default method is equivalent to len() == 0.
     "consensus_encoding/.* EncoderStatus::has_more", # Replacing with true causes an infinite loop
     "consensus_encoding/.* DecoderStatus::is_ready", # Replacing with true causes an infinite loop
     "consensus_encoding/.* delete ! in drain_to_vec", # Causes an infinite loop.


### PR DESCRIPTION
## Summary

Add a cargo-mutants exclusion for the default `ExactSizeEncoder::is_empty` method in `bitcoin-consensus-encoding`.

## Why

The method is the trait default:

```rust
fn is_empty(&self) -> bool { self.len() == 0 }
```

The remaining implementors rely on this default. Mutating it does not meaningfully exercise encoder behavior beyond the already-tested `len()` implementations, so it shows up as an equivalent mutant rather than a useful missing test.

Closes #6227.

## Testing

- `git diff --check`

Notes:

- `cargo mutants` is not installed in my local environment.