### PR TITLE
Backport: Fix `InstructionIndices::nth` byte position bug

### DIFF
--- a/bitcoin/src/blockdata/script/instruction.rs
+++ b/bitcoin/src/blockdata/script/instruction.rs
@@ -240,11 +240,6 @@ impl<'a> Iterator for InstructionIndices<'a> {
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) { self.instructions.size_hint() }
-
-    // the override avoids computing pos multiple times
-    fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        self.next_with(|this| this.instructions.nth(n))
-    }
 }
 
 impl core::iter::FusedIterator for InstructionIndices<'_> {}

--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -879,3 +879,40 @@ fn instruction_script_num_parse() {
         Some(Ok(Instruction::PushBytes(PushBytes::empty()))),
     );
 }
+
+#[test]
+#[allow(clippy::iter_nth_zero, clippy::iter_skip_next)]
+fn instruction_indices_nth_extended() {
+    // Script bytes: OP_FALSE (00) | OP_PUSHBYTES_1 (01) 0x69 | OP_CSV (b2)
+    // Instructions begin at byte positions: 0, 1, 3.
+    let script = ScriptBuf::from_hex("000169b2").unwrap();
+
+    // basic nth() calls from a fresh iterator
+    let pos_0 = script.instruction_indices().nth(0).unwrap().unwrap();
+    assert_eq!(pos_0.1, Instruction::PushBytes(PushBytes::empty()), "nth(0) must be OP_FALSE");
+    assert_eq!(pos_0.0, 0, "nth(0) returned wrong instruction position");
+
+    let pos_1 = script.instruction_indices().nth(1).unwrap().unwrap();
+    assert_eq!(pos_1.1, Instruction::PushBytes([105].as_ref()), "nth(1) must be OP_PUSHBYTES_1");
+    assert_eq!(pos_1.0, 1, "nth(1) returned wrong instruction position");
+
+    let pos_2 = script.instruction_indices().nth(2).unwrap().unwrap();
+    assert_eq!(pos_2.1, Instruction::Op(OP_CSV), "nth(2) must be OP_CSV");
+    assert_eq!(pos_2.0, 3, "nth(2) returned wrong instruction position");
+
+    // out-of-bounds index
+    assert!(
+        script.instruction_indices().nth(3).is_none(),
+        "nth(3) must return None since there are only 3 instructions"
+    );
+
+    // random access via .nth()
+    let mut iter = script.instruction_indices();
+    assert_eq!(iter.nth(1).unwrap().unwrap().0, 1);
+    assert_eq!(iter.nth(0).unwrap().unwrap().0, 3);
+    assert!(iter.nth(0).is_none());
+
+    // skips 2nd, returns 3rd
+    let pos_skip = script.instruction_indices().skip(2).next().unwrap().unwrap().0;
+    assert_eq!(pos_skip, 3, "skip(2).next() returned wrong position");
+}


### PR DESCRIPTION
Remove the custom nth implementation for InstructionIndices because
it captures position via next_with and returns as byte offset instead of advancing it in later next_fn calls.

Adding test to show that nth position is not in sync with returned opcode value

(tcharding): This is a backport of #6382.

~Fixes: #6377~