### PR TITLE
consensus_encoding: Close FromHexError

### DIFF
--- a/consensus_encoding/api/all-features.txt
+++ b/consensus_encoding/api/all-features.txt
@@ -236,54 +236,6 @@ impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::error::Decode
 pub unsafe fn bitcoin_consensus_encoding::error::Decoder6Error<A, B, C, D, E, F>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::error::Decoder6Error<A, B, C, D, E, F>
 pub fn bitcoin_consensus_encoding::error::Decoder6Error<A, B, C, D, E, F>::from(t: T) -> T
-pub enum bitcoin_consensus_encoding::error::FromHexError<ParseErr>
-pub bitcoin_consensus_encoding::error::FromHexError::Decode(bitcoin_consensus_encoding::error::DecodeError<ParseErr>)
-pub bitcoin_consensus_encoding::error::FromHexError::InvalidChar(hex_conservative::error::InvalidCharError)
-pub bitcoin_consensus_encoding::error::FromHexError::OddLength(hex_conservative::error::OddLengthStringError)
-impl<ParseErr: core::clone::Clone> core::clone::Clone for bitcoin_consensus_encoding::error::FromHexError<ParseErr>
-pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::clone(&self) -> bitcoin_consensus_encoding::error::FromHexError<ParseErr>
-impl<ParseErr: core::cmp::Eq> core::cmp::Eq for bitcoin_consensus_encoding::error::FromHexError<ParseErr>
-impl<ParseErr: core::cmp::PartialEq> core::cmp::PartialEq for bitcoin_consensus_encoding::error::FromHexError<ParseErr>
-pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::eq(&self, other: &bitcoin_consensus_encoding::error::FromHexError<ParseErr>) -> bool
-impl<ParseErr: core::fmt::Debug> core::fmt::Debug for bitcoin_consensus_encoding::error::FromHexError<ParseErr>
-pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl<ParseErr: core::fmt::Display> core::fmt::Display for bitcoin_consensus_encoding::error::FromHexError<ParseErr>
-impl<ParseErr> core::convert::From<core::convert::Infallible> for bitcoin_consensus_encoding::error::FromHexError<ParseErr>
-pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::from(never: core::convert::Infallible) -> Self
-impl<ParseErr> core::error::Error for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where ParseErr: core::error::Error + 'static
-pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
-impl<ParseErr> core::marker::StructuralPartialEq for bitcoin_consensus_encoding::error::FromHexError<ParseErr>
-impl<ParseErr> core::marker::Freeze for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where ParseErr: core::marker::Freeze
-impl<ParseErr> core::marker::Send for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where ParseErr: core::marker::Send
-impl<ParseErr> core::marker::Sync for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where ParseErr: core::marker::Sync
-impl<ParseErr> core::marker::Unpin for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where ParseErr: core::marker::Unpin
-impl<ParseErr> core::marker::UnsafeUnpin for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where ParseErr: core::marker::UnsafeUnpin
-impl<ParseErr> core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where ParseErr: core::panic::unwind_safe::RefUnwindSafe
-impl<ParseErr> core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where ParseErr: core::panic::unwind_safe::UnwindSafe
-impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where U: core::convert::From<T>
-pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where U: core::convert::Into<T>
-pub type bitcoin_consensus_encoding::error::FromHexError<ParseErr>::Error = core::convert::Infallible
-pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where U: core::convert::TryFrom<T>
-pub type bitcoin_consensus_encoding::error::FromHexError<ParseErr>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where T: core::clone::Clone
-pub type bitcoin_consensus_encoding::error::FromHexError<ParseErr>::Owned = T
-pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::clone_into(&self, target: &mut T)
-pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::to_owned(&self) -> T
-impl<T> alloc::string::ToString for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where T: core::fmt::Display + ?core::marker::Sized
-pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::to_string(&self) -> alloc::string::String
-impl<T> core::any::Any for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where T: 'static + ?core::marker::Sized
-pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where T: ?core::marker::Sized
-pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where T: ?core::marker::Sized
-pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where T: core::clone::Clone
-pub unsafe fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::clone_to_uninit(&self, dest: *mut u8)
-impl<T> core::convert::From<T> for bitcoin_consensus_encoding::error::FromHexError<ParseErr>
-pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::from(t: T) -> T
 pub enum bitcoin_consensus_encoding::error::ReadError<D>
 pub bitcoin_consensus_encoding::error::ReadError::Decode(D)
 pub bitcoin_consensus_encoding::error::ReadError::Io(std::io::error::Error)
