### PR TITLE
Move some script functions to `primitives`

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -71,6 +71,7 @@ exclude_re = [
     "primitives/.* <impl MerkleNode for TxMerkleNode>::calculate_root", # Behind cfg(target_arch = "aarch64"), not compiled on x86_64 CI runner
     "primitives/.* <impl MerkleNode for WitnessMerkleNode>::calculate_root", # Behind cfg(target_arch = "aarch64"), not compiled on x86_64 CI runner
     "primitives/.* replace \\% with \\+ in ScriptBuf<T>::push_slice_no_opt", # as u8 truncation makes >= 0x100 impossible to test
+    "primitives/.* replace \\|\\| with && in Script<T>::witness_version", # && is impossible, and every byte is rejected by the length checks
 
     # consensus_encoding - most of these are for mutations in the logic used to determine when to stop encoding or decoding.
     "consensus_encoding/.* <impl Decoder for ArrayDecoder<N>>::push_bytes", # Mutations cause an infinite loop

--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -65,9 +65,8 @@ use crate::script::witness_program::WitnessProgram;
 use crate::script::witness_version::WitnessVersion;
 use crate::script::{
     self, BuilderExt as _, RedeemScriptSizeError, Script, ScriptExt as _, ScriptHash,
-    ScriptHashableTag, ScriptPubKey, ScriptPubKeyBuf, ScriptPubKeyBufExt as _,
-    ScriptPubKeyExt as _, WScriptHash, WitnessScript, WitnessScriptExt as _,
-    WitnessScriptSizeError,
+    ScriptHashableTag, ScriptPubKey, ScriptPubKeyBuf, ScriptPubKeyBufExt as _, WScriptHash,
+    WitnessScript, WitnessScriptExt as _, WitnessScriptSizeError,
 };
 use crate::taproot::TapNodeHash;
 

--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -46,7 +46,7 @@ use io::{BufRead, Write};
 use crate::block::{Block, BlockHash, Checked};
 use crate::encoding::{CompactSizeEncoder, CompactSizeU64Decoder, ExactSizeEncoder as _};
 use crate::prelude::{BTreeSet, Borrow, Vec};
-use crate::script::{ScriptPubKey, ScriptPubKeyExt as _};
+use crate::script::ScriptPubKey;
 use crate::transaction::OutPoint;
 use crate::ToU64 as _;
 

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -18,7 +18,6 @@ use crate::policy::{DUST_RELAY_TX_FEE, MAX_OP_RETURN_RELAY};
 use crate::prelude::{String, ToString};
 use crate::script::{self, ScriptPubKeyBufExt as _};
 use crate::taproot::{LeafVersion, TapLeafHash, TapLeafHashExt as _, TapNodeHash};
-use crate::witness_program::P2A_PROGRAM;
 use crate::{internal_macros, Amount, FeeRate, ScriptPubKeyBuf, ToU64 as _, WitnessScriptBuf};
 
 internal_macros::define_extension_trait! {
@@ -179,26 +178,6 @@ internal_macros::define_extension_trait! {
                 None
             }
         }
-
-        /// Checks whether a script pubkey is a P2WSH output.
-        #[inline]
-        fn is_p2wsh(&self) -> bool
-        where T: ScriptHashableTag
-        {
-            self.len() == 34
-                && self.witness_version() == Some(WitnessVersion::V0)
-                && self.as_bytes()[1] == OP_PUSHBYTES_32.to_u8()
-        }
-
-        /// Checks whether a script pubkey is a P2WPKH output.
-        #[inline]
-        fn is_p2wpkh(&self) -> bool
-        where T: ScriptHashableTag
-        {
-            self.len() == 22
-                && self.witness_version() == Some(WitnessVersion::V0)
-                && self.as_bytes()[1] == OP_PUSHBYTES_20.to_u8()
-        }
     }
 }
 
@@ -260,26 +239,6 @@ internal_macros::define_extension_trait! {
             LegacyPublicKey::from_slice(self.p2pk_pubkey_bytes()?).ok()
         }
 
-        /// Checks whether a script pubkey is a P2SH output.
-        #[inline]
-        fn is_p2sh(&self) -> bool {
-            self.len() == 23
-                && self.as_bytes()[0] == OP_HASH160.to_u8()
-                && self.as_bytes()[1] == OP_PUSHBYTES_20.to_u8()
-                && self.as_bytes()[22] == OP_EQUAL.to_u8()
-        }
-
-        /// Checks whether a script pubkey is a P2PKH output.
-        #[inline]
-        fn is_p2pkh(&self) -> bool {
-            self.len() == 25
-                && self.as_bytes()[0] == OP_DUP.to_u8()
-                && self.as_bytes()[1] == OP_HASH160.to_u8()
-                && self.as_bytes()[2] == OP_PUSHBYTES_20.to_u8()
-                && self.as_bytes()[23] == OP_EQUALVERIFY.to_u8()
-                && self.as_bytes()[24] == OP_CHECKSIG.to_u8()
-        }
-
         /// Checks whether a script pubkey is a bare multisig output.
         ///
         /// In a bare multisig pubkey script the keys are not hashed, the script
@@ -320,25 +279,12 @@ internal_macros::define_extension_trait! {
             instructions.next().is_none()
         }
 
-        /// Checks whether a script pubkey is a Segregated Witness (SegWit) program.
-        #[inline]
-        fn is_witness_program(&self) -> bool { self.witness_version().is_some() }
-
         /// Checks whether a script pubkey is a P2TR output.
         #[inline]
         fn is_p2tr(&self) -> bool {
             self.len() == 34
                 && self.witness_version() == Some(WitnessVersion::V1)
                 && self.as_bytes()[1] == OP_PUSHBYTES_32.to_u8()
-        }
-
-        /// Checks whether a script pubkey is a P2A output.
-        #[inline]
-        fn is_p2a(&self) -> bool {
-            self.len() == 4
-                && self.witness_version() == Some(WitnessVersion::V1)
-                && self.as_bytes()[1] == OP_PUSHBYTES_2.to_u8()
-                && self.as_bytes()[2..] == P2A_PROGRAM
         }
 
         /// Check if this is a consensus-valid OP_RETURN output.

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -180,39 +180,6 @@ internal_macros::define_extension_trait! {
             }
         }
 
