### PR TITLE
primitives: Avoid allocating claimed size when decoding witness length

### DIFF
--- a/primitives/src/witness.rs
+++ b/primitives/src/witness.rs
@@ -468,8 +468,7 @@ impl encoding::Decoder for WitnessDecoder {
 
                 // Re-encode the length back into the buffer.
                 let encoded_size = CompactSizeEncoder::encoded_size(element_length);
-                let required_len =
-                    self.cursor.saturating_add(encoded_size).saturating_add(element_length);
+                let required_len = self.cursor.saturating_add(encoded_size).saturating_add(element_length.min(MIN_VECTOR_ALLOCATE));
                 self.reserve_batch(required_len);
                 let encoded_compact_size = crate::compact_size_encode(element_length);
                 self.content[self.cursor..self.cursor + encoded_size]


### PR DESCRIPTION
Avoid allocating the claimed size when decoding witness length.

It's currently possible to claim a length and have the decoder reserve up to `MAX_VECTOR_ALLOCATE` before any data bytes have arrived, just from reading the length prefix.

Instead, we can reserve only the prefix, and let the buffer grow incrementally as bytes arrive.