### PR TITLE
Move `Builder` to `primitives`

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -70,6 +70,7 @@ exclude_re = [
     "primitives/.* calculate_root_batched", # Behind cfg(target_arch = "aarch64"), not compiled on x86_64 CI runner
     "primitives/.* <impl MerkleNode for TxMerkleNode>::calculate_root", # Behind cfg(target_arch = "aarch64"), not compiled on x86_64 CI runner
     "primitives/.* <impl MerkleNode for WitnessMerkleNode>::calculate_root", # Behind cfg(target_arch = "aarch64"), not compiled on x86_64 CI runner
+    "primitives/.* replace \\% with \\+ in ScriptBuf<T>::push_slice_no_opt", # as u8 truncation makes >= 0x100 impossible to test
 
     # consensus_encoding - most of these are for mutations in the logic used to determine when to stop encoding or decoding.
     "consensus_encoding/.* <impl Decoder for ArrayDecoder<N>>::push_bytes", # Mutations cause an infinite loop

--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -64,9 +64,10 @@ use crate::prelude::{String, ToOwned};
 use crate::script::witness_program::WitnessProgram;
 use crate::script::witness_version::WitnessVersion;
 use crate::script::{
-    self, RedeemScriptSizeError, Script, ScriptExt as _, ScriptHash, ScriptHashableTag,
-    ScriptPubKey, ScriptPubKeyBuf, ScriptPubKeyBufExt as _, ScriptPubKeyExt as _, WScriptHash,
-    WitnessScript, WitnessScriptExt as _, WitnessScriptSizeError,
+    self, BuilderExt as _, RedeemScriptSizeError, Script, ScriptExt as _, ScriptHash,
+    ScriptHashableTag, ScriptPubKey, ScriptPubKeyBuf, ScriptPubKeyBufExt as _,
+    ScriptPubKeyExt as _, WScriptHash, WitnessScript, WitnessScriptExt as _,
+    WitnessScriptSizeError,
 };
 use crate::taproot::TapNodeHash;
 

--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -12,9 +12,10 @@ use crate::locktime::absolute;
 use crate::network::{Network, Params};
 use crate::opcodes::all::*;
 use crate::pow::CompactTarget;
+use crate::script::{self, BuilderExtPriv as _};
 use crate::transaction::{self, OutPoint, Transaction, TxIn, TxOut};
 use crate::witness::Witness;
-use crate::{script, Amount, BlockHash, BlockTime, Sequence, TestnetVersion};
+use crate::{Amount, BlockHash, BlockTime, Sequence, TestnetVersion};
 
 /// How many seconds between blocks we expect on average.
 pub const TARGET_BLOCK_SPACING: u32 = 600;

--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -12,7 +12,7 @@ use crate::locktime::absolute;
 use crate::network::{Network, Params};
 use crate::opcodes::all::*;
 use crate::pow::CompactTarget;
-use crate::script::{self, BuilderExtPriv as _};
+use crate::script::{self, BuilderExt as _, BuilderExtPriv as _};
 use crate::transaction::{self, OutPoint, Transaction, TxIn, TxOut};
 use crate::witness::Witness;
 use crate::{Amount, BlockHash, BlockTime, Sequence, TestnetVersion};

--- a/bitcoin/src/blockdata/script/builder.rs
+++ b/bitcoin/src/blockdata/script/builder.rs
@@ -25,51 +25,6 @@ impl<T> Builder<T> {
     #[inline]
     pub const fn new() -> Self { Self(ScriptBuf::new()) }
 
-    /// Constructs a new empty script builder with at least the specified capacity.
-    #[inline]
-    pub fn with_capacity(capacity: usize) -> Self { Self::from(Vec::with_capacity(capacity)) }
-
-    /// Returns the length in bytes of the script.
-    pub fn len(&self) -> usize { self.as_script().len() }
-
-    /// Checks whether the script is the empty script.
-    pub fn is_empty(&self) -> bool { self.as_script().is_empty() }
-
-    /// Adds instructions to push an integer onto the stack.
-    ///
-    /// Integers are encoded as little-endian signed-magnitude numbers, but there are dedicated
-    /// opcodes to push some small integers.
-    ///
-    /// # Errors
-    ///
-    /// Only errors if `data == i32::MIN` (CScriptNum cannot have value -2^31).
-    pub fn push_int(self, n: i32) -> Result<Self, Error> {
-        let mut script = self.into_script();
-        script.push_int(n)?;
-        Ok(Self::from(script.into_bytes()))
-    }
-
-    /// Adds instructions to push an unchecked integer onto the stack.
-    ///
-    /// Integers are encoded as little-endian signed-magnitude numbers, but there are dedicated
-    /// opcodes to push some small integers.
-    ///
-    /// This function implements `CScript::push_int64` from Core `script.h`.
-    ///
-    /// > Numeric opcodes (OP_1ADD, etc) are restricted to operating on 4-byte integers.
-    /// > The semantics are subtle, though: operands must be in the range [-2^31 +1...2^31 -1],
-    /// > but results may overflow (and are valid as long as they are not used in a subsequent
-    /// > numeric operation). CScriptNum enforces those semantics by storing results as
-    /// > an int64 and allowing out-of-range values to be returned as a vector of bytes but
-    /// > throwing an exception if arithmetic is done or the result is interpreted as an integer.
-    ///
-    /// Does not check whether `n` is in the range of [-2^31 +1...2^31 -1].
-    pub fn push_int_unchecked(self, n: i64) -> Self {
-        let mut script = self.into_script();
-        script.push_int_unchecked(n);
-        Self::from(script.into_bytes())
-    }
-
     /// Adds instructions to push some arbitrary data onto the stack.
     ///
     /// If the data can be exactly produced by a numeric opcode, that opcode
@@ -102,88 +57,138 @@ impl<T> Builder<T> {
         self
     }
 
-    /// Adds an `OP_VERIFY` to the script or replaces the last opcode with VERIFY form.
-    ///
-    /// Some opcodes such as `OP_CHECKSIG` have a verify variant that works as if `VERIFY` was
-    /// in the script right after. To save space this function appends `VERIFY` only if
-    /// the most-recently-added opcode *does not* have an alternate `VERIFY` form. If it does
-    /// the last opcode is replaced. E.g., `OP_CHECKSIG` will become `OP_CHECKSIGVERIFY`.
-    ///
-    /// Note that existing `OP_*VERIFY` opcodes do not lead to the instruction being ignored
-    /// because `OP_VERIFY` consumes an item from the stack so ignoring them would change the
-    /// semantics.
-    pub fn push_verify(self) -> Self {
-        // "duplicated code" because we need to update `1` field
-        match opcode_to_verify(self.as_script().last_opcode()) {
-            Some(opcode) => {
-                let mut script = self.into_script();
-                script.as_byte_vec().pop();
-                let result = Self::from(script.into_bytes());
-                result.push_opcode(opcode)
-            }
-            None => self.push_opcode(OP_VERIFY),
-        }
-    }
-
-    /// Adds instructions to push a public key onto the stack.
-    pub fn push_key(self, key: LegacyPublicKey) -> Self {
-        if key.compressed() {
-            self.push_slice(key.serialize_compressed())
-        } else {
-            self.push_slice(key.serialize_uncompressed())
-        }
-    }
-
-    /// Adds instructions to push an XOnly public key onto the stack.
-    pub fn push_x_only_key(self, x_only_key: XOnlyPublicKey) -> Self {
-        self.push_slice(x_only_key.serialize().0)
-    }
-
-    /// Adds instructions to push an absolute lock time onto the stack.
-    pub fn push_lock_time(self, lock_time: absolute::LockTime) -> Self {
-        self.push_int_unchecked(lock_time.to_consensus_u32().into())
-    }
-
-    /// Adds instructions to push a relative lock time onto the stack.
-    ///
-    /// This is used when creating scripts that use CHECKSEQUENCEVERIFY (CSV) to enforce
-    /// relative time locks.
-    pub fn push_relative_lock_time(self, lock_time: relative::LockTime) -> Self {
-        self.push_int_unchecked(lock_time.to_consensus_u32().into())
-    }
-
-    /// Adds instructions to push a sequence number onto the stack.
-    ///
-    /// # Deprecated
-    /// This method is deprecated in favor of `push_relative_lock_time`.
-    ///
-    /// In Bitcoin script semantics, when using CHECKSEQUENCEVERIFY, you typically
-    /// want to push a relative locktime value to be compared against the input's
-    /// sequence number, not the sequence number itself.
-    #[deprecated(
-        since = "TBD",
-        note = "Use push_relative_lock_time instead for working with timelocks in scripts"
-    )]
-    pub fn push_sequence(self, sequence: Sequence) -> Self {
-        self.push_int_unchecked(sequence.to_consensus_u32().into())
-    }
-
     /// Converts the `Builder` into `ScriptBuf`.
     pub fn into_script(self) -> ScriptBuf<T> { self.0 }
 
-    /// Converts the `Builder` into script bytes
-    pub fn into_bytes(self) -> Vec<u8> { self.into_script().into() }
-
     /// Returns the internal script
     pub fn as_script(&self) -> &Script<T> { &self.0 }
