### PR TITLE
Destructure error types in source impls

### DIFF
--- a/base58/src/error.rs
+++ b/base58/src/error.rs
@@ -117,7 +117,10 @@ impl fmt::Display for IncorrectChecksumError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for IncorrectChecksumError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let Self { incorrect: _, expected: _ } = self;
+        None
+    }
 }
 
 /// The decoded base58 data was too short (require at least 4 bytes for checksum).
@@ -143,7 +146,10 @@ impl fmt::Display for TooShortError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for TooShortError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let Self { length: _ } = self;
+        None
+    }
 }
 
 /// Found an invalid ASCII byte while decoding base58 string.
@@ -178,5 +184,8 @@ impl fmt::Display for InvalidCharacterError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for InvalidCharacterError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let Self(_) = self;
+        None
+    }
 }

--- a/bitcoin/src/address/error.rs
+++ b/bitcoin/src/address/error.rs
@@ -68,7 +68,10 @@ impl fmt::Display for UnknownAddressTypeError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for UnknownAddressTypeError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let Self(_) = self;
+        None
+    }
 }
 
 /// Address parsing error.
@@ -135,7 +138,10 @@ impl fmt::Display for UnknownHrpError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for UnknownHrpError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let Self(_) = self;
+        None
+    }
 }
 
 /// Address's network differs from required one.
@@ -157,7 +163,10 @@ impl fmt::Display for NetworkValidationError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for NetworkValidationError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let Self { required: _, address: _ } = self;
+        None
+    }
 }
 
 /// Bech32 related error.
@@ -312,7 +321,10 @@ impl fmt::Display for InvalidBase58PayloadLengthError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for InvalidBase58PayloadLengthError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let Self { length: _ } = self;
+        None
+    }
 }
 
 /// Legacy base58 address was too long, max 50 characters.
@@ -339,7 +351,10 @@ impl fmt::Display for LegacyAddressTooLongError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for LegacyAddressTooLongError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let Self { length: _ } = self;
+        None
+    }
 }
 
 /// Invalid legacy address prefix in decoded base58 data.
@@ -362,5 +377,8 @@ impl fmt::Display for InvalidLegacyPrefixError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for InvalidLegacyPrefixError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let Self { invalid: _ } = self;
+        None
+    }
 }

--- a/bitcoin/src/blockdata/script/witness_version.rs
+++ b/bitcoin/src/blockdata/script/witness_version.rs
@@ -266,6 +266,9 @@ pub mod error {
 
     #[cfg(feature = "std")]
     impl std::error::Error for TryFromError {
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            let Self { invalid: _ } = self;
+            None
+        }
     }
 }

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -1270,7 +1270,10 @@ pub mod error {
 
     #[cfg(feature = "std")]
     impl std::error::Error for IndexOutOfBoundsError {
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            let Self { index: _, length: _ } = self;
+            None
+        }
     }
 }
 

--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -1051,7 +1051,10 @@ pub mod error {
 
     #[cfg(feature = "std")]
     impl std::error::Error for PrevoutsSizeError {
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            let Self {} = self;
+            None
+        }
     }
 
     /// A single prevout was provided but all prevouts are needed without `ANYONECANPAY`.
@@ -1067,7 +1070,10 @@ pub mod error {
 
     #[cfg(feature = "std")]
     impl std::error::Error for PrevoutsKindError {
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            let Self {} = self;
+            None
+        }
     }
 
     /// [`Prevouts`] index related errors.
@@ -1237,7 +1243,10 @@ pub mod error {
 
     #[cfg(feature = "std")]
     impl std::error::Error for SingleMissingOutputError {
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            let Self { input_index: _, outputs_length: _ } = self;
+            None
+        }
     }
 
     /// Annex must be at least one byte long and the first bytes must be `0x50`.

