### PR TITLE
Replace dyn fmt::Write with fmt::Formatter

### DIFF
--- a/crypto/src/key.rs
+++ b/crypto/src/key.rs
@@ -6,7 +6,7 @@
 //! (de)serialized.
 
 #[cfg(feature = "alloc")]
-use alloc::string::String;
+use alloc::string::{String, ToString as _};
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 use core::borrow::Borrow;
@@ -1168,7 +1168,7 @@ impl WifKey {
     #[rustfmt::skip]
     #[cfg(feature = "alloc")]
     #[inline]
-    pub fn fmt_wif(&self, fmt: &mut dyn fmt::Write) -> fmt::Result {
+    pub fn fmt_wif(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let mut ret = [0; 34];
         ret[0] = if self.network_kind.is_mainnet() { 128 } else { 239 };
 
@@ -1186,10 +1186,11 @@ impl WifKey {
     #[cfg(feature = "alloc")]
     #[inline]
     pub fn to_wif(&self) -> String {
-        let mut buf = String::new();
-        let _ = self.fmt_wif(&mut buf);
-        buf.shrink_to_fit();
-        buf
+        struct WifString<'a>(&'a WifKey);
+        impl fmt::Display for WifString<'_> {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { self.0.fmt_wif(f) }
+        }
+        WifString(self).to_string()
     }
 
     /// Parses the WIF encoded private key.

--- a/units/src/amount/mod.rs
+++ b/units/src/amount/mod.rs
@@ -19,7 +19,7 @@ pub mod serde;
 
 use core::cmp::Ordering;
 use core::convert::Infallible;
-use core::fmt;
+use core::fmt::{self, Write as _};
 use core::str::FromStr;
 
 #[cfg(feature = "arbitrary")]
@@ -439,7 +439,7 @@ fn dec_width(mut num: u64) -> usize {
     width
 }
 
-fn repeat_char(f: &mut dyn fmt::Write, c: char, count: usize) -> fmt::Result {
+fn repeat_char(f: &mut fmt::Formatter, c: char, count: usize) -> fmt::Result {
     for _ in 0..count {
         f.write_char(c)?;
     }
@@ -450,7 +450,7 @@ fn repeat_char(f: &mut dyn fmt::Write, c: char, count: usize) -> fmt::Result {
 fn fmt_satoshi_in(
     mut satoshi: u64,
     negative: bool,
-    f: &mut dyn fmt::Write,
+    f: &mut fmt::Formatter,
     denom: Denomination,
     show_denom: bool,
     options: FormatOptions,

--- a/units/src/amount/tests.rs
+++ b/units/src/amount/tests.rs
@@ -5,7 +5,7 @@
 #[cfg(feature = "alloc")]
 use alloc::format;
 #[cfg(feature = "alloc")]
-use alloc::string::{String, ToString};
+use alloc::string::ToString;
 use core::num::{NonZeroI64, NonZeroU64};
 #[cfg(feature = "std")]
 use std::panic;
@@ -528,10 +528,14 @@ fn to_string() {
 #[test]
 #[cfg(feature = "alloc")]
 fn test_repeat_char() {
-    let mut buf = String::new();
-    repeat_char(&mut buf, '0', 0).unwrap();
+    struct Repeat(char, usize);
+    impl fmt::Display for Repeat {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { repeat_char(f, self.0, self.1) }
+    }
+
+    let buf = Repeat('0', 0).to_string();
     assert_eq!(buf.len(), 0);
-    repeat_char(&mut buf, '0', 42).unwrap();
+    let buf = Repeat('0', 42).to_string();
     assert_eq!(buf.len(), 42);
     assert!(buf.chars().all(|c| c == '0'));
 }


### PR DESCRIPTION
In Rust, the dyn keyword for a function parameter provides generic-like functionality for a parameter. However, unlike impl or a generic, dyn enables dynamic dispatch for the function, preventing inlining by the compiler. Since all such uses of dyn fmt::Write are used with formatter anyway, the dynamic dispatch cost can be eliminated by replacing the dyn param with a fmt::Formatter type.

Replace dyn fmt::Write with fmt::Formatter in all non-deprecated functions.