### PR TITLE
Releases tracking PR: `bitcoin-primitives 0.103.0`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-primitives"
-version = "0.102.0"
+version = "0.103.0"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-primitives"
-version = "0.102.0"
+version = "0.103.0"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/addresses/Cargo.toml
+++ b/addresses/Cargo.toml
@@ -22,7 +22,7 @@ alloc = ["crypto/alloc", "internals/alloc", "primitives/alloc", "taproot_primiti
 crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.2.0", default-features = false, features = [] }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
 taproot_primitives = { package = "bitcoin-taproot-primitives", path = "../taproot-primitives", version = "0.1.0", default-features = false, features = [] }
-primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.102.0", default-features = false, features = ["hex"] }
+primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.103.0", default-features = false, features = ["hex"] }
 
 [dev-dependencies]
 

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -32,7 +32,7 @@ bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
 crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.2.0", default-features = false, features = ["alloc", "hex"] }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.1.0", default-features = false, features = ["alloc", "hex"] }
 key-expression = { package = "bitcoin-key-expression", path = "../key_expression", version = "0.1.0", default-features = false, features = ["alloc"] }
-encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0", default-features = false, features = ["alloc", "hex"] }
+encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.1.0", default-features = false, features = ["alloc", "hex"] }
 hex = { package = "hex-conservative", version = "1.1.0", default-features = false, features = ["alloc"] }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0", features = ["alloc"] }
 io = { package = "bitcoin-io", path = "../io", version = "0.6.0", default-features = false, features = ["alloc", "hashes"] }

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -37,7 +37,7 @@ hex = { package = "hex-conservative", version = "1.1.0", default-features = fals
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0", features = ["alloc"] }
 io = { package = "bitcoin-io", path = "../io", version = "0.6.0", default-features = false, features = ["alloc", "hashes"] }
 network = { package = "bitcoin-network-kind", path = "../network", version = "1.0.0", default-features = false, features = ["alloc"]}
-primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.102.0", default-features = false, features = ["alloc", "hex"] }
+primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.103.0", default-features = false, features = ["alloc", "hex"] }
 secp256k1 = { version = "0.32.0-beta.2", default-features = false, features = ["alloc"] }
 taproot-primitives = { package = "bitcoin-taproot-primitives", path = "../taproot-primitives", version = "0.1.0", default-features = false, features = ["alloc", "hex"] }
 units = { package = "bitcoin-units", path = "../units", version = "0.5.0", default-features = false, features = ["alloc"] }

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -28,7 +28,7 @@ hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.0.0", de
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
 network = { package = "bitcoin-network-kind", path = "../network", version = "1.0.0", default-features = false }
 # This is a temporary dep for the sake of PushBytes impls. This should not be retained for crypto 1.0.
-primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.102.0", default-features = false, features = [] }
+primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.103.0", default-features = false, features = [] }
 secp256k1 = { version = "0.32.0-beta.2", default-features = false }
 
 arbitrary = { version = "1.4.1", optional = true }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -23,7 +23,7 @@ serde = ["dep:serde", "hashes/serde"]
 encoding = { package = "bitcoin-consensus-encoding", version = "1.0.0", path = "../consensus_encoding", features = ["alloc"], default-features = false }
 hashes = { package = "bitcoin_hashes", version = "1.0.0", path = "../hashes", default-features = false }
 network = { package = "bitcoin-network-kind", path = "../network", version = "1.0.0", default-features = false }
-primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.102.0", features = ["hex", "alloc"], default-features = false }
+primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.103.0", features = ["hex", "alloc"], default-features = false }
 hex = { package = "hex-conservative", version = "1.1.0", default-features = false, features = ["alloc"] }
 internals = { package = "bitcoin-internals", path = "../internals", default-features = false }
 units = { package = "bitcoin-units", path = "../units", version = "0.5.0", default-features = false }

--- a/primitives/CHANGELOG.md
+++ b/primitives/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 ## [Unreleased]
 
+# [0.103.0] - 2026-07-14
+
+- Move `script_hash` and `wscript_hash` to primitives [#6504](https://github.com/rust-bitcoin/rust-bitcoin/pull/6504)
+- Move `builder` script functions to primitives [#6514](https://github.com/rust-bitcoin/rust-bitcoin/pull/6514)
+- script: make `new_p2wsh` available on hashable scripts [#6498](https://github.com/rust-bitcoin/rust-bitcoin/pull/6498)
+- hashes: Introduce `drain_to_hash` and `encode_to_hash` [#6456](https://github.com/rust-bitcoin/rust-bitcoin/pull/6456)
+- Implement `ExactSizeEncoder` for `WitnessEncoder` [#6428](https://github.com/rust-bitcoin/rust-bitcoin/pull/6428)
+- Adjust `Arbitrary` impls to enforce invariants from decoders [#6407](https://github.com/rust-bitcoin/rust-bitcoin/pull/6407)
+- Seal the `Tag` trait [#6403](https://github.com/rust-bitcoin/rust-bitcoin/pull/6403)
+- Move `serde_as_consensus` to `consensus_encoding` [#6395](https://github.com/rust-bitcoin/rust-bitcoin/pull/6395)
+- Move some script functions to `primitives` [#6342](https://github.com/rust-bitcoin/rust-bitcoin/pull/6342)
+- Replace `HexPrimitive` decoding with `consensus_encoding` [#6330](https://github.com/rust-bitcoin/rust-bitcoin/pull/6330)
+- Move `Builder` to `primitives` [#6313](https://github.com/rust-bitcoin/rust-bitcoin/pull/6313)
+- Move `WitnessVersion` to `primitives` [#6307](https://github.com/rust-bitcoin/rust-bitcoin/pull/6307)
+- Move `Opcode` to `primitives` [#6306](https://github.com/rust-bitcoin/rust-bitcoin/pull/6306)
+- Simplify and optimize witness decoder [#6321](https://github.com/rust-bitcoin/rust-bitcoin/pull/6321)
+- Remove double allocation from `ScriptBuf::from_hex_prefixed` [#6295](https://github.com/rust-bitcoin/rust-bitcoin/pull/6295)
+- Implement `fmt::LowerHex` and `fmt::UpperHex` for `Witness` [#6316](https://github.com/rust-bitcoin/rust-bitcoin/pull/6316)
+- Avoid allocating claimed size when decoding witness length [#6298](https://github.com/rust-bitcoin/rust-bitcoin/pull/6298)
+- Fix witness commitment check (BIP-141) [#6250](https://github.com/rust-bitcoin/rust-bitcoin/pull/6250)
+- witness: Allocate in `reserve_batch` if `capacity < MIN_VECTOR_ALLOCATE` [#6241](https://github.com/rust-bitcoin/rust-bitcoin/pull/6241)
+- Use optimized `sha256d` for 64-byte in merkle root computation [#5946](https://github.com/rust-bitcoin/rust-bitcoin/pull/5946)
+- Move `PushBytes` and co to `primitives` [#6128](https://github.com/rust-bitcoin/rust-bitcoin/pull/6128)
+- Remove the unstable `hex-conservative` dependency [#6148](https://github.com/rust-bitcoin/rust-bitcoin/pull/6148)
+- Add minimum allocation size [#6198](https://github.com/rust-bitcoin/rust-bitcoin/pull/6198)
+- witness: Allocate in `reserve_batch` if `capacity < MIN_VECTOR_ALLOCATE` [#6241](https://github.com/rust-bitcoin/rust-bitcoin/pull/6241)
+- Add `SignetBlockScript`/`Buf` for signet challenge scripts [#5871](https://github.com/rust-bitcoin/rust-bitcoin/pull/5871)
+- Move script hex parsing functions to `primitives` [#5657](https://github.com/rust-bitcoin/rust-bitcoin/pull/5657)
+- Remove `From<SubError>` for error types [#5855](https://github.com/rust-bitcoin/rust-bitcoin/pull/5855)
+- Do not re-export non-essential hash types [#5891](https://github.com/rust-bitcoin/rust-bitcoin/pull/5891)
+- Re-export `serde` and `arbitrary` when they appear in public API [#5862](https://github.com/rust-bitcoin/rust-bitcoin/pull/5862)
+- Implement stringly traits for `Block` using hex [#5703](https://github.com/rust-bitcoin/rust-bitcoin/pull/5703)
+- Move `TxMerkleNodeDecoder`/`Error` to `merkle_tree` module [#5724](https://github.com/rust-bitcoin/rust-bitcoin/pull/5724)
+- Remove excess allocations from `Witness::from_iter` [#5650](https://github.com/rust-bitcoin/rust-bitcoin/pull/5650)
+- Remove `BlockTime` decoder from root export [#5527](https://github.com/rust-bitcoin/rust-bitcoin/pull/5527)
+- Upgrade to `bitcoin-units 0.5.0` [#6292](https://github.com/rust-bitcoin/rust-bitcoin/pull/6292)
+- Upgrade to `bitcoin_hashes 1.0.0`
+- Upgrade to `consensus-encoding 1.0.0`
+
 ## [0.102.0] - 2026-02-17
 
 It was found that the `1.0.0-rc.x` releases were troublesome because
@@ -117,6 +156,7 @@ Enjoy!
 * Initial release of the `github.com/rust-bitcoin/rust-bitcoin/primitives` crate as
   `bitcoin-primitives`. The name on crates.io was generously transferred to us.
 
-[Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-primitives-0.102.0...HEAD
+[Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-primitives-0.103.0...HEAD
+[0.103.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/primitives-0.102.0...bitcoin-primitives-0.103.0
 [0.102.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/primitives-0.101.0...bitcoin-primitives-0.102.0
 [0.101.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/primitives-0.100.0...primitives-0.101.0

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-primitives"
-version = "0.102.0"
+version = "0.103.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>", "Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin"

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -443,7 +443,7 @@ impl Default for TransactionDecoder {
 }
 
 #[cfg(feature = "alloc")]
-#[allow(clippy::too_many_lines)] // TODO: Can we clean this up?
+#[allow(clippy::too_many_lines)] // State machine, kind of to be expected.
 impl encoding::Decoder for TransactionDecoder {
     type Output = Transaction;
     type Error = TransactionDecoderError;


### PR DESCRIPTION
We are going over the API checklist again so expect more trivial changes before the 'final' RC and `1.0.0`. But we are very close ...

Of note this includes deprecated code so there is a nice upgrade path. See #6130 for more about deprecated code.