@@ -409,6 +361,51 @@ impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::error::Compac
 pub unsafe fn bitcoin_consensus_encoding::error::CompactSizeDecoderError::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::error::CompactSizeDecoderError
 pub fn bitcoin_consensus_encoding::error::CompactSizeDecoderError::from(t: T) -> T
+pub struct bitcoin_consensus_encoding::error::FromHexError<ParseErr>(_)
+impl<ParseErr: core::clone::Clone> core::clone::Clone for bitcoin_consensus_encoding::error::FromHexError<ParseErr>
+pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::clone(&self) -> bitcoin_consensus_encoding::error::FromHexError<ParseErr>
+impl<ParseErr: core::cmp::Eq> core::cmp::Eq for bitcoin_consensus_encoding::error::FromHexError<ParseErr>
+impl<ParseErr: core::cmp::PartialEq> core::cmp::PartialEq for bitcoin_consensus_encoding::error::FromHexError<ParseErr>
+pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::eq(&self, other: &bitcoin_consensus_encoding::error::FromHexError<ParseErr>) -> bool
+impl<ParseErr: core::fmt::Debug> core::fmt::Debug for bitcoin_consensus_encoding::error::FromHexError<ParseErr>
+pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<ParseErr: core::fmt::Display> core::fmt::Display for bitcoin_consensus_encoding::error::FromHexError<ParseErr>
+impl<ParseErr> core::convert::From<core::convert::Infallible> for bitcoin_consensus_encoding::error::FromHexError<ParseErr>
+pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::from(never: core::convert::Infallible) -> Self
+impl<ParseErr> core::error::Error for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where ParseErr: core::error::Error + 'static
+pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl<ParseErr> core::marker::StructuralPartialEq for bitcoin_consensus_encoding::error::FromHexError<ParseErr>
+impl<ParseErr> core::marker::Freeze for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where ParseErr: core::marker::Freeze
+impl<ParseErr> core::marker::Send for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where ParseErr: core::marker::Send
+impl<ParseErr> core::marker::Sync for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where ParseErr: core::marker::Sync
+impl<ParseErr> core::marker::Unpin for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where ParseErr: core::marker::Unpin
+impl<ParseErr> core::marker::UnsafeUnpin for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where ParseErr: core::marker::UnsafeUnpin
+impl<ParseErr> core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where ParseErr: core::panic::unwind_safe::RefUnwindSafe
+impl<ParseErr> core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where ParseErr: core::panic::unwind_safe::UnwindSafe
+impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where U: core::convert::From<T>
+pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where U: core::convert::Into<T>
+pub type bitcoin_consensus_encoding::error::FromHexError<ParseErr>::Error = core::convert::Infallible
+pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where U: core::convert::TryFrom<T>
+pub type bitcoin_consensus_encoding::error::FromHexError<ParseErr>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where T: core::clone::Clone
+pub type bitcoin_consensus_encoding::error::FromHexError<ParseErr>::Owned = T
+pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::clone_into(&self, target: &mut T)
+pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::to_owned(&self) -> T
+impl<T> alloc::string::ToString for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where T: core::fmt::Display + ?core::marker::Sized
+pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where T: 'static + ?core::marker::Sized
+pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where T: ?core::marker::Sized
+pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where T: ?core::marker::Sized
+pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where T: core::clone::Clone
+pub unsafe fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for bitcoin_consensus_encoding::error::FromHexError<ParseErr>
+pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::from(t: T) -> T
 pub struct bitcoin_consensus_encoding::error::LengthPrefixExceedsMaxError
 impl core::clone::Clone for bitcoin_consensus_encoding::error::LengthPrefixExceedsMaxError
 pub fn bitcoin_consensus_encoding::error::LengthPrefixExceedsMaxError::clone(&self) -> bitcoin_consensus_encoding::error::LengthPrefixExceedsMaxError
