### PR TITLE
internals: regenerate api snapshots

### DIFF
--- a/internals/api/all-features.txt
+++ b/internals/api/all-features.txt
@@ -65,9 +65,11 @@ pub struct bitcoin_internals::array_vec::ArrayVec<T: core::marker::Copy, const C
 impl<T: core::marker::Copy, const CAP: usize> bitcoin_internals::array_vec::ArrayVec<T, CAP>
 pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::as_mut_slice(&mut self) -> &mut [T]
 pub const fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::as_slice(&self) -> &[T]
-pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::extend_from_slice(&mut self, slice: &[T])
 pub const fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::from_slice(slice: &[T]) -> Self
 pub const fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::new() -> Self
+pub unsafe fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::set_len(&mut self, new_len: usize)
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::spare_capacity_mut(&mut self) -> &mut [core::mem::maybe_uninit::MaybeUninit<T>]
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::extend_from_slice(&mut self, slice: &[T])
 pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::pop(&mut self) -> core::option::Option<T>
 pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::push(&mut self, element: T)
 pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::try_push(&mut self, element: T) -> core::result::Result<(), bitcoin_internals::array_vec::error::Error>

--- a/internals/api/alloc-only.txt
+++ b/internals/api/alloc-only.txt
@@ -61,9 +61,11 @@ pub struct bitcoin_internals::array_vec::ArrayVec<T: core::marker::Copy, const C
 impl<T: core::marker::Copy, const CAP: usize> bitcoin_internals::array_vec::ArrayVec<T, CAP>
 pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::as_mut_slice(&mut self) -> &mut [T]
 pub const fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::as_slice(&self) -> &[T]
-pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::extend_from_slice(&mut self, slice: &[T])
 pub const fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::from_slice(slice: &[T]) -> Self
 pub const fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::new() -> Self
+pub unsafe fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::set_len(&mut self, new_len: usize)
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::spare_capacity_mut(&mut self) -> &mut [core::mem::maybe_uninit::MaybeUninit<T>]
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::extend_from_slice(&mut self, slice: &[T])
 pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::pop(&mut self) -> core::option::Option<T>
 pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::push(&mut self, element: T)
 pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::try_push(&mut self, element: T) -> core::result::Result<(), bitcoin_internals::array_vec::error::Error>

--- a/internals/api/no-features.txt
+++ b/internals/api/no-features.txt
@@ -55,9 +55,11 @@ pub struct bitcoin_internals::array_vec::ArrayVec<T: core::marker::Copy, const C
 impl<T: core::marker::Copy, const CAP: usize> bitcoin_internals::array_vec::ArrayVec<T, CAP>
 pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::as_mut_slice(&mut self) -> &mut [T]
 pub const fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::as_slice(&self) -> &[T]
-pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::extend_from_slice(&mut self, slice: &[T])
 pub const fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::from_slice(slice: &[T]) -> Self
 pub const fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::new() -> Self
+pub unsafe fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::set_len(&mut self, new_len: usize)
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::spare_capacity_mut(&mut self) -> &mut [core::mem::maybe_uninit::MaybeUninit<T>]
+pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::extend_from_slice(&mut self, slice: &[T])
 pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::pop(&mut self) -> core::option::Option<T>
 pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::push(&mut self, element: T)
 pub fn bitcoin_internals::array_vec::ArrayVec<T, CAP>::try_push(&mut self, element: T) -> core::result::Result<(), bitcoin_internals::array_vec::error::Error>


### PR DESCRIPTION
Closes https://github.com/rust-bitcoin/rust-bitcoin/issues/6268

The api snapshot files were not refreshed when `ArrayVec::set_len` and `ArrayVec::spare_capacity_mut` were added, leaving `cargo rbmt api` failing on master and on every PR that branches from it.

Running `cargo rbmt api` on the pinned nightly toolchain regenerates the three `internals/api/*.txt files`, fixing the drift.