### PR TITLE
Remove double allocation from ScriptBuf::from_hex_prefixed

### DIFF
--- a/primitives/src/script/owned.rs
+++ b/primitives/src/script/owned.rs
@@ -60,8 +60,13 @@ impl<T> ScriptBuf<T> {
     /// * If the parsed bytes cannot be decoded as a valid script (incl.the length prefix).
     #[cfg(feature = "hex")]
     pub fn from_hex_prefixed(s: &str) -> Result<Self, FromHexError> {
-        let v = hex::decode_to_vec(s)?;
-        Ok(encoding::decode_from_slice(&v)?)
+        use crate::hex_codec::{HexPrimitive, ParsePrimitiveError as P};
+
+        HexPrimitive::<Self>::from_str(s).map_err(|err| match err {
+            P::OddLengthString(e) => FromHexError::Hex(e.into()),
+            P::InvalidChar(e) => FromHexError::Hex(e.into()),
+            P::Decode(e) => e.into(),
+        })
     }
 
     /// Constructs a new [`ScriptBuf`] from a hex string.


### PR DESCRIPTION
The ScriptBuf::from_hex_prefixed essentially takes a hex string and consensus decodes to a ScriptBuf object. Currently it requires two allocations to do so as the hex is decoded to a byte vec and then copied into an owned buffer on the type. By using the HexPrimitive iterator, this can be avoided.

Remove decode_to_vec allocation from ScriptBuf::from_hex_prefixed.

Closes #5861 