### PR TITLE
Manual update to rustc nightly-2026-06-12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["benches"]
 resolver = "2"
 
 [workspace.metadata.rbmt.toolchains]
-nightly = "nightly-2026-04-17"
+nightly = "nightly-2026-06-12"
 stable = "1.96.0"
 
 [workspace.lints.rust]

--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -153,10 +153,8 @@ impl<'a, W: Write> BlockFilterWriter<'a, W> {
             .flat_map(|t| t.inputs.iter().map(|i| &i.previous_output))
             .map(script_for_coin)
         {
-            match script {
-                Ok(script) => self.add_element(script.borrow().as_bytes()),
-                Err(e) => return Err(e),
-            }
+            let script = script?;
+            self.add_element(script.borrow().as_bytes());
         }
         Ok(())
     }

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -411,7 +411,6 @@ mod tests {
     use alloc::string::ToString;
 
     use hex::hex;
-    use internals::ToU64 as _;
 
     use super::*;
     use crate::consensus::encode::{deserialize, serialize};

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -1907,10 +1907,10 @@ mod tests {
         let outpoint = OutPoint::COINBASE_PREVOUT;
 
         let debug = "OutPoint { txid: Txid(bitcoin_hashes::sha256d::Hash(0000000000000000000000000000000000000000000000000000000000000000)), vout: 4294967295 }";
-        assert_eq!(debug, format!("{:?}", &outpoint));
+        assert_eq!(debug, format!("{:?}", outpoint));
 
         let display = "0000000000000000000000000000000000000000000000000000000000000000:4294967295";
-        assert_eq!(display, format!("{}", &outpoint));
+        assert_eq!(display, format!("{}", outpoint));
 
         let pretty_debug = "OutPoint {
     txid: Txid(
@@ -1920,16 +1920,16 @@ mod tests {
     ),
     vout: 4294967295,
 }";
-        assert_eq!(pretty_debug, format!("{:#?}", &outpoint));
+        assert_eq!(pretty_debug, format!("{:#?}", outpoint));
 
         let debug_txid = "Txid(bitcoin_hashes::sha256d::Hash(0000000000000000000000000000000000000000000000000000000000000000))";
-        assert_eq!(debug_txid, format!("{:?}", &outpoint.txid));
+        assert_eq!(debug_txid, format!("{:?}", outpoint.txid));
 
         let display_txid = "0000000000000000000000000000000000000000000000000000000000000000";
-        assert_eq!(display_txid, format!("{}", &outpoint.txid));
+        assert_eq!(display_txid, format!("{}", outpoint.txid));
 
         let pretty_txid = "0x0000000000000000000000000000000000000000000000000000000000000000";
-        assert_eq!(pretty_txid, format!("{:#}", &outpoint.txid));
+        assert_eq!(pretty_txid, format!("{:#}", outpoint.txid));
     }
 
     #[test]


### PR DESCRIPTION
Supersedes https://github.com/rust-bitcoin/rust-bitcoin/pull/6326
Supersedes https://github.com/rust-bitcoin/rust-bitcoin/pull/6352
Supersedes https://github.com/rust-bitcoin/rust-bitcoin/pull/6302

Dropped the redundant `&` in all `format!` calls and replaced the match with `?`.
