### PR TITLE
key_expression: bip32 seed length validation follow-up

### DIFF
--- a/key_expression/src/bip32.rs
+++ b/key_expression/src/bip32.rs
@@ -133,6 +133,8 @@ impl PartialEq for Bip32Seed {
     }
 }
 
+impl Eq for Bip32Seed {}
+
 macro_rules! impl_bip32_seed_from_array {
     ($($n:literal),+ $(,)?) => {
         $(

--- a/key_expression/src/bip32.rs
+++ b/key_expression/src/bip32.rs
@@ -1279,7 +1279,7 @@ pub mod error {
     }
 
     /// Master seed had an invalid length.
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
     pub struct InvalidSeedLengthError {
         pub(crate) length: usize,
     }
@@ -1289,14 +1289,20 @@ pub mod error {
         pub fn invalid_seed_length(&self) -> usize { self.length }
     }
 
+    impl From<Infallible> for InvalidSeedLengthError {
+        fn from(never: Infallible) -> Self { match never {} }
+    }
+
     impl fmt::Display for InvalidSeedLengthError {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            write!(f, "invalid BIP-0032 master seed length: {} (expected 16 to 64)", self.length)
+            write!(f, "invalid BIP-0032 master seed length: {} (expected 16 to 64 inclusive)", self.length)
         }
     }
 
     #[cfg(feature = "std")]
-    impl std::error::Error for InvalidSeedLengthError {}
+    impl std::error::Error for InvalidSeedLengthError {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    }
 }
 
 #[cfg(feature = "arbitrary")]

--- a/key_expression/src/bip32.rs
+++ b/key_expression/src/bip32.rs
@@ -655,12 +655,16 @@ impl Xpriv {
     /// Constructs a new master key from a [`Bip32Seed`].
     #[allow(clippy::missing_panics_doc)]
     pub fn new_master(network: impl Into<NetworkKind>, seed: impl AsRef<Bip32Seed>) -> Self {
+        Self::new_master_inner(network.into(), seed.as_ref())
+    }
+
+    fn new_master_inner(network: NetworkKind, seed: &Bip32Seed) -> Self {
         let mut engine = HmacEngine::<sha512::HashEngine>::new(b"Bitcoin seed");
-        engine.input(seed.as_ref().as_bytes());
+        engine.input(seed.as_bytes());
         let hmac = engine.finalize();
 
         Self {
-            network: network.into(),
+            network,
             depth: 0,
             parent_fingerprint: Fingerprint::default(),
             child_number: ChildNumber::ZERO_NORMAL,

--- a/key_expression/src/bip32.rs
+++ b/key_expression/src/bip32.rs
@@ -1176,6 +1176,10 @@ pub mod error {
         MaximumDepthExceeded,
     }
 
+    impl From<Infallible> for DerivationError {
+        fn from(never: Infallible) -> Self { match never {} }
+    }
+
     #[cfg(feature = "std")]
     impl std::error::Error for DerivationError {
         fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
@@ -1265,6 +1269,10 @@ pub mod error {
     impl InvalidBase58PayloadLengthError {
         /// Returns the invalid payload length.
         pub fn invalid_base58_payload_length(&self) -> usize { self.length }
+    }
+
+    impl From<Infallible> for InvalidBase58PayloadLengthError {
+        fn from(never: Infallible) -> Self { match never {} }
     }
 
     impl fmt::Display for InvalidBase58PayloadLengthError {


### PR DESCRIPTION

Follow ups mentioned after the merge of #6212. 

- Commit 1: implements `Eq` for `Bip32Seed` based on [this](https://github.com/rust-bitcoin/rust-bitcoin/pull/6212#issuecomment-4559288637) comment. 
- Commit 2: tidy `InvalidSeedLengthError` to match other errors in the same module based on [these](https://github.com/rust-bitcoin/rust-bitcoin/pull/6212#issuecomment-4559288637) [two](https://github.com/rust-bitcoin/rust-bitcoin/pull/6212#discussion_r3310442807) comments.
- Commit 3: splits `Xpriv::new_master` into a wrapper that does conversions and forwards to a non-generic `new_master_inner`, so the compiler will only duplicate the small function, not the big one that does all the hash computations based on [this](https://github.com/rust-bitcoin/rust-bitcoin/pull/6212#discussion_r3310826352) comment.
- Commit 4: adds two missing `From<Infallible>` for `DerivationError` and `InvalidBase58PayloadLengthError` so every error type in the module is uniform based on [this](https://github.com/rust-bitcoin/rust-bitcoin/pull/6212#issuecomment-4559288637) comment.

