### PR TITLE
taproot: Remove From<&Signature> for SerializedSignature

### DIFF
--- a/crypto/src/taproot.rs
+++ b/crypto/src/taproot.rs
@@ -302,10 +302,6 @@ impl From<Signature> for SerializedSignature {
     fn from(value: Signature) -> Self { Self::from_signature(value) }
 }
 
-impl<'a> From<&'a Signature> for SerializedSignature {
-    fn from(value: &'a Signature) -> Self { Self::from_signature(*value) }
-}
-
 impl TryFrom<SerializedSignature> for Signature {
     type Error = SigFromSliceError;
 


### PR DESCRIPTION
The From<&'a Signature> for SerializedSignature impl functions by derefing the signature and then serializing it. The presence of the trait implies that SerializedSignature is some sort of reference to the signature, when it is instead a type owning its own data.

Remove From<&Signature> impl from taproot::SerializedSignature.