### PR TITLE
Use core::cmp in units kani verification

### DIFF
--- a/units/src/amount/verification.rs
+++ b/units/src/amount/verification.rs
@@ -2,7 +2,7 @@
 
 //! Verification tests for the `amount` module.
 
-use std::cmp;
+use core::cmp;
 
 use super::{Amount, SignedAmount};
 


### PR DESCRIPTION
The units::amount::verification kani tests make use of cmp for min and max calculations. These are imported from std, even though they could be imported from core. In some unpredictable cases, this causes kani to choke on a lack of std. Since there is no functionality loss, it's better to use core::cmp in place of std::cmp and avoid the problem entirely.

Replace use std::cmp with use core::cmp in verification.rs of units::amount.