--- a/bitcoin/src/network/mod.rs
+++ b/bitcoin/src/network/mod.rs
@@ -99,7 +99,10 @@ pub mod error {
 
     #[cfg(feature = "std")]
     impl std::error::Error for UnknownChainHashError {
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            let Self(_) = self;
+            None
+        }
     }
 
     impl TryFrom<ChainHash> for Network {

--- a/bitcoin/src/taproot/merkle_branch/mod.rs
+++ b/bitcoin/src/taproot/merkle_branch/mod.rs
@@ -59,7 +59,10 @@ impl fmt::Display for DecodeError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for DecodeError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let Self { num_bytes: _ } = self;
+        None
+    }
 }
 
 impl From<DecodeError> for TaprootError {

--- a/bitcoin/src/taproot/mod.rs
+++ b/bitcoin/src/taproot/mod.rs
@@ -1408,7 +1408,10 @@ pub mod error {
 
     #[cfg(feature = "std")]
     impl std::error::Error for InvalidMerkleBranchSizeError {
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            let Self(_) = self;
+            None
+        }
     }
 
     /// Merkle tree depth must not be more than 128.
@@ -1436,7 +1439,10 @@ pub mod error {
 
     #[cfg(feature = "std")]
     impl std::error::Error for InvalidMerkleTreeDepthError {
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            let Self(_) = self;
+            None
+        }
     }
 
     /// Invalid control block size.
@@ -1464,7 +1470,10 @@ pub mod error {
 
     #[cfg(feature = "std")]
     impl std::error::Error for InvalidControlBlockSizeError {
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            let Self(_) = self;
+            None
+        }
     }
 }
 

--- a/consensus_encoding/src/error.rs
+++ b/consensus_encoding/src/error.rs
@@ -110,7 +110,10 @@ impl fmt::Display for UnconsumedError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for UnconsumedError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let Self() = self;
+        None
+    }
 }
 
 /// An error consensus decoding a compact size encoded integer.
@@ -194,7 +197,10 @@ impl core::fmt::Display for LengthPrefixExceedsMaxError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for LengthPrefixExceedsMaxError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let Self { limit: _, value: _ } = self;
+        None
+    }
 }
 
 /// The error returned by the [`ByteVecDecoder`].
@@ -313,7 +319,10 @@ impl fmt::Display for UnexpectedEofError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for UnexpectedEofError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let Self { missing: _ } = self;
+        None
+    }
 }
 
 /// Helper macro to define an error type for a `DecoderN`.

--- a/crypto/src/key.rs
+++ b/crypto/src/key.rs
@@ -1765,7 +1765,10 @@ pub mod error {
 
     #[cfg(feature = "std")]
     impl std::error::Error for UncompressedPublicKeyError {
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            let Self {} = self;
+            None
+        }
     }
 
     /// Decoded base58 data was an invalid length.
@@ -1800,7 +1803,10 @@ pub mod error {
     #[cfg(feature = "std")]
     impl std::error::Error for InvalidBase58PayloadLengthError {
         #[inline]
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            let Self { length: _ } = self;
+            None
+        }
     }
 
     /// Invalid address version in decoded base58 data.
@@ -1831,7 +1837,10 @@ pub mod error {
     #[cfg(feature = "std")]
     impl std::error::Error for InvalidAddressVersionError {
         #[inline]
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            let Self { invalid: _ } = self;
+            None
+        }
     }
 
     /// Invalid compression flag for a WIF key
@@ -1867,7 +1876,10 @@ pub mod error {
     #[cfg(feature = "std")]
     impl std::error::Error for InvalidWifCompressionFlagError {
         #[inline]
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            let Self { invalid: _ } = self;
+            None
+        }
     }
 
     /// Error that can occur when parsing an [`XOnlyPublicKey`] from bytes.

--- a/crypto/src/sighash.rs
+++ b/crypto/src/sighash.rs
@@ -243,7 +243,10 @@ pub mod error {
 
     #[cfg(feature = "std")]
     impl std::error::Error for InvalidSighashTypeError {
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            let Self(_) = self;
+            None
+        }
     }
 
     /// This type is consensus valid but an input including it would prevent the transaction from
@@ -259,7 +262,10 @@ pub mod error {
 
     #[cfg(feature = "std")]
     impl std::error::Error for NonStandardSighashTypeError {
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            let Self(_) = self;
+            None
+        }
     }
 
     /// Error returned for failure during parsing one of the sighash types.
@@ -280,7 +286,10 @@ pub mod error {
 
     #[cfg(feature = "std")]
     impl std::error::Error for SighashTypeParseError {
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            let Self { unrecognized: _ } = self;
+            None
+        }
     }
 }
 