-
-    /// Returns script bytes
-    pub fn as_bytes(&self) -> &[u8] { self.as_script().as_bytes() }
 }
 
 mod sealed {
     pub trait Sealed {}
     impl<T> Sealed for super::Builder<T> {}
+}
+
+crate::internal_macros::define_extension_trait! {
+    /// Extension functionality for the [`Builder`] type.
+    pub trait BuilderExt<T> impl<T> for Builder<T> {
+        /// Constructs a new empty script builder with at least the specified capacity.
+        #[inline]
+        fn with_capacity(capacity: usize) -> Self { Self::from(Vec::with_capacity(capacity)) }
+
+        /// Returns the length in bytes of the script.
+        fn len(&self) -> usize { self.as_script().len() }
+
+        /// Checks whether the script is the empty script.
+        fn is_empty(&self) -> bool { self.as_script().is_empty() }
+
+        /// Adds instructions to push an integer onto the stack.
+        ///
+        /// Integers are encoded as little-endian signed-magnitude numbers, but there are dedicated
+        /// opcodes to push some small integers.
+        ///
+        /// # Errors
+        ///
+        /// Only errors if `data == i32::MIN` (CScriptNum cannot have value -2^31).
+        fn push_int(self, n: i32) -> Result<Builder<T>, Error> {
+            let mut script = self.into_script();
+            script.push_int(n)?;
+            Ok(Self::from(script.into_bytes()))
+        }
+
+        /// Adds instructions to push an unchecked integer onto the stack.
+        ///
+        /// Integers are encoded as little-endian signed-magnitude numbers, but there are dedicated
+        /// opcodes to push some small integers.
+        ///
+        /// This function implements `CScript::push_int64` from Core `script.h`.
+        ///
+        /// > Numeric opcodes (OP_1ADD, etc) are restricted to operating on 4-byte integers.
+        /// > The semantics are subtle, though: operands must be in the range [-2^31 +1...2^31 -1],
+        /// > but results may overflow (and are valid as long as they are not used in a subsequent
+        /// > numeric operation). CScriptNum enforces those semantics by storing results as
+        /// > an int64 and allowing out-of-range values to be returned as a vector of bytes but
+        /// > throwing an exception if arithmetic is done or the result is interpreted as an integer.
+        ///
+        /// Does not check whether `n` is in the range of [-2^31 +1...2^31 -1].
+        fn push_int_unchecked(self, n: i64) -> Self {
+            let mut script = self.into_script();
+            script.push_int_unchecked(n);
+            Self::from(script.into_bytes())
+        }
+
+        /// Adds an `OP_VERIFY` to the script or replaces the last opcode with VERIFY form.
+        ///
+        /// Some opcodes such as `OP_CHECKSIG` have a verify variant that works as if `VERIFY` was
+        /// in the script right after. To save space this function appends `VERIFY` only if
+        /// the most-recently-added opcode *does not* have an alternate `VERIFY` form. If it does
+        /// the last opcode is replaced. E.g., `OP_CHECKSIG` will become `OP_CHECKSIGVERIFY`.
+        ///
+        /// Note that existing `OP_*VERIFY` opcodes do not lead to the instruction being ignored
+        /// because `OP_VERIFY` consumes an item from the stack so ignoring them would change the
+        /// semantics.
+        fn push_verify(self) -> Self {
+            // "duplicated code" because we need to update `1` field
+            match opcode_to_verify(self.as_script().last_opcode()) {
+                Some(opcode) => {
+                    let mut script = self.into_script();
+                    script.as_byte_vec().pop();
+                    let result= Self::from(script.into_bytes());
+                    result.push_opcode(opcode)
+                }
+                None => self.push_opcode(OP_VERIFY),
+            }
+        }
+
+        /// Adds instructions to push a public key onto the stack.
+        fn push_key(self, key: LegacyPublicKey) -> Self {
+            if key.compressed() {
+                self.push_slice(key.serialize_compressed())
+            } else {
+                self.push_slice(key.serialize_uncompressed())
+            }
+        }
+
+        /// Adds instructions to push an XOnly public key onto the stack.
+        fn push_x_only_key(self, x_only_key: XOnlyPublicKey) -> Self {
+            self.push_slice(x_only_key.serialize().0)
+        }
+
+        /// Adds instructions to push an absolute lock time onto the stack.
+        fn push_lock_time(self, lock_time: absolute::LockTime) -> Self {
+            self.push_int_unchecked(lock_time.to_consensus_u32().into())
+        }
+
+        /// Adds instructions to push a relative lock time onto the stack.
+        ///
+        /// This is used when creating scripts that use CHECKSEQUENCEVERIFY (CSV) to enforce
+        /// relative time locks.
+        fn push_relative_lock_time(self, lock_time: relative::LockTime) -> Self {
+            self.push_int_unchecked(lock_time.to_consensus_u32().into())
+        }
+
+        /// Adds instructions to push a sequence number onto the stack.
+        ///
+        /// # Deprecated
+        /// This method is deprecated in favor of `push_relative_lock_time`.
+        ///
+        /// In Bitcoin script semantics, when using CHECKSEQUENCEVERIFY, you typically
+        /// want to push a relative locktime value to be compared against the input's
+        /// sequence number, not the sequence number itself.
+        #[deprecated(
+            since = "TBD",
+            note = "Use push_relative_lock_time instead for working with timelocks in scripts"
+        )]
+        fn push_sequence(self, sequence: Sequence) -> Self {
+            self.push_int_unchecked(sequence.to_consensus_u32().into())
+        }
+
+        /// Converts the `Builder` into script bytes
+        fn into_bytes(self) -> Vec<u8> { self.into_script().into() }
+
+        /// Returns script bytes
+        fn as_bytes(&self) -> &[u8] { self.as_script().as_bytes() }
+    }
 }
 
 crate::internal_macros::define_extension_trait! {

--- a/bitcoin/src/blockdata/script/builder.rs
+++ b/bitcoin/src/blockdata/script/builder.rs
@@ -18,16 +18,16 @@ use crate::{relative, Sequence};
 /// `Builder` is backed by [`ScriptBuf`] and inherits its panic behavior. This means that
 /// attempting to construct scripts larger than `isize::MAX` bytes will panic.
 #[derive(PartialEq, Eq, Clone)]
-pub struct Builder<T>(ScriptBuf<T>, Option<Opcode>);
+pub struct Builder<T>(ScriptBuf<T>);
 
 impl<T> Builder<T> {
     /// Constructs a new empty script.
     #[inline]
-    pub const fn new() -> Self { Self(ScriptBuf::new(), None) }
+    pub const fn new() -> Self { Self(ScriptBuf::new()) }
 
     /// Constructs a new empty script builder with at least the specified capacity.
     #[inline]
-    pub fn with_capacity(capacity: usize) -> Self { Self(ScriptBuf::with_capacity(capacity), None) }
+    pub fn with_capacity(capacity: usize) -> Self { Self(ScriptBuf::with_capacity(capacity)) }
 
     /// Returns the length in bytes of the script.
     pub fn len(&self) -> usize { self.0.len() }
@@ -45,7 +45,6 @@ impl<T> Builder<T> {
     /// Only errors if `data == i32::MIN` (CScriptNum cannot have value -2^31).
     pub fn push_int(mut self, n: i32) -> Result<Self, Error> {
         self.0.push_int(n)?;
-        self.1 = None;
         Ok(self)
     }
 
@@ -66,7 +65,6 @@ impl<T> Builder<T> {
     /// Does not check whether `n` is in the range of [-2^31 +1...2^31 -1].
     pub fn push_int_unchecked(mut self, n: i64) -> Self {
         self.0.push_int_unchecked(n);
-        self.1 = None;
         self
     }
 
@@ -75,7 +73,6 @@ impl<T> Builder<T> {
     /// This uses the explicit encoding regardless of the availability of dedicated opcodes.
     pub(in crate::blockdata) fn push_int_non_minimal(mut self, data: i64) -> Self {
         self.0.push_int_non_minimal(data);
-        self.1 = None;
         self
     }
 
@@ -92,7 +89,6 @@ impl<T> Builder<T> {
     /// as an empty string rather than as a single 0 byte.
     pub fn push_slice<D: AsRef<PushBytes>>(mut self, data: D) -> Self {
         self.0.push_slice(data);
-        self.1 = None;
         self
     }
 
@@ -103,14 +99,12 @@ impl<T> Builder<T> {
     /// [CheckMinimalPush]: <https://github.com/bitcoin/bitcoin/blob/99a4ddf5ab1b3e514d08b90ad8565827fda7b63b/src/script/script.cpp#L366>
     pub fn push_slice_non_minimal<D: AsRef<PushBytes>>(mut self, data: D) -> Self {
         self.0.push_slice_non_minimal(data);
-        self.1 = None;
         self
     }
 
     /// Adds a single opcode to the script.
     pub fn push_opcode(mut self, data: Opcode) -> Self {
         self.0.push_opcode(data);
-        self.1 = Some(data);
         self
     }
 
@@ -126,7 +120,7 @@ impl<T> Builder<T> {
     /// semantics.
     pub fn push_verify(mut self) -> Self {
         // "duplicated code" because we need to update `1` field
-        match opcode_to_verify(self.1) {
+        match opcode_to_verify(self.0.last_opcode()) {
             Some(opcode) => {
                 (self.0).as_byte_vec().pop();
                 self.push_opcode(opcode)
@@ -199,8 +193,7 @@ impl<T> Default for Builder<T> {
 impl<T> From<Vec<u8>> for Builder<T> {
     fn from(v: Vec<u8>) -> Self {
         let script = ScriptBuf::from(v);
-        let last_op = script.last_opcode();
-        Self(script, last_op)
+        Self(script)
     }
 }
 

--- a/bitcoin/src/blockdata/script/builder.rs
+++ b/bitcoin/src/blockdata/script/builder.rs
@@ -70,15 +70,6 @@ impl<T> Builder<T> {
         Self::from(script.into_bytes())
     }
 
-    /// Adds instructions to push an integer onto the stack without optimization.
-    ///
-    /// This uses the explicit encoding regardless of the availability of dedicated opcodes.
-    pub(in crate::blockdata) fn push_int_non_minimal(self, data: i64) -> Self {
-        let mut script = self.into_script();
-        script.push_int_non_minimal(data);
-        Self::from(script.into_bytes())
-    }
-
     /// Adds instructions to push some arbitrary data onto the stack.
     ///
     /// If the data can be exactly produced by a numeric opcode, that opcode
@@ -188,6 +179,25 @@ impl<T> Builder<T> {
 
     /// Returns script bytes
     pub fn as_bytes(&self) -> &[u8] { self.as_script().as_bytes() }
+}
+
+mod sealed {
+    pub trait Sealed {}
+    impl<T> Sealed for super::Builder<T> {}
+}
+
+crate::internal_macros::define_extension_trait! {
+    /// Extension functionality for [`Builder`] that should be private.
+    pub(in crate::blockdata) trait BuilderExtPriv<T> impl<T> for Builder<T> {
+        /// Adds instructions to push an integer onto the stack without optimization.
+        ///
+        /// This uses the explicit encoding regardless of the availability of dedicated opcodes.
+        fn push_int_non_minimal(self, data: i64) -> Self {
+            let mut script = self.into_script();
+            script.push_int_non_minimal(data);
+            Self::from(script.into_bytes())
+        }
+    }
 }
 
 impl<T> Default for Builder<T> {

--- a/bitcoin/src/blockdata/script/builder.rs
+++ b/bitcoin/src/blockdata/script/builder.rs
@@ -27,13 +27,13 @@ impl<T> Builder<T> {
 
     /// Constructs a new empty script builder with at least the specified capacity.
     #[inline]
-    pub fn with_capacity(capacity: usize) -> Self { Self(ScriptBuf::with_capacity(capacity)) }
+    pub fn with_capacity(capacity: usize) -> Self { Self::from(Vec::with_capacity(capacity)) }
 
     /// Returns the length in bytes of the script.
-    pub fn len(&self) -> usize { self.0.len() }
+    pub fn len(&self) -> usize { self.as_script().len() }
 
     /// Checks whether the script is the empty script.
-    pub fn is_empty(&self) -> bool { self.0.is_empty() }
+    pub fn is_empty(&self) -> bool { self.as_script().is_empty() }
 
     /// Adds instructions to push an integer onto the stack.
     ///
@@ -43,9 +43,10 @@ impl<T> Builder<T> {
     /// # Errors
     ///
     /// Only errors if `data == i32::MIN` (CScriptNum cannot have value -2^31).
-    pub fn push_int(mut self, n: i32) -> Result<Self, Error> {
-        self.0.push_int(n)?;
-        Ok(self)
+    pub fn push_int(self, n: i32) -> Result<Self, Error> {
+        let mut script = self.into_script();
+        script.push_int(n)?;
+        Ok(Self::from(script.into_bytes()))
     }
 
     /// Adds instructions to push an unchecked integer onto the stack.
@@ -63,17 +64,19 @@ impl<T> Builder<T> {
     /// > throwing an exception if arithmetic is done or the result is interpreted as an integer.
     ///
     /// Does not check whether `n` is in the range of [-2^31 +1...2^31 -1].
-    pub fn push_int_unchecked(mut self, n: i64) -> Self {
-        self.0.push_int_unchecked(n);
-        self
+    pub fn push_int_unchecked(self, n: i64) -> Self {
+        let mut script = self.into_script();
+        script.push_int_unchecked(n);
+        Self::from(script.into_bytes())
     }
 
     /// Adds instructions to push an integer onto the stack without optimization.
     ///
     /// This uses the explicit encoding regardless of the availability of dedicated opcodes.
-    pub(in crate::blockdata) fn push_int_non_minimal(mut self, data: i64) -> Self {
-        self.0.push_int_non_minimal(data);
-        self
+    pub(in crate::blockdata) fn push_int_non_minimal(self, data: i64) -> Self {
+        let mut script = self.into_script();
+        script.push_int_non_minimal(data);
+        Self::from(script.into_bytes())
     }
 
     /// Adds instructions to push some arbitrary data onto the stack.
@@ -118,12 +121,14 @@ impl<T> Builder<T> {
     /// Note that existing `OP_*VERIFY` opcodes do not lead to the instruction being ignored
     /// because `OP_VERIFY` consumes an item from the stack so ignoring them would change the
     /// semantics.
-    pub fn push_verify(mut self) -> Self {
+    pub fn push_verify(self) -> Self {
         // "duplicated code" because we need to update `1` field
-        match opcode_to_verify(self.0.last_opcode()) {
+        match opcode_to_verify(self.as_script().last_opcode()) {
             Some(opcode) => {
-                (self.0).as_byte_vec().pop();
-                self.push_opcode(opcode)
+                let mut script = self.into_script();
+                script.as_byte_vec().pop();
+                let result = Self::from(script.into_bytes());
+                result.push_opcode(opcode)
             }
             None => self.push_opcode(OP_VERIFY),
         }
@@ -176,13 +181,13 @@ impl<T> Builder<T> {
     pub fn into_script(self) -> ScriptBuf<T> { self.0 }
 
     /// Converts the `Builder` into script bytes
-    pub fn into_bytes(self) -> Vec<u8> { self.0.into() }
+    pub fn into_bytes(self) -> Vec<u8> { self.into_script().into() }
 
     /// Returns the internal script
     pub fn as_script(&self) -> &Script<T> { &self.0 }
 
     /// Returns script bytes
-    pub fn as_bytes(&self) -> &[u8] { self.0.as_bytes() }
+    pub fn as_bytes(&self) -> &[u8] { self.as_script().as_bytes() }
 }
 
 impl<T> Default for Builder<T> {

--- a/bitcoin/src/blockdata/script/builder.rs
+++ b/bitcoin/src/blockdata/script/builder.rs
@@ -1,68 +1,16 @@
 // SPDX-License-Identifier: CC0-1.0
 
-use core::fmt;
-
-use super::{opcode_to_verify, Error, PushBytes, Script, ScriptBuf};
+use super::{opcode_to_verify, Error};
 use crate::key::{LegacyPublicKey, XOnlyPublicKey};
 use crate::locktime::absolute;
 use crate::opcodes::all::*;
-use crate::opcodes::Opcode;
 use crate::prelude::Vec;
 use crate::script::{ScriptBufExt as _, ScriptBufExtPriv as _, ScriptExtPriv as _};
 use crate::{relative, Sequence};
 
-/// An Object which can be used to construct a script piece by piece.
-///
-/// # Panics
-///
-/// `Builder` is backed by [`ScriptBuf`] and inherits its panic behavior. This means that
-/// attempting to construct scripts larger than `isize::MAX` bytes will panic.
-#[derive(PartialEq, Eq, Clone)]
-pub struct Builder<T>(ScriptBuf<T>);
-
-impl<T> Builder<T> {
-    /// Constructs a new empty script.
-    #[inline]
-    pub const fn new() -> Self { Self(ScriptBuf::new()) }
-
-    /// Adds instructions to push some arbitrary data onto the stack.
-    ///
-    /// If the data can be exactly produced by a numeric opcode, that opcode
-    /// will be used, since its behavior is equivalent but will not violate minimality
-    /// rules. To avoid this, use [`Builder::push_slice_non_minimal`] which will always
-    /// use a push opcode.
-    ///
-    /// However, this method does *not* enforce any numeric minimality rules.
-    /// If your pushes should be interpreted as numbers, ensure your input does
-    /// not have any leading zeros. In particular, the number 0 should be encoded
-    /// as an empty string rather than as a single 0 byte.
-    pub fn push_slice<D: AsRef<PushBytes>>(mut self, data: D) -> Self {
-        self.0.push_slice(data);
-        self
-    }
-
-    /// Adds instructions to push some arbitrary data onto the stack without minimality.
-    ///
-    /// Standardness rules require push minimality according to [CheckMinimalPush] of core.
-    ///
-    /// [CheckMinimalPush]: <https://github.com/bitcoin/bitcoin/blob/99a4ddf5ab1b3e514d08b90ad8565827fda7b63b/src/script/script.cpp#L366>
-    pub fn push_slice_non_minimal<D: AsRef<PushBytes>>(mut self, data: D) -> Self {
-        self.0.push_slice_non_minimal(data);
-        self
-    }
-
-    /// Adds a single opcode to the script.
-    pub fn push_opcode(mut self, data: Opcode) -> Self {
-        self.0.push_opcode(data);
-        self
-    }
-
-    /// Converts the `Builder` into `ScriptBuf`.
-    pub fn into_script(self) -> ScriptBuf<T> { self.0 }
-
-    /// Returns the internal script
-    pub fn as_script(&self) -> &Script<T> { &self.0 }
-}
+#[rustfmt::skip]                // Keep public re-exports separate.
+#[doc(inline)]
+pub use primitives::script::Builder;
 
 mod sealed {
     pub trait Sealed {}
@@ -203,24 +151,4 @@ crate::internal_macros::define_extension_trait! {
             Self::from(script.into_bytes())
         }
     }
-}
-
-impl<T> Default for Builder<T> {
-    fn default() -> Self { Self::new() }
-}
-
-/// Constructs a new builder from an existing vector.
-impl<T> From<Vec<u8>> for Builder<T> {
-    fn from(v: Vec<u8>) -> Self {
-        let script = ScriptBuf::from(v);
-        Self(script)
-    }
-}
-
-impl<T> fmt::Display for Builder<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(&self.0, f) }
-}
-
-impl<T> fmt::Debug for Builder<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(self, f) }
 }

--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -68,7 +68,7 @@ use crate::prelude::Vec;
 #[doc(inline)]
 pub use self::{
     borrowed::{ScriptExt, TapScriptExt, ScriptPubKeyExt, WitnessScriptExt, ScriptSigExt},
-    builder::Builder,
+    builder::{Builder, BuilderExt},
     instruction::{Instruction, Instructions, InstructionIndices},
     owned::{ScriptBufExt, ScriptPubKeyBufExt, ScriptSigBufExt},
     push_bytes::{PushBytes, PushBytesBuf, PushBytesExt, PushBytesErrorReport},

--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -85,6 +85,7 @@ pub use primitives::script::{
 };
 
 pub(crate) use self::borrowed::ScriptExtPriv;
+pub(in crate::blockdata) use self::builder::BuilderExtPriv;
 #[doc(no_inline)]
 pub use self::error::{
     Error, PushBytesError, RedeemScriptSizeError, ScriptIntError, WitnessScriptSizeError,

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -68,44 +68,6 @@ internal_macros::define_extension_trait! {
             }
         }
 
-        /// Adds a single opcode to the script.
-        fn push_opcode(&mut self, data: Opcode) { self.as_byte_vec().push(data.to_u8()); }
-
-        /// Adds instructions to push some arbitrary data onto the stack.
-        ///
-        /// If the data can be exactly produced by a numeric opcode, that opcode
-        /// will be used, since its behavior is equivalent but will not violate minimality
-        /// rules. To avoid this, use [`ScriptBuf::push_slice_non_minimal`] which will always
-        /// use a push opcode.
-        ///
-        /// However, this method does *not* enforce any numeric minimality rules.
-        /// If your pushes should be interpreted as numbers, ensure your input does
-        /// not have any leading zeros. In particular, the number 0 should be encoded
-        /// as an empty string rather than as a single 0 byte.
-        fn push_slice<D: AsRef<PushBytes>>(&mut self, data: D) {
-            let bytes = data.as_ref().as_bytes();
-            if bytes.len() == 1 {
-                match bytes[0] {
-                    0x81 => { self.push_opcode(OP_1NEGATE); },
-                    1..=16 => { self.push_opcode(Opcode::from(bytes[0] + (OP_1.to_u8() - 1))); },
-                    _ => { self.push_slice_non_minimal(data); },
-                }
-            } else {
-                self.push_slice_non_minimal(data);
-            }
-        }
-
-        /// Adds instructions to push some arbitrary data onto the stack without minimality.
-        ///
-        /// Standardness rules require push minimality according to [CheckMinimalPush] of core.
-        ///
-        /// [CheckMinimalPush]: <https://github.com/bitcoin/bitcoin/blob/99a4ddf5ab1b3e514d08b90ad8565827fda7b63b/src/script/script.cpp#L366>
-        fn push_slice_non_minimal<D: AsRef<PushBytes>>(&mut self, data: D) {
-            let data = data.as_ref();
-            self.reserve(Self::reserved_len_for_slice(data.len()));
-            self.push_slice_no_opt(data);
-        }
-
         /// Add a single instruction to the script.
         ///
         /// # Panics

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -16,7 +16,7 @@ use crate::opcodes::{self, Opcode};
 use crate::prelude::Vec;
 use crate::script::witness_program::{WitnessProgram, P2A_PROGRAM};
 use crate::script::witness_version::WitnessVersion;
-use crate::script::{self, ScriptHash, WScriptHash};
+use crate::script::{self, BuilderExt as _, ScriptHash, WScriptHash};
 use crate::taproot::TapNodeHash;
 use crate::{internal_macros, ToU64 as _};
 

--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: CC0-1.0
 
-#[cfg(feature = "serde")]
-use alloc::borrow::ToOwned;
 use alloc::string::ToString;
 
 use hex::hex;
@@ -265,22 +263,6 @@ fn script_x_only_key() {
     let x_only_key = KEYSTR[2..].parse::<XOnlyPublicKey>().unwrap();
     let script = Builder::<Tag>::new().push_x_only_key(x_only_key);
     assert_eq!(script.into_bytes(), &hex!(KEYSTR) as &[u8]);
-}
-
-#[test]
-fn script_builder() {
-    // from txid 3bb5e6434c11fb93f64574af5d116736510717f2c595eb45b52c28e31622dfff which was in my mempool when I wrote the test
-    let script = ScriptPubKey::builder()
-        .push_opcode(OP_DUP)
-        .push_opcode(OP_HASH160)
-        .push_slice(hex!("16e1ae70ff0fa102905d4af297f6912bda6cce19"))
-        .push_opcode(OP_EQUALVERIFY)
-        .push_opcode(OP_CHECKSIG)
-        .into_script();
-    assert_eq!(
-        script.to_hex_string_no_length_prefix(),
-        "76a91416e1ae70ff0fa102905d4af297f6912bda6cce1988ac"
-    );
 }
 
 #[test]
@@ -585,55 +567,6 @@ fn multisig() {
     )
     .unwrap()
     .is_multisig());
-}
-
-#[test]
-#[cfg(feature = "serde")]
-fn script_json_serialize() {
-    use serde_json;
-
-    let original = ScriptBuf::from_hex_no_length_prefix("827651a0698faaa9a8a7a687").unwrap();
-    let json = serde_json::to_value(&original).unwrap();
-    assert_eq!(json, serde_json::Value::String("827651a0698faaa9a8a7a687".to_owned()));
-    let des = serde_json::from_value::<ScriptBuf>(json).unwrap();
-    assert_eq!(original, des);
-}
-
-#[test]
-fn script_asm() {
-    assert_eq!(
-        ScriptBuf::from_hex_no_length_prefix("6363636363686868686800").unwrap().to_string(),
-        "OP_IF OP_IF OP_IF OP_IF OP_IF OP_ENDIF OP_ENDIF OP_ENDIF OP_ENDIF OP_ENDIF OP_0"
-    );
-    assert_eq!(ScriptBuf::from_hex_no_length_prefix("2102715e91d37d239dea832f1460e91e368115d8ca6cc23a7da966795abad9e3b699ac").unwrap().to_string(),
-               "OP_PUSHBYTES_33 02715e91d37d239dea832f1460e91e368115d8ca6cc23a7da966795abad9e3b699 OP_CHECKSIG");
-    // Elements Alpha peg-out transaction with some signatures removed for brevity. Mainly to test PUSHDATA1
-    assert_eq!(ScriptBuf::from_hex_no_length_prefix("0047304402202457e78cc1b7f50d0543863c27de75d07982bde8359b9e3316adec0aec165f2f02200203fd331c4e4a4a02f48cf1c291e2c0d6b2f7078a784b5b3649fca41f8794d401004cf1552103244e602b46755f24327142a0517288cebd159eccb6ccf41ea6edf1f601e9af952103bbbacc302d19d29dbfa62d23f37944ae19853cf260c745c2bea739c95328fcb721039227e83246bd51140fe93538b2301c9048be82ef2fb3c7fc5d78426ed6f609ad210229bf310c379b90033e2ecb07f77ecf9b8d59acb623ab7be25a0caed539e2e6472103703e2ed676936f10b3ce9149fa2d4a32060fb86fa9a70a4efe3f21d7ab90611921031e9b7c6022400a6bb0424bbcde14cff6c016b91ee3803926f3440abf5c146d05210334667f975f55a8455d515a2ef1c94fdfa3315f12319a14515d2a13d82831f62f57ae").unwrap().to_string(),
-               "OP_0 OP_PUSHBYTES_71 304402202457e78cc1b7f50d0543863c27de75d07982bde8359b9e3316adec0aec165f2f02200203fd331c4e4a4a02f48cf1c291e2c0d6b2f7078a784b5b3649fca41f8794d401 OP_0 OP_PUSHDATA1 552103244e602b46755f24327142a0517288cebd159eccb6ccf41ea6edf1f601e9af952103bbbacc302d19d29dbfa62d23f37944ae19853cf260c745c2bea739c95328fcb721039227e83246bd51140fe93538b2301c9048be82ef2fb3c7fc5d78426ed6f609ad210229bf310c379b90033e2ecb07f77ecf9b8d59acb623ab7be25a0caed539e2e6472103703e2ed676936f10b3ce9149fa2d4a32060fb86fa9a70a4efe3f21d7ab90611921031e9b7c6022400a6bb0424bbcde14cff6c016b91ee3803926f3440abf5c146d05210334667f975f55a8455d515a2ef1c94fdfa3315f12319a14515d2a13d82831f62f57ae");
-    // Various weird scripts found in transaction 6d7ed9914625c73c0288694a6819196a27ef6c08f98e1270d975a8e65a3dc09a
-    // which triggered overflow bugs on 32-bit machines in script formatting in the past.
-    assert_eq!(
-        ScriptBuf::from_hex_no_length_prefix("01").unwrap().to_string(),
-        "OP_PUSHBYTES_1 <push past end>"
-    );
-    assert_eq!(
-        ScriptBuf::from_hex_no_length_prefix("0201").unwrap().to_string(),
-        "OP_PUSHBYTES_2 <push past end>"
-    );
-    assert_eq!(ScriptBuf::from_hex_no_length_prefix("4c").unwrap().to_string(), "<unexpected end>");
-    assert_eq!(
-        ScriptBuf::from_hex_no_length_prefix("4c0201").unwrap().to_string(),
-        "OP_PUSHDATA1 <push past end>"
-    );
-    assert_eq!(ScriptBuf::from_hex_no_length_prefix("4d").unwrap().to_string(), "<unexpected end>");
-    assert_eq!(
-        ScriptBuf::from_hex_no_length_prefix("4dffff01").unwrap().to_string(),
-        "OP_PUSHDATA2 <push past end>"
-    );
-    assert_eq!(
-        ScriptBuf::from_hex_no_length_prefix("4effffffff01").unwrap().to_string(),
-        "OP_PUSHDATA4 <push past end>"
-    );
 }
 
 #[test]

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -105,7 +105,7 @@ pub mod ext {
         network::NetworkExt as _,
         opcodes::OpcodeExt as _,
         pow::{CompactTargetExt as _, TargetExt as _, WorkExt as _},
-        script::{PushBytesExt as _, ScriptExt as _, ScriptBufExt as _, TapScriptExt as _, ScriptPubKeyExt as _, ScriptPubKeyBufExt as _, WitnessScriptExt as _, ScriptSigExt as _},
+        script::{BuilderExt as _, PushBytesExt as _, ScriptExt as _, ScriptBufExt as _, TapScriptExt as _, ScriptPubKeyExt as _, ScriptPubKeyBufExt as _, WitnessScriptExt as _, ScriptSigExt as _},
         taproot::{TapLeafHashExt as _, TapNodeHashExt as _},
         transaction::{TxidExt as _, WtxidExt as _, OutPointExt as _, TxInExt as _, TxOutExt as _, TransactionExt as _},
         witness::WitnessExt as _,

--- a/primitives/api/all-features.txt
+++ b/primitives/api/all-features.txt
@@ -1959,6 +1959,58 @@ impl<T> core::clone::CloneToUninit for bitcoin_primitives::script::WitnessScript
 pub unsafe fn bitcoin_primitives::script::WitnessScriptTag::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::script::WitnessScriptTag
 pub fn bitcoin_primitives::script::WitnessScriptTag::from(t: T) -> T
+pub struct bitcoin_primitives::script::Builder<T>(_)
+impl<T> bitcoin_primitives::script::Builder<T>
+pub fn bitcoin_primitives::script::Builder<T>::as_script(&self) -> &bitcoin_primitives::script::Script<T>
+pub fn bitcoin_primitives::script::Builder<T>::into_script(self) -> bitcoin_primitives::script::ScriptBuf<T>
+pub const fn bitcoin_primitives::script::Builder<T>::new() -> Self
+pub fn bitcoin_primitives::script::Builder<T>::push_opcode(self, data: bitcoin_primitives::opcodes::Opcode) -> Self
+pub fn bitcoin_primitives::script::Builder<T>::push_slice<D: core::convert::AsRef<bitcoin_primitives::script::PushBytes>>(self, data: D) -> Self
+pub fn bitcoin_primitives::script::Builder<T>::push_slice_non_minimal<D: core::convert::AsRef<bitcoin_primitives::script::PushBytes>>(self, data: D) -> Self
+impl<T: core::clone::Clone> core::clone::Clone for bitcoin_primitives::script::Builder<T>
+pub fn bitcoin_primitives::script::Builder<T>::clone(&self) -> bitcoin_primitives::script::Builder<T>
+impl<T: core::cmp::Eq> core::cmp::Eq for bitcoin_primitives::script::Builder<T>
+impl<T: core::cmp::PartialEq> core::cmp::PartialEq for bitcoin_primitives::script::Builder<T>
+pub fn bitcoin_primitives::script::Builder<T>::eq(&self, other: &bitcoin_primitives::script::Builder<T>) -> bool
+impl<T> core::convert::From<alloc::vec::Vec<u8>> for bitcoin_primitives::script::Builder<T>
+pub fn bitcoin_primitives::script::Builder<T>::from(v: alloc::vec::Vec<u8>) -> Self
+impl<T> core::default::Default for bitcoin_primitives::script::Builder<T>
+pub fn bitcoin_primitives::script::Builder<T>::default() -> Self
+impl<T> core::fmt::Debug for bitcoin_primitives::script::Builder<T>
+pub fn bitcoin_primitives::script::Builder<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<T> core::fmt::Display for bitcoin_primitives::script::Builder<T>
+impl<T> core::marker::StructuralPartialEq for bitcoin_primitives::script::Builder<T>
+impl<T> core::marker::Freeze for bitcoin_primitives::script::Builder<T>
+impl<T> core::marker::Send for bitcoin_primitives::script::Builder<T> where T: core::marker::Send
+impl<T> core::marker::Sync for bitcoin_primitives::script::Builder<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bitcoin_primitives::script::Builder<T> where T: core::marker::Unpin
+impl<T> core::marker::UnsafeUnpin for bitcoin_primitives::script::Builder<T>
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::script::Builder<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::script::Builder<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<T, U> core::convert::Into<U> for bitcoin_primitives::script::Builder<T> where U: core::convert::From<T>
+pub fn bitcoin_primitives::script::Builder<T>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::script::Builder<T> where U: core::convert::Into<T>
+pub type bitcoin_primitives::script::Builder<T>::Error = core::convert::Infallible
+pub fn bitcoin_primitives::script::Builder<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::script::Builder<T> where U: core::convert::TryFrom<T>
+pub type bitcoin_primitives::script::Builder<T>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_primitives::script::Builder<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_primitives::script::Builder<T> where T: core::clone::Clone
+pub type bitcoin_primitives::script::Builder<T>::Owned = T
+pub fn bitcoin_primitives::script::Builder<T>::clone_into(&self, target: &mut T)
+pub fn bitcoin_primitives::script::Builder<T>::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin_primitives::script::Builder<T> where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_primitives::script::Builder<T>::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin_primitives::script::Builder<T> where T: 'static + ?core::marker::Sized
+pub fn bitcoin_primitives::script::Builder<T>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_primitives::script::Builder<T> where T: ?core::marker::Sized
+pub fn bitcoin_primitives::script::Builder<T>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::script::Builder<T> where T: ?core::marker::Sized
+pub fn bitcoin_primitives::script::Builder<T>::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_primitives::script::Builder<T> where T: core::clone::Clone
+pub unsafe fn bitcoin_primitives::script::Builder<T>::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_primitives::script::Builder<T>
+pub fn bitcoin_primitives::script::Builder<T>::from(t: T) -> T
 #[repr(transparent)] pub struct bitcoin_primitives::script::PushBytes(_)
 impl bitcoin_primitives::script::PushBytes
 pub fn bitcoin_primitives::script::PushBytes::as_bytes(&self) -> &[u8]
@@ -3208,6 +3260,9 @@ pub fn bitcoin_primitives::script::ScriptBuf<T>::from_hex_prefixed(s: &str) -> c
 pub fn bitcoin_primitives::script::ScriptBuf<T>::into_boxed_script(self) -> alloc::boxed::Box<bitcoin_primitives::script::Script<T>>
 pub fn bitcoin_primitives::script::ScriptBuf<T>::into_bytes(self) -> alloc::vec::Vec<u8>
 pub const fn bitcoin_primitives::script::ScriptBuf<T>::new() -> Self
+pub fn bitcoin_primitives::script::ScriptBuf<T>::push_opcode(&mut self, data: bitcoin_primitives::opcodes::Opcode)
+pub fn bitcoin_primitives::script::ScriptBuf<T>::push_slice<D: core::convert::AsRef<bitcoin_primitives::script::PushBytes>>(&mut self, data: D)
+pub fn bitcoin_primitives::script::ScriptBuf<T>::push_slice_non_minimal<D: core::convert::AsRef<bitcoin_primitives::script::PushBytes>>(&mut self, data: D)
 pub fn bitcoin_primitives::script::ScriptBuf<T>::reserve(&mut self, additional_len: usize)
 pub fn bitcoin_primitives::script::ScriptBuf<T>::reserve_exact(&mut self, additional_len: usize)
 pub fn bitcoin_primitives::script::ScriptBuf<T>::to_hex(&self) -> alloc::string::String

--- a/primitives/api/alloc-only.txt
+++ b/primitives/api/alloc-only.txt
@@ -1849,6 +1849,58 @@ impl<T> core::clone::CloneToUninit for bitcoin_primitives::script::WitnessScript
 pub unsafe fn bitcoin_primitives::script::WitnessScriptTag::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_primitives::script::WitnessScriptTag
 pub fn bitcoin_primitives::script::WitnessScriptTag::from(t: T) -> T
+pub struct bitcoin_primitives::script::Builder<T>(_)
+impl<T> bitcoin_primitives::script::Builder<T>
+pub fn bitcoin_primitives::script::Builder<T>::as_script(&self) -> &bitcoin_primitives::script::Script<T>
+pub fn bitcoin_primitives::script::Builder<T>::into_script(self) -> bitcoin_primitives::script::ScriptBuf<T>
+pub const fn bitcoin_primitives::script::Builder<T>::new() -> Self
+pub fn bitcoin_primitives::script::Builder<T>::push_opcode(self, data: bitcoin_primitives::opcodes::Opcode) -> Self
+pub fn bitcoin_primitives::script::Builder<T>::push_slice<D: core::convert::AsRef<bitcoin_primitives::script::PushBytes>>(self, data: D) -> Self
+pub fn bitcoin_primitives::script::Builder<T>::push_slice_non_minimal<D: core::convert::AsRef<bitcoin_primitives::script::PushBytes>>(self, data: D) -> Self
+impl<T: core::clone::Clone> core::clone::Clone for bitcoin_primitives::script::Builder<T>
+pub fn bitcoin_primitives::script::Builder<T>::clone(&self) -> bitcoin_primitives::script::Builder<T>
+impl<T: core::cmp::Eq> core::cmp::Eq for bitcoin_primitives::script::Builder<T>
+impl<T: core::cmp::PartialEq> core::cmp::PartialEq for bitcoin_primitives::script::Builder<T>
+pub fn bitcoin_primitives::script::Builder<T>::eq(&self, other: &bitcoin_primitives::script::Builder<T>) -> bool
+impl<T> core::convert::From<alloc::vec::Vec<u8>> for bitcoin_primitives::script::Builder<T>
+pub fn bitcoin_primitives::script::Builder<T>::from(v: alloc::vec::Vec<u8>) -> Self
+impl<T> core::default::Default for bitcoin_primitives::script::Builder<T>
+pub fn bitcoin_primitives::script::Builder<T>::default() -> Self
+impl<T> core::fmt::Debug for bitcoin_primitives::script::Builder<T>
+pub fn bitcoin_primitives::script::Builder<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<T> core::fmt::Display for bitcoin_primitives::script::Builder<T>
+impl<T> core::marker::StructuralPartialEq for bitcoin_primitives::script::Builder<T>
+impl<T> core::marker::Freeze for bitcoin_primitives::script::Builder<T>
+impl<T> core::marker::Send for bitcoin_primitives::script::Builder<T> where T: core::marker::Send
+impl<T> core::marker::Sync for bitcoin_primitives::script::Builder<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bitcoin_primitives::script::Builder<T> where T: core::marker::Unpin
+impl<T> core::marker::UnsafeUnpin for bitcoin_primitives::script::Builder<T>
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::script::Builder<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::script::Builder<T> where T: core::panic::unwind_safe::UnwindSafe
+impl<T, U> core::convert::Into<U> for bitcoin_primitives::script::Builder<T> where U: core::convert::From<T>
+pub fn bitcoin_primitives::script::Builder<T>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::script::Builder<T> where U: core::convert::Into<T>
+pub type bitcoin_primitives::script::Builder<T>::Error = core::convert::Infallible
+pub fn bitcoin_primitives::script::Builder<T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::script::Builder<T> where U: core::convert::TryFrom<T>
+pub type bitcoin_primitives::script::Builder<T>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_primitives::script::Builder<T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_primitives::script::Builder<T> where T: core::clone::Clone
+pub type bitcoin_primitives::script::Builder<T>::Owned = T
+pub fn bitcoin_primitives::script::Builder<T>::clone_into(&self, target: &mut T)
+pub fn bitcoin_primitives::script::Builder<T>::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin_primitives::script::Builder<T> where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_primitives::script::Builder<T>::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin_primitives::script::Builder<T> where T: 'static + ?core::marker::Sized
+pub fn bitcoin_primitives::script::Builder<T>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_primitives::script::Builder<T> where T: ?core::marker::Sized
+pub fn bitcoin_primitives::script::Builder<T>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::script::Builder<T> where T: ?core::marker::Sized
+pub fn bitcoin_primitives::script::Builder<T>::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_primitives::script::Builder<T> where T: core::clone::Clone
+pub unsafe fn bitcoin_primitives::script::Builder<T>::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_primitives::script::Builder<T>
+pub fn bitcoin_primitives::script::Builder<T>::from(t: T) -> T
 #[repr(transparent)] pub struct bitcoin_primitives::script::PushBytes(_)
 impl bitcoin_primitives::script::PushBytes
 pub fn bitcoin_primitives::script::PushBytes::as_bytes(&self) -> &[u8]
@@ -3085,6 +3137,9 @@ pub const fn bitcoin_primitives::script::ScriptBuf<T>::from_bytes(bytes: alloc::
 pub fn bitcoin_primitives::script::ScriptBuf<T>::into_boxed_script(self) -> alloc::boxed::Box<bitcoin_primitives::script::Script<T>>
 pub fn bitcoin_primitives::script::ScriptBuf<T>::into_bytes(self) -> alloc::vec::Vec<u8>
 pub const fn bitcoin_primitives::script::ScriptBuf<T>::new() -> Self
+pub fn bitcoin_primitives::script::ScriptBuf<T>::push_opcode(&mut self, data: bitcoin_primitives::opcodes::Opcode)
+pub fn bitcoin_primitives::script::ScriptBuf<T>::push_slice<D: core::convert::AsRef<bitcoin_primitives::script::PushBytes>>(&mut self, data: D)
+pub fn bitcoin_primitives::script::ScriptBuf<T>::push_slice_non_minimal<D: core::convert::AsRef<bitcoin_primitives::script::PushBytes>>(&mut self, data: D)
 pub fn bitcoin_primitives::script::ScriptBuf<T>::reserve(&mut self, additional_len: usize)
 pub fn bitcoin_primitives::script::ScriptBuf<T>::reserve_exact(&mut self, additional_len: usize)
 pub fn bitcoin_primitives::script::ScriptBuf<T>::with_capacity(capacity: usize) -> Self

--- a/primitives/src/script/builder.rs
+++ b/primitives/src/script/builder.rs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: CC0-1.0
+
+use core::fmt;
+
+use super::{PushBytes, Script, ScriptBuf};
+use crate::opcodes::Opcode;
+use crate::prelude::Vec;
+
+/// An Object which can be used to construct a script piece by piece.
+///
+/// # Panics
+///
+/// `Builder` is backed by [`ScriptBuf`] and inherits its panic behavior. This means that
+/// attempting to construct scripts larger than `isize::MAX` bytes will panic.
+#[derive(PartialEq, Eq, Clone)]
+pub struct Builder<T>(ScriptBuf<T>);
+
+impl<T> Builder<T> {
+    /// Constructs a new empty script.
+    #[inline]
+    pub const fn new() -> Self { Self(ScriptBuf::new()) }
+
+    /// Adds instructions to push some arbitrary data onto the stack.
+    ///
+    /// If the data can be exactly produced by a numeric opcode, that opcode
+    /// will be used, since its behavior is equivalent but will not violate minimality
+    /// rules. To avoid this, use [`Builder::push_slice_non_minimal`] which will always
+    /// use a push opcode.
+    ///
+    /// However, this method does *not* enforce any numeric minimality rules.
+    /// If your pushes should be interpreted as numbers, ensure your input does
+    /// not have any leading zeros. In particular, the number 0 should be encoded
+    /// as an empty string rather than as a single 0 byte.
+    pub fn push_slice<D: AsRef<PushBytes>>(mut self, data: D) -> Self {
+        self.0.push_slice(data);
+        self
+    }
+
+    /// Adds instructions to push some arbitrary data onto the stack without minimality.
+    ///
+    /// Standardness rules require push minimality according to [CheckMinimalPush] of core.
+    ///
+    /// [CheckMinimalPush]: <https://github.com/bitcoin/bitcoin/blob/99a4ddf5ab1b3e514d08b90ad8565827fda7b63b/src/script/script.cpp#L366>
+    pub fn push_slice_non_minimal<D: AsRef<PushBytes>>(mut self, data: D) -> Self {
+        self.0.push_slice_non_minimal(data);
+        self
+    }
+
+    /// Adds a single opcode to the script.
+    pub fn push_opcode(mut self, data: Opcode) -> Self {
+        self.0.push_opcode(data);
+        self
+    }
+
+    /// Converts the `Builder` into `ScriptBuf`.
+    pub fn into_script(self) -> ScriptBuf<T> { self.0 }
+
+    /// Returns the internal script
+    pub fn as_script(&self) -> &Script<T> { &self.0 }
+}
+
+impl<T> Default for Builder<T> {
+    fn default() -> Self { Self::new() }
+}
+
+/// Constructs a new builder from an existing vector.
+impl<T> From<Vec<u8>> for Builder<T> {
+    fn from(v: Vec<u8>) -> Self {
+        let script = ScriptBuf::from(v);
+        Self(script)
+    }
+}
+
+impl<T> fmt::Display for Builder<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(&self.0, f) }
+}
+
+impl<T> fmt::Debug for Builder<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(self, f) }
+}

--- a/primitives/src/script/builder.rs
+++ b/primitives/src/script/builder.rs
@@ -31,6 +31,7 @@ impl<T> Builder<T> {
     /// If your pushes should be interpreted as numbers, ensure your input does
     /// not have any leading zeros. In particular, the number 0 should be encoded
     /// as an empty string rather than as a single 0 byte.
+    #[must_use]
     pub fn push_slice<D: AsRef<PushBytes>>(mut self, data: D) -> Self {
         self.0.push_slice(data);
         self
@@ -41,12 +42,14 @@ impl<T> Builder<T> {
     /// Standardness rules require push minimality according to [CheckMinimalPush] of core.
     ///
     /// [CheckMinimalPush]: <https://github.com/bitcoin/bitcoin/blob/99a4ddf5ab1b3e514d08b90ad8565827fda7b63b/src/script/script.cpp#L366>
+    #[must_use]
     pub fn push_slice_non_minimal<D: AsRef<PushBytes>>(mut self, data: D) -> Self {
         self.0.push_slice_non_minimal(data);
         self
     }
 
     /// Adds a single opcode to the script.
+    #[must_use]
     pub fn push_opcode(mut self, data: Opcode) -> Self {
         self.0.push_opcode(data);
         self

--- a/primitives/src/script/builder.rs
+++ b/primitives/src/script/builder.rs
@@ -81,3 +81,113 @@ impl<T> fmt::Display for Builder<T> {
 impl<T> fmt::Debug for Builder<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(self, f) }
 }
+
+#[cfg(test)]
+mod tests {
+    use alloc::{format, vec};
+
+    use super::Builder;
+    use crate::script::{PushBytes, ScriptSigTag as Tag};
+
+    #[test]
+    fn push_slice_minimal() {
+        let script = Builder::<Tag>::new().push_slice([0x81]).into_script();
+        assert_eq!(script.as_bytes(), &[0x4f]);
+
+        for n in 1u8..=16 {
+            let script = Builder::<Tag>::new().push_slice([n]).into_script();
+            assert_eq!(script.as_bytes(), &[0x50 + n]);
+        }
+
+        let script = Builder::<Tag>::new().push_slice([0u8]).into_script();
+        assert_eq!(script.as_bytes(), &[1, 0]);
+        let script = Builder::<Tag>::new().push_slice([17u8]).into_script();
+        assert_eq!(script.as_bytes(), &[1, 17]);
+        let script = Builder::<Tag>::new().push_slice(b"NRA4VR").into_script();
+        assert_eq!(script.as_bytes(), &[6, b'N', b'R', b'A', b'4', b'V', b'R']);
+    }
+
+    #[test]
+    fn push_slice_non_minimal() {
+        let script = Builder::<Tag>::new().push_slice_non_minimal([0x81]).into_script();
+        assert_eq!(script.as_bytes(), &[1, 0x81]);
+
+        let script = Builder::<Tag>::new().push_slice_non_minimal([1u8]).into_script();
+        assert_eq!(script.as_bytes(), &[1, 1]);
+    }
+
+    #[test]
+    fn push_slice_pushdata1_and_pushdata2() {
+        let script = Builder::<Tag>::new()
+            .push_slice(<&PushBytes>::try_from([0xab; 0x4b].as_slice()).unwrap())
+            .into_script();
+        assert_eq!(script.as_bytes()[0], 0x4b);
+        assert_eq!(script.len(), 1 + 0x4b);
+
+        let script = Builder::<Tag>::new()
+            .push_slice(<&PushBytes>::try_from([0xab; 0x4c].as_slice()).unwrap())
+            .into_script();
+        assert_eq!(&script.as_bytes()[..2], &[0x4c, 0x4c]);
+        assert_eq!(script.len(), 2 + 0x4c);
+
+        let script = Builder::<Tag>::new()
+            .push_slice(<&PushBytes>::try_from([0xab; 0xff].as_slice()).unwrap())
+            .into_script();
+        assert_eq!(&script.as_bytes()[..2], &[0x4c, 0xff]);
+        assert_eq!(script.len(), 2 + 0xff);
+
+        let script = Builder::<Tag>::new()
+            .push_slice(<&PushBytes>::try_from([0xab; 0x100].as_slice()).unwrap())
+            .into_script();
+        assert_eq!(&script.as_bytes()[..3], &[0x4d, 0x00, 0x01]);
+        assert_eq!(script.len(), 3 + 0x100);
+
+        let script = Builder::<Tag>::new()
+            .push_slice(<&PushBytes>::try_from([0xab; 0x102].as_slice()).unwrap())
+            .into_script();
+        assert_eq!(&script.as_bytes()[..3], &[0x4d, 0x02, 0x01]);
+        assert_eq!(script.len(), 3 + 0x102);
+
+        let script = Builder::<Tag>::new()
+            .push_slice(<&PushBytes>::try_from(vec![0xab; 0xffff].as_slice()).unwrap())
+            .into_script();
+        assert_eq!(&script.as_bytes()[..3], &[0x4d, 0xff, 0xff]);
+        assert_eq!(script.len(), 3 + 0xffff);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn push_slice_pushdata4_boundary() {
+        let script = Builder::<Tag>::new()
+            .push_slice(<&PushBytes>::try_from(vec![0u8; 0x10000].as_slice()).unwrap())
+            .into_script();
+        assert_eq!(&script.as_bytes()[..5], &[0x4e, 0x00, 0x00, 0x01, 0x00]);
+        assert_eq!(script.len(), 5 + 0x10000);
+    }
+
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    #[cfg_attr(miri, ignore)]
+    fn push_slice_pushdata4_length_bytes() {
+        let len = 0x0102_0304;
+        let script = Builder::<Tag>::new()
+            .push_slice(<&PushBytes>::try_from(vec![0u8; len].as_slice()).unwrap())
+            .into_script();
+        assert_eq!(&script.as_bytes()[..5], &[0x4e, 0x04, 0x03, 0x02, 0x01]);
+        assert_eq!(script.len(), 5 + len);
+    }
+
+    #[test]
+    fn from_vec() {
+        let script = Builder::<Tag>::from(vec![0xac, 0x51]).into_script();
+        assert_eq!(script.as_bytes(), &[0xac, 0x51]);
+    }
+
+    #[test]
+    fn display_delegates_to_script() {
+        let builder = Builder::<Tag>::from(vec![0x51, 0x52]);
+        let displayed = format!("{}", builder);
+        assert!(!displayed.is_empty());
+        assert_eq!(displayed, format!("{}", builder.as_script()));
+    }
+}

--- a/primitives/src/script/mod.rs
+++ b/primitives/src/script/mod.rs
@@ -3,6 +3,7 @@
 //! Bitcoin scripts.
 
 mod borrowed;
+mod builder;
 mod owned;
 mod push_bytes;
 mod tag;
@@ -29,6 +30,7 @@ use crate::prelude::{Borrow, BorrowMut, Box, Cow, ToOwned, Vec};
 #[doc(inline)]
 pub use self::{
     borrowed::{Script, ScriptEncoder},
+    builder::Builder,
     owned::{ScriptBuf, ScriptBufDecoder},
     push_bytes::{PushBytes, PushBytesBuf, PushBytesErrorReport},
     tag::{Tag, RedeemScriptTag, ScriptPubKeyTag, ScriptSigTag, SignetBlockScriptTag, TapScriptTag, WitnessScriptTag},

--- a/primitives/src/script/owned.rs
+++ b/primitives/src/script/owned.rs
@@ -342,3 +342,34 @@ impl<'a, T> Arbitrary<'a> for ScriptBuf<T> {
         Ok(Self::from_bytes(v))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use super::ScriptBuf;
+    use crate::script::ScriptSigTag as Tag;
+
+    #[test]
+    fn reserved_len_for_slice() {
+        // Length plus the size of the push opcode that prefixes it.
+        assert_eq!(ScriptBuf::<Tag>::reserved_len_for_slice(0), 1);
+        assert_eq!(ScriptBuf::<Tag>::reserved_len_for_slice(0x4b), 0x4b + 1);
+        assert_eq!(ScriptBuf::<Tag>::reserved_len_for_slice(0x4c), 0x4c + 2);
+        assert_eq!(ScriptBuf::<Tag>::reserved_len_for_slice(0xff), 0xff + 2);
+        assert_eq!(ScriptBuf::<Tag>::reserved_len_for_slice(0x100), 0x100 + 3);
+        assert_eq!(ScriptBuf::<Tag>::reserved_len_for_slice(0xffff), 0xffff + 3);
+        assert_eq!(ScriptBuf::<Tag>::reserved_len_for_slice(0x10000), 0x10000 + 5);
+    }
+
+    #[test]
+    fn as_byte_vec_deref_restores() {
+        let mut script = ScriptBuf::<Tag>::from_bytes(vec![1, 2, 3]);
+        {
+            let vec = script.as_byte_vec();
+            assert_eq!(vec.len(), 3);
+            assert_eq!(vec.as_slice(), &[1, 2, 3]);
+        }
+        assert_eq!(script.as_bytes(), &[1, 2, 3]);
+    }
+}

--- a/primitives/src/script/owned.rs
+++ b/primitives/src/script/owned.rs
@@ -250,7 +250,7 @@ impl<T> ScriptBuf<T> {
                 this.push((n % 0x100) as u8);
                 this.push(((n / 0x100) % 0x100) as u8);
                 this.push(((n / 0x10000) % 0x100) as u8);
-                this.push((n / 0x1000000) as u8);
+                this.push((n / 0x0100_0000) as u8);
             }
         }
         // Then push the raw bytes

--- a/primitives/src/script/owned.rs
+++ b/primitives/src/script/owned.rs
@@ -8,7 +8,10 @@ use arbitrary::{Arbitrary, Unstructured};
 use encoding::{ByteVecDecoder, DecoderStatus};
 
 use super::{Script, ScriptBufDecoderError};
+use crate::opcodes::all::{OP_1, OP_1NEGATE};
+use crate::opcodes::{self, Opcode};
 use crate::prelude::{Box, Vec};
+use crate::script::PushBytes;
 
 /// An owned, growable script.
 ///
@@ -160,6 +163,99 @@ impl<T> ScriptBuf<T> {
     #[inline]
     #[deprecated(since = "1.0.0-rc.0", note = "use `format!(\"{var:x}\")` instead")]
     pub fn to_hex(&self) -> alloc::string::String { alloc::format!("{:x}", self) }
+
+    /// Adds a single opcode to the script.
+    pub fn push_opcode(&mut self, data: Opcode) { self.as_byte_vec().push(data.to_u8()); }
+
+    /// Adds instructions to push some arbitrary data onto the stack.
+    ///
+    /// If the data can be exactly produced by a numeric opcode, that opcode
+    /// will be used, since its behavior is equivalent but will not violate minimality
+    /// rules. To avoid this, use [`ScriptBuf::push_slice_non_minimal`] which will always
+    /// use a push opcode.
+    ///
+    /// However, this method does *not* enforce any numeric minimality rules.
+    /// If your pushes should be interpreted as numbers, ensure your input does
+    /// not have any leading zeros. In particular, the number 0 should be encoded
+    /// as an empty string rather than as a single 0 byte.
+    pub fn push_slice<D: AsRef<PushBytes>>(&mut self, data: D) {
+        let bytes = data.as_ref().as_bytes();
+        if bytes.len() == 1 {
+            match bytes[0] {
+                0x81 => {
+                    self.push_opcode(OP_1NEGATE);
+                }
+                1..=16 => {
+                    self.push_opcode(Opcode::from(bytes[0] + (OP_1.to_u8() - 1)));
+                }
+                _ => {
+                    self.push_slice_non_minimal(data);
+                }
+            }
+        } else {
+            self.push_slice_non_minimal(data);
+        }
+    }
+
+    /// Adds instructions to push some arbitrary data onto the stack without minimality.
+    ///
+    /// Standardness rules require push minimality according to [CheckMinimalPush] of core.
+    ///
+    /// [CheckMinimalPush]: <https://github.com/bitcoin/bitcoin/blob/99a4ddf5ab1b3e514d08b90ad8565827fda7b63b/src/script/script.cpp#L366>
+    pub fn push_slice_non_minimal<D: AsRef<PushBytes>>(&mut self, data: D) {
+        let data = data.as_ref();
+        self.reserve(Self::reserved_len_for_slice(data.len()));
+        self.push_slice_no_opt(data);
+    }
+
+    /// Computes the sum of `len` and the length of an appropriate push opcode.
+    fn reserved_len_for_slice(len: usize) -> usize {
+        len + match len {
+            0..=0x4b => 1,
+            0x4c..=0xff => 2,
+            0x100..=0xffff => 3,
+            // we don't care about oversized, the other fn will panic anyway
+            _ => 5,
+        }
+    }
+
+    /// Pretends to convert `&mut ScriptBuf` to `&mut Vec<u8>` so that it can be modified.
+    ///
+    /// Note: if the returned value leaks the original `ScriptBuf` will become empty.
+    fn as_byte_vec(&mut self) -> ScriptBufAsVec<'_, T> {
+        let vec = core::mem::take(self).into_bytes();
+        ScriptBufAsVec(self, vec)
+    }
+
+    /// Pushes the slice without reserving
+    fn push_slice_no_opt(&mut self, data: &PushBytes) {
+        let mut this = self.as_byte_vec();
+        // Start with a PUSH opcode
+        match data.len() as u64 {
+            n if n < opcodes::OP_PUSHDATA1.into() => {
+                this.push(n as u8);
+            }
+            n if n < 0x100 => {
+                this.push(opcodes::OP_PUSHDATA1);
+                this.push(n as u8);
+            }
+            n if n < 0x10000 => {
+                this.push(opcodes::OP_PUSHDATA2);
+                this.push((n % 0x100) as u8);
+                this.push((n / 0x100) as u8);
+            }
+            // `PushBytes` enforces len < 0x100000000
+            n => {
+                this.push(opcodes::OP_PUSHDATA4);
+                this.push((n % 0x100) as u8);
+                this.push(((n / 0x100) % 0x100) as u8);
+                this.push(((n / 0x10000) % 0x100) as u8);
+                this.push((n / 0x1000000) as u8);
+            }
+        }
+        // Then push the raw bytes
+        this.extend_from_slice(data.as_bytes());
+    }
 }
 
 // Cannot derive due to generics.
@@ -212,6 +308,30 @@ impl<T> encoding::Decoder for ScriptBufDecoder<T> {
 
     #[inline]
     fn read_limit(&self) -> usize { self.0.read_limit() }
+}
+
+/// Pretends that this is a mutable reference to [`ScriptBuf`]'s internal buffer.
+///
+/// In reality the backing `Vec<u8>` is swapped with an empty one and this is holding both the
+/// reference and the vec. The vec is put back when this drops so it also covers panics. (But not
+/// leaks, which is OK since we never leak.)
+pub(crate) struct ScriptBufAsVec<'a, T>(&'a mut ScriptBuf<T>, Vec<u8>);
+
+impl<T> core::ops::Deref for ScriptBufAsVec<'_, T> {
+    type Target = Vec<u8>;
+
+    fn deref(&self) -> &Self::Target { &self.1 }
+}
+
+impl<T> core::ops::DerefMut for ScriptBufAsVec<'_, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target { &mut self.1 }
+}
+
+impl<T> Drop for ScriptBufAsVec<'_, T> {
+    fn drop(&mut self) {
+        let vec = core::mem::take(&mut self.1);
+        *(self.0) = ScriptBuf::from_bytes(vec);
+    }
 }
 
 #[cfg(feature = "arbitrary")]

--- a/primitives/src/script/tests.rs
+++ b/primitives/src/script/tests.rs
@@ -187,6 +187,78 @@ fn script_is_empty() {
 }
 
 #[test]
+#[cfg(feature = "hex")]
+fn script_builder() {
+    use hex::hex;
+
+    use crate::opcodes::all::{OP_CHECKSIG, OP_DUP, OP_EQUALVERIFY, OP_HASH160};
+
+    // from txid 3bb5e6434c11fb93f64574af5d116736510717f2c595eb45b52c28e31622dfff which was in my mempool when I wrote the test
+    let script = Builder::<ScriptPubKeyTag>::new()
+        .push_opcode(OP_DUP)
+        .push_opcode(OP_HASH160)
+        .push_slice(hex!("16e1ae70ff0fa102905d4af297f6912bda6cce19"))
+        .push_opcode(OP_EQUALVERIFY)
+        .push_opcode(OP_CHECKSIG)
+        .into_script();
+    assert_eq!(
+        script.to_hex_string_no_length_prefix(),
+        "76a91416e1ae70ff0fa102905d4af297f6912bda6cce1988ac"
+    );
+}
+
+#[test]
+#[cfg(feature = "hex")]
+#[cfg(feature = "serde")]
+fn script_json_serialize() {
+    use serde_json;
+
+    let original = ScriptBuf::from_hex_no_length_prefix("827651a0698faaa9a8a7a687").unwrap();
+    let json = serde_json::to_value(&original).unwrap();
+    assert_eq!(json, serde_json::Value::String("827651a0698faaa9a8a7a687".to_owned()));
+    let des = serde_json::from_value::<ScriptBuf>(json).unwrap();
+    assert_eq!(original, des);
+}
+
+#[test]
+#[cfg(feature = "hex")]
+fn script_asm() {
+    assert_eq!(
+        ScriptBuf::from_hex_no_length_prefix("6363636363686868686800").unwrap().to_string(),
+        "OP_IF OP_IF OP_IF OP_IF OP_IF OP_ENDIF OP_ENDIF OP_ENDIF OP_ENDIF OP_ENDIF OP_0"
+    );
+    assert_eq!(ScriptBuf::from_hex_no_length_prefix("2102715e91d37d239dea832f1460e91e368115d8ca6cc23a7da966795abad9e3b699ac").unwrap().to_string(),
+               "OP_PUSHBYTES_33 02715e91d37d239dea832f1460e91e368115d8ca6cc23a7da966795abad9e3b699 OP_CHECKSIG");
+    // Elements Alpha peg-out transaction with some signatures removed for brevity. Mainly to test PUSHDATA1
+    assert_eq!(ScriptBuf::from_hex_no_length_prefix("0047304402202457e78cc1b7f50d0543863c27de75d07982bde8359b9e3316adec0aec165f2f02200203fd331c4e4a4a02f48cf1c291e2c0d6b2f7078a784b5b3649fca41f8794d401004cf1552103244e602b46755f24327142a0517288cebd159eccb6ccf41ea6edf1f601e9af952103bbbacc302d19d29dbfa62d23f37944ae19853cf260c745c2bea739c95328fcb721039227e83246bd51140fe93538b2301c9048be82ef2fb3c7fc5d78426ed6f609ad210229bf310c379b90033e2ecb07f77ecf9b8d59acb623ab7be25a0caed539e2e6472103703e2ed676936f10b3ce9149fa2d4a32060fb86fa9a70a4efe3f21d7ab90611921031e9b7c6022400a6bb0424bbcde14cff6c016b91ee3803926f3440abf5c146d05210334667f975f55a8455d515a2ef1c94fdfa3315f12319a14515d2a13d82831f62f57ae").unwrap().to_string(),
+               "OP_0 OP_PUSHBYTES_71 304402202457e78cc1b7f50d0543863c27de75d07982bde8359b9e3316adec0aec165f2f02200203fd331c4e4a4a02f48cf1c291e2c0d6b2f7078a784b5b3649fca41f8794d401 OP_0 OP_PUSHDATA1 552103244e602b46755f24327142a0517288cebd159eccb6ccf41ea6edf1f601e9af952103bbbacc302d19d29dbfa62d23f37944ae19853cf260c745c2bea739c95328fcb721039227e83246bd51140fe93538b2301c9048be82ef2fb3c7fc5d78426ed6f609ad210229bf310c379b90033e2ecb07f77ecf9b8d59acb623ab7be25a0caed539e2e6472103703e2ed676936f10b3ce9149fa2d4a32060fb86fa9a70a4efe3f21d7ab90611921031e9b7c6022400a6bb0424bbcde14cff6c016b91ee3803926f3440abf5c146d05210334667f975f55a8455d515a2ef1c94fdfa3315f12319a14515d2a13d82831f62f57ae");
+    // Various weird scripts found in transaction 6d7ed9914625c73c0288694a6819196a27ef6c08f98e1270d975a8e65a3dc09a
+    // which triggered overflow bugs on 32-bit machines in script formatting in the past.
+    assert_eq!(
+        ScriptBuf::from_hex_no_length_prefix("01").unwrap().to_string(),
+        "OP_PUSHBYTES_1 <push past end>"
+    );
+    assert_eq!(
+        ScriptBuf::from_hex_no_length_prefix("0201").unwrap().to_string(),
+        "OP_PUSHBYTES_2 <push past end>"
+    );
+    assert_eq!(ScriptBuf::from_hex_no_length_prefix("4c").unwrap().to_string(), "<unexpected end>");
+    assert_eq!(
+        ScriptBuf::from_hex_no_length_prefix("4c0201").unwrap().to_string(),
+        "OP_PUSHDATA1 <push past end>"
+    );
+    assert_eq!(ScriptBuf::from_hex_no_length_prefix("4d").unwrap().to_string(), "<unexpected end>");
+    assert_eq!(
+        ScriptBuf::from_hex_no_length_prefix("4dffff01").unwrap().to_string(),
+        "OP_PUSHDATA2 <push past end>"
+    );
+    assert_eq!(
+        ScriptBuf::from_hex_no_length_prefix("4effffffff01").unwrap().to_string(),
+        "OP_PUSHDATA4 <push past end>"
+    );
+}
+
+#[test]
 fn test_index() {
     let script = Script::from_bytes(&[1, 2, 3, 4, 5]);
 


### PR DESCRIPTION
As part of the plan to move script functionality from extension traits to the types in primitives, the Builder type must be moved to primitives first.

- Patch 1 removes the second Option\<Opcode> field from Builder, replacing it's one read-usage with a call to last_opcode().
- Patch 2 removes all access to the private fields of Builder from the functions that will be left in bitcoin.
- Patch 3 moves push_int_non_minimal to a private extension trait BuilderExtPriv.
- Patch 4 splits the remaining functions in Builder into a public extension trait BuilderExt.
- Patch 5 moves a small subset of ScriptBuf extension trait functions to ScriptBuf in primitives. This duplicates necessary private functions and the ScriptBufAsVec type.
- Patch 6 moves the Builder type to primitives.
- Patch 7 fixes the lint errors in primitives.
- Patch 8 moves and adds tests to cover mutants.
- Patch 9 updates the API files.