### PR TITLE
Fixup changelog links and follow new policy

### DIFF
--- a/base58/CHANGELOG.md
+++ b/base58/CHANGELOG.md
@@ -2,15 +2,15 @@
 
 ## [Unreleased]
 
-## 0.4.0 - 2025-01-08
+## [0.4.0] - 2025-01-08
 
 - Update to latest `hashes 0.20.0`
 
-## 0.3.0 - 2025-12-15
+## [0.3.0] - 2025-12-15
 
 - Bump MSRV from 1.63.0 to 1.74.0 for all crates in the repo [#4926](https://github.com/rust-bitcoin/rust-bitcoin/pull/4926)
 
-## 0.2.0 - 2024-12-10
+## [0.2.0] - 2024-12-10
 
 - Bump MSRV to `1.63` [#3100](https://github.com/rust-bitcoin/rust-bitcoin/pull/3100)
 - Optimize `base58` on small inputs [#3002](https://github.com/rust-bitcoin/rust-bitcoin/pull/3002)
@@ -19,7 +19,24 @@
 - Close all errors [#3533](https://github.com/rust-bitcoin/rust-bitcoin/pull/3533)
 - Bump `hex-conservative` to `0.3.0` [#3543](https://github.com/rust-bitcoin/rust-bitcoin/pull/3543)
 
+## [0.1.100] - 2026-05-27
+
+- Bump MSRV to Rust 1.74.0 [#6126](https://github.com/rust-bitcoin/rust-bitcoin/pull/6126)
+
+> Note the version number jump. We jumped to `v0.1.100` when doing the MSRV bump so as to leave room for a bunch of secuity releases up to this number if needed
+
+## [0.1.1] - 2026-05-23
+
+- Remove `internals` dependency [#6200](https://github.com/rust-bitcoin/rust-bitcoin/pull/6200)
+
 ## 0.1.0 - 2024-03-14
 
 Initial release of the `base58ck` crate. This crate was cut out of
 `rust-bitcoin` and cleaned up for release as a separate crate.
+
+[Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/base58ck-0.4.0...HEAD
+[0.4.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/base58ck-0.3.0...base58ck-0.4.0
+[0.3.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/base58ck-0.2.0...base58ck-0.3.0
+[0.2.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/base58ck-0.1.100...base58ck-0.2.0
+[0.1.100]: https://github.com/rust-bitcoin/rust-bitcoin/compare/base58ck-0.1.1...base58ck-0.1.100
+[0.1.1]: https://github.com/rust-bitcoin/rust-bitcoin/compare/base58ck-0.1.0...base58ck-0.1.1

--- a/bip158/CHANGELOG.md
+++ b/bip158/CHANGELOG.md
@@ -2,6 +2,6 @@
 
 ## [Unreleased]
 
-## 0.1.0 - 2025-12-09
+## 0.0.0 - 2025-12-09
 
-* Initial release of the `github.com/rust-bitcoin/rust-bitcoin/bip158` crate as `bip158`.
+* Empty crate to reserve the name on crates.io.

--- a/bitcoin/CHANGELOG.md
+++ b/bitcoin/CHANGELOG.md
@@ -47,6 +47,35 @@ The `serde` serialization for `Psbt` has changed.
 
 - BREAKING: Change `Psbt` serde implementations [#4496](https://github.com/rust-bitcoin/rust-bitcoin/pull/4496)
 
+## [0.32.100] - 2026-05-26
+
+**Bump the MSRV to Rust 1.74.0**
+
+Note the version number jump. We jumped to `v0.32.100` when doing the MSRV bump so as to
+leave room for a bunch of secuity releases up to this number if needed.
+
+- Our primary users (BDK and LDK) are at 1.85 already well ahead of `1.74`.
+- We would like to deliver the new sans-IO `consensus_encoding` crate in a point release.
+- The would like to later support ergonomic conversion to other 1.0 types (from `bitcoin-units`, and
+  and `bitcoin-primitives`) without forcing the whole ecosystem to upgrade.
+- Opens the door to the possibility of doing releases and then using the semver trick.
+
+## [0.32.10] - 2026-04-23
+
+- Fix bug in `LeafVerison::Future`'s `Display` output [#6208](https://github.com/rust-bitcoin/rust-bitcoin/pull/6208)
+- Manually revert `VarInt` range check [#6182](https://github.com/rust-bitcoin/rust-bitcoin/pull/6182)
+- Backport - p2p: Add a hash value to `Inventory`'s `Error` variant [#6147](https://github.com/rust-bitcoin/rust-bitcoin/pull/6147)
+- Backport - p2p: Error on `RawNetworkMessage` decode if payload partly consumed [#6140](https://github.com/rust-bitcoin/rust-bitcoin/pull/6140)
+- Backport - p2p: Error on invalid `FeeRate` in `FeeFilter` decode [#6142](https://github.com/rust-bitcoin/rust-bitcoin/pull/6142)
+- Backport - Validate ASCII and preserve embedded nulls in `CommandString` parsing [#6136](https://github.com/rust-bitcoin/rust-bitcoin/pull/6136)
+- Remove the `internals` dependency [#6200](https://github.com/rust-bitcoin/rust-bitcoin/pull/6200)
+
+## [0.32.9] - 2025-03-26
+
+- Backport - Fix `Unknown` `NetworkMessage` encoding [#6106](https://github.com/rust-bitcoin/rust-bitcoin/pull/6106)
+- Backport - `Arbitrary` [#5085](https://github.com/rust-bitcoin/rust-bitcoin/pull/5085)
+- Backport - Add `CompactSize` range check to deserialization [#5921](https://github.com/rust-bitcoin/rust-bitcoin/pull/5921)
+
 ### Changes
 
 - Bump MSRV from 1.63.0 to 1.74.0 for all crates in the repo [#4926](https://github.com/rust-bitcoin/rust-bitcoin/pull/4926)
@@ -863,7 +892,10 @@ See `Transaction::verify` and `Script::verify` methods.
 downstream users to also have a `num` dependency just so they can use `Uint256::from_u64`.
 
 [Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.33.0-beta...HEAD
-[0.33.0-beta]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.8...bitcoin-0.33.0-beta
+[0.33.0-beta]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.100...bitcoin-0.33.0-beta
+[0.32.100]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.10...bitcoin-0.32.100
+[0.32.10]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.9...bitcoin-0.32.10
+[0.32.9]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.8...bitcoin-0.32.9
 [0.32.8]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.7...bitcoin-0.32.8
 [0.32.7]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.6...bitcoin-0.32.7
 [0.32.6]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.5...bitcoin-0.32.6

--- a/bitcoin/CHANGELOG.md
+++ b/bitcoin/CHANGELOG.md
@@ -34,7 +34,7 @@ For changes to our dependencies included in this release see:
 - `hex-conservative 1.0.0`: [changelog](https://github.com/rust-bitcoin/hex-conservative/blob/1.x/CHANGELOG.md)
 - `hex-conservative 0.3`: [changelog](https://github.com/rust-bitcoin/hex-conservative/blob/master/CHANGELOG.md)
 
-## Worthy of note
+### Worthy of note
 
 This release introduces an upper limit on the `Amount` type.
 
@@ -47,7 +47,7 @@ The `serde` serialization for `Psbt` has changed.
 
 - BREAKING: Change `Psbt` serde implementations [#4496](https://github.com/rust-bitcoin/rust-bitcoin/pull/4496)
 
-## Changes
+### Changes
 
 - Bump MSRV from 1.63.0 to 1.74.0 for all crates in the repo [#4926](https://github.com/rust-bitcoin/rust-bitcoin/pull/4926)
 - Deprecate unchecked `amount` ops [#3759](https://github.com/rust-bitcoin/rust-bitcoin/pull/3759)
@@ -135,7 +135,7 @@ The `serde` serialization for `Psbt` has changed.
 - Upgrade `base64` dependency [#2721](https://github.com/rust-bitcoin/rust-bitcoin/pull/2721)
 - Some additional inspectors on `Script` and `Witness` [#2646](https://github.com/rust-bitcoin/rust-bitcoin/pull/2646)
 
-## Upgrade notes
+### Upgrade notes
 
 - `MAX_SCRIPT_ELEMENT_SIZE` was removed in [#2794](https://github.com/rust-bitcoin/rust-bitcoin/pull/2794)
   you may want to use `MAX_REDEEM_SCRIPT_SIZE` or perhaps `MAX_STACK_ELEMENT_SIZE` (see `bitcoin/src/blockdata/constants`).
@@ -207,7 +207,7 @@ might be what you are after.
 - Remove "no-std" feature [#2233](https://github.com/rust-bitcoin/rust-bitcoin/pull/2233)
 - Enforce displaying `Amount` with trailing zeros [#2604](https://github.com/rust-bitcoin/rust-bitcoin/pull/2604)
 
-## Things you will almost certainly hit when upgrading
+### Things you will almost certainly hit when upgrading
 
 - Rename `Signature` field names [#2338](https://github.com/rust-bitcoin/rust-bitcoin/pull/2338)
   - `sig` becomes `signature`
@@ -215,7 +215,7 @@ might be what you are after.
 - Rename `txid` to `compute_txid` [#2366](https://github.com/rust-bitcoin/rust-bitcoin/pull/2366)
 - In hardcoded BIP-0032 derivation paths: Remove `m/` prefix requirement [#2451](https://github.com/rust-bitcoin/rust-bitcoin/pull/2451)
 
-## Crate smashing
+### Crate smashing
 
 This release we continued our effort to split up the library into
 smaller crates AKA crate smashing.
@@ -224,7 +224,7 @@ smaller crates AKA crate smashing.
 - Release new `base58ck` crate [docs](https://docs.rs/base58ck/0.1.0/base58ck/)
 - Release new `bitcoin-io` crate [docs](https://docs.rs/bitcoin-io/0.1.2/bitcoin_io/)
 
-## Bug fixes
+### Bug fixes
 
 - Fix `FeeRate::checked_mul_by_weight` [#2182](https://github.com/rust-bitcoin/rust-bitcoin/pull/2182)
 - Use network when calculating difficulty [#2168](https://github.com/rust-bitcoin/rust-bitcoin/pull/2168)
@@ -232,7 +232,7 @@ smaller crates AKA crate smashing.
 - Fix CJDNS marker byte check [#2546](https://github.com/rust-bitcoin/rust-bitcoin/pull/2546)
 - Add resource limit check during deserialization of Merkle block [#2607](https://github.com/rust-bitcoin/rust-bitcoin/pull/2607)
 
-## Changes to and involving the `Network` type
+### Changes to and involving the `Network` type
 
 In release 0.31.0 we managed to annoy a lot of people by the addition of `non_exhaustive` to the
 `Network` type. After much discussion, and in an effort to cater to multiple camps, we did a bunch
@@ -251,7 +251,7 @@ In particular consider having some type that implements `AsRef<Params>`, we have
 - Use `KnownHrp` instead of `Network` [#2387](https://github.com/rust-bitcoin/rust-bitcoin/pull/2387)
 - Add check to max difficulty transition threshold [#2337](https://github.com/rust-bitcoin/rust-bitcoin/pull/2337)
 
-## Other API additions
+### Other API additions
 
 - Add `CompressedPublicKey` [#2277](https://github.com/rust-bitcoin/rust-bitcoin/pull/2277)
 - Add a `consensus::deserialize_hex` function [#2039](https://github.com/rust-bitcoin/rust-bitcoin/pull/2039)
@@ -282,7 +282,7 @@ In particular consider having some type that implements `AsRef<Params>`, we have
 - Implement `From<core::convert::Infallible>` for errors [#2516](https://github.com/rust-bitcoin/rust-bitcoin/pull/2516)
 - Add ServiceFlags::P2P_V2 [#2555](https://github.com/rust-bitcoin/rust-bitcoin/pull/2555)
 
-## Other API breaking changes
+### Other API breaking changes
 
 - Require `io::BufRead` instead of `io::Read` in consensus decode trait [#2240](https://github.com/rust-bitcoin/rust-bitcoin/pull/2240)
 - Make `Payload` and `AddressEncoding` private [#1979](https://github.com/rust-bitcoin/rust-bitcoin/pull/1979)
@@ -290,7 +290,7 @@ In particular consider having some type that implements `AsRef<Params>`, we have
 - Make from_hex inherent for byte-like types [#2491](https://github.com/rust-bitcoin/rust-bitcoin/pull/2491)
 - Remove the FromHexStr trait [#2492](https://github.com/rust-bitcoin/rust-bitcoin/pull/2492)
 
-## Error handling
+### Error handling
 
 - Split `Prevouts` errors out into specific error types [#2042](https://github.com/rust-bitcoin/rust-bitcoin/pull/2042)
 - Improve error handling in the `sighash` module [#2329](https://github.com/rust-bitcoin/rust-bitcoin/pull/2329)
@@ -376,7 +376,7 @@ In particular consider having some type that implements `AsRef<Params>`, we have
 
 - Fix compilation when [`RUSTFLAGS=--cfg=bench` is set](https://github.com/rust-bitcoin/rust-bitcoin/pull/1943)
 
-# 0.30 - 2023-03-21 "The First Crate-Smashing Release"
+## 0.30 - 2023-03-21 "The First Crate-Smashing Release"
 
 We now have a website for crates that live under the `rust-bitcoin` GitHub organization: https://rust-bitcoin.org/
 
@@ -455,7 +455,7 @@ This work saw a bunch of new language features become available to us. At the
 same time we were able to start using `rustfmt`. We also started linting as part
 of CI.
 
-## Breaking changes
+### Breaking changes
 
 There are numerous breaking changes in this release related to the new language features but also
 other improvements such as more newtypes added. Note that not all changes cause compilation failure!
@@ -464,7 +464,7 @@ to support human-readable formats.
 
 [Detailed list of breaking changes](https://github.com/rust-bitcoin/rust-bitcoin/pulls?q=is%3Apr+label%3A%22API+break%22+is%3Aclosed+milestone%3A0.29.0+)
 
-## Highlights
+### Highlights
 
 - Added support for BIP 152 [#1088](https://github.com/rust-bitcoin/rust-bitcoin/pull/1088)
 - Edition 2018 improvements
@@ -506,7 +506,7 @@ Backported a set of changes from 0.29 which may cause some specific
 transactions and/or blocks to fail to deserialize. No known such transactions
 exist on any public blockchain.
 
-# 0.28 - 2022-04-20 "The Taproot Release"
+## 0.28 - 2022-04-20 "The Taproot Release"
 
 At nearly nine months, this is our longest release cycle ever, and thanks
 to a huge increase in the number of active contributors this year and last,
@@ -566,7 +566,7 @@ Additionally we made several minor API changes (renaming methods, etc.) to impro
 compliance with modern Rust conventions. Where possible we left the existing methods
 in place, marked as deprecated.
 
-# 0.27 - 2021-07-21
+## 0.27 - 2021-07-21
 
 - [Bigendian fixes and CI test](https://github.com/rust-bitcoin/rust-bitcoin/pull/627)
 - [no_std support, keeping MSRV](https://github.com/rust-bitcoin/rust-bitcoin/pull/603)
@@ -833,19 +833,19 @@ the case and how we broke both `rust-miniscript` and BDK.
 * Update to secp256k1 0.11.0
 * Many, many documentation and test improvements.
 
-## [0.13.1]
+## 0.13.1
 
 * Add `Display` trait to uints, `FromStr` trait to `Network` enum
 * Add witness inv types to inv enum, constants for Bitcoin regtest network, `is_coin_base` accessor for tx inputs
 * Expose `merkleroot(Vec<Sha256dHash>)`
 
-# 0.13
+## 0.13
 
 * Move witnesses inside the `TxIn` structure
 * Add `Transaction::get_weight()`
 * Update bip143 `sighash_all` API to be more ergonomic
 
-# 0.12
+## 0.12
 
 * The in-memory blockchain was moved into a dedicated project rust-bitcoin-chain.
 * Removed old script interpreter
@@ -857,23 +857,23 @@ See `Transaction::verify` and `Script::verify` methods.
 * Add bech32 support
 * Support segwit address types
 
-### 0.11
+## 0.11
 
 * Remove `num` dependency at Matt's request; agree this is obnoxious to require all
 downstream users to also have a `num` dependency just so they can use `Uint256::from_u64`.
 
 [Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.33.0-beta...HEAD
-[0.33.0-beta]: https://github.com/rust-bitcoin/rust-bitcoin/releases/tag/bitcoin-0.33.0-beta
-[0.32.8]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.8...bitcoin-0.33.0-beta
-[0.32.7]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.7...bitcoin-0.32.8
-[0.32.6]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.6...bitcoin-0.32.7
-[0.32.5]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.5...bitcoin-0.32.6
-[0.32.4]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.4...bitcoin-0.32.5
-[0.32.3]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.3...bitcoin-0.32.4
-[0.32.2]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.2...bitcoin-0.32.3
-[0.32.1]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.1...bitcoin-0.32.2
-[0.32.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.0...bitcoin-0.32.1
-[0.31.1]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.31.1...bitcoin-0.32.0
-[0.31.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.31.0...bitcoin-0.31.1
-[0.30.2]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.30.2...bitcoin-0.31.0
-[0.30.1]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.30.1...bitcoin-0.30.2
+[0.33.0-beta]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.8...bitcoin-0.33.0-beta
+[0.32.8]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.7...bitcoin-0.32.8
+[0.32.7]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.6...bitcoin-0.32.7
+[0.32.6]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.5...bitcoin-0.32.6
+[0.32.5]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.4...bitcoin-0.32.5
+[0.32.4]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.3...bitcoin-0.32.4
+[0.32.3]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.2...bitcoin-0.32.3
+[0.32.2]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.1...bitcoin-0.32.2
+[0.32.1]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.0...bitcoin-0.32.1
+[0.32.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.31.1...bitcoin-0.32.0
+[0.31.1]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.31.0...bitcoin-0.31.1
+[0.31.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.30.2...bitcoin-0.31.0
+[0.30.2]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.30.1...bitcoin-0.30.2
+[0.30.1]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.30.0...bitcoin-0.30.1

--- a/chacha20_poly1305/CHANGELOG.md
+++ b/chacha20_poly1305/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 * The crate is now `no_std`.
 
-## [0.1.0] - 2024-10-28
+## 0.1.0 - 2024-10-28
 
 * Initial release to create the chacha20-poly1305 crate.
 
@@ -25,4 +25,3 @@
 [0.2.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/chacha20-poly1305-0.1.2...chacha20-poly1305-0.2.0
 [0.1.2]: https://github.com/rust-bitcoin/rust-bitcoin/compare/chacha20-poly1305-0.1.1...chacha20-poly1305-0.1.2
 [0.1.1]: https://github.com/rust-bitcoin/rust-bitcoin/compare/chacha20-poly1305-0.1.0...chacha20-poly1305-0.1.1
-[0.1.0]: https://github.com/rust-bitcoin/rust-bitcoin/releases/tag/chacha20-poly1305-0.1.0

--- a/consensus_encoding/CHANGELOG.md
+++ b/consensus_encoding/CHANGELOG.md
@@ -14,7 +14,7 @@ Team Rust Bitcoin - LFG.
 
 - Replace `bool` on `Decoder` trait with the `DecoderStatus` type (includes Encoder side too) [#6189](https://github.com/rust-bitcoin/rust-bitcoin/pull/6189)
 - Add checked decode functions [#6195](https://github.com/rust-bitcoin/rust-bitcoin/pull/6195)
-- Re-name main traits [#6028](https://github.com/rust-bitcoin/rust-bitcoin/pull/60428)
+- Re-name main traits [#6028](https://github.com/rust-bitcoin/rust-bitcoin/pull/6028)
 - Change `EncodableByteIter` to `EncoderByteIter` [#6044](https://github.com/rust-bitcoin/rust-bitcoin/pull/6044)
 - Encoder/decoder improvements [#6004](https://github.com/rust-bitcoin/rust-bitcoin/pull/6004)
 - Re-name `flush_to` functions to `drain_to` [#6064](https://github.com/rust-bitcoin/rust-bitcoin/pull/6064)
@@ -84,4 +84,3 @@ Empty crate to reserve the name on crates.io
 [Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-consensus-encoding-1.0.0...HEAD
 [1.0.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-consensus-encoding-0.2.0...bitcoin-consensus-encoding-1.0.0
 [0.2.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-consensus-encoding-0.1.0...bitcoin-consensus-encoding-0.2.0
-[0.1.0]: https://github.com/rust-bitcoin/rust-bitcoin/releases/tag/bitcoin-consensus-encoding-0.1.0

--- a/crypto/CHANGELOG.md
+++ b/crypto/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Remove error conversion `From` impls [#6041](https://github.com/rust-bitcoin/rust-bitcoin/pull/6041)
 - Remove `bitcoin-io` dependency [#6049](https://github.com/rust-bitcoin/rust-bitcoin/pull/6049)
 
-## [0.1.0] - Initial migration
+## 0.1.0 - Initial migration
 
 - Migrate all code from `rust-bitcoin::crypto::ecdsa` to this crate.
 - Migrate all key types from `rust-bitcoin::crypto::key` to this crate. The `TapTweak` trait
@@ -20,5 +20,4 @@
 - Empty crate to reserve the name on crates.io
 
 [Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-crypto-0.2.0...HEAD
-[0.2.0]: https://github.com/rust-bitcoin/rust-bitcoin/releases/tag/bitcoin-crypto-0.2.0
-[0.1.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-crypto-0.1.0...bitcoin-crypto-0.2.0
+[0.2.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-crypto-0.1.0...bitcoin-crypto-0.2.0

--- a/hashes/CHANGELOG.md
+++ b/hashes/CHANGELOG.md
@@ -30,7 +30,7 @@ Props to jrakibi for all the SIMD work in this release.
 * Use Rust-like syntax in hash type macros [#5853](https://github.com/rust-bitcoin/rust-bitcoin/pull/5853)
 * Remove the unstable `hex-conservative` dependency [#6148](https://github.com/rust-bitcoin/rust-bitcoin/pull/6148)
 
-SIMD optimizaions: 
+SIMD optimizaions:
 
 * https://github.com/rust-bitcoin/rust-bitcoin/pull/6060
 * https://github.com/rust-bitcoin/rust-bitcoin/pull/6069
@@ -171,7 +171,7 @@ bumped the Minimum Supported Rust Version across the `rust-bitcoin` ecosystem to
 * Add simd sha256 intrinsics for x86 machines [#1962](https://github.com/rust-bitcoin/rust-bitcoin/pull/1962).
 * Introduce the "small-hash" feature for `bitcoin_hashes` [#1990](https://github.com/rust-bitcoin/rust-bitcoin/pull/1990).
 
-## [0.12.0] - 2023-03-05
+## 0.12.0 - 2023-03-05
 
 0.12 is a significant release. We pulled the repository into the rust-bitcoin
 repo to improve our integration testing and to get more eyes on this crate. We
@@ -365,4 +365,3 @@ Note that we have stopped re-exporting the `core` crate when compiling without `
 [0.14.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin_hashes-0.13.1...bitcoin_hashes-0.14.0
 [0.13.1]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin_hashes-0.13.0...bitcoin_hashes-0.13.1
 [0.13.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin_hashes-0.12.0...bitcoin_hashes-0.13.0
-[0.12.0]: https://github.com/rust-bitcoin/rust-bitcoin/releases/tag/bitcoin_hashes-0.12.0

--- a/internals/CHANGELOG.md
+++ b/internals/CHANGELOG.md
@@ -34,7 +34,7 @@ This release will be yanked because the following were included and are breaking
 - Remove usage of `impl_from_infallible` in crates [#3859](https://github.com/rust-bitcoin/rust-bitcoin/pull/3859)
 - Removed `impl_array_newtype` [#3544](https://github.com/rust-bitcoin/rust-bitcoin/pull/3544)
 
-## 0.4.0 - 2024-09-18
+## [0.4.0] - 2024-09-18
 
 - Introduce `ToU64` trait [#2929](https://github.com/rust-bitcoin/rust-bitcoin/pull/2929)
 - Add macro `impl_to_hex_from_lower_hex ` [#3150](https://github.com/rust-bitcoin/rust-bitcoin/pull/3150)
@@ -42,12 +42,12 @@ This release will be yanked because the following were included and are breaking
 - Introduce `read_push_data_len()` and [#3293](https://github.com/rust-bitcoin/rust-bitcoin/pull/3293/)
 - Introduce new `compact_size` module [#3259](https://github.com/rust-bitcoin/rust-bitcoin/pull/3259)
 
-## 0.3.0 - 2024-03-24
+## [0.3.0] - 2024-03-24
 
 - Bump MSRV to Rust version 1.56.1 [#2188](https://github.com/rust-bitcoin/rust-bitcoin/pull/2188)
 - Implement custom `ArrayVec` that is `Copy` [#2287](https://github.com/rust-bitcoin/rust-bitcoin/pull/2287)
 
-## [0.2.0] - 2023-06-20
+## 0.2.0 - 2023-06-20
 
 - [Rename crate](https://github.com/rust-bitcoin/rust-bitcoin/pull/1885) to `bitcoin-internals`
 - Add module to assist [alloc-free parse error handling](https://github.com/rust-bitcoin/rust-bitcoin/pull/1297)
@@ -62,6 +62,7 @@ For previous development history see the original
 [Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-internals-0.5.0...HEAD
 [0.5.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-internals-0.4.2...bitcoin-internals-0.5.0
 [0.4.2]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-internals-0.4.1...bitcoin-internals-0.4.2
-[0.4.1]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-internals-0.2.1...bitcoin-internals-0.4.1
+[0.4.1]: https://github.com/rust-bitcoin/rust-bitcoin/compare/internals-0.4.0...bitcoin-internals-0.4.1
+[0.4.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/internals-0.3.0...internals-0.4.0
+[0.3.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-internals-0.2.1...internals-0.3.0
 [0.2.1]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-internals-0.2.0...bitcoin-internals-0.2.1
-[0.2.0]: https://github.com/rust-bitcoin/rust-bitcoin/releases/tag/bitcoin-internals-0.2.0

--- a/io/CHANGELOG.md
+++ b/io/CHANGELOG.md
@@ -17,7 +17,7 @@ update the other `rust-bitcoin` repo dependencies.
 
 ## [0.3.0] - 2025-12-01
 
-* Bump MSRV to Rust `1.74` [#4926](https://github.com/rust-bitcoin/rust-bitcoin/pull/)
+* Bump MSRV to Rust `1.74` [#4926](https://github.com/rust-bitcoin/rust-bitcoin/pull/4926)
 * Make traits dyn compatible [#5249](https://github.com/rust-bitcoin/rust-bitcoin/pull/5249)
 * Invert dependency between `io` and `hashes` [#3961](https://github.com/rust-bitcoin/rust-bitcoin/pull/3961)
 * Introduce `encode_to_writer` for `Write` trait [#5214](https://github.com/rust-bitcoin/rust-bitcoin/pull/5214)
@@ -27,19 +27,19 @@ update the other `rust-bitcoin` repo dependencies.
 * Make `io::Error` `Sync` [#3920](https://github.com/rust-bitcoin/rust-bitcoin/pull/3920)
 * Use `get_ref` / `get_mut` API [#3855](https://github.com/rust-bitcoin/rust-bitcoin/pull/3855)
 
-## 0.2.0 - 2024-09-18
+## [0.2.0] - 2024-09-18
 
 * Add blanket impl of io traits for `&mut T` [#3188](https://github.com/rust-bitcoin/rust-bitcoin/pull/3188)
 * Add `std` bridge [#3176](https://github.com/rust-bitcoin/rust-bitcoin/pull/3176)
 * Bump MSRV to Rust `v1.63.0` [#3100](https://github.com/rust-bitcoin/rust-bitcoin/pull/3100)
 * Remove blanket trait impls [#2453](https://github.com/rust-bitcoin/rust-bitcoin/pull/2453)
 
-## 0.1.3 - 2024-11-02
+## [0.1.3] - 2024-11-02
 
 * Backport IO improvements [#3181](https://github.com/rust-bitcoin/rust-bitcoin/pull/3181)
   (Original PR: [#3176](https://github.com/rust-bitcoin/rust-bitcoin/pull/3176))
 
-## 0.1.2 - 2024-03-14
+## [0.1.2] - 2024-03-14
 
 * Implement `From<core::convert::Infallible>` for Errors [#2516](https://github.com/rust-bitcoin/rust-bitcoin/pull/2516)
 * Fix new CI build warnings [#2488](https://github.com/rust-bitcoin/rust-bitcoin/pull/2488)
@@ -67,4 +67,7 @@ Empty crate to reserve the name on crates.io
 [Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-io-0.5.0...HEAD
 [0.5.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-io-0.4.0-rc.0...bitcoin-io-0.5.0
 [0.4.0-rc.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-io-0.3.0...bitcoin-io-0.4.0-rc.0
-[0.3.0]: https://github.com/rust-bitcoin/rust-bitcoin/releases/tag/bitcoin-io-0.3.0
+[0.3.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/io-0.2.0...bitcoin-io-0.3.0
+[0.2.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/io-0.1.3...io-0.2.0
+[0.1.3]: https://github.com/rust-bitcoin/rust-bitcoin/compare/io-0.1.2...io-0.1.3
+[0.1.2]: https://github.com/rust-bitcoin/rust-bitcoin/compare/io-0.1.1...io-0.1.2

--- a/key_expression/CHANGELOG.md
+++ b/key_expression/CHANGELOG.md
@@ -2,9 +2,8 @@
 
 ## [Unreleased]
 
-## [0.0.0] - Initial dummy release
+## 0.0.0 - Initial dummy release
 
 - Empty crate to reserve the name on crates.io
 
 [Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-key-expression-0.0.0...HEAD
-[0.0.0]: https://github.com/rust-bitcoin/rust-bitcoin/releases/tag/bitcoin-key-expression-0.0.0

--- a/network/CHANGELOG.md
+++ b/network/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-## [0.1.0] - Initial release
+## 0.1.0 - Initial release
 
 This is, and should remain, a very simple crate.
 
@@ -13,4 +13,3 @@ Currently provides:
 - `TestnetVersion`
 
 [Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-network-kind-0.1.0...HEAD
-[0.1.0]: https://github.com/rust-bitcoin/rust-bitcoin/releases/tag/bitcoin-network-kind-0.1.0

--- a/primitives/CHANGELOG.md
+++ b/primitives/CHANGELOG.md
@@ -18,7 +18,7 @@ release is still explicitly a 1.0 release candidate.
 - Reject txs with output sum > MAX_MONEY [#5443](https://github.com/rust-bitcoin/rust-bitcoin/pull/5443)
 - Reject transactions with invalid coinbase `scriptSig` length [#5430](https://github.com/rust-bitcoin/rust-bitcoin/pull/5430)
 
-# 1.0.0 Release Candidates - 2025-10-18
+## 1.0.0 Release Candidates - 2025-10-18
 
 This changelog is a rolling description of everything that will eventually end up in `v1.0`.
 EDIT: This changelog is for `1.0.0-rc.0` through `1.0.0-rc.2` and may well be missing stuff.
@@ -63,7 +63,7 @@ And also we did:
 - Re-export `block::Header` as `BlockHeader` [#3562](https://github.com/rust-bitcoin/rust-bitcoin/pull/3562)
 - Favour `to_vec` over `to_bytes` [#3544](https://github.com/rust-bitcoin/rust-bitcoin/pull/3544)
 
-## Locktimes
+### Locktimes
 
 Lock times got a bit of work. A big win was:
 
@@ -77,16 +77,16 @@ we changed the format:
 
 - Modify locktime serde implementations #4511
 
-## Arbitrary
+### Arbitrary
 
 - Add Arbitrary impl for BlockHash, TxMerkleNode, and Wtxid #4720
 - Add Arbitrary impl for relative::LockTime #4689
 
-## Mutation testing
+### Mutation testing
 
 The whole crate is mutation tested using `cargo-mutants` - BOOM!
 
-## 0.101.0 - 2024-11-15
+## [0.101.0] - 2024-11-15
 
 This is the first "real" release of the `primitives` crate, as such it
 includes a lot of work. Search GitHub with the following filter to see
@@ -118,4 +118,5 @@ Enjoy!
   `bitcoin-primitives`. The name on crates.io was generously transferred to us.
 
 [Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-primitives-0.102.0...HEAD
-[0.102.0]: https://github.com/rust-bitcoin/rust-bitcoin/releases/tag/bitcoin-primitives-0.102.0
+[0.102.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/primitives-0.101.0...bitcoin-primitives-0.102.0
+[0.101.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/primitives-0.100.0...primitives-0.101.0

--- a/taproot-primitives/CHANGELOG.md
+++ b/taproot-primitives/CHANGELOG.md
@@ -2,9 +2,8 @@
 
 ## [Unreleased]
 
-## [0.1.0] - Initial release
+## 0.1.0 - Initial release
 
 - All the hash types and also the `LeafVersion` enum.
 
 [Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-taproot-primitives-0.1.0...HEAD
-[0.1.0]: https://github.com/rust-bitcoin/rust-bitcoin/releases/tag/bitcoin-taproot-primitives-0.1.0

--- a/units/CHANGELOG.md
+++ b/units/CHANGELOG.md
@@ -27,7 +27,7 @@ this reason we elected to go back to pre-1.0 version numbers.
 
 - Add next target calculation [#5544](https://github.com/rust-bitcoin/rust-bitcoin/pull/5544)
 
-# 1.0.0 Release Candidates - 2025-02-24
+## 1.0.0 Release Candidates - 2025-02-24
 
 BOOM! A long time in the making but here goes, our first 1.0 crate release.
 
@@ -68,16 +68,16 @@ EDIT: This changelog is for `1.0.0-rc.0` through `1.0.0-rc.4` and may well be mi
   * Decoders with phantoms [#5008](https://github.com/rust-bitcoin/rust-bitcoin/pull/5008)
   * Improve the decoders [#5027](https://github.com/rust-bitcoin/rust-bitcoin/pull/5027)
 
-## Changes relate to error types
+### Changes relate to error types
 
 * Close the hex parse errors [#3673](https://github.com/rust-bitcoin/rust-bitcoin/pull/3673)
 
-## Improved support for `Arbitrary`
+### Improved support for `Arbitrary`
 
 * Implement `Arbitrary` for `units` types [#3777](https://github.com/rust-bitcoin/rust-bitcoin/pull/3777)
 * Add `Arbitrary` to `Weight` [#3257](https://github.com/rust-bitcoin/rust-bitcoin/pull/3257)
 
-## 0.2.0 - 2024-09-18
+## [0.2.0] - 2024-09-18
 
 * Bump MSRV to 1.63.0 [#3100](https://github.com/rust-bitcoin/rust-bitcoin/pull/3100)
 * Remove re-export of `ParseIntError` [#3069](https://github.com/rust-bitcoin/rust-bitcoin/pull/3069)
@@ -93,7 +93,7 @@ EDIT: This changelog is for `1.0.0-rc.0` through `1.0.0-rc.4` and may well be mi
 * Add `FeeRate` addition and subtraction traits [#3381](https://github.com/rust-bitcoin/rust-bitcoin/pull/3381)
 * Add `BlockHeight` and `BlockInterval` types [#2615](https://github.com/rust-bitcoin/rust-bitcoin/pull/2615)
 
-## Additional test infrastructure:`Arbitrary`
+### Additional test infrastructure:`Arbitrary`
 
 This release we started adding implementations of
 [`arbitrary::Arbitrary`](https://docs.rs/arbitrary/latest/arbitrary/trait.Arbitrary.html).
@@ -102,11 +102,11 @@ Types implemented: `Amount`, `SignedAmount`, `FeeRate`, and `Weight`.
 
 In the following PRs:
 
-* [#3305](https://github.com/rust-bitcoin/rust-bitcoin/pull/3015)
+* [#3015](https://github.com/rust-bitcoin/rust-bitcoin/pull/3015)
 * [#3257](https://github.com/rust-bitcoin/rust-bitcoin/pull/3257)
 * [#3247](https://github.com/rust-bitcoin/rust-bitcoin/pull/3274)
 
-## 0.1.2 - 2024-07-01
+## [0.1.2] - 2024-07-01
 
 * Remove enable of `alloc` feature in the `internals` dependency.
 
@@ -117,7 +117,7 @@ was incorrect because we have an `alloc` feature that enables
 
 `v0.1.1` will be yanked for this reason.
 
-## 0.1.1 - 2024-04-04
+## [0.1.1] - 2024-04-04
 
 * Enable "alloc" feature for `internals` dependency - enables caching
   of parsed input strings in a couple of `amount` error types.
@@ -141,5 +141,8 @@ The main types are:
 Empty crate to reserve the name on crates.io
 
 [Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-units-0.4.0...HEAD
-[0.4.0]: https://github.com/rust-bitcoin/rust-bitcoin/releases/tag/bitcoin-units-0.4.0
-[0.3.0]: https://github.com/rust-bitcoin/rust-bitcoin/releases/tag/bitcoin-units-0.3.0
+[0.4.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-units-0.3.0...bitcoin-units-0.4.0
+[0.3.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/units-0.2.0...bitcoin-units-0.3.0
+[0.2.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/units-0.1.2...units-0.2.0
+[0.1.2]: https://github.com/rust-bitcoin/rust-bitcoin/compare/units-0.1.1...units-0.1.2
+[0.1.1]: https://github.com/rust-bitcoin/rust-bitcoin/compare/units-0.1.0...units-0.1.1


### PR DESCRIPTION
Based on feedback from the previous rev, drop all links which are not helpful compares. Links to a single tag are not all the helpful and neither is comparing to the beginning of time.

Fixup off-by-one error in `bitcoin` links. Not adding links for `bitcoin`'s `0.32.x` tags, the diff compare gets a little wonky as the branch drifts further from master.

Fwiw `internals` and `units` have some inconsistent tag formatting, and the `bitcoin-bip158` package does not have any tags yet.

Closes #6288