--- a/hashes/src/hkdf/mod.rs
+++ b/hashes/src/hkdf/mod.rs
@@ -167,7 +167,10 @@ pub mod error {
     #[cfg(feature = "std")]
     impl std::error::Error for MaxLengthError {
         #[inline]
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            let Self { max: _ } = self;
+            None
+        }
     }
 }
 

--- a/hashes/src/sha256/mod.rs
+++ b/hashes/src/sha256/mod.rs
@@ -312,6 +312,14 @@ pub mod error {
     #[cfg(feature = "std")]
     impl std::error::Error for MidstateError {
         #[inline]
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            let Self {
+                invalid_n_bytes_hashed: _,
+                block_aligned_midstate: _,
+                unprocessed_bytes: _,
+                unprocessed_bytes_len: _,
+            } = self;
+            None
+        }
     }
 }

--- a/key_expression/src/bip32.rs
+++ b/key_expression/src/bip32.rs
@@ -1282,7 +1282,10 @@ pub mod error {
 
     #[cfg(feature = "std")]
     impl std::error::Error for IndexOutOfRangeError {
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            let Self { index: _ } = self;
+            None
+        }
     }
 
     /// Error parsing a child number.
@@ -1389,7 +1392,10 @@ pub mod error {
 
     #[cfg(feature = "std")]
     impl std::error::Error for InvalidBase58PayloadLengthError {
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            let Self { length: _ } = self;
+            None
+        }
     }
 
     /// Master seed had an invalid length.
@@ -1419,7 +1425,10 @@ pub mod error {
 
     #[cfg(feature = "std")]
     impl std::error::Error for InvalidSeedLengthError {
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            let Self { length: _ } = self;
+            None
+        }
     }
 }
 

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -311,7 +311,10 @@ pub mod error {
 
     #[cfg(feature = "std")]
     impl std::error::Error for ParseNetworkError {
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            let Self(_) = self;
+            None
+        }
     }
 }
 

--- a/p2p/src/bip152.rs
+++ b/p2p/src/bip152.rs
@@ -769,7 +769,10 @@ pub mod error {
 
     #[cfg(feature = "std")]
     impl std::error::Error for TxIndexOutOfRangeError {
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            let Self(_) = self;
+            None
+        }
     }
 
     /// An error occuring decoding a [`BlockTransactions`] message.

--- a/p2p/src/error.rs
+++ b/p2p/src/error.rs
@@ -110,7 +110,10 @@ impl fmt::Display for UnknownMagicError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for UnknownMagicError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let Self(_) = self;
+        None
+    }
 }
 
 /// Error in creating a Magic from a Network.
@@ -124,5 +127,8 @@ impl fmt::Display for UnknownNetworkError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for UnknownNetworkError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let Self(_) = self;
+        None
+    }
 }

--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -1903,7 +1903,10 @@ pub mod error {
     }
 
     impl std::error::Error for CommandStringError {
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            let Self(_) = self;
+            None
+        }
     }
 
     /// An error consensus decoding a [`V1MessageHeader`].

--- a/primitives/src/hash_types/script_hash.rs
+++ b/primitives/src/hash_types/script_hash.rs
@@ -90,7 +90,10 @@ impl fmt::Display for RedeemScriptSizeError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for RedeemScriptSizeError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let Self { size: _ } = self;
+        None
+    }
 }
 
 // The new hash wrapper type.

--- a/primitives/src/hash_types/witness_script_hash.rs
+++ b/primitives/src/hash_types/witness_script_hash.rs
@@ -85,7 +85,10 @@ impl fmt::Display for WitnessScriptSizeError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for WitnessScriptSizeError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let Self { size: _ } = self;
+        None
+    }
 }
 
 include!("./generic.rs");

--- a/primitives/src/script/push_bytes.rs
+++ b/primitives/src/script/push_bytes.rs
@@ -379,7 +379,7 @@ mod error {
     #[allow(unused)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct PushBytesError {
-        never: core::convert::Infallible,
+        pub(super) never: core::convert::Infallible,
     }
 
     impl super::PushBytesErrorReport for PushBytesError {
@@ -427,7 +427,13 @@ impl From<Infallible> for PushBytesError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for PushBytesError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        #[cfg(any(target_pointer_width = "16", target_pointer_width = "32"))]
+        let Self { never: _ } = self;
+        #[cfg(not(any(target_pointer_width = "16", target_pointer_width = "32")))]
+        let Self { len: _ } = self;
+        None
+    }
 }
 
 #[cfg(test)]

