### PR TITLE
Use write! in UnknownAddressTypeError display

### DIFF
--- a/bitcoin/src/address/error.rs
+++ b/bitcoin/src/address/error.rs
@@ -62,7 +62,7 @@ pub struct UnknownAddressTypeError(pub String);
 
 impl fmt::Display for UnknownAddressTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write_err!(f, "failed to parse {} as address type", self.0; self)
+        write!(f, "failed to parse {} as address type", self.0)
     }
 }
 


### PR DESCRIPTION
The write_err! macro is intended to provide source information for errors in no_std environments. Where an error type does not have a source, the write! macro should be used instead.
For UnknownAddressTypeError specifically, the use of write_err! causes a stack overflow as it recurses infinitely to attempt to display self as the source in write_err! in no_std builds.

Replace use of write_err! with write! in UnknownAddressTypeError Display impl.

Closes #6370 