### PR TITLE
Move `TapTweak` to `taproot-primitives`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -246,6 +246,7 @@ name = "bitcoin-taproot-primitives"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
+ "bitcoin-crypto",
  "bitcoin-internals 0.5.0",
  "bitcoin_hashes 1.0.0",
  "secp256k1 0.32.0-beta.2",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -239,6 +239,7 @@ name = "bitcoin-taproot-primitives"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
+ "bitcoin-crypto",
  "bitcoin-internals 0.5.0",
  "bitcoin_hashes 1.0.0",
  "secp256k1 0.32.0-beta.2",

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -9,7 +9,6 @@ use crate::internal_macros::define_extension_trait;
 use crate::script::{self, WitnessScriptBuf};
 #[cfg(feature = "secp-recovery")]
 use crate::sign_message::MessageSignature;
-use crate::taproot::{TapNodeHash, TapTweakHash};
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 pub use secp256k1::{constants, Parity};
@@ -25,6 +24,8 @@ pub use crypto::key::{
     SerializedXOnlyPublicKey, TweakedKeypair, TweakedPublicKey, UntweakedKeypair,
     UntweakedPublicKey, WPubkeyHash, WifKey, XOnlyPublicKey,
 };
+#[doc(inline)]
+pub use taproot_primitives::TapTweak;
 
 #[deprecated(since = "TBD", note = "use `LegacyPublicKey` instead")]
 #[doc(hidden)]
@@ -96,91 +97,6 @@ mod sealed {
     impl Sealed for super::FullPublicKey {}
     impl Sealed for super::LegacyPublicKey {}
     impl Sealed for super::PrivateKey {}
-}
-
-/// A trait for tweaking BIP-0340 key types (x-only public keys and key pairs).
-pub trait TapTweak {
-    /// Tweaked key type with optional auxiliary information.
-    type TweakedAux;
-    /// Tweaked key type.
-    type TweakedKey;
-
-    /// Tweaks an untweaked key with corresponding public key value and optional script tree Merkle
-    /// root. For the [`Keypair`] type this also tweaks the private key in the pair.
-    ///
-    /// This is done by using the equation Q = P + H(P|c)G, where
-    ///  * Q is the tweaked public key
-    ///  * P is the internal public key
-    ///  * H is the hash function
-    ///  * c is the commitment data
-    ///  * G is the generator point
-    ///
-    /// # Returns
-    ///
-    /// The tweaked key, with the required parity.
-    fn tap_tweak(&self, merkle_root: Option<TapNodeHash>) -> Self::TweakedAux;
-
-    /// Directly converts an [`UntweakedPublicKey`] to a [`TweakedPublicKey`].
-    ///
-    /// This method is dangerous and can lead to loss of funds if used incorrectly.
-    /// Specifically, in multi-party protocols a peer can provide a value that allows them to steal.
-    fn dangerous_assume_tweaked(self) -> Self::TweakedKey;
-}
-
-impl TapTweak for UntweakedPublicKey {
-    type TweakedAux = TweakedPublicKey;
-    type TweakedKey = TweakedPublicKey;
-
-    /// Tweaks an untweaked public key with corresponding public key value and optional script tree
-    /// Merkle root.
-    ///
-    /// This is done by using the equation Q = P + H(P|c)G, where
-    ///  * Q is the tweaked public key
-    ///  * P is the internal public key
-    ///  * H is the hash function
-    ///  * c is the commitment data
-    ///  * G is the generator point
-    ///
-    /// # Returns
-    ///
-    /// The tweaked key and its parity.
-    fn tap_tweak(&self, merkle_root: Option<TapNodeHash>) -> TweakedPublicKey {
-        let tweak = TapTweakHash::from_key_and_merkle_root(*self, merkle_root).to_scalar();
-        let output_key = self.add_tweak(&tweak).expect("Tap tweak failed");
-
-        debug_assert!(self.tweak_add_check(&output_key, tweak));
-        TweakedPublicKey::dangerous_assume_tweaked(output_key)
-    }
-
-    fn dangerous_assume_tweaked(self) -> TweakedPublicKey {
-        TweakedPublicKey::dangerous_assume_tweaked(self)
-    }
-}
-
-impl TapTweak for UntweakedKeypair {
-    type TweakedAux = TweakedKeypair;
-    type TweakedKey = TweakedKeypair;
-
-    /// Applies a Taproot tweak to both keys within the keypair.
-    ///
-    /// If `merkle_root` is provided, produces a Taproot key that can be spent by any
-    /// of the script paths committed to by the root. If it is not provided, produces
-    /// a Taproot key which can [provably only be spent via
-    /// keyspend](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#cite_note-23).
-    ///
-    /// # Returns
-    ///
-    /// The tweaked keypair.
-    fn tap_tweak(&self, merkle_root: Option<TapNodeHash>) -> TweakedKeypair {
-        let pubkey = XOnlyPublicKey::from_keypair(self);
-        let tweak = TapTweakHash::from_key_and_merkle_root(pubkey, merkle_root).to_scalar();
-        let tweaked = self.as_inner().add_xonly_tweak(&tweak).expect("Tap tweak failed");
-        TweakedKeypair::dangerous_assume_tweaked(Self::from(tweaked))
-    }
-
-    fn dangerous_assume_tweaked(self) -> TweakedKeypair {
-        TweakedKeypair::dangerous_assume_tweaked(self)
-    }
 }
 
 #[cfg(test)]