-        /// Returns witness version of the script, if any, assuming the script is a `scriptPubkey`.
-        ///
-        /// # Returns
-        ///
-        /// The witness version if this script is found to conform to the SegWit rules:
-        ///
-        /// > A scriptPubKey (or redeemScript as defined in BIP-0016/P2SH) that consists of a 1-byte
-        /// > push opcode (for 0 to 16) followed by a data push between 2 and 40 bytes gets a new
-        /// > special meaning. The value of the first push is called the "version byte". The following
-        /// > byte vector pushed is called the "witness program".
-        #[inline]
-        fn witness_version(&self) -> Option<WitnessVersion>
-        where T: ScriptHashableTag
-        {
-            let script_len = self.len();
-            if !(4..=42).contains(&script_len) {
-                return None;
-            }
-
-            let ver_opcode = Opcode::from(self.as_bytes()[0]); // Version 0 or PUSHNUM_1-PUSHNUM_16
-            let push_opbyte = self.as_bytes()[1]; // Second byte push opcode 2-40 bytes
-
-            if push_opbyte < OP_PUSHBYTES_2.to_u8() || push_opbyte > OP_PUSHBYTES_40.to_u8() {
-                return None;
-            }
-            // Check that the rest of the script has the correct size
-            if script_len - 2 != push_opbyte as usize {
-                return None;
-            }
-
-            WitnessVersion::try_from(ver_opcode).ok()
-        }
-
         /// Checks whether a script pubkey is a P2WSH output.
         #[inline]
         fn is_p2wsh(&self) -> bool

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -287,15 +287,6 @@ internal_macros::define_extension_trait! {
                 && self.as_bytes()[1] == OP_PUSHBYTES_32.to_u8()
         }
 
