### PR TITLE
consensus_encoding: hex encoding/decoding support

### DIFF
--- a/consensus_encoding/Cargo.toml
+++ b/consensus_encoding/Cargo.toml
@@ -16,11 +16,13 @@ exclude = ["api", "tests", "contrib"]
 
 [features]
 default = ["std"]
-std = ["alloc", "internals/std"]
-alloc = ["internals/alloc"]
+std = ["alloc", "internals/std", "hex?/std"]
+alloc = ["internals/alloc", "hex?/alloc"]
 
 [dependencies]
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
+
+hex = { package = "hex-conservative", version = "1.1.0", default-features = false, features = [], optional = true }
 
 [dev-dependencies]
 hex = { package = "hex-conservative", version = "1.1.0" }

--- a/consensus_encoding/api/all-features.txt
+++ b/consensus_encoding/api/all-features.txt
@@ -234,6 +234,54 @@ impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::error::Decode
 pub unsafe fn bitcoin_consensus_encoding::error::Decoder6Error<A, B, C, D, E, F>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::error::Decoder6Error<A, B, C, D, E, F>
 pub fn bitcoin_consensus_encoding::error::Decoder6Error<A, B, C, D, E, F>::from(t: T) -> T
+pub enum bitcoin_consensus_encoding::error::FromHexError<ParseErr>
+pub bitcoin_consensus_encoding::error::FromHexError::Decode(bitcoin_consensus_encoding::error::DecodeError<ParseErr>)
+pub bitcoin_consensus_encoding::error::FromHexError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub bitcoin_consensus_encoding::error::FromHexError::OddLength(hex_conservative::error::OddLengthStringError)
+impl<ParseErr: core::clone::Clone> core::clone::Clone for bitcoin_consensus_encoding::error::FromHexError<ParseErr>
+pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::clone(&self) -> bitcoin_consensus_encoding::error::FromHexError<ParseErr>
+impl<ParseErr: core::cmp::Eq> core::cmp::Eq for bitcoin_consensus_encoding::error::FromHexError<ParseErr>
+impl<ParseErr: core::cmp::PartialEq> core::cmp::PartialEq for bitcoin_consensus_encoding::error::FromHexError<ParseErr>
+pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::eq(&self, other: &bitcoin_consensus_encoding::error::FromHexError<ParseErr>) -> bool
+impl<ParseErr: core::fmt::Debug> core::fmt::Debug for bitcoin_consensus_encoding::error::FromHexError<ParseErr>
+pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<ParseErr: core::fmt::Display> core::fmt::Display for bitcoin_consensus_encoding::error::FromHexError<ParseErr>
+impl<ParseErr> core::convert::From<core::convert::Infallible> for bitcoin_consensus_encoding::error::FromHexError<ParseErr>
+pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::from(never: core::convert::Infallible) -> Self
+impl<ParseErr> core::error::Error for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where ParseErr: core::error::Error + 'static
+pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl<ParseErr> core::marker::StructuralPartialEq for bitcoin_consensus_encoding::error::FromHexError<ParseErr>
+impl<ParseErr> core::marker::Freeze for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where ParseErr: core::marker::Freeze
+impl<ParseErr> core::marker::Send for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where ParseErr: core::marker::Send
+impl<ParseErr> core::marker::Sync for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where ParseErr: core::marker::Sync
+impl<ParseErr> core::marker::Unpin for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where ParseErr: core::marker::Unpin
+impl<ParseErr> core::marker::UnsafeUnpin for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where ParseErr: core::marker::UnsafeUnpin
+impl<ParseErr> core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where ParseErr: core::panic::unwind_safe::RefUnwindSafe
+impl<ParseErr> core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where ParseErr: core::panic::unwind_safe::UnwindSafe
+impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where U: core::convert::From<T>
+pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where U: core::convert::Into<T>
+pub type bitcoin_consensus_encoding::error::FromHexError<ParseErr>::Error = core::convert::Infallible
+pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where U: core::convert::TryFrom<T>
+pub type bitcoin_consensus_encoding::error::FromHexError<ParseErr>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where T: core::clone::Clone
+pub type bitcoin_consensus_encoding::error::FromHexError<ParseErr>::Owned = T
+pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::clone_into(&self, target: &mut T)
+pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where T: 'static + ?core::marker::Sized
+pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where T: ?core::marker::Sized
+pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where T: ?core::marker::Sized
+pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where T: core::clone::Clone
+pub unsafe fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_consensus_encoding::error::FromHexError<ParseErr>
+pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::from(t: T) -> T
 pub enum bitcoin_consensus_encoding::error::ReadError<D>
 pub bitcoin_consensus_encoding::error::ReadError::Decode(D)
 pub bitcoin_consensus_encoding::error::ReadError::Io(std::io::error::Error)
