### PR TITLE
0.32.x: patch internal crates to local copies

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,9 @@ name: Continuous integration
 
 permissions: {}
 
+env:
+  RBMT_LOG_LEVEL: "progress"
+
 jobs:
   Test:
     name: Test - ${{ matrix.toolchain }} toolchain, ${{ matrix.dep }} deps
@@ -61,55 +64,83 @@ jobs:
           persist-credentials: false
       - name: "Read workspace versions"
         id: read_toolchain
-        run: echo "nightly_version=$(cargo metadata --format-version 1 | jq -r '.metadata.rbmt.toolchains.nightly')" >> $GITHUB_OUTPUT
+        run: echo "nightly_version=$(cargo metadata --no-deps --format-version 1 | jq -r '.metadata.rbmt.toolchains.nightly')" >> $GITHUB_OUTPUT
 
   Arch32bit:
     name: Test 32-bit version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: "Select toolchain"
-        uses: dtolnay/rust-toolchain@stable
-      - name: "Add architecture i386"
-        run: sudo dpkg --add-architecture i386
+        uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6 # stable
+      - name: "Add architecture i386 and install dependencies"
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo apt-get update -y
+          sudo apt-get install -y \
+            gcc-multilib \
+            g++-multilib \
+            libc6-dev-i386 \
+            lib32stdc++-13-dev
       - name: "Install i686 gcc"
         run: sudo apt-get update -y && sudo apt-get install -y gcc-multilib
       - name: "Install target"
         run: rustup target add i686-unknown-linux-gnu
+      - name: "Set dependencies"
+        run: cp Cargo-recent.lock Cargo.lock
       - name: "Run test on i686"
-        run: cargo test --target i686-unknown-linux-gnu
+        run: cargo test --locked --target i686-unknown-linux-gnu
 
   Cross:
     name: Cross test - stable toolchain