@@ -710,10 +707,6 @@ impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::EncoderStatus
 pub unsafe fn bitcoin_consensus_encoding::EncoderStatus::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::EncoderStatus
 pub fn bitcoin_consensus_encoding::EncoderStatus::from(t: T) -> T
-pub enum bitcoin_consensus_encoding::FromHexError<ParseErr>
-pub bitcoin_consensus_encoding::FromHexError::Decode(bitcoin_consensus_encoding::error::DecodeError<ParseErr>)
-pub bitcoin_consensus_encoding::FromHexError::InvalidChar(hex_conservative::error::InvalidCharError)
-pub bitcoin_consensus_encoding::FromHexError::OddLength(hex_conservative::error::OddLengthStringError)
 pub enum bitcoin_consensus_encoding::ReadError<D>
 pub bitcoin_consensus_encoding::ReadError::Decode(D)
 pub bitcoin_consensus_encoding::ReadError::Io(std::io::error::Error)
@@ -1450,6 +1443,7 @@ impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::EncoderByteIt
 pub unsafe fn bitcoin_consensus_encoding::EncoderByteIter<T>::clone_to_uninit(&self, dest: *mut u8)
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::EncoderByteIter<T>
 pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::from(t: T) -> T
+pub struct bitcoin_consensus_encoding::FromHexError<ParseErr>(_)
 pub struct bitcoin_consensus_encoding::LengthPrefixExceedsMaxError
 pub struct bitcoin_consensus_encoding::SliceEncoder<'e, T: bitcoin_consensus_encoding::Encode>
 impl<'e, T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::SliceEncoder<'e, T>

--- a/consensus_encoding/src/decode/mod.rs
+++ b/consensus_encoding/src/decode/mod.rs
@@ -5,7 +5,7 @@
 pub mod decoders;
 
 #[cfg(feature = "hex")]
-use crate::FromHexError;
+use crate::error::{FromHexError, FromHexErrorInner};
 #[cfg(feature = "std")]
 use crate::ReadError;
 use crate::{DecodeError, UnconsumedError};
