### PR TITLE
Remove `From<Infallible>` on inner error types

### DIFF
--- a/base58/src/error.rs
+++ b/base58/src/error.rs
@@ -51,10 +51,6 @@ impl From<Infallible> for Error {
     fn from(never: Infallible) -> Self { match never {} }
 }
 
-impl From<Infallible> for ErrorInner {
-    fn from(never: Infallible) -> Self { match never {} }
-}
-
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use ErrorInner::{Decode, IncorrectChecksum, TooShort};
@@ -169,10 +165,6 @@ impl InvalidCharacterError {
 }
 
 impl From<Infallible> for InvalidCharacterError {
-    fn from(never: Infallible) -> Self { match never {} }
-}
-
-impl From<Infallible> for InvalidCharacterErrorInner {
     fn from(never: Infallible) -> Self { match never {} }
 }
 

--- a/units/src/amount/error.rs
+++ b/units/src/amount/error.rs
@@ -29,10 +29,6 @@ impl From<Infallible> for ParseError {
     fn from(never: Infallible) -> Self { match never {} }
 }
 
-impl From<Infallible> for ParseErrorInner {
-    fn from(never: Infallible) -> Self { match never {} }
-}
-
 impl fmt::Display for ParseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.0 {
@@ -81,10 +77,6 @@ pub(crate) enum ParseAmountErrorInner {
 }
 
 impl From<Infallible> for ParseAmountError {
-    fn from(never: Infallible) -> Self { match never {} }
-}
-
-impl From<Infallible> for ParseAmountErrorInner {
     fn from(never: Infallible) -> Self { match never {} }
 }
 

--- a/units/src/parse_int.rs
+++ b/units/src/parse_int.rs
@@ -470,10 +470,6 @@ pub mod error {
         fn from(never: Infallible) -> Self { match never {} }
     }
 
-    impl From<Infallible> for PrefixedHexErrorInner {
-        fn from(never: Infallible) -> Self { match never {} }
-    }
-
     impl fmt::Display for PrefixedHexError {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             use PrefixedHexErrorInner as E;
@@ -511,10 +507,6 @@ pub mod error {
     }
 
     impl From<Infallible> for UnprefixedHexError {
-        fn from(never: Infallible) -> Self { match never {} }
-    }
-
-    impl From<Infallible> for UnprefixedHexErrorInner {
         fn from(never: Infallible) -> Self { match never {} }
     }
 


### PR DESCRIPTION
Inner error types do not appear in the public API, nor does a From\<Infallible> on them serve any internal purpose.

Remove From\<Infallible> from private inner error types in base58 and units.