--- a/bitcoin/src/crypto/key.rs
+++ b/bitcoin/src/crypto/key.rs
@@ -9,7 +9,7 @@ use crate::internal_macros::define_extension_trait;
 use crate::script::{self, WitnessScriptBuf};
 #[cfg(feature = "secp-recovery")]
 use crate::sign_message::MessageSignature;
-use crate::taproot::{TapNodeHash, TapTweakHash, TapTweakHashExt as _};
+use crate::taproot::{TapNodeHash, TapTweakHash};
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 pub use secp256k1::{constants, Parity};

--- a/bitcoin/src/taproot/mod.rs
+++ b/bitcoin/src/taproot/mod.rs
@@ -99,35 +99,10 @@ crate::internal_macros::define_extension_trait! {
     }
 }
 
-crate::internal_macros::define_extension_trait! {
-    /// Extension functionality for the [`TapTweakHash`] type.
-    pub trait TapTweakHashExt impl for TapTweakHash {
-        /// Constructs a new BIP-0341 [`TapTweakHash`] from key and Merkle root. Produces `H_taptweak(P||R)` where
-        /// `P` is the internal key and `R` is the Merkle root.
-        fn from_key_and_merkle_root<K: Into<UntweakedPublicKey>>(
-            internal_key: K,
-            merkle_root: Option<TapNodeHash>,
-        ) -> Self {
-            let internal_key = internal_key.into();
-            let mut eng = sha256t::Hash::<TapTweakTag>::engine();
-            // always hash the key
-            eng.input(&internal_key.serialize().0);
-            if let Some(h) = merkle_root {
-                eng.input(h.as_ref());
-            } else {
-                // nothing to hash
-            }
-            let inner = sha256t::Hash::<TapTweakTag>::from_engine(eng);
-            Self::from_byte_array(inner.to_byte_array())
-        }
-    }
-}
-
 mod sealed {
     pub trait Sealed {}
     impl Sealed for super::TapLeafHash {}
     impl Sealed for super::TapNodeHash {}
-    impl Sealed for super::TapTweakHash {}
 }
 
 /// Computes branch hash given two hashes of the nodes underneath it and returns

--- a/taproot-primitives/Cargo.toml
+++ b/taproot-primitives/Cargo.toml
@@ -21,6 +21,7 @@ arbitrary = ["dep:arbitrary", "secp256k1/arbitrary"]
 hex = ["hashes/hex"]
 
 [dependencies]
+crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.2.0", default-features = false }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.0.0", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
 

--- a/taproot-primitives/src/lib.rs
+++ b/taproot-primitives/src/lib.rs
@@ -36,7 +36,9 @@ use core::fmt;
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
-use crypto::key::UntweakedPublicKey;
+use crypto::key::{
+    TweakedKeypair, TweakedPublicKey, UntweakedKeypair, UntweakedPublicKey, XOnlyPublicKey,
+};
 use hashes::{hash_newtype, sha256t, sha256t_tag, HashEngine as _};
 use secp256k1::Scalar;
 
