### PR TITLE
untis: Do final polish before 1.0 

### DIFF
--- a/units/CHANGELOG.md
+++ b/units/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+* Remove all deprecated code.
+
 ## [0.4.0] - 2026-05-27
 
 * Add format traits for `Target` and `Work` [#5626](https://github.com/rust-bitcoin/rust-bitcoin/pull/5626)

--- a/units/api/all-features.txt
+++ b/units/api/all-features.txt
@@ -1699,7 +1699,6 @@ pub const bitcoin_units::SignedAmount::ONE_BTC: Self
 pub const bitcoin_units::SignedAmount::ONE_SAT: Self
 pub const bitcoin_units::SignedAmount::ZERO: Self
 pub const fn bitcoin_units::SignedAmount::abs(self) -> Self
-pub const fn bitcoin_units::SignedAmount::checked_abs(self) -> core::option::Option<Self>
 pub const fn bitcoin_units::SignedAmount::checked_add(self, rhs: Self) -> core::option::Option<Self>
 pub const fn bitcoin_units::SignedAmount::checked_div(self, rhs: i64) -> core::option::Option<Self>
 pub const fn bitcoin_units::SignedAmount::checked_mul(self, rhs: i64) -> core::option::Option<Self>
@@ -2649,8 +2648,6 @@ pub const fn bitcoin_units::FeeRate::checked_add(self, rhs: Self) -> core::optio
 pub const fn bitcoin_units::FeeRate::checked_div(self, rhs: u64) -> core::option::Option<Self>
 pub const fn bitcoin_units::FeeRate::checked_mul(self, rhs: u64) -> core::option::Option<Self>
 pub const fn bitcoin_units::FeeRate::checked_sub(self, rhs: Self) -> core::option::Option<Self>
-pub fn bitcoin_units::FeeRate::fee_vb(self, vb: u64) -> core::option::Option<bitcoin_units::Amount>
-pub fn bitcoin_units::FeeRate::fee_wu(self, weight: bitcoin_units::Weight) -> core::option::Option<bitcoin_units::Amount>
 pub const fn bitcoin_units::FeeRate::from_per_kvb(rate: bitcoin_units::Amount) -> bitcoin_units::result::NumOpResult<Self>
 pub const fn bitcoin_units::FeeRate::from_per_kwu(rate: bitcoin_units::Amount) -> bitcoin_units::result::NumOpResult<Self>
 pub const fn bitcoin_units::FeeRate::from_per_vb(rate: bitcoin_units::Amount) -> bitcoin_units::result::NumOpResult<Self>
@@ -3355,7 +3352,6 @@ pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_seconds
 pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError>
 pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockMtp, utxo_mined_at: bitcoin_units::block::BlockMtp) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::InvalidTimeError>
 pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::to_512_second_intervals(self) -> u16
-pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::to_consensus_u32(self) -> u32
 pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::to_seconds(self) -> u32
 impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOf512Seconds
 pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::clone(&self) -> bitcoin_units::locktime::relative::NumberOf512Seconds
@@ -3431,7 +3427,6 @@ pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::from_height(bloc
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::PrefixedHexError>
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError>
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockHeight, utxo_mined_at: bitcoin_units::block::BlockHeight) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::InvalidHeightError>
-pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::to_consensus_u32(self) -> u32
 pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::to_height(self) -> u16
 impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOfBlocks
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::clone(&self) -> bitcoin_units::locktime::relative::NumberOfBlocks
@@ -3820,7 +3815,6 @@ pub fn bitcoin_units::pow::CompactTarget::from_consensus(bits: u32) -> Self
 pub fn bitcoin_units::pow::CompactTarget::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::PrefixedHexError> where Self: core::marker::Sized
 pub fn bitcoin_units::pow::CompactTarget::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError> where Self: core::marker::Sized
 pub const fn bitcoin_units::pow::CompactTarget::to_consensus(self) -> u32
-pub fn bitcoin_units::pow::CompactTarget::to_hex(self) -> alloc::string::String
 impl bitcoin_consensus_encoding::decode::Decode for bitcoin_units::pow::CompactTarget
 pub type bitcoin_units::pow::CompactTarget::Decoder = bitcoin_units::pow::CompactTargetDecoder
 impl bitcoin_consensus_encoding::encode::Encode for bitcoin_units::pow::CompactTarget
@@ -4620,7 +4614,6 @@ pub struct bitcoin_units::sequence::Sequence(pub u32)
 impl bitcoin_units::sequence::Sequence
 pub const bitcoin_units::sequence::Sequence::ENABLE_LOCKTIME_AND_RBF: Self
 pub const bitcoin_units::sequence::Sequence::ENABLE_LOCKTIME_NO_RBF: Self
-pub const bitcoin_units::sequence::Sequence::ENABLE_RBF_NO_LOCKTIME: Self
 pub const bitcoin_units::sequence::Sequence::FINAL: Self
 pub const bitcoin_units::sequence::Sequence::MAX: Self
 pub const bitcoin_units::sequence::Sequence::SIZE: usize
@@ -4639,7 +4632,6 @@ pub fn bitcoin_units::sequence::Sequence::is_rbf(self) -> bool
 pub fn bitcoin_units::sequence::Sequence::is_relative_lock_time(self) -> bool
 pub fn bitcoin_units::sequence::Sequence::is_time_locked(self) -> bool
 pub const fn bitcoin_units::sequence::Sequence::to_consensus_u32(self) -> u32
