### PR TITLE
units `0.32.x`: backport kani std to core usage

### DIFF
--- a/units/src/amount.rs
+++ b/units/src/amount.rs
@@ -2021,7 +2021,7 @@ impl<'a> Arbitrary<'a> for SignedAmount {
 
 #[cfg(kani)]
 mod verification {
-    use std::cmp;
+    use core::cmp;
     use std::convert::TryInto;
 
     use super::*;


### PR DESCRIPTION
Attempting to iron out hangs like: https://github.com/rust-bitcoin/rust-bitcoin/actions/runs/28268734832/job/83761410294?pr=6427. #6425's CI updates probably fix the Kani hangs by updating the job's runner to `24.04`, but a backport of #6393 won't hurt.