### PR TITLE
0.32.x: Add `consensus_encoding` to types present in primitives 1.0

### DIFF
--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -14,7 +14,9 @@ use core::fmt;
 #[cfg(feature = "arbitrary")]
 use actual_arbitrary::{self as arbitrary, Arbitrary, Unstructured};
 #[cfg(feature = "encoding")]
-use encoding::{ArrayDecoder, Decoder6};
+use encoding::{
+    ArrayDecoder, CompactSizeEncoder, Decoder2, Decoder6, Encoder2, SliceEncoder, VecDecoder,
+};
 use hashes::{sha256d, Hash, HashEngine};
 use io::{Read, Write};
 
@@ -784,6 +786,78 @@ impl Block {
             _ => Err(Bip34Error::NotPresent),
         }
     }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for Block {
+    type Encoder<'e> =
+        Encoder2<HeaderEncoder<'e>, Encoder2<CompactSizeEncoder, SliceEncoder<'e, Transaction>>>;
+
+    fn encoder(&self) -> Self::Encoder<'_> {
+        Encoder2::new(
+            self.header.encoder(),
+            Encoder2::new(
+                CompactSizeEncoder::new(self.txdata.len()),
+                SliceEncoder::without_length_prefix(&self.txdata),
+            ),
+        )
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for Block {
+    type Decoder = BlockDecoder;
+}
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype! {
+    /// The encoder for the [`Block`] type.
+    #[derive(Debug, Clone)]
+    pub struct BlockEncoder<'e>(
+        Encoder2<HeaderEncoder<'e>, Encoder2<CompactSizeEncoder, SliceEncoder<'e, Transaction>>>
+    );
+}
+
+#[cfg(feature = "encoding")]
+type BlockInnerDecoder = Decoder2<HeaderDecoder, VecDecoder<Transaction>>;
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// The decoder for the [`Block`] type.
+    #[derive(Debug, Clone)]
+    pub struct BlockDecoder(BlockInnerDecoder);
+
+    /// Constructs a new [`Block`] decoder.
+    pub const fn new() -> Self {
+        Self(Decoder2::new(HeaderDecoder::new(), VecDecoder::new()))
+    }
+
+    fn end(result: Result<(Header, Vec<Transaction>), <BlockInnerDecoder as encoding::Decoder>::Error>) -> Result<Block, BlockDecoderError> {
+        let (header, txdata) = result.map_err(BlockDecoderError)?;
+        Ok(Block { header, txdata })
+    }
+}
+
+/// An error consensus decoding a `Block`.
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlockDecoderError(pub(crate) <BlockInnerDecoder as encoding::Decoder>::Error);
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for BlockDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl fmt::Display for BlockDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write_err!(f, "block decoder error"; self.0)
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for BlockDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
 }
 
 impl From<Header> for BlockHash {

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -13,6 +13,8 @@ use core::fmt;
 
 #[cfg(feature = "arbitrary")]
 use actual_arbitrary::{self as arbitrary, Arbitrary, Unstructured};
+#[cfg(feature = "encoding")]
+use encoding::{ArrayDecoder, Decoder6};
 use hashes::{sha256d, Hash, HashEngine};
 use io::{Read, Write};
 
@@ -24,6 +26,8 @@ use crate::consensus::{encode, Decodable, Encodable, Params};
 use crate::internal_macros::write_err;
 use crate::internal_macros::{impl_consensus_encoding, impl_hashencode};
 use crate::pow::{CompactTarget, Target, Work};
+#[cfg(feature = "encoding")]
+use crate::pow::{CompactTargetDecoder, CompactTargetDecoderError};
 use crate::prelude::*;
 use crate::{merkle_tree, VarInt};
 
@@ -314,6 +318,151 @@ impl fmt::Debug for Header {
             .field("bits", &self.bits)
             .field("nonce", &self.nonce)
             .finish()
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for Header {
+    type Encoder<'e> = HeaderEncoder<'e>;
+
+    fn encoder(&self) -> Self::Encoder<'_> {
+        HeaderEncoder::new(encoding::Encoder6::new(
+            self.version.encoder(),
+            self.prev_blockhash.encoder(),
+            self.merkle_root.encoder(),
+            encoding::ArrayEncoder::without_length_prefix(self.time.to_le_bytes()),
+            self.bits.encoder(),
+            encoding::ArrayEncoder::without_length_prefix(self.nonce.to_le_bytes()),
+        ))
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for Header {
+    type Decoder = HeaderDecoder;
+}
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// The encoder for the [`Header`] type.
+    #[derive(Debug, Clone)]
+    pub struct HeaderEncoder<'e>(
+        encoding::Encoder6<
+            VersionEncoder<'e>,
+            BlockHashEncoder<'e>,
+            TxMerkleNodeEncoder<'e>,
+            encoding::ArrayEncoder<4>,
+            crate::pow::CompactTargetEncoder<'e>,
+            encoding::ArrayEncoder<4>,
+        >
+    );
+}
+
+#[cfg(feature = "encoding")]
+type HeaderInnerDecoder = Decoder6<
+    VersionDecoder,
+    BlockHashDecoder,
+    TxMerkleNodeDecoder,
+    encoding::ArrayDecoder<4>, // Time
+    CompactTargetDecoder,
+    encoding::ArrayDecoder<4>, // Nonce
+>;
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// The decoder for the [`Header`] type.
+    #[derive(Debug, Clone)]
+    pub struct HeaderDecoder(HeaderInnerDecoder);
+
+    /// Constructs a new [`Header`] decoder.
+    pub const fn new() -> Self {
+        Self(Decoder6::new(
+            VersionDecoder::new(),
+            BlockHashDecoder::new(),
+            TxMerkleNodeDecoder::new(),
+            ArrayDecoder::new(),
+            CompactTargetDecoder::new(),
+            ArrayDecoder::new(),
+        ))
+    }
+
+    fn map_push_bytes_err(err: <HeaderInnerDecoder as encoding::Decoder>::Error) -> HeaderDecoderError {
+        Self::from_inner(err)
+    }
+
+    fn end(
+        result: Result<<HeaderInnerDecoder as encoding::Decoder>::Output, <HeaderInnerDecoder as encoding::Decoder>::Error>
+    ) -> Result<Header, HeaderDecoderError> {
+        let (version, prev_blockhash, merkle_root, time, bits, nonce) = result.map_err(Self::from_inner)?;
+        let time = u32::from_le_bytes(time);
+        let nonce = u32::from_le_bytes(nonce);
+        Ok(Header { version, prev_blockhash, merkle_root, time, bits, nonce })
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl HeaderDecoder {
+    fn from_inner(e: <HeaderInnerDecoder as encoding::Decoder>::Error) -> HeaderDecoderError {
+        match e {
+            encoding::Decoder6Error::First(e) => HeaderDecoderError::Version(e),
+            encoding::Decoder6Error::Second(e) => HeaderDecoderError::PrevBlockhash(e),
+            encoding::Decoder6Error::Third(e) => HeaderDecoderError::MerkleRoot(e),
+            encoding::Decoder6Error::Fourth(e) => HeaderDecoderError::Time(e),
+            encoding::Decoder6Error::Fifth(e) => HeaderDecoderError::Bits(e),
+            encoding::Decoder6Error::Sixth(e) => HeaderDecoderError::Nonce(e),
+        }
+    }
+}
+
+/// An error consensus decoding a `Header`.
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum HeaderDecoderError {
+    /// Error while decoding the `version`.
+    Version(VersionDecoderError),
+    /// Error while decoding the `prev_blockhash`.
+    PrevBlockhash(BlockHashDecoderError),
+    /// Error while decoding the `merkle_root`.
+    MerkleRoot(TxMerkleNodeDecoderError),
+    /// Error while decoding the `time`.
+    Time(encoding::UnexpectedEofError),
+    /// Error while decoding the `bits`.
+    Bits(CompactTargetDecoderError),
+    /// Error while decoding the `nonce`.
+    Nonce(encoding::UnexpectedEofError),
+}
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for HeaderDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl fmt::Display for HeaderDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Self::Version(ref e) => write_err!(f, "header decoder error"; e),
+            Self::PrevBlockhash(ref e) => write_err!(f, "header decoder error"; e),
+            Self::MerkleRoot(ref e) => write_err!(f, "header decoder error"; e),
+            Self::Time(ref e) => write_err!(f, "header decoder error"; e),
+            Self::Bits(ref e) => write_err!(f, "header decoder error"; e),
+            Self::Nonce(ref e) => write_err!(f, "header decoder error"; e),
+        }
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for HeaderDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match *self {
+            Self::Version(ref e) => Some(e),
+            Self::PrevBlockhash(ref e) => Some(e),
+            Self::MerkleRoot(ref e) => Some(e),
+            Self::Time(ref e) => Some(e),
+            Self::Bits(ref e) => Some(e),
+            Self::Nonce(ref e) => Some(e),
+        }
     }
 }
 

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -20,6 +20,8 @@ use super::Weight;
 use crate::blockdata::script;
 use crate::blockdata::transaction::{Transaction, Txid, Wtxid};
 use crate::consensus::{encode, Decodable, Encodable, Params};
