### PR TITLE
p2p: Drop length and checksum from V1NetworkMessage

### DIFF
--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -2858,6 +2858,32 @@ mod test {
     }
 
     #[test]
+    #[rustfmt::skip]
+    fn v1_message_with_noncanonical_encoding_roundtrips() {
+        // Wire data has a non-canonical `send_compact` (0x0c instead of 0x01).
+        let raw_msg = [
+            0xf9, 0xbe, 0xb4, 0xd9,                                                 // Network Magic
+            0x73, 0x65, 0x6e, 0x64, 0x63, 0x6d, 0x70, 0x63, 0x74, 0x00, 0x00, 0x00, // "sendcmpct"
+            0x09, 0x00, 0x00, 0x00,                                                 // Length
+            0xf9, 0x9c, 0x95, 0x43,                                                 // Checksum (for 0x0c)
+            0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x0c,                   // Payload (0x0c)
+        ];
+
+        // 1. Decode raw bytes (succeeds; checksum matches non-canonical 0x0c payload).
+        let msg = encoding::decode_from_slice::<V1NetworkMessage>(&raw_msg)
+            .expect("valid checksum against raw payload");
+
+        // 2. Re-encode normalizes payload to 0x01; computes checksum for the new payload.
+        let re_encoded = encoding::encode_to_vec(&msg);
+
+        // 3. Decode again (succeeds; checksum matches canonical 0x01 payload).
+        let decoded_again = encoding::decode_from_slice::<V1NetworkMessage>(&re_encoded)
+            .expect("re-encoded message must be self-consistent");
+
+        assert_eq!(msg.into_payload(), decoded_again.into_payload());
+    }
+
+    #[test]
     #[rustfmt::skip] // Keep readable byte layout with comments.
     fn v1_message_rejects_invalid_checksum_with_noncanonical_encoding() {
         // Derived from a fuzzer crash case, a SendCmpct message with a non-canonical

--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -734,21 +734,11 @@ impl NetworkMessage {
 pub struct V1NetworkMessage {
     magic: Magic,
     payload: NetworkMessage,
-    payload_len: u32,
-    checksum: [u8; 4],
 }
 
 impl V1NetworkMessage {
-    /// Constructs a new [`V1NetworkMessage`]
-    ///
-    /// # Panics
-    ///
-    /// Panics if the payload length exceeds `u32::MAX`.
-    pub fn new(magic: Magic, payload: NetworkMessage) -> Self {
-        let (bytes_hashed, checksum) = sha2_checksum(&payload);
-        let payload_len = u32::try_from(bytes_hashed).expect("network message use u32 as length");
-        Self { magic, payload, payload_len, checksum }
-    }
+    /// Constructs a new [`V1NetworkMessage`].
+    pub const fn new(magic: Magic, payload: NetworkMessage) -> Self { Self { magic, payload } }
 
     /// Consumes the [`V1NetworkMessage`] instance and returns the inner payload.
     pub fn into_payload(self) -> NetworkMessage { self.payload }
@@ -1007,13 +997,23 @@ encoding::encoder_newtype! {
 impl encoding::Encode for V1NetworkMessage {
     type Encoder<'e> = V1NetworkMessageEncoder<'e>;
 
+    /// Builds an encoder that emits a self-consistent v1 message.
+    ///
+    /// The header's `length` and `checksum` are derived from the encoded payload bytes here,
+    /// rather than being read from stored fields.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the encoded payload length exceeds `u32::MAX`.
     fn encoder(&self) -> Self::Encoder<'_> {
+        let (bytes_hashed, checksum) = sha2_checksum(&self.payload);
+        let payload_len = u32::try_from(bytes_hashed).expect("network message use u32 as length");
         V1NetworkMessageEncoder::new(encoding::Encoder2::new(
             encoding::Encoder4::new(
                 encoding::ArrayEncoder::without_length_prefix(self.magic.to_bytes()),
                 self.command().encoder(),
-                encoding::ArrayEncoder::without_length_prefix(self.payload_len.to_le_bytes()),
-                encoding::ArrayEncoder::without_length_prefix(self.checksum),
+                encoding::ArrayEncoder::without_length_prefix(payload_len.to_le_bytes()),
+                encoding::ArrayEncoder::without_length_prefix(checksum),
             ),
             NetworkMessageEncoder::new(&self.payload),
         ))
@@ -1316,7 +1316,6 @@ enum DecoderState {
     },
     ReadingPayload {
         magic: Magic,
-        length: u32,
         checksum: [u8; 4],
         payload_decoder: NetworkMessageDecoder,
         // Hash engine to compute checksum over raw payload bytes as they arrive.
@@ -1367,7 +1366,6 @@ impl encoding::Decoder for V1NetworkMessageDecoder {
                     let payload_decoder = NetworkMessageDecoder::new(header.command, payload_len);
                     self.state = DecoderState::ReadingPayload {
                         magic: header.magic,
-                        length: header.length,
                         checksum: header.checksum,
                         payload_decoder,
                         checksum_engine: sha256d::HashEngine::new(),
@@ -1396,13 +1394,7 @@ impl encoding::Decoder for V1NetworkMessageDecoder {
                 .map_err(V1NetworkMessageDecoderErrorInner::Header)
                 .map_err(V1NetworkMessageDecoderError)
                 .expect_err("push_bytes() moves to ReadingPayload on header_decoder completion")),
-            DecoderState::ReadingPayload {
-                magic,
-                length,
-                checksum,
-                payload_decoder,
-                checksum_engine,
-            } => {
+            DecoderState::ReadingPayload { magic, checksum, payload_decoder, checksum_engine } => {
                 let payload = payload_decoder.end()?;
 
                 let hash_bytes = checksum_engine.finalize().to_byte_array();
@@ -1418,7 +1410,7 @@ impl encoding::Decoder for V1NetworkMessageDecoder {
                     ));
                 }
 
-                Ok(V1NetworkMessage { magic, payload, payload_len: length, checksum })
+                Ok(V1NetworkMessage { magic, payload })
             }
         }
     }


### PR DESCRIPTION
The length and checksum being stored on V1NetworkMessage at construction could contain  payload information inconsistent with the actual message when re-encoded, this can lead to subtle issues including the V1NetworkMessage not roundtripping through the encode and decode cycle successfully.

Dropping the fields from the struct and deriving them at encode time eliminates the inconsistencies between the constructed and encoded network message.

Most recent issues encountered by this:
#5894
be668315372e8e1f17e8e2745ae68014d07a888c
#6194 

These fields were added in #1954 to prevent allocations when encoding the network message, which isn't the case anymore.