### PR TITLE
consensus_encoding: always enable alloc for serde

### DIFF
--- a/consensus_encoding/Cargo.toml
+++ b/consensus_encoding/Cargo.toml
@@ -18,6 +18,7 @@ exclude = ["api", "tests", "contrib"]
 default = ["std"]
 std = ["alloc", "internals/std", "hex?/std", "serde?/std"]
 alloc = ["internals/alloc", "hex?/alloc", "serde?/alloc"]
+serde = ["alloc", "hex", "dep:serde"]
 
 [dependencies]
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }

--- a/consensus_encoding/src/lib.rs
+++ b/consensus_encoding/src/lib.rs
@@ -86,7 +86,6 @@ mod decode;
 mod encode;
 
 pub mod error;
-#[cfg(feature = "hex")]
 #[cfg(feature = "serde")]
 pub mod serde_as_consensus;
 

--- a/consensus_encoding/tests/serde.rs
+++ b/consensus_encoding/tests/serde.rs
@@ -2,7 +2,7 @@
 
 //! Tests for `serde_as_consensus`.
 
-#![cfg(all(feature = "hex", feature = "serde"))]
+#![cfg(feature = "serde")]
 
 use bitcoin_consensus_encoding::{
     ArrayDecoder, ArrayEncoder, Decode, Decoder, DecoderStatus, Encode, UnexpectedEofError,


### PR DESCRIPTION
The `[hex, serde]` feature subset is failing (#6414) in `consensus_encoding` since the `serde` code requires `alloc`. Since there is no "collect_bytes" exposed in serde, an allocation is unavoidable (I think?) for non-human-readable serialization.

I chose to make the `alloc` and `hex` dependencies explicit in the feature declaration. This does result in a circular looking situation with the weak-deps, but appears to work fine. Maybe there is a cleaner way to declare this though?