### PR TITLE
Add ExactSizeEncoder impl for Option<T: ExactSizeEncoder>

### DIFF
--- a/consensus_encoding/api/all-features.txt
+++ b/consensus_encoding/api/all-features.txt
@@ -1559,6 +1559,8 @@ pub fn core::option::Option<T>::current_chunk(&self) -> &[u8]
 pub trait bitcoin_consensus_encoding::ExactSizeEncoder: bitcoin_consensus_encoding::Encoder
 pub fn bitcoin_consensus_encoding::ExactSizeEncoder::is_empty(&self) -> bool
 pub fn bitcoin_consensus_encoding::ExactSizeEncoder::len(&self) -> usize
+impl<T: bitcoin_consensus_encoding::ExactSizeEncoder> bitcoin_consensus_encoding::ExactSizeEncoder for core::option::Option<T>
+pub fn core::option::Option<T>::len(&self) -> usize
 pub fn bitcoin_consensus_encoding::check_decode<T: bitcoin_consensus_encoding::Decode + core::cmp::Eq + core::fmt::Debug>(bytes: &[u8], expected: &T) where <<T as bitcoin_consensus_encoding::Decode>::Decoder as bitcoin_consensus_encoding::Decoder>::Error: core::fmt::Debug
 pub fn bitcoin_consensus_encoding::check_decoder<D: bitcoin_consensus_encoding::Decoder>(decoder: D, bytes: &[u8], expected: &<D as bitcoin_consensus_encoding::Decoder>::Output) where <D as bitcoin_consensus_encoding::Decoder>::Output: core::cmp::Eq + core::fmt::Debug, <D as bitcoin_consensus_encoding::Decoder>::Error: core::fmt::Debug
 pub fn bitcoin_consensus_encoding::check_encode<T: bitcoin_consensus_encoding::Encode + ?core::marker::Sized>(value: &T, expected: &[u8])

--- a/consensus_encoding/api/alloc-only.txt
+++ b/consensus_encoding/api/alloc-only.txt
@@ -1436,6 +1436,8 @@ pub fn core::option::Option<T>::current_chunk(&self) -> &[u8]
 pub trait bitcoin_consensus_encoding::ExactSizeEncoder: bitcoin_consensus_encoding::Encoder
 pub fn bitcoin_consensus_encoding::ExactSizeEncoder::is_empty(&self) -> bool
 pub fn bitcoin_consensus_encoding::ExactSizeEncoder::len(&self) -> usize
+impl<T: bitcoin_consensus_encoding::ExactSizeEncoder> bitcoin_consensus_encoding::ExactSizeEncoder for core::option::Option<T>
+pub fn core::option::Option<T>::len(&self) -> usize
 pub fn bitcoin_consensus_encoding::check_decode<T: bitcoin_consensus_encoding::Decode + core::cmp::Eq + core::fmt::Debug>(bytes: &[u8], expected: &T) where <<T as bitcoin_consensus_encoding::Decode>::Decoder as bitcoin_consensus_encoding::Decoder>::Error: core::fmt::Debug
 pub fn bitcoin_consensus_encoding::check_decoder<D: bitcoin_consensus_encoding::Decoder>(decoder: D, bytes: &[u8], expected: &<D as bitcoin_consensus_encoding::Decoder>::Output) where <D as bitcoin_consensus_encoding::Decoder>::Output: core::cmp::Eq + core::fmt::Debug, <D as bitcoin_consensus_encoding::Decoder>::Error: core::fmt::Debug
 pub fn bitcoin_consensus_encoding::check_encode<T: bitcoin_consensus_encoding::Encode + ?core::marker::Sized>(value: &T, expected: &[u8])

--- a/consensus_encoding/api/no-features.txt
+++ b/consensus_encoding/api/no-features.txt
@@ -1127,6 +1127,8 @@ pub fn core::option::Option<T>::current_chunk(&self) -> &[u8]
 pub trait bitcoin_consensus_encoding::ExactSizeEncoder: bitcoin_consensus_encoding::Encoder
 pub fn bitcoin_consensus_encoding::ExactSizeEncoder::is_empty(&self) -> bool
 pub fn bitcoin_consensus_encoding::ExactSizeEncoder::len(&self) -> usize
+impl<T: bitcoin_consensus_encoding::ExactSizeEncoder> bitcoin_consensus_encoding::ExactSizeEncoder for core::option::Option<T>
+pub fn core::option::Option<T>::len(&self) -> usize
 pub fn bitcoin_consensus_encoding::check_decode<T: bitcoin_consensus_encoding::Decode + core::cmp::Eq + core::fmt::Debug>(bytes: &[u8], expected: &T) where <<T as bitcoin_consensus_encoding::Decode>::Decoder as bitcoin_consensus_encoding::Decoder>::Error: core::fmt::Debug
 pub fn bitcoin_consensus_encoding::check_decoder<D: bitcoin_consensus_encoding::Decoder>(decoder: D, bytes: &[u8], expected: &<D as bitcoin_consensus_encoding::Decoder>::Output) where <D as bitcoin_consensus_encoding::Decoder>::Output: core::cmp::Eq + core::fmt::Debug, <D as bitcoin_consensus_encoding::Decoder>::Error: core::fmt::Debug
 pub fn bitcoin_consensus_encoding::check_encode<T: bitcoin_consensus_encoding::Encode + ?core::marker::Sized>(value: &T, expected: &[u8])

--- a/consensus_encoding/src/encode/mod.rs
+++ b/consensus_encoding/src/encode/mod.rs
@@ -488,3 +488,12 @@ impl<T: Encoder> Encoder for Option<T> {
         }
     }
 }
+
+impl<T: ExactSizeEncoder> ExactSizeEncoder for Option<T> {
+    fn len(&self) -> usize {
+        match self {
+            Some(encoder) => encoder.len(),
+            None => 0,
+        }
+    }
+}

--- a/consensus_encoding/tests/encode.rs
+++ b/consensus_encoding/tests/encode.rs
@@ -204,12 +204,14 @@ fn encode_encoder2_with_first_empty_encoder() {
 #[test]
 fn encode_option_encoder_some() {
     let mut encoder = Some(ArrayEncoder::<3>::without_length_prefix([1, 2, 3]));
+    assert_eq!(encoder.len(), 3);
     check_encoder(&mut encoder, &[1, 2, 3]);
 }
 
 #[test]
 fn encode_option_encoder_none() {
     let mut encoder: Option<ArrayEncoder<3>> = None;
+    assert_eq!(encoder.len(), 0);
     check_encoder(&mut encoder, &[]);
 }
 


### PR DESCRIPTION
Currently, there exists an Encoder impl for Option<T: Encoder>. Since ExactSizeEncoder can be useful, there is no reason not to include an ExactSizeEncoder impl for Option<T: ExactSizeEncoder> also.

Add ExactSizeEncoder impl for Option<T: ExactSizeEncoder>.

Closes #6420