-        /// Check if this is a consensus-valid OP_RETURN output.
-        ///
-        /// To validate if the OP_RETURN obeys Bitcoin Core's current standardness policy, use
-        /// [`is_standard_op_return()`](Self::is_standard_op_return) instead.
-        #[inline]
-        fn is_op_return(&self) -> bool {
-            self.as_bytes().first().is_some_and(|&b| b == OP_RETURN.to_u8())
-        }
-
         /// Check if this is an OP_RETURN that obeys Bitcoin Core standardness policy.
         ///
         /// What this function considers to be standard may change without warning pending Bitcoin Core

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -126,11 +126,6 @@ internal_macros::define_extension_trait! {
 crate::internal_macros::define_extension_trait! {
     /// Extension functionality for the [`ScriptPubKeyBuf`] type.
     pub trait ScriptPubKeyBufExt impl for ScriptPubKeyBuf {
-        /// Generates OP_RETURN-type of scriptPubkey for the given data.
-        fn new_op_return<T: AsRef<PushBytes>>(data: T) -> Self {
-            Builder::new().push_opcode(OP_RETURN).push_slice(data).into_script()
-        }
-
         /// Generates P2PK-type of scriptPubkey.
         fn new_p2pk(pubkey: LegacyPublicKey) -> Self {
             Builder::new().push_key(pubkey).push_opcode(OP_CHECKSIG).into_script()

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -14,9 +14,9 @@ use crate::key::{
 use crate::opcodes::all::*;
 use crate::opcodes::{self, Opcode};
 use crate::prelude::Vec;
-use crate::script::witness_program::{WitnessProgram, P2A_PROGRAM};
+use crate::script::witness_program::WitnessProgram;
 use crate::script::witness_version::WitnessVersion;
-use crate::script::{self, BuilderExt as _, ScriptHash, WScriptHash};
+use crate::script::{self, BuilderExt as _};
 use crate::taproot::TapNodeHash;
 use crate::{internal_macros, ToU64 as _};
 
@@ -147,21 +147,6 @@ crate::internal_macros::define_extension_trait! {
                 .into_script()
         }
 
-        /// Generates P2SH-type of scriptPubkey with a given hash of the redeem script.
-        fn new_p2sh(script_hash: ScriptHash) -> Self {
-            Builder::new()
-                .push_opcode(OP_HASH160)
-                .push_slice(script_hash)
-                .push_opcode(OP_EQUAL)
-                .into_script()
-        }
-
-        /// Generates P2WSH-type of scriptPubkey with a given hash of the redeem script.
-        fn new_p2wsh(script_hash: WScriptHash) -> Self {
-            // script hash is 32 bytes long, so it's safe to use `new_witness_program_unchecked` (Segwitv0)
-            script::new_witness_program_unchecked(WitnessVersion::V0, script_hash)
-        }
-
         /// Generates P2TR for script spending path using an internal public key and some optional
         /// script tree Merkle root.
         fn new_p2tr<K: Into<UntweakedPublicKey>>(
@@ -178,11 +163,6 @@ crate::internal_macros::define_extension_trait! {
         fn new_p2tr_tweaked(output_key: TweakedPublicKey) -> Self {
             // output key is 32 bytes long, so it's safe to use `new_witness_program_unchecked` (Segwitv1)
             script::new_witness_program_unchecked(WitnessVersion::V1, output_key.serialize())
-        }
-
-        /// Generates pay to anchor output.
-        fn new_p2a() -> Self {
-            script::new_witness_program_unchecked(WitnessVersion::V1, P2A_PROGRAM)
         }
 
         /// Generates P2WSH-type of scriptPubkey with a given [`WitnessProgram`].

--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -470,39 +470,6 @@ fn script_hashes() {
 }
 
 #[test]
-fn provably_unspendable() {
-    // p2pk
-    assert!(!ScriptPubKeyBuf::from_hex_no_length_prefix("410446ef0102d1ec5240f0d061a4246c1bdef63fc3dbab7733052fbbf0ecd8f41fc26bf049ebb4f9527f374280259e7cfa99c48b0e3f39c51347a19a5819651503a5ac").unwrap().is_op_return());
-    assert!(!ScriptPubKeyBuf::from_hex_no_length_prefix("4104ea1feff861b51fe3f5f8a3b12d0f4712db80e919548a80839fc47c6a21e66d957e9c5d8cd108c7a2d2324bad71f9904ac0ae7336507d785b17a2c115e427a32fac").unwrap().is_op_return());
-    // p2pkhash
-    assert!(!ScriptPubKeyBuf::from_hex_no_length_prefix(
-        "76a914ee61d57ab51b9d212335b1dba62794ac20d2bcf988ac"
-    )
-    .unwrap()
-    .is_op_return());
-    assert!(ScriptPubKeyBuf::from_hex_no_length_prefix(
-        "6aa9149eb21980dc9d413d8eac27314938b9da920ee53e87"
-    )
-    .unwrap()
-    .is_op_return());
-}
-
-#[test]
-fn op_return() {
-    assert!(ScriptPubKeyBuf::from_hex_no_length_prefix(
-        "6aa9149eb21980dc9d413d8eac27314938b9da920ee53e87"
-    )
-    .unwrap()
-    .is_op_return());
-    assert!(!ScriptPubKeyBuf::from_hex_no_length_prefix(
-        "76a914ee61d57ab51b9d212335b1dba62794ac20d2bcf988ac"
-    )
-    .unwrap()
-    .is_op_return());
-    assert!(!ScriptPubKeyBuf::from_hex_no_length_prefix("").unwrap().is_op_return());
-}
-
-#[test]
 fn standard_op_return() {
     assert!(ScriptPubKeyBuf::from_hex_no_length_prefix(
         "6aa9149eb21980dc9d413d8eac27314938b9da920ee53e87"
@@ -581,42 +548,6 @@ fn script_buf_collect() {
     assert_eq!(&core::iter::empty::<Instruction<'_>>().collect::<ScriptBuf>(), Script::new());
     let script = ScriptBuf::from_hex_no_length_prefix("0047304402202457e78cc1b7f50d0543863c27de75d07982bde8359b9e3316adec0aec165f2f02200203fd331c4e4a4a02f48cf1c291e2c0d6b2f7078a784b5b3649fca41f8794d401004cf1552103244e602b46755f24327142a0517288cebd159eccb6ccf41ea6edf1f601e9af952103bbbacc302d19d29dbfa62d23f37944ae19853cf260c745c2bea739c95328fcb721039227e83246bd51140fe93538b2301c9048be82ef2fb3c7fc5d78426ed6f609ad210229bf310c379b90033e2ecb07f77ecf9b8d59acb623ab7be25a0caed539e2e6472103703e2ed676936f10b3ce9149fa2d4a32060fb86fa9a70a4efe3f21d7ab90611921031e9b7c6022400a6bb0424bbcde14cff6c016b91ee3803926f3440abf5c146d05210334667f975f55a8455d515a2ef1c94fdfa3315f12319a14515d2a13d82831f62f57ae").unwrap();
     assert_eq!(script.instructions().collect::<Result<ScriptBuf, _>>().unwrap(), script);
-}
-
-#[test]
-fn script_p2sh_p2pkh_template() {
-    // random outputs I picked out of the mempool
-    assert!(ScriptPubKeyBuf::from_hex_no_length_prefix(
-        "76a91402306a7c23f3e8010de41e9e591348bb83f11daa88ac"
-    )
-    .unwrap()
-    .is_p2pkh());
-    assert!(!ScriptPubKeyBuf::from_hex_no_length_prefix(
-        "76a91402306a7c23f3e8010de41e9e591348bb83f11daa88ac"
-    )
-    .unwrap()
-    .is_p2sh());
-    assert!(!ScriptPubKeyBuf::from_hex_no_length_prefix(
-        "76a91402306a7c23f3e8010de41e9e591348bb83f11daa88ad"
-    )
-    .unwrap()
-    .is_p2pkh());
-    assert!(!ScriptPubKeyBuf::from_hex_no_length_prefix("").unwrap().is_p2pkh());
-    assert!(ScriptPubKeyBuf::from_hex_no_length_prefix(
-        "a914acc91e6fef5c7f24e5c8b3f11a664aa8f1352ffd87"
-    )
-    .unwrap()
-    .is_p2sh());
-    assert!(!ScriptPubKeyBuf::from_hex_no_length_prefix(
-        "a914acc91e6fef5c7f24e5c8b3f11a664aa8f1352ffd87"
-    )
-    .unwrap()
-    .is_p2pkh());
-    assert!(!ScriptPubKeyBuf::from_hex_no_length_prefix(
-        "a314acc91e6fef5c7f24e5c8b3f11a664aa8f1352ffd87"
-    )
-    .unwrap()
-    .is_p2sh());
 }
 
 #[test]

--- a/bitcoin/src/blockdata/witness.rs
+++ b/bitcoin/src/blockdata/witness.rs
@@ -152,7 +152,7 @@ internal_macros::define_extension_trait! {
         /// Unlike the Taproot case, we do no validation to determine whether this is a
         /// witness script: it may be a Taproot control block, annex, or some other kind
         /// of object. If you are not certain whether the output being spent is Segwit v0,
-        /// use [`crate::script::ScriptExt::is_p2wsh`] on the output's script.
+        /// use [`crate::script::Script::is_p2wsh`] on the output's script.
         fn witness_script(&self) -> Option<&WitnessScript> { self.last().map(WitnessScript::from_bytes) }
     }
 }

--- a/primitives/api/all-features.txt
+++ b/primitives/api/all-features.txt
@@ -3136,11 +3136,19 @@ pub fn bitcoin_primitives::script::PushBytesBuf::from(t: T) -> T
 pub struct bitcoin_primitives::script::PushBytesError
 pub struct bitcoin_primitives::script::RedeemScriptSizeError
 #[repr(transparent)] pub struct bitcoin_primitives::script::Script<T>(_, _)
+impl bitcoin_primitives::script::Script<bitcoin_primitives::script::ScriptPubKeyTag>
+pub fn bitcoin_primitives::script::Script<bitcoin_primitives::script::ScriptPubKeyTag>::is_op_return(&self) -> bool
+pub fn bitcoin_primitives::script::Script<bitcoin_primitives::script::ScriptPubKeyTag>::is_p2a(&self) -> bool
+pub fn bitcoin_primitives::script::Script<bitcoin_primitives::script::ScriptPubKeyTag>::is_p2pkh(&self) -> bool
+pub fn bitcoin_primitives::script::Script<bitcoin_primitives::script::ScriptPubKeyTag>::is_p2sh(&self) -> bool
+pub fn bitcoin_primitives::script::Script<bitcoin_primitives::script::ScriptPubKeyTag>::is_witness_program(&self) -> bool
 impl<T> bitcoin_primitives::script::Script<T>
 pub const fn bitcoin_primitives::script::Script<T>::as_bytes(&self) -> &[u8]
 pub fn bitcoin_primitives::script::Script<T>::as_mut_bytes(&mut self) -> &mut [u8]
 pub fn bitcoin_primitives::script::Script<T>::into_script_buf(self: alloc::boxed::Box<Self>) -> bitcoin_primitives::script::ScriptBuf<T>
 pub const fn bitcoin_primitives::script::Script<T>::is_empty(&self) -> bool
+pub fn bitcoin_primitives::script::Script<T>::is_p2wpkh(&self) -> bool where T: bitcoin_primitives::script::ScriptHashableTag
+pub fn bitcoin_primitives::script::Script<T>::is_p2wsh(&self) -> bool where T: bitcoin_primitives::script::ScriptHashableTag
 pub const fn bitcoin_primitives::script::Script<T>::len(&self) -> usize
 pub const fn bitcoin_primitives::script::Script<T>::new() -> &'static Self
 pub fn bitcoin_primitives::script::Script<T>::to_bytes(&self) -> alloc::vec::Vec<u8>
@@ -3148,6 +3156,7 @@ pub fn bitcoin_primitives::script::Script<T>::to_hex(&self) -> alloc::string::St
 pub fn bitcoin_primitives::script::Script<T>::to_hex_string_no_length_prefix(&self) -> alloc::string::String
 pub fn bitcoin_primitives::script::Script<T>::to_hex_string_prefixed(&self) -> alloc::string::String
 pub fn bitcoin_primitives::script::Script<T>::to_vec(&self) -> alloc::vec::Vec<u8>
+pub fn bitcoin_primitives::script::Script<T>::witness_version(&self) -> core::option::Option<bitcoin_primitives::witness_version::WitnessVersion> where T: bitcoin_primitives::script::ScriptHashableTag
 pub const fn bitcoin_primitives::script::Script<T>::from_bytes(bytes: &[u8]) -> &Self
 pub fn bitcoin_primitives::script::Script<T>::from_bytes_mut(bytes: &mut [u8]) -> &mut Self
 impl core::convert::TryFrom<&bitcoin_primitives::script::Script<bitcoin_primitives::script::WitnessScriptTag>> for bitcoin_primitives::script::WScriptHash
@@ -3255,6 +3264,11 @@ pub fn bitcoin_primitives::script::Script<T>::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::script::Script<T> where T: ?core::marker::Sized
 pub fn bitcoin_primitives::script::Script<T>::borrow_mut(&mut self) -> &mut T
 pub struct bitcoin_primitives::script::ScriptBuf<T>(_, _)
+impl bitcoin_primitives::script::ScriptBuf<bitcoin_primitives::script::ScriptPubKeyTag>
+pub fn bitcoin_primitives::script::ScriptBuf<bitcoin_primitives::script::ScriptPubKeyTag>::new_op_return<T: core::convert::AsRef<bitcoin_primitives::script::PushBytes>>(data: T) -> Self
+pub fn bitcoin_primitives::script::ScriptBuf<bitcoin_primitives::script::ScriptPubKeyTag>::new_p2a() -> Self
+pub fn bitcoin_primitives::script::ScriptBuf<bitcoin_primitives::script::ScriptPubKeyTag>::new_p2sh(script_hash: bitcoin_primitives::script::ScriptHash) -> Self
+pub fn bitcoin_primitives::script::ScriptBuf<bitcoin_primitives::script::ScriptPubKeyTag>::new_p2wsh(script_hash: bitcoin_primitives::script::WScriptHash) -> Self
 impl<T> bitcoin_primitives::script::ScriptBuf<T>
 pub fn bitcoin_primitives::script::ScriptBuf<T>::as_mut_script(&mut self) -> &mut bitcoin_primitives::script::Script<T>
 pub fn bitcoin_primitives::script::ScriptBuf<T>::as_script(&self) -> &bitcoin_primitives::script::Script<T>

--- a/primitives/api/alloc-only.txt
+++ b/primitives/api/alloc-only.txt
@@ -3026,15 +3026,24 @@ pub fn bitcoin_primitives::script::PushBytesBuf::from(t: T) -> T
 pub struct bitcoin_primitives::script::PushBytesError
 pub struct bitcoin_primitives::script::RedeemScriptSizeError
 #[repr(transparent)] pub struct bitcoin_primitives::script::Script<T>(_, _)
+impl bitcoin_primitives::script::Script<bitcoin_primitives::script::ScriptPubKeyTag>
+pub fn bitcoin_primitives::script::Script<bitcoin_primitives::script::ScriptPubKeyTag>::is_op_return(&self) -> bool
+pub fn bitcoin_primitives::script::Script<bitcoin_primitives::script::ScriptPubKeyTag>::is_p2a(&self) -> bool
+pub fn bitcoin_primitives::script::Script<bitcoin_primitives::script::ScriptPubKeyTag>::is_p2pkh(&self) -> bool
+pub fn bitcoin_primitives::script::Script<bitcoin_primitives::script::ScriptPubKeyTag>::is_p2sh(&self) -> bool
+pub fn bitcoin_primitives::script::Script<bitcoin_primitives::script::ScriptPubKeyTag>::is_witness_program(&self) -> bool
 impl<T> bitcoin_primitives::script::Script<T>
 pub const fn bitcoin_primitives::script::Script<T>::as_bytes(&self) -> &[u8]
 pub fn bitcoin_primitives::script::Script<T>::as_mut_bytes(&mut self) -> &mut [u8]
 pub fn bitcoin_primitives::script::Script<T>::into_script_buf(self: alloc::boxed::Box<Self>) -> bitcoin_primitives::script::ScriptBuf<T>
 pub const fn bitcoin_primitives::script::Script<T>::is_empty(&self) -> bool
+pub fn bitcoin_primitives::script::Script<T>::is_p2wpkh(&self) -> bool where T: bitcoin_primitives::script::ScriptHashableTag
+pub fn bitcoin_primitives::script::Script<T>::is_p2wsh(&self) -> bool where T: bitcoin_primitives::script::ScriptHashableTag
 pub const fn bitcoin_primitives::script::Script<T>::len(&self) -> usize
 pub const fn bitcoin_primitives::script::Script<T>::new() -> &'static Self
 pub fn bitcoin_primitives::script::Script<T>::to_bytes(&self) -> alloc::vec::Vec<u8>
 pub fn bitcoin_primitives::script::Script<T>::to_vec(&self) -> alloc::vec::Vec<u8>
+pub fn bitcoin_primitives::script::Script<T>::witness_version(&self) -> core::option::Option<bitcoin_primitives::witness_version::WitnessVersion> where T: bitcoin_primitives::script::ScriptHashableTag
 pub const fn bitcoin_primitives::script::Script<T>::from_bytes(bytes: &[u8]) -> &Self
 pub fn bitcoin_primitives::script::Script<T>::from_bytes_mut(bytes: &mut [u8]) -> &mut Self
 impl core::convert::TryFrom<&bitcoin_primitives::script::Script<bitcoin_primitives::script::WitnessScriptTag>> for bitcoin_primitives::script::WScriptHash
@@ -3134,6 +3143,11 @@ pub fn bitcoin_primitives::script::Script<T>::borrow(&self) -> &T
 impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::script::Script<T> where T: ?core::marker::Sized
 pub fn bitcoin_primitives::script::Script<T>::borrow_mut(&mut self) -> &mut T
 pub struct bitcoin_primitives::script::ScriptBuf<T>(_, _)
+impl bitcoin_primitives::script::ScriptBuf<bitcoin_primitives::script::ScriptPubKeyTag>
+pub fn bitcoin_primitives::script::ScriptBuf<bitcoin_primitives::script::ScriptPubKeyTag>::new_op_return<T: core::convert::AsRef<bitcoin_primitives::script::PushBytes>>(data: T) -> Self
+pub fn bitcoin_primitives::script::ScriptBuf<bitcoin_primitives::script::ScriptPubKeyTag>::new_p2a() -> Self
+pub fn bitcoin_primitives::script::ScriptBuf<bitcoin_primitives::script::ScriptPubKeyTag>::new_p2sh(script_hash: bitcoin_primitives::script::ScriptHash) -> Self
+pub fn bitcoin_primitives::script::ScriptBuf<bitcoin_primitives::script::ScriptPubKeyTag>::new_p2wsh(script_hash: bitcoin_primitives::script::WScriptHash) -> Self
 impl<T> bitcoin_primitives::script::ScriptBuf<T>
 pub fn bitcoin_primitives::script::ScriptBuf<T>::as_mut_script(&mut self) -> &mut bitcoin_primitives::script::Script<T>
 pub fn bitcoin_primitives::script::ScriptBuf<T>::as_script(&self) -> &bitcoin_primitives::script::Script<T>

--- a/primitives/src/opcodes.rs
+++ b/primitives/src/opcodes.rs
@@ -166,6 +166,18 @@ pub(crate) const OP_PUSHDATA4: u8 = 0x4e;
 /// Push an empty array onto the stack.
 pub(crate) const OP_PUSHBYTES_0: Opcode = Opcode::from_u8(0x00);
 
+/// Push the next 2 bytes as an array onto the stack.
+#[cfg(feature = "alloc")]
+pub(crate) const OP_PUSHBYTES_2: Opcode = Opcode::from_u8(0x02);
+
+/// Push the next 20 bytes as an array onto the stack.
+#[cfg(feature = "alloc")]
+pub(crate) const OP_PUSHBYTES_20: Opcode = Opcode::from_u8(0x14);
+
+/// Push the next 32 bytes as an array onto the stack.
+#[cfg(feature = "alloc")]
+pub(crate) const OP_PUSHBYTES_32: Opcode = Opcode::from_u8(0x20);
+
 /// Format a byte as a script opcode.
 #[cfg(feature = "alloc")]
 pub(crate) fn fmt_opcode(op: u8, f: &mut fmt::Formatter) -> fmt::Result {

--- a/primitives/src/script/borrowed.rs
+++ b/primitives/src/script/borrowed.rs
@@ -12,11 +12,13 @@ use core::ops::{
 use arbitrary::{Arbitrary, Unstructured};
 use encoding::{BytesEncoder, CompactSizeEncoder, Encode, Encoder2};
 
-use super::ScriptBuf;
-use crate::opcodes::Opcode;
+use super::{ScriptBuf, P2A_PROGRAM};
+use crate::opcodes::all::{OP_CHECKSIG, OP_DUP, OP_EQUAL, OP_EQUALVERIFY, OP_HASH160};
+use crate::opcodes::{Opcode, OP_PUSHBYTES_2, OP_PUSHBYTES_20, OP_PUSHBYTES_32};
 use crate::prelude::{Box, ToOwned, Vec};
 use crate::script::ScriptHashableTag;
 use crate::witness_version::WitnessVersion;
+use crate::ScriptPubKey;
 
 // Defined in `REPO_DIR/include/newtype.rs`.
 crate::transparent_newtype! {
@@ -218,6 +220,63 @@ impl<T> Script<T> {
         }
 
         WitnessVersion::try_from(ver_opcode).ok()
+    }
+
+    /// Checks whether a script pubkey is a P2WSH output.
+    #[inline]
+    pub fn is_p2wsh(&self) -> bool
+    where
+        T: ScriptHashableTag,
+    {
+        self.len() == 34
+            && self.witness_version() == Some(WitnessVersion::V0)
+            && self.as_bytes()[1] == OP_PUSHBYTES_32.to_u8()
+    }
+
+    /// Checks whether a script pubkey is a P2WPKH output.
+    #[inline]
+    pub fn is_p2wpkh(&self) -> bool
+    where
+        T: ScriptHashableTag,
+    {
+        self.len() == 22
+            && self.witness_version() == Some(WitnessVersion::V0)
+            && self.as_bytes()[1] == OP_PUSHBYTES_20.to_u8()
+    }
+}
+
+impl ScriptPubKey {
+    /// Checks whether a script pubkey is a Segregated Witness (SegWit) program.
+    #[inline]
+    pub fn is_witness_program(&self) -> bool { self.witness_version().is_some() }
+
+    /// Checks whether a script pubkey is a P2SH output.
+    #[inline]
+    pub fn is_p2sh(&self) -> bool {
+        self.len() == 23
+            && self.as_bytes()[0] == OP_HASH160.to_u8()
+            && self.as_bytes()[1] == OP_PUSHBYTES_20.to_u8()
+            && self.as_bytes()[22] == OP_EQUAL.to_u8()
+    }
+
+    /// Checks whether a script pubkey is a P2PKH output.
+    #[inline]
+    pub fn is_p2pkh(&self) -> bool {
+        self.len() == 25
+            && self.as_bytes()[0] == OP_DUP.to_u8()
+            && self.as_bytes()[1] == OP_HASH160.to_u8()
+            && self.as_bytes()[2] == OP_PUSHBYTES_20.to_u8()
+            && self.as_bytes()[23] == OP_EQUALVERIFY.to_u8()
+            && self.as_bytes()[24] == OP_CHECKSIG.to_u8()
+    }
+
+    /// Checks whether a script pubkey is a P2A output.
+    #[inline]
+    pub fn is_p2a(&self) -> bool {
+        self.len() == 4
+            && self.witness_version() == Some(WitnessVersion::V1)
+            && self.as_bytes()[1] == OP_PUSHBYTES_2.to_u8()
+            && self.as_bytes()[2..] == P2A_PROGRAM
     }
 }
 

--- a/primitives/src/script/borrowed.rs
+++ b/primitives/src/script/borrowed.rs
@@ -13,7 +13,7 @@ use arbitrary::{Arbitrary, Unstructured};
 use encoding::{BytesEncoder, CompactSizeEncoder, Encode, Encoder2};
 
 use super::{ScriptBuf, P2A_PROGRAM};
-use crate::opcodes::all::{OP_CHECKSIG, OP_DUP, OP_EQUAL, OP_EQUALVERIFY, OP_HASH160};
+use crate::opcodes::all::{OP_CHECKSIG, OP_DUP, OP_EQUAL, OP_EQUALVERIFY, OP_HASH160, OP_RETURN};
 use crate::opcodes::{Opcode, OP_PUSHBYTES_2, OP_PUSHBYTES_20, OP_PUSHBYTES_32};
 use crate::prelude::{Box, ToOwned, Vec};
 use crate::script::ScriptHashableTag;
@@ -277,6 +277,15 @@ impl ScriptPubKey {
             && self.witness_version() == Some(WitnessVersion::V1)
             && self.as_bytes()[1] == OP_PUSHBYTES_2.to_u8()
             && self.as_bytes()[2..] == P2A_PROGRAM
+    }
+
+    /// Check if this is a consensus-valid `OP_RETURN` output.
+    ///
+    /// To validate if the `OP_RETURN` obeys Bitcoin Core's current standardness policy, use
+    /// `bitcoin::ScriptPubKeyExt::is_standard_op_return()` instead.
+    #[inline]
+    pub fn is_op_return(&self) -> bool {
+        self.as_bytes().first().is_some_and(|&b| b == OP_RETURN.to_u8())
     }
 }
 

--- a/primitives/src/script/borrowed.rs
+++ b/primitives/src/script/borrowed.rs
@@ -13,7 +13,10 @@ use arbitrary::{Arbitrary, Unstructured};
 use encoding::{BytesEncoder, CompactSizeEncoder, Encode, Encoder2};
 
 use super::ScriptBuf;
+use crate::opcodes::Opcode;
 use crate::prelude::{Box, ToOwned, Vec};
+use crate::script::ScriptHashableTag;
+use crate::witness_version::WitnessVersion;
 
 // Defined in `REPO_DIR/include/newtype.rs`.
 crate::transparent_newtype! {
@@ -181,6 +184,41 @@ impl<T> Script<T> {
     #[inline]
     #[deprecated(since = "1.0.0-rc.0", note = "use `format!(\"{var:x}\")` instead")]
     pub fn to_hex(&self) -> alloc::string::String { alloc::format!("{:x}", self) }
+
+    /// Returns witness version of the script, if any, assuming the script is a `scriptPubkey`.
+    ///
+    /// # Returns
+    ///
+    /// The witness version if this script is found to conform to the SegWit rules:
+    ///
+    /// > A scriptPubKey (or redeemScript as defined in BIP-0016/P2SH) that consists of a 1-byte
+    /// > push opcode (for 0 to 16) followed by a data push between 2 and 40 bytes gets a new
+    /// > special meaning. The value of the first push is called the "version byte". The following
+    /// > byte vector pushed is called the "witness program".
+    #[inline]
+    pub fn witness_version(&self) -> Option<WitnessVersion>
+    where
+        T: ScriptHashableTag,
+    {
+        let script_len = self.len();
+        if !(4..=42).contains(&script_len) {
+            return None;
+        }
+
+        let ver_opcode = Opcode::from(self.as_bytes()[0]); // Version 0 or PUSHNUM_1-PUSHNUM_16
+        let push_opbyte = self.as_bytes()[1]; // Second byte push opcode 2-40 bytes
+
+        // If push_opbyte < OP_PUSHBYTES_2 || push_opbyte > OP_PUSHBYTES_40
+        if push_opbyte < 0x02 || push_opbyte > 0x28 {
+            return None;
+        }
+        // Check that the rest of the script has the correct size
+        if script_len - 2 != push_opbyte as usize {
+            return None;
+        }
+
+        WitnessVersion::try_from(ver_opcode).ok()
+    }
 }
 
 impl<T> Encode for Script<T> {

--- a/primitives/src/script/mod.rs
+++ b/primitives/src/script/mod.rs
@@ -90,6 +90,9 @@ pub const MAX_REDEEM_SCRIPT_SIZE: usize = 520;
 /// The maximum allowed redeem script size of the witness script.
 pub const MAX_WITNESS_SCRIPT_SIZE: usize = 10_000;
 
+/// The P2A program which is given by 0x4e73.
+pub(crate) const P2A_PROGRAM: [u8; 2] = [78, 115];
+
 /// Generates P2WSH-type of scriptPubkey with a given [`WitnessVersion`] and the program bytes.
 /// Does not do any checks on version or program length.
 ///

--- a/primitives/src/script/mod.rs
+++ b/primitives/src/script/mod.rs
@@ -97,7 +97,6 @@ pub(crate) const P2A_PROGRAM: [u8; 2] = [78, 115];
 /// Does not do any checks on version or program length.
 ///
 /// Convenience method used by `new_p2a`, `new_p2wpkh`, `new_p2wsh`, `new_p2tr`, and `new_p2tr_tweaked`.
-#[allow(dead_code)]
 pub(crate) fn new_witness_program_unchecked<T: AsRef<PushBytes>, Tg>(
     version: WitnessVersion,
     program: T,

--- a/primitives/src/script/mod.rs
+++ b/primitives/src/script/mod.rs
@@ -25,6 +25,7 @@ use crate::prelude::rc::Rc;
 #[cfg(target_has_atomic = "ptr")]
 use crate::prelude::sync::Arc;
 use crate::prelude::{Borrow, BorrowMut, Box, Cow, ToOwned, Vec};
+use crate::witness_version::WitnessVersion;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
@@ -88,6 +89,22 @@ pub type WitnessScript = Script<WitnessScriptTag>;
 pub const MAX_REDEEM_SCRIPT_SIZE: usize = 520;
 /// The maximum allowed redeem script size of the witness script.
 pub const MAX_WITNESS_SCRIPT_SIZE: usize = 10_000;
+
+/// Generates P2WSH-type of scriptPubkey with a given [`WitnessVersion`] and the program bytes.
+/// Does not do any checks on version or program length.
+///
+/// Convenience method used by `new_p2a`, `new_p2wpkh`, `new_p2wsh`, `new_p2tr`, and `new_p2tr_tweaked`.
+#[allow(dead_code)]
+pub(crate) fn new_witness_program_unchecked<T: AsRef<PushBytes>, Tg>(
+    version: WitnessVersion,
+    program: T,
+) -> ScriptBuf<Tg> {
+    let program = program.as_ref();
+    debug_assert!(program.len() >= 2 && program.len() <= 40);
+    // In SegWit v0, the program must be either 20 bytes (P2WPKH) or 32 bytes (P2WSH) long.
+    debug_assert!(version != WitnessVersion::V0 || program.len() == 20 || program.len() == 32);
+    Builder::new().push_opcode(version.into()).push_slice(program).into_script()
+}
 
 /// Either a redeem script or a Segwit version 0 scriptpubkey.
 ///

--- a/primitives/src/script/owned.rs
+++ b/primitives/src/script/owned.rs
@@ -8,7 +8,7 @@ use arbitrary::{Arbitrary, Unstructured};
 use encoding::{ByteVecDecoder, DecoderStatus};
 
 use super::{Script, ScriptBufDecoderError, P2A_PROGRAM};
-use crate::opcodes::all::{OP_1, OP_1NEGATE, OP_EQUAL, OP_HASH160};
+use crate::opcodes::all::{OP_1, OP_1NEGATE, OP_EQUAL, OP_HASH160, OP_RETURN};
 use crate::opcodes::{self, Opcode};
 use crate::prelude::{Box, Vec};
 use crate::script::{Builder, PushBytes, ScriptHash, WScriptHash};
@@ -261,6 +261,11 @@ impl<T> ScriptBuf<T> {
 }
 
 impl ScriptPubKeyBuf {
+    /// Generates OP_RETURN-type of scriptPubkey for the given data.
+    pub fn new_op_return<T: AsRef<PushBytes>>(data: T) -> Self {
+        Builder::new().push_opcode(OP_RETURN).push_slice(data).into_script()
+    }
+
     /// Generates P2SH-type of scriptPubkey with a given hash of the redeem script.
     pub fn new_p2sh(script_hash: ScriptHash) -> Self {
         Builder::new()

--- a/primitives/src/script/owned.rs
+++ b/primitives/src/script/owned.rs
@@ -7,11 +7,13 @@ use core::ops::{Deref, DerefMut};
 use arbitrary::{Arbitrary, Unstructured};
 use encoding::{ByteVecDecoder, DecoderStatus};
 
-use super::{Script, ScriptBufDecoderError};
-use crate::opcodes::all::{OP_1, OP_1NEGATE};
+use super::{Script, ScriptBufDecoderError, P2A_PROGRAM};
+use crate::opcodes::all::{OP_1, OP_1NEGATE, OP_EQUAL, OP_HASH160};
 use crate::opcodes::{self, Opcode};
 use crate::prelude::{Box, Vec};
-use crate::script::PushBytes;
+use crate::script::{Builder, PushBytes, ScriptHash, WScriptHash};
+use crate::witness_version::WitnessVersion;
+use crate::ScriptPubKeyBuf;
 
 /// An owned, growable script.
 ///
@@ -255,6 +257,28 @@ impl<T> ScriptBuf<T> {
         }
         // Then push the raw bytes
         this.extend_from_slice(data.as_bytes());
+    }
+}
+
+impl ScriptPubKeyBuf {
+    /// Generates P2SH-type of scriptPubkey with a given hash of the redeem script.
+    pub fn new_p2sh(script_hash: ScriptHash) -> Self {
+        Builder::new()
+            .push_opcode(OP_HASH160)
+            .push_slice(script_hash)
+            .push_opcode(OP_EQUAL)
+            .into_script()
+    }
+
+    /// Generates P2WSH-type of scriptPubkey with a given hash of the redeem script.
+    pub fn new_p2wsh(script_hash: WScriptHash) -> Self {
+        // script hash is 32 bytes long, so it's safe to use `new_witness_program_unchecked` (Segwitv0)
+        super::new_witness_program_unchecked(WitnessVersion::V0, script_hash)
+    }
+
+    /// Generates pay to anchor output.
+    pub fn new_p2a() -> Self {
+        super::new_witness_program_unchecked(WitnessVersion::V1, P2A_PROGRAM)
     }
 }
 

--- a/primitives/src/script/tests.rs
+++ b/primitives/src/script/tests.rs
@@ -296,6 +296,78 @@ fn partial_ord() {
 }
 
 #[test]
+#[cfg(feature = "hex")]
+fn provably_unspendable() {
+    // p2pk
+    assert!(!ScriptPubKeyBuf::from_hex_no_length_prefix("410446ef0102d1ec5240f0d061a4246c1bdef63fc3dbab7733052fbbf0ecd8f41fc26bf049ebb4f9527f374280259e7cfa99c48b0e3f39c51347a19a5819651503a5ac").unwrap().is_op_return());
+    assert!(!ScriptPubKeyBuf::from_hex_no_length_prefix("4104ea1feff861b51fe3f5f8a3b12d0f4712db80e919548a80839fc47c6a21e66d957e9c5d8cd108c7a2d2324bad71f9904ac0ae7336507d785b17a2c115e427a32fac").unwrap().is_op_return());
+    // p2pkhash
+    assert!(!ScriptPubKeyBuf::from_hex_no_length_prefix(
+        "76a914ee61d57ab51b9d212335b1dba62794ac20d2bcf988ac"
+    )
+    .unwrap()
+    .is_op_return());
+    assert!(ScriptPubKeyBuf::from_hex_no_length_prefix(
+        "6aa9149eb21980dc9d413d8eac27314938b9da920ee53e87"
+    )
+    .unwrap()
+    .is_op_return());
+}
+
+#[test]
+#[cfg(feature = "hex")]
+fn op_return() {
+    assert!(ScriptPubKeyBuf::from_hex_no_length_prefix(
+        "6aa9149eb21980dc9d413d8eac27314938b9da920ee53e87"
+    )
+    .unwrap()
+    .is_op_return());
+    assert!(!ScriptPubKeyBuf::from_hex_no_length_prefix(
+        "76a914ee61d57ab51b9d212335b1dba62794ac20d2bcf988ac"
+    )
+    .unwrap()
+    .is_op_return());
+    assert!(!ScriptPubKeyBuf::from_hex_no_length_prefix("").unwrap().is_op_return());
+}
+
+#[test]
+#[cfg(feature = "hex")]
+fn script_p2sh_p2pkh_template() {
+    // random outputs I picked out of the mempool
+    assert!(ScriptPubKeyBuf::from_hex_no_length_prefix(
+        "76a91402306a7c23f3e8010de41e9e591348bb83f11daa88ac"
+    )
+    .unwrap()
+    .is_p2pkh());
+    assert!(!ScriptPubKeyBuf::from_hex_no_length_prefix(
+        "76a91402306a7c23f3e8010de41e9e591348bb83f11daa88ac"
+    )
+    .unwrap()
+    .is_p2sh());
+    assert!(!ScriptPubKeyBuf::from_hex_no_length_prefix(
+        "76a91402306a7c23f3e8010de41e9e591348bb83f11daa88ad"
+    )
+    .unwrap()
+    .is_p2pkh());
+    assert!(!ScriptPubKeyBuf::from_hex_no_length_prefix("").unwrap().is_p2pkh());
+    assert!(ScriptPubKeyBuf::from_hex_no_length_prefix(
+        "a914acc91e6fef5c7f24e5c8b3f11a664aa8f1352ffd87"
+    )
+    .unwrap()
+    .is_p2sh());
+    assert!(!ScriptPubKeyBuf::from_hex_no_length_prefix(
+        "a914acc91e6fef5c7f24e5c8b3f11a664aa8f1352ffd87"
+    )
+    .unwrap()
+    .is_p2pkh());
+    assert!(!ScriptPubKeyBuf::from_hex_no_length_prefix(
+        "a314acc91e6fef5c7f24e5c8b3f11a664aa8f1352ffd87"
+    )
+    .unwrap()
+    .is_p2sh());
+}
+
+#[test]
 fn script_hash_from_script() {
     let script = RedeemScript::from_bytes(&[0x51; 520]);
     assert!(ScriptHash::from_script(script).is_ok());
@@ -672,6 +744,128 @@ fn witness_to_signet_script() {
     let witness = WitnessScriptBuf::from(bytes.clone());
     let signet: SignetBlockScriptBuf = witness.into();
     assert_eq!(signet.as_bytes(), &bytes);
+}
+
+// Builds a witness-program-shaped script: version byte, push opcode, then `program_len` bytes.
+fn witness_program_bytes(version_byte: u8, push_opcode: u8, program_len: usize) -> Vec<u8> {
+    let mut v = vec![version_byte, push_opcode];
+    v.resize(2 + program_len, 0xab);
+    v
+}
+
+#[test]
+fn witness_version_valid() {
+    use crate::witness_version::WitnessVersion;
+
+    let p2wpkh = ScriptPubKeyBuf::from(witness_program_bytes(0x00, 0x14, 20));
+    assert_eq!(p2wpkh.witness_version(), Some(WitnessVersion::V0));
+
+    let p2wsh = ScriptPubKeyBuf::from(witness_program_bytes(0x00, 0x20, 32));
+    assert_eq!(p2wsh.witness_version(), Some(WitnessVersion::V0));
+
+    let p2tr = ScriptPubKeyBuf::from(witness_program_bytes(0x51, 0x20, 32));
+    assert_eq!(p2tr.witness_version(), Some(WitnessVersion::V1));
+
+    let push2 = ScriptPubKeyBuf::from(witness_program_bytes(0x51, 0x02, 2));
+    assert_eq!(push2.witness_version(), Some(WitnessVersion::V1));
+
+    let max = ScriptPubKeyBuf::from(witness_program_bytes(0x51, 0x28, 40));
+    assert_eq!(max.witness_version(), Some(WitnessVersion::V1));
+
+    assert!(ScriptPubKeyBuf::from(vec![0x00, 0x01, 0xab]).witness_version().is_none());
+    assert!(ScriptPubKeyBuf::from(witness_program_bytes(0x51, 0x28, 41))
+        .witness_version()
+        .is_none());
+
+    assert!(ScriptPubKeyBuf::from(vec![0x00, 0x01, 0xab, 0xab]).witness_version().is_none());
+
+    assert!(ScriptPubKeyBuf::from(witness_program_bytes(0x00, 0x14, 19))
+        .witness_version()
+        .is_none());
+
+    assert!(ScriptPubKeyBuf::from(witness_program_bytes(0x00, 0x14, 21))
+        .witness_version()
+        .is_none());
+}
+
+#[test]
+fn script_is_p2wsh() {
+    let p2wsh = ScriptPubKeyBuf::from(witness_program_bytes(0x00, 0x20, 32));
+    assert!(p2wsh.is_p2wsh());
+
+    assert!(!ScriptPubKeyBuf::from(witness_program_bytes(0x00, 0x21, 33)).is_p2wsh());
+    assert!(!ScriptPubKeyBuf::from(witness_program_bytes(0x51, 0x20, 32)).is_p2wsh());
+    assert!(!ScriptPubKeyBuf::from(vec![0xab; 34]).is_p2wsh());
+}
+
+#[test]
+fn script_is_p2wpkh() {
+    let p2wpkh = ScriptPubKeyBuf::from(witness_program_bytes(0x00, 0x14, 20));
+    assert!(p2wpkh.is_p2wpkh());
+
+    assert!(!ScriptPubKeyBuf::from(witness_program_bytes(0x00, 0x15, 21)).is_p2wpkh());
+    assert!(!ScriptPubKeyBuf::from(witness_program_bytes(0x51, 0x14, 20)).is_p2wpkh());
+    assert!(!ScriptPubKeyBuf::from(vec![0xab; 22]).is_p2wpkh());
+}
+
+#[test]
+fn script_is_witness_program() {
+    let p2wpkh = ScriptPubKeyBuf::from(witness_program_bytes(0x00, 0x14, 20));
+    assert!(p2wpkh.is_witness_program());
+
+    assert!(!ScriptPubKeyBuf::from(vec![0x00, 0x01, 0xab]).is_witness_program());
+}
+
+#[test]
+fn script_is_p2a() {
+    let p2a = ScriptPubKeyBuf::new_p2a();
+    assert!(p2a.is_p2a());
+    assert_eq!(p2a.as_bytes(), &[0x51, 0x02, 0x4e, 0x73]);
+
+    assert!(!ScriptPubKeyBuf::from(vec![0x00, 0x02, 0x4e, 0x73]).is_p2a());
+    assert!(!ScriptPubKeyBuf::from(vec![0x51, 0x02, 0xaa, 0xbb]).is_p2a());
+    assert!(!ScriptPubKeyBuf::from(vec![0x51, 0x03, 0x4e, 0x73, 0x00]).is_p2a());
+}
+
+#[test]
+fn new_op_return() {
+    let op_return = ScriptPubKeyBuf::new_op_return([0x01u8, 0x02, 0x03]);
+    assert!(op_return.is_op_return());
+    assert!(!op_return.is_empty());
+    assert_eq!(op_return.as_bytes(), &[0x6a, 0x03, 0x01, 0x02, 0x03]);
+}
+
+#[test]
+fn new_p2sh() {
+    let script_hash = ScriptHash::from_byte_array([0x12; 20]);
+    let p2sh = ScriptPubKeyBuf::new_p2sh(script_hash);
+    assert!(p2sh.is_p2sh());
+    assert!(!p2sh.is_empty());
+
+    let mut want = vec![0xa9, 0x14];
+    want.extend([0x12; 20]);
+    want.push(0x87);
+    assert_eq!(p2sh.as_bytes(), &want[..]);
+}
+
+#[test]
+fn new_p2wsh() {
+    let wscript_hash = WScriptHash::from_byte_array([0x34; 32]);
+    let p2wsh = ScriptPubKeyBuf::new_p2wsh(wscript_hash);
+    assert!(p2wsh.is_p2wsh());
+    assert!(!p2wsh.is_empty());
+
+    let mut want = vec![0x00, 0x20];
+    want.extend([0x34; 32]);
+    assert_eq!(p2wsh.as_bytes(), &want[..]);
+}
+
+#[test]
+fn new_p2a() {
+    let p2a = ScriptPubKeyBuf::new_p2a();
+    assert!(p2a.is_p2a());
+    assert!(!p2a.is_empty());
+    assert_eq!(p2a.as_bytes(), &[0x51, 0x02, 0x4e, 0x73]);
 }
 
 #[test]


### PR DESCRIPTION
With the move of Opcode, Builder and WitnessVersion to primitives, various script functions from the extension traits can now be moved to primitives. For now, those used in the addresses module are the only ones moved, in preparation for the addresses crate split.

- Patch 1 duplicates new_witness_program_unchecked privately in primitives.
- Patch 2 moves the Script::witness_version function to Script from ScriptExt.
- Patch 3 adds private opcode constants and P2A_PROGRAM constant.
- Patch 4 moves is_ and new_ script functions used in address to primitives.
- Patch 5 moves is_op_return and new_op_return to primitives.
- Patch 6 updates the API files
- Patch 7 adds and moves tests to kill mutants in new primitives code.