### PR TITLE
hashes: fix Miri UB in aarch64 loads

### DIFF
--- a/hashes/src/sha256/crypto/arm_sha2.rs
+++ b/hashes/src/sha256/crypto/arm_sha2.rs
@@ -533,10 +533,10 @@ pub(super) unsafe fn sha256d_64_2way(output: &mut [[u8; 32]; 2], input: &[[u8; 6
     state1_b = vsha256h2q_u32(state1_b, tmp2_b, tmp0_b);
 
     // Transform 1: Update state
-    tmp = vld1q_u32(&INIT[0]);
+    tmp = vld1q_u32(INIT.as_ptr());
     state0_a = vaddq_u32(state0_a, tmp);
     state0_b = vaddq_u32(state0_b, tmp);
-    tmp = vld1q_u32(&INIT[4]);
+    tmp = vld1q_u32(INIT.as_ptr().add(4));
     state1_a = vaddq_u32(state1_a, tmp);
     state1_b = vaddq_u32(state1_b, tmp);
 


### PR DESCRIPTION
`vld1q_u32` loads four `u32` values, but `&INIT[0]`/`&INIT[4]` creates a reference to only one `u32`. We can use `INIT.as_ptr()` instead.

I found this by running `bitcoin_hashes` tests under my local Miri branch that support Aarch64 sha256 intrinsic. 
The related Miri PR is here: https://github.com/rust-lang/miri/pull/5064

I’ll keep this PR as a draft until there is some progress on the Miri PR, unless we think this is good to go.