### PR TITLE
fuzz: migrate 0.32.x fuzz targets to master

### DIFF
--- a/.github/workflows/cron-daily-fuzz.yml
+++ b/.github/workflows/cron-daily-fuzz.yml
@@ -18,6 +18,11 @@ jobs:
       fail-fast: false
       matrix:
         fuzz_target: [
+          bitcoin_0_32_compare_consensus_encoding,
+          bitcoin_0_32_deser_net_msg,
+          bitcoin_0_32_deserialize_address,
+          bitcoin_0_32_deserialize_psbt,
+          bitcoin_0_32_outpoint_string,
           bitcoin_arbitrary_block,
           bitcoin_arbitrary_script,
           bitcoin_arbitrary_transaction,
@@ -61,6 +66,7 @@ jobs:
           bitcoin_encoding_roundtrip_p2p_message_bloom_filter_load,
           bitcoin_encoding_roundtrip_p2p_message_command_string,
           bitcoin_encoding_roundtrip_p2p_message_compact_blocks_send_cmpct,
+          bitcoin_encoding_roundtrip_p2p_message_erlay_send_tx_rcn_cl,
           bitcoin_encoding_roundtrip_p2p_message_fee_filter,
           bitcoin_encoding_roundtrip_p2p_message_filter_c_f_checkpt,
           bitcoin_encoding_roundtrip_p2p_message_filter_c_f_headers,
@@ -104,6 +110,7 @@ jobs:
           consensus_encoding_decode_byte_vec,
           consensus_encoding_decode_compact_size,
           consensus_encoding_decode_decoder2,
+          hashes_0_32_cbor,
           hashes_arbitrary_json,
           hashes_json,
           hashes_ripemd160,
@@ -114,6 +121,7 @@ jobs:
           p2p_arbitrary_addrv2,
           p2p_deserialize_addrv2,
           p2p_deserialize_raw_net_msg,
+          units_0_32_deserialize_amount,
           units_arbitrary_weight,
           units_parse_amount,
           units_parse_int,

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -16,12 +16,11 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "base58ck"
-version = "0.1.0"
+version = "0.1.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
+checksum = "365c0acd5b2e8dd0111a46c4faea83fb3cfb6e39a49a7c73a06e090db7b2eff0"
 dependencies = [
- "bitcoin-internals 0.3.0",
- "bitcoin_hashes 0.14.0",
+ "bitcoin_hashes 0.14.101",
 ]
 
 [[package]]
@@ -57,19 +56,20 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.9"
+version = "0.32.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf93e61f2dbc3e3c41234ca26a65e2c0b0975c52e0f069ab9893ebbede584d3"
+checksum = "8ed8ccb78a9ff7a6fbb90e2fb9b8588b4a9928d49d8af3cb789108a84ea6b0ce"
 dependencies = [
- "base58ck 0.1.0",
+ "base58ck 0.1.101",
  "bech32",
- "bitcoin-internals 0.3.0",
- "bitcoin-io 0.1.1",
- "bitcoin-units 0.1.0",
- "bitcoin_hashes 0.14.0",
+ "bitcoin-consensus-encoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin-io 0.1.101",
+ "bitcoin-units 0.1.101",
+ "bitcoin_hashes 0.14.101",
  "hex-conservative 0.2.2",
  "hex_lit",
  "secp256k1 0.29.0",
+ "serde",
 ]
 
 [[package]]
@@ -81,7 +81,7 @@ dependencies = [
  "base64",
  "bech32",
  "bincode",
- "bitcoin-consensus-encoding",
+ "bitcoin-consensus-encoding 1.0.0",
  "bitcoin-crypto",
  "bitcoin-internals 0.5.0",
  "bitcoin-io 0.5.0",
@@ -118,6 +118,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin-consensus-encoding"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2d6094e2a1ba3c93b5a596fe5a10d1a10c3c6e06785cde89f693a044c01aa40"
+dependencies = [
+ "bitcoin-internals 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bitcoin-crypto"
 version = "0.2.0"
 dependencies = [
@@ -138,21 +147,16 @@ name = "bitcoin-fuzz"
 version = "0.0.1"
 dependencies = [
  "arbitrary",
- "bitcoin 0.32.9",
+ "bitcoin 0.32.101",
  "bitcoin 0.33.0-beta",
- "bitcoin-consensus-encoding",
+ "bitcoin-consensus-encoding 1.0.0",
  "bitcoin-p2p-messages",
  "libfuzzer-sys",
  "serde",
+ "serde_cbor",
  "serde_json",
  "standard_test",
 ]
-
-[[package]]
-name = "bitcoin-internals"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
 
 [[package]]
 name = "bitcoin-internals"
@@ -165,16 +169,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitcoin-io"
-version = "0.1.1"
+name = "bitcoin-internals"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17e5b76b88667412087beea1882980ad843b660490bbf6cce0a6cfc999c5b989"
+checksum = "a30a22d1f112dde8e16be7b45c63645dc165cef254f835b3e1e9553e485cfa64"
+dependencies = [
+ "hex-conservative 0.3.0",
+]
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb5de036369d1ac59d3c1819ebc4d850f89466f5401c571a285b6ed564a4cb78"
+dependencies = [
+ "bitcoin-consensus-encoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "bitcoin-io"
 version = "0.5.0"
 dependencies = [
- "bitcoin-consensus-encoding",
+ "bitcoin-consensus-encoding 1.0.0",
  "bitcoin-internals 0.5.0",
  "bitcoin_hashes 1.0.0",
 ]
@@ -212,7 +228,7 @@ name = "bitcoin-p2p-messages"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "bitcoin-consensus-encoding",
+ "bitcoin-consensus-encoding 1.0.0",
  "bitcoin-internals 0.5.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
@@ -228,7 +244,7 @@ version = "0.102.0"
 dependencies = [
  "arbitrary",
  "bincode",
- "bitcoin-consensus-encoding",
+ "bitcoin-consensus-encoding 1.0.0",
  "bitcoin-internals 0.5.0",
  "bitcoin-units 0.5.0",
  "bitcoin_hashes 1.0.0",
@@ -256,11 +272,12 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-units"
-version = "0.1.0"
+version = "0.1.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d437fd727271c866d6fd5e71eb2c886437d4c97f80d89246be3189b1da4e58b"
+checksum = "9cb95693f371d089a4b5b6fc41c6f3ea6e01ee8c15388335dfac8ea685173b51"
 dependencies = [
- "bitcoin-internals 0.3.0",
+ "bitcoin-consensus-encoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
 ]
 
 [[package]]
@@ -269,7 +286,7 @@ version = "0.5.0"
 dependencies = [
  "arbitrary",
  "bincode",
- "bitcoin-consensus-encoding",
+ "bitcoin-consensus-encoding 1.0.0",
  "bitcoin-internals 0.5.0",
  "serde",
  "serde_json",
@@ -287,12 +304,13 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.0"
+version = "0.14.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
+checksum = "bca4c7abb40c8817d77403c880988cfd484f23ab2365726afb2f798363e2c4a2"
 dependencies = [
- "bitcoin-io 0.1.1",
+ "bitcoin-io 0.1.101",
  "hex-conservative 0.2.2",
+ "serde",
 ]
 
 [[package]]
@@ -300,7 +318,7 @@ name = "bitcoin_hashes"
 version = "1.0.0"
 dependencies = [
  "arbitrary",
- "bitcoin-consensus-encoding",
+ "bitcoin-consensus-encoding 1.0.0",
  "bitcoin-internals 0.5.0",
  "cpufeatures",
  "hex-conservative 1.1.0",
@@ -370,10 +388,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a581f551b77eb3e177584e922a8c057e14311a857f859fd39d9574d97d3547da"
+
+[[package]]
 name = "hex-conservative"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "hex-conservative"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4afe881d0527571892c4034822e59bb10c6c991cce6abe8199b6f5cf10766f55"
 dependencies = [
  "arrayvec",
 ]
@@ -484,6 +517,7 @@ checksum = "0e0cc0f1cf93f4969faf3ea1c7d8a9faed25918d96affa959720823dfe86d4f3"
 dependencies = [
  "bitcoin_hashes 0.12.0",
  "secp256k1-sys 0.10.0",
+ "serde",
 ]
 
 [[package]]
@@ -523,6 +557,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45cd6d95391b16cd57e88b68be41d504183b7faae22030c0cc3b3f73dd57b2fd"
+dependencies = [
+ "byteorder",
+ "half",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -16,12 +16,11 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "base58ck"
-version = "0.1.0"
+version = "0.1.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
+checksum = "365c0acd5b2e8dd0111a46c4faea83fb3cfb6e39a49a7c73a06e090db7b2eff0"
 dependencies = [
- "bitcoin-internals 0.3.0",
- "bitcoin_hashes 0.14.1",
+ "bitcoin_hashes 0.14.101",
 ]
 
 [[package]]
@@ -56,19 +55,20 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.9"
+version = "0.32.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf93e61f2dbc3e3c41234ca26a65e2c0b0975c52e0f069ab9893ebbede584d3"
+checksum = "8ed8ccb78a9ff7a6fbb90e2fb9b8588b4a9928d49d8af3cb789108a84ea6b0ce"
 dependencies = [
- "base58ck 0.1.0",
+ "base58ck 0.1.101",
  "bech32",
- "bitcoin-internals 0.3.0",
- "bitcoin-io 0.1.4",
- "bitcoin-units 0.1.3",
- "bitcoin_hashes 0.14.1",
+ "bitcoin-consensus-encoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin-io 0.1.101",
+ "bitcoin-units 0.1.101",
+ "bitcoin_hashes 0.14.101",
  "hex-conservative 0.2.2",
  "hex_lit",
  "secp256k1 0.29.1",
+ "serde",
 ]
 
 [[package]]
@@ -80,7 +80,7 @@ dependencies = [
  "base64",
  "bech32",
  "bincode",
- "bitcoin-consensus-encoding",
+ "bitcoin-consensus-encoding 1.0.0",
  "bitcoin-crypto",
  "bitcoin-internals 0.5.0",
  "bitcoin-io 0.5.0",
@@ -117,6 +117,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin-consensus-encoding"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2d6094e2a1ba3c93b5a596fe5a10d1a10c3c6e06785cde89f693a044c01aa40"
+dependencies = [
+ "bitcoin-internals 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bitcoin-crypto"
 version = "0.2.0"
 dependencies = [
@@ -137,21 +146,16 @@ name = "bitcoin-fuzz"
 version = "0.0.1"
 dependencies = [
  "arbitrary",
- "bitcoin 0.32.9",
+ "bitcoin 0.32.101",
  "bitcoin 0.33.0-beta",
- "bitcoin-consensus-encoding",
+ "bitcoin-consensus-encoding 1.0.0",
  "bitcoin-p2p-messages",
  "libfuzzer-sys",
  "serde",
+ "serde_cbor",
  "serde_json",
  "standard_test",
 ]
-
-[[package]]
-name = "bitcoin-internals"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
 
 [[package]]
 name = "bitcoin-internals"
@@ -164,16 +168,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitcoin-io"
-version = "0.1.4"
+name = "bitcoin-internals"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
+checksum = "a30a22d1f112dde8e16be7b45c63645dc165cef254f835b3e1e9553e485cfa64"
+dependencies = [
+ "hex-conservative 0.3.2",
+]
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb5de036369d1ac59d3c1819ebc4d850f89466f5401c571a285b6ed564a4cb78"
+dependencies = [
+ "bitcoin-consensus-encoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "bitcoin-io"
 version = "0.5.0"
 dependencies = [
- "bitcoin-consensus-encoding",
+ "bitcoin-consensus-encoding 1.0.0",
  "bitcoin-internals 0.5.0",
  "bitcoin_hashes 1.0.0",
 ]
@@ -211,7 +227,7 @@ name = "bitcoin-p2p-messages"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "bitcoin-consensus-encoding",
+ "bitcoin-consensus-encoding 1.0.0",
  "bitcoin-internals 0.5.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
@@ -227,7 +243,7 @@ version = "0.102.0"
 dependencies = [
  "arbitrary",
  "bincode",
- "bitcoin-consensus-encoding",
+ "bitcoin-consensus-encoding 1.0.0",
  "bitcoin-internals 0.5.0",
  "bitcoin-units 0.5.0",
  "bitcoin_hashes 1.0.0",
@@ -249,11 +265,12 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-units"
-version = "0.1.3"
+version = "0.1.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346568ebaab2918487cea76dd55dae13c27bb618cdb737c952e69eb2017c4118"
+checksum = "9cb95693f371d089a4b5b6fc41c6f3ea6e01ee8c15388335dfac8ea685173b51"
 dependencies = [
- "bitcoin-internals 0.3.0",
+ "bitcoin-consensus-encoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
 ]
 
 [[package]]
@@ -262,7 +279,7 @@ version = "0.5.0"
 dependencies = [
  "arbitrary",
  "bincode",
- "bitcoin-consensus-encoding",
+ "bitcoin-consensus-encoding 1.0.0",
  "bitcoin-internals 0.5.0",
  "serde",
  "serde_json",
@@ -271,12 +288,13 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.1"
+version = "0.14.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
+checksum = "bca4c7abb40c8817d77403c880988cfd484f23ab2365726afb2f798363e2c4a2"
 dependencies = [
- "bitcoin-io 0.1.4",
+ "bitcoin-io 0.1.101",
  "hex-conservative 0.2.2",
+ "serde",
 ]
 
 [[package]]
@@ -284,7 +302,7 @@ name = "bitcoin_hashes"
 version = "1.0.0"
 dependencies = [
  "arbitrary",
- "bitcoin-consensus-encoding",
+ "bitcoin-consensus-encoding 1.0.0",
  "bitcoin-internals 0.5.0",
  "cpufeatures",
  "hex-conservative 1.1.0",
@@ -353,10 +371,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
+
+[[package]]
 name = "hex-conservative"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "hex-conservative"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830e599c2904b08f0834ee6337d8fe8f0ed4a63b5d9e7a7f49c0ffa06d08d360"
 dependencies = [
  "arrayvec",
 ]
@@ -487,8 +520,9 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "bitcoin_hashes 0.14.1",
+ "bitcoin_hashes 0.14.101",
  "secp256k1-sys 0.10.1",
+ "serde",
 ]
 
 [[package]]
@@ -528,6 +562,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45cd6d95391b16cd57e88b68be41d504183b7faae22030c0cc3b3f73dd57b2fd"
+dependencies = [
+ "byteorder",
+ "half",
+ "serde",
 ]
 
 [[package]]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,7 +13,7 @@ cargo-fuzz = true
 # We shouldn't need an explicit version on the next line, but Andrew's tools
 # choke on it otherwise. See https://github.com/nix-community/crate2nix/issues/373
 bitcoin = { path = "../bitcoin", version = "0.33.0-beta", features = [ "serde", "arbitrary" ] }
-old_bitcoin = { version = "0.32.9", package = "bitcoin" }
+old_bitcoin = { version = "0.32.101", package = "bitcoin", features = [ "encoding", "serde" ] }
 bitcoin_consensus_encoding = { path = "../consensus_encoding", package = "bitcoin-consensus-encoding" }
 p2p = { path = "../p2p", package = "bitcoin-p2p-messages", features = ["arbitrary"] }
 
@@ -21,6 +21,7 @@ arbitrary = { version = "1.4.1" }
 libfuzzer-sys = { version = "0.4.0" }
 serde = { version = "1.0.195", features = [ "derive" ] }
 serde_json = "1.0.68"
+serde_cbor = "0.9"
 standard_test = "0.1.0"
 
 [lints.rust]
@@ -39,7 +40,7 @@ allowed_duplicates = [
     "hex-conservative",
     "bitcoin_hashes",
     "bitcoin-io",
-    "hex-conservative",
+    "bitcoin-consensus-encoding",
     "base58ck",
     "bitcoin",
     "bitcoin-internals",
@@ -350,6 +351,13 @@ doc = false
 bench = false
 
 [[bin]]
+name = "bitcoin_encoding_roundtrip_p2p_message_erlay_send_tx_rcn_cl"
+path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_erlay_send_tx_rcn_cl.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_message_fee_filter"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_fee_filter.rs"
 test = false
@@ -623,6 +631,41 @@ doc = false
 bench = false
 
 [[bin]]
+name = "bitcoin_0_32_compare_consensus_encoding"
+path = "fuzz_targets/bitcoin_0_32/compare_consensus_encoding.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "bitcoin_0_32_deser_net_msg"
+path = "fuzz_targets/bitcoin_0_32/deser_net_msg.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "bitcoin_0_32_deserialize_address"
+path = "fuzz_targets/bitcoin_0_32/deserialize_address.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "bitcoin_0_32_deserialize_psbt"
+path = "fuzz_targets/bitcoin_0_32/deserialize_psbt.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "bitcoin_0_32_outpoint_string"
+path = "fuzz_targets/bitcoin_0_32/outpoint_string.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
 name = "consensus_encoding_decode_array"
 path = "fuzz_targets/consensus_encoding/decode_array.rs"
 test = false
@@ -700,6 +743,13 @@ doc = false
 bench = false
 
 [[bin]]
+name = "hashes_0_32_cbor"
+path = "fuzz_targets/hashes_0_32/cbor.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
 name = "p2p_arbitrary_addrv2"
 path = "fuzz_targets/p2p/arbitrary_addrv2.rs"
 test = false
@@ -744,6 +794,13 @@ bench = false
 [[bin]]
 name = "units_standard_checks"
 path = "fuzz_targets/units/standard_checks.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "units_0_32_deserialize_amount"
+path = "fuzz_targets/units_0_32/deserialize_amount.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,7 +13,7 @@ cargo-fuzz = true
 # We shouldn't need an explicit version on the next line, but Andrew's tools
 # choke on it otherwise. See https://github.com/nix-community/crate2nix/issues/373
 bitcoin = { path = "../bitcoin", version = "0.33.0-beta", features = [ "serde", "arbitrary" ] }
-old_bitcoin = { version = "0.32.101", package = "bitcoin", features = [ "encoding", "serde" ] }
+bitcoin_0_32 = { version = "0.32.101", package = "bitcoin", features = [ "encoding", "serde" ] }
 bitcoin_consensus_encoding = { path = "../consensus_encoding", package = "bitcoin-consensus-encoding" }
 p2p = { path = "../p2p", package = "bitcoin-p2p-messages", features = ["arbitrary"] }
 

--- a/fuzz/fuzz_targets/bitcoin/compare_consensus_encoding.rs
+++ b/fuzz/fuzz_targets/bitcoin/compare_consensus_encoding.rs
@@ -71,19 +71,19 @@ fn is_known_decoder_divergence(err: &(dyn std::error::Error + 'static)) -> bool 
 macro_rules! compare_encoding {
     // Simple path for top-level types
     ($data:expr, $ty:ident) => {
-        compare_encoding!($data, bitcoin::$ty, old_bitcoin::$ty);
+        compare_encoding!($data, bitcoin::$ty, bitcoin_0_32::$ty);
     };
 
     // Types in submodules need this because we can't easily concatenate crate prefixes.
     ($data:expr, $new_ty:ty, $old_ty:ty) => {{
         // Try to deserialise using both bitcoin crates. Skip if it can't be deserialised
-        let old_result: Result<$old_ty, _> = old_bitcoin::consensus::encode::deserialize($data);
+        let old_result: Result<$old_ty, _> = bitcoin_0_32::consensus::encode::deserialize($data);
         let new_result: Result<$new_ty, _> = decode_from_slice($data);
 
         match (old_result, new_result) {
             (Ok(old_obj), Ok(new_obj)) => {
                 // Encode with old bitcoin and then compare against new encoding
-                let old_encoded = old_bitcoin::consensus::encode::serialize(&old_obj);
+                let old_encoded = bitcoin_0_32::consensus::encode::serialize(&old_obj);
                 // Uncomment the following two lines if you need to see the difference
                 // in serialisation.
                 // let new_encoded = bitcoin_consensus_encoding::encode_to_vec(&new_obj);
@@ -169,49 +169,49 @@ fn do_test(data: &[u8]) {
     compare_encoding!(data, TxMerkleNode);
     compare_encoding!(data, WitnessMerkleNode);
 
-    compare_encoding!(data, bitcoin::block::Header, old_bitcoin::block::Header);
-    compare_encoding!(data, bitcoin::absolute::LockTime, old_bitcoin::absolute::LockTime);
-    compare_encoding!(data, bitcoin::block::Version, old_bitcoin::block::Version);
-    compare_encoding!(data, bitcoin::transaction::Version, old_bitcoin::transaction::Version);
+    compare_encoding!(data, bitcoin::block::Header, bitcoin_0_32::block::Header);
+    compare_encoding!(data, bitcoin::absolute::LockTime, bitcoin_0_32::absolute::LockTime);
+    compare_encoding!(data, bitcoin::block::Version, bitcoin_0_32::block::Version);
+    compare_encoding!(data, bitcoin::transaction::Version, bitcoin_0_32::transaction::Version);
 
     // P2P types
-    compare_encoding!(data, p2p::ServiceFlags, old_bitcoin::p2p::ServiceFlags);
-    compare_encoding!(data, p2p::Magic, old_bitcoin::p2p::Magic);
-    compare_encoding!(data, p2p::address::Address, old_bitcoin::p2p::address::Address);
-    compare_encoding!(data, p2p::bip152::BlockTransactions, old_bitcoin::bip152::BlockTransactions);
-    compare_encoding!(data, p2p::bip152::BlockTransactionsRequest, old_bitcoin::bip152::BlockTransactionsRequest);
-    compare_encoding!(data, p2p::bip152::HeaderAndShortIds, old_bitcoin::bip152::HeaderAndShortIds);
-    compare_encoding!(data, p2p::bip152::PrefilledTransaction, old_bitcoin::bip152::PrefilledTransaction);
-    compare_encoding!(data, p2p::bip152::ShortId, old_bitcoin::bip152::ShortId);
-    compare_encoding!(data, p2p::merkle_tree::MerkleBlock, old_bitcoin::MerkleBlock);
-    compare_encoding!(data, p2p::merkle_tree::PartialMerkleTree, old_bitcoin::merkle_tree::PartialMerkleTree);
-    compare_encoding!(data, p2p::message_blockdata::GetBlocksMessage, old_bitcoin::p2p::message_blockdata::GetBlocksMessage);
-    compare_encoding!(data, p2p::message_blockdata::GetHeadersMessage, old_bitcoin::p2p::message_blockdata::GetHeadersMessage);
-    compare_encoding!(data, p2p::message_bloom::FilterAdd, old_bitcoin::p2p::message_bloom::FilterAdd);
-    compare_encoding!(data, p2p::message_bloom::FilterLoad, old_bitcoin::p2p::message_bloom::FilterLoad);
-    compare_encoding!(data, p2p::message_bloom::BloomFlags, old_bitcoin::p2p::message_bloom::BloomFlags);
-    compare_encoding!(data, p2p::message_compact_blocks::SendCmpct, old_bitcoin::p2p::message_compact_blocks::SendCmpct);
-    compare_encoding!(data, p2p::message_filter::CFHeaders, old_bitcoin::p2p::message_filter::CFHeaders);
-    compare_encoding!(data, p2p::message_filter::CFilter, old_bitcoin::p2p::message_filter::CFilter);
-    compare_encoding!(data, p2p::message_filter::CFCheckpt, old_bitcoin::p2p::message_filter::CFCheckpt);
-    compare_encoding!(data, p2p::message_filter::GetCFCheckpt, old_bitcoin::p2p::message_filter::GetCFCheckpt);
-    compare_encoding!(data, p2p::message_filter::GetCFHeaders, old_bitcoin::p2p::message_filter::GetCFHeaders);
-    compare_encoding!(data, p2p::message_filter::GetCFilters, old_bitcoin::p2p::message_filter::GetCFilters);
-    compare_encoding!(data, p2p::message_filter::FilterHash, old_bitcoin::bip158::FilterHash);
-    compare_encoding!(data, p2p::message_filter::FilterHeader, old_bitcoin::bip158::FilterHeader);
-    compare_encoding!(data, p2p::message_network::Reject, old_bitcoin::p2p::message_network::Reject);
-    compare_encoding!(data, p2p::message_network::RejectReason, old_bitcoin::p2p::message_network::RejectReason);
-    compare_encoding!(data, p2p::message_network::VersionMessage, old_bitcoin::p2p::message_network::VersionMessage);
+    compare_encoding!(data, p2p::ServiceFlags, bitcoin_0_32::p2p::ServiceFlags);
+    compare_encoding!(data, p2p::Magic, bitcoin_0_32::p2p::Magic);
+    compare_encoding!(data, p2p::address::Address, bitcoin_0_32::p2p::address::Address);
+    compare_encoding!(data, p2p::bip152::BlockTransactions, bitcoin_0_32::bip152::BlockTransactions);
+    compare_encoding!(data, p2p::bip152::BlockTransactionsRequest, bitcoin_0_32::bip152::BlockTransactionsRequest);
+    compare_encoding!(data, p2p::bip152::HeaderAndShortIds, bitcoin_0_32::bip152::HeaderAndShortIds);
+    compare_encoding!(data, p2p::bip152::PrefilledTransaction, bitcoin_0_32::bip152::PrefilledTransaction);
+    compare_encoding!(data, p2p::bip152::ShortId, bitcoin_0_32::bip152::ShortId);
+    compare_encoding!(data, p2p::merkle_tree::MerkleBlock, bitcoin_0_32::MerkleBlock);
+    compare_encoding!(data, p2p::merkle_tree::PartialMerkleTree, bitcoin_0_32::merkle_tree::PartialMerkleTree);
+    compare_encoding!(data, p2p::message_blockdata::GetBlocksMessage, bitcoin_0_32::p2p::message_blockdata::GetBlocksMessage);
+    compare_encoding!(data, p2p::message_blockdata::GetHeadersMessage, bitcoin_0_32::p2p::message_blockdata::GetHeadersMessage);
+    compare_encoding!(data, p2p::message_bloom::FilterAdd, bitcoin_0_32::p2p::message_bloom::FilterAdd);
+    compare_encoding!(data, p2p::message_bloom::FilterLoad, bitcoin_0_32::p2p::message_bloom::FilterLoad);
+    compare_encoding!(data, p2p::message_bloom::BloomFlags, bitcoin_0_32::p2p::message_bloom::BloomFlags);
+    compare_encoding!(data, p2p::message_compact_blocks::SendCmpct, bitcoin_0_32::p2p::message_compact_blocks::SendCmpct);
+    compare_encoding!(data, p2p::message_filter::CFHeaders, bitcoin_0_32::p2p::message_filter::CFHeaders);
+    compare_encoding!(data, p2p::message_filter::CFilter, bitcoin_0_32::p2p::message_filter::CFilter);
+    compare_encoding!(data, p2p::message_filter::CFCheckpt, bitcoin_0_32::p2p::message_filter::CFCheckpt);
+    compare_encoding!(data, p2p::message_filter::GetCFCheckpt, bitcoin_0_32::p2p::message_filter::GetCFCheckpt);
+    compare_encoding!(data, p2p::message_filter::GetCFHeaders, bitcoin_0_32::p2p::message_filter::GetCFHeaders);
+    compare_encoding!(data, p2p::message_filter::GetCFilters, bitcoin_0_32::p2p::message_filter::GetCFilters);
+    compare_encoding!(data, p2p::message_filter::FilterHash, bitcoin_0_32::bip158::FilterHash);
+    compare_encoding!(data, p2p::message_filter::FilterHeader, bitcoin_0_32::bip158::FilterHeader);
+    compare_encoding!(data, p2p::message_network::Reject, bitcoin_0_32::p2p::message_network::Reject);
+    compare_encoding!(data, p2p::message_network::RejectReason, bitcoin_0_32::p2p::message_network::RejectReason);
+    compare_encoding!(data, p2p::message_network::VersionMessage, bitcoin_0_32::p2p::message_network::VersionMessage);
 
     // Types that only exist in new bitcoin, but can encode the same as some known type
     compare_encoding!(data, p2p::ProtocolVersion, u32);
-    compare_encoding!(data, p2p::address::AddrV1Message, (u32, old_bitcoin::p2p::Address));
-    compare_encoding!(data, p2p::message::AddrPayload, Vec<(u32, old_bitcoin::p2p::Address)>);
-    compare_encoding!(data, p2p::message::NetworkHeader, (old_bitcoin::block::Header, u8));
+    compare_encoding!(data, p2p::address::AddrV1Message, (u32, bitcoin_0_32::p2p::Address));
+    compare_encoding!(data, p2p::message::AddrPayload, Vec<(u32, bitcoin_0_32::p2p::Address)>);
+    compare_encoding!(data, p2p::message::NetworkHeader, (bitcoin_0_32::block::Header, u8));
     compare_encoding!(data, p2p::message::Ping, u64);
     compare_encoding!(data, p2p::message::Pong, u64);
-    compare_encoding!(data, p2p::message::V1NetworkMessage, old_bitcoin::p2p::message::RawNetworkMessage);
-    compare_encoding!(data, p2p::message_blockdata::BlockLocator, Vec<old_bitcoin::BlockHash>);
+    compare_encoding!(data, p2p::message::V1NetworkMessage, bitcoin_0_32::p2p::message::RawNetworkMessage);
+    compare_encoding!(data, p2p::message_blockdata::BlockLocator, Vec<bitcoin_0_32::BlockHash>);
     compare_encoding!(data, p2p::message_network::Alert, Vec<u8>);
     compare_encoding!(data, p2p::message_network::UserAgent, String);
     compare_encoding!(data, bitcoin::BlockHeight, u32);
@@ -222,18 +222,18 @@ fn do_test(data: &[u8]) {
     // ServiceFlags > 0x0200_0000 are not supported by the old decoder.
     // Skip inputs that would trigger either known divergence.
     if data.first() != Some(&0x03) {
-        compare_encoding!(data, p2p::address::AddrV2, old_bitcoin::p2p::address::AddrV2);
+        compare_encoding!(data, p2p::address::AddrV2, bitcoin_0_32::p2p::address::AddrV2);
     }
     if !addrv2_message_should_skip(data) {
-        compare_encoding!(data, p2p::address::AddrV2Message, old_bitcoin::p2p::address::AddrV2Message);
+        compare_encoding!(data, p2p::address::AddrV2Message, bitcoin_0_32::p2p::address::AddrV2Message);
     }
     if !addrv2_payload_should_skip(data) {
-        compare_encoding!(data, p2p::message::AddrV2Payload, Vec<old_bitcoin::p2p::address::AddrV2Message>);
+        compare_encoding!(data, p2p::message::AddrV2Payload, Vec<bitcoin_0_32::p2p::address::AddrV2Message>);
     }
     // Inventory::Error (type_id=0) encodes differently between old/new bitcoin: old omits the
     // 32-byte hash field, new includes it. Skip inputs that would decode as the Error variant.
     if data.get(..4) != Some(&[0u8; 4]) {
-        compare_encoding!(data, p2p::message_blockdata::Inventory, old_bitcoin::p2p::message_blockdata::Inventory);
+        compare_encoding!(data, p2p::message_blockdata::Inventory, bitcoin_0_32::p2p::message_blockdata::Inventory);
     }
 }
 

--- a/fuzz/fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_erlay_send_tx_rcn_cl.rs
+++ b/fuzz/fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_erlay_send_tx_rcn_cl.rs
@@ -1,0 +1,12 @@
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use bitcoin_fuzz::check_roundtrip;
+use libfuzzer_sys::fuzz_target;
+
+#[cfg(not(fuzzing))]
+fn main() {}
+
+fuzz_target!(|data: &[u8]| {
+    check_roundtrip::<p2p::message_erlay::SendTxRcnCl>(data);
+});

--- a/fuzz/fuzz_targets/bitcoin_0_32/compare_consensus_encoding.rs
+++ b/fuzz/fuzz_targets/bitcoin_0_32/compare_consensus_encoding.rs
@@ -2,17 +2,17 @@
 #![cfg_attr(not(fuzzing), allow(unused))]
 
 use libfuzzer_sys::fuzz_target;
-use old_bitcoin::absolute;
-use old_bitcoin::consensus::encode::deserialize_partial;
-use old_bitcoin::consensus::serialize;
-use old_bitcoin::encoding::{self, decode_from_slice_unbounded};
+use bitcoin_0_32::absolute;
+use bitcoin_0_32::consensus::encode::deserialize_partial;
+use bitcoin_0_32::consensus::serialize;
+use bitcoin_0_32::encoding::{self, decode_from_slice_unbounded};
 
 #[cfg(not(fuzzing))]
 fn main() {}
 
 macro_rules! compare_encoding {
     ($data:expr, $ty:ident) => {
-        compare_encoding!($data, old_bitcoin::$ty);
+        compare_encoding!($data, bitcoin_0_32::$ty);
     };
 
     ($data:expr, $ty:ty) => {{

--- a/fuzz/fuzz_targets/bitcoin_0_32/compare_consensus_encoding.rs
+++ b/fuzz/fuzz_targets/bitcoin_0_32/compare_consensus_encoding.rs
@@ -1,0 +1,63 @@
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use libfuzzer_sys::fuzz_target;
+use old_bitcoin::absolute;
+use old_bitcoin::consensus::encode::deserialize_partial;
+use old_bitcoin::consensus::serialize;
+use old_bitcoin::encoding::{self, decode_from_slice_unbounded};
+
+#[cfg(not(fuzzing))]
+fn main() {}
+
+macro_rules! compare_encoding {
+    ($data:expr, $ty:ident) => {
+        compare_encoding!($data, old_bitcoin::$ty);
+    };
+
+    ($data:expr, $ty:ty) => {{
+        // Use partial/unbounded decoding so the fuzzer can exercise the actual parsing
+        // logic even when the input is longer than the encoded type. Using strict
+        // deserialize() would reject any input with trailing bytes, reducing coverage.
+        let old_result = deserialize_partial::<$ty>($data);
+        let mut rem = &*$data;
+        let new_result: Result<$ty, _> = decode_from_slice_unbounded(&mut rem);
+
+        match (old_result, new_result) {
+            (Ok((old_obj, old_consumed)), Ok(new_obj)) => {
+                assert_eq!(old_obj, new_obj);
+                let new_consumed = $data.len() - rem.len();
+                assert_eq!(
+                    old_consumed, new_consumed,
+                    "decoders consumed different number of bytes: legacy={old_consumed}, new={new_consumed}"
+                );
+                let old_encoded = serialize(&old_obj);
+                let new_encoded = encoding::encode_to_vec(&new_obj);
+                assert_eq!(old_encoded, new_encoded);
+            }
+            (Err(_), Err(_)) => {}
+            (Ok((old_obj, _)), Err(err)) => {
+                panic!("legacy decoder accepted {old_obj:?}, new decoder failed: {err:?}");
+            }
+            (Err(err), Ok(new_obj)) => {
+                panic!("new decoder accepted {new_obj:?}, legacy decoder failed: {err:?}");
+            }
+        }
+    }};
+}
+
+fn do_test(data: &[u8]) {
+    // Split data evenly so the fuzzer can independently explore each type's input space.
+    // Each type gets its own non-overlapping sub-slice; `Amount` needs 8 bytes (u64 LE),
+    // the rest need 4 bytes (u32 LE). Trailing bytes in each slice are tolerated by the
+    // partial/unbounded decoders used in `compare_encoding!`.
+    let n = data.len() / 4;
+    compare_encoding!(&data[..n], Amount);
+    compare_encoding!(&data[n..2 * n], Sequence);
+    compare_encoding!(&data[2 * n..3 * n], CompactTarget);
+    compare_encoding!(&data[3 * n..4 * n], absolute::LockTime);
+}
+
+fuzz_target!(|data: &[u8]| {
+    do_test(data);
+});

--- a/fuzz/fuzz_targets/bitcoin_0_32/deser_net_msg.rs
+++ b/fuzz/fuzz_targets/bitcoin_0_32/deser_net_msg.rs
@@ -7,8 +7,8 @@ use libfuzzer_sys::fuzz_target;
 fn main() {}
 
 fn do_test(data: &[u8]) {
-    let _: Result<old_bitcoin::p2p::message::RawNetworkMessage, _> =
-        old_bitcoin::consensus::encode::deserialize(data);
+    let _: Result<bitcoin_0_32::p2p::message::RawNetworkMessage, _> =
+        bitcoin_0_32::consensus::encode::deserialize(data);
 }
 
 fuzz_target!(|data: &[u8]| {

--- a/fuzz/fuzz_targets/bitcoin_0_32/deser_net_msg.rs
+++ b/fuzz/fuzz_targets/bitcoin_0_32/deser_net_msg.rs
@@ -1,0 +1,16 @@
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use libfuzzer_sys::fuzz_target;
+
+#[cfg(not(fuzzing))]
+fn main() {}
+
+fn do_test(data: &[u8]) {
+    let _: Result<old_bitcoin::p2p::message::RawNetworkMessage, _> =
+        old_bitcoin::consensus::encode::deserialize(data);
+}
+
+fuzz_target!(|data: &[u8]| {
+    do_test(data);
+});

--- a/fuzz/fuzz_targets/bitcoin_0_32/deserialize_address.rs
+++ b/fuzz/fuzz_targets/bitcoin_0_32/deserialize_address.rs
@@ -8,7 +8,7 @@ fn main() {}
 
 fn do_test(data: &[u8]) {
     let data_str = String::from_utf8_lossy(data);
-    let addr = match data_str.parse::<old_bitcoin::address::Address<_>>() {
+    let addr = match data_str.parse::<bitcoin_0_32::address::Address<_>>() {
         Ok(addr) => addr.assume_checked(),
         Err(_) => return,
     };

--- a/fuzz/fuzz_targets/bitcoin_0_32/deserialize_address.rs
+++ b/fuzz/fuzz_targets/bitcoin_0_32/deserialize_address.rs
@@ -1,0 +1,20 @@
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use libfuzzer_sys::fuzz_target;
+
+#[cfg(not(fuzzing))]
+fn main() {}
+
+fn do_test(data: &[u8]) {
+    let data_str = String::from_utf8_lossy(data);
+    let addr = match data_str.parse::<old_bitcoin::address::Address<_>>() {
+        Ok(addr) => addr.assume_checked(),
+        Err(_) => return,
+    };
+    assert_eq!(addr.to_string(), data_str);
+}
+
+fuzz_target!(|data: &[u8]| {
+    do_test(data);
+});

--- a/fuzz/fuzz_targets/bitcoin_0_32/deserialize_psbt.rs
+++ b/fuzz/fuzz_targets/bitcoin_0_32/deserialize_psbt.rs
@@ -7,14 +7,14 @@ use libfuzzer_sys::fuzz_target;
 fn main() {}
 
 fn do_test(data: &[u8]) {
-    let psbt: Result<old_bitcoin::psbt::Psbt, _> = old_bitcoin::psbt::Psbt::deserialize(data);
+    let psbt: Result<bitcoin_0_32::psbt::Psbt, _> = bitcoin_0_32::psbt::Psbt::deserialize(data);
     match psbt {
         Err(_) => {}
         Ok(psbt) => {
-            let ser = old_bitcoin::psbt::Psbt::serialize(&psbt);
-            let deser = old_bitcoin::psbt::Psbt::deserialize(&ser).unwrap();
+            let ser = bitcoin_0_32::psbt::Psbt::serialize(&psbt);
+            let deser = bitcoin_0_32::psbt::Psbt::deserialize(&ser).unwrap();
             // Since the fuzz data could order psbt fields differently, we compare to our deser/ser instead of data
-            assert_eq!(ser, old_bitcoin::psbt::Psbt::serialize(&deser));
+            assert_eq!(ser, bitcoin_0_32::psbt::Psbt::serialize(&deser));
         }
     }
 }

--- a/fuzz/fuzz_targets/bitcoin_0_32/deserialize_psbt.rs
+++ b/fuzz/fuzz_targets/bitcoin_0_32/deserialize_psbt.rs
@@ -1,0 +1,24 @@
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use libfuzzer_sys::fuzz_target;
+
+#[cfg(not(fuzzing))]
+fn main() {}
+
+fn do_test(data: &[u8]) {
+    let psbt: Result<old_bitcoin::psbt::Psbt, _> = old_bitcoin::psbt::Psbt::deserialize(data);
+    match psbt {
+        Err(_) => {}
+        Ok(psbt) => {
+            let ser = old_bitcoin::psbt::Psbt::serialize(&psbt);
+            let deser = old_bitcoin::psbt::Psbt::deserialize(&ser).unwrap();
+            // Since the fuzz data could order psbt fields differently, we compare to our deser/ser instead of data
+            assert_eq!(ser, old_bitcoin::psbt::Psbt::serialize(&deser));
+        }
+    }
+}
+
+fuzz_target!(|data: &[u8]| {
+    do_test(data);
+});

--- a/fuzz/fuzz_targets/bitcoin_0_32/outpoint_string.rs
+++ b/fuzz/fuzz_targets/bitcoin_0_32/outpoint_string.rs
@@ -23,19 +23,19 @@ fn do_test(data: &[u8]) {
         Err(_) => return,
         Ok(s) => s,
     };
-    match data_str.parse::<old_bitcoin::blockdata::transaction::OutPoint>() {
+    match data_str.parse::<bitcoin_0_32::blockdata::transaction::OutPoint>() {
         Ok(op) => {
             assert_eq!(op.to_string().as_bytes(), data_str.as_bytes());
         }
         Err(_) => {
             // If we can't deserialize as a string, try consensus deserializing
-            let res: Result<old_bitcoin::blockdata::transaction::OutPoint, _> =
-                old_bitcoin::consensus::encode::deserialize(data);
+            let res: Result<bitcoin_0_32::blockdata::transaction::OutPoint, _> =
+                bitcoin_0_32::consensus::encode::deserialize(data);
             if let Ok(deser) = res {
-                let ser = old_bitcoin::consensus::encode::serialize(&deser);
+                let ser = bitcoin_0_32::consensus::encode::serialize(&deser);
                 assert_eq!(ser, data);
                 let string = deser.to_string();
-                match string.parse::<old_bitcoin::blockdata::transaction::OutPoint>() {
+                match string.parse::<bitcoin_0_32::blockdata::transaction::OutPoint>() {
                     Ok(destring) => assert_eq!(destring, deser),
                     Err(_) => panic!(),
                 }

--- a/fuzz/fuzz_targets/bitcoin_0_32/outpoint_string.rs
+++ b/fuzz/fuzz_targets/bitcoin_0_32/outpoint_string.rs
@@ -1,0 +1,49 @@
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use libfuzzer_sys::fuzz_target;
+
+#[cfg(not(fuzzing))]
+fn main() {}
+
+fn do_test(data: &[u8]) {
+    let lowercase: Vec<u8> = data
+        .iter()
+        .map(|c| match *c {
+            b'A' => b'a',
+            b'B' => b'b',
+            b'C' => b'c',
+            b'D' => b'd',
+            b'E' => b'e',
+            b'F' => b'f',
+            x => x,
+        })
+        .collect();
+    let data_str = match String::from_utf8(lowercase) {
+        Err(_) => return,
+        Ok(s) => s,
+    };
+    match data_str.parse::<old_bitcoin::blockdata::transaction::OutPoint>() {
+        Ok(op) => {
+            assert_eq!(op.to_string().as_bytes(), data_str.as_bytes());
+        }
+        Err(_) => {
+            // If we can't deserialize as a string, try consensus deserializing
+            let res: Result<old_bitcoin::blockdata::transaction::OutPoint, _> =
+                old_bitcoin::consensus::encode::deserialize(data);
+            if let Ok(deser) = res {
+                let ser = old_bitcoin::consensus::encode::serialize(&deser);
+                assert_eq!(ser, data);
+                let string = deser.to_string();
+                match string.parse::<old_bitcoin::blockdata::transaction::OutPoint>() {
+                    Ok(destring) => assert_eq!(destring, deser),
+                    Err(_) => panic!(),
+                }
+            }
+        }
+    }
+}
+
+fuzz_target!(|data: &[u8]| {
+    do_test(data);
+});

--- a/fuzz/fuzz_targets/hashes_0_32/cbor.rs
+++ b/fuzz/fuzz_targets/hashes_0_32/cbor.rs
@@ -1,0 +1,32 @@
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use libfuzzer_sys::fuzz_target;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize)]
+struct Hmacs {
+    sha1: old_bitcoin::hashes::hmac::Hmac<old_bitcoin::hashes::sha1::Hash>,
+    sha512: old_bitcoin::hashes::hmac::Hmac<old_bitcoin::hashes::sha512::Hash>,
+}
+
+#[derive(Deserialize, Serialize)]
+struct Main {
+    hmacs: Hmacs,
+    ripemd: old_bitcoin::hashes::ripemd160::Hash,
+    sha2d: old_bitcoin::hashes::sha256d::Hash,
+}
+
+#[cfg(not(fuzzing))]
+fn main() {}
+
+fn do_test(data: &[u8]) {
+    if let Ok(m) = serde_cbor::from_slice::<Main>(data) {
+        let vec = serde_cbor::to_vec(&m).unwrap();
+        assert_eq!(data, &vec[..]);
+    }
+}
+
+fuzz_target!(|data: &[u8]| {
+    do_test(data);
+});

--- a/fuzz/fuzz_targets/hashes_0_32/cbor.rs
+++ b/fuzz/fuzz_targets/hashes_0_32/cbor.rs
@@ -6,15 +6,15 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize)]
 struct Hmacs {
-    sha1: old_bitcoin::hashes::hmac::Hmac<old_bitcoin::hashes::sha1::Hash>,
-    sha512: old_bitcoin::hashes::hmac::Hmac<old_bitcoin::hashes::sha512::Hash>,
+    sha1: bitcoin_0_32::hashes::hmac::Hmac<bitcoin_0_32::hashes::sha1::Hash>,
+    sha512: bitcoin_0_32::hashes::hmac::Hmac<bitcoin_0_32::hashes::sha512::Hash>,
 }
 
 #[derive(Deserialize, Serialize)]
 struct Main {
     hmacs: Hmacs,
-    ripemd: old_bitcoin::hashes::ripemd160::Hash,
-    sha2d: old_bitcoin::hashes::sha256d::Hash,
+    ripemd: bitcoin_0_32::hashes::ripemd160::Hash,
+    sha2d: bitcoin_0_32::hashes::sha256d::Hash,
 }
 
 #[cfg(not(fuzzing))]

--- a/fuzz/fuzz_targets/units_0_32/deserialize_amount.rs
+++ b/fuzz/fuzz_targets/units_0_32/deserialize_amount.rs
@@ -1,0 +1,38 @@
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use libfuzzer_sys::fuzz_target;
+use std::str::FromStr;
+
+#[cfg(not(fuzzing))]
+fn main() {}
+
+fn do_test(data: &[u8]) {
+    let data_str = String::from_utf8_lossy(data);
+
+    // signed
+    let samt = match old_bitcoin::amount::SignedAmount::from_str(&data_str) {
+        Ok(amt) => amt,
+        Err(_) => return,
+    };
+    let samt_roundtrip = match old_bitcoin::amount::SignedAmount::from_str(&samt.to_string()) {
+        Ok(amt) => amt,
+        Err(_) => return,
+    };
+    assert_eq!(samt, samt_roundtrip);
+
+    // unsigned
+    let amt = match old_bitcoin::amount::Amount::from_str(&data_str) {
+        Ok(amt) => amt,
+        Err(_) => return,
+    };
+    let amt_roundtrip = match old_bitcoin::amount::Amount::from_str(&amt.to_string()) {
+        Ok(amt) => amt,
+        Err(_) => return,
+    };
+    assert_eq!(amt, amt_roundtrip);
+}
+
+fuzz_target!(|data: &[u8]| {
+    do_test(data);
+});

--- a/fuzz/fuzz_targets/units_0_32/deserialize_amount.rs
+++ b/fuzz/fuzz_targets/units_0_32/deserialize_amount.rs
@@ -11,22 +11,22 @@ fn do_test(data: &[u8]) {
     let data_str = String::from_utf8_lossy(data);
 
     // signed
-    let samt = match old_bitcoin::amount::SignedAmount::from_str(&data_str) {
+    let samt = match bitcoin_0_32::amount::SignedAmount::from_str(&data_str) {
         Ok(amt) => amt,
         Err(_) => return,
     };
-    let samt_roundtrip = match old_bitcoin::amount::SignedAmount::from_str(&samt.to_string()) {
+    let samt_roundtrip = match bitcoin_0_32::amount::SignedAmount::from_str(&samt.to_string()) {
         Ok(amt) => amt,
         Err(_) => return,
     };
     assert_eq!(samt, samt_roundtrip);
 
     // unsigned
-    let amt = match old_bitcoin::amount::Amount::from_str(&data_str) {
+    let amt = match bitcoin_0_32::amount::Amount::from_str(&data_str) {
         Ok(amt) => amt,
         Err(_) => return,
     };
-    let amt_roundtrip = match old_bitcoin::amount::Amount::from_str(&amt.to_string()) {
+    let amt_roundtrip = match bitcoin_0_32::amount::Amount::from_str(&amt.to_string()) {
         Ok(amt) => amt,
         Err(_) => return,
     };

--- a/fuzz/generate-files.sh
+++ b/fuzz/generate-files.sh
@@ -26,7 +26,7 @@ cargo-fuzz = true
 # We shouldn't need an explicit version on the next line, but Andrew's tools
 # choke on it otherwise. See https://github.com/nix-community/crate2nix/issues/373
 bitcoin = { path = "../bitcoin", version = "0.33.0-beta", features = [ "serde", "arbitrary" ] }
-old_bitcoin = { version = "0.32.9", package = "bitcoin" }
+old_bitcoin = { version = "0.32.101", package = "bitcoin", features = [ "encoding", "serde" ] }
 bitcoin_consensus_encoding = { path = "../consensus_encoding", package = "bitcoin-consensus-encoding" }
 p2p = { path = "../p2p", package = "bitcoin-p2p-messages", features = ["arbitrary"] }
 
@@ -34,6 +34,7 @@ arbitrary = { version = "1.4.1" }
 libfuzzer-sys = { version = "0.4.0" }
 serde = { version = "1.0.195", features = [ "derive" ] }
 serde_json = "1.0.68"
+serde_cbor = "0.9"
 standard_test = "0.1.0"
 
 [lints.rust]
@@ -52,7 +53,7 @@ allowed_duplicates = [
     "hex-conservative",
     "bitcoin_hashes",
     "bitcoin-io",
-    "hex-conservative",
+    "bitcoin-consensus-encoding",
     "base58ck",
     "bitcoin",
     "bitcoin-internals",

--- a/fuzz/generate-files.sh
+++ b/fuzz/generate-files.sh
@@ -26,7 +26,7 @@ cargo-fuzz = true
 # We shouldn't need an explicit version on the next line, but Andrew's tools
 # choke on it otherwise. See https://github.com/nix-community/crate2nix/issues/373
 bitcoin = { path = "../bitcoin", version = "0.33.0-beta", features = [ "serde", "arbitrary" ] }
-old_bitcoin = { version = "0.32.101", package = "bitcoin", features = [ "encoding", "serde" ] }
+bitcoin_0_32 = { version = "0.32.101", package = "bitcoin", features = [ "encoding", "serde" ] }
 bitcoin_consensus_encoding = { path = "../consensus_encoding", package = "bitcoin-consensus-encoding" }
 p2p = { path = "../p2p", package = "bitcoin-p2p-messages", features = ["arbitrary"] }
 


### PR DESCRIPTION
Centralize all fuzz infra on the master branch, including targets from the LTS `0.32.x` branch. This should make the infra and targets easier to maintain, and they will probably be run more often in practice here.

Part of #6388 