+#[cfg(feature = "encoding")]
+use crate::internal_macros::write_err;
 use crate::internal_macros::{impl_consensus_encoding, impl_hashencode};
 use crate::pow::{CompactTarget, Target, Work};
 use crate::prelude::*;
@@ -38,6 +40,66 @@ hashes::hash_newtype! {
 impl_hashencode!(BlockHash);
 impl_hashencode!(TxMerkleNode);
 impl_hashencode!(WitnessMerkleNode);
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for BlockHash {
+    type Encoder<'e> = BlockHashEncoder<'e>;
+    #[inline]
+    fn encoder(&self) -> Self::Encoder<'_> {
+        BlockHashEncoder::new(encoding::ArrayRefEncoder::without_length_prefix(
+            self.as_byte_array(),
+        ))
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for BlockHash {
+    type Decoder = BlockHashDecoder;
+}
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// The encoder for the [`BlockHash`] type.
+    #[derive(Debug, Clone)]
+    pub struct BlockHashEncoder<'e>(encoding::ArrayRefEncoder<'e, 32>);
+}
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// The decoder for the [`BlockHash`] type.
+    #[derive(Debug, Clone)]
+    pub struct BlockHashDecoder(encoding::ArrayDecoder<32>);
+
+    /// Constructs a new [`BlockHash`] decoder.
+    pub const fn new() -> Self { Self(encoding::ArrayDecoder::new()) }
+
+    fn end(result: Result<[u8; 32], encoding::UnexpectedEofError>) -> Result<BlockHash, BlockHashDecoderError> {
+        let bytes = result.map_err(BlockHashDecoderError)?;
+        Ok(BlockHash::from_byte_array(bytes))
+    }
+}
+
+/// An error consensus decoding a `BlockHash`.
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlockHashDecoderError(pub(crate) encoding::UnexpectedEofError);
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for BlockHashDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl fmt::Display for BlockHashDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write_err!(f, "block hash decoder error"; self.0)
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for BlockHashDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
+}
 
 impl From<Txid> for TxMerkleNode {
     fn from(txid: Txid) -> Self { Self::from_byte_array(txid.to_byte_array()) }

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -109,6 +109,66 @@ impl From<Wtxid> for WitnessMerkleNode {
     fn from(wtxid: Wtxid) -> Self { Self::from_byte_array(wtxid.to_byte_array()) }
 }
 
+#[cfg(feature = "encoding")]
+impl encoding::Encode for TxMerkleNode {
+    type Encoder<'e> = TxMerkleNodeEncoder<'e>;
+    #[inline]
+    fn encoder(&self) -> Self::Encoder<'_> {
+        TxMerkleNodeEncoder::new(encoding::ArrayRefEncoder::without_length_prefix(
+            self.as_byte_array(),
+        ))
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for TxMerkleNode {
+    type Decoder = TxMerkleNodeDecoder;
+}
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// The encoder for the [`TxMerkleNode`] type.
+    #[derive(Debug, Clone)]
+    pub struct TxMerkleNodeEncoder<'e>(encoding::ArrayRefEncoder<'e, 32>);
+}
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// The decoder for the [`TxMerkleNode`] type.
+    #[derive(Debug, Clone)]
+    pub struct TxMerkleNodeDecoder(encoding::ArrayDecoder<32>);
+
+    /// Constructs a new [`TxMerkleNode`] decoder.
+    pub const fn new() -> Self { Self(encoding::ArrayDecoder::new()) }
+
+    fn end(result: Result<[u8; 32], encoding::UnexpectedEofError>) -> Result<TxMerkleNode, TxMerkleNodeDecoderError> {
+        let bytes = result.map_err(TxMerkleNodeDecoderError)?;
+        Ok(TxMerkleNode::from_byte_array(bytes))
+    }
+}
+
+/// An error consensus decoding an `TxMerkleNode`.
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TxMerkleNodeDecoderError(pub(crate) encoding::UnexpectedEofError);
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for TxMerkleNodeDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl fmt::Display for TxMerkleNodeDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write_err!(f, "tx merkle node decoder error"; self.0)
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for TxMerkleNodeDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
+}
+
 /// Bitcoin block header.
 ///
 /// Contains all the block's information except the actual transactions, but

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -169,6 +169,66 @@ impl std::error::Error for TxMerkleNodeDecoderError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
 }
 
+#[cfg(feature = "encoding")]
+impl encoding::Encode for WitnessMerkleNode {
+    type Encoder<'e> = WitnessMerkleNodeEncoder<'e>;
+    #[inline]
+    fn encoder(&self) -> Self::Encoder<'_> {
+        WitnessMerkleNodeEncoder::new(encoding::ArrayRefEncoder::without_length_prefix(
+            self.as_byte_array(),
+        ))
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for WitnessMerkleNode {
+    type Decoder = WitnessMerkleNodeDecoder;
+}
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// The encoder for the [`WitnessMerkleNode`] type.
+    #[derive(Debug, Clone)]
+    pub struct WitnessMerkleNodeEncoder<'e>(encoding::ArrayRefEncoder<'e, 32>);
+}
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// The decoder for the [`WitnessMerkleNode`] type.
+    #[derive(Debug, Clone)]
+    pub struct WitnessMerkleNodeDecoder(encoding::ArrayDecoder<32>);
+
+    /// Constructs a new [`WitnessMerkleNode`] decoder.
+    pub const fn new() -> Self { Self(encoding::ArrayDecoder::new()) }
+
+    fn end(result: Result<[u8; 32], encoding::UnexpectedEofError>) -> Result<WitnessMerkleNode, WitnessMerkleNodeDecoderError> {
+        let bytes = result.map_err(WitnessMerkleNodeDecoderError)?;
+        Ok(WitnessMerkleNode::from_byte_array(bytes))
+    }
+}
+
+/// An error consensus decoding an `WitnessMerkleNode`.
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WitnessMerkleNodeDecoderError(pub(crate) encoding::UnexpectedEofError);
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for WitnessMerkleNodeDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl fmt::Display for WitnessMerkleNodeDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write_err!(f, "witness merkle node decoder error"; self.0)
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for WitnessMerkleNodeDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
+}
+
 /// Bitcoin block header.
 ///
 /// Contains all the block's information except the actual transactions, but

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -400,6 +400,66 @@ impl Decodable for Version {
     }
 }
 
+#[cfg(feature = "encoding")]
+impl encoding::Encode for Version {
+    type Encoder<'e> = VersionEncoder<'e>;
+    fn encoder(&self) -> Self::Encoder<'_> {
+        VersionEncoder::new(encoding::ArrayEncoder::without_length_prefix(
+            self.to_consensus().to_le_bytes(),
+        ))
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for Version {
+    type Decoder = VersionDecoder;
+}
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// The encoder for the [`Version`] type.
+    #[derive(Debug, Clone)]
+    pub struct VersionEncoder<'e>(encoding::ArrayEncoder<4>);
+}
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// The decoder for the [`Version`] type.
+    #[derive(Debug, Clone)]
+    pub struct VersionDecoder(encoding::ArrayDecoder<4>);
+
+    /// Constructs a new [`Version`] decoder.
+    pub const fn new() -> Self { Self(encoding::ArrayDecoder::new()) }
+
+    fn end(result: Result<[u8; 4], encoding::UnexpectedEofError>) -> Result<Version, VersionDecoderError> {
+        let value = result.map_err(VersionDecoderError)?;
+        let n = i32::from_le_bytes(value);
+        Ok(Version::from_consensus(n))
+    }
+}
+
+/// An error consensus decoding an `Version`.
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VersionDecoderError(pub(crate) encoding::UnexpectedEofError);
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for VersionDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl fmt::Display for VersionDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write_err!(f, "version decoder error"; self.0)
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for VersionDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
+}
+
 /// Bitcoin block.
 ///
 /// A collection of transactions with an attached proof of work.

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -641,6 +641,25 @@ impl Script {
     }
 }
 
