### PR TITLE
bitcoin: Clear pushnum cache on signature operations in sigop count

### DIFF
--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -476,6 +476,7 @@ internal_macros::define_extension_trait! {
                             // p2pk, p2pkh
                             OP_CHECKSIG | OP_CHECKSIGVERIFY => {
                                 n += 1;
+                                pushnum_cache = None;
                             }
                             OP_CHECKMULTISIG | OP_CHECKMULTISIGVERIFY => {
                                 match (accurate, pushnum_cache) {
@@ -489,6 +490,7 @@ internal_macros::define_extension_trait! {
                                         n += 20;
                                     }
                                 }
+                                pushnum_cache = None;
                             }
                             _ => {
                                 pushnum_cache = opcode.decode_pushnum();

--- a/bitcoin/src/blockdata/script/tests.rs
+++ b/bitcoin/src/blockdata/script/tests.rs
@@ -854,6 +854,16 @@ fn default_dust_value() {
 
 #[test]
 fn script_get_sigop_count() {
+    // 1 (CHECKSIG) + 20 (CHECKMULTISIG, lastOpcode = CHECKSIG)
+    assert_eq!(
+        Script::builder()
+            .push_opcode(OP_1)
+            .push_opcode(OP_CHECKSIG)
+            .push_opcode(OP_CHECKMULTISIG)
+            .into_script()
+            .count_sigops(),
+        21
+    );
     assert_eq!(
         Script::builder()
             .push_opcode(OP_DUP)


### PR DESCRIPTION
The `pushnum_cache` was not cleared when encountering a non-push signature opcode like `OP_CHECKSIG`. This allowed stale push numbers to leak into subsequent multisig operations if they weren't directly preceded by a small int push.

Resetting the cache on signature opcodes fixes this, and aligns the sigop calculation with Bitcoin Core consensus logic.

closes #6368 