### PR TITLE
Release tracking PR: `units 0.5.0`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -89,7 +89,7 @@ dependencies = [
  "bitcoin-network-kind",
  "bitcoin-primitives",
  "bitcoin-taproot-primitives",
- "bitcoin-units 0.4.0",
+ "bitcoin-units 0.5.0",
  "bitcoin_hashes 1.0.0",
  "bitcoinconsensus",
  "hex-conservative 1.1.0",
@@ -214,7 +214,7 @@ dependencies = [
  "bitcoin-internals 0.5.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
- "bitcoin-units 0.4.0",
+ "bitcoin-units 0.5.0",
  "bitcoin_hashes 1.0.0",
  "hex-conservative 1.1.0",
  "serde",
@@ -228,7 +228,7 @@ dependencies = [
  "bincode",
  "bitcoin-consensus-encoding",
  "bitcoin-internals 0.5.0",
- "bitcoin-units 0.4.0",
+ "bitcoin-units 0.5.0",
  "bitcoin_hashes 1.0.0",
  "hex-conservative 1.1.0",
  "serde",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-units"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -88,7 +88,7 @@ dependencies = [
  "bitcoin-network-kind",
  "bitcoin-primitives",
  "bitcoin-taproot-primitives",
- "bitcoin-units 0.4.0",
+ "bitcoin-units 0.5.0",
  "bitcoin_hashes 1.0.0",
  "bitcoinconsensus",
  "hex-conservative 1.1.0",
@@ -213,7 +213,7 @@ dependencies = [
  "bitcoin-internals 0.5.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
- "bitcoin-units 0.4.0",
+ "bitcoin-units 0.5.0",
  "bitcoin_hashes 1.0.0",
  "hex-conservative 1.1.0",
  "serde",
@@ -227,7 +227,7 @@ dependencies = [
  "bincode",
  "bitcoin-consensus-encoding",
  "bitcoin-internals 0.5.0",
- "bitcoin-units 0.4.0",
+ "bitcoin-units 0.5.0",
  "bitcoin_hashes 1.0.0",
  "hex-conservative 1.1.0",
  "serde",
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-units"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -39,7 +39,7 @@ network = { package = "bitcoin-network-kind", path = "../network", version = "1.
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.102.0", default-features = false, features = ["alloc", "hex"] }
 secp256k1 = { version = "0.32.0-beta.2", default-features = false, features = ["alloc"] }
 taproot-primitives = { package = "bitcoin-taproot-primitives", path = "../taproot-primitives", version = "0.1.0", default-features = false, features = ["alloc", "hex"] }
-units = { package = "bitcoin-units", path = "../units", version = "0.4.0", default-features = false, features = ["alloc"] }
+units = { package = "bitcoin-units", path = "../units", version = "0.5.0", default-features = false, features = ["alloc"] }
 
 arbitrary = { version = "1.4.1", optional = true }
 base64 = { version = "0.22.0", optional = true, default-features = false, features = ["alloc"] }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -26,7 +26,7 @@ network = { package = "bitcoin-network-kind", path = "../network", version = "1.
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.102.0", features = ["hex", "alloc"], default-features = false }
 hex = { package = "hex-conservative", version = "1.1.0", default-features = false, features = ["alloc"] }
 internals = { package = "bitcoin-internals", path = "../internals", default-features = false }
-units = { package = "bitcoin-units", path = "../units", version = "0.4.0", default-features = false }
+units = { package = "bitcoin-units", path = "../units", version = "0.5.0", default-features = false }
 
 arbitrary = { version = "1.4.1", optional = true }
 serde = { version = "1.0.195", default-features = false, features = ["derive", "alloc"], optional = true }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -25,7 +25,7 @@ hex = ["dep:hex", "hashes/hex", "internals/hex"]
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0", default-features = false }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.0.0", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
-units = { package = "bitcoin-units", path = "../units", version = "0.4.0", default-features = false, features = [ "encoding" ] }
+units = { package = "bitcoin-units", path = "../units", version = "0.5.0", default-features = false, features = [ "encoding" ] }
 
 arbitrary = { version = "1.4.1", optional = true }
 hex = { package = "hex-conservative", version = "1.1.0", default-features = false, optional = true }

--- a/units/CHANGELOG.md
+++ b/units/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## [Unreleased]
 
-* Remove all deprecated code.
+## [0.5.0] - 2026-06-09
+
+* Remove `_unchecked` hex parsing function [#6292](https://github.com/rust-bitcoin/rust-bitcoin/pull/6292)
+* Remove all deprecated code [#6290](https://github.com/rust-bitcoin/rust-bitcoin/pull/6290).
 
 ## [0.4.0] - 2026-05-27
 
@@ -142,7 +145,8 @@ The main types are:
 
 Empty crate to reserve the name on crates.io
 
-[Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-units-0.4.0...HEAD
+[Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-units-0.5.0...HEAD
+[0.5.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-units-0.3.0...bitcoin-units-0.5.0
 [0.4.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-units-0.3.0...bitcoin-units-0.4.0
 [0.3.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/units-0.2.0...bitcoin-units-0.3.0
 [0.2.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/units-0.1.2...units-0.2.0

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-units"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>", "Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"

--- a/units/api/all-features.txt
+++ b/units/api/all-features.txt
@@ -3655,19 +3655,15 @@ pub fn bitcoin_units::parse_int::hex_check_unprefixed(s: &str) -> core::result::
 pub fn bitcoin_units::parse_int::hex_remove_prefix(s: &str) -> core::result::Result<&str, bitcoin_units::parse_int::error::PrefixedHexError>
 pub fn bitcoin_units::parse_int::hex_u128(s: &str) -> core::result::Result<u128, bitcoin_units::parse_int::error::ParseIntError>
 pub fn bitcoin_units::parse_int::hex_u128_prefixed(s: &str) -> core::result::Result<u128, bitcoin_units::parse_int::error::PrefixedHexError>
-pub fn bitcoin_units::parse_int::hex_u128_unchecked(s: &str) -> core::result::Result<u128, bitcoin_units::parse_int::error::ParseIntError>
 pub fn bitcoin_units::parse_int::hex_u128_unprefixed(s: &str) -> core::result::Result<u128, bitcoin_units::parse_int::error::UnprefixedHexError>
 pub fn bitcoin_units::parse_int::hex_u16(s: &str) -> core::result::Result<u16, bitcoin_units::parse_int::error::ParseIntError>
 pub fn bitcoin_units::parse_int::hex_u16_prefixed(s: &str) -> core::result::Result<u16, bitcoin_units::parse_int::error::PrefixedHexError>
-pub fn bitcoin_units::parse_int::hex_u16_unchecked(s: &str) -> core::result::Result<u16, bitcoin_units::parse_int::error::ParseIntError>
 pub fn bitcoin_units::parse_int::hex_u16_unprefixed(s: &str) -> core::result::Result<u16, bitcoin_units::parse_int::error::UnprefixedHexError>
 pub fn bitcoin_units::parse_int::hex_u32(s: &str) -> core::result::Result<u32, bitcoin_units::parse_int::error::ParseIntError>
 pub fn bitcoin_units::parse_int::hex_u32_prefixed(s: &str) -> core::result::Result<u32, bitcoin_units::parse_int::error::PrefixedHexError>
-pub fn bitcoin_units::parse_int::hex_u32_unchecked(s: &str) -> core::result::Result<u32, bitcoin_units::parse_int::error::ParseIntError>
 pub fn bitcoin_units::parse_int::hex_u32_unprefixed(s: &str) -> core::result::Result<u32, bitcoin_units::parse_int::error::UnprefixedHexError>
 pub fn bitcoin_units::parse_int::hex_u64(s: &str) -> core::result::Result<u64, bitcoin_units::parse_int::error::ParseIntError>
 pub fn bitcoin_units::parse_int::hex_u64_prefixed(s: &str) -> core::result::Result<u64, bitcoin_units::parse_int::error::PrefixedHexError>
-pub fn bitcoin_units::parse_int::hex_u64_unchecked(s: &str) -> core::result::Result<u64, bitcoin_units::parse_int::error::ParseIntError>
 pub fn bitcoin_units::parse_int::hex_u64_unprefixed(s: &str) -> core::result::Result<u64, bitcoin_units::parse_int::error::UnprefixedHexError>
 pub fn bitcoin_units::parse_int::int_from_box<T: bitcoin_units::parse_int::Integer>(s: alloc::boxed::Box<str>) -> core::result::Result<T, bitcoin_units::parse_int::error::ParseIntError>
 pub fn bitcoin_units::parse_int::int_from_str<T: bitcoin_units::parse_int::Integer>(s: &str) -> core::result::Result<T, bitcoin_units::parse_int::error::ParseIntError>

--- a/units/api/alloc-only.txt
+++ b/units/api/alloc-only.txt
@@ -3027,19 +3027,15 @@ pub fn bitcoin_units::parse_int::hex_check_unprefixed(s: &str) -> core::result::
 pub fn bitcoin_units::parse_int::hex_remove_prefix(s: &str) -> core::result::Result<&str, bitcoin_units::parse_int::error::PrefixedHexError>
 pub fn bitcoin_units::parse_int::hex_u128(s: &str) -> core::result::Result<u128, bitcoin_units::parse_int::error::ParseIntError>
 pub fn bitcoin_units::parse_int::hex_u128_prefixed(s: &str) -> core::result::Result<u128, bitcoin_units::parse_int::error::PrefixedHexError>
-pub fn bitcoin_units::parse_int::hex_u128_unchecked(s: &str) -> core::result::Result<u128, bitcoin_units::parse_int::error::ParseIntError>
 pub fn bitcoin_units::parse_int::hex_u128_unprefixed(s: &str) -> core::result::Result<u128, bitcoin_units::parse_int::error::UnprefixedHexError>
 pub fn bitcoin_units::parse_int::hex_u16(s: &str) -> core::result::Result<u16, bitcoin_units::parse_int::error::ParseIntError>
 pub fn bitcoin_units::parse_int::hex_u16_prefixed(s: &str) -> core::result::Result<u16, bitcoin_units::parse_int::error::PrefixedHexError>
-pub fn bitcoin_units::parse_int::hex_u16_unchecked(s: &str) -> core::result::Result<u16, bitcoin_units::parse_int::error::ParseIntError>
 pub fn bitcoin_units::parse_int::hex_u16_unprefixed(s: &str) -> core::result::Result<u16, bitcoin_units::parse_int::error::UnprefixedHexError>
 pub fn bitcoin_units::parse_int::hex_u32(s: &str) -> core::result::Result<u32, bitcoin_units::parse_int::error::ParseIntError>
 pub fn bitcoin_units::parse_int::hex_u32_prefixed(s: &str) -> core::result::Result<u32, bitcoin_units::parse_int::error::PrefixedHexError>
-pub fn bitcoin_units::parse_int::hex_u32_unchecked(s: &str) -> core::result::Result<u32, bitcoin_units::parse_int::error::ParseIntError>
 pub fn bitcoin_units::parse_int::hex_u32_unprefixed(s: &str) -> core::result::Result<u32, bitcoin_units::parse_int::error::UnprefixedHexError>
 pub fn bitcoin_units::parse_int::hex_u64(s: &str) -> core::result::Result<u64, bitcoin_units::parse_int::error::ParseIntError>
 pub fn bitcoin_units::parse_int::hex_u64_prefixed(s: &str) -> core::result::Result<u64, bitcoin_units::parse_int::error::PrefixedHexError>
-pub fn bitcoin_units::parse_int::hex_u64_unchecked(s: &str) -> core::result::Result<u64, bitcoin_units::parse_int::error::ParseIntError>
 pub fn bitcoin_units::parse_int::hex_u64_unprefixed(s: &str) -> core::result::Result<u64, bitcoin_units::parse_int::error::UnprefixedHexError>
 pub fn bitcoin_units::parse_int::int_from_box<T: bitcoin_units::parse_int::Integer>(s: alloc::boxed::Box<str>) -> core::result::Result<T, bitcoin_units::parse_int::error::ParseIntError>
 pub fn bitcoin_units::parse_int::int_from_str<T: bitcoin_units::parse_int::Integer>(s: &str) -> core::result::Result<T, bitcoin_units::parse_int::error::ParseIntError>

--- a/units/api/no-features.txt
+++ b/units/api/no-features.txt
@@ -2711,19 +2711,15 @@ pub fn bitcoin_units::parse_int::hex_check_unprefixed(s: &str) -> core::result::
 pub fn bitcoin_units::parse_int::hex_remove_prefix(s: &str) -> core::result::Result<&str, bitcoin_units::parse_int::error::PrefixedHexError>
 pub fn bitcoin_units::parse_int::hex_u128(s: &str) -> core::result::Result<u128, bitcoin_units::parse_int::error::ParseIntError>
 pub fn bitcoin_units::parse_int::hex_u128_prefixed(s: &str) -> core::result::Result<u128, bitcoin_units::parse_int::error::PrefixedHexError>
-pub fn bitcoin_units::parse_int::hex_u128_unchecked(s: &str) -> core::result::Result<u128, bitcoin_units::parse_int::error::ParseIntError>
 pub fn bitcoin_units::parse_int::hex_u128_unprefixed(s: &str) -> core::result::Result<u128, bitcoin_units::parse_int::error::UnprefixedHexError>
 pub fn bitcoin_units::parse_int::hex_u16(s: &str) -> core::result::Result<u16, bitcoin_units::parse_int::error::ParseIntError>
 pub fn bitcoin_units::parse_int::hex_u16_prefixed(s: &str) -> core::result::Result<u16, bitcoin_units::parse_int::error::PrefixedHexError>
-pub fn bitcoin_units::parse_int::hex_u16_unchecked(s: &str) -> core::result::Result<u16, bitcoin_units::parse_int::error::ParseIntError>
 pub fn bitcoin_units::parse_int::hex_u16_unprefixed(s: &str) -> core::result::Result<u16, bitcoin_units::parse_int::error::UnprefixedHexError>
 pub fn bitcoin_units::parse_int::hex_u32(s: &str) -> core::result::Result<u32, bitcoin_units::parse_int::error::ParseIntError>
 pub fn bitcoin_units::parse_int::hex_u32_prefixed(s: &str) -> core::result::Result<u32, bitcoin_units::parse_int::error::PrefixedHexError>
-pub fn bitcoin_units::parse_int::hex_u32_unchecked(s: &str) -> core::result::Result<u32, bitcoin_units::parse_int::error::ParseIntError>
 pub fn bitcoin_units::parse_int::hex_u32_unprefixed(s: &str) -> core::result::Result<u32, bitcoin_units::parse_int::error::UnprefixedHexError>
 pub fn bitcoin_units::parse_int::hex_u64(s: &str) -> core::result::Result<u64, bitcoin_units::parse_int::error::ParseIntError>
 pub fn bitcoin_units::parse_int::hex_u64_prefixed(s: &str) -> core::result::Result<u64, bitcoin_units::parse_int::error::PrefixedHexError>
-pub fn bitcoin_units::parse_int::hex_u64_unchecked(s: &str) -> core::result::Result<u64, bitcoin_units::parse_int::error::ParseIntError>
 pub fn bitcoin_units::parse_int::hex_u64_unprefixed(s: &str) -> core::result::Result<u64, bitcoin_units::parse_int::error::UnprefixedHexError>
 pub fn bitcoin_units::parse_int::int_from_str<T: bitcoin_units::parse_int::Integer>(s: &str) -> core::result::Result<T, bitcoin_units::parse_int::error::ParseIntError>
 pub mod bitcoin_units::pow

--- a/units/src/parse_int.rs
+++ b/units/src/parse_int.rs
@@ -310,7 +310,7 @@ macro_rules! parse_hex_for {
         #[doc = stringify!($int_type)]
         #[doc = "`."]
         #[inline]
-        pub fn $uncheck_hex_fn(s: &str) -> Result<$int_type, ParseIntError> {
+        fn $uncheck_hex_fn(s: &str) -> Result<$int_type, ParseIntError> {
             <$int_type>::from_str_radix(s, 16).map_err(|error| ParseIntError {
                 input: s.into(),
                 bits: $bits,


### PR DESCRIPTION
Remove from the public API the 'unchecked' hex parsing function. This function is not useful, we proved a prefixed, a non-prefixed, and 'any' (with or without prefix). The 'unchecked' function fails if there is a prefix so should only be called after first ensuring there is no prefix. Hence it is a helper function and should not be part of the public API.

This is the only changes to `units/` since `units v0.4.0`. Includes patch to release `v0.5.0` immediately from this PR. 

EDIT: #6290 merged before this went in. Here is the text from the last patch on this branch

Note on deprecated code:
```
In #6290 we did the 'final polish before 1.0' including removal of
deprecated code. Hoping that the next release was 1.0 and users could
use `0.4.0` as 1.0 + deprecated stuff.

Now we are going to do `0.5.0` and semver everything possible back
into `0.4.1` so this reasoning still stands. From the changelog it
should be clear also what is going on.
```

Close: #6289