### PR TITLE
hashes: add one-shot hash method to HashEngine

### DIFF
--- a/hashes/api/all-features.txt
+++ b/hashes/api/all-features.txt
@@ -1898,8 +1898,10 @@ pub trait bitcoin_hashes::HashEngine: core::clone::Clone
 pub type bitcoin_hashes::HashEngine::Hash: bitcoin_hashes::Hash
 pub const bitcoin_hashes::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::HashEngine::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::HashEngine::hash(data: &[u8]) -> Self::Hash where Self: core::default::Default
 pub fn bitcoin_hashes::HashEngine::input(&mut self, data: &[u8])
 pub fn bitcoin_hashes::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::HashEngine::with_input(self, data: &[u8]) -> Self
 pub trait bitcoin_hashes::IsByteArray: core::convert::AsRef<[u8]> + bitcoin_hashes::sealed::IsByteArray
 pub const bitcoin_hashes::IsByteArray::LEN: usize
 impl<const N: usize> bitcoin_hashes::IsByteArray for [u8; N]

--- a/hashes/api/alloc-only.txt
+++ b/hashes/api/alloc-only.txt
@@ -1673,8 +1673,10 @@ pub trait bitcoin_hashes::HashEngine: core::clone::Clone
 pub type bitcoin_hashes::HashEngine::Hash: bitcoin_hashes::Hash
 pub const bitcoin_hashes::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::HashEngine::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::HashEngine::hash(data: &[u8]) -> Self::Hash where Self: core::default::Default
 pub fn bitcoin_hashes::HashEngine::input(&mut self, data: &[u8])
 pub fn bitcoin_hashes::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::HashEngine::with_input(self, data: &[u8]) -> Self
 pub trait bitcoin_hashes::IsByteArray: core::convert::AsRef<[u8]> + bitcoin_hashes::sealed::IsByteArray
 pub const bitcoin_hashes::IsByteArray::LEN: usize
 impl<const N: usize> bitcoin_hashes::IsByteArray for [u8; N]

--- a/hashes/api/no-features.txt
+++ b/hashes/api/no-features.txt
@@ -1550,8 +1550,10 @@ pub trait bitcoin_hashes::HashEngine: core::clone::Clone
 pub type bitcoin_hashes::HashEngine::Hash: bitcoin_hashes::Hash
 pub const bitcoin_hashes::HashEngine::BLOCK_SIZE: usize
 pub fn bitcoin_hashes::HashEngine::finalize(self) -> Self::Hash
+pub fn bitcoin_hashes::HashEngine::hash(data: &[u8]) -> Self::Hash where Self: core::default::Default
 pub fn bitcoin_hashes::HashEngine::input(&mut self, data: &[u8])
 pub fn bitcoin_hashes::HashEngine::n_bytes_hashed(&self) -> u64
+pub fn bitcoin_hashes::HashEngine::with_input(self, data: &[u8]) -> Self
 pub trait bitcoin_hashes::IsByteArray: core::convert::AsRef<[u8]> + bitcoin_hashes::sealed::IsByteArray
 pub const bitcoin_hashes::IsByteArray::LEN: usize
 impl<const N: usize> bitcoin_hashes::IsByteArray for [u8; N]

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -175,6 +175,13 @@ pub trait HashEngine: Clone {
     /// Adds data to the hash engine.
     fn input(&mut self, data: &[u8]);
 
+    /// Adds data to the hash engine and returns the engine.
+    #[must_use]
+    fn with_input(mut self, data: &[u8]) -> Self {
+        self.input(data);
+        self
+    }
+
     /// Returns the number of bytes already input into the engine.
     fn n_bytes_hashed(&self) -> u64;
 
@@ -344,5 +351,14 @@ mod tests {
         let hex = format!("{}", orig);
         let roundtrip = hex.parse::<TestNewtype>().expect("failed to parse hex");
         assert_eq!(roundtrip, orig);
+    }
+
+    #[test]
+    fn engine_with_input_chains() {
+        use crate::{sha256, HashEngine as _};
+
+        let chained =
+            sha256::HashEngine::default().with_input(b"abc").with_input(b"def").finalize();
+        assert_eq!(chained, sha256::Hash::hash(b"abcdef"));
     }
 }

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -180,6 +180,16 @@ pub trait HashEngine: Clone {
 
     /// Finalizes this engine.
     fn finalize(self) -> Self::Hash;
+
+    /// Hashes bytes in one shot.
+    fn hash(data: &[u8]) -> Self::Hash
+    where
+        Self: Default,
+    {
+        let mut engine = Self::default();
+        engine.input(data);
+        engine.finalize()
+    }
 }
 
 /// Encodes an object into a hash engine.


### PR DESCRIPTION
There is currently no generic way to compute a hash. The hash() methods we have now live on the hash types, not on any trait. This adds a one-shot hash() method to `HashEngine`.

Discussed in https://github.com/rust-bitcoin/rust-bitcoin/issues/6299#issuecomment-4597277808