@@ -651,6 +699,10 @@ impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::EncoderStatus
 pub unsafe fn bitcoin_consensus_encoding::EncoderStatus::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::EncoderStatus
 pub fn bitcoin_consensus_encoding::EncoderStatus::from(t: T) -> T
+pub enum bitcoin_consensus_encoding::FromHexError<ParseErr>
+pub bitcoin_consensus_encoding::FromHexError::Decode(bitcoin_consensus_encoding::error::DecodeError<ParseErr>)
+pub bitcoin_consensus_encoding::FromHexError::InvalidChar(hex_conservative::error::InvalidCharError)
+pub bitcoin_consensus_encoding::FromHexError::OddLength(hex_conservative::error::OddLengthStringError)
 pub enum bitcoin_consensus_encoding::ReadError<D>
 pub bitcoin_consensus_encoding::ReadError::Decode(D)
 pub bitcoin_consensus_encoding::ReadError::Io(std::io::error::Error)
@@ -1500,12 +1552,15 @@ pub fn bitcoin_consensus_encoding::check_decode<T: bitcoin_consensus_encoding::D
 pub fn bitcoin_consensus_encoding::check_decoder<D: bitcoin_consensus_encoding::Decoder>(decoder: D, bytes: &[u8], expected: &<D as bitcoin_consensus_encoding::Decoder>::Output) where <D as bitcoin_consensus_encoding::Decoder>::Output: core::cmp::Eq + core::fmt::Debug, <D as bitcoin_consensus_encoding::Decoder>::Error: core::fmt::Debug
 pub fn bitcoin_consensus_encoding::check_encode<T: bitcoin_consensus_encoding::Encode + ?core::marker::Sized>(value: &T, expected: &[u8])
 pub fn bitcoin_consensus_encoding::check_encoder<T: bitcoin_consensus_encoding::Encoder + ?core::marker::Sized>(encoder: &mut T, expected: &[u8])
+pub fn bitcoin_consensus_encoding::decode_from_hex<T: bitcoin_consensus_encoding::Decode>(hex: &str) -> core::result::Result<T, bitcoin_consensus_encoding::error::FromHexError<<<T as bitcoin_consensus_encoding::Decode>::Decoder as bitcoin_consensus_encoding::Decoder>::Error>>
 pub fn bitcoin_consensus_encoding::decode_from_read<T, R>(reader: R) -> core::result::Result<T, bitcoin_consensus_encoding::error::ReadError<<<T as bitcoin_consensus_encoding::Decode>::Decoder as bitcoin_consensus_encoding::Decoder>::Error>> where T: bitcoin_consensus_encoding::Decode, R: std::io::BufRead
 pub fn bitcoin_consensus_encoding::decode_from_read_unbuffered<T, R>(reader: R) -> core::result::Result<T, bitcoin_consensus_encoding::error::ReadError<<<T as bitcoin_consensus_encoding::Decode>::Decoder as bitcoin_consensus_encoding::Decoder>::Error>> where T: bitcoin_consensus_encoding::Decode, R: std::io::Read
 pub fn bitcoin_consensus_encoding::decode_from_read_unbuffered_with<T, R, const BUFFER_SIZE: usize>(reader: R) -> core::result::Result<T, bitcoin_consensus_encoding::error::ReadError<<<T as bitcoin_consensus_encoding::Decode>::Decoder as bitcoin_consensus_encoding::Decoder>::Error>> where T: bitcoin_consensus_encoding::Decode, R: std::io::Read
 pub fn bitcoin_consensus_encoding::decode_from_slice<T: bitcoin_consensus_encoding::Decode>(bytes: &[u8]) -> core::result::Result<T, bitcoin_consensus_encoding::error::DecodeError<<<T as bitcoin_consensus_encoding::Decode>::Decoder as bitcoin_consensus_encoding::Decoder>::Error>>
 pub fn bitcoin_consensus_encoding::decode_from_slice_unbounded<T>(bytes: &mut &[u8]) -> core::result::Result<T, <<T as bitcoin_consensus_encoding::Decode>::Decoder as bitcoin_consensus_encoding::Decoder>::Error> where T: bitcoin_consensus_encoding::Decode