@@ -136,22 +136,23 @@ impl DecoderStatus {
 ///
 /// # Errors
 ///
-/// - [`FromHexError::OddLength`] if the string has an odd number of characters.
-/// - [`FromHexError::InvalidChar`] if any character is not a valid hex digit.
-/// - [`FromHexError::Decode`] if decoding the type fails, including if bytes remain unconsumed
-///   after the decoder completes.
+/// [`FromHexError`] if the string has an odd number of characters, any character is not a
+/// valid hex digit, or if decoding the type fails, including if bytes remain unconsumed
+/// after the decoder completes.
 #[cfg(feature = "hex")]
 pub fn decode_from_hex<T: Decode>(
     hex: &str,
 ) -> Result<T, FromHexError<<T::Decoder as Decoder>::Error>> {
-    let iter = hex::HexSliceToBytesIter::new(hex).map_err(FromHexError::OddLength)?;
+    let iter = hex::HexSliceToBytesIter::new(hex)
+        .map_err(FromHexErrorInner::OddLength)
+        .map_err(FromHexError)?;
 
     let mut decoder = T::decoder();
     let mut buffer = [0u8; 4096];
     let mut index = 0;
 
     for item in iter {
-        let byte = item.map_err(FromHexError::InvalidChar)?;
+        let byte = item.map_err(FromHexErrorInner::InvalidChar).map_err(FromHexError)?;
 
         if index == buffer.len() {
             let mut to_flush = buffer.as_slice();
@@ -160,10 +161,12 @@ pub fn decode_from_hex<T: Decode>(
             while !to_flush.is_empty() {
                 if decoder
                     .push_bytes(&mut to_flush)
-                    .map_err(|e| FromHexError::Decode(DecodeError::Parse(e)))?
+                    .map_err(|e| FromHexError(FromHexErrorInner::Decode(DecodeError::Parse(e))))?
                     .is_ready()
                 {
-                    return Err(FromHexError::Decode(DecodeError::Unconsumed(UnconsumedError())));
+                    return Err(FromHexError(FromHexErrorInner::Decode(DecodeError::Unconsumed(
+                        UnconsumedError(),
+                    ))));
                 }
             }
             index = 0;
@@ -176,7 +179,7 @@ pub fn decode_from_hex<T: Decode>(
     while !to_flush.is_empty() {
         if decoder
             .push_bytes(&mut to_flush)
-            .map_err(|e| FromHexError::Decode(DecodeError::Parse(e)))?
+            .map_err(|e| FromHexError(FromHexErrorInner::Decode(DecodeError::Parse(e))))?
             .is_ready()
         {
             break;
@@ -184,9 +187,9 @@ pub fn decode_from_hex<T: Decode>(
     }
 
     if to_flush.is_empty() {
-        decoder.end().map_err(|e| FromHexError::Decode(DecodeError::Parse(e)))
+        decoder.end().map_err(|e| FromHexError(FromHexErrorInner::Decode(DecodeError::Parse(e))))
     } else {
-        Err(FromHexError::Decode(DecodeError::Unconsumed(UnconsumedError())))
+        Err(FromHexError(FromHexErrorInner::Decode(DecodeError::Unconsumed(UnconsumedError()))))
     }
 }
 

--- a/consensus_encoding/src/error.rs
+++ b/consensus_encoding/src/error.rs
@@ -328,7 +328,11 @@ impl std::error::Error for UnexpectedEofError {
 /// An error that can occur when decoding from a hex string.
 #[cfg(feature = "hex")]
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum FromHexError<ParseErr> {
+pub struct FromHexError<ParseErr>(pub(crate) FromHexErrorInner<ParseErr>);
+
+#[cfg(feature = "hex")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum FromHexErrorInner<ParseErr> {
     /// The hex string had an odd number of characters.
     OddLength(hex::OddLengthStringError),
     /// A character in the hex string was not a valid hex digit.
@@ -345,10 +349,10 @@ impl<ParseErr> From<Infallible> for FromHexError<ParseErr> {
 #[cfg(feature = "hex")]
 impl<ParseErr: fmt::Display> fmt::Display for FromHexError<ParseErr> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Self::OddLength(ref e) => write_err!(f, "odd length string"; e),
-            Self::InvalidChar(ref e) => write_err!(f, "invalid character"; e),
-            Self::Decode(ref e) => write_err!(f, "decode error"; e),
+        match self.0 {
+            FromHexErrorInner::OddLength(ref e) => write_err!(f, "odd length string"; e),
+            FromHexErrorInner::InvalidChar(ref e) => write_err!(f, "invalid character"; e),
+            FromHexErrorInner::Decode(ref e) => write_err!(f, "decode error"; e),
         }
     }
 }
@@ -360,10 +364,10 @@ where
     ParseErr: std::error::Error + 'static,
 {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match *self {
-            Self::OddLength(ref e) => Some(e),
-            Self::InvalidChar(ref e) => Some(e),
-            Self::Decode(ref e) => Some(e),
+        match self.0 {
+            FromHexErrorInner::OddLength(ref e) => Some(e),
+            FromHexErrorInner::InvalidChar(ref e) => Some(e),
+            FromHexErrorInner::Decode(ref e) => Some(e),
         }
     }
 }

--- a/consensus_encoding/tests/decode.rs
+++ b/consensus_encoding/tests/decode.rs
@@ -7,7 +7,7 @@ use std::io::{Cursor, Read};
 
 use bitcoin_consensus_encoding as encoding;
 #[cfg(feature = "hex")]
-use bitcoin_consensus_encoding::{decode_from_hex, FromHexError};
+use bitcoin_consensus_encoding::decode_from_hex;
 #[cfg(feature = "alloc")]
 use encoding::check_decode;
 use encoding::{
@@ -317,17 +317,36 @@ fn decode_from_hex_larger_than_internal_buffer() {
 
 #[test]
 #[cfg(feature = "hex")]
+#[cfg(feature = "std")]
+#[rustfmt::skip] // matches! statements become tall stacks from fmt
 fn decode_from_hex_error() {
+    use std::error::Error as _;
+
     let result: Result<TestArray, _> = decode_from_hex("0102030");
-    assert!(matches!(result, Err(FromHexError::OddLength(_))));
+    assert!(matches!(
+        result.unwrap_err().source().unwrap().downcast_ref().unwrap(),
+        hex::OddLengthStringError { .. },
+    ));
     let result: Result<TestArray, _> = decode_from_hex("0102GG04");
-    assert!(matches!(result, Err(FromHexError::InvalidChar(_))));
+    assert!(matches!(
+        result.unwrap_err().source().unwrap().downcast_ref().unwrap(),
+        hex::InvalidCharError { .. },
+    ));
     let result: Result<TestArray, _> = decode_from_hex("0102");
-    assert!(matches!(result, Err(FromHexError::Decode(DecodeError::Parse(_)))));
+    assert!(matches!(
+        result.unwrap_err().source().unwrap().downcast_ref::<DecodeError<UnexpectedEofError>>().unwrap(),
+        DecodeError::Parse(_),
+    ));
     let result: Result<TestArray, _> = decode_from_hex("");
-    assert!(matches!(result, Err(FromHexError::Decode(DecodeError::Parse(_)))));
+    assert!(matches!(
+        result.unwrap_err().source().unwrap().downcast_ref::<DecodeError<UnexpectedEofError>>().unwrap(),
+        DecodeError::Parse(_),
+    ));
     let result: Result<TestArray, _> = decode_from_hex("0102030405060708");
-    assert!(matches!(result, Err(FromHexError::Decode(DecodeError::Unconsumed(_)))));
+    assert!(matches!(
+        result.unwrap_err().source().unwrap().downcast_ref::<DecodeError<UnexpectedEofError>>().unwrap(),
+        DecodeError::Unconsumed(_),
+    ));
 }
 
 #[test]

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -1608,8 +1608,6 @@ mod tests {
     #[cfg(feature = "std")]
     use std::error::Error as _;
 
-    #[cfg(feature = "hex")]
-    use encoding::FromHexError;
     use encoding::{Decode as _, Decoder as _};
     #[cfg(feature = "hex")]
     use hex::hex;
@@ -1753,21 +1751,31 @@ mod tests {
 
     #[test]
     #[cfg(feature = "hex")]
+    #[cfg(feature = "std")]
     fn transaction_from_hex_str_error() {
         // OddLength error
         let odd = "abc"; // 3 chars, odd length
         let err = Transaction::from_str(odd).unwrap_err();
-        assert!(matches!(err, FromHexError::OddLength(..)));
+        assert!(matches!(
+            err.source().unwrap().downcast_ref::<hex::OddLengthStringError>().unwrap(),
+            hex::OddLengthStringError { .. },
+        ));
 
         // InvalidChar error
         let invalid = "zz";
         let err = Transaction::from_str(invalid).unwrap_err();
-        assert!(matches!(err, FromHexError::InvalidChar(..)));
+        assert!(matches!(
+            err.source().unwrap().downcast_ref::<hex::InvalidCharError>().unwrap(),
+            hex::InvalidCharError { .. },
+        ));
 
         // Decode error
         let bad = "deadbeef00"; // arbitrary even-length hex that will fail decoding
         let err = Transaction::from_str(bad).unwrap_err();
-        assert!(matches!(err, FromHexError::Decode(..)));
+        assert!(matches!(
+            err.source().unwrap().source().unwrap().downcast_ref::<TransactionDecoderError>().unwrap(),
+            TransactionDecoderError { .. },
+        ));
     }
 
     #[test]


### PR DESCRIPTION
The FromHexError is currently unreleased but is necessary for hex functionality. Since it is not ready for 1.0 as an enum, it should be enclosed in a private struct as is typical for error types from units, primitives, etc.

Rename FromHexError enum to FromHexErrorInner and add a new FromHexError struct to privately wrap the inner enum.