### PR TITLE
policy: update docs on ordering derives in enums

### DIFF
--- a/docs/policy.md
+++ b/docs/policy.md
@@ -332,13 +332,14 @@ enum Foo {
 ```
 
 For types that should not form a total or partial order, or that technically do but it does not
-make sense to compare them, we use the `Ordered` trait from the
-[`ordered`](https://crates.io/crates/ordered) crate. See `absolute::LockTime` for an example.
+make sense to compare them semantically, consider carefully before deriving `PartialOrd` or `Ord`.
+While deterministic sorting is useful for use with collections (e.g. `BTreeMap`), it bakes the
+enum variant order into the public API. Adding enum variants in the middle changes discriminants
+and breaks compatibility.
 
 For error types you likely want to use `#[derive(Debug, Clone, PartialEq, Eq)]`.
 
 See [Errors](#errors) section.
-
 
 ## Attributes
 


### PR DESCRIPTION
I have been digging into the `Ord`/`PartialOrd` derives in the `bitcoin-network` crate trying to wrap my head around if they are necessary. This lead me to these policy docs which look out of date. `rust-ordering` is no longer recommended and was removed from the workspace in #4065 (38c8c9).

There are types like `NetworkKind` which derive order and it is used downstream in other workspace packages to also derive order (e.g. Xpub). I believe this derive actually caused issues before in v0.32.4, discussed in issue #4116. But it probably low risk going forward since the enum is exhaustive and I don't think someone would change the variant order just for fun.

This more general policy is discussed in #3865, but not sure if anything has been codified yet.