### PR TITLE
encoding: add decoder_error! macro for flattening composite decoder errors

### DIFF
--- a/consensus_encoding/src/error.rs
+++ b/consensus_encoding/src/error.rs
@@ -461,3 +461,168 @@ define_decoder_n_error! {
     /// Error from the sixth decoder.
     (Sixth, F, "sixth decoder error."),
 }
+
+/// Defines a flat, named error enum for a composite [`Decoder`] and the conversion
+/// that flattens its positional `DecoderNError` into it.
+///
+/// The pattern otherwise written out by hand (see e.g. `HeaderDecoderError` in `bitcoin-primitives`):
+/// so we rather list `field_name => Variant` pairs together (with the composite decoder they come from) 
+/// than declaring the enum plus `From<Infallible>`, `Display`, [`std::error::Error`] and a positional match by hand.
+/// 
+/// for each variant the inner error type shall be inferred via `<D as Decoder>::Error`.
+/// this eases the fact that they had to be spelled out.
+///
+/// A dropped, duplicated or mistyped field will fail to compile because the generated 'From'
+/// is a single exhaustive `match` over the real `DecoderNError`
+/// 
+/// The generated `Display` reports the field name (of occurence) 
+/// (e.g. 'error decoding `script_sig` field').
+/// 
+///
+/// # Examples:
+///
+/// ```ignore
+/// decoder_error! {
+///     /// An error consensus decoding a `Header`.
+///     #[derive(Debug, Clone, PartialEq, Eq)]
+///     #[non_exhaustive]
+///     pub enum HeaderDecoderError from Decoder6<
+///         VersionDecoder, BlockHashDecoder, TxMerkleNodeDecoder,
+///         BlockTimeDecoder, CompactTargetDecoder, ArrayDecoder<4>,
+///     > {
+///         /// Error while decoding the `version`.
+///         version => Version,
+///         /// Error while decoding the `prev_blockhash`.
+///         prev_blockhash => PrevBlockhash,
+///         /// Error while decoding the `merkle_root`.
+///         merkle_root => MerkleRoot,
+///         /// Error while decoding the `time`.
+///         time => Time,
+///         /// Error while decoding the `bits`.
+///         bits => Bits,
+///         /// Error while decoding the `nonce`.
+///         nonce => Nonce,
+///     }
+/// }
+/// ```
+#[macro_export]
+macro_rules! decoder_error {
+    // ----- arity 2 -----
+    (
+        $(#[$attr:meta])*
+        $vis:vis enum $name:ident from Decoder2<$d0:ty, $d1:ty $(,)?> {
+            $(#[$a0:meta])* $f0:ident => $v0:ident,
+            $(#[$a1:meta])* $f1:ident => $v1:ident $(,)?
+        }
+    ) => {
+        $crate::decoder_error!(@build $(#[$attr])* $vis $name; Decoder2Error;
+            (First,  [$(#[$a0])*], $f0, $v0, $d0),
+            (Second, [$(#[$a1])*], $f1, $v1, $d1),
+        );
+    };
+    // ----- arity 3 -----
+    (
+        $(#[$attr:meta])*
+        $vis:vis enum $name:ident from Decoder3<$d0:ty, $d1:ty, $d2:ty $(,)?> {
+            $(#[$a0:meta])* $f0:ident => $v0:ident,
+            $(#[$a1:meta])* $f1:ident => $v1:ident,
+            $(#[$a2:meta])* $f2:ident => $v2:ident $(,)?
+        }
+    ) => {
+        $crate::decoder_error!(@build $(#[$attr])* $vis $name; Decoder3Error;
+            (First,  [$(#[$a0])*], $f0, $v0, $d0),
+            (Second, [$(#[$a1])*], $f1, $v1, $d1),
+            (Third,  [$(#[$a2])*], $f2, $v2, $d2),
+        );
+    };
+    // ----- arity 4 -----
+    (
+        $(#[$attr:meta])*
+        $vis:vis enum $name:ident from Decoder4<$d0:ty, $d1:ty, $d2:ty, $d3:ty $(,)?> {
+            $(#[$a0:meta])* $f0:ident => $v0:ident,
+            $(#[$a1:meta])* $f1:ident => $v1:ident,
+            $(#[$a2:meta])* $f2:ident => $v2:ident,
+            $(#[$a3:meta])* $f3:ident => $v3:ident $(,)?
+        }
+    ) => {
+        $crate::decoder_error!(@build $(#[$attr])* $vis $name; Decoder4Error;
+            (First,  [$(#[$a0])*], $f0, $v0, $d0),
+            (Second, [$(#[$a1])*], $f1, $v1, $d1),
+            (Third,  [$(#[$a2])*], $f2, $v2, $d2),
+            (Fourth, [$(#[$a3])*], $f3, $v3, $d3),
+        );
+    };
+    // ----- arity 6 -----
+    (
+        $(#[$attr:meta])*
+        $vis:vis enum $name:ident from Decoder6<$d0:ty, $d1:ty, $d2:ty, $d3:ty, $d4:ty, $d5:ty $(,)?> {
+            $(#[$a0:meta])* $f0:ident => $v0:ident,
+            $(#[$a1:meta])* $f1:ident => $v1:ident,
+            $(#[$a2:meta])* $f2:ident => $v2:ident,
+            $(#[$a3:meta])* $f3:ident => $v3:ident,
+            $(#[$a4:meta])* $f4:ident => $v4:ident,
+            $(#[$a5:meta])* $f5:ident => $v5:ident $(,)?
+        }
+    ) => {
+        $crate::decoder_error!(@build $(#[$attr])* $vis $name; Decoder6Error;
+            (First,  [$(#[$a0])*], $f0, $v0, $d0),
+            (Second, [$(#[$a1])*], $f1, $v1, $d1),
+            (Third,  [$(#[$a2])*], $f2, $v2, $d2),
+            (Fourth, [$(#[$a3])*], $f3, $v3, $d3),
+            (Fifth,  [$(#[$a4])*], $f4, $v4, $d4),
+            (Sixth,  [$(#[$a5])*], $f5, $v5, $d5),
+        );
+    };
+
+    // ----- shared codegen -----
+    (@build
+        $(#[$attr:meta])* $vis:vis $name:ident; $errenum:ident;
+        $( ($wrap:ident, [$(#[$fattr:meta])*], $field:ident, $variant:ident, $dec:ty) ),* $(,)?
+    ) => {
+        $(#[$attr])*
+        $vis enum $name {
+            $(
+                $(#[$fattr])*
+                $variant( <$dec as $crate::Decoder>::Error ),
+            )*
+        }
+
+        impl ::core::convert::From< $crate::$errenum< $( <$dec as $crate::Decoder>::Error ),* > >
+            for $name
+        {
+            fn from(e: $crate::$errenum< $( <$dec as $crate::Decoder>::Error ),* >) -> Self {
+                match e {
+                    $( $crate::$errenum::$wrap(e) => $name::$variant(e), )*
+                }
+            }
+        }
+
+        impl ::core::convert::From<::core::convert::Infallible> for $name {
+            fn from(never: ::core::convert::Infallible) -> Self { match never {} }
+        }
+
+        impl ::core::fmt::Display for $name {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                match self {
+                    $(
+                        $name::$variant(e) => {
+                            #[cfg(feature = "std")]
+                            { let _ = e; write!(f, "error decoding `{}` field", stringify!($field)) }
+                            #[cfg(not(feature = "std"))]
+                            { write!(f, "error decoding `{}` field: {}", stringify!($field), e) }
+                        }
+                    )*
+                }
+            }
+        }
+
+        #[cfg(feature = "std")]
+        impl std::error::Error for $name {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                match self {
+                    $( $name::$variant(e) => Some(e), )*
+                }
+            }
+        }
+    };
+}

--- a/consensus_encoding/src/error.rs
+++ b/consensus_encoding/src/error.rs
@@ -466,18 +466,18 @@ define_decoder_n_error! {
 /// that flattens its positional `DecoderNError` into it.
 ///
 /// The pattern otherwise written out by hand (see e.g. `HeaderDecoderError` in `bitcoin-primitives`):
-/// so we rather list `field_name => Variant` pairs together (with the composite decoder they come from) 
+/// so we rather list `field_name => Variant` pairs together (with the composite decoder they come from)
 /// than declaring the enum plus `From<Infallible>`, `Display`, [`std::error::Error`] and a positional match by hand.
-/// 
+///
 /// for each variant the inner error type shall be inferred via `<D as Decoder>::Error`.
 /// this eases the fact that they had to be spelled out.
 ///
 /// A dropped, duplicated or mistyped field will fail to compile because the generated 'From'
 /// is a single exhaustive `match` over the real `DecoderNError`
-/// 
-/// The generated `Display` reports the field name (of occurence) 
+///
+/// The generated `Display` reports the field name (of occurence)
 /// (e.g. 'error decoding `script_sig` field').
-/// 
+///
 ///
 /// # Examples:
 ///

--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -574,28 +574,16 @@ crate::decoder_newtype! {
     }
 
     fn map_push_bytes_err(err: <HeaderInnerDecoder as encoding::Decoder>::Error) -> HeaderDecoderError {
-        Self::from_inner(err)
+        HeaderDecoderError::from(err)
     }
 
     fn end(
         result: Result<<HeaderInnerDecoder as encoding::Decoder>::Output, <HeaderInnerDecoder as encoding::Decoder>::Error>
     ) -> Result<Header, HeaderDecoderError> {
-        let (version, prev_blockhash, merkle_root, time, bits, nonce) = result.map_err(Self::from_inner)?;
+        let (version, prev_blockhash, merkle_root, time, bits, nonce) =
+            result.map_err(HeaderDecoderError::from)?;
         let nonce = u32::from_le_bytes(nonce);
         Ok(Header { version, prev_blockhash, merkle_root, time, bits, nonce })
-    }
-}
-
-impl HeaderDecoder {
-    fn from_inner(e: <HeaderInnerDecoder as encoding::Decoder>::Error) -> HeaderDecoderError {
-        match e {
-            encoding::Decoder6Error::First(e) => HeaderDecoderError::Version(e),
-            encoding::Decoder6Error::Second(e) => HeaderDecoderError::PrevBlockhash(e),
-            encoding::Decoder6Error::Third(e) => HeaderDecoderError::MerkleRoot(e),
-            encoding::Decoder6Error::Fourth(e) => HeaderDecoderError::Time(e),
-            encoding::Decoder6Error::Fifth(e) => HeaderDecoderError::Bits(e),
-            encoding::Decoder6Error::Sixth(e) => HeaderDecoderError::Nonce(e),
-        }
     }
 }
 
@@ -747,10 +735,6 @@ pub mod error {
 
     use internals::write_err;
 
-    use crate::merkle_tree::TxMerkleNodeDecoderError;
-    use crate::pow::CompactTargetDecoderError;
-    use crate::time::BlockTimeDecoderError;
-
     #[rustfmt::skip]                // Keep public re-exports separate.
     #[doc(no_inline)]
     pub use units::block::{BlockHeightDecoderError, TooBigForRelativeHeightError};
@@ -827,52 +811,30 @@ pub mod error {
         }
     }
 
-    /// An error consensus decoding a `Header`.
-    #[derive(Debug, Clone, PartialEq, Eq)]
-    #[non_exhaustive]
-    pub enum HeaderDecoderError {
-        /// Error while decoding the `version`.
-        Version(VersionDecoderError),
-        /// Error while decoding the `prev_blockhash`.
-        PrevBlockhash(BlockHashDecoderError),
-        /// Error while decoding the `merkle_root`.
-        MerkleRoot(TxMerkleNodeDecoderError),
-        /// Error while decoding the `time`.
-        Time(BlockTimeDecoderError),
-        /// Error while decoding the `bits`.
-        Bits(CompactTargetDecoderError),
-        /// Error while decoding the `nonce`.
-        Nonce(encoding::UnexpectedEofError),
-    }
-
-    impl From<Infallible> for HeaderDecoderError {
-        fn from(never: Infallible) -> Self { match never {} }
-    }
-
-    impl fmt::Display for HeaderDecoderError {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            match *self {
-                Self::Version(ref e) => write_err!(f, "header decoder error"; e),
-                Self::PrevBlockhash(ref e) => write_err!(f, "header decoder error"; e),
-                Self::MerkleRoot(ref e) => write_err!(f, "header decoder error"; e),
-                Self::Time(ref e) => write_err!(f, "header decoder error"; e),
-                Self::Bits(ref e) => write_err!(f, "header decoder error"; e),
-                Self::Nonce(ref e) => write_err!(f, "header decoder error"; e),
-            }
-        }
-    }
-
-    #[cfg(feature = "std")]
-    impl std::error::Error for HeaderDecoderError {
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-            match *self {
-                Self::Version(ref e) => Some(e),
-                Self::PrevBlockhash(ref e) => Some(e),
-                Self::MerkleRoot(ref e) => Some(e),
-                Self::Time(ref e) => Some(e),
-                Self::Bits(ref e) => Some(e),
-                Self::Nonce(ref e) => Some(e),
-            }
+    encoding::decoder_error! {
+        /// An error consensus decoding a `Header`.
+        #[derive(Debug, Clone, PartialEq, Eq)]
+        #[non_exhaustive]
+        pub enum HeaderDecoderError from Decoder6<
+            super::VersionDecoder,
+            super::BlockHashDecoder,
+            super::TxMerkleNodeDecoder,
+            super::BlockTimeDecoder,
+            super::CompactTargetDecoder,
+            encoding::ArrayDecoder<4>,
+        > {
+            /// Error while decoding the `version`.
+            version => Version,
+            /// Error while decoding the `prev_blockhash`.
+            prev_blockhash => PrevBlockhash,
+            /// Error while decoding the `merkle_root`.
+            merkle_root => MerkleRoot,
+            /// Error while decoding the `time`.
+            time => Time,
+            /// Error while decoding the `bits`.
+            bits => Bits,
+            /// Error while decoding the `nonce`.
+            nonce => Nonce,
         }
     }
 

--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -557,11 +557,11 @@ type HeaderInnerDecoder = Decoder6<
 >;
 
 crate::decoder_newtype! {
-    /// The decoder for the [`Header`] type.
+    /// decoder for [`Header`] type.
     #[derive(Debug, Clone)]
     pub struct HeaderDecoder(HeaderInnerDecoder);
 
-    /// Constructs a new [`Header`] decoder.
+    /// constructs a new [`Header`] decoder.
     pub const fn new() -> Self {
         Self(Decoder6::new(
             VersionDecoder::new(),
@@ -577,12 +577,16 @@ crate::decoder_newtype! {
         HeaderDecoderError::from(err)
     }
 
+
     fn end(
-        result: Result<<HeaderInnerDecoder as encoding::Decoder>::Output, <HeaderInnerDecoder as encoding::Decoder>::Error>
+        result: Result<<HeaderInnerDecoder as encoding::Decoder>::Output,
+            <HeaderInnerDecoder as encoding::Decoder>::Error>
     ) -> Result<Header, HeaderDecoderError> {
+
         let (version, prev_blockhash, merkle_root, time, bits, nonce) =
             result.map_err(HeaderDecoderError::from)?;
         let nonce = u32::from_le_bytes(nonce);
+
         Ok(Header { version, prev_blockhash, merkle_root, time, bits, nonce })
     }
 }

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -847,10 +847,14 @@ crate::decoder_newtype! {
         ))
     }
 
+    fn map_push_bytes_err(err: <TxInInnerDecoder as encoding::Decoder>::Error) -> TxInDecoderError {
+        TxInDecoderError::from(err)
+    }
+
     fn end(
         result: Result<<TxInInnerDecoder as encoding::Decoder>::Output, <TxInInnerDecoder as encoding::Decoder>::Error>
     ) -> Result<TxIn, TxInDecoderError> {
-        let (previous_output, script_sig, sequence) = result.map_err(TxInDecoderError)?;
+        let (previous_output, script_sig, sequence) = result.map_err(TxInDecoderError::from)?;
         Ok(TxIn { previous_output, script_sig, sequence, witness: Witness::default() })
     }
 }
@@ -913,10 +917,14 @@ crate::decoder_newtype! {
         Self(Decoder2::new(AmountDecoder::new(), ScriptPubKeyBufDecoder::new()))
     }
 
+    fn map_push_bytes_err(err: <TxOutInnerDecoder as encoding::Decoder>::Error) -> TxOutDecoderError {
+        TxOutDecoderError::from(err)
+    }
+
     fn end(
         result: Result<<TxOutInnerDecoder as encoding::Decoder>::Output, <TxOutInnerDecoder as encoding::Decoder>::Error>
     ) -> Result<TxOut, TxOutDecoderError> {
-        let (amount, script_pubkey) = result.map_err(TxOutDecoderError)?;
+        let (amount, script_pubkey) = result.map_err(TxOutDecoderError::from)?;
         Ok(TxOut { amount, script_pubkey })
     }
 }
@@ -1383,49 +1391,37 @@ pub mod error {
         }
     }
 
-    /// An error consensus decoding a `TxIn`.
     #[cfg(feature = "alloc")]
-    #[derive(Debug, Clone, PartialEq, Eq)]
-    pub struct TxInDecoderError(pub(super) <super::TxInInnerDecoder as encoding::Decoder>::Error);
-
-    #[cfg(feature = "alloc")]
-    impl From<Infallible> for TxInDecoderError {
-        fn from(never: Infallible) -> Self { match never {} }
-    }
-
-    #[cfg(feature = "alloc")]
-    impl fmt::Display for TxInDecoderError {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            write_err!(f, "txin decoder error"; self.0)
+    encoding::decoder_error! {
+        /// An error consensus decoding a `TxIn`.
+        #[derive(Debug, Clone, PartialEq, Eq)]
+        pub enum TxInDecoderError from Decoder3<
+            super::OutPointDecoder,
+            super::ScriptSigBufDecoder,
+            super::SequenceDecoder,
+        > {
+            /// Error while decoding the `previous_output`.
+            previous_output => PreviousOutput,
+            /// Error while decoding the `script_sig`.
+            script_sig => ScriptSig,
+            /// Error while decoding the `sequence`.
+            sequence => Sequence,
         }
     }
 
     #[cfg(feature = "alloc")]
-    #[cfg(feature = "std")]
-    impl std::error::Error for TxInDecoderError {
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
-    }
-
-    /// An error consensus decoding a `TxOut`.
-    #[cfg(feature = "alloc")]
-    #[derive(Debug, Clone, PartialEq, Eq)]
-    pub struct TxOutDecoderError(pub(super) <super::TxOutInnerDecoder as encoding::Decoder>::Error);
-
-    #[cfg(feature = "alloc")]
-    impl From<Infallible> for TxOutDecoderError {
-        fn from(never: Infallible) -> Self { match never {} }
-    }
-
-    #[cfg(feature = "alloc")]
-    impl fmt::Display for TxOutDecoderError {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            write_err!(f, "txout decoder error"; self.0)
+    encoding::decoder_error! {
+        /// An error consensus decoding a `TxOut`.
+        #[derive(Debug, Clone, PartialEq, Eq)]
+        pub enum TxOutDecoderError from Decoder2<
+            super::AmountDecoder,
+            super::ScriptPubKeyBufDecoder,
+        > {
+            /// Error while decoding the `amount`.
+            amount => Amount,
+            /// Error while decoding the `script_pubkey`.
+            script_pubkey => ScriptPubKey,
         }
-    }
-
-    #[cfg(feature = "std")]
-    impl std::error::Error for TxOutDecoderError {
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
     }
 
     /// Error while decoding an `OutPoint`.
@@ -3085,7 +3081,7 @@ mod tests {
         assert!(decoder.push_bytes(&mut slice).unwrap().needs_more());
 
         let err = decoder.end().unwrap_err();
-        assert!(matches!(err.0, encoding::Decoder3Error::First(_)));
+        assert!(matches!(err, TxInDecoderError::PreviousOutput(_)));
 
         assert!(!err.to_string().is_empty());
         #[cfg(feature = "std")]
@@ -3106,7 +3102,7 @@ mod tests {
         assert!(decoder.push_bytes(&mut slice).unwrap().needs_more());
 
         let err = decoder.end().unwrap_err();
-        assert!(matches!(err.0, encoding::Decoder3Error::Second(_)));
+        assert!(matches!(err, TxInDecoderError::ScriptSig(_)));
 
         assert!(!err.to_string().is_empty());
         #[cfg(feature = "std")]
@@ -3127,7 +3123,7 @@ mod tests {
         assert!(decoder.push_bytes(&mut slice).unwrap().needs_more());
 
         let err = decoder.end().unwrap_err();
-        assert!(matches!(err.0, encoding::Decoder3Error::Third(_)));
+        assert!(matches!(err, TxInDecoderError::Sequence(_)));
 
         assert!(!err.to_string().is_empty());
         #[cfg(feature = "std")]
@@ -3142,7 +3138,7 @@ mod tests {
         assert!(decoder.push_bytes(&mut slice).unwrap().needs_more());
 
         let err = decoder.end().unwrap_err();
-        assert!(matches!(err.0, encoding::Decoder2Error::First(_)));
+        assert!(matches!(err, TxOutDecoderError::Amount(_)));
 
         assert!(!err.to_string().is_empty());
         #[cfg(feature = "std")]
@@ -3160,7 +3156,7 @@ mod tests {
         assert!(decoder.push_bytes(&mut slice).unwrap().needs_more());
 
         let err = decoder.end().unwrap_err();
-        assert!(matches!(err.0, encoding::Decoder2Error::Second(_)));
+        assert!(matches!(err, TxOutDecoderError::ScriptPubKey(_)));
 
         assert!(!err.to_string().is_empty());
         #[cfg(feature = "std")]

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -852,7 +852,8 @@ crate::decoder_newtype! {
     }
 
     fn end(
-        result: Result<<TxInInnerDecoder as encoding::Decoder>::Output, <TxInInnerDecoder as encoding::Decoder>::Error>
+        result: Result<<TxInInnerDecoder as encoding::Decoder>::Output,
+            <TxInInnerDecoder as encoding::Decoder>::Error>
     ) -> Result<TxIn, TxInDecoderError> {
         let (previous_output, script_sig, sequence) = result.map_err(TxInDecoderError::from)?;
         Ok(TxIn { previous_output, script_sig, sequence, witness: Witness::default() })
@@ -3073,6 +3074,7 @@ mod tests {
         assert!(err.source().is_none());
     }
 
+    /// tests for txin and txout _decoder_variant_error ///
     #[test]
     #[cfg(feature = "alloc")]
     fn txin_decoder_first_error() {
@@ -3094,7 +3096,8 @@ mod tests {
         let mut bytes = vec![];
         bytes.extend_from_slice(&TC_TXID_BYTES);
         bytes.extend_from_slice(&TC_VOUT_BYTES);
-        bytes.push(1); // scriptSig length = 1
+        // scriptSig length = 1
+        bytes.push(1);
 
         let mut decoder = TxIn::decoder();
         let mut slice = bytes.as_slice();
@@ -3115,7 +3118,8 @@ mod tests {
         let mut bytes = vec![];
         bytes.extend_from_slice(&TC_TXID_BYTES);
         bytes.extend_from_slice(&TC_VOUT_BYTES);
-        bytes.push(0); // scriptSig length = 0
+        // scriptSig length = 0
+        bytes.push(0);
 
         let mut decoder = TxIn::decoder();
         let mut slice = bytes.as_slice();


### PR DESCRIPTION
The composite `DecoderN` decoder returns position based errors (`Decoder3Error::Second`, ...); each consuming type hand-writes a named error enum plus `From<Infallible>`, `Display`, `Error`, and a positional `match` to flatten them.

This is already done by hand in `HeaderDecoderError` and `TransactionDecoderError`, and those `Display` impls don't even report which field failed. Meanwhile TxIn and TxOut decoder errors were simply left as raw `DecoderNError` newtypes, so their errors read stuff like "second decoder error".

So decided to add a `macro_rules!` helper, `decoder_error!`, in `bitcoin-consensus-encoding`. From a `field => Variant` list and the composite decoder, it generates the flat enum with the flattening `From` and `From<Infallible>` + `Display` + `Error`.

Converts three errors to use the macro:
- `HeaderDecoderError` (the flat `Decoder6`) -> variants unchanged, so no tests
- `TxInDecoderError` and `TxOutDecoderError` -> previously raw newtypes, now they have named variants PreviousOutput/ScriptSig/Sequence, Amount/ScriptPubKey in place of `.0` access

This handles the **flat-single DecoderN** case. The nested tower case is left as follow-up.