-pub fn bitcoin_units::sequence::Sequence::to_hex(self) -> alloc::string::String
 pub fn bitcoin_units::sequence::Sequence::to_relative_lock_time(self) -> core::option::Option<bitcoin_units::locktime::relative::LockTime>
 impl bitcoin_consensus_encoding::decode::Decode for bitcoin_units::sequence::Sequence
 pub type bitcoin_units::sequence::Sequence::Decoder = bitcoin_units::sequence::SequenceDecoder
@@ -5031,12 +5023,9 @@ pub const fn bitcoin_units::Weight::checked_mul(self, rhs: u64) -> core::option:
 pub const fn bitcoin_units::Weight::checked_sub(self, rhs: Self) -> core::option::Option<Self>
 pub fn bitcoin_units::Weight::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::PrefixedHexError>
 pub const fn bitcoin_units::Weight::from_kwu(wu: u64) -> core::option::Option<Self>
-pub const fn bitcoin_units::Weight::from_non_witness_data_size(non_witness_size: u64) -> Self
 pub fn bitcoin_units::Weight::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError>
 pub const fn bitcoin_units::Weight::from_vb(vb: u64) -> core::option::Option<Self>
 pub const fn bitcoin_units::Weight::from_vb_unchecked(vb: u64) -> Self
-pub const fn bitcoin_units::Weight::from_vb_unwrap(vb: u64) -> Self
-pub const fn bitcoin_units::Weight::from_witness_data_size(witness_size: u64) -> Self
 pub const fn bitcoin_units::Weight::mul_by_fee_rate(self, fee_rate: bitcoin_units::FeeRate) -> bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
 pub const fn bitcoin_units::Weight::to_kwu_ceil(self) -> u64
 pub const fn bitcoin_units::Weight::to_kwu_floor(self) -> u64

--- a/units/api/alloc-only.txt
+++ b/units/api/alloc-only.txt
@@ -1351,7 +1351,6 @@ pub const bitcoin_units::SignedAmount::ONE_BTC: Self
 pub const bitcoin_units::SignedAmount::ONE_SAT: Self
 pub const bitcoin_units::SignedAmount::ZERO: Self
 pub const fn bitcoin_units::SignedAmount::abs(self) -> Self
-pub const fn bitcoin_units::SignedAmount::checked_abs(self) -> core::option::Option<Self>
 pub const fn bitcoin_units::SignedAmount::checked_add(self, rhs: Self) -> core::option::Option<Self>
 pub const fn bitcoin_units::SignedAmount::checked_div(self, rhs: i64) -> core::option::Option<Self>
 pub const fn bitcoin_units::SignedAmount::checked_mul(self, rhs: i64) -> core::option::Option<Self>
@@ -2062,8 +2061,6 @@ pub const fn bitcoin_units::FeeRate::checked_add(self, rhs: Self) -> core::optio
 pub const fn bitcoin_units::FeeRate::checked_div(self, rhs: u64) -> core::option::Option<Self>
 pub const fn bitcoin_units::FeeRate::checked_mul(self, rhs: u64) -> core::option::Option<Self>
 pub const fn bitcoin_units::FeeRate::checked_sub(self, rhs: Self) -> core::option::Option<Self>
-pub fn bitcoin_units::FeeRate::fee_vb(self, vb: u64) -> core::option::Option<bitcoin_units::Amount>
-pub fn bitcoin_units::FeeRate::fee_wu(self, weight: bitcoin_units::Weight) -> core::option::Option<bitcoin_units::Amount>
 pub const fn bitcoin_units::FeeRate::from_per_kvb(rate: bitcoin_units::Amount) -> bitcoin_units::result::NumOpResult<Self>
 pub const fn bitcoin_units::FeeRate::from_per_kwu(rate: bitcoin_units::Amount) -> bitcoin_units::result::NumOpResult<Self>
 pub const fn bitcoin_units::FeeRate::from_per_vb(rate: bitcoin_units::Amount) -> bitcoin_units::result::NumOpResult<Self>
@@ -2737,7 +2734,6 @@ pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_seconds
 pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError>
 pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockMtp, utxo_mined_at: bitcoin_units::block::BlockMtp) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::InvalidTimeError>
 pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::to_512_second_intervals(self) -> u16
-pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::to_consensus_u32(self) -> u32
 pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::to_seconds(self) -> u32
 impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOf512Seconds
 pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::clone(&self) -> bitcoin_units::locktime::relative::NumberOf512Seconds
@@ -2811,7 +2807,6 @@ pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::from_height(bloc
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::PrefixedHexError>
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError>
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockHeight, utxo_mined_at: bitcoin_units::block::BlockHeight) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::InvalidHeightError>
-pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::to_consensus_u32(self) -> u32
 pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::to_height(self) -> u16
 impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOfBlocks
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::clone(&self) -> bitcoin_units::locktime::relative::NumberOfBlocks
@@ -3143,7 +3138,6 @@ pub fn bitcoin_units::pow::CompactTarget::from_consensus(bits: u32) -> Self
 pub fn bitcoin_units::pow::CompactTarget::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::PrefixedHexError> where Self: core::marker::Sized
 pub fn bitcoin_units::pow::CompactTarget::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError> where Self: core::marker::Sized
 pub const fn bitcoin_units::pow::CompactTarget::to_consensus(self) -> u32
-pub fn bitcoin_units::pow::CompactTarget::to_hex(self) -> alloc::string::String
 impl core::clone::Clone for bitcoin_units::pow::CompactTarget
 pub fn bitcoin_units::pow::CompactTarget::clone(&self) -> bitcoin_units::pow::CompactTarget
 impl core::cmp::Eq for bitcoin_units::pow::CompactTarget
