### PR TITLE
primitives: Scrub encoder code

### DIFF
--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -325,15 +325,6 @@ impl<V: Validation> fmt::UpperHex for Block<V> {
 }
 
 #[cfg(feature = "alloc")]
-encoding::encoder_newtype! {
-    /// The encoder for the [`Block`] type.
-    #[derive(Debug, Clone)]
-    pub struct BlockEncoder<'e>(
-        Encoder2<HeaderEncoder<'e>, Encoder2<CompactSizeEncoder, SliceEncoder<'e, Transaction>>>
-    );
-}
-
-#[cfg(feature = "alloc")]
 impl<V> encoding::Encode for Block<V>
 where
     V: Validation,
@@ -355,6 +346,20 @@ where
 }
 
 #[cfg(feature = "alloc")]
+impl encoding::Decode for Block<Unchecked> {
+    type Decoder = BlockDecoder;
+}
+
+#[cfg(feature = "alloc")]
+encoding::encoder_newtype! {
+    /// The encoder for the [`Block`] type.
+    #[derive(Debug, Clone)]
+    pub struct BlockEncoder<'e>(
+        Encoder2<HeaderEncoder<'e>, Encoder2<CompactSizeEncoder, SliceEncoder<'e, Transaction>>>
+    );
+}
+
+#[cfg(feature = "alloc")]
 type BlockInnerDecoder = Decoder2<HeaderDecoder, VecDecoder<Transaction>>;
 
 #[cfg(feature = "alloc")]
@@ -372,11 +377,6 @@ crate::decoder_newtype! {
         let (header, transactions) = result.map_err(BlockDecoderError)?;
         Ok(Self::Output::new_unchecked(header, transactions))
     }
-}
-
-#[cfg(feature = "alloc")]
-impl encoding::Decode for Block<Unchecked> {
-    type Decoder = BlockDecoder;
 }
 
 /// Computes the Merkle root for a list of transactions.
@@ -523,21 +523,6 @@ impl fmt::Debug for Header {
     }
 }
 
-encoding::encoder_newtype_exact! {
-    /// The encoder for the [`Header`] type.
-    #[derive(Debug, Clone)]
-    pub struct HeaderEncoder<'e>(
-        encoding::Encoder6<
-            VersionEncoder<'e>,
-            BlockHashEncoder<'e>,
-            crate::merkle_tree::TxMerkleNodeEncoder<'e>,
-            crate::time::BlockTimeEncoder<'e>,
-            crate::pow::CompactTargetEncoder<'e>,
-            encoding::ArrayEncoder<4>,
-        >
-    );
-}
-
 impl encoding::Encode for Header {
     type Encoder<'e> = HeaderEncoder<'e>;
 
@@ -551,6 +536,25 @@ impl encoding::Encode for Header {
             encoding::ArrayEncoder::without_length_prefix(self.nonce.to_le_bytes()),
         ))
     }
+}
+
+impl encoding::Decode for Header {
+    type Decoder = HeaderDecoder;
+}
+
+encoding::encoder_newtype_exact! {
+    /// The encoder for the [`Header`] type.
+    #[derive(Debug, Clone)]
+    pub struct HeaderEncoder<'e>(
+        encoding::Encoder6<
+            VersionEncoder<'e>,
+            BlockHashEncoder<'e>,
+            crate::merkle_tree::TxMerkleNodeEncoder<'e>,
+            crate::time::BlockTimeEncoder<'e>,
+            crate::pow::CompactTargetEncoder<'e>,
+            encoding::ArrayEncoder<4>,
+        >
+    );
 }
 
 type HeaderInnerDecoder = Decoder6<
@@ -603,10 +607,6 @@ impl HeaderDecoder {
             encoding::Decoder6Error::Sixth(e) => HeaderDecoderError::Nonce(e),
         }
     }
-}
-
-impl encoding::Decode for Header {
-    type Decoder = HeaderDecoder;
 }
 
 impl From<Header> for BlockHash {
@@ -716,12 +716,6 @@ impl Default for Version {
     fn default() -> Self { Self::NO_SOFT_FORK_SIGNALLING }
 }
 
-encoding::encoder_newtype_exact! {
-    /// The encoder for the [`Version`] type.
-    #[derive(Debug, Clone)]
-    pub struct VersionEncoder<'e>(encoding::ArrayEncoder<4>);
-}
-
 impl encoding::Encode for Version {
     type Encoder<'e> = VersionEncoder<'e>;
     fn encoder(&self) -> Self::Encoder<'_> {
@@ -729,6 +723,16 @@ impl encoding::Encode for Version {
             self.to_consensus().to_le_bytes(),
         ))
     }
