### PR TITLE
primitive: Fix typos, grammar and formatting in docs

### DIFF
--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -876,7 +876,7 @@ pub mod error {
         }
     }
 
-    /// An error consensus decoding an `Version`.
+    /// An error consensus decoding a `Version`.
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct VersionDecoderError(pub(super) encoding::UnexpectedEofError);
 

--- a/primitives/src/hash_types/block_hash.rs
+++ b/primitives/src/hash_types/block_hash.rs
@@ -64,7 +64,7 @@ crate::decoder_newtype! {
     }
 }
 
-/// An error consensus decoding an `BlockHash`.
+/// An error consensus decoding a `BlockHash`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BlockHashDecoderError(encoding::UnexpectedEofError);
 

--- a/primitives/src/hash_types/ntxid.rs
+++ b/primitives/src/hash_types/ntxid.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! The `Txid` type.
+//! The `Ntxid` type.
 
 #[cfg(feature = "hex")]
 use core::{fmt, str};

--- a/primitives/src/hash_types/transaction_merkle_node.rs
+++ b/primitives/src/hash_types/transaction_merkle_node.rs
@@ -84,7 +84,7 @@ crate::decoder_newtype! {
     }
 }
 
-/// An error consensus decoding an `TxMerkleNode`.
+/// An error consensus decoding a `TxMerkleNode`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TxMerkleNodeDecoderError(encoding::UnexpectedEofError);
 

--- a/primitives/src/hash_types/witness_merkle_node.rs
+++ b/primitives/src/hash_types/witness_merkle_node.rs
@@ -84,7 +84,7 @@ crate::decoder_newtype! {
     }
 }
 
-/// An error consensus decoding an `WitnessMerkleNode`.
+/// An error consensus decoding a `WitnessMerkleNode`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WitnessMerkleNodeDecoderError(encoding::UnexpectedEofError);
 

--- a/primitives/src/hash_types/wtxid.rs
+++ b/primitives/src/hash_types/wtxid.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! The `Txid` type.
+//! The `Wtxid` type.
 //!
 //! In order to print and parse txids enable the "hex" feature.
 

--- a/primitives/src/merkle_tree.rs
+++ b/primitives/src/merkle_tree.rs
@@ -92,7 +92,7 @@ pub(crate) trait MerkleNode: Copy + PartialEq {
             // construction vulnerable to collisions (see CVE 2012-2459).
             //
             // (It is also vulnerable to collisions because it does not distinguish
-            // between internal nodes and transactions, but this collisions of this
+            // between internal nodes and transactions, but collisions of this
             // form are probably impractical. It is likely that 64-byte transactions
             // will be forbidden in the future which will close this for good.)
             //

--- a/primitives/src/script/owned.rs
+++ b/primitives/src/script/owned.rs
@@ -55,7 +55,7 @@ impl<T> ScriptBuf<T> {
     /// # Errors
     ///
     /// * If `s` cannot be parsed into a vector.
-    /// * If the parsed bytes cannot be decoded as a valid script (incl.the length prefix).
+    /// * If the parsed bytes cannot be decoded as a valid script (incl. the length prefix).
     #[cfg(feature = "hex")]
     pub fn from_hex_prefixed(
         s: &str,
@@ -124,7 +124,7 @@ impl<T> ScriptBuf<T> {
     ///
     /// # Panics
     ///
-    /// Panics if the new capacity exceeds `isize::MAX bytes`.
+    /// Panics if the new capacity exceeds `isize::MAX` bytes.
     #[inline]
     pub fn reserve(&mut self, additional_len: usize) { self.1.reserve(additional_len); }
 
@@ -140,7 +140,7 @@ impl<T> ScriptBuf<T> {
     ///
     /// # Panics
     ///
-    /// Panics if the new capacity exceeds `isize::MAX bytes`.
+    /// Panics if the new capacity exceeds `isize::MAX` bytes.
     #[inline]
     pub fn reserve_exact(&mut self, additional_len: usize) { self.1.reserve_exact(additional_len); }
 

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -127,7 +127,7 @@ pub use crate::hash_types::{BlockHashDecoder, Ntxid, Txid, Wtxid};
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
 #[cfg(feature = "alloc")]
 pub struct Transaction {
-    /// The protocol version, is currently expected to be 1, 2 (BIP-0068) or 3 (BIP-0431).
+    /// The protocol version. This is currently expected to be 1, 2 (BIP-0068) or 3 (BIP-0431).
     pub version: Version,
     /// Block height or timestamp. Transaction cannot be included in a block until this height/time.
     ///
@@ -658,7 +658,7 @@ impl encoding::Decoder for TransactionDecoder {
     }
 }
 
-/// The state of the transiting decoder.
+/// The state of the transaction decoder.
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone)]
 enum TransactionDecoderState {
@@ -708,8 +708,8 @@ struct Iteration(usize);
 
 /// Bitcoin transaction input.
 ///
-/// It contains the location of the previous transaction's output,
-/// that it spends and set of scripts that satisfy its spending
+/// It contains the location of the previous transaction's output
+/// that it spends, and the set of scripts that satisfy its spending
 /// conditions.
 ///
 /// # Bitcoin Core References
@@ -1498,7 +1498,7 @@ pub mod error {
         }
     }
 
-    /// An error consensus decoding an `Version`.
+    /// An error consensus decoding a `Version`.
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct VersionDecoderError(pub(super) encoding::UnexpectedEofError);
 

--- a/primitives/src/witness.rs
+++ b/primitives/src/witness.rs
@@ -132,7 +132,7 @@ impl Witness {
     #[inline]
     pub const fn len(&self) -> usize { self.witness_elements }
 
-    /// Returns the number of bytes this witness contributes to a transactions total size.
+    /// Returns the number of bytes this witness contributes to a transaction's total size.
     ///
     /// # Panics
     ///


### PR DESCRIPTION
The docs have various typos, grammar and formatting mistakes that should ideally be fixed before the 1.0 release.