### PR TITLE
primitives: Seal the `Tag` trait

### DIFF
--- a/primitives/api/all-features.txt
+++ b/primitives/api/all-features.txt
@@ -3540,7 +3540,7 @@ pub fn bitcoin_primitives::script::PushBytesErrorReport::input_len(&self) -> usi
 impl bitcoin_primitives::script::PushBytesErrorReport for core::convert::Infallible
 pub fn core::convert::Infallible::input_len(&self) -> usize
 pub trait bitcoin_primitives::script::ScriptHashableTag: bitcoin_primitives::script::sealed::Sealed
-pub trait bitcoin_primitives::script::Tag
+pub trait bitcoin_primitives::script::Tag: bitcoin_primitives::script::tag::sealed::Sealed
 pub type bitcoin_primitives::script::RedeemScript = bitcoin_primitives::script::Script<bitcoin_primitives::script::RedeemScriptTag>
 pub type bitcoin_primitives::script::RedeemScriptBuf = bitcoin_primitives::script::ScriptBuf<bitcoin_primitives::script::RedeemScriptTag>
 pub type bitcoin_primitives::script::ScriptPubKey = bitcoin_primitives::script::Script<bitcoin_primitives::script::ScriptPubKeyTag>

--- a/primitives/api/alloc-only.txt
+++ b/primitives/api/alloc-only.txt
@@ -3377,7 +3377,7 @@ pub fn bitcoin_primitives::script::PushBytesErrorReport::input_len(&self) -> usi
 impl bitcoin_primitives::script::PushBytesErrorReport for core::convert::Infallible
 pub fn core::convert::Infallible::input_len(&self) -> usize
 pub trait bitcoin_primitives::script::ScriptHashableTag: bitcoin_primitives::script::sealed::Sealed
-pub trait bitcoin_primitives::script::Tag
+pub trait bitcoin_primitives::script::Tag: bitcoin_primitives::script::tag::sealed::Sealed
 pub type bitcoin_primitives::script::RedeemScript = bitcoin_primitives::script::Script<bitcoin_primitives::script::RedeemScriptTag>
 pub type bitcoin_primitives::script::RedeemScriptBuf = bitcoin_primitives::script::ScriptBuf<bitcoin_primitives::script::RedeemScriptTag>
 pub type bitcoin_primitives::script::ScriptPubKey = bitcoin_primitives::script::Script<bitcoin_primitives::script::ScriptPubKeyTag>

--- a/primitives/src/script/tag.rs
+++ b/primitives/src/script/tag.rs
@@ -6,7 +6,17 @@
 //! in Bitcoin transactions.
 
 /// Sealed trait representing a type of script.
-pub trait Tag {}
+pub trait Tag: sealed::Sealed {}
+
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for super::RedeemScriptTag {}
+    impl Sealed for super::ScriptSigTag {}
+    impl Sealed for super::ScriptPubKeyTag {}
+    impl Sealed for super::SignetBlockScriptTag {}
+    impl Sealed for super::TapScriptTag {}
+    impl Sealed for super::WitnessScriptTag {}
+}
 
 /// A P2SH redeem script.
 #[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]


### PR DESCRIPTION
The Tag trait used for script/key tags in primitives claims to be a sealed trait. Sealing prevents outside users from adding new types which satisfy the trait, but the Tag trait has no such sealing.

Add sealed::Sealed module + trait and seal Tag trait on Sealed trait.