+#[cfg(feature = "encoding")]
+impl encoding::Encode for Script {
+    type Encoder<'e> = ScriptEncoder<'e>;
+
+    fn encoder(&self) -> Self::Encoder<'_> {
+        ScriptEncoder::new(encoding::Encoder2::new(
+            encoding::CompactSizeEncoder::new(self.as_bytes().len()),
+            encoding::BytesEncoder::without_length_prefix(self.as_bytes()),
+        ))
+    }
+}
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// The encoder for the [`Script`] type.
+    #[derive(Debug, Clone)]
+    pub struct ScriptEncoder<'e>(encoding::Encoder2<encoding::CompactSizeEncoder, encoding::BytesEncoder<'e>>);
+}
+
 /// Iterator over bytes of a script
 pub struct Bytes<'a>(core::iter::Copied<core::slice::Iter<'a, u8>>);
 

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: CC0-1.0
 
+#[cfg(feature = "encoding")]
+use core::convert::Infallible;
+#[cfg(feature = "encoding")]
+use core::fmt;
 #[cfg(doc)]
 use core::ops::Deref;
 
@@ -15,6 +19,8 @@ use crate::blockdata::script::witness_version::WitnessVersion;
 use crate::blockdata::script::{
     opcode_to_verify, Builder, Instruction, PushBytes, Script, ScriptHash, WScriptHash,
 };
+#[cfg(feature = "encoding")]
+use crate::internal_macros::write_err;
 use crate::key::{
     PubkeyHash, PublicKey, TapTweak, TweakedPublicKey, UntweakedPublicKey, WPubkeyHash,
 };
@@ -366,4 +372,64 @@ impl<'a> Arbitrary<'a> for ScriptBuf {
         let v = Vec::<u8>::arbitrary(u)?;
         Ok(ScriptBuf(v))
     }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for ScriptBuf {
+    type Decoder = ScriptBufDecoder;
+}
+
+/// The decoder for the [`ScriptBuf`] type.
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone)]
+pub struct ScriptBufDecoder(encoding::ByteVecDecoder);
+
+#[cfg(feature = "encoding")]
+impl ScriptBufDecoder {
+    /// Constructs a new [`ScriptBuf`] decoder.
+    pub const fn new() -> Self { Self(encoding::ByteVecDecoder::new()) }
+}
+
+#[cfg(feature = "encoding")]
+impl Default for ScriptBufDecoder {
+    fn default() -> Self { Self::new() }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decoder for ScriptBufDecoder {
+    type Output = ScriptBuf;
+    type Error = ScriptBufDecoderError;
+
+    #[inline]
+    fn push_bytes(&mut self, bytes: &mut &[u8]) -> Result<encoding::DecoderStatus, Self::Error> {
+        self.0.push_bytes(bytes).map_err(ScriptBufDecoderError)
+    }
+
+    #[inline]
+    fn end(self) -> Result<Self::Output, Self::Error> {
+        Ok(ScriptBuf::from_bytes(self.0.end().map_err(ScriptBufDecoderError)?))
+    }
+
+    #[inline]
+    fn read_limit(&self) -> usize { self.0.read_limit() }
+}
+
+/// An error consensus decoding a [`ScriptBuf`].
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScriptBufDecoderError(pub(super) encoding::ByteVecDecoderError);
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for ScriptBufDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl fmt::Display for ScriptBufDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write_err!(f, "decoder error"; self.0) }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for ScriptBufDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
 }

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -15,6 +15,8 @@ use core::convert::Infallible;
 use core::str::FromStr;
 use core::{cmp, fmt};
 
+#[cfg(feature = "encoding")]
+use encoding::{ArrayEncoder, BytesEncoder, Encoder2};
 use hashes::{sha256d, Hash};
 use io::{Read, Write};
 use units::parse::{self, ParseIntError};
@@ -1321,6 +1323,74 @@ impl Decodable for OutPoint {
             vout: Decodable::consensus_decode(r)?,
         })
     }
+}
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// The encoder for the [`OutPoint`] type.
+    #[derive(Debug, Clone)]
+    pub struct OutPointEncoder<'e>(Encoder2<BytesEncoder<'e>, ArrayEncoder<4>>);
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for OutPoint {
+    type Encoder<'e> = OutPointEncoder<'e>;
+
+    fn encoder(&self) -> Self::Encoder<'_> {
+        OutPointEncoder::new(Encoder2::new(
+            BytesEncoder::without_length_prefix(self.txid.as_byte_array()),
+            ArrayEncoder::without_length_prefix(self.vout.to_le_bytes()),
+        ))
+    }
+}
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// The decoder for the [`OutPoint`] type.
+    // 32 for the txid + 4 for the vout
+    #[derive(Debug, Clone)]
+    pub struct OutPointDecoder(encoding::ArrayDecoder<36>);
+
+    /// Constructs a new [`OutPoint`] decoder.
+    pub const fn new() -> Self { Self(encoding::ArrayDecoder::new()) }
+
+    fn end(result: Result<[u8; 36], encoding::UnexpectedEofError>) -> Result<OutPoint, OutPointDecoderError> {
+        let encoded = result.map_err(OutPointDecoderError)?;
+        let txid_buf: [u8; 32] = encoded[..32].try_into().expect("32 bytes");
+        let vout_buf: [u8; 4] = encoded[32..].try_into().expect("4 bytes");
+
+        let txid = Txid::from_byte_array(txid_buf);
+        let vout = u32::from_le_bytes(vout_buf);
+
+        Ok(OutPoint { txid, vout })
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for OutPoint {
+    type Decoder = OutPointDecoder;
+}
+
+/// Error while decoding an `OutPoint`.
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutPointDecoderError(pub(crate) encoding::UnexpectedEofError);
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for OutPointDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl core::fmt::Display for OutPointDecoderError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write_err!(f, "out point decoder error"; self.0)
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for OutPointDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
 }
 
 impl Encodable for TxIn {

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -16,7 +16,7 @@ use core::str::FromStr;
 use core::{cmp, fmt};
 
 #[cfg(feature = "encoding")]
-use encoding::{ArrayEncoder, BytesEncoder, Encoder2};
+use encoding::{ArrayEncoder, BytesEncoder, Decoder3, Encoder2, Encoder3};
 use hashes::{sha256d, Hash};
 use io::{Read, Write};
 use units::parse::{self, ParseIntError};
@@ -25,6 +25,8 @@ use super::Weight;
 use crate::blockdata::locktime::absolute::{self, Height, Time};
 use crate::blockdata::locktime::relative::{self, TimeOverflowError};
 use crate::blockdata::script::{Script, ScriptBuf};
+#[cfg(feature = "encoding")]
+use crate::blockdata::script::{ScriptBufDecoder, ScriptEncoder};
 use crate::blockdata::witness::Witness;
 use crate::blockdata::FeeRate;
 use crate::consensus::{encode, Decodable, Encodable};
@@ -1414,6 +1416,81 @@ impl Decodable for TxIn {
             witness: Witness::default(),
         })
     }
