### PR TITLE
consensus_encoding:: Fix buffer bug in `decode_from_read_unbuffered_with`

### DIFF
--- a/consensus_encoding/src/decode/mod.rs
+++ b/consensus_encoding/src/decode/mod.rs
@@ -434,12 +434,11 @@ where
                 return decoder.end().map_err(ReadError::Decode);
             }
             Ok(bytes_read) => {
-                if decoder
-                    .push_bytes(&mut &clamped_buffer[..bytes_read])
-                    .map_err(ReadError::Decode)?
-                    .is_ready()
-                {
-                    return decoder.end().map_err(ReadError::Decode);
+                let mut to_push = &clamped_buffer[..bytes_read];
+                while !to_push.is_empty() {
+                    if decoder.push_bytes(&mut to_push).map_err(ReadError::Decode)?.is_ready() {
+                        return decoder.end().map_err(ReadError::Decode);
+                    }
                 }
             }
             Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => {

--- a/consensus_encoding/tests/decode.rs
+++ b/consensus_encoding/tests/decode.rs
@@ -698,3 +698,65 @@ fn check_decoder_panic_on_mismatched_value() {
     let expected = [0x99u8];
     check_decoder(decoder, bytes, &expected);
 }
+
+#[test]
+#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
+fn decode_from_read_unbuffered_with_loses_unconsumed_bytes() {
+    use std::io::Cursor;
+
+    use bitcoin_consensus_encoding::{
+        decode_from_read_unbuffered_with, Decode, Decoder, DecoderStatus,
+    };
+
+    #[derive(Default)]
+    struct OneAtATimeDecoder {
+        buf: Vec<u8>,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct OneAtATime(Vec<u8>);
+
+    #[derive(Debug)]
+    struct OneAtATimeError;
+
+    impl Decoder for OneAtATimeDecoder {
+        type Output = OneAtATime;
+        type Error = OneAtATimeError;
+
+        fn push_bytes(
+            &mut self,
+            bytes: &mut &[u8],
+        ) -> core::result::Result<DecoderStatus, Self::Error> {
+            if self.buf.len() < 4 && !bytes.is_empty() {
+                self.buf.push(bytes[0]);
+                *bytes = &bytes[1..];
+            }
+            if self.buf.len() == 4 {
+                Ok(DecoderStatus::Ready)
+            } else {
+                Ok(DecoderStatus::NeedsMore)
+            }
+        }
+
+        fn end(self) -> core::result::Result<Self::Output, Self::Error> {
+            if self.buf.len() == 4 {
+                Ok(OneAtATime(self.buf))
+            } else {
+                Err(OneAtATimeError)
+            }
+        }
+
+        fn read_limit(&self) -> usize { 4 - self.buf.len() }
+    }
+
+    impl Decode for OneAtATime {
+        type Decoder = OneAtATimeDecoder;
+    }
+
+    let data = [0x11, 0x22, 0x33, 0x44];
+    let cursor = Cursor::new(&data);
+    let decoded: OneAtATime =
+        decode_from_read_unbuffered_with::<_, _, 16>(cursor).expect("decode succeeds");
+    assert_eq!(decoded.0, vec![0x11, 0x22, 0x33, 0x44]);
+}


### PR DESCRIPTION
In decode_from_read_unbuffered_with, the clamped buffer is pushed into the decoder after a successful read. Some decoders do not completely consume all provided bytes in a single push_bytes call, which can lead to parts of the buffer being dropped. Like encoding::decode_from_hex, the push_bytes should instead be called in a loop until the buffer is empty, or the error case occurs.

- Patch 1 adjusts encoding::decode_from_read_unbuffered_with to call push_bytes in a loop to prevent the buffer drop bug.
- Patch 2 introduces a regression test produced by Loupe in #6375.

Closes #6375