### PR TITLE
Move `WitnessVersion` to `primitives`

### DIFF
--- a/bitcoin/src/blockdata/script/witness_version.rs
+++ b/bitcoin/src/blockdata/script/witness_version.rs
@@ -7,128 +7,14 @@
 //!
 //! [BIP-0141]: <https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki>
 
-use core::fmt;
-use core::str::FromStr;
-
-use crate::opcodes::all::*;
-use crate::opcodes::Opcode;
-use crate::parse_int;
 use crate::script::Instruction;
 
 #[rustfmt::skip]            // Keep public re-exports separate.
 #[doc(no_inline)]
 pub use self::error::{FromStrError, TryFromInstructionError, TryFromError};
 
-/// Version of the segregated witness program.
-///
-/// Helps limit possible versions of the witness according to the specification. If a plain `u8`
-/// type was used instead it would mean that the version may be > 16, which would be incorrect.
-///
-/// First byte of `scriptPubkey` in transaction output for transactions starting with opcodes
-/// ranging from 0 to 16 (inclusive).
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
-#[repr(u8)]
-pub enum WitnessVersion {
-    /// Initial version of witness program. Used for P2WPKH and P2WSH outputs
-    V0 = 0,
-    /// Version of witness program used for Taproot P2TR outputs.
-    V1 = 1,
-    /// Future (unsupported) version of witness program.
-    V2 = 2,
-    /// Future (unsupported) version of witness program.
-    V3 = 3,
-    /// Future (unsupported) version of witness program.
-    V4 = 4,
-    /// Future (unsupported) version of witness program.
-    V5 = 5,
-    /// Future (unsupported) version of witness program.
-    V6 = 6,
-    /// Future (unsupported) version of witness program.
-    V7 = 7,
-    /// Future (unsupported) version of witness program.
-    V8 = 8,
-    /// Future (unsupported) version of witness program.
-    V9 = 9,
-    /// Future (unsupported) version of witness program.
-    V10 = 10,
-    /// Future (unsupported) version of witness program.
-    V11 = 11,
-    /// Future (unsupported) version of witness program.
-    V12 = 12,
-    /// Future (unsupported) version of witness program.
-    V13 = 13,
-    /// Future (unsupported) version of witness program.
-    V14 = 14,
-    /// Future (unsupported) version of witness program.
-    V15 = 15,
-    /// Future (unsupported) version of witness program.
-    V16 = 16,
-}
-
-impl WitnessVersion {
-    /// Returns integer version number representation for a given [`WitnessVersion`] value.
-    ///
-    /// NB: this is not the same as an integer representation of the opcode signifying witness
-    /// version in bitcoin script. Thus, there is no function to directly convert witness version
-    /// into a byte since the conversion requires context (bitcoin script or just a version number).
-    pub fn to_num(self) -> u8 { self as u8 }
-}
-
-/// Prints [`WitnessVersion`] number (from 0 to 16) as integer, without any prefix or suffix.
-impl fmt::Display for WitnessVersion {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "{}", *self as u8) }
-}
-
-impl FromStr for WitnessVersion {
-    type Err = FromStrError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let version: u8 = parse_int::int_from_str(s)?;
-        Ok(Self::try_from(version)?)
-    }
-}
-
-impl TryFrom<u8> for WitnessVersion {
-    type Error = TryFromError;
-
-    fn try_from(no: u8) -> Result<Self, Self::Error> {
-        use WitnessVersion::*;
-
-        Ok(match no {
-            0 => V0,
-            1 => V1,
-            2 => V2,
-            3 => V3,
-            4 => V4,
-            5 => V5,
-            6 => V6,
-            7 => V7,
-            8 => V8,
-            9 => V9,
-            10 => V10,
-            11 => V11,
-            12 => V12,
-            13 => V13,
-            14 => V14,
-            15 => V15,
-            16 => V16,
-            invalid => return Err(TryFromError { invalid }),
-        })
-    }
-}
-
-impl TryFrom<Opcode> for WitnessVersion {
-    type Error = TryFromError;
-
-    fn try_from(opcode: Opcode) -> Result<Self, Self::Error> {
-        match opcode.to_u8() {
-            0 => Ok(Self::V0),
-            version if version >= OP_1.to_u8() && version <= OP_16.to_u8() =>
-                Self::try_from(version - OP_1.to_u8() + 1),
-            invalid => Err(TryFromError { invalid }),
-        }
-    }
-}
+#[doc(inline)]
+pub use primitives::witness_version::WitnessVersion;
 
 impl TryFrom<Instruction<'_>> for WitnessVersion {
     type Error = TryFromInstructionError;
@@ -142,15 +28,6 @@ impl TryFrom<Instruction<'_>> for WitnessVersion {
     }
 }
 
-impl From<WitnessVersion> for Opcode {
-    fn from(version: WitnessVersion) -> Self {
-        match version {
-            WitnessVersion::V0 => OP_PUSHBYTES_0,
-            no => Self::from(OP_1.to_u8() + no.to_num() - 1),
-        }
-    }
-}
-
 /// Error types for the segwit version number.
 pub mod error {
     use core::convert::Infallible;
@@ -158,50 +35,9 @@ pub mod error {
 
     use internals::write_err;
 
-    use crate::parse_int::ParseIntError;
-
-    /// Error parsing [`WitnessVersion`] from a string.
-    ///
-    /// [`WitnessVersion`]: super::WitnessVersion
-    #[derive(Clone, Debug, PartialEq, Eq)]
-    #[non_exhaustive]
-    pub enum FromStrError {
-        /// Unable to parse integer from string.
-        Unparsable(ParseIntError),
-        /// String contained an invalid witness version number.
-        Invalid(TryFromError),
-    }
-
-    impl From<Infallible> for FromStrError {
-        fn from(never: Infallible) -> Self { match never {} }
-    }
-
-    impl fmt::Display for FromStrError {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            match self {
-                Self::Unparsable(ref e) => write_err!(f, "integer parse error"; e),
-                Self::Invalid(ref e) => write_err!(f, "invalid version number"; e),
-            }
-        }
-    }
-
-    #[cfg(feature = "std")]
-    impl std::error::Error for FromStrError {
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-            match self {
-                Self::Unparsable(ref e) => Some(e),
-                Self::Invalid(ref e) => Some(e),
-            }
-        }
-    }
-
-    impl From<ParseIntError> for FromStrError {
-        fn from(e: ParseIntError) -> Self { Self::Unparsable(e) }
-    }
-
-    impl From<TryFromError> for FromStrError {
-        fn from(e: TryFromError) -> Self { Self::Invalid(e) }
-    }
+    #[rustfmt::skip]            // Keep public re-exports separate.
+    #[doc(no_inline)]
+    pub use primitives::witness_version::error::{FromStrError, TryFromError};
 
     /// Error attempting to create a [`WitnessVersion`] from an [`Instruction`]
     ///
@@ -242,33 +78,5 @@ pub mod error {
 
     impl From<TryFromError> for TryFromInstructionError {
         fn from(e: TryFromError) -> Self { Self::TryFrom(e) }
-    }
-
-    /// Error attempting to create a [`WitnessVersion`] from an integer.
-    ///
-    /// [`WitnessVersion`]: super::WitnessVersion
-    #[derive(Clone, Debug, PartialEq, Eq)]
-    pub struct TryFromError {
-        /// The invalid non-witness version integer.
-        pub(super) invalid: u8,
-    }
-
-    impl TryFromError {
-        /// Returns the invalid non-witness version integer.
-        pub fn invalid_version(&self) -> u8 { self.invalid }
-    }
-
-    impl fmt::Display for TryFromError {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            write!(f, "invalid witness script version: {}", self.invalid)
-        }
-    }
-
-    #[cfg(feature = "std")]
-    impl std::error::Error for TryFromError {
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-            let Self { invalid: _ } = self;
-            None
-        }
     }
 }

--- a/primitives/api/all-features.txt
+++ b/primitives/api/all-features.txt
@@ -1464,8 +1464,13 @@ impl core::cmp::PartialEq for bitcoin_primitives::opcodes::Opcode
 pub fn bitcoin_primitives::opcodes::Opcode::eq(&self, other: &bitcoin_primitives::opcodes::Opcode) -> bool
 impl core::convert::From<bitcoin_primitives::opcodes::Opcode> for u8
 pub fn u8::from(op: bitcoin_primitives::opcodes::Opcode) -> Self
