### PR TITLE
hashes: Final clean ups

### DIFF
--- a/hashes/api/all-features.txt
+++ b/hashes/api/all-features.txt
@@ -146,6 +146,8 @@ pub fn bitcoin_hashes::hkdf::error::MaxLengthError::clone(&self) -> bitcoin_hash
 impl core::cmp::Eq for bitcoin_hashes::hkdf::error::MaxLengthError
 impl core::cmp::PartialEq for bitcoin_hashes::hkdf::error::MaxLengthError
 pub fn bitcoin_hashes::hkdf::error::MaxLengthError::eq(&self, other: &bitcoin_hashes::hkdf::error::MaxLengthError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_hashes::hkdf::error::MaxLengthError
+pub fn bitcoin_hashes::hkdf::error::MaxLengthError::from(never: core::convert::Infallible) -> Self
 impl core::error::Error for bitcoin_hashes::hkdf::error::MaxLengthError
 pub fn bitcoin_hashes::hkdf::error::MaxLengthError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 impl core::fmt::Debug for bitcoin_hashes::hkdf::error::MaxLengthError
@@ -699,6 +701,8 @@ pub fn bitcoin_hashes::sha256::error::MidstateError::clone(&self) -> bitcoin_has
 impl core::cmp::Eq for bitcoin_hashes::sha256::error::MidstateError
 impl core::cmp::PartialEq for bitcoin_hashes::sha256::error::MidstateError
 pub fn bitcoin_hashes::sha256::error::MidstateError::eq(&self, other: &bitcoin_hashes::sha256::error::MidstateError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_hashes::sha256::error::MidstateError
+pub fn bitcoin_hashes::sha256::error::MidstateError::from(never: core::convert::Infallible) -> Self
 impl core::error::Error for bitcoin_hashes::sha256::error::MidstateError
 pub fn bitcoin_hashes::sha256::error::MidstateError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 impl core::fmt::Debug for bitcoin_hashes::sha256::error::MidstateError

--- a/hashes/api/alloc-only.txt
+++ b/hashes/api/alloc-only.txt
@@ -126,6 +126,8 @@ pub fn bitcoin_hashes::hkdf::error::MaxLengthError::clone(&self) -> bitcoin_hash
 impl core::cmp::Eq for bitcoin_hashes::hkdf::error::MaxLengthError
 impl core::cmp::PartialEq for bitcoin_hashes::hkdf::error::MaxLengthError
 pub fn bitcoin_hashes::hkdf::error::MaxLengthError::eq(&self, other: &bitcoin_hashes::hkdf::error::MaxLengthError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_hashes::hkdf::error::MaxLengthError
+pub fn bitcoin_hashes::hkdf::error::MaxLengthError::from(never: core::convert::Infallible) -> Self
 impl core::fmt::Debug for bitcoin_hashes::hkdf::error::MaxLengthError
 pub fn bitcoin_hashes::hkdf::error::MaxLengthError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for bitcoin_hashes::hkdf::error::MaxLengthError
@@ -618,6 +620,8 @@ pub fn bitcoin_hashes::sha256::error::MidstateError::clone(&self) -> bitcoin_has
 impl core::cmp::Eq for bitcoin_hashes::sha256::error::MidstateError
 impl core::cmp::PartialEq for bitcoin_hashes::sha256::error::MidstateError
 pub fn bitcoin_hashes::sha256::error::MidstateError::eq(&self, other: &bitcoin_hashes::sha256::error::MidstateError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_hashes::sha256::error::MidstateError
+pub fn bitcoin_hashes::sha256::error::MidstateError::from(never: core::convert::Infallible) -> Self
 impl core::fmt::Debug for bitcoin_hashes::sha256::error::MidstateError
 pub fn bitcoin_hashes::sha256::error::MidstateError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for bitcoin_hashes::sha256::error::MidstateError

--- a/hashes/api/no-features.txt
+++ b/hashes/api/no-features.txt
@@ -118,6 +118,8 @@ pub fn bitcoin_hashes::hkdf::error::MaxLengthError::clone(&self) -> bitcoin_hash
 impl core::cmp::Eq for bitcoin_hashes::hkdf::error::MaxLengthError
 impl core::cmp::PartialEq for bitcoin_hashes::hkdf::error::MaxLengthError
 pub fn bitcoin_hashes::hkdf::error::MaxLengthError::eq(&self, other: &bitcoin_hashes::hkdf::error::MaxLengthError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_hashes::hkdf::error::MaxLengthError
+pub fn bitcoin_hashes::hkdf::error::MaxLengthError::from(never: core::convert::Infallible) -> Self
 impl core::fmt::Debug for bitcoin_hashes::hkdf::error::MaxLengthError
 pub fn bitcoin_hashes::hkdf::error::MaxLengthError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for bitcoin_hashes::hkdf::error::MaxLengthError
@@ -569,6 +571,8 @@ pub fn bitcoin_hashes::sha256::error::MidstateError::clone(&self) -> bitcoin_has
 impl core::cmp::Eq for bitcoin_hashes::sha256::error::MidstateError
 impl core::cmp::PartialEq for bitcoin_hashes::sha256::error::MidstateError
 pub fn bitcoin_hashes::sha256::error::MidstateError::eq(&self, other: &bitcoin_hashes::sha256::error::MidstateError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_hashes::sha256::error::MidstateError
+pub fn bitcoin_hashes::sha256::error::MidstateError::from(never: core::convert::Infallible) -> Self
 impl core::fmt::Debug for bitcoin_hashes::sha256::error::MidstateError
 pub fn bitcoin_hashes::sha256::error::MidstateError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for bitcoin_hashes::sha256::error::MidstateError

--- a/hashes/src/hash160/mod.rs
+++ b/hashes/src/hash160/mod.rs
@@ -17,7 +17,7 @@ crate::internal_macros::general_hash_type! {
 }
 
 impl Hash {
-    /// Finalize a hash engine to produce a hash.
+    /// Finalizes a hash engine to produce a hash.
     pub fn from_engine(e: HashEngine) -> Self {
         let sha2 = sha256::Hash::from_engine(e.0);
         let rmd = ripemd160::Hash::hash(sha2.as_byte_array());

--- a/hashes/src/hkdf/mod.rs
+++ b/hashes/src/hkdf/mod.rs
@@ -145,12 +145,17 @@ impl<T: HashEngine> fmt::Debug for Hkdf<T> {
 
 /// Error types for the HKDF hash.
 pub mod error {
+    use core::convert::Infallible;
     use core::fmt;
 
     /// Size of output exceeds maximum length allowed.
     #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub struct MaxLengthError {
         pub(super) max: usize,
+    }
+
+    impl From<Infallible> for MaxLengthError {
+        fn from(never: Infallible) -> Self { match never {} }
     }
 
     impl fmt::Display for MaxLengthError {

--- a/hashes/src/hkdf/mod.rs
+++ b/hashes/src/hkdf/mod.rs
@@ -166,6 +166,7 @@ pub mod error {
 
     #[cfg(feature = "std")]
     impl std::error::Error for MaxLengthError {
+        #[inline]
         fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
     }
 }

--- a/hashes/src/internal_macros.rs
+++ b/hashes/src/internal_macros.rs
@@ -202,7 +202,6 @@ macro_rules! engine_input_impl(
     () => (
         #[cfg(not(hashes_fuzz))]
         fn input(&mut self, mut inp: &[u8]) {
-
             let buf_idx = $crate::incomplete_block_len(self);
             let block_size = <Self as crate::HashEngine>::BLOCK_SIZE;
             self.bytes_hashed += inp.len() as u64;

--- a/hashes/src/internal_macros.rs
+++ b/hashes/src/internal_macros.rs
@@ -61,8 +61,7 @@ pub(crate) use hash_trait_impls;
 ///
 /// Restrictions on usage:
 ///
-/// * Requires a `HashEngine` type in this module implementing `Default`
-///   and `crate::HashEngine<Hash = Hash, Bytes = [u8; $len]>`.
+/// * Requires a `HashEngine` type in this module implementing `Default`.
 macro_rules! general_hash_type {
     (
         $(#[$type_attrs:meta])*

--- a/hashes/src/internal_macros.rs
+++ b/hashes/src/internal_macros.rs
@@ -198,8 +198,8 @@ macro_rules! impl_write {
 }
 pub(crate) use impl_write;
 
-macro_rules! engine_input_impl(
-    () => (
+macro_rules! impl_engine_input {
+    () => {
         #[cfg(not(hashes_fuzz))]
         fn input(&mut self, mut inp: &[u8]) {
             let buf_idx = $crate::incomplete_block_len(self);
@@ -237,6 +237,6 @@ macro_rules! engine_input_impl(
             }
             self.bytes_hashed += inp.len() as u64;
         }
-    )
-);
-pub(crate) use engine_input_impl;
+    }
+}
+pub(crate) use impl_engine_input;

--- a/hashes/src/internal_macros.rs
+++ b/hashes/src/internal_macros.rs
@@ -25,7 +25,7 @@ macro_rules! hash_trait_impls {
         $crate::impl_debug_only!(Hash, { $bits / 8 }, $reverse $(, $gen: $gent)*);
 
         #[cfg(feature = "serde")]
-        $crate::serde_impl!(Hash, { $bits / 8} $(, $gen: $gent)*);
+        $crate::impl_serde_traits!(Hash, { $bits / 8} $(, $gen: $gent)*);
 
         impl<$($gen: $gent),*> $crate::Hash for Hash<$($gen),*> {
             type Bytes = [u8; $bits / 8];

--- a/hashes/src/internal_macros.rs
+++ b/hashes/src/internal_macros.rs
@@ -9,13 +9,13 @@
 /// # Parameters
 ///
 /// * `$bits` - the number of bits this hash type has
-/// * `$reverse` - `bool`  - `true` if the hash type should be displayed backwards, `false`
-///   otherwise.
+/// * `$reverse` - `bool`, `true` if the hash type should be displayed backwards, `false` otherwise.
 /// * `$gen: $gent` - the generic type(s) and trait bound(s)
 ///
 /// Restrictions on usage:
 ///
-/// * The `Hash` type in scope must provide `from_byte_array`, `to_byte_array`, and `as_byte_array` (e.g., via `hash_type_no_default!`).
+/// * The `Hash` type in scope must provide `from_byte_array`, `to_byte_array`, and
+///   `as_byte_array` (e.g., via `hash_type_no_default!`).
 macro_rules! hash_trait_impls {
     ($bits:expr, $reverse:expr $(, $gen:ident: $gent:ident)*) => {
         $crate::impl_bytelike_traits!(Hash, { $bits / 8 } $(, $gen: $gent)*);
@@ -61,7 +61,8 @@ pub(crate) use hash_trait_impls;
 ///
 /// Restrictions on usage:
 ///
-/// * Requires a `HashEngine` type in this module implementing `Default` and `crate::HashEngine<Hash = Hash, Bytes = [u8; $len]>`.
+/// * Requires a `HashEngine` type in this module implementing `Default`
+///   and `crate::HashEngine<Hash = Hash, Bytes = [u8; $len]>`.
 macro_rules! general_hash_type {
     (
         $(#[$type_attrs:meta])*

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -192,7 +192,7 @@ where
     drain_to_engine(&mut encoder, engine);
 }
 
-/// Drain the output of an [`encoding::Encoder`] into a hash engine.
+/// Drains the output of an [`encoding::Encoder`] into a hash engine.
 pub fn drain_to_engine<T, H>(encoder: &mut T, engine: &mut H)
 where
     T: encoding::Encoder + ?Sized,

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -55,14 +55,8 @@
 #![warn(missing_docs)]
 #![warn(deprecated_in_future)]
 #![doc(test(attr(warn(unused))))]
-// Pedantic lints that we enforce.
-#![warn(clippy::return_self_not_must_use)]
 // Instead of littering the codebase for non-fuzzing and bench code just globally allow.
 #![cfg_attr(hashes_fuzz, allow(dead_code, unused_imports))]
-// Exclude lints we don't think are valuable.
-#![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
-#![allow(clippy::manual_range_contains)] // More readable than clippy's format.
-#![allow(clippy::uninlined_format_args)] // Allow `format!("{}", x)` instead of enforcing `format!("{x}")`
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/hashes/src/macros.rs
+++ b/hashes/src/macros.rs
@@ -562,7 +562,7 @@ macro_rules! serde_impl(
 #[macro_export]
 #[cfg(not(feature = "serde"))]
 macro_rules! serde_impl(
-        ($t:ident, $len:expr $(, $gen:ident: $gent:ident)*) => ()
+    ($t:ident, $len:expr $(, $gen:ident: $gent:ident)*) => ()
 );
 
 #[cfg(test)]

--- a/hashes/src/macros.rs
+++ b/hashes/src/macros.rs
@@ -522,7 +522,7 @@ pub mod serde_details {
 macro_rules! impl_serde_for_newtype {
     ($($newtype:ident),*) => {
         $(
-            $crate::serde_impl!($newtype, { <$newtype as $crate::Hash>::LEN });
+            $crate::impl_serde_traits!($newtype, { <$newtype as $crate::Hash>::LEN });
         )*
     }
 }
@@ -532,7 +532,7 @@ macro_rules! impl_serde_for_newtype {
 #[doc(hidden)]
 #[macro_export]
 #[cfg(feature = "serde")]
-macro_rules! serde_impl(
+macro_rules! impl_serde_traits(
     ($t:ident, $len:expr $(, $gen:ident: $gent:ident)*) => (
         impl<$($gen: $gent),*> $crate::serde::Serialize for $t<$($gen),*> {
             fn serialize<S: $crate::serde::Serializer>(&self, s: S) -> core::result::Result<S::Ok, S::Error> {
@@ -561,7 +561,7 @@ macro_rules! serde_impl(
 #[doc(hidden)]
 #[macro_export]
 #[cfg(not(feature = "serde"))]
-macro_rules! serde_impl(
+macro_rules! impl_serde_traits(
     ($t:ident, $len:expr $(, $gen:ident: $gent:ident)*) => ()
 );
 

--- a/hashes/src/macros.rs
+++ b/hashes/src/macros.rs
@@ -5,6 +5,7 @@
 //! - [`sha256t_tag`](crate::sha256t_tag)
 //! - [`hash_newtype`](crate::hash_newtype)
 //! - [`impl_hex_for_newtype`](crate::impl_hex_for_newtype)
+//! - [`impl_debug_only_for_newtype`](crate::impl_debug_only_for_newtype)
 //! - [`impl_serde_for_newtype`](crate::impl_serde_for_newtype)
 
 /// Macro used to define a tag.

--- a/hashes/src/ripemd160/mod.rs
+++ b/hashes/src/ripemd160/mod.rs
@@ -94,6 +94,6 @@ impl crate::HashEngine for HashEngine {
     const BLOCK_SIZE: usize = 64;
 
     fn n_bytes_hashed(&self) -> u64 { self.bytes_hashed }
-    crate::internal_macros::engine_input_impl!();
+    crate::internal_macros::impl_engine_input!();
     fn finalize(self) -> Self::Hash { Hash::from_engine(self) }
 }

--- a/hashes/src/ripemd160/mod.rs
+++ b/hashes/src/ripemd160/mod.rs
@@ -19,7 +19,7 @@ crate::internal_macros::general_hash_type! {
 }
 
 impl Hash {
-    /// Finalize a hash engine to produce a hash.
+    /// Finalizes a hash engine to produce a hash.
     #[cfg(not(hashes_fuzz))]
     pub fn from_engine(mut e: HashEngine) -> Self {
         let n_bytes_hashed = e.bytes_hashed;
@@ -39,7 +39,7 @@ impl Hash {
         Self(e.midstate())
     }
 
-    /// Finalize a hash engine to produce a hash.
+    /// Finalizes a hash engine to produce a hash.
     #[cfg(hashes_fuzz)]
     pub fn from_engine(e: HashEngine) -> Self {
         let mut res = e.midstate();

--- a/hashes/src/sha1/mod.rs
+++ b/hashes/src/sha1/mod.rs
@@ -19,7 +19,7 @@ crate::internal_macros::general_hash_type! {
 }
 
 impl Hash {
-    /// Finalize a hash engine to produce a hash.
+    /// Finalizes a hash engine to produce a hash.
     pub fn from_engine(mut e: HashEngine) -> Self {
         let n_bytes_hashed = e.bytes_hashed;
         let buf_idx = incomplete_block_len(&e);

--- a/hashes/src/sha1/mod.rs
+++ b/hashes/src/sha1/mod.rs
@@ -86,7 +86,7 @@ impl crate::HashEngine for HashEngine {
 
     fn n_bytes_hashed(&self) -> u64 { self.bytes_hashed }
 
-    crate::internal_macros::engine_input_impl!();
+    crate::internal_macros::impl_engine_input!();
 
     fn finalize(self) -> Self::Hash { Hash::from_engine(self) }
 }

--- a/hashes/src/sha256/mod.rs
+++ b/hashes/src/sha256/mod.rs
@@ -266,6 +266,7 @@ impl convert::AsRef<[u8]> for Midstate {
 
 /// Error types for the SHA256 hash.
 pub mod error {
+    use core::convert::Infallible;
     use core::fmt;
 
     use super::{Midstate, BLOCK_SIZE};
@@ -290,6 +291,10 @@ pub mod error {
         pub fn unprocessed_bytes(&self) -> &[u8] {
             &self.unprocessed_bytes[..self.unprocessed_bytes_len]
         }
+    }
+
+    impl From<Infallible> for MidstateError {
+        fn from(never: Infallible) -> Self { match never {} }
     }
 
     impl fmt::Display for MidstateError {

--- a/hashes/src/sha256/mod.rs
+++ b/hashes/src/sha256/mod.rs
@@ -285,9 +285,11 @@ pub mod error {
 
     impl MidstateError {
         /// Returns block-aligned midstate.
+        #[inline]
         pub const fn midstate(&self) -> &Midstate { &self.block_aligned_midstate }
 
         /// returns the unprocessed bytes remaining in the buffer.
+        #[inline]
         pub fn unprocessed_bytes(&self) -> &[u8] {
             &self.unprocessed_bytes[..self.unprocessed_bytes_len]
         }
@@ -309,6 +311,7 @@ pub mod error {
 
     #[cfg(feature = "std")]
     impl std::error::Error for MidstateError {
+        #[inline]
         fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
     }
 }

--- a/hashes/src/sha256/mod.rs
+++ b/hashes/src/sha256/mod.rs
@@ -169,7 +169,7 @@ impl crate::HashEngine for HashEngine {
     const BLOCK_SIZE: usize = 64;
 
     fn n_bytes_hashed(&self) -> u64 { self.bytes_hashed }
-    crate::internal_macros::engine_input_impl!();
+    crate::internal_macros::impl_engine_input!();
     fn finalize(self) -> Self::Hash { Hash::from_engine(self) }
 }
 

--- a/hashes/src/sha256/mod.rs
+++ b/hashes/src/sha256/mod.rs
@@ -28,7 +28,7 @@ crate::internal_macros::general_hash_type! {
 }
 
 impl Hash {
-    /// Finalize a hash engine to obtain a hash.
+    /// Finalizes a hash engine to obtain a hash.
     #[cfg(not(hashes_fuzz))]
     pub fn from_engine(mut e: HashEngine) -> Self {
         // pad buffer with a single 1-bit then all 0s, until there are exactly 8 bytes remaining
@@ -50,7 +50,7 @@ impl Hash {
         Self(e.midstate_unchecked().bytes)
     }
 
-    /// Finalize a hash engine to obtain a hash.
+    /// Finalizes a hash engine to obtain a hash.
     #[cfg(hashes_fuzz)]
     pub fn from_engine(e: HashEngine) -> Self {
         let mut hash = e.midstate_unchecked().bytes;
@@ -62,7 +62,7 @@ impl Hash {
         Hash(hash)
     }
 
-    /// Iterate the SHA256 algorithm to turn a SHA256 hash into a `SHA256d` hash.
+    /// Iterates the SHA256 algorithm to turn a SHA256 hash into a `SHA256d` hash.
     #[must_use]
     pub fn hash_again(&self) -> sha256d::Hash { sha256d::Hash::from_byte_array(hash(&self.0).0) }
 

--- a/hashes/src/sha256d/mod.rs
+++ b/hashes/src/sha256d/mod.rs
@@ -21,7 +21,7 @@ impl Hash {
         sha256::HashEngine::sha256d_64(outputs, inputs);
     }
 
-    /// Finalize a hash engine to produce a hash.
+    /// Finalizes a hash engine to produce a hash.
     pub fn from_engine(e: HashEngine) -> Self {
         let sha2 = sha256::Hash::from_engine(e.0);
         let sha2d = sha256::Hash::hash(sha2.as_byte_array());

--- a/hashes/src/sha384/mod.rs
+++ b/hashes/src/sha384/mod.rs
@@ -12,7 +12,7 @@ crate::internal_macros::general_hash_type! {
 }
 
 impl Hash {
-    /// Finalize a hash engine to produce a hash.
+    /// Finalizes a hash engine to produce a hash.
     pub fn from_engine(e: HashEngine) -> Self {
         let mut ret = [0; 48];
         ret.copy_from_slice(&sha512::Hash::from_engine(e.0).as_byte_array()[..48]);

--- a/hashes/src/sha3_256/mod.rs
+++ b/hashes/src/sha3_256/mod.rs
@@ -214,7 +214,7 @@ impl crate::HashEngine for HashEngine {
     type Hash = Hash;
     const BLOCK_SIZE: usize = RATE;
 
-    crate::internal_macros::engine_input_impl!();
+    crate::internal_macros::impl_engine_input!();
 
     fn n_bytes_hashed(&self) -> u64 { self.bytes_hashed }
 

--- a/hashes/src/sha512/mod.rs
+++ b/hashes/src/sha512/mod.rs
@@ -20,7 +20,7 @@ crate::internal_macros::general_hash_type! {
 }
 
 impl Hash {
-    /// Finalize a hash engine to produce a hash.
+    /// Finalizes a hash engine to produce a hash.
     #[cfg(not(hashes_fuzz))]
     pub fn from_engine(mut e: HashEngine) -> Self {
         let n_bytes_hashed = e.bytes_hashed;
@@ -40,7 +40,7 @@ impl Hash {
         Self(e.midstate())
     }
 
-    /// Finalize a hash engine to produce a hash.
+    /// Finalizes a hash engine to produce a hash.
     #[cfg(hashes_fuzz)]
     pub fn from_engine(e: HashEngine) -> Self {
         let mut hash = e.midstate();

--- a/hashes/src/sha512/mod.rs
+++ b/hashes/src/sha512/mod.rs
@@ -127,6 +127,6 @@ impl crate::HashEngine for HashEngine {
     const BLOCK_SIZE: usize = 128;
 
     fn n_bytes_hashed(&self) -> u64 { self.bytes_hashed }
-    crate::internal_macros::engine_input_impl!();
+    crate::internal_macros::impl_engine_input!();
     fn finalize(self) -> Self::Hash { Hash::from_engine(self) }
 }

--- a/hashes/src/sha512_256/mod.rs
+++ b/hashes/src/sha512_256/mod.rs
@@ -21,7 +21,7 @@ crate::internal_macros::general_hash_type! {
 }
 
 impl Hash {
-    /// Finalize a hash engine to produce a hash.
+    /// Finalizes a hash engine to produce a hash.
     pub fn from_engine(e: HashEngine) -> Self {
         let mut ret = [0; 32];
         ret.copy_from_slice(&sha512::Hash::from_engine(e.0).as_byte_array()[..32]);


### PR DESCRIPTION
Go ever the crate one last time and clean up some stuff. Done in preparation for 1.0-ing.

Mostly docs and trivial stuff, internal macro renames. One API change, adds `From<Infallible>` for the two error types.