+pub fn bitcoin_consensus_encoding::drain_to_hex<T>(encoder: T, case: hex_conservative::Case) -> alloc::string::String where T: bitcoin_consensus_encoding::Encoder
 pub fn bitcoin_consensus_encoding::drain_to_vec<T>(encoder: &mut T) -> alloc::vec::Vec<u8> where T: bitcoin_consensus_encoding::Encoder + ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::drain_to_writer<T, W>(encoder: &mut T, writer: W) -> core::result::Result<(), std::io::error::Error> where T: bitcoin_consensus_encoding::Encoder + ?core::marker::Sized, W: std::io::Write
+pub fn bitcoin_consensus_encoding::encode_to_hex<T>(object: &T, case: hex_conservative::Case) -> alloc::string::String where T: bitcoin_consensus_encoding::Encode + ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::encode_to_vec<T>(object: &T) -> alloc::vec::Vec<u8> where T: bitcoin_consensus_encoding::Encode + ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::encode_to_writer<T, W>(object: &T, writer: W) -> core::result::Result<(), std::io::error::Error> where T: bitcoin_consensus_encoding::Encode + ?core::marker::Sized, W: std::io::Write

--- a/consensus_encoding/src/decode/mod.rs
+++ b/consensus_encoding/src/decode/mod.rs
@@ -4,6 +4,8 @@
 
 pub mod decoders;
 
+#[cfg(feature = "hex")]
+use crate::FromHexError;
 #[cfg(feature = "std")]
 use crate::ReadError;
 use crate::{DecodeError, UnconsumedError};
@@ -128,6 +130,64 @@ impl DecoderStatus {
 
     /// Returns `true` if ready to produce decoded value with [`Decoder::end`].
     pub fn is_ready(&self) -> bool { matches!(self, Self::Ready) }
+}
+
+/// Decodes an object from a hex string without heap allocations.
+///
+/// # Errors
+///
+/// - [`FromHexError::OddLength`] if the string has an odd number of characters.
+/// - [`FromHexError::InvalidChar`] if any character is not a valid hex digit.
+/// - [`FromHexError::Decode`] if decoding the type fails, including if bytes remain unconsumed
+///   after the decoder completes.
+#[cfg(feature = "hex")]
+pub fn decode_from_hex<T: Decode>(
+    hex: &str,
+) -> Result<T, FromHexError<<T::Decoder as Decoder>::Error>> {
+    let iter = hex::HexSliceToBytesIter::new(hex).map_err(FromHexError::OddLength)?;
+
+    let mut decoder = T::decoder();
+    let mut buffer = [0u8; 4096];
+    let mut index = 0;
+
+    for item in iter {
+        let byte = item.map_err(FromHexError::InvalidChar)?;
+
+        if index == buffer.len() {
+            let mut to_flush = buffer.as_slice();
+            // There is at least a single byte left after flushing the buffer. Error if the decoder
+            // is ready after flush.
+            while !to_flush.is_empty() {
+                if decoder
+                    .push_bytes(&mut to_flush)
+                    .map_err(|e| FromHexError::Decode(DecodeError::Parse(e)))?
+                    .is_ready()
+                {
+                    return Err(FromHexError::Decode(DecodeError::Unconsumed(UnconsumedError())));
+                }
+            }
+            index = 0;
+        }
+        buffer[index] = byte;
+        index += 1;
+    }
+
+    let mut to_flush = &buffer[..index];
+    while !to_flush.is_empty() {
+        if decoder
+            .push_bytes(&mut to_flush)
+            .map_err(|e| FromHexError::Decode(DecodeError::Parse(e)))?
+            .is_ready()
+        {
+            break;
+        }
+    }
+
+    if to_flush.is_empty() {
+        decoder.end().map_err(|e| FromHexError::Decode(DecodeError::Parse(e)))
+    } else {
+        Err(FromHexError::Decode(DecodeError::Unconsumed(UnconsumedError())))
+    }
 }
 
 /// Decodes an object from a byte slice.