+impl core::convert::From<bitcoin_primitives::witness_version::WitnessVersion> for bitcoin_primitives::opcodes::Opcode
+pub fn bitcoin_primitives::opcodes::Opcode::from(version: bitcoin_primitives::witness_version::WitnessVersion) -> Self
 impl core::convert::From<u8> for bitcoin_primitives::opcodes::Opcode
 pub fn bitcoin_primitives::opcodes::Opcode::from(b: u8) -> Self
+impl core::convert::TryFrom<bitcoin_primitives::opcodes::Opcode> for bitcoin_primitives::witness_version::WitnessVersion
+pub type bitcoin_primitives::witness_version::WitnessVersion::Error = bitcoin_primitives::witness_version::error::TryFromError
+pub fn bitcoin_primitives::witness_version::WitnessVersion::try_from(opcode: bitcoin_primitives::opcodes::Opcode) -> core::result::Result<Self, Self::Error>
 impl core::fmt::Debug for bitcoin_primitives::opcodes::Opcode
 pub fn bitcoin_primitives::opcodes::Opcode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for bitcoin_primitives::opcodes::Opcode
@@ -5207,6 +5212,176 @@ impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness::WitnessEncod
 pub unsafe fn bitcoin_primitives::witness::WitnessEncoder<'e>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::witness::WitnessEncoder<'e>
 pub fn bitcoin_primitives::witness::WitnessEncoder<'e>::from(t: T) -> T
