### PR TITLE
Remove mutagen

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -3,12 +3,6 @@
 version = 3
 
 [[package]]
-name = "anyhow"
-version = "1.0.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
-
-[[package]]
 name = "arbitrary"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,7 +69,6 @@ dependencies = [
  "bitcoinconsensus",
  "hex-conservative",
  "hex_lit",
- "mutagen",
  "ordered",
  "secp256k1",
  "serde",
@@ -252,12 +245,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 
 [[package]]
-name = "json"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,39 +266,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mutagen"
-version = "0.2.0"
-source = "git+https://github.com/llogiq/mutagen#a6377c4c3f360afeb7a287c1c17e4b69456d5f53"
-dependencies = [
- "mutagen-core",
- "mutagen-transform",
-]
-
-[[package]]
-name = "mutagen-core"
-version = "0.2.0"
-source = "git+https://github.com/llogiq/mutagen#a6377c4c3f360afeb7a287c1c17e4b69456d5f53"
-dependencies = [
- "anyhow",
- "json",
- "lazy_static",
- "proc-macro2",
- "quote",
- "serde",
- "serde_json",
- "syn",
-]
-
-[[package]]
-name = "mutagen-transform"
-version = "0.2.0"
-source = "git+https://github.com/llogiq/mutagen#a6377c4c3f360afeb7a287c1c17e4b69456d5f53"
-dependencies = [
- "mutagen-core",
- "proc-macro2",
-]
-
-[[package]]
 name = "ordered"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,18 +279,18 @@ checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.29"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
+checksum = "51ef7cd2518ead700af67bf9d1a658d90b6037d77110fd9c0445429d0ba1c6c9"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "7ab938ebe6f1c82426b5fb82eaf10c3e3028c53deaa3fbe38f5904b37cf4d767"
 dependencies = [
  "proc-macro2",
 ]
@@ -487,9 +441,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.76"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
+checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -3,12 +3,6 @@
 version = 3
 
 [[package]]
-name = "anyhow"
-version = "1.0.71"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
-
-[[package]]
 name = "arbitrary"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,7 +68,6 @@ dependencies = [
  "bitcoinconsensus",
  "hex-conservative",
  "hex_lit",
- "mutagen",
  "ordered",
  "secp256k1",
  "serde",
@@ -236,12 +229,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
-name = "json"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,39 +247,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "mutagen"
-version = "0.2.0"
-source = "git+https://github.com/llogiq/mutagen#a6377c4c3f360afeb7a287c1c17e4b69456d5f53"
-dependencies = [
- "mutagen-core",
- "mutagen-transform",
-]
-
-[[package]]
-name = "mutagen-core"
-version = "0.2.0"
-source = "git+https://github.com/llogiq/mutagen#a6377c4c3f360afeb7a287c1c17e4b69456d5f53"
-dependencies = [
- "anyhow",
- "json",
- "lazy_static",
- "proc-macro2",
- "quote",
- "serde",
- "serde_json",
- "syn",
-]
-
-[[package]]
-name = "mutagen-transform"
-version = "0.2.0"
-source = "git+https://github.com/llogiq/mutagen#a6377c4c3f360afeb7a287c1c17e4b69456d5f53"
-dependencies = [
- "mutagen-core",
- "proc-macro2",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ Unit and integration tests are available for those interested, along with benchm
 developers, especially new contributors looking for something to work on, we do:
 
 - Fuzz testing with [`Hongfuzz`](https://github.com/rust-fuzz/honggfuzz-rs)
-- Mutation testing with [`Mutagen`](https://github.com/llogiq/mutagen)
 - Code verification with [`Kani`](https://github.com/model-checking/kani)
 
 There are always more tests to write and more bugs to find, contributions to our testing efforts
@@ -155,12 +154,6 @@ Run as for any other Rust project `cargo test --all-features`.
 
 We use a custom Rust compiler configuration conditional to guard the bench mark code. To run the
 bench marks use: `RUSTFLAGS='--cfg=bench' cargo +nightly bench`.
-
-### Mutation tests
-
-We have started doing mutation testing with [mutagen](https://github.com/llogiq/mutagen). To run
-these tests first install the latest dev version with `cargo +nightly install --git https://github.com/llogiq/mutagen`
-then run with `RUSTFLAGS='--cfg=mutate' cargo +nightly mutagen`.
 
 ### Code verification
 

--- a/bitcoin/CHANGELOG.md
+++ b/bitcoin/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+- Remove mutagen
+
 # 0.32.100 - 2025-05-26
 
 **Bump the MSRV to Rust 1.74.0**

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -57,9 +57,6 @@ serde_json = "1.0.68"
 serde_test = "1.0.19"
 bincode = "1.3.1"
 
-[target.'cfg(mutate)'.dev-dependencies]
-mutagen = { git = "https://github.com/llogiq/mutagen" }
-
 [[example]]
 name = "bip32"
 

--- a/bitcoin/src/blockdata/locktime/absolute.rs
+++ b/bitcoin/src/blockdata/locktime/absolute.rs
@@ -13,8 +13,6 @@ use core::str::FromStr;
 #[cfg(feature = "arbitrary")]
 use actual_arbitrary::{self as arbitrary, Arbitrary, Unstructured};
 use io::{Read, Write};
-#[cfg(all(test, mutate))]
-use mutagen::mutate;
 use units::parse::{self, ParseIntError};
 
 #[cfg(doc)]
@@ -215,7 +213,6 @@ impl LockTime {
     /// }
     /// ````
     #[inline]
-    #[cfg_attr(all(test, mutate), mutate)]
     pub fn is_satisfied_by(&self, height: Height, time: Time) -> bool {
         use LockTime::*;
 
@@ -245,7 +242,6 @@ impl LockTime {
     /// assert!(lock_time.is_implied_by(check));
     /// ```
     #[inline]
-    #[cfg_attr(all(test, mutate), mutate)]
     pub fn is_implied_by(&self, other: LockTime) -> bool {
         use LockTime::*;
 

--- a/bitcoin/src/blockdata/locktime/relative.rs
+++ b/bitcoin/src/blockdata/locktime/relative.rs
@@ -10,9 +10,6 @@
 use core::cmp::Ordering;
 use core::{cmp, convert, fmt};
 
-#[cfg(all(test, mutate))]
-use mutagen::mutate;
-
 #[cfg(doc)]
 use crate::relative;
 use crate::Sequence;
@@ -182,7 +179,6 @@ impl LockTime {
     /// assert!(lock.is_satisfied_by(current_height(), current_time()));
     /// ```
     #[inline]
-    #[cfg_attr(all(test, mutate), mutate)]
     pub fn is_satisfied_by(&self, h: Height, t: Time) -> bool {
         if let Ok(true) = self.is_satisfied_by_height(h) {
             true
@@ -222,7 +218,6 @@ impl LockTime {
     /// assert!(satisfied);
     /// ```
     #[inline]
-    #[cfg_attr(all(test, mutate), mutate)]
     pub fn is_implied_by(&self, other: LockTime) -> bool {
         use LockTime::*;
 
@@ -264,7 +259,6 @@ impl LockTime {
     /// assert!(lock.is_satisfied_by_height(Height::from(height+1)).expect("a height"));
     /// ```
     #[inline]
-    #[cfg_attr(all(test, mutate), mutate)]
     pub fn is_satisfied_by_height(&self, height: Height) -> Result<bool, IncompatibleHeightError> {
         use LockTime::*;
 
@@ -291,7 +285,6 @@ impl LockTime {
     /// assert!(lock.is_satisfied_by_time(Time::from_512_second_intervals(intervals + 10)).expect("a time"));
     /// ```
     #[inline]
-    #[cfg_attr(all(test, mutate), mutate)]
     pub fn is_satisfied_by_time(&self, time: Time) -> Result<bool, IncompatibleTimeError> {
         use LockTime::*;
 

--- a/bitcoin/src/pow.rs
+++ b/bitcoin/src/pow.rs
@@ -11,8 +11,6 @@ use core::fmt::{self, LowerHex, UpperHex};
 use core::ops::{Add, Div, Mul, Not, Rem, Shl, Shr, Sub};
 
 use io::{Read, Write};
-#[cfg(all(test, mutate))]
-use mutagen::mutate;
 use units::parse;
 
 use crate::block::Header;
@@ -219,7 +217,6 @@ impl Target {
     ///
     /// Proof-of-work validity for a block requires the hash of the block to be less than or equal
     /// to the target.
-    #[cfg_attr(all(test, mutate), mutate)]
     pub fn is_met_by(&self, hash: BlockHash) -> bool {
         use hashes::Hash;
         let hash = U256::from_le_bytes(hash.to_byte_array());
@@ -257,7 +254,6 @@ impl Target {
     ///
     /// [max]: Target::max
     /// [target]: crate::blockdata::block::Header::target
-    #[cfg_attr(all(test, mutate), mutate)]
     pub fn difficulty(&self, params: impl AsRef<Params>) -> u128 {
         // Panic here may be eaiser to debug than during the actual division.
         assert_ne!(self.0, U256::ZERO, "divide by zero");
@@ -276,7 +272,6 @@ impl Target {
     /// Returns [`f64::INFINITY`] if `self` is zero (caused by divide by zero).
     ///
     /// [`difficulty`]: Target::difficulty
-    #[cfg_attr(all(test, mutate), mutate)]
     pub fn difficulty_float(&self) -> f64 { TARGET_MAX_F64 / self.0.to_f64() }
 
     /// Computes the minimum valid [`Target`] threshold allowed for a block in which a difficulty
@@ -530,7 +525,6 @@ impl U256 {
     }
 
     /// Creates `U256` from a big-endian array of `u8`s.
-    #[cfg_attr(all(test, mutate), mutate)]
     fn from_be_bytes(a: [u8; 32]) -> U256 {
         let (high, low) = split_in_half(a);
         let big = u128::from_be_bytes(high);
@@ -539,7 +533,6 @@ impl U256 {
     }
 
     /// Creates a `U256` from a little-endian array of `u8`s.
-    #[cfg_attr(all(test, mutate), mutate)]
     fn from_le_bytes(a: [u8; 32]) -> U256 {
         let (high, low) = split_in_half(a);
         let little = u128::from_le_bytes(high);
@@ -548,7 +541,6 @@ impl U256 {
     }
 
     /// Converts `U256` to a big-endian array of `u8`s.
-    #[cfg_attr(all(test, mutate), mutate)]
     fn to_be_bytes(self) -> [u8; 32] {
         let mut out = [0; 32];
         out[..16].copy_from_slice(&self.0.to_be_bytes());
@@ -557,7 +549,6 @@ impl U256 {
     }
 
     /// Converts `U256` to a little-endian array of `u8`s.
-    #[cfg_attr(all(test, mutate), mutate)]
     fn to_le_bytes(self) -> [u8; 32] {
         let mut out = [0; 32];
         out[..16].copy_from_slice(&self.1.to_le_bytes());
@@ -589,13 +580,10 @@ impl U256 {
         ret.wrapping_inc()
     }
 
-    #[cfg_attr(all(test, mutate), mutate)]
     fn is_zero(&self) -> bool { self.0 == 0 && self.1 == 0 }
 
-    #[cfg_attr(all(test, mutate), mutate)]
     fn is_one(&self) -> bool { self.0 == 0 && self.1 == 1 }
 
-    #[cfg_attr(all(test, mutate), mutate)]
     fn is_max(&self) -> bool { self.0 == u128::MAX && self.1 == u128::MAX }
 
     /// Returns the low 32 bits.
@@ -618,7 +606,6 @@ impl U256 {
     }
 
     /// Returns the least number of bits needed to represent the number.
-    #[cfg_attr(all(test, mutate), mutate)]
     fn bits(&self) -> u32 {
         if self.0 > 0 {
             256 - self.0.leading_zeros()
@@ -633,9 +620,6 @@ impl U256 {
     ///
     /// The multiplication result along with a boolean indicating whether an arithmetic overflow
     /// occurred. If an overflow occurred then the wrapped value is returned.
-    // mutagen false pos mul_u64: replace `|` with `^` (XOR is same as OR when combined with <<)
-    // mutagen false pos mul_u64: replace `|` with `^`
-    #[cfg_attr(all(test, mutate), mutate)]
     fn mul_u64(self, rhs: u64) -> (U256, bool) {
         let mut carry: u128 = 0;
         let mut split_le =
@@ -663,7 +647,6 @@ impl U256 {
     /// # Panics
     ///
     /// If `rhs` is zero.
-    #[cfg_attr(all(test, mutate), mutate)]
     fn div_rem(self, rhs: Self) -> (Self, Self) {
         let mut sub_copy = self;
         let mut shift_copy = rhs;
@@ -703,7 +686,6 @@ impl U256 {
     /// Returns a tuple of the addition along with a boolean indicating whether an arithmetic
     /// overflow would occur. If an overflow would have occurred then the wrapped value is returned.
     #[must_use = "this returns the result of the operation, without modifying the original"]
-    #[cfg_attr(all(test, mutate), mutate)]
     fn overflowing_add(self, rhs: Self) -> (Self, bool) {
         let mut ret = U256::ZERO;
         let mut ret_overflow = false;
@@ -728,7 +710,6 @@ impl U256 {
     /// Returns a tuple of the subtraction along with a boolean indicating whether an arithmetic
     /// overflow would occur. If an overflow would have occurred then the wrapped value is returned.
     #[must_use = "this returns the result of the operation, without modifying the original"]
-    #[cfg_attr(all(test, mutate), mutate)]
     fn overflowing_sub(self, rhs: Self) -> (Self, bool) {
         let ret = self.wrapping_add(!rhs).wrapping_add(Self::ONE);
         let overflow = rhs > self;
@@ -741,7 +722,6 @@ impl U256 {
     /// indicating whether an arithmetic overflow would occur. If an
     /// overflow would have occurred then the wrapped value is returned.
     #[must_use = "this returns the result of the operation, without modifying the original"]
-    #[cfg_attr(all(test, mutate), mutate)]
     fn overflowing_mul(self, rhs: Self) -> (Self, bool) {
         let mut ret = U256::ZERO;
         let mut ret_overflow = false;
@@ -789,7 +769,6 @@ impl U256 {
 
     /// Returns `self` incremented by 1 wrapping around at the boundary of the type.
     #[must_use = "this returns the result of the increment, without modifying the original"]
-    #[cfg_attr(all(test, mutate), mutate)]
     fn wrapping_inc(&self) -> U256 {
         let mut ret = U256::ZERO;
 
@@ -809,7 +788,6 @@ impl U256 {
     /// restricted to the range of the type, rather than the bits shifted out of the LHS being
     /// returned to the other end. We do not currently support `rotate_left`.
     #[must_use = "this returns the result of the operation, without modifying the original"]
-    #[cfg_attr(all(test, mutate), mutate)]
     fn wrapping_shl(self, rhs: u32) -> Self {
         let shift = rhs & 0x000000ff;
 
@@ -836,7 +814,6 @@ impl U256 {
     /// restricted to the range of the type, rather than the bits shifted out of the LHS being
     /// returned to the other end. We do not currently support `rotate_right`.
     #[must_use = "this returns the result of the operation, without modifying the original"]
-    #[cfg_attr(all(test, mutate), mutate)]
     fn wrapping_shr(self, rhs: u32) -> Self {
         let shift = rhs & 0x000000ff;
 


### PR DESCRIPTION
Same as we did in #3931 remove mutagen from the 0.32.x branch.

The reason is that it is no longer used and causes dependency graph problems even though its only a dev dependency.

Close: #6331