### PR TITLE
Destructure structs in Error impls

### DIFF
--- a/key_expression/src/bip32.rs
+++ b/key_expression/src/bip32.rs
@@ -1224,7 +1224,10 @@ pub mod error {
 
     #[cfg(feature = "std")]
     impl std::error::Error for IndexOutOfRangeError {
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            let Self { index: _ } = self;
+            None
+        }
     }
 
     /// Error parsing a child number.
@@ -1287,7 +1290,10 @@ pub mod error {
 
     #[cfg(feature = "std")]
     impl std::error::Error for InvalidBase58PayloadLengthError {
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            let Self { length: _ } = self;
+            None
+        }
     }
 
     /// Master seed had an invalid length.
@@ -1313,7 +1319,10 @@ pub mod error {
 
     #[cfg(feature = "std")]
     impl std::error::Error for InvalidSeedLengthError {
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            let Self { length: _ } = self;
+            None
+        }
     }
 }
 


### PR DESCRIPTION
Explicitly destructure self in all Error trait methods using `Self { field: _ }` patterns. 
This ensures exhaustiveness, if new fields are added later the compiler  will throw an error and force a
conscious review of whether those fields should influence the
error's cause chain, rather than silently accepting the change.

Fix: #6279