### PR TITLE
Clean up stale duplicate dep overrides

### DIFF
--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -56,10 +56,5 @@ exact_features = [
     ["std", "serde", "small-hash"],
 ]
 
-[package.metadata.rbmt.lint]
-allowed_duplicates = [
-    "hex-conservative",
-]
-
 [package.metadata.rbmt.prerelease]
 enabled = true

--- a/io/Cargo.toml
+++ b/io/Cargo.toml
@@ -40,8 +40,3 @@ exact_features = [
     ["alloc", "hashes"],
     ["std", "hashes"],
 ]
-
-[package.metadata.rbmt.lint]
-allowed_duplicates = [
-    "hex-conservative",
-]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -57,10 +57,5 @@ exact_features = [
     ["std", "hex", "serde"],
 ]
 
-[package.metadata.rbmt.lint]
-allowed_duplicates = [
-    "hex-conservative",
-]
-
 [package.metadata.rbmt.prerelease]
 enabled = true

--- a/taproot-primitives/Cargo.toml
+++ b/taproot-primitives/Cargo.toml
@@ -36,8 +36,3 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true
-
-[package.metadata.rbmt.lint]
-allowed_duplicates = [
-    "hex-conservative",
-]


### PR DESCRIPTION
These are no longer needed with the `hex` release.