--- a/primitives/src/witness.rs
+++ b/primitives/src/witness.rs
@@ -998,7 +998,10 @@ pub mod error {
 
     #[cfg(feature = "std")]
     impl std::error::Error for UnexpectedEofError {
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            let Self { missing_elements: _ } = self;
+            None
+        }
     }
 }
 

--- a/taproot-primitives/src/lib.rs
+++ b/taproot-primitives/src/lib.rs
@@ -302,7 +302,10 @@ pub mod error {
 
     #[cfg(feature = "std")]
     impl std::error::Error for InvalidTaprootLeafVersionError {
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            let Self(_) = self;
+            None
+        }
     }
 }
 

--- a/units/src/amount/error.rs
+++ b/units/src/amount/error.rs
@@ -194,7 +194,10 @@ impl fmt::Display for OutOfRangeError {
 #[cfg(feature = "std")]
 impl std::error::Error for OutOfRangeError {
     #[inline]
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let Self { is_signed: _, is_greater_than_max: _ } = self;
+        None
+    }
 }
 
 /// Error returned when the input string has higher precision than satoshis.
@@ -223,7 +226,10 @@ impl fmt::Display for TooPreciseError {
 #[cfg(feature = "std")]
 impl std::error::Error for TooPreciseError {
     #[inline]
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let Self { position: _ } = self;
+        None
+    }
 }
 
 /// Error returned when the input string is too large.
@@ -256,7 +262,10 @@ impl fmt::Display for InputTooLargeError {
 #[cfg(feature = "std")]
 impl std::error::Error for InputTooLargeError {
     #[inline]
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let Self { len: _ } = self;
+        None
+    }
 }
 
 /// Error returned when digits were expected in the input but there were none.
@@ -285,7 +294,10 @@ impl fmt::Display for MissingDigitsError {
 #[cfg(feature = "std")]
 impl std::error::Error for MissingDigitsError {
     #[inline]
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let Self { kind: _ } = self;
+        None
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -322,7 +334,10 @@ impl fmt::Display for InvalidCharacterError {
 #[cfg(feature = "std")]
 impl std::error::Error for InvalidCharacterError {
     #[inline]
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let Self { invalid_char: _, position: _ } = self;
+        None
+    }
 }
 
 /// Error returned when a valid character (e.g. '_') is in an invalid/bad position.
@@ -355,7 +370,10 @@ impl fmt::Display for BadPositionError {
 #[cfg(feature = "std")]
 impl std::error::Error for BadPositionError {
     #[inline]
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let Self { char: _, position: _ } = self;
+        None
+    }
 }
 
 /// An error during amount parsing.
@@ -410,7 +428,10 @@ impl fmt::Display for MissingDenominationError {
 #[cfg(feature = "std")]
 impl std::error::Error for MissingDenominationError {
     #[inline]
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let Self {} = self;
+        None
+    }
 }
 
 /// Error returned when parsing an unknown denomination.
@@ -432,7 +453,10 @@ impl fmt::Display for UnknownDenominationError {
 #[cfg(feature = "std")]
 impl std::error::Error for UnknownDenominationError {
     #[inline]
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let Self(_) = self;
+        None
+    }
 }
 
 /// Error returned when parsing a possibly confusing denomination.
@@ -453,7 +477,10 @@ impl fmt::Display for PossiblyConfusingDenominationError {
 #[cfg(feature = "std")]
 impl std::error::Error for PossiblyConfusingDenominationError {
     #[inline]
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let Self(_) = self;
+        None
+    }
 }
 
 /// An error consensus decoding an `Amount`.

--- a/units/src/block.rs
+++ b/units/src/block.rs
@@ -657,7 +657,10 @@ pub mod error {
 
     #[cfg(feature = "std")]
     impl std::error::Error for TooBigForRelativeHeightError {
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            let Self(_) = self;
+            None
+        }
     }
 
     /// An error consensus decoding an `BlockHeight`.

--- a/units/src/fee_rate/serde.rs
+++ b/units/src/fee_rate/serde.rs
@@ -424,5 +424,8 @@ impl fmt::Display for OverflowError {
 #[cfg(feature = "std")]
 impl std::error::Error for OverflowError {
     #[inline]
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let Self {} = self;
+        None
+    }
 }

--- a/units/src/locktime/absolute/error.rs
+++ b/units/src/locktime/absolute/error.rs
@@ -73,7 +73,10 @@ impl fmt::Display for IncompatibleHeightError {
 #[cfg(feature = "std")]
 impl std::error::Error for IncompatibleHeightError {
     #[inline]
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let Self { lock: _, incompatible: _ } = self;
+        None
+    }
 }
 
 /// Tried to satisfy a lock-by-height lock using a height value.
@@ -113,7 +116,10 @@ impl fmt::Display for IncompatibleTimeError {
 #[cfg(feature = "std")]
 impl std::error::Error for IncompatibleTimeError {
     #[inline]
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let Self { lock: _, incompatible: _ } = self;
+        None
+    }
 }
 
 /// Error returned when parsing block height fails.
@@ -324,7 +330,10 @@ impl fmt::Display for ConversionError {
 #[cfg(feature = "std")]
 impl std::error::Error for ConversionError {
     #[inline]
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let Self { unit: _, input: _ } = self;
+        None
+    }
 }
 
 /// Describes the two types of locking, lock-by-height and lock-by-time.

--- a/units/src/locktime/relative/error.rs
+++ b/units/src/locktime/relative/error.rs
@@ -35,7 +35,10 @@ impl fmt::Display for DisabledLockTimeError {
 #[cfg(feature = "std")]
 impl std::error::Error for DisabledLockTimeError {
     #[inline]
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let Self(_) = self;
+        None
+    }
 }
 
 /// Error returned when attempting to satisfy lock fails.
@@ -123,7 +126,10 @@ impl fmt::Display for IncompatibleHeightError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for IncompatibleHeightError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let Self(_) = self;
+        None
+    }
 }
 
 /// Error returned when `is_satisfied_by_time` fails.