--- a/consensus_encoding/src/encode/mod.rs
+++ b/consensus_encoding/src/encode/mod.rs
@@ -3,6 +3,9 @@
 //! Consensus Encoding Traits
 
 #[cfg(feature = "alloc")]
+#[cfg(feature = "hex")]
+use alloc::string::String;
+#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
 pub mod encoders;
@@ -337,6 +340,28 @@ where
         }
     }
     vec
+}
+
+/// Encodes an object into a hex string.
+#[cfg(feature = "alloc")]
+#[cfg(feature = "hex")]
+pub fn encode_to_hex<T>(object: &T, case: hex::Case) -> String
+where
+    T: Encode + ?Sized,
+{
+    drain_to_hex(object.encoder(), case)
+}
+
+/// Drains the output of an [`Encoder`] into a hex string.
+#[cfg(feature = "alloc")]
+#[cfg(feature = "hex")]
+pub fn drain_to_hex<T>(encoder: T, case: hex::Case) -> String
+where
+    T: Encoder,
+{
+    let iter = EncoderByteIter::new(encoder);
+    let hex_iter = hex::BytesToHexIter::new(iter, case);
+    hex_iter.flatten().map(char::from).collect()
 }
 
 /// Encodes an object to a standard I/O writer.

--- a/consensus_encoding/src/error.rs
+++ b/consensus_encoding/src/error.rs
@@ -325,6 +325,49 @@ impl std::error::Error for UnexpectedEofError {
     }
 }
 
