### PR TITLE
consensus_encoding: Use crate alias in test code

### DIFF
--- a/consensus_encoding/tests/api.rs
+++ b/consensus_encoding/tests/api.rs
@@ -83,10 +83,7 @@ impl Decoder for FooDecoder {
     type Output = Foo;
     type Error = UnexpectedEofError;
 
-    fn push_bytes(
-        &mut self,
-        bytes: &mut &[u8],
-    ) -> Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error> {
+    fn push_bytes(&mut self, bytes: &mut &[u8]) -> Result<encoding::DecoderStatus, Self::Error> {
         self.0.push_bytes(bytes)
     }
     fn end(self) -> Result<Self::Output, Self::Error> { self.0.end().map(Foo) }

--- a/consensus_encoding/tests/compact_size.rs
+++ b/consensus_encoding/tests/compact_size.rs
@@ -3,8 +3,9 @@
 //! Round-trip integration tests for `CompactSize` codec.
 
 use bitcoin_consensus_encoding::{
-    check_decode, check_encode, decode_from_slice, CompactSizeDecoder, CompactSizeDecoderError,
-    CompactSizeEncoder, CompactSizeU64Decoder, Decode, Decoder, Encode, ExactSizeEncoder,
+    self as encoding, check_decode, check_encode, decode_from_slice, CompactSizeDecoder,
+    CompactSizeDecoderError, CompactSizeEncoder, CompactSizeU64Decoder, Decode, Decoder, Encode,
+    ExactSizeEncoder,
 };
 
 /// A `usize` value encoded and decoded as a compact size length prefix.
@@ -27,10 +28,7 @@ impl Decoder for CompactSizeUsizeDecoderWrapper {
     type Output = CompactSizeUsize;
     type Error = CompactSizeDecoderError;
 
-    fn push_bytes(
-        &mut self,
-        bytes: &mut &[u8],
-    ) -> Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error> {
+    fn push_bytes(&mut self, bytes: &mut &[u8]) -> Result<encoding::DecoderStatus, Self::Error> {
         self.0.push_bytes(bytes)
     }
 
@@ -63,10 +61,7 @@ impl Decoder for CompactSizeU64DecoderWrapper {
     type Output = CompactSizeU64;
     type Error = CompactSizeDecoderError;
 
-    fn push_bytes(
-        &mut self,
-        bytes: &mut &[u8],
-    ) -> Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error> {
+    fn push_bytes(&mut self, bytes: &mut &[u8]) -> Result<encoding::DecoderStatus, Self::Error> {
         self.0.push_bytes(bytes)
     }
 
@@ -288,7 +283,7 @@ fn decoder_compact_size_end_incomplete_one_byte() {
     assert!(decoder.push_bytes(&mut slice).unwrap().needs_more());
 
     let err = decoder.end().unwrap_err();
-    assert!(matches!(err, bitcoin_consensus_encoding::CompactSizeDecoderError { .. }));
+    assert!(matches!(err, encoding::CompactSizeDecoderError { .. }));
 }
 
 #[test]
@@ -300,7 +295,7 @@ fn decoder_compact_size_end_incomplete_three_byte() {
     assert!(decoder.push_bytes(&mut slice).unwrap().needs_more());
 
     let err = decoder.end().unwrap_err();
-    assert!(matches!(err, bitcoin_consensus_encoding::CompactSizeDecoderError { .. }));
+    assert!(matches!(err, encoding::CompactSizeDecoderError { .. }));
 }
 
 #[test]
@@ -312,7 +307,7 @@ fn decoder_compact_size_end_incomplete_five_byte() {
     assert!(decoder.push_bytes(&mut slice).unwrap().needs_more());
 
     let err = decoder.end().unwrap_err();
-    assert!(matches!(err, bitcoin_consensus_encoding::CompactSizeDecoderError { .. }));
+    assert!(matches!(err, encoding::CompactSizeDecoderError { .. }));
 }
 
 #[test]
@@ -324,7 +319,7 @@ fn decoder_compact_size_end_incomplete_nine_byte() {
     assert!(decoder.push_bytes(&mut slice).unwrap().needs_more());
 
     let err = decoder.end().unwrap_err();
-    assert!(matches!(err, bitcoin_consensus_encoding::CompactSizeDecoderError { .. }));
+    assert!(matches!(err, encoding::CompactSizeDecoderError { .. }));
 }
 
 #[test]

--- a/consensus_encoding/tests/composition.rs
+++ b/consensus_encoding/tests/composition.rs
@@ -2,12 +2,13 @@
 
 //! Test composition of encoders and decoders.
 
+use bitcoin_consensus_encoding as encoding;
 #[cfg(feature = "alloc")]
-use bitcoin_consensus_encoding::{
+use encoding::{
     check_decode, check_encoder, drain_to_vec, encode_to_vec, ArrayEncoder, BytesEncoder, Decode,
     Encode, Encoder2, Encoder3, Encoder6,
 };
-use bitcoin_consensus_encoding::{
+use encoding::{
     ArrayDecoder, Decoder, Decoder2, Decoder2Error, Decoder6, DecoderStatus, UnexpectedEofError,
 };
 
@@ -266,7 +267,7 @@ fn composition_error_unification() {
         fn push_bytes(
             &mut self,
             bytes: &mut &[u8],
-        ) -> Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error> {
+        ) -> Result<encoding::DecoderStatus, Self::Error> {
             self.inner.push_bytes(bytes).map_err(NestedError::from)
         }
 

--- a/consensus_encoding/tests/decode.rs
+++ b/consensus_encoding/tests/decode.rs
@@ -5,16 +5,17 @@
 #[cfg(feature = "std")]
 use std::io::{Cursor, Read};
 
+use bitcoin_consensus_encoding as encoding;
 #[cfg(feature = "alloc")]
-use bitcoin_consensus_encoding::check_decode;
-use bitcoin_consensus_encoding::{
+use encoding::check_decode;
+use encoding::{
     check_decoder, decode_from_slice, decode_from_slice_unbounded, ArrayDecoder,
     CompactSizeDecoder, Decode, DecodeError, Decoder, Decoder2, UnexpectedEofError,
 };
 #[cfg(feature = "std")]
-use bitcoin_consensus_encoding::{decode_from_read, decode_from_read_unbuffered, ReadError};
+use encoding::{decode_from_read, decode_from_read_unbuffered, ReadError};
 #[cfg(feature = "alloc")]
-use bitcoin_consensus_encoding::{ByteVecDecoder, VecDecoder, VecDecoderError};
+use encoding::{ByteVecDecoder, VecDecoder, VecDecoderError};
 
 const EMPTY: &[u8] = &[];
 
@@ -146,10 +147,7 @@ fn decode_decoder2_end_with_first_decoder_incomplete() {
     let _ = decoder.push_bytes(&mut data);
     let err = decoder.end().unwrap_err();
 
-    assert!(matches!(
-        err,
-        bitcoin_consensus_encoding::Decoder2Error::First(UnexpectedEofError { .. })
-    ));
+    assert!(matches!(err, encoding::Decoder2Error::First(UnexpectedEofError { .. })));
 }
 
 #[test]
@@ -161,10 +159,7 @@ fn decode_decoder2_end_with_second_decoder_incomplete() {
     let _ = decoder.push_bytes(&mut data);
     let err = decoder.end().unwrap_err();
 
-    assert!(matches!(
-        err,
-        bitcoin_consensus_encoding::Decoder2Error::Second(UnexpectedEofError { .. })
-    ));
+    assert!(matches!(err, encoding::Decoder2Error::Second(UnexpectedEofError { .. })));
 }
 
 #[test]
@@ -176,17 +171,14 @@ fn decode_decoder2_with_zero_sized_first_decoder_end() {
     let _ = decoder.push_bytes(&mut data);
 
     let err = decoder.end().unwrap_err();
-    assert!(matches!(
-        err,
-        bitcoin_consensus_encoding::Decoder2Error::Second(UnexpectedEofError { .. })
-    ));
+    assert!(matches!(err, encoding::Decoder2Error::Second(UnexpectedEofError { .. })));
 }
 
 #[test]
 #[cfg(feature = "alloc")]
 fn decode_byte_vec_decoder_empty() {
     // Test decoding empty byte vector, with length prefix of 0.
-    use bitcoin_consensus_encoding::{ByteVecDecoder, Decoder};
+    use encoding::{ByteVecDecoder, Decoder};
 
     let mut decoder = ByteVecDecoder::new();
     let mut data = &[0x00][..];
@@ -201,7 +193,7 @@ fn decode_byte_vec_decoder_empty() {
 #[test]
 #[cfg(feature = "alloc")]
 fn decode_byte_vec_decoder_does_not_overconsume() {
-    use bitcoin_consensus_encoding::ByteVecDecoder;
+    use encoding::ByteVecDecoder;
 
     let mut decoder = ByteVecDecoder::new();
     let mut data = &[0x02, 0xAA, 0xBB, 0xCC, 0xDD][..];
@@ -213,7 +205,7 @@ fn decode_byte_vec_decoder_does_not_overconsume() {
 #[test]
 #[cfg(feature = "alloc")]
 fn decode_byte_vec_decoder_does_not_overconsume_on_second_chunk() {
-    use bitcoin_consensus_encoding::ByteVecDecoder;
+    use encoding::ByteVecDecoder;
 
     // First chunk prefix declares 4 payload bytes and provides the first one.
     let mut first_chunk: &[u8] = &[0x04, 0xAA];
@@ -249,10 +241,7 @@ impl Decoder for TestArrayDecoder {
     type Output = TestArray;
     type Error = UnexpectedEofError;
 
-    fn push_bytes(
-        &mut self,
-        bytes: &mut &[u8],
-    ) -> Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error> {
+    fn push_bytes(&mut self, bytes: &mut &[u8]) -> Result<encoding::DecoderStatus, Self::Error> {
         self.inner.push_bytes(bytes)
     }
 
@@ -409,10 +398,7 @@ impl Decoder for InnerDecoder {
     type Output = Inner;
     type Error = UnexpectedEofError;
 
-    fn push_bytes(
-        &mut self,
-        bytes: &mut &[u8],
-    ) -> Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error> {
+    fn push_bytes(&mut self, bytes: &mut &[u8]) -> Result<encoding::DecoderStatus, Self::Error> {
         self.0.push_bytes(bytes)
     }
 
@@ -442,10 +428,7 @@ impl Decoder for TestDecoder {
     type Output = Test;
     type Error = VecDecoderError<UnexpectedEofError>;
 
-    fn push_bytes(
-        &mut self,
-        bytes: &mut &[u8],
-    ) -> Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error> {
+    fn push_bytes(&mut self, bytes: &mut &[u8]) -> Result<encoding::DecoderStatus, Self::Error> {
         self.0.push_bytes(bytes)
     }
 
@@ -597,8 +580,7 @@ fn decode_vec_from_read_unbuffered_success() {
     let encoded = [0x01, 0xEF, 0xBE, 0xAD, 0xDE, 0xff, 0xff, 0xff, 0xff];
     let mut cursor = Cursor::new(&encoded);
 
-    let got =
-        bitcoin_consensus_encoding::decode_from_read_unbuffered::<Test, _>(&mut cursor).unwrap();
+    let got = encoding::decode_from_read_unbuffered::<Test, _>(&mut cursor).unwrap();
     assert_eq!(cursor.position(), 5);
 
     let want = Test(vec![Inner(0xDEAD_BEEF)]);
@@ -614,7 +596,7 @@ fn decode_byte_vec_decoder_end_incomplete_length_prefix() {
     assert!(status.needs_more());
 
     let err = decoder.end().unwrap_err();
-    assert!(matches!(err, bitcoin_consensus_encoding::ByteVecDecoderError { .. }));
+    assert!(matches!(err, encoding::ByteVecDecoderError { .. }));
 }
 
 #[test]
@@ -627,7 +609,7 @@ fn decode_byte_vec_decoder_end_incomplete_data() {
     assert!(status.needs_more());
 
     let err = decoder.end().unwrap_err();
-    assert!(matches!(err, bitcoin_consensus_encoding::ByteVecDecoderError { .. }));
+    assert!(matches!(err, encoding::ByteVecDecoderError { .. }));
 }
 
 #[test]
@@ -639,7 +621,7 @@ fn decode_vec_decoder_end_incomplete_length_prefix() {
     assert!(status.needs_more());
 
     let err = decoder.end().unwrap_err();
-    assert!(matches!(err, bitcoin_consensus_encoding::VecDecoderError { .. }));
+    assert!(matches!(err, encoding::VecDecoderError { .. }));
 }
 
 #[test]
@@ -652,7 +634,7 @@ fn decode_vec_decoder_end_incomplete_item() {
     assert!(status.needs_more());
 
     let err = decoder.end().unwrap_err();
-    assert!(matches!(err, bitcoin_consensus_encoding::VecDecoderError { .. }));
+    assert!(matches!(err, encoding::VecDecoderError { .. }));
 }
 
 #[test]

--- a/consensus_encoding/tests/encode.rs
+++ b/consensus_encoding/tests/encode.rs
@@ -6,8 +6,9 @@
 use std::io::{Cursor, Write};
 
 use bitcoin_consensus_encoding::{
-    check_encode, check_encoder, ArrayEncoder, ArrayRefEncoder, BytesEncoder, Encode, Encoder,
-    Encoder2, Encoder3, Encoder4, Encoder6, EncoderByteIter, ExactSizeEncoder, SliceEncoder,
+    self as encoding, check_encode, check_encoder, ArrayEncoder, ArrayRefEncoder, BytesEncoder,
+    Encode, Encoder, Encoder2, Encoder3, Encoder4, Encoder6, EncoderByteIter, ExactSizeEncoder,
+    SliceEncoder,
 };
 
 struct TestBytes<'a>(&'a [u8]);
@@ -68,7 +69,7 @@ fn encode_std_writer() {
     let data = TestData(0x1234_5678);
 
     let mut cursor = Cursor::new(Vec::new());
-    bitcoin_consensus_encoding::encode_to_writer(&data, &mut cursor).unwrap();
+    encoding::encode_to_writer(&data, &mut cursor).unwrap();
 
     let result = cursor.into_inner();
     assert_eq!(result, vec![0x78, 0x56, 0x34, 0x12]);
@@ -78,7 +79,7 @@ fn encode_std_writer() {
 #[cfg(feature = "alloc")]
 fn encode_vec() {
     let data = TestData(0xDEAD_BEEF);
-    let vec = bitcoin_consensus_encoding::encode_to_vec(&data);
+    let vec = encoding::encode_to_vec(&data);
     assert_eq!(vec, vec![0xEF, 0xBE, 0xAD, 0xDE]);
 }
 
@@ -86,7 +87,7 @@ fn encode_vec() {
 #[cfg(feature = "alloc")]
 fn encode_vec_empty_data() {
     let data = EmptyData;
-    let result = bitcoin_consensus_encoding::encode_to_vec(&data);
+    let result = encoding::encode_to_vec(&data);
     assert!(result.is_empty());
 }
 
@@ -95,7 +96,7 @@ fn encode_vec_empty_data() {
 fn encode_std_writer_empty_data() {
     let data = EmptyData;
     let mut cursor = Cursor::new(Vec::new());
-    bitcoin_consensus_encoding::encode_to_writer(&data, &mut cursor).unwrap();
+    encoding::encode_to_writer(&data, &mut cursor).unwrap();
 
     let result = cursor.into_inner();
     assert!(result.is_empty());
@@ -118,7 +119,7 @@ fn encode_std_writer_io_error() {
     let data = TestData(0x1234_5678);
     let mut writer = FailingWriter;
 
-    let result = bitcoin_consensus_encoding::encode_to_writer(&data, &mut writer);
+    let result = encoding::encode_to_writer(&data, &mut writer);
 
     assert!(result.is_err());
     assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::Other);
@@ -128,10 +129,10 @@ fn encode_std_writer_io_error() {
 fn encode_newtype_lifetime_flexibility() {
     // Test that the encoder_newtype macro allows different lifetime names.
 
-    bitcoin_consensus_encoding::encoder_newtype! {
+    encoding::encoder_newtype! {
         pub struct CustomEncoder<'data>(BytesEncoder<'data>);
     }
-    bitcoin_consensus_encoding::encoder_newtype! {
+    encoding::encoder_newtype! {
         pub struct NoLifetimeEncoder<'e>(ArrayEncoder<4>);
     }
 


### PR DESCRIPTION
`bitcoin_consensus_encoding` is one hell of a mouthful. Add an alias to `encoding`.

Test code only.