@@ -177,7 +183,10 @@ impl fmt::Display for IncompatibleTimeError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for IncompatibleTimeError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let Self(_) = self;
+        None
+    }
 }
 
 /// Error returned when the input time in seconds was too large to be encoded to a 16 bit 512 second interval.
@@ -205,7 +214,10 @@ impl fmt::Display for TimeOverflowError {
 #[cfg(feature = "std")]
 impl std::error::Error for TimeOverflowError {
     #[inline]
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let Self { seconds: _ } = self;
+        None
+    }
 }
 
 /// Error returned when `NumberOfBlocks::is_satisfied_by` is incorrectly called.
@@ -231,7 +243,10 @@ impl fmt::Display for InvalidHeightError {
 #[cfg(feature = "std")]
 impl std::error::Error for InvalidHeightError {
     #[inline]
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let Self { chain_tip: _, utxo_mined_at: _ } = self;
+        None
+    }
 }
 
 /// Error returned when `NumberOf512Seconds::is_satisfied_by` is incorrectly called.
@@ -257,7 +272,10 @@ impl fmt::Display for InvalidTimeError {
 #[cfg(feature = "std")]
 impl std::error::Error for InvalidTimeError {
     #[inline]
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let Self { chain_tip: _, utxo_mined_at: _ } = self;
+        None
+    }
 }
 
 #[cfg(test)]

--- a/units/src/parse_int.rs
+++ b/units/src/parse_int.rs
@@ -566,7 +566,10 @@ pub mod error {
     #[cfg(feature = "std")]
     impl std::error::Error for MissingPrefixError {
         #[inline]
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            let Self { hex: _ } = self;
+            None
+        }
     }
 
     /// Error when hex string contains a prefix (e.g. 0x).
@@ -594,7 +597,10 @@ pub mod error {
     #[cfg(feature = "std")]
     impl std::error::Error for ContainsPrefixError {
         #[inline]
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            let Self { hex: _ } = self;
+            None
+        }
     }
 }
 

--- a/units/src/result.rs
+++ b/units/src/result.rs
@@ -440,7 +440,10 @@ pub mod error {
     #[cfg(feature = "std")]
     impl std::error::Error for NumOpError {
         #[inline]
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            let Self(_) = self;
+            None
+        }
     }
 }
 


### PR DESCRIPTION
In the source impls of error types, we previously decided to use explicit impls to try to prevent changes in the error type from introducing errors. However, impls that simply return None do not help to solve this issue.

Add a complete error type destructure to all None source impls to catch future error shape changes.

Closes #6279