### PR TITLE
Adjust `Arbitrary` impls to enforce invariants from decoders

### DIFF
--- a/p2p/src/address.rs
+++ b/p2p/src/address.rs
@@ -1031,29 +1031,26 @@ impl<'a> Arbitrary<'a> for AddrV2 {
                 u.arbitrary()?,
                 u.arbitrary()?,
             ))),
-            1 => Ok(Self::Ipv6(Ipv6Addr::new(
-                u.arbitrary()?,
-                u.arbitrary()?,
-                u.arbitrary()?,
-                u.arbitrary()?,
-                u.arbitrary()?,
-                u.arbitrary()?,
-                u.arbitrary()?,
-                u.arbitrary()?,
-            ))),
+            1 => {
+                let mut segments: [u16; 8] = u.arbitrary()?;
+                if segments[0..3] == ONION || segments[0..6] == IPV4_EMBEDDED_IPV6 {
+                    segments[0] ^= 1;
+                }
+                Ok(Self::Ipv6(Ipv6Addr::from(segments)))
+            }
             2 => Ok(Self::TorV3(u.arbitrary()?)),
             3 => Ok(Self::I2p(u.arbitrary()?)),
-            4 => Ok(Self::Cjdns(Ipv6Addr::new(
-                u.arbitrary()?,
-                u.arbitrary()?,
-                u.arbitrary()?,
-                u.arbitrary()?,
-                u.arbitrary()?,
-                u.arbitrary()?,
-                u.arbitrary()?,
-                u.arbitrary()?,
-            ))),
-            _ => Ok(Self::Unknown(u.arbitrary()?, Vec::<u8>::arbitrary(u)?)),
+            4 => {
+                let mut segments: [u16; 8] = u.arbitrary()?;
+                segments[0] = 0xFC00 | (segments[0] & 0x00FF);
+                Ok(Self::Cjdns(Ipv6Addr::from(segments)))
+            }
+            _ => {
+                let network = u.int_in_range(7..=u8::MAX)?;
+                let mut bytes = Vec::<u8>::arbitrary(u)?;
+                bytes.truncate(512);
+                Ok(Self::Unknown(network, bytes))
+            }
         }
     }
 }

--- a/p2p/src/merkle_tree.rs
+++ b/p2p/src/merkle_tree.rs
@@ -651,9 +651,13 @@ pub mod error {
 #[cfg(feature = "arbitrary")]
 impl<'a> Arbitrary<'a> for PartialMerkleTree {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let mut bits = Vec::<bool>::arbitrary(u)?;
+        while bits.len() % 8 != 0 {
+            bits.push(false);
+        }
         Ok(Self {
             num_transactions: u.arbitrary()?,
-            bits: Vec::<bool>::arbitrary(u)?,
+            bits,
             hashes: Vec::<TxMerkleNode>::arbitrary(u)?,
         })
     }

--- a/p2p/src/message_network.rs
+++ b/p2p/src/message_network.rs
@@ -778,7 +778,19 @@ impl<'a> Arbitrary<'a> for UserAgentVersion {
 #[cfg(feature = "arbitrary")]
 impl<'a> Arbitrary<'a> for UserAgent {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        Ok(Self::new(u.arbitrary::<String>()?, &u.arbitrary()?))
+        let version = UserAgentVersion::arbitrary(u)?;
+
+        let mut name: String = u
+            .arbitrary::<String>()?
+            .chars()
+            .filter(|c| !matches!(c, '/' | '(' | ')' | ':'))
+            .collect();
+
+        let overhead = 3 + version.to_string().chars().count();
+        let max_name = Self::MAX_USER_AGENT_LEN - overhead;
+        name.truncate(max_name);
+
+        Ok(Self::new(name, &version))
     }
 }
 

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -1522,12 +1522,37 @@ pub mod error {
 #[cfg(feature = "alloc")]
 impl<'a> Arbitrary<'a> for Transaction {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        Ok(Self {
-            version: Version::arbitrary(u)?,
-            lock_time: absolute::LockTime::arbitrary(u)?,
-            inputs: Vec::<TxIn>::arbitrary(u)?,
-            outputs: Vec::<TxOut>::arbitrary(u)?,
-        })
+        let version = Version::arbitrary(u)?;
+        let lock_time = absolute::LockTime::arbitrary(u)?;
+        let mut inputs = Vec::<TxIn>::arbitrary(u)?;
+        let mut outputs = Vec::<TxOut>::arbitrary(u)?;
+
+        let mut seen = alloc::collections::BTreeSet::new();
+        inputs.retain(|input| seen.insert(input.previous_output));
+
+        if inputs.len() > 1 {
+            inputs.retain(|input| input.previous_output != OutPoint::COINBASE_PREVOUT);
+        }
+
+        if inputs.len() == 1 && inputs[0].previous_output == OutPoint::COINBASE_PREVOUT {
+            let len = inputs[0].script_sig.len();
+            if len < 2 || len > 100 {
+                inputs[0].script_sig = ScriptSigBuf::from_bytes(Vec::from([0u8; 2]));
+            }
+        }
+
+        if outputs.is_empty() {
+            outputs.push(TxOut::arbitrary(u)?);
+        }
+
+        let mut remaining = Amount::MAX_MONEY.to_sat();
+        for output in &mut outputs {
+            let capped = output.amount.to_sat().min(remaining);
+            output.amount = Amount::from_sat(capped).expect("capped <= MAX_MONEY");
+            remaining -= capped;
+        }
+
+        Ok(Self { version, lock_time, inputs, outputs })
     }
 }
 


### PR DESCRIPTION
Various decoders include checks in their end() functions that enforce certain invariants for the decoded values. Arbitrary impls should enforce the same invariants on constructed values as the decoders do. Further, Arbitrary impls should not panic on account of incorrectly structured arbitrary values.

- Patch 1 adjusts Transaction's Arbitrary impl to match the decoder.
- Patch 2 adjusts AddrV2's Arbitrary impl to match the decoder.
- Patch 3 adjusts PartialMerkleTree's Arbitrary impl to match the decoder.
- Patch 4 adjusts UserAgent's Arbitrary impl to prevent panics from improperly structured values.