+}
+
+impl encoding::Decode for Version {
+    type Decoder = VersionDecoder;
+}
+
+encoding::encoder_newtype_exact! {
+    /// The encoder for the [`Version`] type.
+    #[derive(Debug, Clone)]
+    pub struct VersionEncoder<'e>(encoding::ArrayEncoder<4>);
 }
 
 crate::decoder_newtype! {
@@ -744,10 +748,6 @@ crate::decoder_newtype! {
         let n = i32::from_le_bytes(value);
         Ok(Version::from_consensus(n))
     }
-}
-
-impl encoding::Decode for Version {
-    type Decoder = VersionDecoder;
 }
 
 /// Error types for Bitcoin blocks.

--- a/primitives/src/script/borrowed.rs
+++ b/primitives/src/script/borrowed.rs
@@ -183,12 +183,6 @@ impl<T> Script<T> {
     pub fn to_hex(&self) -> alloc::string::String { alloc::format!("{:x}", self) }
 }
 
-encoding::encoder_newtype_exact! {
-    /// The encoder for the [`Script<T>`] type.
-    #[derive(Debug, Clone)]
-    pub struct ScriptEncoder<'e>(Encoder2<CompactSizeEncoder, BytesEncoder<'e>>);
-}
-
 impl<T> Encode for Script<T> {
     type Encoder<'e>
         = ScriptEncoder<'e>
@@ -201,6 +195,12 @@ impl<T> Encode for Script<T> {
             BytesEncoder::without_length_prefix(self.as_bytes()),
         ))
     }
+}
+
+encoding::encoder_newtype_exact! {
+    /// The encoder for the [`Script<T>`] type.
+    #[derive(Debug, Clone)]
+    pub struct ScriptEncoder<'e>(Encoder2<CompactSizeEncoder, BytesEncoder<'e>>);
 }
 
 #[cfg(feature = "arbitrary")]

--- a/primitives/src/script/owned.rs
+++ b/primitives/src/script/owned.rs
@@ -180,6 +180,10 @@ impl<T> DerefMut for ScriptBuf<T> {
     fn deref_mut(&mut self) -> &mut Self::Target { self.as_mut_script() }
 }
 
+impl<T> encoding::Decode for ScriptBuf<T> {
+    type Decoder = ScriptBufDecoder<T>;
+}
+
 /// The decoder for the [`ScriptBuf`] type.
 #[derive(Debug, Clone)]
 pub struct ScriptBufDecoder<T>(ByteVecDecoder, PhantomData<T>);
@@ -209,10 +213,6 @@ impl<T> encoding::Decoder for ScriptBufDecoder<T> {
 
     #[inline]
     fn read_limit(&self) -> usize { self.0.read_limit() }
-}
-
-impl<T> encoding::Decode for ScriptBuf<T> {
-    type Decoder = ScriptBufDecoder<T>;
 }
 
 #[cfg(feature = "arbitrary")]

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -239,6 +239,40 @@ impl cmp::Ord for Transaction {
 }
 
 #[cfg(feature = "alloc")]
+#[cfg(feature = "hex")]
+impl core::str::FromStr for Transaction {
+    type Err = ParseTransactionError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        HexPrimitive::from_str(s).map_err(ParseTransactionError)
+    }
+}
+
+#[cfg(feature = "alloc")]
+#[cfg(feature = "hex")]
+impl fmt::Display for Transaction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&HexPrimitive(self), f)
+    }
+}
+
+#[cfg(feature = "alloc")]
+#[cfg(feature = "hex")]
+impl fmt::LowerHex for Transaction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::LowerHex::fmt(&HexPrimitive(self), f)
+    }
+}
+
+#[cfg(feature = "alloc")]
+#[cfg(feature = "hex")]
+impl fmt::UpperHex for Transaction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::UpperHex::fmt(&HexPrimitive(self), f)
+    }
+}
+
+#[cfg(feature = "alloc")]
 impl From<Transaction> for Txid {
     #[inline]
     fn from(tx: Transaction) -> Self { tx.compute_txid() }
@@ -336,23 +370,6 @@ fn hash_transaction(tx: &Transaction, uses_segwit_serialization: bool) -> sha256
 }
 
 #[cfg(feature = "alloc")]
