### PR TITLE
Add recent 0.32.x releases to relevant changelogs

### DIFF
--- a/base58/CHANGELOG.md
+++ b/base58/CHANGELOG.md
@@ -19,7 +19,13 @@
 - Close all errors [#3533](https://github.com/rust-bitcoin/rust-bitcoin/pull/3533)
 - Bump `hex-conservative` to `0.3.0` [#3543](https://github.com/rust-bitcoin/rust-bitcoin/pull/3543)
 
-## [0.1.100] - 2026-05-27
+## [0.1.101] - 2026-06-24
+
+**Bump the MSRV to Rust 1.60.0**
+
+## [0.1.100] - 2026-05-27 [YANKED]
+
+> This release was yanked because the MSRV bump to 1.74.0 was too aggressive for some users. See version 0.1.101 for a smaller upgrade to 1.60.0.
 
 - Bump MSRV to Rust 1.74.0 [#6126](https://github.com/rust-bitcoin/rust-bitcoin/pull/6126)
 
@@ -38,5 +44,6 @@ Initial release of the `base58ck` crate. This crate was cut out of
 [0.4.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/base58ck-0.3.0...base58ck-0.4.0
 [0.3.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/base58ck-0.2.0...base58ck-0.3.0
 [0.2.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/base58ck-0.1.100...base58ck-0.2.0
+[0.1.101]: https://github.com/rust-bitcoin/rust-bitcoin/compare/base58ck-0.1.100...base58ck-0.1.101
 [0.1.100]: https://github.com/rust-bitcoin/rust-bitcoin/compare/base58ck-0.1.1...base58ck-0.1.100
 [0.1.1]: https://github.com/rust-bitcoin/rust-bitcoin/compare/base58ck-0.1.0...base58ck-0.1.1

--- a/bitcoin/CHANGELOG.md
+++ b/bitcoin/CHANGELOG.md
@@ -47,7 +47,15 @@ The `serde` serialization for `Psbt` has changed.
 
 - BREAKING: Change `Psbt` serde implementations [#4496](https://github.com/rust-bitcoin/rust-bitcoin/pull/4496)
 
-## [0.32.100] - 2026-05-26
+## [0.32.101] - 2026-06-24
+
+**Bump the MSRV to Rust 1.60.0**
+
+- Exposes the new stabilized encoding library through the optional `encoding` feature. Note that enabling it bumps the MSRV to 1.74.0.
+
+## [0.32.100] - 2026-05-26 [YANKED]
+
+> This release was yanked because the MSRV bump to 1.74.0 was too aggressive for some users. See version 0.32.101 for a smaller upgrade to 1.60.0.
 
 **Bump the MSRV to Rust 1.74.0**
 
@@ -893,6 +901,7 @@ downstream users to also have a `num` dependency just so they can use `Uint256::
 
 [Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.33.0-beta...HEAD
 [0.33.0-beta]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.100...bitcoin-0.33.0-beta
+[0.32.101]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.100...bitcoin-0.32.101
 [0.32.100]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.10...bitcoin-0.32.100
 [0.32.10]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.9...bitcoin-0.32.10
 [0.32.9]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.8...bitcoin-0.32.9

--- a/hashes/CHANGELOG.md
+++ b/hashes/CHANGELOG.md
@@ -127,6 +127,21 @@ using `hashes` in `rust-bitcoin` to see an example. Enjoy!
   }
 ```
 
+## [0.14.101] - 2026-06-24
+
+**Bump the MSRV to Rust 1.60.0**
+
+## [0.14.100] - 2026-05-26 [YANKED]
+
+> This release was yanked because the MSRV bump to 1.74.0 was too aggressive for some users. See version 0.14.101 for a smaller upgrade to 1.60.0.
+
+**Bump the MSRV to Rust 1.74.0**
+
+## [0.14.2] - 2026-05-23
+
+* Enable `alloc` feature from `schemars` feature and fix feature gating.
+* Remove the `internals` dependency [#6200](https://github.com/rust-bitcoin/rust-bitcoin/pull/6200)
+
 ## [0.14.1] - 2025-12-03
 
 * remove `doc_auto_cfg`
@@ -360,6 +375,8 @@ Note that we have stopped re-exporting the `core` crate when compiling without `
 [0.17.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin_hashes-0.16.0...bitcoin_hashes-0.17.0
 [0.16.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin_hashes-0.15.0...bitcoin_hashes-0.16.0
 [0.15.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin_hashes-0.14.2...bitcoin_hashes-0.15.0
+[0.14.101]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin_hashes-0.14.100...bitcoin_hashes-0.14.101
+[0.14.100]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin_hashes-0.14.2...bitcoin_hashes-0.14.100
 [0.14.2]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin_hashes-0.14.1...bitcoin_hashes-0.14.2
 [0.14.1]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin_hashes-0.14.0...bitcoin_hashes-0.14.1
 [0.14.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin_hashes-0.13.1...bitcoin_hashes-0.14.0

--- a/io/CHANGELOG.md
+++ b/io/CHANGELOG.md
@@ -34,6 +34,22 @@ update the other `rust-bitcoin` repo dependencies.
 * Bump MSRV to Rust `v1.63.0` [#3100](https://github.com/rust-bitcoin/rust-bitcoin/pull/3100)
 * Remove blanket trait impls [#2453](https://github.com/rust-bitcoin/rust-bitcoin/pull/2453)
 
+## [0.1.101] - 2026-06-24
+
+**Bump the MSRV to Rust 1.60.0**
+
+- Exposes the new stabilized encoding library through the optional `encoding` feature. Note that enabling it bumps the MSRV to 1.74.0.
+
+## [0.1.100] - 2026-05-26 [YANKED]
+
+> This release was yanked because the MSRV bump to 1.74.0 was too aggressive for some users. See version 0.1.101 for a smaller upgrade to 1.60.0.
+
+**Bump the MSRV to Rust 1.74.0**
+
+## [0.1.4] - 2025-10-30
+
+* Remove `doc_auto_cfg`
+
 ## [0.1.3] - 2024-11-02
 
 * Backport IO improvements [#3181](https://github.com/rust-bitcoin/rust-bitcoin/pull/3181)
@@ -69,5 +85,8 @@ Empty crate to reserve the name on crates.io
 [0.4.0-rc.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-io-0.3.0...bitcoin-io-0.4.0-rc.0
 [0.3.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/io-0.2.0...bitcoin-io-0.3.0
 [0.2.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/io-0.1.3...io-0.2.0
+[0.1.101]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-io-0.1.100...bitcoin-io-0.1.101
+[0.1.100]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-io-0.1.4...bitcoin-io-0.1.100
+[0.1.4]: https://github.com/rust-bitcoin/rust-bitcoin/compare/io-0.1.3...bitcoin-io-0.1.4
 [0.1.3]: https://github.com/rust-bitcoin/rust-bitcoin/compare/io-0.1.2...io-0.1.3
 [0.1.2]: https://github.com/rust-bitcoin/rust-bitcoin/compare/io-0.1.1...io-0.1.2

--- a/units/CHANGELOG.md
+++ b/units/CHANGELOG.md
@@ -111,6 +111,27 @@ In the following PRs:
 * [#3257](https://github.com/rust-bitcoin/rust-bitcoin/pull/3257)
 * [#3247](https://github.com/rust-bitcoin/rust-bitcoin/pull/3274)
 
+## [0.1.101] - 2026-06-24
+
+**Bump the MSRV to Rust 1.60.0**
+
+- Exposes the new stabilized encoding library through the optional `encoding` feature. Note that enabling it bumps the MSRV to 1.74.0.
+
+## [0.1.100] - 2026-05-26 [YANKED]
+
+> This release was yanked because the MSRV bump to 1.74.0 was too aggressive for some users. See version 0.1.101 for a smaller upgrade to 1.60.0.
+
+**Bump the MSRV to Rust 1.74.0**
+
+## [0.1.4] - 2026-05-23
+
+* Remove the `internals` dependency [#6200](https://github.com/rust-bitcoin/rust-bitcoin/pull/6200)
+
+## [0.1.3] - 2026-04-19
+
+* Backport `Arbitrary` to `0.32.x` [#5085](https://github.com/rust-bitcoin/rust-bitcoin/pull/5085)
+* Backport: Add CompactSize range check to deserialization [#5921](https://github.com/rust-bitcoin/rust-bitcoin/pull/5921)
+
 ## [0.1.2] - 2024-07-01
 
 * Remove enable of `alloc` feature in the `internals` dependency.
@@ -150,5 +171,9 @@ Empty crate to reserve the name on crates.io
 [0.4.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-units-0.3.0...bitcoin-units-0.4.0
 [0.3.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/units-0.2.0...bitcoin-units-0.3.0
 [0.2.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/units-0.1.2...units-0.2.0
+[0.1.101]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-units-0.1.100...bitcoin-units-0.1.101
+[0.1.100]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-units-0.1.4...bitcoin-units-0.1.100
+[0.1.4]: https://github.com/rust-bitcoin/rust-bitcoin/compare/units-0.1.3...bitcoin-units-0.1.4
+[0.1.3]: https://github.com/rust-bitcoin/rust-bitcoin/compare/units-0.1.2...units-0.1.3
 [0.1.2]: https://github.com/rust-bitcoin/rust-bitcoin/compare/units-0.1.1...units-0.1.2
 [0.1.1]: https://github.com/rust-bitcoin/rust-bitcoin/compare/units-0.1.0...units-0.1.1


### PR DESCRIPTION
Ported over a few `0.32.x` entries which only existed on that branch and added the new `101` (MSRV to 1.60.0) entries. Making `master` the canonical changelog home has been kicked around a bit I think, but not sure a policy call has been made. The only downside I envision is if we remove a package on `master` (e.g. delete `io` or something), but keep making releases on `0.32.x`. Maybe will never happen?

The `[YANKED]` tag is following the [keep-a-changelog convention](https://keepachangelog.com/en/1.1.0/).