+}
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// The encoder for the [`TxIn`] type.
+    #[derive(Debug, Clone)]
+    pub struct TxInEncoder<'e>(
+        Encoder3<OutPointEncoder<'e>, ScriptEncoder<'e>, SequenceEncoder<'e>>
+    );
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for TxIn {
+    type Encoder<'e> = Encoder3<OutPointEncoder<'e>, ScriptEncoder<'e>, SequenceEncoder<'e>>;
+
+    fn encoder(&self) -> Self::Encoder<'_> {
+        Encoder3::new(
+            self.previous_output.encoder(),
+            self.script_sig.encoder(),
+            self.sequence.encoder(),
+        )
+    }
+}
+
+#[cfg(feature = "encoding")]
+type TxInInnerDecoder = Decoder3<OutPointDecoder, ScriptBufDecoder, SequenceDecoder>;
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// The decoder for the [`TxIn`] type.
+    #[derive(Debug, Clone)]
+    pub struct TxInDecoder(TxInInnerDecoder);
+
+    /// Constructs a new [`TxIn`] decoder.
+    pub const fn new() -> Self {
+        Self(Decoder3::new(
+            OutPointDecoder::new(),
+            ScriptBufDecoder::new(),
+            SequenceDecoder::new(),
+        ))
+    }
+
+    fn end(
+        result: Result<<TxInInnerDecoder as encoding::Decoder>::Output, <TxInInnerDecoder as encoding::Decoder>::Error>
+    ) -> Result<TxIn, TxInDecoderError> {
+        let (previous_output, script_sig, sequence) = result.map_err(TxInDecoderError)?;
+        Ok(TxIn { previous_output, script_sig, sequence, witness: Witness::default() })
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for TxIn {
+    type Decoder = TxInDecoder;
+}
+
+/// An error consensus decoding a `TxIn`.
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TxInDecoderError(pub(super) <TxInInnerDecoder as encoding::Decoder>::Error);
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for TxInDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl fmt::Display for TxInDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write_err!(f, "txin decoder error"; self.0)
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for TxInDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
 }
 
 impl Encodable for Sequence {

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -1248,6 +1248,64 @@ impl fmt::Display for Version {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { fmt::Display::fmt(&self.0, f) }
 }
 
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// The encoder for the [`Version`] type.
+    #[derive(Debug, Clone)]
+    pub struct VersionEncoder<'e>(encoding::ArrayEncoder<4>);
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for Version {
+    type Encoder<'e> = VersionEncoder<'e>;
+    fn encoder(&self) -> Self::Encoder<'_> {
+        VersionEncoder::new(encoding::ArrayEncoder::without_length_prefix(self.0.to_le_bytes()))
+    }
+}
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// The decoder for the [`Version`] type.
+    #[derive(Debug, Clone)]
+    pub struct VersionDecoder(encoding::ArrayDecoder<4>);
+
+    /// Constructs a new [`Version`] decoder.
+    pub const fn new() -> Self { Self(encoding::ArrayDecoder::new()) }
+
+    fn end(result: Result<[u8; 4], encoding::UnexpectedEofError>) -> Result<Version, VersionDecoderError> {
+        let bytes = result.map_err(VersionDecoderError)?;
+        let n = i32::from_le_bytes(bytes);
+        Ok(Version::non_standard(n))
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for Version {
+    type Decoder = VersionDecoder;
+}
+
+/// An error consensus decoding a `Version`.
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VersionDecoderError(pub(super) encoding::UnexpectedEofError);
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for VersionDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl fmt::Display for VersionDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write_err!(f, "version decoder error"; self.0)
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for VersionDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
+}
+
 impl_consensus_encoding!(TxOut, value, script_pubkey);
 
 impl Encodable for OutPoint {

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -12,11 +12,16 @@
 //!
 
 use core::convert::Infallible;
+#[cfg(feature = "encoding")]
+use core::mem;
 use core::str::FromStr;
 use core::{cmp, fmt};
 
 #[cfg(feature = "encoding")]
-use encoding::{ArrayEncoder, BytesEncoder, Decoder2, Decoder3, Encoder2, Encoder3};
+use encoding::{
+    ArrayEncoder, BytesEncoder, CompactSizeEncoder, Decoder2, Decoder3, DecoderStatus, Encode as _,
+    Encoder2, Encoder3, Encoder6, EncoderStatus, SliceEncoder, VecDecoder,
+};
 use hashes::{sha256d, Hash};
 use io::{Read, Write};
 #[cfg(feature = "encoding")]
@@ -25,11 +30,17 @@ use units::parse::{self, ParseIntError};
 
 use super::Weight;
 use crate::blockdata::locktime::absolute::{self, Height, Time};
+#[cfg(feature = "encoding")]
+use crate::blockdata::locktime::absolute::{
+    LockTimeDecoder, LockTimeDecoderError, LockTimeEncoder,
+};
 use crate::blockdata::locktime::relative::{self, TimeOverflowError};
 use crate::blockdata::script::{Script, ScriptBuf};
 #[cfg(feature = "encoding")]
 use crate::blockdata::script::{ScriptBufDecoder, ScriptEncoder};
 use crate::blockdata::witness::Witness;
+#[cfg(feature = "encoding")]
+use crate::blockdata::witness::{WitnessDecoder, WitnessDecoderError, WitnessEncoder};
 use crate::blockdata::FeeRate;
 use crate::consensus::{encode, Decodable, Encodable};
 use crate::error::{ContainsPrefixError, MissingPrefixError, PrefixedHexError, UnprefixedHexError};
@@ -1507,6 +1518,59 @@ impl encoding::Encode for TxIn {
     }
 }
 
+/// Encodes the witnesses from a list of inputs.
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone)]
+pub struct WitnessesEncoder<'e> {
+    inputs: &'e [TxIn],
+    /// Encoder for the current witness being encoded.
+    cur_enc: Option<WitnessEncoder<'e>>,
+}
+
+#[cfg(feature = "encoding")]
+impl<'e> WitnessesEncoder<'e> {
+    /// Constructs a new encoder for all witnesses in a list of transaction inputs.
+    pub fn new(inputs: &'e [TxIn]) -> Self {
+        Self { inputs, cur_enc: inputs.first().map(|input| input.witness.encoder()) }
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encoder for WitnessesEncoder<'_> {
+    #[inline]
+    fn current_chunk(&self) -> &[u8] {
+        self.cur_enc.as_ref().map(WitnessEncoder::current_chunk).unwrap_or_default()
+    }
+
+    #[inline]
+    fn advance(&mut self) -> EncoderStatus {
+        let Some(cur) = self.cur_enc.as_mut() else {
+            return EncoderStatus::Finished;
+        };
+
+        loop {
+            // On subsequent calls, attempt to advance the current encoder and return
+            // success if this succeeds.
+            if cur.advance().has_more() {
+                return EncoderStatus::HasMore;
+            }
+            // self.inputs guaranteed to be non-empty if cur_enc is non-None.
+            self.inputs = &self.inputs[1..];
+
+            // If advancing the current encoder failed, attempt to move to the next encoder.
+            if let Some(input) = self.inputs.first() {
+                *cur = input.witness.encoder();
+                if !cur.current_chunk().is_empty() {
+                    return EncoderStatus::HasMore;
+                }
+            } else {
+                self.cur_enc = None; // shortcut the next call to advance()
+                return EncoderStatus::Finished;
+            }
+        }
+    }
+}
+
 #[cfg(feature = "encoding")]
 type TxInInnerDecoder = Decoder3<OutPointDecoder, ScriptBufDecoder, SequenceDecoder>;
 
@@ -1635,6 +1699,443 @@ impl Decodable for Transaction {
                 output: Decodable::consensus_decode_from_finite_reader(r)?,
                 lock_time: Decodable::consensus_decode_from_finite_reader(r)?,
             })