-    if: ${{ !github.event.act }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - s390x-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: "Select toolchain"
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6 # stable
       - name: "Install target"
-        run: rustup target add s390x-unknown-linux-gnu
+        run: rustup target add ${{ matrix.target }}
       - name: "Install cross"
         run: cargo install cross --locked
+      - name: "Set dependencies"
+        run: cp Cargo-recent.lock Cargo.lock
       - name: "Run cross test"
-        run: cross test --target s390x-unknown-linux-gnu
+        run: cross test --locked --target ${{ matrix.target }}
 
   Embedded:
     name: Embedded - nightly toolchain
     needs: Prepare
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     env:
       RUSTFLAGS: "-C link-arg=-Tlink.x"
       CARGO_TARGET_THUMBV7M_NONE_EABI_RUNNER: "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: "Set up QEMU"
         run: sudo apt update && sudo apt install -y qemu-system-arm gcc-arm-none-eabi
       - name: "Select toolchain"
-        uses: dtolnay/rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: ${{ needs.Prepare.outputs.nightly_version }}
           targets: thumbv7m-none-eabi
@@ -125,16 +156,20 @@ jobs:
   ASAN:                         # hashes crate only.
     name: ASAN - nightly toolchain
     needs: Prepare
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
         dep: [recent]
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: "Select toolchain"
-        uses: dtolnay/rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: ${{ needs.Prepare.outputs.nightly_version }}
       - name: "Install rust-src"
@@ -144,27 +179,17 @@ jobs:
       - name: "Run sanitizer script"
         run: cd ./hashes && ./contrib/sanitizer.sh
 
-  WASM:                         # hashes crate only.
-    name: WASM - stable toolchain
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      # Note we do not use the recent lock file for wasm testing.
-    steps:
-      - name: "Checkout repo"
-        uses: actions/checkout@v4
-      - name: "Select toolchain"
-        uses: dtolnay/rust-toolchain@stable
-      - name: "Run wasm script"
-        run: cd hashes && ./contrib/wasm.sh
-
   Kani:
     name: Kani codegen - stable toolchain
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: "Build Kani proofs"
-        uses: model-checking/kani-github-action@v1.1
+        uses: model-checking/kani-github-action@f838096619a707b0f6b2118cf435eaccfa33e51f # v1.1
         with:
           args: "--only-codegen"

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -18,17 +18,8 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 name = "base58ck"
 version = "0.1.100"
 dependencies = [
- "bitcoin_hashes 0.14.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin_hashes 0.14.100",
  "hex-conservative 0.2.2",
-]
-
-[[package]]
-name = "base58ck"
-version = "0.1.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec5dc7e09f7bb15f0062da7c03086d6b71a2c84e0af4fccbbc7d8c6559847816"
-dependencies = [
- "bitcoin_hashes 0.14.100 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -58,14 +49,14 @@ name = "bitcoin"
 version = "0.32.100"
 dependencies = [
  "arbitrary",
- "base58ck 0.1.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base58ck",
  "base64",
  "bech32",
  "bincode",
  "bitcoin-consensus-encoding",
- "bitcoin-io 0.1.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin-io",
  "bitcoin-units",
- "bitcoin_hashes 0.14.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin_hashes 0.14.100",
  "bitcoinconsensus",
  "hex-conservative 0.2.2",
  "hex_lit",
@@ -110,12 +101,6 @@ name = "bitcoin-io"
 version = "0.1.100"
 
 [[package]]
-name = "bitcoin-io"
-version = "0.1.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11301df0b06f22dea7bb1916403fdd88a371031e495c49b8f96931b28189e175"
-
-[[package]]
 name = "bitcoin-private"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,23 +130,12 @@ dependencies = [
 name = "bitcoin_hashes"
 version = "0.14.100"
 dependencies = [
- "bitcoin-io 0.1.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin-io",
  "hex-conservative 0.2.2",
  "schemars",
  "serde",
  "serde_json",
  "serde_test",
-]
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.14.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9901a56e133a1fc86eeb1113e2591f45f4682451ca893bff494d2f88918e3f"
-dependencies = [
- "bitcoin-io 0.1.100 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex-conservative 0.2.2",
- "serde",
 ]
 
 [[package]]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -18,17 +18,8 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 name = "base58ck"
 version = "0.1.100"
 dependencies = [
- "bitcoin_hashes 0.14.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin_hashes",
  "hex-conservative 0.2.2",
-]
-
-[[package]]
-name = "base58ck"
-version = "0.1.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec5dc7e09f7bb15f0062da7c03086d6b71a2c84e0af4fccbbc7d8c6559847816"
-dependencies = [
- "bitcoin_hashes 0.14.100 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -57,14 +48,14 @@ name = "bitcoin"
 version = "0.32.100"
 dependencies = [
  "arbitrary",
- "base58ck 0.1.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base58ck",
  "base64",
  "bech32",
  "bincode",
  "bitcoin-consensus-encoding",
- "bitcoin-io 0.1.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin-io",
  "bitcoin-units",
- "bitcoin_hashes 0.14.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin_hashes",
  "bitcoinconsensus",
  "hex-conservative 0.2.2",
  "hex_lit",
@@ -109,12 +100,6 @@ name = "bitcoin-io"
 version = "0.1.100"
 
 [[package]]
-name = "bitcoin-io"
-version = "0.1.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11301df0b06f22dea7bb1916403fdd88a371031e495c49b8f96931b28189e175"
-
-[[package]]
 name = "bitcoin-units"
 version = "0.1.100"
 dependencies = [
@@ -127,25 +112,14 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.100"
+version = "0.14.101"
 dependencies = [
- "bitcoin-io 0.1.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin-io",
  "hex-conservative 0.2.2",
  "schemars",
  "serde",
  "serde_json",
  "serde_test",
-]
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.14.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9901a56e133a1fc86eeb1113e2591f45f4682451ca893bff494d2f88918e3f"
-dependencies = [
- "bitcoin-io 0.1.100 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex-conservative 0.2.2",
- "serde",
 ]
 
 [[package]]
@@ -366,7 +340,7 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "bitcoin_hashes 0.14.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin_hashes",
  "rand",
  "secp256k1-sys",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,9 @@ resolver = "2"
 [workspace.metadata.rbmt.toolchains]
 nightly = "nightly-2026-03-27"
 stable = "1.91.1"
+
+# secp256k1 depends on the crates.io bitcoin_hashes, which is also a local
+# workspace member. Cargo would treat them as two versions, so this patch points
+# secp256k1 at the local copy, keeping a single version in the lockfile for tests.
+[patch.crates-io]
+bitcoin_hashes = { path = "hashes" }

--- a/base58/Cargo.toml
+++ b/base58/Cargo.toml
@@ -24,7 +24,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-hashes = { package = "bitcoin_hashes", version = "0.14.100", default-features = false, features = ["alloc"] }
+hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.14.101", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 hex = { package = "hex-conservative", version = "0.2.2", default-features = false, features = ["alloc"] }

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -34,12 +34,12 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-base58 = { package = "base58ck", version = "0.1.100", default-features = false }
+base58 = { package = "base58ck", path = "../base58", version = "0.1.100", default-features = false }
 bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
-hashes = { package = "bitcoin_hashes", version = "0.14.100", default-features = false, features = ["alloc", "io"] }
+hashes = { package = "bitcoin_hashes", path = "../hashes", version = "0.14.101", default-features = false, features = ["alloc", "io"] }
 hex = { package = "hex-conservative", version = "0.2.2", default-features = false, features = ["alloc"] }
 hex_lit = "0.1.1"
-io = { package = "bitcoin-io", version = "0.1.100", default-features = false, features = ["alloc"] }
+io = { package = "bitcoin-io", path = "../io", version = "0.1.100", default-features = false, features = ["alloc"] }
 secp256k1 = { version = "0.29.0", default-features = false, features = ["hashes", "alloc"] }
 units = { package = "bitcoin-units", path = "../units", version = "0.1.100", default-features = false, features = ["alloc"] }
 

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -3,7 +3,7 @@ name = "bitcoin_hashes"
 # We jumped to `v0.14.100` when doing the MSRV bump to Rust `1.74`
 # leaving room for a bunch of secuity releases upto this number if
 # needed.
-version = "0.14.100"
+version = "0.14.101"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin"
@@ -33,7 +33,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 hex = { package = "hex-conservative", version = "0.2.2", default-features = false }
 
-bitcoin-io = { version = "0.1.100", default-features = false, optional = true }
+bitcoin-io = { path = "../io", version = "0.1.100", default-features = false, optional = true }
 # Do NOT use this as a feature! Use the `schemars` feature instead.
 actual-schemars = { package = "schemars", version = "0.8.3", default-features = false, optional = true }
 serde = { version = "1.0.130", default-features = false, optional = true }


### PR DESCRIPTION
The workspace pulled [`base58ck`](https://crates.io/crates/base58ck/versions), [`bitcoin_hashes`](https://crates.io/crates/bitcoin_hashes/versions), [`bitcoin-io`](https://crates.io/crates/bitcoin-io/versions), and [`bitcoin-units`](https://crates.io/crates/bitcoin-units/versions) from crates.io by version, but all four `.100` versions have been yanked.

That broke the jobs that resolve without a committed lockfile (32-bit, WASM, cross) and, via `cargo metadata` in `Prepare`, left the embedded and ASAN jobs with an empty toolchain.

This PR points the internal crates at their local copies with `[patch.crates-io]`, like `bitcoin/embedded`. A plain path dep was not enough because `secp256k1` pulls `bitcoin_hashes` from the registry, which would duplicate the local copy and fail lint. Lock files regenerated to match.