### PR TITLE
Remove Verification re-exports

### DIFF
--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -12,7 +12,7 @@ use crate::sign_message::MessageSignature;
 use crate::taproot::{TapNodeHash, TapTweakHash, TapTweakHashExt as _};
 
 #[rustfmt::skip]                // Keep public re-exports separate.
-pub use secp256k1::{constants, Parity, Verification};
+pub use secp256k1::{constants, Parity};
 #[doc(no_inline)]
 pub use crypto::key::{
     FromSliceError, FromWifError, InvalidAddressVersionError, InvalidBase58PayloadLengthError,

--- a/crypto/src/key.rs
+++ b/crypto/src/key.rs
@@ -33,7 +33,7 @@ use crate::ecdsa;
 use crate::hex::{self, DecodeFixedLengthBytesError};
 
 #[rustfmt::skip]                // Keep public re-exports separate.
-pub use secp256k1::{constants, Parity, Verification};
+pub use secp256k1::{constants, Parity};
 #[doc(no_inline)]
 pub use self::error::{
     FromSliceError, InvalidAddressVersionError, InvalidBase58PayloadLengthError, ParseKeypairError,


### PR DESCRIPTION
These re-exports exist from the days when secp required an explicit context for cryptographic operations. With the introduction of the global context in recent secp versions, they are no longer needed.

Remove Verification re-exports from key modules.