+        }
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for Transaction {
+    type Encoder<'e> = TransactionEncoder<'e>;
+
+    fn encoder(&self) -> Self::Encoder<'_> {
+        let version = self.version.encoder();
+        let inputs = Encoder2::new(
+            CompactSizeEncoder::new(self.input.len()),
+            SliceEncoder::without_length_prefix(self.input.as_ref()),
+        );
+        let outputs = Encoder2::new(
+            CompactSizeEncoder::new(self.output.len()),
+            SliceEncoder::without_length_prefix(self.output.as_ref()),
+        );
+        let lock_time = self.lock_time.encoder();
+
+        if self.uses_segwit_serialization() {
+            let segwit = ArrayEncoder::without_length_prefix([0x00, 0x01]);
+            let witnesses = WitnessesEncoder::new(self.input.as_slice());
+            TransactionEncoder::new(Encoder6::new(
+                version,
+                Some(segwit),
+                inputs,
+                outputs,
+                Some(witnesses),
+                lock_time,
+            ))
+        } else {
+            TransactionEncoder::new(Encoder6::new(version, None, inputs, outputs, None, lock_time))
+        }
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for Transaction {
+    type Decoder = TransactionDecoder;
+}
+
+#[cfg(feature = "encoding")]
+type TransactionEncoderInner<'e> = Encoder6<
+    VersionEncoder<'e>,
+    Option<ArrayEncoder<2>>,
+    Encoder2<CompactSizeEncoder, SliceEncoder<'e, TxIn>>,
+    Encoder2<CompactSizeEncoder, SliceEncoder<'e, TxOut>>,
+    Option<WitnessesEncoder<'e>>,
+    LockTimeEncoder<'e>,
+>;
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype! {
+    /// The encoder for the [`Transaction`] type.
+    #[derive(Debug, Clone)]
+    pub struct TransactionEncoder<'e>(TransactionEncoderInner<'e>);
+}
+
+/// The decoder for the [`Transaction`] type.
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone)]
+pub struct TransactionDecoder {
+    state: TransactionDecoderState,
+}
+
+#[cfg(feature = "encoding")]
+impl TransactionDecoder {
+    /// Constructs a new [`TransactionDecoder`].
+    pub const fn new() -> Self {
+        Self { state: TransactionDecoderState::Version(VersionDecoder::new()) }
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl Default for TransactionDecoder {
+    fn default() -> Self { Self::new() }
+}
+
+#[cfg(feature = "encoding")]
+#[allow(clippy::too_many_lines)] // TODO: Can we clean this up?
+impl encoding::Decoder for TransactionDecoder {
+    type Output = Transaction;
+    type Error = TransactionDecoderError;
+
+    #[inline]
+    fn push_bytes(&mut self, bytes: &mut &[u8]) -> Result<DecoderStatus, Self::Error> {
+        use TransactionDecoderError as E;
+        use TransactionDecoderErrorInner as Inner;
+        use TransactionDecoderState as State;
+
+        loop {
+            // Attempt to push to the currently-active decoder and return early on success.
+            match &mut self.state {
+                State::Version(decoder) => {
+                    if decoder.push_bytes(bytes).map_err(|e| E(Inner::Version(e)))?.needs_more() {
+                        // Still more bytes required.
+                        return Ok(DecoderStatus::NeedsMore);
+                    }
+                }
+                State::Inputs(_, _, decoder) =>
+                    if decoder.push_bytes(bytes).map_err(|e| E(Inner::Inputs(e)))?.needs_more() {
+                        return Ok(DecoderStatus::NeedsMore);
+                    },
+                State::SegwitFlag(_) =>
+                    if bytes.is_empty() {
+                        return Ok(DecoderStatus::NeedsMore);
+                    },
+                State::Outputs(_, _, _, decoder) =>
+                    if decoder.push_bytes(bytes).map_err(|e| E(Inner::Outputs(e)))?.needs_more() {
+                        return Ok(DecoderStatus::NeedsMore);
+                    },
+                State::Witnesses(_, _, _, _, decoder) =>
+                    if decoder.push_bytes(bytes).map_err(|e| E(Inner::Witness(e)))?.needs_more() {
+                        return Ok(DecoderStatus::NeedsMore);
+                    },
+                State::LockTime(_, _, _, decoder) =>
+                    if decoder.push_bytes(bytes).map_err(|e| E(Inner::LockTime(e)))?.needs_more() {
+                        return Ok(DecoderStatus::NeedsMore);
+                    },
+                State::Done(..) => return Ok(DecoderStatus::Ready),
+                State::Errored => panic!("call to push_bytes() after decoder errored"),
+            }
+
+            // If the above failed, end the current decoder and go to the next state.
+            match mem::replace(&mut self.state, State::Errored) {
+                State::Version(decoder) => {
+                    let version = decoder.end().map_err(|e| E(Inner::Version(e)))?;
+                    self.state = State::Inputs(version, Attempt::First, VecDecoder::<TxIn>::new());
+                }
+                State::Inputs(version, attempt, decoder) => {
+                    let inputs = decoder.end().map_err(|e| E(Inner::Inputs(e)))?;
+
+                    if Attempt::First == attempt {
+                        if inputs.is_empty() {
+                            self.state = State::SegwitFlag(version);
+                        } else {
+                            self.state = State::Outputs(
+                                version,
+                                inputs,
+                                IsSegwit::No,
+                                VecDecoder::<TxOut>::new(),
+                            );
+                        }
+                    } else {
+                        self.state = State::Outputs(
+                            version,
+                            inputs,
+                            IsSegwit::Yes,
+                            VecDecoder::<TxOut>::new(),
+                        );
+                    }
+                }
+                State::SegwitFlag(version) => {
+                    let segwit_flag = bytes[0];
+                    *bytes = &bytes[1..];
+
+                    if segwit_flag != 1 {
+                        return Err(E(Inner::UnsupportedSegwitFlag(segwit_flag)));
+                    }
+                    self.state = State::Inputs(version, Attempt::Second, VecDecoder::<TxIn>::new());
+                }
+                State::Outputs(version, inputs, is_segwit, decoder) => {
+                    let outputs = decoder.end().map_err(|e| E(Inner::Outputs(e)))?;
+                    // Handle the zero-input case described in the `Transaction` docs.
+                    if is_segwit == IsSegwit::Yes && !inputs.is_empty() {
+                        self.state = State::Witnesses(
+                            version,
+                            inputs,
+                            outputs,
+                            Iteration(0),
+                            WitnessDecoder::new(),
+                        );
+                    } else {
+                        self.state =
+                            State::LockTime(version, inputs, outputs, LockTimeDecoder::new());
+                    }
+                }
+                State::Witnesses(version, mut inputs, outputs, iteration, decoder) => {
+                    let iteration = iteration.0;
+
+                    inputs[iteration].witness = decoder.end().map_err(|e| E(Inner::Witness(e)))?;
+                    if iteration < inputs.len() - 1 {
+                        self.state = State::Witnesses(
+                            version,
+                            inputs,
+                            outputs,
+                            Iteration(iteration + 1),
+                            WitnessDecoder::new(),
+                        );
+                    } else {
+                        if !inputs.is_empty() && inputs.iter().all(|input| input.witness.is_empty())
+                        {
+                            return Err(E(Inner::NoWitnesses));
+                        }
+                        self.state =
+                            State::LockTime(version, inputs, outputs, LockTimeDecoder::new());
+                    }
+                }
+                State::LockTime(version, inputs, outputs, decoder) => {
+                    let lock_time = decoder.end().map_err(|e| E(Inner::LockTime(e)))?;
+                    self.state = State::Done(Transaction {
+                        version,
+                        lock_time,
+                        input: inputs,
+                        output: outputs,
+                    });
+                    return Ok(DecoderStatus::Ready);
+                }
+                State::Done(..) => return Ok(DecoderStatus::Ready),
+                State::Errored => unreachable!("checked above"),
+            }
+        }
+    }
+
+    #[inline]
+    fn end(self) -> Result<Self::Output, Self::Error> {
+        use TransactionDecoderError as E;
+        use TransactionDecoderErrorInner as Inner;
+        use TransactionDecoderState as State;
+
+        match self.state {
+            State::Version(_) => Err(E(Inner::EarlyEnd("version"))),
+            State::Inputs(..) => Err(E(Inner::EarlyEnd("inputs"))),
+            State::SegwitFlag(..) => Err(E(Inner::EarlyEnd("segwit flag"))),
+            State::Outputs(..) => Err(E(Inner::EarlyEnd("outputs"))),
+            State::Witnesses(..) => Err(E(Inner::EarlyEnd("witnesses"))),
+            State::LockTime(..) => Err(E(Inner::EarlyEnd("locktime"))),
+            State::Done(tx) => {
+                // Reject transactions with no outputs
+                if tx.output.is_empty() {
+                    return Err(E(Inner::NoOutputs));
+                }
+                // check for null prevout in non-coinbase txs
+                if tx.input.len() > 1 {
+                    for (index, input) in tx.input.iter().enumerate() {
+                        if input.previous_output == OutPoint::null() {
+                            return Err(E(Inner::NullPrevoutInNonCoinbase(index)));
+                        }
+                    }
+                }
+                // check coinbase scriptSig length (must be 2-100 bytes)
+                if tx.is_coinbase() {
+                    let len = tx.input[0].script_sig.len();
+                    if len < 2 {
+                        return Err(E(Inner::CoinbaseScriptSigTooSmall(len)));
+                    }
+                    if len > 100 {
+                        return Err(E(Inner::CoinbaseScriptSigTooLarge(len)));
+                    }
+                }
+                // check for duplicate inputs (CVE-2018-17144).
+                let mut outpoints: Vec<_> = tx.input.iter().map(|i| i.previous_output).collect();
+                outpoints.sort_unstable();
+                for pair in outpoints.windows(2) {
+                    if pair[0] == pair[1] {
+                        return Err(E(Inner::DuplicateInput(pair[0])));
+                    }
+                }
+                // Check that sum of output values doesn't exceed MAX_MONEY (see CVE-2010-5139)
+                // Note: Individual output values are already validated by Amount::from_sat()
+                // during decoding, so we only need to check the sum here.
+                let mut total_out: u64 = 0;
+                for output in &tx.output {
+                    total_out = total_out.saturating_add(output.value.to_sat());
+                    if total_out > Amount::MAX_MONEY.to_sat() {
+                        return Err(E(Inner::OutputValueSumTooLarge(total_out)));
+                    }
+                }
+                Ok(tx)
+            }
+            State::Errored => panic!("call to end() after decoder errored"),
+        }
+    }
+
+    #[inline]
+    fn read_limit(&self) -> usize {
+        use TransactionDecoderState as State;
+
+        match &self.state {
+            State::Version(decoder) => decoder.read_limit(),
+            State::Inputs(_, _, decoder) => decoder.read_limit(),
+            State::SegwitFlag(_) => 1,
+            State::Outputs(_, _, _, decoder) => decoder.read_limit(),
+            State::Witnesses(_, _, _, _, decoder) => decoder.read_limit(),
+            State::LockTime(_, _, _, decoder) => decoder.read_limit(),
+            State::Done(_) => 0,
+            // `read_limit` is not documented to panic or return an error, so we
+            // return a dummy value if the decoder is in an error state.
+            State::Errored => 0,
+        }
+    }
+}
+
+/// The state of the transiting decoder.
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone)]
+enum TransactionDecoderState {
+    /// Decoding the transaction version.
+    Version(VersionDecoder),
+    /// Decoding the transaction inputs.
+    Inputs(Version, Attempt, VecDecoder<TxIn>),
+    /// Decoding the segwit flag.
+    SegwitFlag(Version),
+    /// Decoding the transaction outputs.
+    Outputs(Version, Vec<TxIn>, IsSegwit, VecDecoder<TxOut>),
+    /// Decoding the segwit transaction witnesses.
+    Witnesses(Version, Vec<TxIn>, Vec<TxOut>, Iteration, WitnessDecoder),
+    /// Decoding the transaction lock time.
+    LockTime(Version, Vec<TxIn>, Vec<TxOut>, LockTimeDecoder),
+    /// Done decoding the [`Transaction`].
+    Done(Transaction),
+    /// When `end()`ing a sub-decoder, encountered an error which prevented us
+    /// from constructing the next sub-decoder.
+    Errored,
+}
+
+/// Boolean used to track number of times we have attempted to decode the inputs vector.
+#[cfg(feature = "encoding")]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum Attempt {
+    /// First time reading inputs.
+    First,
+    /// Second time reading inputs.
+    Second,
+}
+
+/// Boolean used to track whether or not this transaction uses segwit encoding.
+#[cfg(feature = "encoding")]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum IsSegwit {
+    /// Yes so uses segwit encoding.
+    Yes,
+    /// No segwit flag, marker, or witnesses.
+    No,
+}
+
+/// How many times we have state transitioned to encoding a witness (zero-based).
+#[cfg(feature = "encoding")]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+struct Iteration(usize);
+
+/// An error consensus decoding a `Transaction`.
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransactionDecoderError(pub(crate) TransactionDecoderErrorInner);
+
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TransactionDecoderErrorInner {
+    /// Error while decoding the `version`.
+    Version(VersionDecoderError),
+    /// We only support segwit flag value 0x01.
+    UnsupportedSegwitFlag(u8),
+    /// Error while decoding the `inputs`.
+    Inputs(encoding::VecDecoderError<TxInDecoderError>),
+    /// Error while decoding the `outputs`.
+    Outputs(encoding::VecDecoderError<TxOutDecoderError>),
+    /// Error while decoding one of the witnesses.
+    Witness(WitnessDecoderError),
+    /// Non-empty Segwit transaction with no witnesses.
+    NoWitnesses,
+    /// Error while decoding the `lock_time`.
+    LockTime(LockTimeDecoderError),
+    /// Attempt to call `end()` before the transaction was complete. Holds
+    /// a description of the current state.
+    EarlyEnd(&'static str),
+    /// Null prevout in non-coinbase transaction.
+    NullPrevoutInNonCoinbase(usize),
+    /// Coinbase scriptSig too small (must be at least 2 bytes).
+    CoinbaseScriptSigTooSmall(usize),
+    /// Coinbase scriptSig is too large (must be at most 100 bytes).
+    CoinbaseScriptSigTooLarge(usize),
+    /// Transaction has duplicate inputs (this check prevents CVE-2018-17144 ).
+    DuplicateInput(OutPoint),
+    /// Sum of output values exceeds `MAX_MONEY`
+    OutputValueSumTooLarge(u64),
+    /// Transaction has no outputs.
+    NoOutputs,
+}
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for TransactionDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl fmt::Display for TransactionDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use TransactionDecoderErrorInner as E;
+
+        match self.0 {
+            E::Version(ref e) => write_err!(f, "transaction decoder error"; e),
+            E::UnsupportedSegwitFlag(v) => {
+                write!(f, "we only support segwit flag value 0x01: {}", v)
+            }
+            E::Inputs(ref e) => write_err!(f, "transaction decoder error"; e),
+            E::Outputs(ref e) => write_err!(f, "transaction decoder error"; e),
+            E::Witness(ref e) => write_err!(f, "transaction decoder error"; e),
+            E::NoWitnesses => write!(f, "non-empty Segwit transaction with no witnesses"),
+            E::LockTime(ref e) => write_err!(f, "transaction decoder error"; e),
+            E::EarlyEnd(s) => write!(f, "early end of transaction (still decoding {})", s),
+            E::NullPrevoutInNonCoinbase(index) =>
+                write!(f, "null prevout in non-coinbase transaction at input {}", index),
+            E::CoinbaseScriptSigTooSmall(len) =>
+                write!(f, "coinbase scriptSig too small: {} bytes (min 2)", len),
+            E::CoinbaseScriptSigTooLarge(len) =>
+                write!(f, "coinbase scriptSig too large: {} bytes (max 100)", len),
+            E::DuplicateInput(ref outpoint) =>
+                write!(f, "duplicate input: {:?}:{}", outpoint.txid, outpoint.vout),
+            E::OutputValueSumTooLarge(val) =>
+                write!(f, "sum of output values {} satoshis exceeds MAX_MONEY", val),
+            E::NoOutputs => write!(f, "transaction has no outputs"),
+        }
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for TransactionDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use TransactionDecoderErrorInner as E;
+
+        match self.0 {
+            E::Version(ref e) => Some(e),
+            E::UnsupportedSegwitFlag(_) => None,
+            E::Inputs(ref e) => Some(e),
+            E::Outputs(ref e) => Some(e),
+            E::Witness(ref e) => Some(e),
+            E::NoWitnesses => None,
+            E::LockTime(ref e) => Some(e),
+            E::EarlyEnd(_) => None,
+            E::NullPrevoutInNonCoinbase(_) => None,
+            E::CoinbaseScriptSigTooSmall(_) => None,
+            E::CoinbaseScriptSigTooLarge(_) => None,
+            E::DuplicateInput(_) => None,
+            E::OutputValueSumTooLarge(_) => None,
+            E::NoOutputs => None,
         }
     }
 }

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -16,9 +16,11 @@ use core::str::FromStr;
 use core::{cmp, fmt};
 
 #[cfg(feature = "encoding")]
