### PR TITLE
bitcoin: Reject non-pushnum opcodes in multisig pattern

### DIFF
--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -340,13 +340,9 @@ internal_macros::define_extension_trait! {
                     Instruction::PushBytes(_) => {
                         num_pubkeys += 1;
                     }
-                    Instruction::Op(op) => {
-                        if let Some(pushnum) = op.decode_pushnum() {
-                            if pushnum != num_pubkeys {
-                                return false;
-                            }
-                        }
-                        break;
+                    Instruction::Op(op) => match op.decode_pushnum() {
+                        Some(push_num) if push_num == num_pubkeys => break,
+                        _ => return false,
                     }
                 }
             }

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -321,18 +321,13 @@ internal_macros::define_extension_trait! {
         ///    `2 <pubkey1> <pubkey2> <pubkey3> 3 OP_CHECKMULTISIG`
         #[inline]
         fn is_multisig(&self) -> bool {
-            let required_sigs;
-
             let mut instructions = self.instructions();
-            if let Some(Ok(Instruction::Op(op))) = instructions.next() {
-                if let Some(pushnum) = op.decode_pushnum() {
-                    required_sigs = pushnum;
-                } else {
-                    return false;
-                }
-            } else {
+            let Some(Ok(Instruction::Op(op))) = instructions.next() else {
                 return false;
-            }
+            };
+            let Some(required_sigs) = op.decode_pushnum() else {
+                return false;
+            };
 
             let mut num_pubkeys: u8 = 0;
             while let Some(Ok(instruction)) = instructions.next() {
@@ -351,13 +346,9 @@ internal_macros::define_extension_trait! {
                 return false;
             }
 
-            if let Some(Ok(Instruction::Op(op))) = instructions.next() {
-                if op != OP_CHECKMULTISIG {
-                    return false;
-                }
-            } else {
+            let Some(Ok(Instruction::Op(OP_CHECKMULTISIG))) = instructions.next() else {
                 return false;
-            }
+            };
 
             instructions.next().is_none()
         }

--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -585,6 +585,13 @@ fn multisig() {
     )
     .unwrap()
     .is_multisig());
+
+    // Num pubkeys must be a pushnum opcode (OP_1..OP_16).
+    assert!(
+            !ScriptPubKeyBuf::from_hex_no_length_prefix("5221021c4ac2ecebc398e390e07f045aac5cc421f82f0739c1ce724d3d53964dc6537d21023a2e9155e0b62f76737605504819a2b4e5ce20653f6c397d7a178ae42ba702f475ae")
+                .unwrap()
+                .is_multisig()
+        );
 }
 
 #[test]


### PR DESCRIPTION
- 71392401e926285f1cb09e65f903a58079213d42 Rejects opcodes that are not `OP_PUSH` when validating public key counts in multisig patterns.
- 6eba70192a16990d73fe2c99485965866122fca3 Refactored nested `if let` statements using Rust's `let else` syntax to improve readability and flatten the control flow.

closes #6372 