### PR TITLE
p2p: create Arbitrary `CommandString` from a buffer of ASCII chars

### DIFF
--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -2248,8 +2248,15 @@ impl<'a> Arbitrary<'a> for InventoryPayload {
 #[cfg(feature = "arbitrary")]
 impl<'a> Arbitrary<'a> for CommandString {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let s = u.arbitrary::<String>()?;
-        Self::try_from(s).map_err(|_| arbitrary::Error::IncorrectFormat)
+        let mut buf = [0; Self::MAX_LEN];
+        let mut buf_iter = buf.iter_mut();
+
+        // ascii `0` pads end of command.
+        while let (Some(dest), ascii @ 1..) = (buf_iter.next(), u8::arbitrary(u)? % 128) {
+            *dest = ascii;
+        }
+
+        Ok(Self(buf))
     }
 }
 


### PR DESCRIPTION
To improve performance of downstream fuzzing by removing String allocation for each Arbitrary `CommandString`.