-use encoding::{ArrayEncoder, BytesEncoder, Decoder3, Encoder2, Encoder3};
+use encoding::{ArrayEncoder, BytesEncoder, Decoder2, Decoder3, Encoder2, Encoder3};
 use hashes::{sha256d, Hash};
 use io::{Read, Write};
+#[cfg(feature = "encoding")]
+use units::amount::{AmountDecoder, AmountEncoder};
 use units::parse::{self, ParseIntError};
 
 use super::Weight;
@@ -1311,6 +1313,71 @@ impl std::error::Error for VersionDecoderError {
 }
 
 impl_consensus_encoding!(TxOut, value, script_pubkey);
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// The encoder for the [`TxOut`] type.
+    #[derive(Debug, Clone)]
+    pub struct TxOutEncoder<'e>(Encoder2<AmountEncoder<'e>, ScriptEncoder<'e>>);
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for TxOut {
+    type Encoder<'e> = Encoder2<AmountEncoder<'e>, ScriptEncoder<'e>>;
+
+    fn encoder(&self) -> Self::Encoder<'_> {
+        Encoder2::new(self.value.encoder(), self.script_pubkey.encoder())
+    }
+}
+
+#[cfg(feature = "encoding")]
+type TxOutInnerDecoder = Decoder2<AmountDecoder, ScriptBufDecoder>;
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// The decoder for the [`TxOut`] type.
+    #[derive(Debug, Clone)]
+    pub struct TxOutDecoder(TxOutInnerDecoder);
+
+    /// Constructs a new [`TxOut`] decoder.
+    pub const fn new() -> Self {
+        Self(Decoder2::new(AmountDecoder::new(), ScriptBufDecoder::new()))
+    }
+
+    fn end(
+        result: Result<<TxOutInnerDecoder as encoding::Decoder>::Output, <TxOutInnerDecoder as encoding::Decoder>::Error>
+    ) -> Result<TxOut, TxOutDecoderError> {
+        let (value, script_pubkey) = result.map_err(TxOutDecoderError)?;
+        Ok(TxOut { value, script_pubkey })
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for TxOut {
+    type Decoder = TxOutDecoder;
+}
+
+/// An error consensus decoding a `TxOut`.
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TxOutDecoderError(pub(super) <TxOutInnerDecoder as encoding::Decoder>::Error);
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for TxOutDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl fmt::Display for TxOutDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write_err!(f, "txout decoder error"; self.0)
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for TxOutDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
+}
 
 impl Encodable for OutPoint {
     fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -5,22 +5,49 @@
 //! This module contains the [`Witness`] struct and related methods to operate on it
 //!
 
+#[cfg(feature = "encoding")]
+use core::convert::Infallible;
 use core::fmt;
 use core::ops::Index;
 
 #[cfg(feature = "arbitrary")]
 use actual_arbitrary::{self as arbitrary, Arbitrary, Unstructured};
+#[cfg(feature = "encoding")]
+use encoding::{
+    BytesEncoder, CompactSizeDecoder, CompactSizeDecoderError, CompactSizeEncoder, DecoderStatus,
+    Encoder, Encoder2, EncoderStatus,
+};
 use io::{Read, Write};
 
+#[cfg(feature = "encoding")]
+use crate::array_vec::ArrayVec;
 use crate::consensus::encode::{Error, MAX_VEC_SIZE};
 use crate::consensus::{Decodable, Encodable, WriteExt};
 use crate::crypto::ecdsa;
+#[cfg(feature = "encoding")]
+use crate::internal_macros::write_err;
 use crate::prelude::*;
 use crate::taproot::{
     self, LeafScript, LeafVersion, TAPROOT_ANNEX_PREFIX, TAPROOT_CONTROL_BASE_SIZE,
     TAPROOT_LEAF_MASK,
 };
 use crate::{Script, VarInt};
+
+/// Maximum number of items in a witness stack.
+///
+/// This is an anti-DoS limit based on Bitcoin's 4MB block weight limit.
+/// Witness data is part of transactions, which are part of blocks, so witness
+/// items (assuming 1-byte per item) cannot exceed what fits in a block.
+#[cfg(feature = "encoding")]
+const MAX_WITNESS_STACK_ITEMS: usize = 4_000_000;
+
+/// Maximum byte size of a single witness stack item.
+///
+/// This is an anti-DoS limit based on Bitcoin's 4MB block weight limit.
+/// Witness data is part of transactions, which are part of blocks, so a
+/// single witness item cannot exceed what fits in a block.
+#[cfg(feature = "encoding")]
+const MAX_WITNESS_ITEM_SIZE: usize = 4_000_000;
 
 /// The Witness is the data used to unlock bitcoin since the [segwit upgrade].
 ///
@@ -233,6 +260,305 @@ impl Encodable for Witness {
         let content_len = content_with_indices_len - indices_size;
         w.emit_slice(&self.content[..content_len])?;
         Ok(content_len + len.size())
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for Witness {
+    type Encoder<'e> = WitnessEncoder<'e>;
+
+    fn encoder(&self) -> Self::Encoder<'_> {
+        let num_elements = CompactSizeEncoder::new(self.len());
+        let witness_elements =
+            BytesEncoder::without_length_prefix(&self.content[..self.indices_start]);
+
+        WitnessEncoder(Encoder2::new(num_elements, witness_elements))
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for Witness {
+    type Decoder = WitnessDecoder;
+}
+
+/// The encoder for the [`Witness`] type.
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone)]
+pub struct WitnessEncoder<'e>(Encoder2<CompactSizeEncoder, BytesEncoder<'e>>);
+
+#[cfg(feature = "encoding")]
+impl encoding::Encoder for WitnessEncoder<'_> {
+    #[inline]
+    fn current_chunk(&self) -> &[u8] { self.0.current_chunk() }
+
+    #[inline]
+    fn advance(&mut self) -> EncoderStatus { self.0.advance() }
+}
+
+/// The decoder for the [`Witness`] type.
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone)]
+pub struct WitnessDecoder {
+    /// The single buffer that will become the Witness content.
+    /// The index entries are written in [`Self::end`].
+    content: Vec<u8>,
+    /// Decoder for the initial witness element count.
+    witness_count_decoder: CompactSizeDecoder,
+    /// Total number of witness elements to decode (None until initial count is read).
+    witness_elements: Option<usize>,
+    /// Index of the current element being decoded.
+    element_idx: usize,
+    /// Decoder for the current element's length.
+    element_length_decoder: CompactSizeDecoder,
+    /// Bytes remaining to read for the current element's data.
+    /// - `None` means we're currently reading the length.
+    /// - `Some(n)` means we're reading element data with `n` bytes remaining.
+    element_bytes_remaining: Option<usize>,
+}
+
+#[cfg(feature = "encoding")]
+impl WitnessDecoder {
+    /// Constructs a new witness decoder.
+    pub const fn new() -> Self {
+        Self {
+            content: Vec::new(),
+            witness_elements: None,
+            witness_count_decoder: CompactSizeDecoder::new_with_limit(MAX_WITNESS_STACK_ITEMS),
+            element_idx: 0,
+            element_length_decoder: CompactSizeDecoder::new_with_limit(MAX_WITNESS_ITEM_SIZE),
+            element_bytes_remaining: None,
+        }
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl Default for WitnessDecoder {
+    fn default() -> Self { Self::new() }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decoder for WitnessDecoder {
+    type Output = Witness;
+    type Error = WitnessDecoderError;
+
+    fn push_bytes(&mut self, bytes: &mut &[u8]) -> Result<DecoderStatus, Self::Error> {
+        use WitnessDecoderError as E;
+        use WitnessDecoderErrorInner as Inner;
+
+        // Read initial witness element count.
+        if self.witness_elements.is_none() {
+            if self
+                .witness_count_decoder
+                .push_bytes(bytes)
+                .map_err(|e| E(Inner::LengthPrefixDecode(e)))?
+                .needs_more()
+            {
+                return Ok(DecoderStatus::NeedsMore);
+            }
+            // Take ownership of the decoder in order to consume it.
+            let decoder = core::mem::take(&mut self.witness_count_decoder);
+            let witness_elements = decoder.end().map_err(|e| E(Inner::LengthPrefixDecode(e)))?;
+            self.witness_elements = Some(witness_elements);
+
+            // Short circuit for zero witness elements.
+            if witness_elements == 0 {
+                return Ok(DecoderStatus::Ready);
+            }
+
+            // Allocate space for the buffer. The buffer
+            // is initialized to 128 bytes which should be large enough
+            // to cover most witnesses, the typical pubkey + signature
+            // and some overhead (e.g. P2WPKH witness is ~100 bytes),
+            // without reallocating.
+            self.content.reserve(128);
+        }
+
+        let Some(witness_elements) = self.witness_elements else {
+            unreachable!("witness_elements must be Some after initial read")
+        };
+
+        // Read witness elements.
+        loop {
+            // Check if we're done processing all elements.
+            if self.element_idx >= witness_elements {
+                return Ok(DecoderStatus::Ready);
+            }
+
+            if bytes.is_empty() {
+                return Ok(DecoderStatus::NeedsMore);
+            }
+
+            // If we have some bytes to read, then reading element data.
+            // Else we are reading the element's length.
+            if let Some(bytes_to_read) = self.element_bytes_remaining {
+                let can_copy = bytes.len().min(bytes_to_read);
+                // To avoid reallocating the index space in `end()` we reserve it here, the moment
+                // the final element's data is copied.
+                if can_copy == bytes_to_read && self.element_idx + 1 == witness_elements {
+                    self.content.reserve_exact(can_copy + witness_elements * 4);
+                }
+                self.content.extend_from_slice(&bytes[..can_copy]);
+                *bytes = &bytes[can_copy..];
+                let remaining = bytes_to_read - can_copy;
+
+                if remaining == 0 {
+                    // Element complete, move to next element.
+                    self.element_idx += 1;
+                    self.element_bytes_remaining = None;
+                } else {
+                    self.element_bytes_remaining = Some(remaining);
+                }
+            } else {
+                if self
+                    .element_length_decoder
+                    .push_bytes(bytes)
+                    .map_err(|e| E(Inner::LengthPrefixDecode(e)))?
+                    .needs_more()
+                {
+                    return Ok(DecoderStatus::NeedsMore);
+                }
+
+                // Take ownership of the decoder so we can consume it.
+                let decoder = core::mem::take(&mut self.element_length_decoder);
+                let element_length = decoder.end().map_err(|e| E(Inner::LengthPrefixDecode(e)))?;
+
+                // keep the element length prefix in the content area.
+                let encoded_compact_size = compact_size_encode(element_length);
+                self.content.extend_from_slice(encoded_compact_size.as_slice());
+
+                if element_length == 0 {
+                    // Complete immediately for zero-length element to
+                    // avoid incorrectly signaling "need more data".
+                    self.element_idx += 1;
+                    self.element_bytes_remaining = None;
+                } else {
+                    self.element_bytes_remaining = Some(element_length);
+                }
+            }
+        }
+    }
+
+    fn end(mut self) -> Result<Self::Output, Self::Error> {
+        use WitnessDecoderError as E;
+        use WitnessDecoderErrorInner as Inner;
+
+        let Some(witness_elements) = self.witness_elements else {
+            // Never read the witness element count.
+            return Err(E(Inner::UnexpectedEof(UnexpectedEofError { missing_elements: 0 })));
+        };
+
+        let remaining = witness_elements - self.element_idx;
+
+        if remaining == 0 {
+            // `content` now holds the complete content area (all element bytes have been already received)
+            // The index area begins at its current end.
+            let indices_start = self.content.len();
+
+            // Build the index area by walking the content area
+            // This is the only allocation sized by the element count, and it happens only here
+            self.content.reserve(witness_elements * 4);
+            let mut read_pos = 0;
+            for _ in 0..witness_elements {
+                let offset = u32::try_from(read_pos).expect("larger than u32");
+                let (element_length, prefix_size) = {
+                    let mut slice = &self.content[read_pos..indices_start];
+                    let before = slice.len();
+                    let element_length = decode_unchecked(&mut slice);
+                    (element_length, before - slice.len())
+                };
+                let data_len = usize::try_from(element_length).expect("element data is present");
+                read_pos += prefix_size + data_len;
+                self.content.extend_from_slice(&offset.to_ne_bytes());
+            }
+
+            Ok(Witness { content: self.content, witness_elements, indices_start })
+        } else {
+            Err(E(Inner::UnexpectedEof(UnexpectedEofError { missing_elements: remaining })))
+        }
+    }
+
+    fn read_limit(&self) -> usize {
+        if self.witness_elements.is_none() {
+            // Reading witness count (haven't started processing elements yet).
+            self.witness_count_decoder.read_limit()
+        } else {
+            // Reading an element.
+            match self.element_bytes_remaining {
+                None => self.element_length_decoder.read_limit(),
+                Some(remaining) => remaining,
+            }
+        }
+    }
+}
+
+/// An error when consensus decoding a [`Witness`].
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WitnessDecoderError(pub(super) WitnessDecoderErrorInner);
+
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum WitnessDecoderErrorInner {
+    /// Error decoding the vector length prefix.
+    LengthPrefixDecode(CompactSizeDecoderError),
+    /// Not enough bytes given to decoder.
+    UnexpectedEof(UnexpectedEofError),
+}
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for WitnessDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl fmt::Display for WitnessDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use WitnessDecoderErrorInner as E;
+
+        match self.0 {
+            E::LengthPrefixDecode(ref e) => write_err!(f, "vec decoder error"; e),
+            E::UnexpectedEof(ref e) => write_err!(f, "decoder error"; e),
+        }
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for WitnessDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use WitnessDecoderErrorInner as E;
+
+        match self.0 {
+            E::LengthPrefixDecode(ref e) => Some(e),
+            E::UnexpectedEof(ref e) => Some(e),
+        }
+    }
+}
+
+/// Not enough witness elements (bytes) given to decoder.
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnexpectedEofError {
+    /// Number of elements missing to complete decoder.
+    pub(crate) missing_elements: usize,
+}
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for UnexpectedEofError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl fmt::Display for UnexpectedEofError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "not enough witness elements for decoder, missing {}", self.missing_elements)
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for UnexpectedEofError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let Self { missing_elements: _ } = self;
+        None
     }
 }
 
