### PR TITLE
Move `ToU64` to `bitcoin`

### DIFF
--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -41,7 +41,6 @@ use core::cmp::{self, Ordering};
 
 use hashes::{sha256d, siphash24};
 use internals::array::ArrayExt as _;
-use internals::ToU64 as _;
 use io::{BufRead, Write};
 
 use crate::block::{Block, BlockHash, Checked};
@@ -49,6 +48,7 @@ use crate::consensus::{ReadExt, WriteExt};
 use crate::prelude::{BTreeSet, Borrow, Vec};
 use crate::script::{ScriptPubKey, ScriptPubKeyExt as _};
 use crate::transaction::OutPoint;
+use crate::ToU64 as _;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(no_inline)]

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -8,7 +8,6 @@
 //! these blocks and the blockchain.
 
 use encoding::CompactSizeEncoder;
-use internals::ToU64;
 use io::{BufRead, Write};
 
 use crate::consensus::encode::{self, Decodable, Encodable, WriteExt as _};
@@ -18,7 +17,7 @@ use crate::pow::TargetExt as _;
 use crate::prelude::Vec;
 use crate::script::{PushBytesExt as _, ScriptExt as _};
 use crate::transaction::{Coinbase, Transaction, TransactionExt as _};
-use crate::{internal_macros, BlockTime, Target, Weight, Work};
+use crate::{internal_macros, BlockTime, Target, ToU64, Weight, Work};
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
@@ -283,7 +282,7 @@ impl Decodable for Block<Unchecked> {
 
     #[inline]
     fn consensus_decode<R: io::BufRead + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
-        let mut r = io::Read::take(r, internals::ToU64::to_u64(encode::MAX_VEC_SIZE));
+        let mut r = io::Read::take(r, crate::ToU64::to_u64(encode::MAX_VEC_SIZE));
         let header = Decodable::consensus_decode(&mut r)?;
         let transactions = Decodable::consensus_decode(&mut r)?;
 
@@ -411,7 +410,6 @@ mod tests {
     use alloc::string::ToString;
 
     use hex::hex;
-    use internals::ToU64 as _;
 
     use super::*;
     use crate::consensus::encode::{deserialize, serialize};

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -3,7 +3,6 @@
 use core::fmt;
 
 use internals::array::ArrayExt; // For `split_first`.
-use internals::ToU64 as _;
 
 use super::witness_version::WitnessVersion;
 use super::{
@@ -20,7 +19,7 @@ use crate::prelude::{sink, String, ToString};
 use crate::script::{self, ScriptPubKeyBufExt as _};
 use crate::taproot::{LeafVersion, TapLeafHash, TapLeafHashExt as _, TapNodeHash};
 use crate::witness_program::P2A_PROGRAM;
-use crate::{internal_macros, Amount, FeeRate, ScriptPubKeyBuf, WitnessScriptBuf};
+use crate::{internal_macros, Amount, FeeRate, ScriptPubKeyBuf, ToU64 as _, WitnessScriptBuf};
 
 internal_macros::define_extension_trait! {
     /// Extension functionality for the [`Script`] type.

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -3,13 +3,10 @@
 #[cfg(doc)]
 use core::ops::Deref;
 
-use internals::ToU64 as _;
-
 use super::{
     opcode_to_verify, write_scriptint, Builder, Error, Instruction, PushBytes, ScriptBuf,
     ScriptExtPriv as _, ScriptPubKeyBuf, ScriptSigBuf, WitnessScript,
 };
-use crate::internal_macros;
 use crate::key::{
     FullPublicKey, LegacyPublicKey, PubkeyHash, TapTweak, TweakedPublicKey, UntweakedPublicKey,
     WPubkeyHash,
@@ -21,6 +18,7 @@ use crate::script::witness_program::{WitnessProgram, P2A_PROGRAM};
 use crate::script::witness_version::WitnessVersion;
 use crate::script::{self, ScriptHash, WScriptHash};
 use crate::taproot::TapNodeHash;
+use crate::{internal_macros, ToU64 as _};
 
 internal_macros::define_extension_trait! {
     /// Extension functionality for the [`ScriptBuf`] type.

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -13,7 +13,7 @@
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
 use encoding::CompactSizeEncoder;
-use internals::{const_casts, ToU64};
+use internals::const_casts;
 use io::{BufRead, Write};
 
 use super::Weight;
@@ -27,7 +27,7 @@ use crate::script::{
 #[cfg(doc)]
 use crate::sighash::{EcdsaSighashType, TapSighashType};
 use crate::witness::Witness;
-use crate::{internal_macros, Amount, FeeRate, Sequence, SignedAmount};
+use crate::{internal_macros, Amount, FeeRate, Sequence, SignedAmount, ToU64};
 
 #[rustfmt::skip]            // Keep public re-exports separate.
 #[doc(no_inline)]

--- a/bitcoin/src/consensus/encode.rs
+++ b/bitcoin/src/consensus/encode.rs
@@ -20,12 +20,12 @@ use core::{cmp, mem, slice};
 use encoding::{CompactSizeEncoder, Encoder};
 use hashes::{sha256, sha256d, Hash};
 use hex::DisplayHex as _;
-use internals::ToU64;
 use io::{BufRead, Cursor, Read, Write};
 
 use super::IterReader;
 use crate::prelude::{rc, sync, Box, Cow, String, Vec};
 use crate::taproot::TapLeafHash;
+use crate::ToU64;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 pub use super::{Error, FromHexError, ParseError, DeserializeError};

--- a/bitcoin/src/internal_macros.rs
+++ b/bitcoin/src/internal_macros.rs
@@ -33,7 +33,7 @@ macro_rules! impl_consensus_encoding {
             fn consensus_decode<R: $crate::io::BufRead + ?Sized>(
                 r: &mut R,
             ) -> core::result::Result<$thing, $crate::consensus::encode::Error> {
-                let mut r = $crate::io::Read::take(r, internals::ToU64::to_u64($crate::consensus::encode::MAX_VEC_SIZE));
+                let mut r = $crate::io::Read::take(r, crate::ToU64::to_u64($crate::consensus::encode::MAX_VEC_SIZE));
                 Ok($thing {
                     $($field: $crate::consensus::Decodable::consensus_decode(&mut r)?),+
                 })

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -321,3 +321,31 @@ mod encode_impls {
     impl_encodable_for_u32_wrapper!(BlockHeight);
     impl_encodable_for_u32_wrapper!(BlockHeightInterval);
 }
+
+/// A conversion trait for unsigned integer types smaller than or equal to 64-bits.
+///
+/// This trait exists because [`usize`] doesn't implement `Into<u64>`. We only support 32 and 64 bit
+/// architectures because of consensus code so we can infallibly do the conversion.
+pub trait ToU64 {
+    /// Converts unsigned integer type to a [`u64`].
+    fn to_u64(self) -> u64;
+}
+
+macro_rules! impl_to_u64 {
+    ($($ty:ident),*) => {
+        $(
+            impl ToU64 for $ty { fn to_u64(self) -> u64 { self.into() } }
+        )*
+    }
+}
+impl_to_u64!(u8, u16, u32, u64);
+
+impl ToU64 for usize {
+    fn to_u64(self) -> u64 {
+        internals::const_assert!(
+            core::mem::size_of::<usize>() <= 8;
+            "platforms that have usize larger than 64 bits are not supported"
+        );
+        self as u64
+    }
+}

--- a/internals/api/all-features.txt
+++ b/internals/api/all-features.txt
@@ -332,15 +332,3 @@ pub macro bitcoin_internals::serde_string_impl!
 pub macro bitcoin_internals::serde_string_serialize_impl!
 pub macro bitcoin_internals::transparent_newtype!
 pub macro bitcoin_internals::write_err!
-pub trait bitcoin_internals::ToU64
-pub fn bitcoin_internals::ToU64::to_u64(self) -> u64
-impl bitcoin_internals::ToU64 for u16
-pub fn u16::to_u64(self) -> u64
-impl bitcoin_internals::ToU64 for u32
-pub fn u32::to_u64(self) -> u64
-impl bitcoin_internals::ToU64 for u64
-pub fn u64::to_u64(self) -> u64
-impl bitcoin_internals::ToU64 for u8
-pub fn u8::to_u64(self) -> u64
-impl bitcoin_internals::ToU64 for usize
-pub fn usize::to_u64(self) -> u64

--- a/internals/api/alloc-only.txt
+++ b/internals/api/alloc-only.txt
@@ -319,15 +319,3 @@ pub macro bitcoin_internals::parse_error_type!
 pub macro bitcoin_internals::rust_version!
 pub macro bitcoin_internals::transparent_newtype!
 pub macro bitcoin_internals::write_err!
-pub trait bitcoin_internals::ToU64
-pub fn bitcoin_internals::ToU64::to_u64(self) -> u64
-impl bitcoin_internals::ToU64 for u16
-pub fn u16::to_u64(self) -> u64
-impl bitcoin_internals::ToU64 for u32
-pub fn u32::to_u64(self) -> u64
-impl bitcoin_internals::ToU64 for u64
-pub fn u64::to_u64(self) -> u64
-impl bitcoin_internals::ToU64 for u8
-pub fn u8::to_u64(self) -> u64
-impl bitcoin_internals::ToU64 for usize
-pub fn usize::to_u64(self) -> u64

--- a/internals/api/no-features.txt
+++ b/internals/api/no-features.txt
@@ -293,15 +293,3 @@ pub macro bitcoin_internals::parse_error_type!
 pub macro bitcoin_internals::rust_version!
 pub macro bitcoin_internals::transparent_newtype!
 pub macro bitcoin_internals::write_err!
-pub trait bitcoin_internals::ToU64
-pub fn bitcoin_internals::ToU64::to_u64(self) -> u64
-impl bitcoin_internals::ToU64 for u16
-pub fn u16::to_u64(self) -> u64
-impl bitcoin_internals::ToU64 for u32
-pub fn u32::to_u64(self) -> u64
-impl bitcoin_internals::ToU64 for u64
-pub fn u64::to_u64(self) -> u64
-impl bitcoin_internals::ToU64 for u8
-pub fn u8::to_u64(self) -> u64
-impl bitcoin_internals::ToU64 for usize
-pub fn usize::to_u64(self) -> u64

--- a/internals/src/lib.rs
+++ b/internals/src/lib.rs
@@ -46,31 +46,3 @@ pub mod slice;
 #[macro_use]
 pub mod serde;
 pub mod const_casts;
-
-/// A conversion trait for unsigned integer types smaller than or equal to 64-bits.
-///
-/// This trait exists because [`usize`] doesn't implement `Into<u64>`. We only support 32 and 64 bit
-/// architectures because of consensus code so we can infallibly do the conversion.
-pub trait ToU64 {
-    /// Converts unsigned integer type to a [`u64`].
-    fn to_u64(self) -> u64;
-}
-
-macro_rules! impl_to_u64 {
-    ($($ty:ident),*) => {
-        $(
-            impl ToU64 for $ty { fn to_u64(self) -> u64 { self.into() } }
-        )*
-    }
-}
-impl_to_u64!(u8, u16, u32, u64);
-
-impl ToU64 for usize {
-    fn to_u64(self) -> u64 {
-        crate::const_assert!(
-            core::mem::size_of::<usize>() <= 8;
-            "platforms that have usize larger than 64 bits are not supported"
-        );
-        self as u64
-    }
-}

--- a/p2p/src/merkle_tree.rs
+++ b/p2p/src/merkle_tree.rs
@@ -18,7 +18,6 @@ use encoding::{
     ArrayDecoder, ArrayEncoder, ByteVecDecoder, CompactSizeEncoder, Decoder2, Decoder3, Encoder2,
     Encoder3, EncoderStatus, SliceEncoder, VecDecoder,
 };
-use internals::ToU64 as _;
 use primitives::block::{self, Block, Checked, Header, HeaderDecoder, HeaderEncoder};
 use primitives::merkle_tree::TxMerkleNode;
 use primitives::transaction::{Transaction, Txid};
@@ -279,7 +278,7 @@ impl PartialMerkleTree {
             return Err(MerkleBlockError::NoTransactions);
         };
         // check for excessively high numbers of transactions
-        if self.num_transactions.to_u64() > Weight::MAX_BLOCK / Weight::MIN_TRANSACTION {
+        if u64::from(self.num_transactions) > Weight::MAX_BLOCK / Weight::MIN_TRANSACTION {
             return Err(MerkleBlockError::TooManyTransactions);
         }
         // there can never be more hashes provided than one for every txid


### PR DESCRIPTION
Outside of a single usage in p2p which can be replaced by a From call, the ToU64 trait is only used in bitcoin. It has in the past been a source of accidental API leak, and so is better moved only to the crate is is used in. Due to use in old consensus encoding code, it is to remain public for now and can be made pub(crate) when the old consensus code is dropped.

- Patch 1 removes the single use of ToU64 in p2p.
- Patch 2 moves ToU64 to bitcoin, keeping it pub to satisfy use in the public API of bitcoin.
- Patch 3 updates the API files.