### PR TITLE
ci: sync 0.32.x workflow with master

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,9 @@ name: Continuous integration
 
 permissions: {}
 
+env:
+  RBMT_LOG_LEVEL: "progress"
+
 jobs:
   Test:
     name: Test - ${{ matrix.toolchain }} toolchain, ${{ matrix.dep }} deps
@@ -59,55 +62,83 @@ jobs:
           persist-credentials: false
       - name: "Read workspace versions"
         id: read_toolchain
-        run: echo "nightly_version=$(cargo metadata --format-version 1 | jq -r '.metadata.rbmt.toolchains.nightly')" >> $GITHUB_OUTPUT
+        run: echo "nightly_version=$(cargo metadata --no-deps --format-version 1 | jq -r '.metadata.rbmt.toolchains.nightly')" >> $GITHUB_OUTPUT
 
   Arch32bit:
     name: Test 32-bit version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: "Select toolchain"
-        uses: dtolnay/rust-toolchain@stable
-      - name: "Add architecture i386"
-        run: sudo dpkg --add-architecture i386
+        uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6 # stable
+      - name: "Add architecture i386 and install dependencies"
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo apt-get update -y
+          sudo apt-get install -y \
+            gcc-multilib \
+            g++-multilib \
+            libc6-dev-i386 \
+            lib32stdc++-13-dev
       - name: "Install i686 gcc"
         run: sudo apt-get update -y && sudo apt-get install -y gcc-multilib
       - name: "Install target"
         run: rustup target add i686-unknown-linux-gnu
+      - name: "Set dependencies"
+        run: cp Cargo-recent.lock Cargo.lock
       - name: "Run test on i686"
-        run: cargo test --target i686-unknown-linux-gnu
+        run: cargo test --locked --target i686-unknown-linux-gnu
 
   Cross:
     name: Cross test - stable toolchain
-    if: ${{ !github.event.act }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - s390x-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: "Select toolchain"
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6 # stable
       - name: "Install target"
-        run: rustup target add s390x-unknown-linux-gnu
+        run: rustup target add ${{ matrix.target }}
       - name: "Install cross"
         run: cargo install cross --locked
+      - name: "Set dependencies"
+        run: cp Cargo-recent.lock Cargo.lock
       - name: "Run cross test"
-        run: cross test --target s390x-unknown-linux-gnu
+        run: cross test --locked --target ${{ matrix.target }}
 
   Embedded:
     name: Embedded - nightly toolchain
     needs: Prepare
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     env:
       RUSTFLAGS: "-C link-arg=-Tlink.x"
       CARGO_TARGET_THUMBV7M_NONE_EABI_RUNNER: "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: "Set up QEMU"
         run: sudo apt update && sudo apt install -y qemu-system-arm gcc-arm-none-eabi
       - name: "Select toolchain"
-        uses: dtolnay/rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: ${{ needs.Prepare.outputs.nightly_version }}
           targets: thumbv7m-none-eabi
@@ -123,16 +154,20 @@ jobs:
   ASAN:                         # hashes crate only.
     name: ASAN - nightly toolchain
     needs: Prepare
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
         dep: [recent]
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: "Select toolchain"
-        uses: dtolnay/rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: ${{ needs.Prepare.outputs.nightly_version }}
       - name: "Install rust-src"
@@ -142,27 +177,17 @@ jobs:
       - name: "Run sanitizer script"
         run: cd ./hashes && ./contrib/sanitizer.sh
 
-  WASM:                         # hashes crate only.
-    name: WASM - stable toolchain
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      # Note we do not use the recent lock file for wasm testing.
-    steps:
-      - name: "Checkout repo"
-        uses: actions/checkout@v4
-      - name: "Select toolchain"
-        uses: dtolnay/rust-toolchain@stable
-      - name: "Run wasm script"
-        run: cd hashes && ./contrib/wasm.sh
-
   Kani:
     name: Kani codegen - stable toolchain
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: "Build Kani proofs"
-        uses: model-checking/kani-github-action@v1.1
+        uses: model-checking/kani-github-action@f838096619a707b0f6b2118cf435eaccfa33e51f # v1.1
         with:
           args: "--only-codegen"


### PR DESCRIPTION
Brings 0.32.x rust.yml closer to master, as per https://github.com/rust-bitcoin/rust-bitcoin/pull/6322#issuecomment-4713889574.

This PR takes master's rust.yml and trims it down to what 0.32.x can actually run. Keeps the pinned action hashes, ubuntu-24.04 runners, permissions blocks and the s390x/aarch64 matrix.

But the PR drops the jobs that depend on things absent here: Prerelease, Policy, Re-exports, Encodable-coverage and DiffMutants all call contrib scripts or hit the primitives crate that 0.32.x doesn't have. Same for the bench task (recent rbmt change) and the `free-disk-space` step, and the `alloc,hex` embedded run since hashes/embedded have no hex feature.

The 32-bit and cross jobs copy `Cargo-recent.lock` and run with `--locked` so they build against a pinned resolution, and `Prepare` reads the toolchain with `cargo metadata --no-deps` to skip resolving the graph for one field.