@@ -3786,7 +3780,6 @@ pub struct bitcoin_units::sequence::Sequence(pub u32)
 impl bitcoin_units::sequence::Sequence
 pub const bitcoin_units::sequence::Sequence::ENABLE_LOCKTIME_AND_RBF: Self
 pub const bitcoin_units::sequence::Sequence::ENABLE_LOCKTIME_NO_RBF: Self
-pub const bitcoin_units::sequence::Sequence::ENABLE_RBF_NO_LOCKTIME: Self
 pub const bitcoin_units::sequence::Sequence::FINAL: Self
 pub const bitcoin_units::sequence::Sequence::MAX: Self
 pub const bitcoin_units::sequence::Sequence::SIZE: usize
@@ -3805,7 +3798,6 @@ pub fn bitcoin_units::sequence::Sequence::is_rbf(self) -> bool
 pub fn bitcoin_units::sequence::Sequence::is_relative_lock_time(self) -> bool
 pub fn bitcoin_units::sequence::Sequence::is_time_locked(self) -> bool
 pub const fn bitcoin_units::sequence::Sequence::to_consensus_u32(self) -> u32
-pub fn bitcoin_units::sequence::Sequence::to_hex(self) -> alloc::string::String
 pub fn bitcoin_units::sequence::Sequence::to_relative_lock_time(self) -> core::option::Option<bitcoin_units::locktime::relative::LockTime>
 impl core::clone::Clone for bitcoin_units::sequence::Sequence
 pub fn bitcoin_units::sequence::Sequence::clone(&self) -> bitcoin_units::sequence::Sequence
@@ -3960,12 +3952,9 @@ pub const fn bitcoin_units::Weight::checked_mul(self, rhs: u64) -> core::option:
 pub const fn bitcoin_units::Weight::checked_sub(self, rhs: Self) -> core::option::Option<Self>
 pub fn bitcoin_units::Weight::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::PrefixedHexError>
 pub const fn bitcoin_units::Weight::from_kwu(wu: u64) -> core::option::Option<Self>
-pub const fn bitcoin_units::Weight::from_non_witness_data_size(non_witness_size: u64) -> Self
 pub fn bitcoin_units::Weight::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError>
 pub const fn bitcoin_units::Weight::from_vb(vb: u64) -> core::option::Option<Self>
 pub const fn bitcoin_units::Weight::from_vb_unchecked(vb: u64) -> Self
-pub const fn bitcoin_units::Weight::from_vb_unwrap(vb: u64) -> Self
-pub const fn bitcoin_units::Weight::from_witness_data_size(witness_size: u64) -> Self
 pub const fn bitcoin_units::Weight::mul_by_fee_rate(self, fee_rate: bitcoin_units::FeeRate) -> bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
 pub const fn bitcoin_units::Weight::to_kwu_ceil(self) -> u64
 pub const fn bitcoin_units::Weight::to_kwu_floor(self) -> u64

--- a/units/api/no-features.txt
+++ b/units/api/no-features.txt
@@ -1195,7 +1195,6 @@ pub const bitcoin_units::SignedAmount::ONE_BTC: Self
 pub const bitcoin_units::SignedAmount::ONE_SAT: Self
 pub const bitcoin_units::SignedAmount::ZERO: Self
 pub const fn bitcoin_units::SignedAmount::abs(self) -> Self
-pub const fn bitcoin_units::SignedAmount::checked_abs(self) -> core::option::Option<Self>
 pub const fn bitcoin_units::SignedAmount::checked_add(self, rhs: Self) -> core::option::Option<Self>
 pub const fn bitcoin_units::SignedAmount::checked_div(self, rhs: i64) -> core::option::Option<Self>
 pub const fn bitcoin_units::SignedAmount::checked_mul(self, rhs: i64) -> core::option::Option<Self>
@@ -1848,8 +1847,6 @@ pub const fn bitcoin_units::FeeRate::checked_add(self, rhs: Self) -> core::optio
 pub const fn bitcoin_units::FeeRate::checked_div(self, rhs: u64) -> core::option::Option<Self>
 pub const fn bitcoin_units::FeeRate::checked_mul(self, rhs: u64) -> core::option::Option<Self>
 pub const fn bitcoin_units::FeeRate::checked_sub(self, rhs: Self) -> core::option::Option<Self>
-pub fn bitcoin_units::FeeRate::fee_vb(self, vb: u64) -> core::option::Option<bitcoin_units::Amount>
-pub fn bitcoin_units::FeeRate::fee_wu(self, weight: bitcoin_units::Weight) -> core::option::Option<bitcoin_units::Amount>
 pub const fn bitcoin_units::FeeRate::from_per_kvb(rate: bitcoin_units::Amount) -> bitcoin_units::result::NumOpResult<Self>
 pub const fn bitcoin_units::FeeRate::from_per_kwu(rate: bitcoin_units::Amount) -> bitcoin_units::result::NumOpResult<Self>
 pub const fn bitcoin_units::FeeRate::from_per_vb(rate: bitcoin_units::Amount) -> bitcoin_units::result::NumOpResult<Self>
@@ -2459,7 +2456,6 @@ pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_seconds
 pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError>
 pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockMtp, utxo_mined_at: bitcoin_units::block::BlockMtp) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::InvalidTimeError>
 pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::to_512_second_intervals(self) -> u16
-pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::to_consensus_u32(self) -> u32
 pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::to_seconds(self) -> u32
 impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOf512Seconds
 pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::clone(&self) -> bitcoin_units::locktime::relative::NumberOf512Seconds