+pub mod bitcoin_primitives::witness_version
+pub mod bitcoin_primitives::witness_version::error
+#[non_exhaustive] pub enum bitcoin_primitives::witness_version::error::FromStrError
+pub bitcoin_primitives::witness_version::error::FromStrError::Invalid(bitcoin_primitives::witness_version::error::TryFromError)
+pub bitcoin_primitives::witness_version::error::FromStrError::Unparsable(bitcoin_units::parse_int::error::ParseIntError)
+impl core::clone::Clone for bitcoin_primitives::witness_version::error::FromStrError
+pub fn bitcoin_primitives::witness_version::error::FromStrError::clone(&self) -> bitcoin_primitives::witness_version::error::FromStrError
+impl core::cmp::Eq for bitcoin_primitives::witness_version::error::FromStrError
+impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::FromStrError
+pub fn bitcoin_primitives::witness_version::error::FromStrError::eq(&self, other: &bitcoin_primitives::witness_version::error::FromStrError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::witness_version::error::FromStrError
+pub fn bitcoin_primitives::witness_version::error::FromStrError::from(never: core::convert::Infallible) -> Self
+impl core::error::Error for bitcoin_primitives::witness_version::error::FromStrError
+pub fn bitcoin_primitives::witness_version::error::FromStrError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl core::fmt::Debug for bitcoin_primitives::witness_version::error::FromStrError
+pub fn bitcoin_primitives::witness_version::error::FromStrError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_primitives::witness_version::error::FromStrError
+impl core::marker::StructuralPartialEq for bitcoin_primitives::witness_version::error::FromStrError
+impl core::marker::Freeze for bitcoin_primitives::witness_version::error::FromStrError
+impl core::marker::Send for bitcoin_primitives::witness_version::error::FromStrError
+impl core::marker::Sync for bitcoin_primitives::witness_version::error::FromStrError
+impl core::marker::Unpin for bitcoin_primitives::witness_version::error::FromStrError
+impl core::marker::UnsafeUnpin for bitcoin_primitives::witness_version::error::FromStrError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness_version::error::FromStrError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness_version::error::FromStrError
+impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::From<T>
+pub fn bitcoin_primitives::witness_version::error::FromStrError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::Into<T>
+pub type bitcoin_primitives::witness_version::error::FromStrError::Error = core::convert::Infallible
+pub fn bitcoin_primitives::witness_version::error::FromStrError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::TryFrom<T>
+pub type bitcoin_primitives::witness_version::error::FromStrError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_primitives::witness_version::error::FromStrError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::FromStrError where T: core::clone::Clone
+pub type bitcoin_primitives::witness_version::error::FromStrError::Owned = T
+pub fn bitcoin_primitives::witness_version::error::FromStrError::clone_into(&self, target: &mut T)
+pub fn bitcoin_primitives::witness_version::error::FromStrError::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin_primitives::witness_version::error::FromStrError where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_primitives::witness_version::error::FromStrError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin_primitives::witness_version::error::FromStrError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_primitives::witness_version::error::FromStrError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::FromStrError where T: ?core::marker::Sized
+pub fn bitcoin_primitives::witness_version::error::FromStrError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::FromStrError where T: ?core::marker::Sized
+pub fn bitcoin_primitives::witness_version::error::FromStrError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::FromStrError where T: core::clone::Clone
+pub unsafe fn bitcoin_primitives::witness_version::error::FromStrError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::FromStrError
+pub fn bitcoin_primitives::witness_version::error::FromStrError::from(t: T) -> T
+pub struct bitcoin_primitives::witness_version::error::TryFromError
+impl bitcoin_primitives::witness_version::error::TryFromError
+pub fn bitcoin_primitives::witness_version::error::TryFromError::invalid_version(&self) -> u8
+impl core::clone::Clone for bitcoin_primitives::witness_version::error::TryFromError
+pub fn bitcoin_primitives::witness_version::error::TryFromError::clone(&self) -> bitcoin_primitives::witness_version::error::TryFromError
+impl core::cmp::Eq for bitcoin_primitives::witness_version::error::TryFromError
+impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::TryFromError
+pub fn bitcoin_primitives::witness_version::error::TryFromError::eq(&self, other: &bitcoin_primitives::witness_version::error::TryFromError) -> bool
+impl core::error::Error for bitcoin_primitives::witness_version::error::TryFromError
+pub fn bitcoin_primitives::witness_version::error::TryFromError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl core::fmt::Debug for bitcoin_primitives::witness_version::error::TryFromError
+pub fn bitcoin_primitives::witness_version::error::TryFromError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_primitives::witness_version::error::TryFromError
+impl core::marker::StructuralPartialEq for bitcoin_primitives::witness_version::error::TryFromError
+impl core::marker::Freeze for bitcoin_primitives::witness_version::error::TryFromError
+impl core::marker::Send for bitcoin_primitives::witness_version::error::TryFromError
+impl core::marker::Sync for bitcoin_primitives::witness_version::error::TryFromError
+impl core::marker::Unpin for bitcoin_primitives::witness_version::error::TryFromError
+impl core::marker::UnsafeUnpin for bitcoin_primitives::witness_version::error::TryFromError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness_version::error::TryFromError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness_version::error::TryFromError
+impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::From<T>
+pub fn bitcoin_primitives::witness_version::error::TryFromError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::Into<T>
+pub type bitcoin_primitives::witness_version::error::TryFromError::Error = core::convert::Infallible
+pub fn bitcoin_primitives::witness_version::error::TryFromError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::TryFrom<T>
+pub type bitcoin_primitives::witness_version::error::TryFromError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_primitives::witness_version::error::TryFromError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::TryFromError where T: core::clone::Clone
+pub type bitcoin_primitives::witness_version::error::TryFromError::Owned = T
+pub fn bitcoin_primitives::witness_version::error::TryFromError::clone_into(&self, target: &mut T)
+pub fn bitcoin_primitives::witness_version::error::TryFromError::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin_primitives::witness_version::error::TryFromError where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_primitives::witness_version::error::TryFromError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin_primitives::witness_version::error::TryFromError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_primitives::witness_version::error::TryFromError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::TryFromError where T: ?core::marker::Sized
+pub fn bitcoin_primitives::witness_version::error::TryFromError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::TryFromError where T: ?core::marker::Sized
+pub fn bitcoin_primitives::witness_version::error::TryFromError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::TryFromError where T: core::clone::Clone
+pub unsafe fn bitcoin_primitives::witness_version::error::TryFromError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::TryFromError
+pub fn bitcoin_primitives::witness_version::error::TryFromError::from(t: T) -> T
+#[non_exhaustive] pub enum bitcoin_primitives::witness_version::FromStrError
+pub bitcoin_primitives::witness_version::FromStrError::Invalid(bitcoin_primitives::witness_version::error::TryFromError)
+pub bitcoin_primitives::witness_version::FromStrError::Unparsable(bitcoin_units::parse_int::error::ParseIntError)
+#[repr(u8)] pub enum bitcoin_primitives::witness_version::WitnessVersion
+pub bitcoin_primitives::witness_version::WitnessVersion::V0 = 0
+pub bitcoin_primitives::witness_version::WitnessVersion::V1 = 1
+pub bitcoin_primitives::witness_version::WitnessVersion::V10 = 10
+pub bitcoin_primitives::witness_version::WitnessVersion::V11 = 11
+pub bitcoin_primitives::witness_version::WitnessVersion::V12 = 12
+pub bitcoin_primitives::witness_version::WitnessVersion::V13 = 13
+pub bitcoin_primitives::witness_version::WitnessVersion::V14 = 14
+pub bitcoin_primitives::witness_version::WitnessVersion::V15 = 15
+pub bitcoin_primitives::witness_version::WitnessVersion::V16 = 16
+pub bitcoin_primitives::witness_version::WitnessVersion::V2 = 2
+pub bitcoin_primitives::witness_version::WitnessVersion::V3 = 3
+pub bitcoin_primitives::witness_version::WitnessVersion::V4 = 4
+pub bitcoin_primitives::witness_version::WitnessVersion::V5 = 5
+pub bitcoin_primitives::witness_version::WitnessVersion::V6 = 6
+pub bitcoin_primitives::witness_version::WitnessVersion::V7 = 7
+pub bitcoin_primitives::witness_version::WitnessVersion::V8 = 8
+pub bitcoin_primitives::witness_version::WitnessVersion::V9 = 9
+impl bitcoin_primitives::witness_version::WitnessVersion
+pub fn bitcoin_primitives::witness_version::WitnessVersion::to_num(self) -> u8
+impl core::clone::Clone for bitcoin_primitives::witness_version::WitnessVersion
+pub fn bitcoin_primitives::witness_version::WitnessVersion::clone(&self) -> bitcoin_primitives::witness_version::WitnessVersion
+impl core::cmp::Eq for bitcoin_primitives::witness_version::WitnessVersion
+impl core::cmp::Ord for bitcoin_primitives::witness_version::WitnessVersion
+pub fn bitcoin_primitives::witness_version::WitnessVersion::cmp(&self, other: &bitcoin_primitives::witness_version::WitnessVersion) -> core::cmp::Ordering
+impl core::cmp::PartialEq for bitcoin_primitives::witness_version::WitnessVersion
+pub fn bitcoin_primitives::witness_version::WitnessVersion::eq(&self, other: &bitcoin_primitives::witness_version::WitnessVersion) -> bool
+impl core::cmp::PartialOrd for bitcoin_primitives::witness_version::WitnessVersion
+pub fn bitcoin_primitives::witness_version::WitnessVersion::partial_cmp(&self, other: &bitcoin_primitives::witness_version::WitnessVersion) -> core::option::Option<core::cmp::Ordering>
+impl core::convert::TryFrom<u8> for bitcoin_primitives::witness_version::WitnessVersion
+pub fn bitcoin_primitives::witness_version::WitnessVersion::try_from(no: u8) -> core::result::Result<Self, Self::Error>
+impl core::fmt::Debug for bitcoin_primitives::witness_version::WitnessVersion
+pub fn bitcoin_primitives::witness_version::WitnessVersion::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_primitives::witness_version::WitnessVersion
+impl core::hash::Hash for bitcoin_primitives::witness_version::WitnessVersion
+pub fn bitcoin_primitives::witness_version::WitnessVersion::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::Copy for bitcoin_primitives::witness_version::WitnessVersion
+impl core::marker::StructuralPartialEq for bitcoin_primitives::witness_version::WitnessVersion
+impl core::str::traits::FromStr for bitcoin_primitives::witness_version::WitnessVersion
+pub type bitcoin_primitives::witness_version::WitnessVersion::Err = bitcoin_primitives::witness_version::error::FromStrError
+pub fn bitcoin_primitives::witness_version::WitnessVersion::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+impl core::marker::Freeze for bitcoin_primitives::witness_version::WitnessVersion
+impl core::marker::Send for bitcoin_primitives::witness_version::WitnessVersion
+impl core::marker::Sync for bitcoin_primitives::witness_version::WitnessVersion
+impl core::marker::Unpin for bitcoin_primitives::witness_version::WitnessVersion
+impl core::marker::UnsafeUnpin for bitcoin_primitives::witness_version::WitnessVersion
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness_version::WitnessVersion
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness_version::WitnessVersion
+impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::WitnessVersion where U: core::convert::From<T>
+pub fn bitcoin_primitives::witness_version::WitnessVersion::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::WitnessVersion where U: core::convert::Into<T>
+pub type bitcoin_primitives::witness_version::WitnessVersion::Error = core::convert::Infallible
+pub fn bitcoin_primitives::witness_version::WitnessVersion::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::WitnessVersion where U: core::convert::TryFrom<T>
+pub type bitcoin_primitives::witness_version::WitnessVersion::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_primitives::witness_version::WitnessVersion::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::WitnessVersion where T: core::clone::Clone
+pub type bitcoin_primitives::witness_version::WitnessVersion::Owned = T
+pub fn bitcoin_primitives::witness_version::WitnessVersion::clone_into(&self, target: &mut T)
+pub fn bitcoin_primitives::witness_version::WitnessVersion::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin_primitives::witness_version::WitnessVersion where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_primitives::witness_version::WitnessVersion::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin_primitives::witness_version::WitnessVersion where T: 'static + ?core::marker::Sized
+pub fn bitcoin_primitives::witness_version::WitnessVersion::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::WitnessVersion where T: ?core::marker::Sized
+pub fn bitcoin_primitives::witness_version::WitnessVersion::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::WitnessVersion where T: ?core::marker::Sized
+pub fn bitcoin_primitives::witness_version::WitnessVersion::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::WitnessVersion where T: core::clone::Clone
+pub unsafe fn bitcoin_primitives::witness_version::WitnessVersion::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::WitnessVersion
+pub fn bitcoin_primitives::witness_version::WitnessVersion::from(t: T) -> T
+pub struct bitcoin_primitives::witness_version::TryFromError
 pub enum bitcoin_primitives::BlockChecked
 pub enum bitcoin_primitives::BlockUnchecked
 pub struct bitcoin_primitives::Block<V> where V: bitcoin_primitives::block::Validation

--- a/primitives/api/alloc-only.txt
+++ b/primitives/api/alloc-only.txt
@@ -1362,8 +1362,13 @@ impl core::cmp::PartialEq for bitcoin_primitives::opcodes::Opcode
 pub fn bitcoin_primitives::opcodes::Opcode::eq(&self, other: &bitcoin_primitives::opcodes::Opcode) -> bool
 impl core::convert::From<bitcoin_primitives::opcodes::Opcode> for u8
 pub fn u8::from(op: bitcoin_primitives::opcodes::Opcode) -> Self
+impl core::convert::From<bitcoin_primitives::witness_version::WitnessVersion> for bitcoin_primitives::opcodes::Opcode
+pub fn bitcoin_primitives::opcodes::Opcode::from(version: bitcoin_primitives::witness_version::WitnessVersion) -> Self
 impl core::convert::From<u8> for bitcoin_primitives::opcodes::Opcode
 pub fn bitcoin_primitives::opcodes::Opcode::from(b: u8) -> Self
+impl core::convert::TryFrom<bitcoin_primitives::opcodes::Opcode> for bitcoin_primitives::witness_version::WitnessVersion
+pub type bitcoin_primitives::witness_version::WitnessVersion::Error = bitcoin_primitives::witness_version::error::TryFromError
+pub fn bitcoin_primitives::witness_version::WitnessVersion::try_from(opcode: bitcoin_primitives::opcodes::Opcode) -> core::result::Result<Self, Self::Error>
 impl core::fmt::Debug for bitcoin_primitives::opcodes::Opcode
 pub fn bitcoin_primitives::opcodes::Opcode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for bitcoin_primitives::opcodes::Opcode
@@ -4876,6 +4881,172 @@ impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness::WitnessEncod
 pub unsafe fn bitcoin_primitives::witness::WitnessEncoder<'e>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::witness::WitnessEncoder<'e>
 pub fn bitcoin_primitives::witness::WitnessEncoder<'e>::from(t: T) -> T
+pub mod bitcoin_primitives::witness_version
+pub mod bitcoin_primitives::witness_version::error
+#[non_exhaustive] pub enum bitcoin_primitives::witness_version::error::FromStrError
+pub bitcoin_primitives::witness_version::error::FromStrError::Invalid(bitcoin_primitives::witness_version::error::TryFromError)
+pub bitcoin_primitives::witness_version::error::FromStrError::Unparsable(bitcoin_units::parse_int::error::ParseIntError)
+impl core::clone::Clone for bitcoin_primitives::witness_version::error::FromStrError
+pub fn bitcoin_primitives::witness_version::error::FromStrError::clone(&self) -> bitcoin_primitives::witness_version::error::FromStrError
+impl core::cmp::Eq for bitcoin_primitives::witness_version::error::FromStrError
+impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::FromStrError
+pub fn bitcoin_primitives::witness_version::error::FromStrError::eq(&self, other: &bitcoin_primitives::witness_version::error::FromStrError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::witness_version::error::FromStrError
+pub fn bitcoin_primitives::witness_version::error::FromStrError::from(never: core::convert::Infallible) -> Self
+impl core::fmt::Debug for bitcoin_primitives::witness_version::error::FromStrError
+pub fn bitcoin_primitives::witness_version::error::FromStrError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_primitives::witness_version::error::FromStrError
+impl core::marker::StructuralPartialEq for bitcoin_primitives::witness_version::error::FromStrError
+impl core::marker::Freeze for bitcoin_primitives::witness_version::error::FromStrError
+impl core::marker::Send for bitcoin_primitives::witness_version::error::FromStrError
+impl core::marker::Sync for bitcoin_primitives::witness_version::error::FromStrError
+impl core::marker::Unpin for bitcoin_primitives::witness_version::error::FromStrError
+impl core::marker::UnsafeUnpin for bitcoin_primitives::witness_version::error::FromStrError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness_version::error::FromStrError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness_version::error::FromStrError
+impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::From<T>
+pub fn bitcoin_primitives::witness_version::error::FromStrError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::Into<T>
+pub type bitcoin_primitives::witness_version::error::FromStrError::Error = core::convert::Infallible
+pub fn bitcoin_primitives::witness_version::error::FromStrError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::TryFrom<T>
+pub type bitcoin_primitives::witness_version::error::FromStrError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_primitives::witness_version::error::FromStrError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::FromStrError where T: core::clone::Clone
+pub type bitcoin_primitives::witness_version::error::FromStrError::Owned = T
+pub fn bitcoin_primitives::witness_version::error::FromStrError::clone_into(&self, target: &mut T)
+pub fn bitcoin_primitives::witness_version::error::FromStrError::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin_primitives::witness_version::error::FromStrError where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_primitives::witness_version::error::FromStrError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin_primitives::witness_version::error::FromStrError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_primitives::witness_version::error::FromStrError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::FromStrError where T: ?core::marker::Sized
+pub fn bitcoin_primitives::witness_version::error::FromStrError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::FromStrError where T: ?core::marker::Sized
+pub fn bitcoin_primitives::witness_version::error::FromStrError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::FromStrError where T: core::clone::Clone
+pub unsafe fn bitcoin_primitives::witness_version::error::FromStrError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::FromStrError
+pub fn bitcoin_primitives::witness_version::error::FromStrError::from(t: T) -> T
+pub struct bitcoin_primitives::witness_version::error::TryFromError
+impl bitcoin_primitives::witness_version::error::TryFromError
+pub fn bitcoin_primitives::witness_version::error::TryFromError::invalid_version(&self) -> u8
+impl core::clone::Clone for bitcoin_primitives::witness_version::error::TryFromError
+pub fn bitcoin_primitives::witness_version::error::TryFromError::clone(&self) -> bitcoin_primitives::witness_version::error::TryFromError
+impl core::cmp::Eq for bitcoin_primitives::witness_version::error::TryFromError
+impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::TryFromError
+pub fn bitcoin_primitives::witness_version::error::TryFromError::eq(&self, other: &bitcoin_primitives::witness_version::error::TryFromError) -> bool
+impl core::fmt::Debug for bitcoin_primitives::witness_version::error::TryFromError
+pub fn bitcoin_primitives::witness_version::error::TryFromError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_primitives::witness_version::error::TryFromError
+impl core::marker::StructuralPartialEq for bitcoin_primitives::witness_version::error::TryFromError
+impl core::marker::Freeze for bitcoin_primitives::witness_version::error::TryFromError
+impl core::marker::Send for bitcoin_primitives::witness_version::error::TryFromError
+impl core::marker::Sync for bitcoin_primitives::witness_version::error::TryFromError
+impl core::marker::Unpin for bitcoin_primitives::witness_version::error::TryFromError
+impl core::marker::UnsafeUnpin for bitcoin_primitives::witness_version::error::TryFromError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness_version::error::TryFromError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness_version::error::TryFromError
+impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::From<T>
+pub fn bitcoin_primitives::witness_version::error::TryFromError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::Into<T>
+pub type bitcoin_primitives::witness_version::error::TryFromError::Error = core::convert::Infallible
+pub fn bitcoin_primitives::witness_version::error::TryFromError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::TryFrom<T>
+pub type bitcoin_primitives::witness_version::error::TryFromError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_primitives::witness_version::error::TryFromError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::TryFromError where T: core::clone::Clone
+pub type bitcoin_primitives::witness_version::error::TryFromError::Owned = T
+pub fn bitcoin_primitives::witness_version::error::TryFromError::clone_into(&self, target: &mut T)
+pub fn bitcoin_primitives::witness_version::error::TryFromError::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin_primitives::witness_version::error::TryFromError where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_primitives::witness_version::error::TryFromError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin_primitives::witness_version::error::TryFromError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_primitives::witness_version::error::TryFromError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::TryFromError where T: ?core::marker::Sized
+pub fn bitcoin_primitives::witness_version::error::TryFromError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::TryFromError where T: ?core::marker::Sized
+pub fn bitcoin_primitives::witness_version::error::TryFromError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::TryFromError where T: core::clone::Clone
+pub unsafe fn bitcoin_primitives::witness_version::error::TryFromError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::TryFromError
+pub fn bitcoin_primitives::witness_version::error::TryFromError::from(t: T) -> T
+#[non_exhaustive] pub enum bitcoin_primitives::witness_version::FromStrError
+pub bitcoin_primitives::witness_version::FromStrError::Invalid(bitcoin_primitives::witness_version::error::TryFromError)
+pub bitcoin_primitives::witness_version::FromStrError::Unparsable(bitcoin_units::parse_int::error::ParseIntError)
+#[repr(u8)] pub enum bitcoin_primitives::witness_version::WitnessVersion
+pub bitcoin_primitives::witness_version::WitnessVersion::V0 = 0
+pub bitcoin_primitives::witness_version::WitnessVersion::V1 = 1
+pub bitcoin_primitives::witness_version::WitnessVersion::V10 = 10
+pub bitcoin_primitives::witness_version::WitnessVersion::V11 = 11
+pub bitcoin_primitives::witness_version::WitnessVersion::V12 = 12
+pub bitcoin_primitives::witness_version::WitnessVersion::V13 = 13
+pub bitcoin_primitives::witness_version::WitnessVersion::V14 = 14
+pub bitcoin_primitives::witness_version::WitnessVersion::V15 = 15
+pub bitcoin_primitives::witness_version::WitnessVersion::V16 = 16
+pub bitcoin_primitives::witness_version::WitnessVersion::V2 = 2
+pub bitcoin_primitives::witness_version::WitnessVersion::V3 = 3
+pub bitcoin_primitives::witness_version::WitnessVersion::V4 = 4
+pub bitcoin_primitives::witness_version::WitnessVersion::V5 = 5
+pub bitcoin_primitives::witness_version::WitnessVersion::V6 = 6
+pub bitcoin_primitives::witness_version::WitnessVersion::V7 = 7
+pub bitcoin_primitives::witness_version::WitnessVersion::V8 = 8
+pub bitcoin_primitives::witness_version::WitnessVersion::V9 = 9
+impl bitcoin_primitives::witness_version::WitnessVersion
+pub fn bitcoin_primitives::witness_version::WitnessVersion::to_num(self) -> u8
+impl core::clone::Clone for bitcoin_primitives::witness_version::WitnessVersion
+pub fn bitcoin_primitives::witness_version::WitnessVersion::clone(&self) -> bitcoin_primitives::witness_version::WitnessVersion
+impl core::cmp::Eq for bitcoin_primitives::witness_version::WitnessVersion
+impl core::cmp::Ord for bitcoin_primitives::witness_version::WitnessVersion
+pub fn bitcoin_primitives::witness_version::WitnessVersion::cmp(&self, other: &bitcoin_primitives::witness_version::WitnessVersion) -> core::cmp::Ordering
+impl core::cmp::PartialEq for bitcoin_primitives::witness_version::WitnessVersion
+pub fn bitcoin_primitives::witness_version::WitnessVersion::eq(&self, other: &bitcoin_primitives::witness_version::WitnessVersion) -> bool
+impl core::cmp::PartialOrd for bitcoin_primitives::witness_version::WitnessVersion
+pub fn bitcoin_primitives::witness_version::WitnessVersion::partial_cmp(&self, other: &bitcoin_primitives::witness_version::WitnessVersion) -> core::option::Option<core::cmp::Ordering>
+impl core::convert::TryFrom<u8> for bitcoin_primitives::witness_version::WitnessVersion
+pub fn bitcoin_primitives::witness_version::WitnessVersion::try_from(no: u8) -> core::result::Result<Self, Self::Error>
+impl core::fmt::Debug for bitcoin_primitives::witness_version::WitnessVersion
+pub fn bitcoin_primitives::witness_version::WitnessVersion::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_primitives::witness_version::WitnessVersion
+impl core::hash::Hash for bitcoin_primitives::witness_version::WitnessVersion
+pub fn bitcoin_primitives::witness_version::WitnessVersion::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::Copy for bitcoin_primitives::witness_version::WitnessVersion
+impl core::marker::StructuralPartialEq for bitcoin_primitives::witness_version::WitnessVersion
+impl core::str::traits::FromStr for bitcoin_primitives::witness_version::WitnessVersion
+pub type bitcoin_primitives::witness_version::WitnessVersion::Err = bitcoin_primitives::witness_version::error::FromStrError
+pub fn bitcoin_primitives::witness_version::WitnessVersion::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+impl core::marker::Freeze for bitcoin_primitives::witness_version::WitnessVersion
+impl core::marker::Send for bitcoin_primitives::witness_version::WitnessVersion
+impl core::marker::Sync for bitcoin_primitives::witness_version::WitnessVersion
+impl core::marker::Unpin for bitcoin_primitives::witness_version::WitnessVersion
+impl core::marker::UnsafeUnpin for bitcoin_primitives::witness_version::WitnessVersion
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness_version::WitnessVersion
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness_version::WitnessVersion
+impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::WitnessVersion where U: core::convert::From<T>
+pub fn bitcoin_primitives::witness_version::WitnessVersion::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::WitnessVersion where U: core::convert::Into<T>
+pub type bitcoin_primitives::witness_version::WitnessVersion::Error = core::convert::Infallible
+pub fn bitcoin_primitives::witness_version::WitnessVersion::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::WitnessVersion where U: core::convert::TryFrom<T>
+pub type bitcoin_primitives::witness_version::WitnessVersion::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_primitives::witness_version::WitnessVersion::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::WitnessVersion where T: core::clone::Clone
+pub type bitcoin_primitives::witness_version::WitnessVersion::Owned = T
+pub fn bitcoin_primitives::witness_version::WitnessVersion::clone_into(&self, target: &mut T)
+pub fn bitcoin_primitives::witness_version::WitnessVersion::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin_primitives::witness_version::WitnessVersion where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_primitives::witness_version::WitnessVersion::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin_primitives::witness_version::WitnessVersion where T: 'static + ?core::marker::Sized
+pub fn bitcoin_primitives::witness_version::WitnessVersion::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::WitnessVersion where T: ?core::marker::Sized
+pub fn bitcoin_primitives::witness_version::WitnessVersion::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::WitnessVersion where T: ?core::marker::Sized
+pub fn bitcoin_primitives::witness_version::WitnessVersion::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::WitnessVersion where T: core::clone::Clone
+pub unsafe fn bitcoin_primitives::witness_version::WitnessVersion::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::WitnessVersion
+pub fn bitcoin_primitives::witness_version::WitnessVersion::from(t: T) -> T
+pub struct bitcoin_primitives::witness_version::TryFromError
 pub enum bitcoin_primitives::BlockChecked
 pub enum bitcoin_primitives::BlockUnchecked
 pub struct bitcoin_primitives::Block<V> where V: bitcoin_primitives::block::Validation

--- a/primitives/api/no-features.txt
+++ b/primitives/api/no-features.txt
@@ -945,8 +945,13 @@ impl core::cmp::PartialEq for bitcoin_primitives::opcodes::Opcode
 pub fn bitcoin_primitives::opcodes::Opcode::eq(&self, other: &bitcoin_primitives::opcodes::Opcode) -> bool
 impl core::convert::From<bitcoin_primitives::opcodes::Opcode> for u8
 pub fn u8::from(op: bitcoin_primitives::opcodes::Opcode) -> Self
+impl core::convert::From<bitcoin_primitives::witness_version::WitnessVersion> for bitcoin_primitives::opcodes::Opcode
+pub fn bitcoin_primitives::opcodes::Opcode::from(version: bitcoin_primitives::witness_version::WitnessVersion) -> Self
 impl core::convert::From<u8> for bitcoin_primitives::opcodes::Opcode
 pub fn bitcoin_primitives::opcodes::Opcode::from(b: u8) -> Self
+impl core::convert::TryFrom<bitcoin_primitives::opcodes::Opcode> for bitcoin_primitives::witness_version::WitnessVersion
+pub type bitcoin_primitives::witness_version::WitnessVersion::Error = bitcoin_primitives::witness_version::error::TryFromError
+pub fn bitcoin_primitives::witness_version::WitnessVersion::try_from(opcode: bitcoin_primitives::opcodes::Opcode) -> core::result::Result<Self, Self::Error>
 impl core::fmt::Debug for bitcoin_primitives::opcodes::Opcode
 pub fn bitcoin_primitives::opcodes::Opcode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for bitcoin_primitives::opcodes::Opcode
@@ -1478,6 +1483,154 @@ impl<T> core::clone::CloneToUninit for bitcoin_primitives::Wtxid where T: core::
 pub unsafe fn bitcoin_primitives::Wtxid::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::Wtxid
 pub fn bitcoin_primitives::Wtxid::from(t: T) -> T
+pub mod bitcoin_primitives::witness_version
+pub mod bitcoin_primitives::witness_version::error
+#[non_exhaustive] pub enum bitcoin_primitives::witness_version::error::FromStrError
+pub bitcoin_primitives::witness_version::error::FromStrError::Invalid(bitcoin_primitives::witness_version::error::TryFromError)
+pub bitcoin_primitives::witness_version::error::FromStrError::Unparsable(bitcoin_units::parse_int::error::ParseIntError)
+impl core::clone::Clone for bitcoin_primitives::witness_version::error::FromStrError
+pub fn bitcoin_primitives::witness_version::error::FromStrError::clone(&self) -> bitcoin_primitives::witness_version::error::FromStrError
+impl core::cmp::Eq for bitcoin_primitives::witness_version::error::FromStrError
+impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::FromStrError
+pub fn bitcoin_primitives::witness_version::error::FromStrError::eq(&self, other: &bitcoin_primitives::witness_version::error::FromStrError) -> bool
+impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::witness_version::error::FromStrError
+pub fn bitcoin_primitives::witness_version::error::FromStrError::from(never: core::convert::Infallible) -> Self
+impl core::fmt::Debug for bitcoin_primitives::witness_version::error::FromStrError
+pub fn bitcoin_primitives::witness_version::error::FromStrError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_primitives::witness_version::error::FromStrError
+impl core::marker::StructuralPartialEq for bitcoin_primitives::witness_version::error::FromStrError
+impl core::marker::Freeze for bitcoin_primitives::witness_version::error::FromStrError
+impl core::marker::Send for bitcoin_primitives::witness_version::error::FromStrError
+impl core::marker::Sync for bitcoin_primitives::witness_version::error::FromStrError
+impl core::marker::Unpin for bitcoin_primitives::witness_version::error::FromStrError
+impl core::marker::UnsafeUnpin for bitcoin_primitives::witness_version::error::FromStrError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness_version::error::FromStrError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness_version::error::FromStrError
+impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::From<T>
+pub fn bitcoin_primitives::witness_version::error::FromStrError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::Into<T>
+pub type bitcoin_primitives::witness_version::error::FromStrError::Error = core::convert::Infallible
+pub fn bitcoin_primitives::witness_version::error::FromStrError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::TryFrom<T>
+pub type bitcoin_primitives::witness_version::error::FromStrError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_primitives::witness_version::error::FromStrError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for bitcoin_primitives::witness_version::error::FromStrError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_primitives::witness_version::error::FromStrError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::FromStrError where T: ?core::marker::Sized
+pub fn bitcoin_primitives::witness_version::error::FromStrError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::FromStrError where T: ?core::marker::Sized
+pub fn bitcoin_primitives::witness_version::error::FromStrError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::FromStrError where T: core::clone::Clone
+pub unsafe fn bitcoin_primitives::witness_version::error::FromStrError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::FromStrError
+pub fn bitcoin_primitives::witness_version::error::FromStrError::from(t: T) -> T
+pub struct bitcoin_primitives::witness_version::error::TryFromError
+impl bitcoin_primitives::witness_version::error::TryFromError
+pub fn bitcoin_primitives::witness_version::error::TryFromError::invalid_version(&self) -> u8
+impl core::clone::Clone for bitcoin_primitives::witness_version::error::TryFromError
+pub fn bitcoin_primitives::witness_version::error::TryFromError::clone(&self) -> bitcoin_primitives::witness_version::error::TryFromError
+impl core::cmp::Eq for bitcoin_primitives::witness_version::error::TryFromError
+impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::TryFromError
+pub fn bitcoin_primitives::witness_version::error::TryFromError::eq(&self, other: &bitcoin_primitives::witness_version::error::TryFromError) -> bool
+impl core::fmt::Debug for bitcoin_primitives::witness_version::error::TryFromError
+pub fn bitcoin_primitives::witness_version::error::TryFromError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_primitives::witness_version::error::TryFromError
+impl core::marker::StructuralPartialEq for bitcoin_primitives::witness_version::error::TryFromError
+impl core::marker::Freeze for bitcoin_primitives::witness_version::error::TryFromError
+impl core::marker::Send for bitcoin_primitives::witness_version::error::TryFromError
+impl core::marker::Sync for bitcoin_primitives::witness_version::error::TryFromError
+impl core::marker::Unpin for bitcoin_primitives::witness_version::error::TryFromError
+impl core::marker::UnsafeUnpin for bitcoin_primitives::witness_version::error::TryFromError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness_version::error::TryFromError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness_version::error::TryFromError
+impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::From<T>
+pub fn bitcoin_primitives::witness_version::error::TryFromError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::Into<T>
+pub type bitcoin_primitives::witness_version::error::TryFromError::Error = core::convert::Infallible
+pub fn bitcoin_primitives::witness_version::error::TryFromError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::TryFrom<T>
+pub type bitcoin_primitives::witness_version::error::TryFromError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_primitives::witness_version::error::TryFromError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for bitcoin_primitives::witness_version::error::TryFromError where T: 'static + ?core::marker::Sized
+pub fn bitcoin_primitives::witness_version::error::TryFromError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::TryFromError where T: ?core::marker::Sized
+pub fn bitcoin_primitives::witness_version::error::TryFromError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::TryFromError where T: ?core::marker::Sized
+pub fn bitcoin_primitives::witness_version::error::TryFromError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::TryFromError where T: core::clone::Clone
+pub unsafe fn bitcoin_primitives::witness_version::error::TryFromError::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::TryFromError
+pub fn bitcoin_primitives::witness_version::error::TryFromError::from(t: T) -> T
+#[non_exhaustive] pub enum bitcoin_primitives::witness_version::FromStrError
+pub bitcoin_primitives::witness_version::FromStrError::Invalid(bitcoin_primitives::witness_version::error::TryFromError)
+pub bitcoin_primitives::witness_version::FromStrError::Unparsable(bitcoin_units::parse_int::error::ParseIntError)
+#[repr(u8)] pub enum bitcoin_primitives::witness_version::WitnessVersion
+pub bitcoin_primitives::witness_version::WitnessVersion::V0 = 0
+pub bitcoin_primitives::witness_version::WitnessVersion::V1 = 1
+pub bitcoin_primitives::witness_version::WitnessVersion::V10 = 10
+pub bitcoin_primitives::witness_version::WitnessVersion::V11 = 11
+pub bitcoin_primitives::witness_version::WitnessVersion::V12 = 12
+pub bitcoin_primitives::witness_version::WitnessVersion::V13 = 13
+pub bitcoin_primitives::witness_version::WitnessVersion::V14 = 14
+pub bitcoin_primitives::witness_version::WitnessVersion::V15 = 15
+pub bitcoin_primitives::witness_version::WitnessVersion::V16 = 16
+pub bitcoin_primitives::witness_version::WitnessVersion::V2 = 2
+pub bitcoin_primitives::witness_version::WitnessVersion::V3 = 3
+pub bitcoin_primitives::witness_version::WitnessVersion::V4 = 4
+pub bitcoin_primitives::witness_version::WitnessVersion::V5 = 5
+pub bitcoin_primitives::witness_version::WitnessVersion::V6 = 6
+pub bitcoin_primitives::witness_version::WitnessVersion::V7 = 7
+pub bitcoin_primitives::witness_version::WitnessVersion::V8 = 8
+pub bitcoin_primitives::witness_version::WitnessVersion::V9 = 9
+impl bitcoin_primitives::witness_version::WitnessVersion
+pub fn bitcoin_primitives::witness_version::WitnessVersion::to_num(self) -> u8
+impl core::clone::Clone for bitcoin_primitives::witness_version::WitnessVersion
+pub fn bitcoin_primitives::witness_version::WitnessVersion::clone(&self) -> bitcoin_primitives::witness_version::WitnessVersion
+impl core::cmp::Eq for bitcoin_primitives::witness_version::WitnessVersion
+impl core::cmp::Ord for bitcoin_primitives::witness_version::WitnessVersion
+pub fn bitcoin_primitives::witness_version::WitnessVersion::cmp(&self, other: &bitcoin_primitives::witness_version::WitnessVersion) -> core::cmp::Ordering
+impl core::cmp::PartialEq for bitcoin_primitives::witness_version::WitnessVersion
+pub fn bitcoin_primitives::witness_version::WitnessVersion::eq(&self, other: &bitcoin_primitives::witness_version::WitnessVersion) -> bool
+impl core::cmp::PartialOrd for bitcoin_primitives::witness_version::WitnessVersion
+pub fn bitcoin_primitives::witness_version::WitnessVersion::partial_cmp(&self, other: &bitcoin_primitives::witness_version::WitnessVersion) -> core::option::Option<core::cmp::Ordering>
+impl core::convert::TryFrom<u8> for bitcoin_primitives::witness_version::WitnessVersion
+pub fn bitcoin_primitives::witness_version::WitnessVersion::try_from(no: u8) -> core::result::Result<Self, Self::Error>
+impl core::fmt::Debug for bitcoin_primitives::witness_version::WitnessVersion
+pub fn bitcoin_primitives::witness_version::WitnessVersion::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitcoin_primitives::witness_version::WitnessVersion
+impl core::hash::Hash for bitcoin_primitives::witness_version::WitnessVersion
+pub fn bitcoin_primitives::witness_version::WitnessVersion::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::Copy for bitcoin_primitives::witness_version::WitnessVersion
+impl core::marker::StructuralPartialEq for bitcoin_primitives::witness_version::WitnessVersion
+impl core::str::traits::FromStr for bitcoin_primitives::witness_version::WitnessVersion
+pub type bitcoin_primitives::witness_version::WitnessVersion::Err = bitcoin_primitives::witness_version::error::FromStrError
+pub fn bitcoin_primitives::witness_version::WitnessVersion::from_str(s: &str) -> core::result::Result<Self, Self::Err>
+impl core::marker::Freeze for bitcoin_primitives::witness_version::WitnessVersion
+impl core::marker::Send for bitcoin_primitives::witness_version::WitnessVersion
+impl core::marker::Sync for bitcoin_primitives::witness_version::WitnessVersion
+impl core::marker::Unpin for bitcoin_primitives::witness_version::WitnessVersion
+impl core::marker::UnsafeUnpin for bitcoin_primitives::witness_version::WitnessVersion
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness_version::WitnessVersion
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness_version::WitnessVersion
+impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::WitnessVersion where U: core::convert::From<T>
+pub fn bitcoin_primitives::witness_version::WitnessVersion::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::WitnessVersion where U: core::convert::Into<T>
+pub type bitcoin_primitives::witness_version::WitnessVersion::Error = core::convert::Infallible
+pub fn bitcoin_primitives::witness_version::WitnessVersion::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::WitnessVersion where U: core::convert::TryFrom<T>
+pub type bitcoin_primitives::witness_version::WitnessVersion::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_primitives::witness_version::WitnessVersion::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for bitcoin_primitives::witness_version::WitnessVersion where T: 'static + ?core::marker::Sized
+pub fn bitcoin_primitives::witness_version::WitnessVersion::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::WitnessVersion where T: ?core::marker::Sized
+pub fn bitcoin_primitives::witness_version::WitnessVersion::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::WitnessVersion where T: ?core::marker::Sized
+pub fn bitcoin_primitives::witness_version::WitnessVersion::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::WitnessVersion where T: core::clone::Clone
+pub unsafe fn bitcoin_primitives::witness_version::WitnessVersion::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::WitnessVersion
+pub fn bitcoin_primitives::witness_version::WitnessVersion::from(t: T) -> T
+pub struct bitcoin_primitives::witness_version::TryFromError
 pub struct bitcoin_primitives::BlockHash(_)
 pub struct bitcoin_primitives::BlockHeader
 pub bitcoin_primitives::BlockHeader::bits: bitcoin_units::pow::CompactTarget

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -59,6 +59,7 @@ pub mod serde_as_consensus;
 pub mod transaction;
 #[cfg(feature = "alloc")]
 pub mod witness;
+pub mod witness_version;
 
 #[cfg(feature = "hex")]
 mod hex_codec;

--- a/primitives/src/opcodes.rs
+++ b/primitives/src/opcodes.rs
@@ -160,7 +160,7 @@ pub(crate) const OP_PUSHDATA2: u8 = 0x4d;
 
 /// Read the following 4 bytes as a little-endian length, and read the following
 /// bytes as a push of that length.
-#[cfg(feature = "alloc")]
+#[cfg(any(feature = "alloc", test))]
 pub(crate) const OP_PUSHDATA4: u8 = 0x4e;
 
 /// Push an empty array onto the stack.

--- a/primitives/src/opcodes.rs
+++ b/primitives/src/opcodes.rs
@@ -163,6 +163,9 @@ pub(crate) const OP_PUSHDATA2: u8 = 0x4d;
 #[cfg(feature = "alloc")]
 pub(crate) const OP_PUSHDATA4: u8 = 0x4e;
 
+/// Push an empty array onto the stack.
+pub(crate) const OP_PUSHBYTES_0: Opcode = Opcode::from_u8(0x00);
+
 /// Format a byte as a script opcode.
 #[cfg(feature = "alloc")]
 pub(crate) fn fmt_opcode(op: u8, f: &mut fmt::Formatter) -> fmt::Result {

--- a/primitives/src/witness_version.rs
+++ b/primitives/src/witness_version.rs
@@ -218,3 +218,62 @@ pub mod error {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "alloc")]
+    use alloc::string::ToString;
+
+    use super::*;
+    use crate::opcodes::OP_PUSHDATA4;
+
+    #[test]
+    fn witness_version_to_num() {
+        assert_eq!(WitnessVersion::V0.to_num(), 0);
+        assert_eq!(WitnessVersion::V1.to_num(), 1);
+        assert_eq!(WitnessVersion::V2.to_num(), 2);
+        assert_eq!(WitnessVersion::V16.to_num(), 16);
+    }
+
+    #[test]
+    #[cfg(feature = "alloc")]
+    fn witness_version_display() {
+        assert_eq!(WitnessVersion::V0.to_string(), "0");
+        assert_eq!(WitnessVersion::V1.to_string(), "1");
+        assert_eq!(WitnessVersion::V10.to_string(), "10");
+        assert_eq!(WitnessVersion::V16.to_string(), "16");
+    }
+
+    #[test]
+    fn witness_version_try_from_opcode() {
+        assert_eq!(WitnessVersion::try_from(OP_PUSHBYTES_0).unwrap(), WitnessVersion::V0);
+        assert_eq!(WitnessVersion::try_from(OP_1).unwrap(), WitnessVersion::V1);
+        assert_eq!(WitnessVersion::try_from(OP_16).unwrap(), WitnessVersion::V16);
+
+        // Only Opcodes in range OP_1 to OP_16, or 0, are valid.
+        let op = Opcode::from(OP_1.to_u8() - 1);
+        assert_eq!(WitnessVersion::try_from(op).unwrap_err().invalid_version(), OP_1.to_u8() - 1);
+        let op = Opcode::from(0xff);
+        assert_eq!(WitnessVersion::try_from(op).unwrap_err().invalid_version(), 0xff);
+        assert_eq!(
+            WitnessVersion::try_from(Opcode::from(OP_PUSHDATA4)).unwrap_err().invalid_version(),
+            OP_PUSHDATA4
+        );
+    }
+
+    #[test]
+    fn witness_version_into_opcode() {
+        assert_eq!(Opcode::from(WitnessVersion::V0), OP_PUSHBYTES_0);
+        assert_eq!(Opcode::from(WitnessVersion::V1), OP_1);
+        assert_eq!(Opcode::from(WitnessVersion::V16), OP_16);
+    }
+
+    #[test]
+    fn witness_version_opcode_round_trip() {
+        for version in 0u8..=16 {
+            let wv = WitnessVersion::try_from(version).unwrap();
+            let opcode = Opcode::from(wv);
+            assert_eq!(WitnessVersion::try_from(opcode).unwrap(), wv);
+        }
+    }
+}

--- a/primitives/src/witness_version.rs
+++ b/primitives/src/witness_version.rs
@@ -165,7 +165,7 @@ pub mod error {
 
     impl fmt::Display for FromStrError {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            match self {
+            match *self {
                 Self::Unparsable(ref e) => write_err!(f, "integer parse error"; e),
                 Self::Invalid(ref e) => write_err!(f, "invalid version number"; e),
             }
@@ -175,7 +175,7 @@ pub mod error {
     #[cfg(feature = "std")]
     impl std::error::Error for FromStrError {
         fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-            match self {
+            match *self {
                 Self::Unparsable(ref e) => Some(e),
                 Self::Invalid(ref e) => Some(e),
             }

--- a/primitives/src/witness_version.rs
+++ b/primitives/src/witness_version.rs
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! The segregated witness version byte as defined by [BIP-0141].
+//!
+//! > A scriptPubKey (or redeemScript as defined in BIP-0016/P2SH) that consists of a 1-byte push
+//! > opcode (for 0 to 16) followed by a data push between 2 and 40 bytes gets a new special
+//! > meaning. The value of the first push is called the "version byte". The following byte
+//! > vector pushed is called the "witness program".
+//!
+//! [BIP-0141]: <https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki>
+
+use core::fmt;
+use core::str::FromStr;
+
+use units::parse_int;
+
+use crate::opcodes::all::{OP_1, OP_16};
+use crate::opcodes::{Opcode, OP_PUSHBYTES_0};
+
+#[rustfmt::skip]            // Keep public re-exports separate.
+#[doc(no_inline)]
+pub use self::error::{FromStrError, TryFromError};
+
+/// Version of the segregated witness program.
+///
+/// Helps limit possible versions of the witness according to the specification. If a plain `u8`
+/// type was used instead it would mean that the version may be > 16, which would be incorrect.
+///
+/// First byte of `scriptPubkey` in transaction output for transactions starting with opcodes
+/// ranging from 0 to 16 (inclusive).
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[repr(u8)]
+pub enum WitnessVersion {
+    /// Initial version of witness program. Used for P2WPKH and P2WSH outputs
+    V0 = 0,
+    /// Version of witness program used for Taproot P2TR outputs.
+    V1 = 1,
+    /// Future (unsupported) version of witness program.
+    V2 = 2,
+    /// Future (unsupported) version of witness program.
+    V3 = 3,
+    /// Future (unsupported) version of witness program.
+    V4 = 4,
+    /// Future (unsupported) version of witness program.
+    V5 = 5,
+    /// Future (unsupported) version of witness program.
+    V6 = 6,
+    /// Future (unsupported) version of witness program.
+    V7 = 7,
+    /// Future (unsupported) version of witness program.
+    V8 = 8,
+    /// Future (unsupported) version of witness program.
+    V9 = 9,
+    /// Future (unsupported) version of witness program.
+    V10 = 10,
+    /// Future (unsupported) version of witness program.
+    V11 = 11,
+    /// Future (unsupported) version of witness program.
+    V12 = 12,
+    /// Future (unsupported) version of witness program.
+    V13 = 13,
+    /// Future (unsupported) version of witness program.
+    V14 = 14,
+    /// Future (unsupported) version of witness program.
+    V15 = 15,
+    /// Future (unsupported) version of witness program.
+    V16 = 16,
+}
+
+impl WitnessVersion {
+    /// Returns integer version number representation for a given [`WitnessVersion`] value.
+    ///
+    /// NB: this is not the same as an integer representation of the opcode signifying witness
+    /// version in bitcoin script. Thus, there is no function to directly convert witness version
+    /// into a byte since the conversion requires context (bitcoin script or just a version number).
+    pub fn to_num(self) -> u8 { self as u8 }
+}
+
+/// Prints [`WitnessVersion`] number (from 0 to 16) as integer, without any prefix or suffix.
+impl fmt::Display for WitnessVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "{}", *self as u8) }
+}
+
+impl FromStr for WitnessVersion {
+    type Err = FromStrError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let version: u8 = parse_int::int_from_str(s)?;
+        Ok(Self::try_from(version)?)
+    }
+}
+
+impl TryFrom<u8> for WitnessVersion {
+    type Error = TryFromError;
+
+    fn try_from(no: u8) -> Result<Self, Self::Error> {
+        Ok(match no {
+            0 => Self::V0,
+            1 => Self::V1,
+            2 => Self::V2,
+            3 => Self::V3,
+            4 => Self::V4,
+            5 => Self::V5,
+            6 => Self::V6,
+            7 => Self::V7,
+            8 => Self::V8,
+            9 => Self::V9,
+            10 => Self::V10,
+            11 => Self::V11,
+            12 => Self::V12,
+            13 => Self::V13,
+            14 => Self::V14,
+            15 => Self::V15,
+            16 => Self::V16,
+            invalid => return Err(TryFromError { invalid }),
+        })
+    }
+}
+
+impl TryFrom<Opcode> for WitnessVersion {
+    type Error = TryFromError;
+
+    fn try_from(opcode: Opcode) -> Result<Self, Self::Error> {
+        match opcode.to_u8() {
+            0 => Ok(Self::V0),
+            version if version >= OP_1.to_u8() && version <= OP_16.to_u8() =>
+                Self::try_from(version - OP_1.to_u8() + 1),
+            invalid => Err(TryFromError { invalid }),
+        }
+    }
+}
+
+impl From<WitnessVersion> for Opcode {
+    fn from(version: WitnessVersion) -> Self {
+        match version {
+            WitnessVersion::V0 => OP_PUSHBYTES_0,
+            no => Self::from(OP_1.to_u8() + no.to_num() - 1),
+        }
+    }
+}
+
+/// Error types for the segwit version number.
+pub mod error {
+    use core::convert::Infallible;
+    use core::fmt;
+
+    use internals::write_err;
+    use units::parse_int::ParseIntError;
+
+    /// Error parsing [`WitnessVersion`] from a string.
+    ///
+    /// [`WitnessVersion`]: super::WitnessVersion
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    #[non_exhaustive]
+    pub enum FromStrError {
+        /// Unable to parse integer from string.
+        Unparsable(ParseIntError),
+        /// String contained an invalid witness version number.
+        Invalid(TryFromError),
+    }
+
+    impl From<Infallible> for FromStrError {
+        fn from(never: Infallible) -> Self { match never {} }
+    }
+
+    impl fmt::Display for FromStrError {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            match self {
+                Self::Unparsable(ref e) => write_err!(f, "integer parse error"; e),
+                Self::Invalid(ref e) => write_err!(f, "invalid version number"; e),
+            }
+        }
+    }
+
+    #[cfg(feature = "std")]
+    impl std::error::Error for FromStrError {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            match self {
+                Self::Unparsable(ref e) => Some(e),
+                Self::Invalid(ref e) => Some(e),
+            }
+        }
+    }
+
+    impl From<ParseIntError> for FromStrError {
+        fn from(e: ParseIntError) -> Self { Self::Unparsable(e) }
+    }
+
+    impl From<TryFromError> for FromStrError {
+        fn from(e: TryFromError) -> Self { Self::Invalid(e) }
+    }
+
+    /// Error attempting to create a [`WitnessVersion`] from an integer.
+    ///
+    /// [`WitnessVersion`]: super::WitnessVersion
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    pub struct TryFromError {
+        /// The invalid non-witness version integer.
+        pub(super) invalid: u8,
+    }
+
+    impl TryFromError {
+        /// Returns the invalid non-witness version integer.
+        pub fn invalid_version(&self) -> u8 { self.invalid }
+    }
+
+    impl fmt::Display for TryFromError {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "invalid witness script version: {}", self.invalid)
+        }
+    }
+
+    #[cfg(feature = "std")]
+    impl std::error::Error for TryFromError {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            let Self { invalid: _ } = self;
+            None
+        }
+    }
+}