@@ -699,6 +1025,72 @@ impl<'a> Arbitrary<'a> for Witness {
         let arbitrary_bytes = Vec::<Vec<u8>>::arbitrary(u)?;
         Ok(Witness::from_slice(&arbitrary_bytes))
     }
+}
+
+/// Gets the compact size encoded value from `slice` and moves slice past the encoding.
+///
+/// Caller to guarantee that the encoding is well formed. Well formed is defined as:
+///
+/// * Being at least long enough.
+/// * Containing a minimal encoding.
+///
+/// # Panics
+///
+/// * Panics in release mode if the `slice` does not contain a valid minimal compact size encoding.
+/// * Panics in debug mode if the encoding is not minimal (referred to as "non-canonical" in Core).
+#[cfg(feature = "encoding")]
+fn decode_unchecked(slice: &mut &[u8]) -> u64 {
+    assert!(!slice.is_empty(), "tried to decode an empty slice");
+
+    match slice[0] {
+        0xFF => {
+            const SIZE: usize = 9;
+            assert!(slice.len() >= SIZE, "slice too short, expected at least 9 bytes");
+
+            let mut bytes = [0_u8; SIZE - 1];
+            bytes.copy_from_slice(&slice[1..SIZE]);
+
+            let v = u64::from_le_bytes(bytes);
+            debug_assert!(v > u32::MAX.into(), "non-minimal encoding of a u64");
+            *slice = &slice[SIZE..];
+            v
+        }
+        0xFE => {
+            const SIZE: usize = 5;
+            assert!(slice.len() >= SIZE, "slice too short, expected at least 5 bytes");
+
+            let mut bytes = [0_u8; SIZE - 1];
+            bytes.copy_from_slice(&slice[1..SIZE]);
+
+            let v = u32::from_le_bytes(bytes);
+            debug_assert!(v > u16::MAX.into(), "non-minimal encoding of a u32");
+            *slice = &slice[SIZE..];
+            u64::from(v)
+        }
+        0xFD => {
+            const SIZE: usize = 3;
+            assert!(slice.len() >= SIZE, "slice too short, expected at least 3 bytes");
+
+            let mut bytes = [0_u8; SIZE - 1];
+            bytes.copy_from_slice(&slice[1..SIZE]);
+
+            let v = u16::from_le_bytes(bytes);
+            debug_assert!(v >= 0xFD, "non-minimal encoding of a u16");
+            *slice = &slice[SIZE..];
+            u64::from(v)
+        }
+        n => {
+            *slice = &slice[1..];
+            u64::from(n)
+        }
+    }
+}
+
+// Encode a compact size to a slice without allocating
+#[cfg(feature = "encoding")]
+fn compact_size_encode(value: usize) -> ArrayVec<u8, 9> {
+    let encoder = encoding::CompactSizeEncoder::new(value);
+    ArrayVec::from_slice(encoder.current_chunk())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Add consensus encoding support to all of the types in primitives 1.0 that are also the same on the 0.32.x branch. 

Extend the fuzzing to cover all of the types with encoding support added in this PR.