### PR TITLE
crypto: Improve sighash errors

### DIFF
--- a/crypto/src/sighash.rs
+++ b/crypto/src/sighash.rs
@@ -233,7 +233,7 @@ pub mod error {
 
     /// Integer is not a consensus valid sighash type.
     #[derive(Debug, Clone, PartialEq, Eq)]
-    pub struct InvalidSighashTypeError(pub u32);
+    pub struct InvalidSighashTypeError(pub(crate) u32);
 
     impl fmt::Display for InvalidSighashTypeError {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -252,7 +252,7 @@ pub mod error {
     /// This type is consensus valid but an input including it would prevent the transaction from
     /// being relayed on today's Bitcoin network.
     #[derive(Debug, Clone, PartialEq, Eq)]
-    pub struct NonStandardSighashTypeError(pub u32);
+    pub struct NonStandardSighashTypeError(pub(crate) u32);
 
     impl fmt::Display for NonStandardSighashTypeError {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -275,7 +275,7 @@ pub mod error {
     #[non_exhaustive]
     pub struct SighashTypeParseError {
         /// The unrecognized string we attempted to parse.
-        pub unrecognized: InputString,
+        pub(super) unrecognized: InputString,
     }
 
     impl fmt::Display for SighashTypeParseError {

--- a/crypto/src/sighash.rs
+++ b/crypto/src/sighash.rs
@@ -227,6 +227,7 @@ impl From<EcdsaSighashType> for TapSighashType {
 
 /// Error types for signature hashing.
 pub mod error {
+    use core::convert::Infallible;
     use core::fmt;
 
     use internals::error::InputString;
@@ -234,6 +235,10 @@ pub mod error {
     /// Integer is not a consensus valid sighash type.
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct InvalidSighashTypeError(pub(crate) u32);
+
+    impl From<Infallible> for InvalidSighashTypeError {
+        fn from(never: Infallible) -> Self { match never {} }
+    }
 
     impl fmt::Display for InvalidSighashTypeError {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -253,6 +258,10 @@ pub mod error {
     /// being relayed on today's Bitcoin network.
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct NonStandardSighashTypeError(pub(crate) u32);
+
+    impl From<Infallible> for NonStandardSighashTypeError {
+        fn from(never: Infallible) -> Self { match never {} }
+    }
 
     impl fmt::Display for NonStandardSighashTypeError {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -276,6 +285,10 @@ pub mod error {
     pub struct SighashTypeParseError {
         /// The unrecognized string we attempted to parse.
         pub(super) unrecognized: InputString,
+    }
+
+    impl From<Infallible> for SighashTypeParseError {
+        fn from(never: Infallible) -> Self { match never {} }
     }
 
     impl fmt::Display for SighashTypeParseError {


### PR DESCRIPTION
The error types in the sighash module of crypto are missing From\<Infallible> and still use public fields for their inner data. So that these are consistent with the standard practice, the inner fields should be private and they should all implement From\<Infallible>.