@@ -2523,7 +2519,6 @@ pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::from_height(bloc
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::PrefixedHexError>
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError>
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockHeight, utxo_mined_at: bitcoin_units::block::BlockHeight) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::InvalidHeightError>
-pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::to_consensus_u32(self) -> u32
 pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::to_height(self) -> u16
 impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOfBlocks
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::clone(&self) -> bitcoin_units::locktime::relative::NumberOfBlocks
@@ -3417,7 +3412,6 @@ pub struct bitcoin_units::sequence::Sequence(pub u32)
 impl bitcoin_units::sequence::Sequence
 pub const bitcoin_units::sequence::Sequence::ENABLE_LOCKTIME_AND_RBF: Self
 pub const bitcoin_units::sequence::Sequence::ENABLE_LOCKTIME_NO_RBF: Self
-pub const bitcoin_units::sequence::Sequence::ENABLE_RBF_NO_LOCKTIME: Self
 pub const bitcoin_units::sequence::Sequence::FINAL: Self
 pub const bitcoin_units::sequence::Sequence::MAX: Self
 pub const bitcoin_units::sequence::Sequence::SIZE: usize
@@ -3570,12 +3564,9 @@ pub const fn bitcoin_units::Weight::checked_mul(self, rhs: u64) -> core::option:
 pub const fn bitcoin_units::Weight::checked_sub(self, rhs: Self) -> core::option::Option<Self>
 pub fn bitcoin_units::Weight::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::PrefixedHexError>
 pub const fn bitcoin_units::Weight::from_kwu(wu: u64) -> core::option::Option<Self>
-pub const fn bitcoin_units::Weight::from_non_witness_data_size(non_witness_size: u64) -> Self
 pub fn bitcoin_units::Weight::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError>
 pub const fn bitcoin_units::Weight::from_vb(vb: u64) -> core::option::Option<Self>
 pub const fn bitcoin_units::Weight::from_vb_unchecked(vb: u64) -> Self
-pub const fn bitcoin_units::Weight::from_vb_unwrap(vb: u64) -> Self
-pub const fn bitcoin_units::Weight::from_witness_data_size(witness_size: u64) -> Self
 pub const fn bitcoin_units::Weight::mul_by_fee_rate(self, fee_rate: bitcoin_units::FeeRate) -> bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
 pub const fn bitcoin_units::Weight::to_kwu_ceil(self) -> u64
 pub const fn bitcoin_units::Weight::to_kwu_floor(self) -> u64

--- a/units/src/amount/mod.rs
+++ b/units/src/amount/mod.rs
@@ -5,17 +5,17 @@
 //! This module mainly introduces the [`Amount`] and [`SignedAmount`] types.
 //! We refer to the documentation on the types for more information.
 
-pub mod error;
-mod result;
-#[cfg(feature = "serde")]
-pub mod serde;
-
 mod signed;
+mod result;
 #[cfg(test)]
 mod tests;
 mod unsigned;
 #[cfg(kani)]
 mod verification;
+
+pub mod error;
+#[cfg(feature = "serde")]
+pub mod serde;
 
 use core::cmp::Ordering;
 use core::convert::Infallible;

