### PR TITLE
Make sendcmpt idempotent

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -56,9 +56,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.101"
+version = "0.32.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed8ccb78a9ff7a6fbb90e2fb9b8588b4a9928d49d8af3cb789108a84ea6b0ce"
+checksum = "bb0ce8bd5baaa0d303a19915a6d93afed161f528654e42da2a7a97d05c59499a"
 dependencies = [
  "base58ck 0.1.101",
  "bech32",
@@ -154,7 +154,7 @@ name = "bitcoin-fuzz"
 version = "0.0.1"
 dependencies = [
  "arbitrary",
- "bitcoin 0.32.101",
+ "bitcoin 0.32.102",
  "bitcoin 0.33.0-beta",
  "bitcoin-consensus-encoding 1.1.0",
  "bitcoin-p2p-messages",
@@ -260,12 +260,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitcoin-private"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
-
-[[package]]
 name = "bitcoin-taproot-primitives"
 version = "0.1.0"
 dependencies = [
@@ -298,15 +292,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_test",
-]
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
-dependencies = [
- "bitcoin-private",
 ]
 
 [[package]]
@@ -522,7 +507,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e0cc0f1cf93f4969faf3ea1c7d8a9faed25918d96affa959720823dfe86d4f3"
 dependencies = [
- "bitcoin_hashes 0.12.0",
+ "bitcoin_hashes 0.14.101",
  "secp256k1-sys 0.10.0",
  "serde",
 ]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -55,9 +55,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.101"
+version = "0.32.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed8ccb78a9ff7a6fbb90e2fb9b8588b4a9928d49d8af3cb789108a84ea6b0ce"
+checksum = "bb0ce8bd5baaa0d303a19915a6d93afed161f528654e42da2a7a97d05c59499a"
 dependencies = [
  "base58ck 0.1.101",
  "bech32",
@@ -153,7 +153,7 @@ name = "bitcoin-fuzz"
 version = "0.0.1"
 dependencies = [
  "arbitrary",
- "bitcoin 0.32.101",
+ "bitcoin 0.32.102",
  "bitcoin 0.33.0-beta",
  "bitcoin-consensus-encoding 1.1.0",
  "bitcoin-p2p-messages",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,7 +13,7 @@ cargo-fuzz = true
 # We shouldn't need an explicit version on the next line, but Andrew's tools
 # choke on it otherwise. See https://github.com/nix-community/crate2nix/issues/373
 bitcoin = { path = "../bitcoin", version = "0.33.0-beta", features = [ "serde", "arbitrary" ] }
-bitcoin_0_32 = { version = "0.32.101", package = "bitcoin", features = [ "encoding", "serde" ] }
+bitcoin_0_32 = { version = "0.32.102", package = "bitcoin", features = [ "encoding", "serde" ] }
 bitcoin_consensus_encoding = { path = "../consensus_encoding", package = "bitcoin-consensus-encoding" }
 p2p = { path = "../p2p", package = "bitcoin-p2p-messages", features = ["arbitrary"] }
 

--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -2859,6 +2859,22 @@ mod test {
     }
 
     #[test]
+    #[rustfmt::skip]
+    fn sendcmpct_v1_network_message_with_invalid_mode_bit() {
+        // Wire data has a non-canonical `send_compact` (0x12 instead of 0x01 or 0).
+        let raw_msg = [
+            0xf9, 0xbe, 0xb4, 0xd9,
+            0x73, 0x65, 0x6e, 0x64, 0x63, 0x6d, 0x70, 0x63, 0x74, 0x00, 0x00, 0x00, 
+            0x09, 0x00, 0x00, 0x00, 
+            0xf9, 0x9c, 0x95, 0x43,                                                 
+            0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x0c, // Mode byte (0x12)
+        ];
+
+        let msg = encoding::decode_from_slice::<V1NetworkMessage>(&raw_msg);
+        assert!(msg.is_err());
+    }
+
+    #[test]
     #[rustfmt::skip] // Keep readable byte layout with comments.
     fn v1_message_rejects_invalid_checksum_with_noncanonical_encoding() {
         // Derived from a fuzzer crash case, a SendCmpct message with a non-canonical

--- a/p2p/src/message_compact_blocks.rs
+++ b/p2p/src/message_compact_blocks.rs
@@ -44,12 +44,21 @@ crate::decoder_newtype! {
     #[derive(Debug, Default, Clone)]
     pub struct SendCmpctDecoder(SendCmpctInnerDecoder);
 
+    fn map_push_bytes_err(e: <SendCmpctInnerDecoder as encoding::Decoder>::Error) -> SendCmpctDecoderError {
+        SendCmpctDecoderError::eof(e)
+    }
+
     fn end(
         result: Result<([u8; 1], [u8; 8]), <SendCmpctInnerDecoder as encoding::Decoder>::Error>
     ) -> Result<SendCmpct, SendCmpctDecoderError> {
-        let (send_cmpct, version) = result.map_err(SendCmpctDecoderError)?;
-        let send_compact = u8::from_le_bytes(send_cmpct) != 0;
-        Ok(SendCmpct { send_compact, version: u64::from_le_bytes(version) })
+        let (send_cmpct, version) = result.map_err(SendCmpctDecoderError::eof)?;
+
+        if send_cmpct[0] == 1 || send_cmpct[0] == 0 {
+            let send_compact = u8::from_le_bytes(send_cmpct) != 0;
+            Ok(SendCmpct { send_compact, version: u64::from_le_bytes(version) })
+        } else {
+            Err(SendCmpctDecoderError::invalid_mode())
+        }
     }
 }
 
@@ -64,13 +73,35 @@ pub mod error {
 
     use internals::write_err;
 
+    use crate::message_compact_blocks::SendCmpctInnerDecoder;
+
     /// Errors occurring when decoding a [`SendCmpct`] message.
     ///
     /// [`SendCmpct`]: super::SendCmpct
     #[derive(Debug, Clone, PartialEq, Eq)]
-    pub struct SendCmpctDecoderError(
-        pub(super) <super::SendCmpctInnerDecoder as encoding::Decoder>::Error,
-    );
+    pub struct SendCmpctDecoderError(pub(super) SendCmpctDecoderErrorInner);
+
+    impl SendCmpctDecoderError {
+        /// Constructs an EOF error.
+        #[inline]
+        pub(super) fn eof(e: <SendCmpctInnerDecoder as encoding::Decoder>::Error) -> Self {
+            Self(SendCmpctDecoderErrorInner::UnexpectedEof(e))
+        }
+        /// Constructs an invalid mode error.
+        #[inline]
+        pub(super) fn invalid_mode() -> Self { Self(SendCmpctDecoderErrorInner::InvalidMode) }
+    }
+
+    /// Errors occuring when decoding a [`SendCmpct`] message.
+    ///
+    /// [`SendCmpct`]: super::SendCmpct
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub(super) enum SendCmpctDecoderErrorInner {
+        /// First byte was not a boolean value (0 or 1).
+        InvalidMode,
+        /// `UnexpectedEofError` Error by way of associated type on `ArrayDecoder<N>`.
+        UnexpectedEof(<super::SendCmpctInnerDecoder as encoding::Decoder>::Error),
+    }
 
     impl From<Infallible> for SendCmpctDecoderError {
         fn from(never: Infallible) -> Self { match never {} }
@@ -78,13 +109,18 @@ pub mod error {
 
     impl fmt::Display for SendCmpctDecoderError {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            write_err!(f, "sendcmpct error"; self.0)
+            write_err!(f, "sendcmpct error"; self)
         }
     }
 
     #[cfg(feature = "std")]
     impl std::error::Error for SendCmpctDecoderError {
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            match self.0 {
+                SendCmpctDecoderErrorInner::InvalidMode => None,
+                SendCmpctDecoderErrorInner::UnexpectedEof(ref e) => Some(e),
+            }
+        }
     }
 }
 


### PR DESCRIPTION
variation of https://github.com/rust-bitcoin/rust-bitcoin/pull/6297

From the spec https://bips.dev/152/

> The "high-bandwidth" mode, which nodes may only enable for a few of their peers, is enabled by setting the first boolean to 1 in a sendcmpct message.

> The "low-bandwidth" mode is enabled by setting the first boolean to 0 in a sendcmpct message

It seems like the spec says that anything besides 1 or 0 is actually an error, though..