### PR TITLE
Remove `PrivateKeyExt` and make `PrivateKey::as_inner` private

### DIFF
--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -7,8 +7,6 @@
 
 use crate::internal_macros::define_extension_trait;
 use crate::script::{self, WitnessScriptBuf};
-#[cfg(feature = "secp-recovery")]
-use crate::sign_message::MessageSignature;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 pub use secp256k1::{constants, Parity};
@@ -68,35 +66,10 @@ define_extension_trait! {
     }
 }
 
-#[cfg(feature = "secp-recovery")]
-define_extension_trait! {
-    /// Extension functionality for the [`PrivateKey`] type.
-    pub trait PrivateKeyExt impl for PrivateKey {
-        /// ECDSA signs a [`Message`] with this private key.
-        ///
-        /// This produces an ECDSA signature with a recovery ID for pubkey recovery.
-        /// See [`RecoverableSignature::sign_ecdsa_recoverable`] for details.
-        ///
-        /// [`Message`]: secp256k1::Message
-        /// [`RecoverableSignature::sign_ecdsa_recoverable`]: secp256k1::ecdsa::RecoverableSignature::sign_ecdsa_recoverable
-        #[inline]
-        fn raw_ecdsa_sign_recoverable(
-            &self,
-            msg: impl Into<secp256k1::Message>,
-        ) -> MessageSignature {
-            MessageSignature::new(
-                secp256k1::ecdsa::RecoverableSignature::sign_ecdsa_recoverable(msg, self.as_inner()),
-                self.compressed(),
-            )
-        }
-    }
-}
-
 mod sealed {
     pub trait Sealed {}
     impl Sealed for super::FullPublicKey {}
     impl Sealed for super::LegacyPublicKey {}
-    impl Sealed for super::PrivateKey {}
 }
 
 #[cfg(test)]

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -113,8 +113,6 @@ pub mod ext {
     };
     #[cfg(feature = "bitcoinconsensus")]
     pub use crate::consensus_validation::{ScriptPubKeyExt as _, TransactionExt as _};
-    #[cfg(feature = "secp-recovery")]
-    pub use crate::key::PrivateKeyExt as _;
 }
 pub mod address;
 pub mod bip158;

--- a/bitcoin/src/sign_message.rs
+++ b/bitcoin/src/sign_message.rs
@@ -9,8 +9,6 @@ use encoding::CompactSizeEncoder;
 use hashes::{sha256d, HashEngine};
 
 #[cfg(feature = "secp-recovery")]
-use crate::key::PrivateKeyExt as _;
-#[cfg(feature = "secp-recovery")]
 use crate::PrivateKey;
 
 #[rustfmt::skip]
@@ -179,7 +177,13 @@ pub fn signed_msg_hash(msg: impl AsRef<[u8]>) -> sha256d::Hash {
 pub fn sign(msg: impl AsRef<[u8]>, privkey: &PrivateKey) -> MessageSignature {
     let msg_hash = signed_msg_hash(msg);
     let msg_to_sign = secp256k1::Message::from_digest(msg_hash.to_byte_array());
-    privkey.raw_ecdsa_sign_recoverable(msg_to_sign)
+
+    let secp_key = secp256k1::SecretKey::from_secret_bytes(privkey.to_secret_bytes())
+        .expect("to_secret_bytes yields underlying valid secp bytes");
+    MessageSignature::new(
+        secp256k1::ecdsa::RecoverableSignature::sign_ecdsa_recoverable(msg_to_sign, &secp_key),
+        privkey.compressed(),
+    )
 }
 
 /// Error types for message signing.
@@ -267,7 +271,12 @@ mod tests {
         let msg_hash = super::signed_msg_hash(message);
         let msg = secp256k1::Message::from_digest(msg_hash.to_byte_array());
         let privkey = PrivateKey::generate();
-        let signature = privkey.raw_ecdsa_sign_recoverable(msg);
+        let secp_key = secp256k1::SecretKey::from_secret_bytes(privkey.to_secret_bytes())
+            .expect("to_secret_bytes yields underlying valid secp bytes");
+        let signature = MessageSignature::new(
+            secp256k1::ecdsa::RecoverableSignature::sign_ecdsa_recoverable(msg, &secp_key),
+            privkey.compressed(),
+        );
 
         assert_eq!(signature.to_string(), super::sign(message, &privkey).to_string());
         assert_eq!(signature.to_base64(), signature.to_string());

--- a/crypto/src/key.rs
+++ b/crypto/src/key.rs
@@ -206,7 +206,7 @@ mod private_key {
 
         /// Returns a reference to the inner secp256k1 secret key.
         #[inline]
-        pub fn as_inner(&self) -> &secp256k1::SecretKey { &self.inner }
+        pub(super) fn as_inner(&self) -> &secp256k1::SecretKey { &self.inner }
 
         /// Returns whether this private key should be serialized as compressed.
         #[inline]


### PR DESCRIPTION
The raw_ecdsa_sign_recoverable function on PrivateKeyExt is intended to provide a cleaner interface for working with recoverable signatures. However, this function requires the presence of an extension trait and blocks the hiding of the PrivateKey::as_inner function. Since sign_message is considered unofficially deprecated anyway, it's better to make its API messy in the pursuit of a cleaner key API.

Remove PrivateKeyExt trait and make PrivateKey::as_inner private.