--- a/units/src/amount/signed.rs
+++ b/units/src/amount/signed.rs
@@ -423,16 +423,6 @@ impl SignedAmount {
     #[inline]
     pub fn is_negative(self) -> bool { self.to_sat().is_negative() }
 
-    /// Returns the absolute value of this [`SignedAmount`].
-    ///
-    /// Consider using `unsigned_abs` which is often more practical.
-    ///
-    /// Returns [`None`] if overflow occurred. (`self == i64::MIN`)
-    #[must_use]
-    #[deprecated(since = "1.0.0-rc.0", note = "Never returns none, use `abs()` instead")]
-    #[allow(clippy::unnecessary_wraps)] // To match stdlib function definition.
-    pub const fn checked_abs(self) -> Option<Self> { Some(self.abs()) }
-
     /// Checked addition.
     ///
     /// Returns [`None`] if the sum is above [`SignedAmount::MAX`] or below [`SignedAmount::MIN`].

--- a/units/src/amount/signed.rs
+++ b/units/src/amount/signed.rs
@@ -55,6 +55,7 @@ mod encapsulate {
     impl SignedAmount {
         /// The maximum value of an amount.
         pub const MAX: Self = Self(21_000_000 * 100_000_000);
+
         /// The minimum value of an amount.
         pub const MIN: Self = Self(-21_000_000 * 100_000_000);
 
@@ -103,12 +104,16 @@ use internals::const_casts;
 impl SignedAmount {
     /// The zero amount.
     pub const ZERO: Self = Self::from_sat_i32(0);
+
     /// Exactly one satoshi.
     pub const ONE_SAT: Self = Self::from_sat_i32(1);
+
     /// Exactly one bitcoin.
     pub const ONE_BTC: Self = Self::from_btc_i16(1);
+
     /// Exactly fifty bitcoin.
     pub const FIFTY_BTC: Self = Self::from_btc_i16(50);
+
     /// The maximum value allowed as an amount. Useful for sanity checking.
     pub const MAX_MONEY: Self = Self::MAX;
 

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -60,6 +60,7 @@ mod encapsulate {
     impl Amount {
         /// The maximum value of an amount.
         pub const MAX: Self = Self(21_000_000 * 100_000_000);
+
         /// The minimum value of an amount.
         pub const MIN: Self = Self(0);
 
@@ -105,14 +106,19 @@ pub use encapsulate::Amount;
 impl Amount {
     /// The zero amount.
     pub const ZERO: Self = Self::from_sat_u32(0);
+
     /// Exactly one satoshi.
     pub const ONE_SAT: Self = Self::from_sat_u32(1);
+
     /// Exactly one bitcoin.
     pub const ONE_BTC: Self = Self::from_btc_u16(1);
+
     /// Exactly fifty bitcoin.
     pub const FIFTY_BTC: Self = Self::from_btc_u16(50);
+
     /// The maximum value allowed as an amount. Useful for sanity checking.
     pub const MAX_MONEY: Self = Self::MAX;
+
     /// The number of bytes that an amount contributes to the size of a transaction.
     pub const SIZE: usize = 8; // Serialized length of a u64.
 

--- a/units/src/fee_rate/mod.rs
+++ b/units/src/fee_rate/mod.rs
@@ -208,23 +208,6 @@ impl FeeRate {
         }
     }
 
-    /// Calculates the fee by multiplying this fee rate by weight, in weight units, returning [`None`]
-    /// if an overflow occurred.
-    ///
-    /// This is equivalent to `Self::mul_by_weight(weight).ok()`.
-    #[must_use]
-    #[deprecated(since = "1.0.0-rc.0", note = "use `to_fee()` instead")]
-    pub fn fee_wu(self, weight: Weight) -> Option<Amount> { self.mul_by_weight(weight).ok() }
-
-    /// Calculates the fee by multiplying this fee rate by weight, in virtual bytes, returning [`None`]
-    /// if `vb` cannot be represented as [`Weight`].
-    ///
-    /// This is equivalent to converting `vb` to [`Weight`] using [`Weight::from_vb`] and then calling
-    /// [`Self::to_fee`].
-    #[must_use]
-    #[deprecated(since = "1.0.0-rc.0", note = "use Weight::from_vb and then `to_fee()` instead")]
-    pub fn fee_vb(self, vb: u64) -> Option<Amount> { Weight::from_vb(vb).map(|w| self.to_fee(w)) }
-
     /// Checked weight multiplication.
     ///
     /// Computes the absolute fee amount for a given [`Weight`] at this fee rate. When the resulting

--- a/units/src/fee_rate/mod.rs
+++ b/units/src/fee_rate/mod.rs
@@ -104,7 +104,7 @@ impl FeeRate {
         Self::from_sat_per_mvb(fee_rate)
     }
 
-    /// Constructs a new [`FeeRate`] from satoshis per kilo virtual bytes (1,000 vbytes).
+    /// Constructs a new [`FeeRate`] from amount per kilo virtual bytes (1,000 vbytes).
     #[inline]
     pub const fn from_per_kvb(rate: Amount) -> NumOpResult<Self> {
         // No `map()` in const context.

--- a/units/src/fee_rate/mod.rs
+++ b/units/src/fee_rate/mod.rs
@@ -23,7 +23,7 @@ mod encapsulate {
     ///
     /// NOTE: `FeeRate` explicitly does not have any format/display trait implementations, as it
     /// doesn't have a standard unit for measure. Users are expected to format it on their own by
-    /// extracting values in desired units with `from_sat_per*` functions.
+    /// extracting values in desired units with `to_sat_per*` functions.
     #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
     pub struct FeeRate(u64);
 

--- a/units/src/fee_rate/mod.rs
+++ b/units/src/fee_rate/mod.rs
@@ -63,14 +63,14 @@ impl FeeRate {
     /// The fee rate used to compute dust amount.
     pub const DUST: Self = Self::from_sat_per_vb(3);
 
-    /// Constructs a new [`FeeRate`] from satoshis per 1000 weight units.
+    /// Constructs a new [`FeeRate`] from satoshis per 1,000 weight units.
     #[inline]
     pub const fn from_sat_per_kwu(sat_kwu: u32) -> Self {
         let fee_rate = (const_casts::u32_to_u64(sat_kwu)) * 4_000;
         Self::from_sat_per_mvb(fee_rate)
     }
 
-    /// Constructs a new [`FeeRate`] from amount per 1000 weight units.
+    /// Constructs a new [`FeeRate`] from amount per 1,000 weight units.
     #[inline]
     pub const fn from_per_kwu(rate: Amount) -> NumOpResult<Self> {
         // No `map()` in const context.

--- a/units/src/lib.rs
+++ b/units/src/lib.rs
@@ -74,10 +74,6 @@ pub use self::{
     weight::Weight
 };
 
-#[deprecated(since = "1.0.0-rc.0", note = "use `BlockHeightInterval` instead")]
-#[doc(hidden)]
-pub type BlockInterval = BlockHeightInterval;
-
 // decoder_newtype! macro
 #[cfg(feature = "encoding")]
 include!("../include/decoder_newtype.rs");

--- a/units/src/lib.rs
+++ b/units/src/lib.rs
@@ -23,8 +23,6 @@
 #![warn(missing_docs)]
 #![warn(deprecated_in_future)]
 #![doc(test(attr(warn(unused))))]
-// Exclude lints we don't think are valuable.
-#![allow(clippy::uninlined_format_args)] // Allow `format!("{}", x)` instead of enforcing `format!("{x}")`
 // Extra restriction lints.
 #![warn(clippy::indexing_slicing)] // Avoid implicit panics from indexing/slicing.
 

--- a/units/src/lib.rs
+++ b/units/src/lib.rs
@@ -28,18 +28,15 @@
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
-
 #[cfg(feature = "std")]
 extern crate std;
 
-#[cfg(feature = "encoding")]
-pub extern crate encoding;
-
-#[cfg(feature = "serde")]
-pub extern crate serde;
-
 #[cfg(feature = "arbitrary")]
 pub extern crate arbitrary;
+#[cfg(feature = "encoding")]
+pub extern crate encoding;
+#[cfg(feature = "serde")]
+pub extern crate serde;
 
 #[doc(hidden)]
 pub mod _export {

--- a/units/src/locktime/absolute/mod.rs
+++ b/units/src/locktime/absolute/mod.rs
@@ -207,11 +207,6 @@ impl LockTime {
         Ok(Self::Blocks(height))
     }
 
-    #[inline]
-    #[deprecated(since = "1.0.0-rc.0", note = "use `from_mtp` instead")]
-    #[doc(hidden)]
-    pub fn from_time(n: u32) -> Result<Self, ConversionError> { Self::from_mtp(n) }
-
     /// Constructs a new `LockTime` from `n`, expecting `n` to be a median-time-past (MTP)
     /// which is in range for a locktime.
     ///
@@ -532,14 +527,6 @@ impl Height {
         Ok(Self::from_u32(height).map_err(|_| ParseError::Conversion(height.into()))?)
     }
 
-    #[deprecated(since = "1.0.0-rc.0", note = "use `from_u32` instead")]
-    #[doc(hidden)]
-    pub const fn from_consensus(n: u32) -> Result<Self, ConversionError> { Self::from_u32(n) }
-
-    #[deprecated(since = "1.0.0-rc.0", note = "use `to_u32` instead")]
-    #[doc(hidden)]
-    pub const fn to_consensus_u32(self) -> u32 { self.to_u32() }
-
     /// Constructs a new block height directly from a `u32` value.
     ///
     /// # Errors
@@ -598,10 +585,6 @@ impl fmt::Display for Height {
 }
 
 parse_int::impl_parse_str!(Height, ParseHeightError, parser(Height::from_u32));
-
-#[deprecated(since = "1.0.0-rc.0", note = "use `MedianTimePast` instead")]
-#[doc(hidden)]
-pub type Time = MedianTimePast;
 
 /// The median timestamp of 11 consecutive blocks, representing "the timestamp" of the
 /// final block for locktime-checking purposes.
@@ -662,14 +645,6 @@ impl MedianTimePast {
         let height = parse_int::hex_u32_unprefixed(s).map_err(ParseError::UnprefixedHex)?;
         Ok(Self::from_u32(height).map_err(|_| ParseError::Conversion(height.into()))?)
     }
-
-    #[deprecated(since = "1.0.0-rc.0", note = "use `from_u32` instead")]
-    #[doc(hidden)]
-    pub const fn from_consensus(n: u32) -> Result<Self, ConversionError> { Self::from_u32(n) }
-
-    #[deprecated(since = "1.0.0-rc.0", note = "use `to_u32` instead")]
-    #[doc(hidden)]
-    pub const fn to_consensus_u32(self) -> u32 { self.to_u32() }
 
     /// Constructs a new MTP directly from a `u32` value.
     ///

--- a/units/src/locktime/absolute/mod.rs
+++ b/units/src/locktime/absolute/mod.rs
@@ -25,6 +25,7 @@ pub use self::error::{
     ConversionError, IncompatibleHeightError, IncompatibleTimeError, ParseHeightError, ParseTimeError,
 };
 #[cfg(feature = "encoding")]
+#[doc(no_inline)]
 pub use self::error::LockTimeDecoderError;
 
 /// The Threshold for deciding whether a lock time value is a height or a time (see [Bitcoin Core]).

--- a/units/src/locktime/absolute/mod.rs
+++ b/units/src/locktime/absolute/mod.rs
@@ -213,10 +213,10 @@ impl LockTime {
     ///
     /// # Note
     ///
-    /// If the locktime is set to an MTP `T`, the transaction can be included in a block only if
-    /// the MTP of last recent 11 blocks is greater than `T`.
+    /// If the locktime is set to an MTP `t`, the transaction can be included in a block only if
+    /// the MTP of last recent 11 blocks is greater than `t`.
     ///
-    /// It is possible to broadcast the transaction once the MTP is greater than `T`. See BIP-0113.
+    /// It is possible to broadcast the transaction once the MTP is greater than `t`. See BIP-0113.
     ///
     /// [BIP-0113 Median time-past as endpoint for lock-time calculations](https://github.com/bitcoin/bips/blob/master/bip-0113.mediawiki)
     ///

--- a/units/src/locktime/relative/mod.rs
+++ b/units/src/locktime/relative/mod.rs
@@ -389,10 +389,6 @@ impl<'de> serde::Deserialize<'de> for LockTime {
     }
 }
 
-#[deprecated(since = "1.0.0-rc.0", note = "use `NumberOfBlocks` instead")]
-#[doc(hidden)]
-pub type Height = NumberOfBlocks;
-
 /// A relative lock time lock-by-height value.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NumberOfBlocks(u16);
@@ -415,23 +411,6 @@ impl NumberOfBlocks {
     #[inline]
     #[must_use]
     pub const fn to_height(self) -> u16 { self.0 }
-
-    /// Returns the inner `u16` value.
-    #[inline]
-    #[must_use]
-    #[deprecated(since = "1.0.0-rc.0", note = "use `to_height` instead")]
-    #[doc(hidden)]
-    pub const fn value(self) -> u16 { self.0 }
-
-    /// Returns the `u32` value used to encode this locktime in an nSequence field or
-    /// argument to `OP_CHECKSEQUENCEVERIFY`.
-    #[deprecated(
-        since = "1.0.0-rc.0",
-        note = "use `LockTime::from` followed by `to_consensus_u32` instead"
-    )]
-    pub const fn to_consensus_u32(self) -> u32 {
-        self.0 as u32 // cast safety: u32 is wider than u16 on all architectures
-    }
 
     /// Constructs a new `NumberOfBlocks` from a prefixed hex string.
     ///
@@ -494,10 +473,6 @@ impl fmt::Display for NumberOfBlocks {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(&self.0, f) }
 }
-
-#[deprecated(since = "1.0.0-rc.0", note = "use `NumberOf512Seconds` instead")]
-#[doc(hidden)]
-pub type Time = NumberOf512Seconds;
 
 /// A relative lock time lock-by-time value.
 ///
@@ -564,23 +539,6 @@ impl NumberOf512Seconds {
     /// Represents the [`NumberOf512Seconds`] as an integer number of seconds.
     #[inline]
     pub const fn to_seconds(self) -> u32 { const_casts::u16_to_u32(self.0) * 512 }
-
-    /// Returns the inner `u16` value.
-    #[inline]
-    #[must_use]
-    #[deprecated(since = "1.0.0-rc.0", note = "use `to_512_second_intervals` instead")]
-    #[doc(hidden)]
-    pub const fn value(self) -> u16 { self.0 }
-
-    /// Returns the `u32` value used to encode this locktime in an nSequence field or
-    /// argument to `OP_CHECKSEQUENCEVERIFY`.
-    #[deprecated(
-        since = "1.0.0-rc.0",
-        note = "use `LockTime::from` followed by `to_consensus_u32` instead"
-    )]
-    pub const fn to_consensus_u32(self) -> u32 {
-        (1u32 << 22) | self.0 as u32 // cast safety: u32 is wider than u16 on all architectures
-    }
 
     /// Constructs a new `NumberOf512Seconds` from a prefixed hex string.
     ///
@@ -947,7 +905,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(deprecated_in_future)]
     fn sanity_check() {
         assert_eq!(LockTime::from(NumberOfBlocks::MAX).to_consensus_u32(), u32::from(u16::MAX));
         assert_eq!(

--- a/units/src/pow.rs
+++ b/units/src/pow.rs
@@ -252,12 +252,6 @@ impl CompactTarget {
     #[inline]
     pub const fn to_consensus(self) -> u32 { self.0 }
 
-    /// Gets the hex representation of this [`CompactTarget`].
-    #[cfg(feature = "alloc")]
-    #[inline]
-    #[deprecated(since = "1.0.0-rc.0", note = "use `format!(\"{var:x}\")` instead")]
-    pub fn to_hex(self) -> alloc::string::String { alloc::format!("{:x}", self) }
-
     /// Constructs a new `CompactTarget` from a prefixed hex string.
     ///
     /// # Errors

--- a/units/src/pow.rs
+++ b/units/src/pow.rs
@@ -134,6 +134,7 @@ pub struct Target(U256);
 impl Target {
     /// When parsing nBits, Bitcoin Core converts a negative target threshold into a target of zero.
     pub const ZERO: Self = Self(U256::ZERO);
+
     /// The maximum possible target.
     ///
     /// This value is used to calculate difficulty, which is defined as how difficult the current

--- a/units/src/pow.rs
+++ b/units/src/pow.rs
@@ -548,8 +548,6 @@ mod tests {
     #[cfg(feature = "alloc")]
     #[cfg(feature = "encoding")]
     use alloc::string::ToString;
-    #[cfg(feature = "std")]
-    use std::error::Error as _;
 
     #[cfg(feature = "encoding")]
     use encoding::Decoder as _;
@@ -1537,16 +1535,19 @@ mod tests {
 
     #[test]
     #[cfg(feature = "alloc")]
-    #[allow(deprecated)]
     fn compact_target_to_hex() {
         let compact_target = CompactTarget::from_consensus(0x1d00_ffff);
-        assert_eq!(compact_target.to_hex(), "1d00ffff");
+        let got = alloc::format!("{:x}", compact_target);
+        assert_eq!(got, "1d00ffff");
     }
 
     #[test]
     #[cfg(feature = "encoding")]
     #[cfg(feature = "alloc")]
     fn compact_target_decoder_error_display_and_source() {
+        #[cfg(feature = "std")]
+        use std::error::Error as _;
+
         let mut slice = [0u8; 3].as_slice();
         let mut decoder = CompactTargetDecoder::new();
 

--- a/units/src/sequence.rs
+++ b/units/src/sequence.rs
@@ -49,10 +49,6 @@ impl Sequence {
     /// The sequence number that enables absolute lock time but disables replace-by-fee
     /// and relative lock time.
     pub const ENABLE_LOCKTIME_NO_RBF: Self = Self::MIN_NO_RBF;
-    /// The sequence number that enables replace-by-fee and absolute lock time but
-    /// disables relative lock time.
-    #[deprecated(since = "1.0.0-rc.0", note = "use `ENABLE_LOCKTIME_AND_RBF` instead")]
-    pub const ENABLE_RBF_NO_LOCKTIME: Self = Self(0xFFFF_FFFD);
     /// The maximum sequence number that enables replace-by-fee and absolute lock time but
     /// disables relative lock time.
     ///
@@ -198,12 +194,6 @@ impl Sequence {
     /// Returns the inner 32bit integer value of Sequence.
     #[inline]
     pub const fn to_consensus_u32(self) -> u32 { self.0 }
-
-    /// Gets the hex representation of this [`Sequence`].
-    #[cfg(feature = "alloc")]
-    #[inline]
-    #[deprecated(since = "1.0.0-rc.0", note = "use `format!(\"{var:x}\")` instead")]
-    pub fn to_hex(self) -> alloc::string::String { alloc::format!("{:x}", self) }
 
     /// Constructs a new [`relative::LockTime`] from this [`Sequence`] number.
     #[inline]

--- a/units/src/sequence.rs
+++ b/units/src/sequence.rs
@@ -40,15 +40,19 @@ impl Sequence {
     ///
     /// The sequence number that disables replace-by-fee, absolute lock time and relative lock time.
     pub const MAX: Self = Self(0xFFFF_FFFF);
+
     /// Zero value sequence.
     ///
     /// This sequence number enables replace-by-fee and absolute lock time.
     pub const ZERO: Self = Self(0);
+
     /// The sequence number that disables replace-by-fee, absolute lock time and relative lock time.
     pub const FINAL: Self = Self::MAX;
+
     /// The sequence number that enables absolute lock time but disables replace-by-fee
     /// and relative lock time.
     pub const ENABLE_LOCKTIME_NO_RBF: Self = Self::MIN_NO_RBF;
+
     /// The maximum sequence number that enables replace-by-fee and absolute lock time but
     /// disables relative lock time.
     ///
@@ -66,8 +70,10 @@ impl Sequence {
     ///
     /// [BIP-0125]: <https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki>
     const MIN_NO_RBF: Self = Self(0xFFFF_FFFE);
+
     /// BIP-0068 relative lock time disable flag mask.
     const LOCK_TIME_DISABLE_FLAG_MASK: u32 = 0x8000_0000;
+
     /// BIP-0068 relative lock time type flag mask.
     pub(super) const LOCK_TYPE_MASK: u32 = 0x0040_0000;
 

--- a/units/src/weight.rs
+++ b/units/src/weight.rs
@@ -415,26 +415,6 @@ mod tests {
     fn from_vb_unchecked_panic() { Weight::from_vb_unchecked(u64::MAX); }
 
     #[test]
-    #[allow(deprecated)] // tests the deprecated function
-    #[allow(deprecated_in_future)]
-    fn from_witness_data_size() {
-        let witness_data_size = 1;
-        let got = Weight::from_witness_data_size(witness_data_size);
-        let want = Weight::from_wu(witness_data_size);
-        assert_eq!(got, want);
-    }
-
-    #[test]
-    #[allow(deprecated)] // tests the deprecated function
-    #[allow(deprecated_in_future)]
-    fn from_non_witness_data_size() {
-        let non_witness_data_size = 1;
-        let got = Weight::from_non_witness_data_size(non_witness_data_size);
-        let want = Weight::from_wu(non_witness_data_size * 4);
-        assert_eq!(got, want);
-    }
-
-    #[test]
     #[cfg(feature = "alloc")]
     fn try_from_string() {
         let weight_value: alloc::string::String = "10".into();

--- a/units/src/weight.rs
+++ b/units/src/weight.rs
@@ -90,6 +90,8 @@ impl Weight {
 
     /// Constructs a new `Weight` from a prefixed hex string.
     ///
+    /// The hex string once parsed is assumed to represent weight units.
+    ///
     /// # Errors
     ///
     /// If the input string is not a valid hex representation of a weight in weight units or it
@@ -101,6 +103,8 @@ impl Weight {
     }
 
     /// Constructs a new `Weight` from an unprefixed hex string.
+    ///
+    /// The hex string once parsed is assumed to represent weight units.
     ///
     /// # Errors
     ///

--- a/units/src/weight.rs
+++ b/units/src/weight.rs
@@ -82,37 +82,10 @@ impl Weight {
         }
     }
 
-    /// Constructs a new [`Weight`] from virtual bytes panicking if an overflow occurred.
-    ///
-    /// # Panics
-    ///
-    /// If the conversion from virtual bytes overflows.
-    #[deprecated(since = "1.0.0-rc.0", note = "use `from_vb_unchecked` instead")]
-    pub const fn from_vb_unwrap(vb: u64) -> Self {
-        match vb.checked_mul(Self::WITNESS_SCALE_FACTOR) {
-            Some(weight) => Self::from_wu(weight),
-            None => panic!("checked_mul overflowed"),
-        }
-    }
-
     /// Constructs a new [`Weight`] from virtual bytes without an overflow check.
     #[inline]
     pub const fn from_vb_unchecked(vb: u64) -> Self {
         Self::from_wu(vb * Self::WITNESS_SCALE_FACTOR)
-    }
-
-    /// Constructs a new [`Weight`] from witness size.
-    #[deprecated(since = "1.0.0-rc.1", note = "use `from_wu` instead")]
-    pub const fn from_witness_data_size(witness_size: u64) -> Self { Self::from_wu(witness_size) }
-
-    /// Constructs a new [`Weight`] from non-witness size.
-    ///
-    /// # Panics
-    ///
-    /// If the conversion from virtual bytes overflows.
-    #[deprecated(since = "1.0.0-rc.1", note = "use `from_vb` or `from_vb_unchecked` instead")]
-    pub const fn from_non_witness_data_size(non_witness_size: u64) -> Self {
-        Self::from_wu(non_witness_size * Self::WITNESS_SCALE_FACTOR)
     }
 
     /// Constructs a new `Weight` from a prefixed hex string.


### PR DESCRIPTION
A few things to note:

- Removes deprecated code, the `units v0.4.0` release can be used during upgrade to get the `v1.0` + deprecated code.
- Sets new policy for:
  -  spacing in consts
  - grouping of pub extern crates

Everything else is reasonably trivial.