### PR TITLE
hashes: fix tag name in sha256t_tag macro docs

### DIFF
--- a/hashes/src/macros.rs
+++ b/hashes/src/macros.rs
@@ -31,7 +31,7 @@
 #[macro_export]
 macro_rules! sha256t_tag {
     ($(#[$($tag_attr:tt)*])* $tag_vis:vis struct $tag:ident = $constructor:tt($($tag_value:tt)+);) => {
-        $crate::sha256t_tag_struct!($tag_vis, $tag, stringify!($hash_name), $(#[$($tag_attr)*])*);
+        $crate::sha256t_tag_struct!($tag_vis, $tag, stringify!($tag), $(#[$($tag_attr)*])*);
 
         impl $crate::sha256t::Tag for $tag {
             const MIDSTATE: $crate::sha256::Midstate = $crate::sha256t_tag_constructor!($constructor, $($tag_value)+);


### PR DESCRIPTION
sha256t_tag! macro referred to `$hash_name`, which does not exist, so every generated tag showed "The tag used for [`$hash_name`]" in its docs.

eg: https://docs.rs/bitcoin-taproot-primitives/0.1.0/bitcoin_taproot_primitives/

noticed this while working on https://github.com/rust-bitcoin/rust-bitcoin/issues/6299