-type TransactionEncoderInner<'e> = Encoder6<
-    VersionEncoder<'e>,
-    Option<ArrayEncoder<2>>,
-    Encoder2<CompactSizeEncoder, SliceEncoder<'e, TxIn>>,
-    Encoder2<CompactSizeEncoder, SliceEncoder<'e, TxOut>>,
-    Option<WitnessesEncoder<'e>>,
-    LockTimeEncoder<'e>,
->;
-
-#[cfg(feature = "alloc")]
-encoding::encoder_newtype! {
-    /// The encoder for the [`Transaction`] type.
-    #[derive(Debug, Clone)]
-    pub struct TransactionEncoder<'e>(TransactionEncoderInner<'e>);
-}
-
-#[cfg(feature = "alloc")]
 impl encoding::Encode for Transaction {
     type Encoder<'e>
         = TransactionEncoder<'e>
@@ -389,37 +406,25 @@ impl encoding::Encode for Transaction {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg(feature = "hex")]
-impl core::str::FromStr for Transaction {
-    type Err = ParseTransactionError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        HexPrimitive::from_str(s).map_err(ParseTransactionError)
-    }
+impl encoding::Decode for Transaction {
+    type Decoder = TransactionDecoder;
 }
 
 #[cfg(feature = "alloc")]
-#[cfg(feature = "hex")]
-impl fmt::Display for Transaction {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(&HexPrimitive(self), f)
-    }
-}
+type TransactionEncoderInner<'e> = Encoder6<
+    VersionEncoder<'e>,
+    Option<ArrayEncoder<2>>,
+    Encoder2<CompactSizeEncoder, SliceEncoder<'e, TxIn>>,
+    Encoder2<CompactSizeEncoder, SliceEncoder<'e, TxOut>>,
+    Option<WitnessesEncoder<'e>>,
+    LockTimeEncoder<'e>,
+>;
 
 #[cfg(feature = "alloc")]
-#[cfg(feature = "hex")]
-impl fmt::LowerHex for Transaction {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::LowerHex::fmt(&HexPrimitive(self), f)
-    }
-}
-
-#[cfg(feature = "alloc")]
-#[cfg(feature = "hex")]
-impl fmt::UpperHex for Transaction {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::UpperHex::fmt(&HexPrimitive(self), f)
-    }
+encoding::encoder_newtype! {
+    /// The encoder for the [`Transaction`] type.
+    #[derive(Debug, Clone)]
+    pub struct TransactionEncoder<'e>(TransactionEncoderInner<'e>);
 }
 
 /// The decoder for the [`Transaction`] type.
@@ -650,11 +655,6 @@ impl encoding::Decoder for TransactionDecoder {
             State::Errored => 0,
         }
     }
-}
-
-#[cfg(feature = "alloc")]
-impl encoding::Decode for Transaction {
-    type Decoder = TransactionDecoder;
 }
 
 /// The state of the transiting decoder.

--- a/primitives/src/witness.rs
+++ b/primitives/src/witness.rs
@@ -280,10 +280,6 @@ fn decode_cursor(bytes: &[u8], start_of_indices: usize, index: usize) -> Option<
     usize::try_from(pos).ok()
 }
 
-/// The encoder for the [`Witness`] type.
-#[derive(Debug, Clone)]
-pub struct WitnessEncoder<'e>(Encoder2<CompactSizeEncoder, BytesEncoder<'e>>);
-
 impl encoding::Encode for Witness {
     type Encoder<'e>
         = WitnessEncoder<'e>
@@ -298,6 +294,14 @@ impl encoding::Encode for Witness {
         WitnessEncoder(Encoder2::new(num_elements, witness_elements))
     }
 }
+
+impl encoding::Decode for Witness {
+    type Decoder = WitnessDecoder;
+}
+
+/// The encoder for the [`Witness`] type.
+#[derive(Debug, Clone)]
+pub struct WitnessEncoder<'e>(Encoder2<CompactSizeEncoder, BytesEncoder<'e>>);
 
 impl encoding::Encoder for WitnessEncoder<'_> {
     #[inline]
@@ -529,10 +533,6 @@ impl encoding::Decoder for WitnessDecoder {
             }
         }
     }
-}
-
-impl encoding::Decode for Witness {
-    type Decoder = WitnessDecoder;
 }
 
 // Note: we use `Borrow` in the following `PartialEq` impls specifically because of its additional


### PR DESCRIPTION
Some stuff got missed. The point here is that this code is boilerplate and is going to live on multiple branches (`0.32` and `master`) so it would be nice if it was exactly the same everywhere. And its write-once-read-many code.

This whole PR is code moves only.