### PR TITLE
Fix typo in p2p decoding error docs

### DIFF
--- a/p2p/src/address.rs
+++ b/p2p/src/address.rs
@@ -674,7 +674,7 @@ pub mod error {
         fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
     }
 
-    /// An error occuring when decoding a [`AddrV1Message`].
+    /// An error occurring when decoding a [`AddrV1Message`].
     ///
     /// [`AddrV1Message`]: super::AddrV1Message
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -749,7 +749,7 @@ pub mod error {
         }
     }
 
-    /// An error occuring when decoding a [`AddrV2Message`].
+    /// An error occurring when decoding a [`AddrV2Message`].
     ///
     /// [`AddrV2Message`]: super::AddrV2Message
     #[derive(Debug, Clone, PartialEq, Eq)]

--- a/p2p/src/bip152.rs
+++ b/p2p/src/bip152.rs
@@ -637,7 +637,7 @@ pub mod error {
         }
     }
 
-    /// An error occuring when decoding a [`PrefilledTransaction`].
+    /// An error occurring when decoding a [`PrefilledTransaction`].
     ///
     /// [`PrefilledTransaction`]: super::PrefilledTransaction
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -694,7 +694,7 @@ pub mod error {
         fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
     }
 
-    /// Errors occuring when decoding a [`HeaderAndShortIds`] message.
+    /// Errors occurring when decoding a [`HeaderAndShortIds`] message.
     ///
     /// [`HeaderAndShortIds`]: super::HeaderAndShortIds
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -775,7 +775,7 @@ pub mod error {
         }
     }
 
-    /// An error occuring decoding a [`BlockTransactions`] message.
+    /// An error occurring when decoding a [`BlockTransactions`] message.
     ///
     /// [`BlockTransactions`]: super::BlockTransactions
     #[derive(Debug, Clone, PartialEq, Eq)]

--- a/p2p/src/error.rs
+++ b/p2p/src/error.rs
@@ -57,7 +57,7 @@ impl std::error::Error for ServiceFlagsDecoderError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
 }
 
-/// Errors occuring when decoding a network [`Magic`].
+/// Errors occurring when decoding a network [`Magic`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MagicDecoderError(pub(super) <super::MagicInnerDecoder as encoding::Decoder>::Error);
 

--- a/p2p/src/merkle_tree.rs
+++ b/p2p/src/merkle_tree.rs
@@ -535,7 +535,7 @@ pub mod error {
 
     use internals::write_err;
 
-    /// An error occuring when decoding a [`MerkleBlock`].
+    /// An error occurring when decoding a [`MerkleBlock`].
     ///
     /// [`MerkleBlock`]: super::MerkleBlock
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -558,7 +558,7 @@ pub mod error {
         fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
     }
 
-    /// An error occuring when decoding a [`PartialMerkleTree`].
+    /// An error occurring when decoding a [`PartialMerkleTree`].
     ///
     /// [`PartialMerkleTree`]: super::PartialMerkleTree
     #[derive(Debug, Clone, PartialEq, Eq)]

--- a/p2p/src/message_bloom.rs
+++ b/p2p/src/message_bloom.rs
@@ -199,7 +199,7 @@ pub mod error {
 
     use internals::write_err;
 
-    /// An error occuring when decoding a [`FilterLoad`] message.
+    /// An error occurring when decoding a [`FilterLoad`] message.
     ///
     /// [`FilterLoad`]: super::FilterLoad
     #[derive(Debug, Clone, PartialEq, Eq)]

--- a/p2p/src/message_compact_blocks.rs
+++ b/p2p/src/message_compact_blocks.rs
@@ -64,7 +64,7 @@ pub mod error {
 
     use internals::write_err;
 
-    /// Errors occuring when decoding a [`SendCmpct`] message.
+    /// Errors occurring when decoding a [`SendCmpct`] message.
     ///
     /// [`SendCmpct`]: super::SendCmpct
     #[derive(Debug, Clone, PartialEq, Eq)]

--- a/p2p/src/message_filter.rs
+++ b/p2p/src/message_filter.rs
@@ -464,7 +464,7 @@ pub mod error {
 
     use internals::write_err;
 
-    /// Errors occuring when decoding a [`FilterHash`] message.
+    /// Errors occurring when decoding a [`FilterHash`] message.
     ///
     /// [`FilterHash`]: super::FilterHash
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -487,7 +487,7 @@ pub mod error {
         fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
     }
 
-    /// Errors occuring when decoding a [`FilterHeader`] message.
+    /// Errors occurring when decoding a [`FilterHeader`] message.
     ///
     /// [`FilterHeader`]: super::FilterHeader
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -510,7 +510,7 @@ pub mod error {
         fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
     }
 
-    /// Errors occuring when decoding a [`GetCFilters`] message.
+    /// Errors occurring when decoding a [`GetCFilters`] message.
     ///
     /// [`GetCFilters`]: super::GetCFilters
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -533,7 +533,7 @@ pub mod error {
         fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
     }
 
-    /// Errors occuring when decoding a [`CFilter`] message.
+    /// Errors occurring when decoding a [`CFilter`] message.
     ///
     /// [`CFilter`]: super::CFilter
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -556,7 +556,7 @@ pub mod error {
         fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
     }
 
-    /// Errors occuring when decoding a [`GetCFHeaders`] message.
+    /// Errors occurring when decoding a [`GetCFHeaders`] message.
     ///
     /// [`GetCFHeaders`]: super::GetCFHeaders
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -579,7 +579,7 @@ pub mod error {
         fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
     }
 
-    /// Errors occuring when decoding a [`CFHeaders`] message.
+    /// Errors occurring when decoding a [`CFHeaders`] message.
     ///
     /// [`CFHeaders`]: super::CFHeaders
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -602,7 +602,7 @@ pub mod error {
         fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
     }
 
-    /// Errors occuring when decoding a [`GetCFCheckpt`] message.
+    /// Errors occurring when decoding a [`GetCFCheckpt`] message.
     ///
     /// [`GetCFCheckpt`]: super::GetCFCheckpt
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -625,7 +625,7 @@ pub mod error {
         fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
     }
 
-    /// Errors occuring when decoding a [`CFCheckpt`] message.
+    /// Errors occurring when decoding a [`CFCheckpt`] message.
     ///
     /// [`CFCheckpt`]: super::CFCheckpt
     #[derive(Debug, Clone, PartialEq, Eq)]

--- a/p2p/src/message_network.rs
+++ b/p2p/src/message_network.rs
@@ -664,7 +664,7 @@ pub mod error {
         }
     }
 
-    /// Errors occuring when decoding a [`RejectReason`].
+    /// Errors occurring when decoding a [`RejectReason`].
     ///
     /// [`RejectReason`]: super::RejectReason
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -698,7 +698,7 @@ pub mod error {
         }
     }
 
-    /// Errors occuring when decoding a [`Reject`].
+    /// Errors occurring when decoding a [`Reject`].
     ///
     /// [`Reject`]: super::Reject
     #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
Fix a repeated typo in the `bitcoin-p2p-messages` rustdoc comments by changing `occuring` to `occurring`.

This only updates documentation comments for decoding error types and does not change any API or runtime behavior.