+/// An error that can occur when decoding from a hex string.
+#[cfg(feature = "hex")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FromHexError<ParseErr> {
+    /// The hex string had an odd number of characters.
+    OddLength(hex::OddLengthStringError),
+    /// A character in the hex string was not a valid hex digit.
+    InvalidChar(hex::InvalidCharError),
+    /// The decoder rejected the decoded bytes, or bytes remained unconsumed after decoding.
+    Decode(DecodeError<ParseErr>),
+}
+
+#[cfg(feature = "hex")]
+impl<ParseErr> From<Infallible> for FromHexError<ParseErr> {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "hex")]
+impl<ParseErr: fmt::Display> fmt::Display for FromHexError<ParseErr> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Self::OddLength(ref e) => write_err!(f, "odd length string"; e),
+            Self::InvalidChar(ref e) => write_err!(f, "invalid character"; e),
+            Self::Decode(ref e) => write_err!(f, "decode error"; e),
+        }
+    }
+}
+
+#[cfg(feature = "hex")]
+#[cfg(feature = "std")]
+impl<ParseErr> std::error::Error for FromHexError<ParseErr>
+where
+    ParseErr: std::error::Error + 'static,
+{
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match *self {
+            Self::OddLength(ref e) => Some(e),
+            Self::InvalidChar(ref e) => Some(e),
+            Self::Decode(ref e) => Some(e),
+        }
+    }
+}
+
 /// Helper macro to define an error type for a `DecoderN`.
 macro_rules! define_decoder_n_error {
     (

--- a/consensus_encoding/src/lib.rs
+++ b/consensus_encoding/src/lib.rs
@@ -54,7 +54,8 @@
 //!
 //! * `std` - Enables std lib I/O driver functions and `std::error::Error` impls (implies `alloc`).
 //! * `alloc` - Enables [`encode_to_vec`], `Vec`-based decoders, and allocation-based helpers.
-//! * `hex` - Enables [`encode_to_hex`] and [`drain_to_hex`] (also requires `alloc`).
+//! * `hex` - Enables [`decode_from_hex`], [`encode_to_hex`] and [`drain_to_hex`]. Encoding also
+//!   requires `alloc`.
 
 #![no_std]
 // Coding conventions.
@@ -75,6 +76,9 @@ pub mod error;
 
 #[doc(inline)]
 pub use self::compact_size::{CompactSizeDecoder, CompactSizeEncoder, CompactSizeU64Decoder};
+#[cfg(feature = "hex")]
+#[doc(inline)]
+pub use self::decode::decode_from_hex;
 #[doc(inline)]
 pub use self::decode::decoders::{ArrayDecoder, Decoder2, Decoder3, Decoder4, Decoder6};
 #[cfg(feature = "alloc")]
@@ -109,6 +113,9 @@ pub use self::encode::{drain_to_vec, encode_to_vec};
 #[cfg(feature = "std")]
 #[doc(inline)]
 pub use self::encode::{drain_to_writer, encode_to_writer};
+#[cfg(feature = "hex")]
+#[doc(no_inline)]
+pub use self::error::FromHexError;
 #[cfg(feature = "alloc")]
 #[doc(no_inline)]
 pub use self::error::LengthPrefixExceedsMaxError;

--- a/consensus_encoding/src/lib.rs
+++ b/consensus_encoding/src/lib.rs
@@ -47,11 +47,14 @@
 //! * [`drain_to_writer`]: Drain an encoder to a stdlib writer.
 //! * [`encode_to_vec`]: Encode to the heap.
 //! * [`drain_to_vec`]: Drain an encoder to the heap.
+//! * [`encode_to_hex`]: Encode to a hex string.
+//! * [`drain_to_hex`]: Drain an encoder to a hex string.
 //!
 //! # Feature Flags
 //!
 //! * `std` - Enables std lib I/O driver functions and `std::error::Error` impls (implies `alloc`).
 //! * `alloc` - Enables [`encode_to_vec`], `Vec`-based decoders, and allocation-based helpers.
+//! * `hex` - Enables [`encode_to_hex`] and [`drain_to_hex`] (also requires `alloc`).
 
 #![no_std]
 // Coding conventions.
@@ -96,6 +99,10 @@ pub use self::encode::encoders::{
 pub use self::encode::{
     check_encode, check_encoder, Encode, Encoder, EncoderByteIter, EncoderStatus, ExactSizeEncoder,
 };
+#[cfg(feature = "alloc")]
+#[cfg(feature = "hex")]
+#[doc(inline)]
+pub use self::encode::{drain_to_hex, encode_to_hex};
 #[cfg(feature = "alloc")]
 #[doc(inline)]
 pub use self::encode::{drain_to_vec, encode_to_vec};

--- a/consensus_encoding/tests/decode.rs
+++ b/consensus_encoding/tests/decode.rs
@@ -11,6 +11,8 @@ use bitcoin_consensus_encoding::{
     check_decoder, decode_from_slice, decode_from_slice_unbounded, ArrayDecoder,
     CompactSizeDecoder, Decode, DecodeError, Decoder, Decoder2, UnexpectedEofError,
 };
+#[cfg(feature = "hex")]
+use bitcoin_consensus_encoding::{decode_from_hex, FromHexError};
 #[cfg(feature = "std")]
 use bitcoin_consensus_encoding::{decode_from_read, decode_from_read_unbuffered, ReadError};
 #[cfg(feature = "alloc")]
@@ -295,6 +297,48 @@ fn decode_from_slice_unbounded_extra_data() {
     let decoded = result.unwrap();
     assert_eq!(decoded.0, [1, 2, 3, 4]);
     assert_eq!(bytes.len(), 1);
+}
+
+#[test]
+#[cfg(feature = "hex")]
+fn decode_from_hex_test() {
+    let result: Result<TestArray, _> = decode_from_hex("01020304");
+    assert_eq!(result.unwrap().0, [0x01, 0x02, 0x03, 0x04]);
+    let result: Result<TestArray, _> = decode_from_hex("DEADBEEF");
+    assert_eq!(result.unwrap().0, [0xDE, 0xAD, 0xBE, 0xEF]);
+}
+
+#[test]
+#[cfg(all(feature = "hex", feature = "alloc"))]
+fn decode_from_hex_larger_than_internal_buffer() {
+    const COUNT: usize = 1100;
+
+    let mut encoded = vec![0xFD, 0x4C, 0x04];
+    encoded.extend(core::iter::repeat(0xDEAD_BEEF_u32.to_le_bytes()).take(COUNT).flatten());
+    assert!(encoded.len() > 4096);
+
+    let mut hex = String::with_capacity(encoded.len() * 2);
+    for byte in &encoded {
+        hex.push_str(&format!("{:02x}", byte));
+    }
+
+    let result: Result<Test, _> = decode_from_hex(&hex);
+    assert_eq!(result.unwrap(), Test(vec![Inner(0xDEAD_BEEF); COUNT]));
+}
+
+#[test]
+#[cfg(feature = "hex")]
+fn decode_from_hex_error() {
+    let result: Result<TestArray, _> = decode_from_hex("0102030");
+    assert!(matches!(result, Err(FromHexError::OddLength(_))));
+    let result: Result<TestArray, _> = decode_from_hex("0102GG04");
+    assert!(matches!(result, Err(FromHexError::InvalidChar(_))));
+    let result: Result<TestArray, _> = decode_from_hex("0102");
+    assert!(matches!(result, Err(FromHexError::Decode(DecodeError::Parse(_)))));
+    let result: Result<TestArray, _> = decode_from_hex("");
+    assert!(matches!(result, Err(FromHexError::Decode(DecodeError::Parse(_)))));
+    let result: Result<TestArray, _> = decode_from_hex("0102030405060708");
+    assert!(matches!(result, Err(FromHexError::Decode(DecodeError::Unconsumed(_)))));
 }
 
 #[test]

--- a/consensus_encoding/tests/encode.rs
+++ b/consensus_encoding/tests/encode.rs
@@ -91,6 +91,24 @@ fn encode_vec_empty_data() {
 }
 
 #[test]
+#[cfg(all(feature = "alloc", feature = "hex"))]
+fn encode_hex() {
+    let data = TestData(0xDEAD_BEEF);
+    let hex = bitcoin_consensus_encoding::encode_to_hex(&data, hex::Case::Lower);
+    assert_eq!(hex, "efbeadde");
+    let hex = bitcoin_consensus_encoding::encode_to_hex(&data, hex::Case::Upper);
+    assert_eq!(hex, "EFBEADDE");
+}
+
+#[test]
+#[cfg(all(feature = "alloc", feature = "hex"))]
+fn encode_hex_empty_data() {
+    let data = EmptyData;
+    let hex = bitcoin_consensus_encoding::encode_to_hex(&data, hex::Case::Lower);
+    assert!(hex.is_empty());
+}
+
+#[test]
 #[cfg(feature = "std")]
 fn encode_std_writer_empty_data() {
     let data = EmptyData;
@@ -474,4 +492,14 @@ fn check_encoder_detects_error_byte_offset() {
         BytesEncoder::without_length_prefix(&[0xFF, 0x03]),
     );
     check_encoder(&mut encoder, &[0x01, 0x02, 0x03]);
+}
+
+#[test]
+#[cfg(all(feature = "alloc", feature = "hex"))]
+fn drain_hex_multi_chunk() {
+    let enc1 = ArrayEncoder::without_length_prefix([0xDE_u8, 0xAD]);
+    let enc2 = ArrayEncoder::without_length_prefix([0xBE_u8, 0xEF]);
+    let encoder = Encoder2::new(enc1, enc2);
+    let hex = bitcoin_consensus_encoding::drain_to_hex(encoder, hex::Case::Lower);
+    assert_eq!(hex, "deadbeef");
 }


### PR DESCRIPTION
As part of consensus encoding, moving to and from hexadecimal provides a convenient method for ASCII encoding of consensus objects. Currently, encoding is possible by pairing EncoderByteIter with hex-conservative, but decoding is non-trivial without heap allocations. By adding a hex feature to consensus_encoding, hex encoding and decoding can be included directly in consensus encoding, avoiding users needing to implement it themselves.

- Patch 1 adds encode_to_hex and drain_to_hex to generate alloc::string::String from encodable objects/encoders.
- Patch 2 adds decode_from_hex that decodes an object from a hex &str without heap allocation.
- Patch 3 updates the API files.

Closes #6281