--- a/primitives/src/witness_version.rs
+++ b/primitives/src/witness_version.rs
@@ -31,7 +31,7 @@ pub use self::error::{FromStrError, TryFromError};
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 #[repr(u8)]
 pub enum WitnessVersion {
-    /// Initial version of witness program. Used for P2WPKH and P2WSH outputs
+    /// Initial version of witness program. Used for P2WPKH and P2WSH outputs.
     V0 = 0,
     /// Version of witness program used for Taproot P2TR outputs.
     V1 = 1,

--- a/primitives/src/witness_version.rs
+++ b/primitives/src/witness_version.rs
@@ -85,8 +85,8 @@ impl FromStr for WitnessVersion {
     type Err = FromStrError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let version: u8 = parse_int::int_from_str(s)?;
-        Ok(Self::try_from(version)?)
+        let version: u8 = parse_int::int_from_str(s).map_err(FromStrError::Unparsable)?;
+        Self::try_from(version).map_err(FromStrError::Invalid)
     }
 }
 
@@ -181,15 +181,6 @@ pub mod error {
             }
         }
     }
-
-    impl From<ParseIntError> for FromStrError {
-        fn from(e: ParseIntError) -> Self { Self::Unparsable(e) }
-    }
-
-    impl From<TryFromError> for FromStrError {
-        fn from(e: TryFromError) -> Self { Self::Invalid(e) }
-    }
-
     /// Error attempting to create a [`WitnessVersion`] from an integer.
     ///
     /// [`WitnessVersion`]: super::WitnessVersion


### PR DESCRIPTION
As part of moving Address to addresses and the script functionality to primitives, WitnessVersion will both also need to be available to both.

Move WitnessVersion and associated errors to primitives, re-exporting from bitcoin.