@@ -294,6 +296,93 @@ internals::impl_to_hex_from_lower_hex!(FutureLeafVersion, |_| 2);
 impl fmt::UpperHex for FutureLeafVersion {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { fmt::UpperHex::fmt(&self.0, f) }
+}
+
+/// A trait for tweaking BIP-0340 key types (x-only public keys and key pairs).
+pub trait TapTweak {
+    /// Tweaked key type with optional auxiliary information.
+    type TweakedAux;
+    /// Tweaked key type.
+    type TweakedKey;
+
+    /// Tweaks an untweaked key with corresponding public key value and optional script tree Merkle
+    /// root. For the [`Keypair`] type this also tweaks the private key in the pair.
+    ///
+    /// This is done by using the equation Q = P + H(P|c)G, where
+    ///  * Q is the tweaked public key
+    ///  * P is the internal public key
+    ///  * H is the hash function
+    ///  * c is the commitment data
+    ///  * G is the generator point
+    ///
+    /// # Returns
+    ///
+    /// The tweaked key, with the required parity.
+    ///
+    /// [`Keypair`]: crypto::Keypair
+    fn tap_tweak(&self, merkle_root: Option<TapNodeHash>) -> Self::TweakedAux;
+
+    /// Directly converts an [`UntweakedPublicKey`] to a [`TweakedPublicKey`].
+    ///
+    /// This method is dangerous and can lead to loss of funds if used incorrectly.
+    /// Specifically, in multi-party protocols a peer can provide a value that allows them to steal.
+    fn dangerous_assume_tweaked(self) -> Self::TweakedKey;
+}
+
+impl TapTweak for UntweakedPublicKey {
+    type TweakedAux = TweakedPublicKey;
+    type TweakedKey = TweakedPublicKey;
+
+    /// Tweaks an untweaked public key with corresponding public key value and optional script tree
+    /// Merkle root.
+    ///
+    /// This is done by using the equation Q = P + H(P|c)G, where
+    ///  * Q is the tweaked public key
+    ///  * P is the internal public key
+    ///  * H is the hash function
+    ///  * c is the commitment data
+    ///  * G is the generator point
+    ///
+    /// # Returns
+    ///
+    /// The tweaked key and its parity.
+    fn tap_tweak(&self, merkle_root: Option<TapNodeHash>) -> TweakedPublicKey {
+        let tweak = TapTweakHash::from_key_and_merkle_root(*self, merkle_root).to_scalar();
+        let output_key = self.add_tweak(&tweak).expect("Tap tweak failed");
+
+        debug_assert!(self.tweak_add_check(&output_key, tweak));
+        TweakedPublicKey::dangerous_assume_tweaked(output_key)
+    }
+
+    fn dangerous_assume_tweaked(self) -> TweakedPublicKey {
+        TweakedPublicKey::dangerous_assume_tweaked(self)
+    }
+}
+
+impl TapTweak for UntweakedKeypair {
+    type TweakedAux = TweakedKeypair;
+    type TweakedKey = TweakedKeypair;
+
+    /// Applies a Taproot tweak to both keys within the keypair.
+    ///
+    /// If `merkle_root` is provided, produces a Taproot key that can be spent by any
+    /// of the script paths committed to by the root. If it is not provided, produces
+    /// a Taproot key which can [provably only be spent via
+    /// keyspend](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#cite_note-23).
+    ///
+    /// # Returns
+    ///
+    /// The tweaked keypair.
+    fn tap_tweak(&self, merkle_root: Option<TapNodeHash>) -> TweakedKeypair {
+        let pubkey = XOnlyPublicKey::from_keypair(self);
+        let tweak = TapTweakHash::from_key_and_merkle_root(pubkey, merkle_root).to_scalar();
+        let tweaked = self.as_inner().add_xonly_tweak(&tweak).expect("Tap tweak failed");
+        TweakedKeypair::dangerous_assume_tweaked(Self::from(tweaked))
+    }
+
+    fn dangerous_assume_tweaked(self) -> TweakedKeypair {
+        TweakedKeypair::dangerous_assume_tweaked(self)
+    }
 }
 
 /// Error types for taproot primitives

--- a/taproot-primitives/src/lib.rs
+++ b/taproot-primitives/src/lib.rs
@@ -36,7 +36,8 @@ use core::fmt;
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
-use hashes::{hash_newtype, sha256t, sha256t_tag};
+use crypto::key::UntweakedPublicKey;
+use hashes::{hash_newtype, sha256t, sha256t_tag, HashEngine as _};
 use secp256k1::Scalar;
 
 /// Maximum depth of a Taproot tree script spend path.
@@ -123,6 +124,25 @@ impl TapTweakHash {
     pub fn to_scalar(self) -> Scalar {
         // This is statistically extremely unlikely to panic.
         Scalar::from_be_bytes(self.to_byte_array()).expect("hash value greater than curve order")
+    }
+
+    /// Constructs a new BIP-0341 [`TapTweakHash`] from key and Merkle root. Produces `H_taptweak(P||R)` where
+    /// `P` is the internal key and `R` is the Merkle root.
+    pub fn from_key_and_merkle_root<K: Into<UntweakedPublicKey>>(
+        internal_key: K,
+        merkle_root: Option<TapNodeHash>,
+    ) -> Self {
+        let internal_key = internal_key.into();
+        let mut eng = sha256t::Hash::<TapTweakTag>::engine();
+        // always hash the key
+        eng.input(&internal_key.serialize().0);
+        if let Some(h) = merkle_root {
+            eng.input(h.as_ref());
+        } else {
+            // nothing to hash
+        }
+        let inner = sha256t::Hash::<TapTweakTag>::from_engine(eng);
+        Self::from_byte_array(inner.to_byte_array())
     }
 }
 


### PR DESCRIPTION
The TapTweak trait is necessary for WitnessProgram::p2tr and thus Address::p2tr. By moving from_key_and_merkle_root back to taproot-primitives, this trait can be moved alongside it and and later used in addresses to allow for a more complete crate smashing.

- Patch 1 moves from_key_and_merkle_root to taproot-primitives, deleting the TapTweakHashExt extension trait.
- Patch 2 moves TapTweak trait to taproot-primitives, re-exporting from bitcoin.