### PR TITLE
units: Add compat layer

### DIFF
--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -18,16 +18,18 @@ exclude = ["api", "tests", "contrib"]
 
 [features]
 default = [ "std", "secp-recovery" ]
-std = ["base58/std", "bech32/std", "hashes/std", "hex/std", "io/std", "secp256k1/std", "units/std"]
+std = ["base58/std", "bech32/std", "hashes/std", "hex/std", "io/std", "secp256k1/std", "units/std", "bitcoin-units-stable?/std"]
 rand-std = ["secp256k1/rand-std", "std"]
 rand = ["secp256k1/rand"]
-serde = ["actual-serde", "hashes/serde", "secp256k1/serde", "units/serde"]
-# Raises the MSRV to 1.74.0.
-encoding = ["dep:encoding", "units/encoding"]
+serde = ["actual-serde", "hashes/serde", "secp256k1/serde", "units/serde", "bitcoin-units-stable?/serde"]
 secp-lowmemory = ["secp256k1/lowmemory"]
 secp-recovery = ["secp256k1/recovery"]
 bitcoinconsensus-std = ["bitcoinconsensus/std", "std"]
-arbitrary = ["actual-arbitrary", "units/arbitrary"]
+arbitrary = ["actual-arbitrary", "units/arbitrary"] # arbitrary doesn't work for `bitcoin-units-stable`. 
+
+# Both these features raise the MSRV to 1.74.0.
+compat = ["dep:bitcoin-units-stable", "encoding", "units/compat"]
+encoding = ["dep:encoding", "units/encoding", "bitcoin-units-stable?/encoding"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -48,6 +50,8 @@ encoding = { package = "bitcoin-consensus-encoding", version = "1.1", default-fe
 ordered = { version = "0.2.0", optional = true }
 # Only use this feature for no-std builds, otherwise use bitcoinconsensus-std.
 bitcoinconsensus = { version = "0.105.0+25.1", default-features = false, optional = true }
+# 1.0.0 release tracking PR: https://github.com/rust-bitcoin/rust-bitcoin/pull/6248
+bitcoin-units-stable = { package = "bitcoin-units", git = "https://github.com/tcharding/rust-bitcoin", branch = "push-puzmtlnlttlr", default-features = false, features = ["alloc"], optional = true }
 
 # Do NOT use this as a feature! Use the `serde` feature instead.
 actual-serde = { package = "serde", version = "1.0.195", default-features = false, features = [ "derive", "alloc" ], optional = true }
@@ -93,7 +97,7 @@ unexpected_cfgs = { level = "deny", check-cfg = ['cfg(bench)', 'cfg(fuzzing)', '
 enabled = true
 
 [package.metadata.rbmt.test]
-msrv_overrides = { "encoding" = "1.74.0" }
+msrv_overrides = { "compat" = "1.74.0", "encoding" = "1.74.0" }
 examples = [
     "sign-tx-segwit-v0:std rand-std",
     "sign-tx-taproot:std rand-std",
@@ -102,6 +106,12 @@ examples = [
 exact_features = [
     ["bitcoinconsensus", "secp-recovery", "base64", "serde"],
     ["std", "bitcoinconsensus-std", "secp-recovery", "base64", "serde"],
+]
+
+[package.metadata.rbmt.lint]
+allowed_duplicates = [
+    "bitcoin-units",
+    "bitcoin-internals",
 ]
 
 [package.metadata.rbmt.prerelease]

--- a/bitcoin/src/blockdata/locktime/absolute.rs
+++ b/bitcoin/src/blockdata/locktime/absolute.rs
@@ -14,6 +14,8 @@ use core::str::FromStr;
 
 #[cfg(feature = "arbitrary")]
 use actual_arbitrary::{self as arbitrary, Arbitrary, Unstructured};
+#[cfg(feature = "compat")]
+use bitcoin_units_stable as stable;
 use io::{Read, Write};
 use units::parse::{self, ParseIntError};
 
@@ -287,6 +289,18 @@ impl LockTime {
             LockTime::Blocks(ref h) => h.to_consensus_u32(),
             LockTime::Seconds(ref t) => t.to_consensus_u32(),
         }
+    }
+
+    /// Converts pre-1.0 type to a stable type.
+    #[cfg(feature = "compat")]
+    pub fn to_stable(self) -> stable::absolute::LockTime {
+        stable::absolute::LockTime::from_consensus(self.to_consensus_u32())
+    }
+
+    /// Converts a stable type to a pre-1.0 type.
+    #[cfg(feature = "compat")]
+    pub fn from_stable(stable: stable::absolute::LockTime) -> Self {
+        Self::from_consensus(stable.to_consensus_u32())
     }
 }
 

--- a/bitcoin/src/blockdata/locktime/relative.rs
+++ b/bitcoin/src/blockdata/locktime/relative.rs
@@ -10,6 +10,9 @@
 use core::cmp::Ordering;
 use core::{cmp, convert, fmt};
 
+#[cfg(feature = "compat")]
+use bitcoin_units_stable as stable;
+
 #[cfg(doc)]
 use crate::relative;
 use crate::Sequence;
@@ -292,6 +295,18 @@ impl LockTime {
             Time(ref t) => Ok(t.value() <= time.value()),
             Blocks(height) => Err(IncompatibleTimeError { time, height }),
         }
+    }
+
+    /// Converts pre-1.0 type to a stable type.
+    #[cfg(feature = "compat")]
+    pub fn to_stable(self) -> stable::relative::LockTime {
+        stable::relative::LockTime::from_consensus(self.to_consensus_u32()).expect("self type is guaranteed valid")
+    }
+
+    /// Converts a stable type to a pre-1.0 type.
+    #[cfg(feature = "compat")]
+    pub fn from_stable(stable: stable::relative::LockTime) -> Self {
+        Self::from_consensus(stable.to_consensus_u32()).expect("stable type is guaranteed valid")
     }
 }
 

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -17,6 +17,8 @@ use core::mem;
 use core::str::FromStr;
 use core::{cmp, fmt};
 
+#[cfg(feature = "compat")]
+use bitcoin_units_stable as stable;
 #[cfg(feature = "encoding")]
 use encoding::{
     ArrayEncoder, BytesEncoder, Decoder2, Decoder3, DecoderStatus, Encode as _, Encoder2, Encoder3,
@@ -514,6 +516,18 @@ impl Sequence {
         } else {
             Some(LockTime::from(Height::from(lock_value)))
         }
+    }
+
+    /// Converts pre-1.0 type to a stable type.
+    #[cfg(feature = "compat")]
+    pub fn to_stable(self) -> stable::Sequence {
+        stable::Sequence::from_consensus(self.to_consensus_u32())
+    }
+
+    /// Converts a stable type to a pre-1.0 type.
+    #[cfg(feature = "compat")]
+    pub fn from_stable(stable: stable::Sequence) -> Self {
+        Self::from_consensus(stable.to_consensus_u32())
     }
 
     /// Returns the low 16 bits from sequence number.

--- a/bitcoin/src/compat.rs
+++ b/bitcoin/src/compat.rs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Stable compatibility layer.
+//!
+//! This module re-exports types from stable crates (e.g. `bitcoin-units-1.0.0`). The aim is to ease
+//! the upgrade path from `bitcoin 0.32` to subsequent `bitcoin` versions as we release them.
+//!
+//! With this module, coupled with the `to_stable`/`from_stable` functions, downstream projects can
+//! update to use stable crates at their leisure without the whole ecosystem having to upgrade at
+//! once. The intention is to provide stable types for the most common `rust-bitcoin` types used by
+//! downstream libraries.
+//!
+//! # Examples
+//!
+//! ```
+//! use bitcoin::Sequence;
+//!
+//! let seq = Sequence::default();
+//! let stable = seq.to_stable();
+//! 
+//! // Now call into some other library that uses stable types in its API.
+//! // E.g., `other_lib::some_function(stable);`
+//! let unstable = Sequence::from_stable(stable);
+//! assert_eq!(unstable, seq);
+//! ```
+
+#[doc(inline)]
+pub use bitcoin_units_stable::{
+    amount, block, fee_rate, locktime, parse_int, pow, result, sequence, time, weight
+};
+#[doc(inline)]
+#[rustfmt::skip]
+pub use self::{
+    amount::{Amount, SignedAmount},
+    block::{BlockHeight, BlockHeightInterval, BlockMtp, BlockMtpInterval},
+    fee_rate::FeeRate,
+    locktime::{absolute, relative},
+    pow::{CompactTarget, Target, Work},
+    result::NumOpResult,
+    sequence::Sequence,
+    time::BlockTime,
+    weight::Weight
+};

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -28,6 +28,8 @@
 //!   achieve the same without this feature but it could happen the implementations diverge one
 //!   day.
 //! * `ordered` - (dependency), adds implementations of `ArbitraryOrdOrd` to some structs.
+//! * `compat` - adds a compatibility layer to convert to/from `units-1.0.0` types as well
+//!   as a `compat` module that re-exports the stable types.
 
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 // Experimental features we need.
@@ -106,6 +108,8 @@ pub mod bip152;
 pub mod bip158;
 pub mod bip32;
 pub mod blockdata;
+#[cfg(feature = "compat")]
+pub mod compat;
 pub mod consensus;
 // Private until we either make this a crate or flatten it - still to be decided.
 pub(crate) mod crypto;

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -12,6 +12,8 @@ use core::convert::Infallible;
 use core::fmt::{self, LowerHex, UpperHex};
 use core::ops::{Add, Div, Mul, Not, Rem, Shl, Shr, Sub};
 
+#[cfg(feature = "compat")]
+use bitcoin_units_stable as stable;
 use io::{Read, Write};
 use units::parse;
 
@@ -66,6 +68,18 @@ macro_rules! do_impl {
             #[doc = "` to a little-endian byte array."]
             #[inline]
             pub fn to_le_bytes(self) -> [u8; 32] { self.0.to_le_bytes() }
+
+            /// Converts pre-1.0 type to a stable type.
+            #[cfg(feature = "compat")]
+            pub fn to_stable(self) -> stable::$ty {
+                stable::$ty::from_be_bytes(self.to_be_bytes())
+            }
+
+            /// Converts a stable type to a pre-1.0 type.
+            #[cfg(feature = "compat")]
+            pub fn from_stable(stable: stable::$ty) -> Self {
+                Self::from_be_bytes(stable.to_be_bytes())
+            }
         }
 
         impl fmt::Display for $ty {
@@ -447,6 +461,18 @@ impl CompactTarget {
 
     /// Returns the consensus encoded `u32` representation of this [`CompactTarget`].
     pub fn to_consensus(self) -> u32 { self.0 }
+
+    /// Converts pre-1.0 type to a stable type.
+    #[cfg(feature = "compat")]
+    pub fn to_stable(self) -> stable::CompactTarget {
+        stable::CompactTarget::from_consensus(self.to_consensus())
+    }
+
+    /// Converts a stable type to a pre-1.0 type.
+    #[cfg(feature = "compat")]
+    pub fn from_stable(stable: stable::CompactTarget) -> Self {
+        Self::from_consensus(stable.to_consensus())
+    }
 }
 
 impl From<CompactTarget> for Target {

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -20,14 +20,21 @@ default = ["std"]
 std = ["alloc", "encoding?/std"]
 alloc = ["encoding?/alloc"]
 
+# Raises the MSRV to 1.74.0.
+compat = ["dep:bitcoin-units-stable", "encoding"]
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 arbitrary = { version = "1.0.1", optional = true }
+# Raises the MSRV to 1.74.0.
 encoding = { package = "bitcoin-consensus-encoding", version = "1.1", default-features = false, optional = true }
 serde = { version = "1.0.195", default-features = false, features = ["derive"], optional = true }
+
+# 1.0.0 release tracking PR: https://github.com/rust-bitcoin/rust-bitcoin/pull/6248
+bitcoin-units-stable = { package = "bitcoin-units", git = "https://github.com/tcharding/rust-bitcoin", branch = "push-puzmtlnlttlr", default-features = false, optional = true }
 
 [dev-dependencies]
 serde_test = "1.0.19"
@@ -41,10 +48,16 @@ enabled = true
 features = [["alloc"]]
 
 [package.metadata.rbmt.test]
-msrv_overrides = { "encoding" = "1.74.0" }
+msrv_overrides = { "compat" = "1.74.0", "encoding" = "1.74.0" }
 exact_features = [
     ["alloc", "serde"],
     ["std", "serde"],
+]
+
+[package.metadata.rbmt.lint]
+allowed_duplicates = [
+    "bitcoin-units",
+    "bitcoin-internals",
 ]
 
 [package.metadata.rbmt.prerelease]

--- a/units/src/amount.rs
+++ b/units/src/amount.rs
@@ -18,6 +18,8 @@ use core::{default, fmt, ops};
 use ::serde::{Deserialize, Serialize};
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
+#[cfg(feature = "compat")]
+use bitcoin_units_stable as stable;
 
 use crate::input_string::InputString;
 use crate::internal_macros::write_err;
@@ -1103,6 +1105,23 @@ impl Amount {
             Ok(SignedAmount::from_sat(self.to_sat() as i64))
         }
     }
+
+    /// Converts pre-1.0 type to a stable type.
+    ///
+    /// # Errors
+    ///
+    /// Errors if the unstable amount is outside the range of the stable amount type
+    /// ([`stable::Amount::MAX_MONEY`]).
+    #[cfg(feature = "compat")]
+    pub fn to_stable(self) -> Result<stable::Amount, stable::amount::OutOfRangeError> {
+        stable::Amount::from_sat(self.to_sat())
+    }
+
+    /// Converts a stable type to a pre-1.0 type.
+    #[cfg(feature = "compat")]
+    pub fn from_stable(stable: stable::Amount) -> Self {
+        Self::from_sat(stable.to_sat())
+    }
 }
 
 impl default::Default for Amount {
@@ -1563,6 +1582,23 @@ impl SignedAmount {
         } else {
             Ok(Amount::from_sat(self.to_sat() as u64))
         }
+    }
+
+    /// Converts pre-1.0 type to a stable type.
+    ///
+    /// # Errors
+    ///
+    /// Errors if the unstable amount is outside the range of the stable amount type
+    /// ([`stable::SignedAmount::MAX`]).
+    #[cfg(feature = "compat")]
+    pub fn to_stable(self) -> Result<stable::SignedAmount, stable::amount::OutOfRangeError> {
+        stable::SignedAmount::from_sat(self.to_sat())
+    }
+
+    /// Converts a stable type to a pre-1.0 type.
+    #[cfg(feature = "compat")]
+    pub fn from_stable(stable: stable::SignedAmount) -> Self {
+        Self::from_sat(stable.to_sat())
     }
 }
 

--- a/units/src/fee_rate.rs
+++ b/units/src/fee_rate.rs
@@ -7,6 +7,8 @@ use core::ops::{Div, Mul};
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
+#[cfg(feature = "compat")]
+use bitcoin_units_stable as stable;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -113,6 +115,25 @@ impl FeeRate {
     /// `Self::fee_wu(weight)`.
     pub fn fee_vb(self, vb: u64) -> Option<Amount> {
         Weight::from_vb(vb).and_then(|w| self.fee_wu(w))
+    }
+
+    /// Converts pre-1.0 type to a stable type.
+    ///
+    /// Casts away anything greater than a `u32` and floors to the
+    /// nearest sat/kwu; precision is lost if the stable value is not
+    /// an exact multiple of 4,000 sat/MvB (1 sat/kwu).
+    #[cfg(feature = "compat")]
+    pub fn to_stable(self) -> stable::FeeRate {
+        stable::FeeRate::from_sat_per_kwu(self.to_sat_per_kwu() as u32)
+    }
+
+    /// Converts a stable type to a pre-1.0 type.
+    ///
+    /// Floors to the nearest sat/kwu; precision is lost if the stable value is not an exact
+    /// multiple of 4,000 sat/MvB (1 sat/kwu).
+    #[cfg(feature = "compat")]
+    pub fn from_stable(stable: stable::FeeRate) -> Self {
+        Self::from_sat_per_kwu(stable.to_sat_per_kwu_floor())
     }
 }
 

--- a/units/src/locktime/absolute.rs
+++ b/units/src/locktime/absolute.rs
@@ -7,6 +7,8 @@ use core::fmt;
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
+#[cfg(feature = "compat")]
+use bitcoin_units_stable as stable;
 
 use crate::internal_macros::write_err;
 use crate::parse::{self, ParseIntError};
@@ -73,6 +75,20 @@ impl Height {
     /// Converts this `Height` to its inner `u32` value.
     #[inline]
     pub fn to_consensus_u32(self) -> u32 { self.0 }
+
+    /// Converts pre-1.0 type to a stable type.
+    #[cfg(feature = "compat")]
+    pub fn to_stable(self) -> stable::absolute::Height {
+        stable::absolute::Height::from_u32(self.to_consensus_u32())
+            .expect("pre-1.0 Height guarantees a valid consensus value")
+    }
+
+    /// Converts a stable type to a pre-1.0 type.
+    #[cfg(feature = "compat")]
+    pub fn from_stable(stable: stable::absolute::Height) -> Self {
+        Self::from_consensus(stable.to_u32())
+            .expect("stable Height guarantees a valid consensus value")
+    }
 }
 
 impl fmt::Display for Height {
@@ -168,6 +184,20 @@ impl Time {
     /// Converts this `Time` to its inner `u32` value.
     #[inline]
     pub fn to_consensus_u32(self) -> u32 { self.0 }
+
+    /// Converts pre-1.0 type to a stable type.
+    #[cfg(feature = "compat")]
+    pub fn to_stable(self) -> stable::absolute::MedianTimePast {
+        stable::absolute::MedianTimePast::from_u32(self.to_consensus_u32())
+            .expect("pre-1.0 Time guarantees a valid consensus value")
+    }
+
+    /// Converts a stable type to a pre-1.0 type.
+    #[cfg(feature = "compat")]
+    pub fn from_stable(stable: stable::locktime::absolute::MedianTimePast) -> Self {
+        Self::from_consensus(stable.to_u32())
+            .expect("stable MedianTimePast guarantees a valid consensus value")
+    }
 }
 
 impl fmt::Display for Time {

--- a/units/src/locktime/relative.rs
+++ b/units/src/locktime/relative.rs
@@ -6,6 +6,8 @@ use core::fmt;
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
+#[cfg(feature = "compat")]
+use bitcoin_units_stable as stable;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -36,6 +38,18 @@ impl Height {
     /// argument to `OP_CHECKSEQUENCEVERIFY`.
     #[inline]
     pub fn to_consensus_u32(&self) -> u32 { self.0.into() }
+
+    /// Converts pre-1.0 type to a stable type.
+    #[cfg(feature = "compat")]
+    pub fn to_stable(self) -> stable::locktime::relative::NumberOfBlocks {
+        stable::locktime::relative::NumberOfBlocks::from_height(self.value())
+    }
+
+    /// Converts a stable type to a pre-1.0 type.
+    #[cfg(feature = "compat")]
+    pub fn from_stable(stable: stable::locktime::relative::NumberOfBlocks) -> Self {
+        Self::from_height(stable.to_height())
+    }
 }
 
 impl From<u16> for Height {
@@ -114,6 +128,18 @@ impl Time {
     /// argument to `OP_CHECKSEQUENCEVERIFY`.
     #[inline]
     pub fn to_consensus_u32(&self) -> u32 { (1u32 << 22) | u32::from(self.0) }
+
+    /// Converts pre-1.0 type to a stable type.
+    #[cfg(feature = "compat")]
+    pub fn to_stable(self) -> stable::locktime::relative::NumberOf512Seconds {
+        stable::locktime::relative::NumberOf512Seconds::from_512_second_intervals(self.value())
+    }
+
+    /// Converts a stable type to a pre-1.0 type.
+    #[cfg(feature = "compat")]
+    pub fn from_stable(stable: stable::locktime::relative::NumberOf512Seconds) -> Self {
+        Self::from_512_second_intervals(stable.to_512_second_intervals())
+    }
 }
 
 crate::impl_parse_str_from_int_infallible!(Time, u16, from_512_second_intervals);

--- a/units/src/weight.rs
+++ b/units/src/weight.rs
@@ -7,6 +7,8 @@ use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
+#[cfg(feature = "compat")]
+use bitcoin_units_stable as stable;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -130,6 +132,18 @@ impl Weight {
     /// Computes `self * WITNESS_SCALE_FACTOR` returning `None` if an overflow occurred.
     pub fn scale_by_witness_factor(self) -> Option<Self> {
         Self::checked_mul(self, Self::WITNESS_SCALE_FACTOR)
+    }
+
+    /// Converts pre-1.0 type to a stable type.
+    #[cfg(feature = "compat")]
+    pub fn to_stable(self) -> stable::Weight {
+        stable::Weight::from_wu(self.to_wu())
+    }
+
+    /// Converts a stable type to a pre-1.0 type.
+    #[cfg(feature = "compat")]
+    pub fn from_stable(stable: stable::Weight) -> Self {
+        Self::from_wu(stable.to_wu())
     }
 }
 


### PR DESCRIPTION
Currently we have a problem, the ecosystem is on `rust-bitcoin 0.32` and master is so far ahead that there is no palatable upgrade path.

The idea is that some users can start using stable crates and when they need to interoperate with libraries that are yet to do so they can use the provided compat layer to convert types. Furthermore if a library started to use stable types in their API applications that did not want to upgrade could use the compat layer instead.

Draft until 1.0 is out. Currently uses https://github.com/rust-bitcoin/rust-bitcoin/pull/6248 as the dependency. 

Adds these as well as `from_stable` to the same type

```rust
to_stable(self) -> stable::Sequence
to_stable(self) -> stable::Work
to_stable(self) -> stable::Target
to_stable(self) -> stable::CompactTarget
to_stable(self) -> Result<stable::Amount, stable::amount::OutOfRangeError>
to_stable(self) -> Result<stable::SignedAmount, stable::amount::OutOfRangeError>
to_stable(self) -> stable::FeeRate
to_stable(self) -> stable::absolute::Height
to_stable(self) -> stable::absolute::MedianTimePast // `self` is `Time`
to_stable(self) -> stable::absolute::LockTime;
to_stable(self) -> stable::relative::NumberOfBlocks // `self` is `Height`
to_stable(self) -> stable::relative::NumberOf512Seconds // `self` is `Time`
to_stable(self) -> stable::relative::LockTime;
to_stable(self) -> stable::Weight
```

Now adds a `compat` module that re-exports everything from `units 1.0.0`.