### PR TITLE
units: Docs fixes

### DIFF
--- a/units/src/amount/mod.rs
+++ b/units/src/amount/mod.rs
@@ -155,7 +155,7 @@ impl Denomination {
     }
 }
 
-/// These forms are ambiguous and could have many meanings.  For example, M could denote Mega or Milli.
+/// These forms are ambiguous and could have many meanings. For example, M could denote Mega or Milli.
 /// If any of these forms are used, an error type `PossiblyConfusingDenomination` is returned.
 const CONFUSING_FORMS: [&str; 6] = ["CBTC", "Cbtc", "MBTC", "Mbtc", "UBTC", "Ubtc"];
 
@@ -584,7 +584,7 @@ fn fmt_satoshi_in(
 ///
 /// Note: This implementation is currently **unstable**. The only thing that we can promise is that
 /// unless the precision is changed, this will display an accurate, human-readable number, and the
-/// default serialization (one with unmodified [`fmt::Formatter`] options) will round-trip with [`FromStr`]
+/// default serialization (one with unmodified [`fmt::Formatter`] options) will round-trip with [`FromStr`].
 ///
 /// See [`Amount::display_in`] and [`Amount::display_dynamic`] on how to construct this.
 #[derive(Debug, Clone)]

--- a/units/src/amount/signed.rs
+++ b/units/src/amount/signed.rs
@@ -133,7 +133,7 @@ impl SignedAmount {
 
     /// Construct a [`SignedAmount`] value from a `u64` satoshi value.
     ///
-    /// # Errors:
+    /// # Errors
     ///
     /// Returns an [`OutOfRangeError`] if the satoshi value > [`Self::MAX_MONEY`].
     #[inline]
@@ -405,7 +405,7 @@ impl SignedAmount {
         self.abs().to_unsigned().expect("a positive signed amount is always valid")
     }
 
-    /// Returns a number representing sign of this [`SignedAmount`].
+    /// Returns a number representing the sign of this [`SignedAmount`].
     ///
     /// - `0` if the amount is zero
     /// - `1` if the amount is positive

--- a/units/src/amount/signed.rs
+++ b/units/src/amount/signed.rs
@@ -295,7 +295,7 @@ impl SignedAmount {
     #[cfg(feature = "alloc")]
     pub fn to_btc(self) -> f64 { self.to_float_in(Denomination::Bitcoin) }
 
-    /// Converts this [`SignedAmount`] in floating-point notation in the given [`Denomination`].
+    /// Constructs a [`SignedAmount`] from floating-point notation in the given [`Denomination`].
     ///
     /// # Errors
     ///

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -258,7 +258,7 @@ impl Amount {
     #[cfg(feature = "alloc")]
     pub fn to_btc(self) -> f64 { self.to_float_in(Denomination::Bitcoin) }
 
-    /// Converts this [`Amount`] in floating-point notation in the given [`Denomination`].
+    /// Constructs an [`Amount`] from floating-point notation in the given [`Denomination`].
     ///
     /// # Errors
     ///

--- a/units/src/block.rs
+++ b/units/src/block.rs
@@ -4,7 +4,7 @@
 //!
 //! These types are thin wrappers around `u32`, no invariants implemented or implied.
 //!
-//! These are general types for abstracting over block heights, they are not designed to use with
+//! These are general types for abstracting over block heights, they are not designed for use with
 //! lock times. If you are creating lock times you should be using the
 //! [`locktime::absolute::Height`] and [`locktime::relative::NumberOfBlocks`] types.
 //!
@@ -345,7 +345,7 @@ impl BlockMtp {
     #[inline]
     pub const fn to_u32(self) -> u32 { self.0 }
 
-    /// Constructs a [`BlockMtp`] by computing the median‐time‐past from the last 11 block timestamps
+    /// Constructs a [`BlockMtp`] by computing the median-time-past from the last 11 block timestamps.
     ///
     /// Because block timestamps are not monotonic, this function internally sorts them;
     /// it is therefore not important what order they appear in the array; use whatever
@@ -663,7 +663,7 @@ pub mod error {
         }
     }
 
-    /// An error consensus decoding an `BlockHeight`.
+    /// An error consensus decoding a `BlockHeight`.
     #[cfg(feature = "encoding")]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct BlockHeightDecoderError(pub(super) encoding::UnexpectedEofError);

--- a/units/src/locktime/absolute/error.rs
+++ b/units/src/locktime/absolute/error.rs
@@ -12,7 +12,7 @@ use internals::write_err;
 use super::{Height, MedianTimePast, LOCK_TIME_THRESHOLD};
 use crate::parse_int::{ParseIntError, PrefixedHexError, UnprefixedHexError};
 
-/// An error consensus decoding an `LockTime`.
+/// An error consensus decoding a `LockTime`.
 #[cfg(feature = "encoding")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LockTimeDecoderError(pub(super) encoding::UnexpectedEofError);

--- a/units/src/locktime/absolute/mod.rs
+++ b/units/src/locktime/absolute/mod.rs
@@ -53,7 +53,7 @@ pub const LOCK_TIME_THRESHOLD: u32 = 500_000_000;
 /// ordering on locktimes. In order to compare locktimes, instead of using `<` or `>` we provide the
 /// [`LockTime::is_satisfied_by`] API.
 ///
-/// For transaction, which has a locktime field, we implement a total ordering to make
+/// For `Transaction`, which has a locktime field, we implement a total ordering to make
 /// it easy to store transactions in sorted data structures, and use the locktime's 32-bit integer
 /// consensus encoding to order it.
 ///
@@ -170,6 +170,7 @@ impl LockTime {
     /// let n_lock_time: u32 = 741521;
     /// let lock_time = absolute::LockTime::from_consensus(n_lock_time);
     /// assert_eq!(lock_time.to_consensus_u32(), n_lock_time);
+    /// ```
     #[inline]
     #[allow(clippy::missing_panics_doc)]
     pub fn from_consensus(n: u32) -> Self {
@@ -284,7 +285,7 @@ impl LockTime {
     /// if n.is_satisfied_by(get_height(), get_time()) {
     ///     // Can create and mine a transaction that satisfies the OP_CLTV timelock constraint.
     /// }
-    /// ````
+    /// ```
     #[inline]
     pub fn is_satisfied_by(self, height: Height, mtp: MedianTimePast) -> bool {
         match self {
@@ -363,7 +364,7 @@ impl LockTime {
     /// # Warning
     ///
     /// Do not compare values return by this method. The whole point of the `LockTime` type is to
-    /// assist in doing correct comparisons. Either use `is_satisfied_by`, `is_satisfied_by_lock`,
+    /// assist in doing correct comparisons. Either use `is_satisfied_by`, `is_satisfied_by_time`,
     /// or use the pattern below:
     ///
     /// # Examples
@@ -605,7 +606,7 @@ impl MedianTimePast {
     /// The maximum MTP allowable in a locktime (Sun Feb 07 2106 06:28:15 GMT+0000).
     pub const MAX: Self = Self(u32::MAX);
 
-    /// Constructs an [`MedianTimePast`] by computing the median-time-past from the last
+    /// Constructs a [`MedianTimePast`] by computing the median-time-past from the last
     /// 11 block timestamps.
     ///
     /// Because block timestamps are not monotonic, this function internally sorts them;
@@ -650,7 +651,7 @@ impl MedianTimePast {
     /// Constructs a new MTP directly from a `u32` value.
     ///
     /// This function, with [`MedianTimePast::to_u32`], is used to obtain a raw MTP value. It is
-    /// **not** used to convert to or from a block timestamp, which is not a MTP.
+    /// **not** used to convert to or from a block timestamp, which is not an MTP.
     ///
     /// # Errors
     ///

--- a/units/src/locktime/relative/mod.rs
+++ b/units/src/locktime/relative/mod.rs
@@ -221,9 +221,6 @@ impl LockTime {
 
     /// Returns true if an output with this locktime can be spent in the next block.
     ///
-    /// If this function returns true then an output with this locktime can be spent in the next
-    /// block.
-    ///
     /// # Errors
     ///
     /// Returns an error if this lock is not lock-by-height.
@@ -243,9 +240,6 @@ impl LockTime {
     }
 
     /// Returns true if an output with this locktime can be spent in the next block.
-    ///
-    /// If this function returns true then an output with this locktime can be spent in the next
-    /// block.
     ///
     /// # Errors
     ///

--- a/units/src/locktime/relative/mod.rs
+++ b/units/src/locktime/relative/mod.rs
@@ -200,7 +200,7 @@ impl LockTime {
     ///
     /// # Errors
     ///
-    /// If `chain_tip` as not _after_ `utxo_mined_at` i.e., if you get the args mixed up.
+    /// If `chain_tip` is not _after_ `utxo_mined_at` i.e., if you get the args mixed up.
     #[inline]
     pub fn is_satisfied_by(
         self,
@@ -440,7 +440,7 @@ impl NumberOfBlocks {
     ///
     /// # Errors
     ///
-    /// If `chain_tip` as not _after_ `utxo_mined_at` i.e., if you get the args mixed up.
+    /// If `chain_tip` is not _after_ `utxo_mined_at` i.e., if you get the args mixed up.
     pub fn is_satisfied_by(
         self,
         chain_tip: crate::BlockHeight,
@@ -568,7 +568,7 @@ impl NumberOf512Seconds {
     ///
     /// # Errors
     ///
-    /// If `chain_tip` as not _after_ `utxo_mined_at` i.e., if you get the args mixed up.
+    /// If `chain_tip` is not _after_ `utxo_mined_at` i.e., if you get the args mixed up.
     pub fn is_satisfied_by(
         self,
         chain_tip: crate::BlockMtp,

--- a/units/src/parse_int.rs
+++ b/units/src/parse_int.rs
@@ -523,7 +523,7 @@ pub mod error {
             use UnprefixedHexErrorInner as E;
 
             match self.0 {
-                E::ContainsPrefix(ref e) => write_err!(f, "hex string is contains prefix"; e),
+                E::ContainsPrefix(ref e) => write_err!(f, "hex string contains prefix"; e),
                 E::ParseInt(ref e) => write_err!(f, "hex string parse int"; e),
             }
         }

--- a/units/src/parse_int.rs
+++ b/units/src/parse_int.rs
@@ -104,7 +104,7 @@ fn int<T: Integer, S: AsRef<str> + Into<InputString>>(s: S) -> Result<T, ParseIn
 /// # Parameters
 ///
 /// * `to` - the type converted to e.g., `impl From<&str> for $to`.
-/// * `err` - the error type returned by `$inner_fn` (implies returned by `FromStr` and `TryFrom`).
+/// * `inner` - the inner integer type to be provided to `fn`. Must implement [`Integer`].
 /// * `fn`: the infallible conversion function to call to convert from an integer.
 ///
 /// # Errors

--- a/units/src/pow.rs
+++ b/units/src/pow.rs
@@ -345,7 +345,7 @@ pub mod error {
 
     use super::ParseU256Error;
 
-    /// An error consensus decoding an `CompactTarget`.
+    /// An error consensus decoding a `CompactTarget`.
     #[derive(Debug, Clone, PartialEq, Eq)]
     #[cfg(feature = "encoding")]
     pub struct CompactTargetDecoderError(pub(super) encoding::UnexpectedEofError);

--- a/units/src/result.rs
+++ b/units/src/result.rs
@@ -148,7 +148,7 @@ impl<T: fmt::Debug> NumOpResult<T> {
         }
     }
 
-    /// Returns the contained Some value or a provided default.
+    /// Returns the contained `Valid` value or a provided default.
     ///
     /// Arguments passed to `unwrap_or` are eagerly evaluated; if you are passing the result of a
     /// function call, it is recommended to use `unwrap_or_else`, which is lazily evaluated.
@@ -161,7 +161,7 @@ impl<T: fmt::Debug> NumOpResult<T> {
         }
     }
 
-    /// Returns the contained `Some` value or computes it from a closure.
+    /// Returns the contained `Valid` value or computes it from a closure.
     #[inline]
     #[track_caller]
     pub fn unwrap_or_else<F>(self, f: F) -> T

--- a/units/src/result.rs
+++ b/units/src/result.rs
@@ -37,7 +37,7 @@ pub use self::error::NumOpError;
 /// // And another value from some other UTXO.
 /// let a2 = Amount::from_sat(765_432)?;
 /// // Just an example (typically one would calculate fee using weight and fee rate).
-/// let fee = Amount::from_sat(1_00)?;
+/// let fee = Amount::from_sat(100)?;
 /// // The amount we want to send.
 /// let spend = Amount::from_sat(1_200_000)?;
 ///

--- a/units/src/sequence.rs
+++ b/units/src/sequence.rs
@@ -157,7 +157,7 @@ impl Sequence {
     /// Constructs a new relative lock-time using time intervals where each interval is equivalent
     /// to 512 seconds.
     ///
-    /// Encoding finer granularity of time for relative lock-times is not supported in Bitcoin
+    /// Encoding finer granularity of time for relative lock-times is not supported in Bitcoin.
     #[inline]
     pub fn from_512_second_intervals(intervals: u16) -> Self {
         Self(u32::from(intervals) | Self::LOCK_TYPE_MASK)
@@ -197,7 +197,7 @@ impl Sequence {
     #[inline]
     pub fn from_consensus(n: u32) -> Self { Self(n) }
 
-    /// Returns the inner 32bit integer value of Sequence.
+    /// Returns the inner 32-bit integer value of Sequence.
     #[inline]
     pub const fn to_consensus_u32(self) -> u32 { self.0 }
 
@@ -303,7 +303,7 @@ pub mod error {
     #[cfg(feature = "encoding")]
     use internals::write_err;
 
-    /// An error consensus decoding an `Sequence`.
+    /// An error consensus decoding a `Sequence`.
     #[cfg(feature = "encoding")]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct SequenceDecoderError(pub(super) encoding::UnexpectedEofError);


### PR DESCRIPTION
There are some typos, formatting and grammar problems with the docs in units, as well as some clunky wording for a small handful of functions. These should all be fixed before the units 1.0 release.