### PR TITLE
hashes: remove outdated readme sections

### DIFF
--- a/hashes/README.md
+++ b/hashes/README.md
@@ -10,20 +10,3 @@ since these are needed to display hashes anyway.
 ## Contributions
 
 Contributions are welcome, including additional hash function implementations.
-
-### Githooks
-
-To assist devs in catching errors _before_ running CI we provide some githooks. If you do not
-already have locally configured githooks you can use the ones in this repository by running, in the
-root directory of the repository:
-
-```bash
-git config --local core.hooksPath githooks/
-```
-
-Alternatively add symlinks in your `.git/hooks` directory to any of the githooks we provide.
-
-### Running Benchmarks
-
-We use a custom Rust compiler configuration conditional to guard the benchmark code. To run the
-benchmarks use: `RUSTFLAGS='--cfg=bench' cargo +nightly bench`.


### PR DESCRIPTION
In preparation for hashes v1.0, drop some outdated sections in the readme.