### PR TITLE
Use write! in ParseNetwork and UnknownAddressType error displays

### DIFF
--- a/bitcoin/src/address/error.rs
+++ b/bitcoin/src/address/error.rs
@@ -98,7 +98,7 @@ pub struct UnknownAddressTypeError(pub String);
 
 impl fmt::Display for UnknownAddressTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write_err!(f, "failed to parse {} as address type", self.0; self)
+        write!(f, "failed to parse {} as address type", self.0)
     }
 }
 

--- a/bitcoin/src/network.rs
+++ b/bitcoin/src/network.rs
@@ -27,7 +27,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::consensus::Params;
 use crate::constants::ChainHash;
-use crate::internal_macros::write_err;
 use crate::p2p::Magic;
 use crate::prelude::*;
 
@@ -260,7 +259,7 @@ pub struct ParseNetworkError(String);
 
 impl fmt::Display for ParseNetworkError {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write_err!(f, "failed to parse {} as network", self.0; self)
+        write!(f, "failed to parse {} as network", self.0)
     }
 }
 


### PR DESCRIPTION
The write_err! macro is intended to provide source information for errors in no_std environments. Where an error type does not have a source, the write! macro should be used instead.
For ParseNetworkError and UnknownAddressTypeError, the use of write_err! causes a stack overflow as it recurses infinitely to attempt to display self as the source in write_err! in no_std builds.

Replace use of write_err! with write! in UnknownAddressTypeError and ParseNetworkError Display impls.

Backport of #6378 with extra fix for ParseNetworkError