### PR TITLE
encoding: add decoder_error! macro for flattening composite decoder errors

### DIFF
--- a/include/decoder_error.rs
+++ b/include/decoder_error.rs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: CC0-1.0
+
+/// Defines a flat, named error enum for a composite [`Decoder`](encoding::Decoder) and the
+/// conversion that flattens its positional `DecoderNError` into it.
+///
+/// The pattern is otherwise written out by hand (see e.g. `HeaderDecoderError`): rather than
+/// declaring the enum plus `From<Infallible>`, `Display`, [`std::error::Error`] and a positional
+/// `match` by hand, list `field: ErrorType => Variant` entries together with the composite decoder
+/// they come from.
+///
+/// Each entry names its error type explicitly rather than having the macro infer it as
+/// `<D as Decoder>::Error`. The inferred form is shorter to write, but it is what ends up in
+/// rustdoc and in the checked-in API files, where a variant is far more useful spelled
+/// `Bits(CompactTargetDecoderError)` than `Bits(<CompactTargetDecoder as Decoder>::Error)`. The
+/// two cannot drift: the generated code statically asserts that each named error type really is
+/// the associated error type of the decoder in that position.
+///
+/// The generated flattening is a single exhaustive `match` over `DecoderNError`, so a dropped,
+/// mistyped or duplicated field will fail to compile. It is a private constructor rather than a
+/// `From` impl, so flattening an encoding-internal positional error stays an implementation
+/// detail instead of becoming public API.
+///
+/// The generated `Display` reports the field name (``error decoding `script_sig` field``).
+macro_rules! decoder_error {
+    // ----- arity 6 -----
+    (
+        $(#[$attr:meta])*
+        $vis:vis enum $name:ident from Decoder6<$d0:ty, $d1:ty, $d2:ty, $d3:ty, $d4:ty, $d5:ty $(,)?> {
+            $(#[$a0:meta])* $f0:ident: $e0:ty => $v0:ident,
+            $(#[$a1:meta])* $f1:ident: $e1:ty => $v1:ident,
+            $(#[$a2:meta])* $f2:ident: $e2:ty => $v2:ident,
+            $(#[$a3:meta])* $f3:ident: $e3:ty => $v3:ident,
+            $(#[$a4:meta])* $f4:ident: $e4:ty => $v4:ident,
+            $(#[$a5:meta])* $f5:ident: $e5:ty => $v5:ident $(,)?
+        }
+    ) => {
+        crate::decoder_error!(@build $(#[$attr])* $vis $name; Decoder6Error;
+            (First,  [$(#[$a0])*], $f0, $v0, $d0, $e0),
+            (Second, [$(#[$a1])*], $f1, $v1, $d1, $e1),
+            (Third,  [$(#[$a2])*], $f2, $v2, $d2, $e2),
+            (Fourth, [$(#[$a3])*], $f3, $v3, $d3, $e3),
+            (Fifth,  [$(#[$a4])*], $f4, $v4, $d4, $e4),
+            (Sixth,  [$(#[$a5])*], $f5, $v5, $d5, $e5),
+        );
+    };
+
+    // ----- shared codegen -----
+    (@build
+        $(#[$attr:meta])* $vis:vis $name:ident; $errenum:ident;
+        $( ($wrap:ident, [$(#[$fattr:meta])*], $field:ident, $variant:ident, $dec:ty, $err:ty) ),* $(,)?
+    ) => {
+        $(#[$attr])*
+        $vis enum $name {
+            $(
+                $(#[$fattr])*
+                $variant($err),
+            )*
+        }
+
+        // Ties the spelled-out error types back to the decoders they came from: this fails to
+        // compile unless each `$err` is exactly `<$dec as Decoder>::Error`. The closure is only
+        // ever type checked, never called.
+        const _: fn() = || {
+            fn assert_decoder_error<D: encoding::Decoder<Error = E>, E>() {}
+            $( assert_decoder_error::<$dec, $err>(); )*
+        };
+
+        impl $name {
+            /// Flattens the positional error of the composite decoder into this named enum.
+            ///
+            /// Kept private: the positional `DecoderNError` types are an implementation detail of
+            /// the encoding crate and we do not want to commit to converting from them.
+            pub(crate) fn from_inner(e: encoding::$errenum< $($err),* >) -> Self {
+                match e {
+                    $( encoding::$errenum::$wrap(e) => $name::$variant(e), )*
+                }
+            }
+        }
+
+        impl ::core::convert::From<::core::convert::Infallible> for $name {
+            fn from(never: ::core::convert::Infallible) -> Self { match never {} }
+        }
+
+        impl ::core::fmt::Display for $name {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                match self {
+                    $(
+                        // This is what `internals::write_err!` does, hand-inlined: that macro
+                        // needs a literal format string and `stringify!($field)` is not one.
+                        // Without `std` there is no `source()`, so the source is appended here
+                        // instead of being lost.
+                        $name::$variant(e) => {
+                            #[cfg(feature = "std")]
+                            { let _ = e; write!(f, "error decoding `{}` field", stringify!($field)) }
+                            #[cfg(not(feature = "std"))]
+                            { write!(f, "error decoding `{}` field: {}", stringify!($field), e) }
+                        }
+                    )*
+                }
+            }
+        }
+
+        #[cfg(feature = "std")]
+        impl std::error::Error for $name {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                match self {
+                    $( $name::$variant(e) => Some(e), )*
+                }
+            }
+        }
+    };
+}
+pub(crate) use decoder_error;

--- a/include/decoder_error.rs
+++ b/include/decoder_error.rs
@@ -22,6 +22,19 @@
 ///
 /// The generated `Display` reports the field name (``error decoding `script_sig` field``).
 macro_rules! decoder_error {
+    // ----- arity 2 -----
+    (
+        $(#[$attr:meta])*
+        $vis:vis enum $name:ident from Decoder2<$d0:ty, $d1:ty $(,)?> {
+            $(#[$a0:meta])* $f0:ident: $e0:ty => $v0:ident,
+            $(#[$a1:meta])* $f1:ident: $e1:ty => $v1:ident $(,)?
+        }
+    ) => {
+        crate::decoder_error!(@build $(#[$attr])* $vis $name; Decoder2Error;
+            (First,  [$(#[$a0])*], $f0, $v0, $d0, $e0),
+            (Second, [$(#[$a1])*], $f1, $v1, $d1, $e1),
+        );
+    };
     // ----- arity 3 -----
     (
         $(#[$attr:meta])*

--- a/include/decoder_error.rs
+++ b/include/decoder_error.rs
@@ -22,6 +22,21 @@
 ///
 /// The generated `Display` reports the field name (``error decoding `script_sig` field``).
 macro_rules! decoder_error {
+    // ----- arity 3 -----
+    (
+        $(#[$attr:meta])*
+        $vis:vis enum $name:ident from Decoder3<$d0:ty, $d1:ty, $d2:ty $(,)?> {
+            $(#[$a0:meta])* $f0:ident: $e0:ty => $v0:ident,
+            $(#[$a1:meta])* $f1:ident: $e1:ty => $v1:ident,
+            $(#[$a2:meta])* $f2:ident: $e2:ty => $v2:ident $(,)?
+        }
+    ) => {
+        crate::decoder_error!(@build $(#[$attr])* $vis $name; Decoder3Error;
+            (First,  [$(#[$a0])*], $f0, $v0, $d0, $e0),
+            (Second, [$(#[$a1])*], $f1, $v1, $d1, $e1),
+            (Third,  [$(#[$a2])*], $f2, $v2, $d2, $e2),
+        );
+    };
     // ----- arity 6 -----
     (
         $(#[$attr:meta])*

--- a/primitives/api/all-features.txt
+++ b/primitives/api/all-features.txt
@@ -4347,6 +4347,54 @@ impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::T
   pub unsafe fn bitcoin_primitives::transaction::error::TxInDecoderError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxInDecoderError
   pub fn bitcoin_primitives::transaction::error::TxInDecoderError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxInDecoderError]
+#[non_exhaustive] pub enum bitcoin_primitives::transaction::error::TxOutDecoderError
+pub bitcoin_primitives::transaction::error::TxOutDecoderError::Amount(bitcoin_units::amount::error::AmountDecoderError)
+pub bitcoin_primitives::transaction::error::TxOutDecoderError::ScriptPubKey(bitcoin_primitives::script::error::ScriptBufDecoderError)
+impl core::clone::Clone for bitcoin_primitives::transaction::error::TxOutDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::clone(&self) -> bitcoin_primitives::transaction::error::TxOutDecoderError [impl: impl core::clone::Clone for bitcoin_primitives::transaction::error::TxOutDecoderError]
+impl core::cmp::Eq for bitcoin_primitives::transaction::error::TxOutDecoderError
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::error::TxOutDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::eq(&self, other: &bitcoin_primitives::transaction::error::TxOutDecoderError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::transaction::error::TxOutDecoderError]
+impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::transaction::error::TxOutDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::transaction::error::TxOutDecoderError]
+impl core::error::Error for bitcoin_primitives::transaction::error::TxOutDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)> [impl: impl core::error::Error for bitcoin_primitives::transaction::error::TxOutDecoderError]
+impl core::fmt::Debug for bitcoin_primitives::transaction::error::TxOutDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::transaction::error::TxOutDecoderError]
+impl core::fmt::Display for bitcoin_primitives::transaction::error::TxOutDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::transaction::error::TxOutDecoderError]
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::error::TxOutDecoderError
+impl core::marker::Freeze for bitcoin_primitives::transaction::error::TxOutDecoderError
+impl core::marker::Send for bitcoin_primitives::transaction::error::TxOutDecoderError
+impl core::marker::Sync for bitcoin_primitives::transaction::error::TxOutDecoderError
+impl core::marker::Unpin for bitcoin_primitives::transaction::error::TxOutDecoderError
+impl core::marker::UnsafeUnpin for bitcoin_primitives::transaction::error::TxOutDecoderError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::error::TxOutDecoderError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::error::TxOutDecoderError
+impl<T, U> core::convert::Into<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::From<T>
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::Into<T>
+  pub type bitcoin_primitives::transaction::error::TxOutDecoderError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::Into<T>]
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::TryFrom<T>
+  pub type bitcoin_primitives::transaction::error::TxOutDecoderError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::TryFrom<T>]
+impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone
+  pub type bitcoin_primitives::transaction::error::TxOutDecoderError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone]
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone]
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone]
+impl<T> alloc::string::ToString for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::fmt::Display + ?core::marker::Sized
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::fmt::Display + ?core::marker::Sized]
+impl<T> core::any::Any for bitcoin_primitives::transaction::error::TxOutDecoderError where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::transaction::error::TxOutDecoderError where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::error::TxOutDecoderError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::error::TxOutDecoderError where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::error::TxOutDecoderError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::error::TxOutDecoderError where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone
+  pub unsafe fn bitcoin_primitives::transaction::error::TxOutDecoderError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxOutDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxOutDecoderError]
 pub struct bitcoin_primitives::transaction::error::OutPointDecoderError(_)
 impl core::clone::Clone for bitcoin_primitives::transaction::error::OutPointDecoderError
   pub fn bitcoin_primitives::transaction::error::OutPointDecoderError::clone(&self) -> bitcoin_primitives::transaction::error::OutPointDecoderError [impl: impl core::clone::Clone for bitcoin_primitives::transaction::error::OutPointDecoderError]
@@ -4439,52 +4487,6 @@ impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::T
   pub unsafe fn bitcoin_primitives::transaction::error::TransactionDecoderError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TransactionDecoderError where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TransactionDecoderError
   pub fn bitcoin_primitives::transaction::error::TransactionDecoderError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TransactionDecoderError]
-pub struct bitcoin_primitives::transaction::error::TxOutDecoderError(_)
-impl core::clone::Clone for bitcoin_primitives::transaction::error::TxOutDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::clone(&self) -> bitcoin_primitives::transaction::error::TxOutDecoderError [impl: impl core::clone::Clone for bitcoin_primitives::transaction::error::TxOutDecoderError]
-impl core::cmp::Eq for bitcoin_primitives::transaction::error::TxOutDecoderError
-impl core::cmp::PartialEq for bitcoin_primitives::transaction::error::TxOutDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::eq(&self, other: &bitcoin_primitives::transaction::error::TxOutDecoderError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::transaction::error::TxOutDecoderError]
-impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::transaction::error::TxOutDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::transaction::error::TxOutDecoderError]
-impl core::error::Error for bitcoin_primitives::transaction::error::TxOutDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)> [impl: impl core::error::Error for bitcoin_primitives::transaction::error::TxOutDecoderError]
-impl core::fmt::Debug for bitcoin_primitives::transaction::error::TxOutDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::transaction::error::TxOutDecoderError]
-impl core::fmt::Display for bitcoin_primitives::transaction::error::TxOutDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::transaction::error::TxOutDecoderError]
-impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::error::TxOutDecoderError
-impl core::marker::Freeze for bitcoin_primitives::transaction::error::TxOutDecoderError
-impl core::marker::Send for bitcoin_primitives::transaction::error::TxOutDecoderError
-impl core::marker::Sync for bitcoin_primitives::transaction::error::TxOutDecoderError
-impl core::marker::Unpin for bitcoin_primitives::transaction::error::TxOutDecoderError
-impl core::marker::UnsafeUnpin for bitcoin_primitives::transaction::error::TxOutDecoderError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::error::TxOutDecoderError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::error::TxOutDecoderError
-impl<T, U> core::convert::Into<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::From<T>
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::From<T>]
-impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::Into<T>
-  pub type bitcoin_primitives::transaction::error::TxOutDecoderError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::Into<T>]
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::Into<T>]
-impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::TryFrom<T>
-  pub type bitcoin_primitives::transaction::error::TxOutDecoderError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::TryFrom<T>]
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::TryFrom<T>]
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone
-  pub type bitcoin_primitives::transaction::error::TxOutDecoderError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone]
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone]
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone]
-impl<T> alloc::string::ToString for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::fmt::Display + ?core::marker::Sized
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::fmt::Display + ?core::marker::Sized]
-impl<T> core::any::Any for bitcoin_primitives::transaction::error::TxOutDecoderError where T: 'static + ?core::marker::Sized
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::transaction::error::TxOutDecoderError where T: 'static + ?core::marker::Sized]
-impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::error::TxOutDecoderError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::error::TxOutDecoderError where T: ?core::marker::Sized]
-impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::error::TxOutDecoderError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::error::TxOutDecoderError where T: ?core::marker::Sized]
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone
-  pub unsafe fn bitcoin_primitives::transaction::error::TxOutDecoderError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone]
-impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxOutDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxOutDecoderError]
 pub struct bitcoin_primitives::transaction::error::VersionDecoderError(_)
 impl core::clone::Clone for bitcoin_primitives::transaction::error::VersionDecoderError
   pub fn bitcoin_primitives::transaction::error::VersionDecoderError::clone(&self) -> bitcoin_primitives::transaction::error::VersionDecoderError [impl: impl core::clone::Clone for bitcoin_primitives::transaction::error::VersionDecoderError]
@@ -4631,6 +4633,54 @@ impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::T
   pub unsafe fn bitcoin_primitives::transaction::error::TxInDecoderError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxInDecoderError
   pub fn bitcoin_primitives::transaction::error::TxInDecoderError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxInDecoderError]
+#[non_exhaustive] pub enum bitcoin_primitives::transaction::TxOutDecoderError
+pub bitcoin_primitives::transaction::TxOutDecoderError::Amount(bitcoin_units::amount::error::AmountDecoderError)
+pub bitcoin_primitives::transaction::TxOutDecoderError::ScriptPubKey(bitcoin_primitives::script::error::ScriptBufDecoderError)
+impl core::clone::Clone for bitcoin_primitives::transaction::error::TxOutDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::clone(&self) -> bitcoin_primitives::transaction::error::TxOutDecoderError [impl: impl core::clone::Clone for bitcoin_primitives::transaction::error::TxOutDecoderError]
+impl core::cmp::Eq for bitcoin_primitives::transaction::error::TxOutDecoderError
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::error::TxOutDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::eq(&self, other: &bitcoin_primitives::transaction::error::TxOutDecoderError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::transaction::error::TxOutDecoderError]
+impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::transaction::error::TxOutDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::transaction::error::TxOutDecoderError]
+impl core::error::Error for bitcoin_primitives::transaction::error::TxOutDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)> [impl: impl core::error::Error for bitcoin_primitives::transaction::error::TxOutDecoderError]
+impl core::fmt::Debug for bitcoin_primitives::transaction::error::TxOutDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::transaction::error::TxOutDecoderError]
+impl core::fmt::Display for bitcoin_primitives::transaction::error::TxOutDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::transaction::error::TxOutDecoderError]
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::error::TxOutDecoderError
+impl core::marker::Freeze for bitcoin_primitives::transaction::error::TxOutDecoderError
+impl core::marker::Send for bitcoin_primitives::transaction::error::TxOutDecoderError
+impl core::marker::Sync for bitcoin_primitives::transaction::error::TxOutDecoderError
+impl core::marker::Unpin for bitcoin_primitives::transaction::error::TxOutDecoderError
+impl core::marker::UnsafeUnpin for bitcoin_primitives::transaction::error::TxOutDecoderError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::error::TxOutDecoderError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::error::TxOutDecoderError
+impl<T, U> core::convert::Into<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::From<T>
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::Into<T>
+  pub type bitcoin_primitives::transaction::error::TxOutDecoderError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::Into<T>]
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::TryFrom<T>
+  pub type bitcoin_primitives::transaction::error::TxOutDecoderError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::TryFrom<T>]
+impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone
+  pub type bitcoin_primitives::transaction::error::TxOutDecoderError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone]
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone]
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone]
+impl<T> alloc::string::ToString for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::fmt::Display + ?core::marker::Sized
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::fmt::Display + ?core::marker::Sized]
+impl<T> core::any::Any for bitcoin_primitives::transaction::error::TxOutDecoderError where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::transaction::error::TxOutDecoderError where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::error::TxOutDecoderError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::error::TxOutDecoderError where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::error::TxOutDecoderError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::error::TxOutDecoderError where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone
+  pub unsafe fn bitcoin_primitives::transaction::error::TxOutDecoderError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxOutDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxOutDecoderError]
 pub struct bitcoin_primitives::transaction::BlockHashDecoder(_)
 impl bitcoin_primitives::block::BlockHashDecoder
 pub const fn bitcoin_primitives::block::BlockHashDecoder::new() -> Self
@@ -5438,52 +5488,6 @@ impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::TxOutDec
   pub unsafe fn bitcoin_primitives::transaction::TxOutDecoder::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::TxOutDecoder where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_primitives::transaction::TxOutDecoder
   pub fn bitcoin_primitives::transaction::TxOutDecoder::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::transaction::TxOutDecoder]
-pub struct bitcoin_primitives::transaction::TxOutDecoderError(_)
-impl core::clone::Clone for bitcoin_primitives::transaction::error::TxOutDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::clone(&self) -> bitcoin_primitives::transaction::error::TxOutDecoderError [impl: impl core::clone::Clone for bitcoin_primitives::transaction::error::TxOutDecoderError]
-impl core::cmp::Eq for bitcoin_primitives::transaction::error::TxOutDecoderError
-impl core::cmp::PartialEq for bitcoin_primitives::transaction::error::TxOutDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::eq(&self, other: &bitcoin_primitives::transaction::error::TxOutDecoderError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::transaction::error::TxOutDecoderError]
-impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::transaction::error::TxOutDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::transaction::error::TxOutDecoderError]
-impl core::error::Error for bitcoin_primitives::transaction::error::TxOutDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)> [impl: impl core::error::Error for bitcoin_primitives::transaction::error::TxOutDecoderError]
-impl core::fmt::Debug for bitcoin_primitives::transaction::error::TxOutDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::transaction::error::TxOutDecoderError]
-impl core::fmt::Display for bitcoin_primitives::transaction::error::TxOutDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::transaction::error::TxOutDecoderError]
-impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::error::TxOutDecoderError
-impl core::marker::Freeze for bitcoin_primitives::transaction::error::TxOutDecoderError
-impl core::marker::Send for bitcoin_primitives::transaction::error::TxOutDecoderError
-impl core::marker::Sync for bitcoin_primitives::transaction::error::TxOutDecoderError
-impl core::marker::Unpin for bitcoin_primitives::transaction::error::TxOutDecoderError
-impl core::marker::UnsafeUnpin for bitcoin_primitives::transaction::error::TxOutDecoderError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::error::TxOutDecoderError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::error::TxOutDecoderError
-impl<T, U> core::convert::Into<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::From<T>
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::From<T>]
-impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::Into<T>
-  pub type bitcoin_primitives::transaction::error::TxOutDecoderError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::Into<T>]
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::Into<T>]
-impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::TryFrom<T>
-  pub type bitcoin_primitives::transaction::error::TxOutDecoderError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::TryFrom<T>]
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::TryFrom<T>]
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone
-  pub type bitcoin_primitives::transaction::error::TxOutDecoderError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone]
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone]
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone]
-impl<T> alloc::string::ToString for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::fmt::Display + ?core::marker::Sized
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::fmt::Display + ?core::marker::Sized]
-impl<T> core::any::Any for bitcoin_primitives::transaction::error::TxOutDecoderError where T: 'static + ?core::marker::Sized
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::transaction::error::TxOutDecoderError where T: 'static + ?core::marker::Sized]
-impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::error::TxOutDecoderError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::error::TxOutDecoderError where T: ?core::marker::Sized]
-impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::error::TxOutDecoderError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::error::TxOutDecoderError where T: ?core::marker::Sized]
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone
-  pub unsafe fn bitcoin_primitives::transaction::error::TxOutDecoderError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone]
-impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxOutDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxOutDecoderError]
 pub struct bitcoin_primitives::transaction::TxOutEncoder<'e>(_, _)
 impl<'e> bitcoin_consensus_encoding::encode::Encoder for bitcoin_primitives::transaction::TxOutEncoder<'e>
   pub fn bitcoin_primitives::transaction::TxOutEncoder<'e>::advance(&mut self) -> bitcoin_consensus_encoding::encode::EncoderStatus [impl: impl<'e> bitcoin_consensus_encoding::encode::Encoder for bitcoin_primitives::transaction::TxOutEncoder<'e>]

--- a/primitives/api/all-features.txt
+++ b/primitives/api/all-features.txt
@@ -4298,6 +4298,55 @@ impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::P
   pub unsafe fn bitcoin_primitives::transaction::error::ParseOutPointError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::ParseOutPointError where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::ParseOutPointError
   pub fn bitcoin_primitives::transaction::error::ParseOutPointError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::ParseOutPointError]
+#[non_exhaustive] pub enum bitcoin_primitives::transaction::error::TxInDecoderError
+pub bitcoin_primitives::transaction::error::TxInDecoderError::PreviousOutput(bitcoin_primitives::transaction::error::OutPointDecoderError)
+pub bitcoin_primitives::transaction::error::TxInDecoderError::ScriptSig(bitcoin_primitives::script::error::ScriptBufDecoderError)
+pub bitcoin_primitives::transaction::error::TxInDecoderError::Sequence(bitcoin_units::sequence::error::SequenceDecoderError)
+impl core::clone::Clone for bitcoin_primitives::transaction::error::TxInDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::clone(&self) -> bitcoin_primitives::transaction::error::TxInDecoderError [impl: impl core::clone::Clone for bitcoin_primitives::transaction::error::TxInDecoderError]
+impl core::cmp::Eq for bitcoin_primitives::transaction::error::TxInDecoderError
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::error::TxInDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::eq(&self, other: &bitcoin_primitives::transaction::error::TxInDecoderError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::transaction::error::TxInDecoderError]
+impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::transaction::error::TxInDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::transaction::error::TxInDecoderError]
+impl core::error::Error for bitcoin_primitives::transaction::error::TxInDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)> [impl: impl core::error::Error for bitcoin_primitives::transaction::error::TxInDecoderError]
+impl core::fmt::Debug for bitcoin_primitives::transaction::error::TxInDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::transaction::error::TxInDecoderError]
+impl core::fmt::Display for bitcoin_primitives::transaction::error::TxInDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::transaction::error::TxInDecoderError]
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::error::TxInDecoderError
+impl core::marker::Freeze for bitcoin_primitives::transaction::error::TxInDecoderError
+impl core::marker::Send for bitcoin_primitives::transaction::error::TxInDecoderError
+impl core::marker::Sync for bitcoin_primitives::transaction::error::TxInDecoderError
+impl core::marker::Unpin for bitcoin_primitives::transaction::error::TxInDecoderError
+impl core::marker::UnsafeUnpin for bitcoin_primitives::transaction::error::TxInDecoderError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::error::TxInDecoderError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::error::TxInDecoderError
+impl<T, U> core::convert::Into<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::From<T>
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::Into<T>
+  pub type bitcoin_primitives::transaction::error::TxInDecoderError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::Into<T>]
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::TryFrom<T>
+  pub type bitcoin_primitives::transaction::error::TxInDecoderError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::TryFrom<T>]
+impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone
+  pub type bitcoin_primitives::transaction::error::TxInDecoderError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone]
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone]
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone]
+impl<T> alloc::string::ToString for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::fmt::Display + ?core::marker::Sized
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::fmt::Display + ?core::marker::Sized]
+impl<T> core::any::Any for bitcoin_primitives::transaction::error::TxInDecoderError where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::transaction::error::TxInDecoderError where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::error::TxInDecoderError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::error::TxInDecoderError where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::error::TxInDecoderError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::error::TxInDecoderError where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone
+  pub unsafe fn bitcoin_primitives::transaction::error::TxInDecoderError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxInDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxInDecoderError]
 pub struct bitcoin_primitives::transaction::error::OutPointDecoderError(_)
 impl core::clone::Clone for bitcoin_primitives::transaction::error::OutPointDecoderError
   pub fn bitcoin_primitives::transaction::error::OutPointDecoderError::clone(&self) -> bitcoin_primitives::transaction::error::OutPointDecoderError [impl: impl core::clone::Clone for bitcoin_primitives::transaction::error::OutPointDecoderError]
@@ -4390,52 +4439,6 @@ impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::T
   pub unsafe fn bitcoin_primitives::transaction::error::TransactionDecoderError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TransactionDecoderError where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TransactionDecoderError
   pub fn bitcoin_primitives::transaction::error::TransactionDecoderError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TransactionDecoderError]
-pub struct bitcoin_primitives::transaction::error::TxInDecoderError(_)
-impl core::clone::Clone for bitcoin_primitives::transaction::error::TxInDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::clone(&self) -> bitcoin_primitives::transaction::error::TxInDecoderError [impl: impl core::clone::Clone for bitcoin_primitives::transaction::error::TxInDecoderError]
-impl core::cmp::Eq for bitcoin_primitives::transaction::error::TxInDecoderError
-impl core::cmp::PartialEq for bitcoin_primitives::transaction::error::TxInDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::eq(&self, other: &bitcoin_primitives::transaction::error::TxInDecoderError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::transaction::error::TxInDecoderError]
-impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::transaction::error::TxInDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::transaction::error::TxInDecoderError]
-impl core::error::Error for bitcoin_primitives::transaction::error::TxInDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)> [impl: impl core::error::Error for bitcoin_primitives::transaction::error::TxInDecoderError]
-impl core::fmt::Debug for bitcoin_primitives::transaction::error::TxInDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::transaction::error::TxInDecoderError]
-impl core::fmt::Display for bitcoin_primitives::transaction::error::TxInDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::transaction::error::TxInDecoderError]
-impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::error::TxInDecoderError
-impl core::marker::Freeze for bitcoin_primitives::transaction::error::TxInDecoderError
-impl core::marker::Send for bitcoin_primitives::transaction::error::TxInDecoderError
-impl core::marker::Sync for bitcoin_primitives::transaction::error::TxInDecoderError
-impl core::marker::Unpin for bitcoin_primitives::transaction::error::TxInDecoderError
-impl core::marker::UnsafeUnpin for bitcoin_primitives::transaction::error::TxInDecoderError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::error::TxInDecoderError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::error::TxInDecoderError
-impl<T, U> core::convert::Into<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::From<T>
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::From<T>]
-impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::Into<T>
-  pub type bitcoin_primitives::transaction::error::TxInDecoderError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::Into<T>]
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::Into<T>]
-impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::TryFrom<T>
-  pub type bitcoin_primitives::transaction::error::TxInDecoderError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::TryFrom<T>]
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::TryFrom<T>]
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone
-  pub type bitcoin_primitives::transaction::error::TxInDecoderError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone]
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone]
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone]
-impl<T> alloc::string::ToString for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::fmt::Display + ?core::marker::Sized
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::fmt::Display + ?core::marker::Sized]
-impl<T> core::any::Any for bitcoin_primitives::transaction::error::TxInDecoderError where T: 'static + ?core::marker::Sized
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::transaction::error::TxInDecoderError where T: 'static + ?core::marker::Sized]
-impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::error::TxInDecoderError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::error::TxInDecoderError where T: ?core::marker::Sized]
-impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::error::TxInDecoderError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::error::TxInDecoderError where T: ?core::marker::Sized]
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone
-  pub unsafe fn bitcoin_primitives::transaction::error::TxInDecoderError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone]
-impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxInDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxInDecoderError]
 pub struct bitcoin_primitives::transaction::error::TxOutDecoderError(_)
 impl core::clone::Clone for bitcoin_primitives::transaction::error::TxOutDecoderError
   pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::clone(&self) -> bitcoin_primitives::transaction::error::TxOutDecoderError [impl: impl core::clone::Clone for bitcoin_primitives::transaction::error::TxOutDecoderError]
@@ -4579,6 +4582,55 @@ impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::P
   pub unsafe fn bitcoin_primitives::transaction::error::ParseOutPointError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::ParseOutPointError where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::ParseOutPointError
   pub fn bitcoin_primitives::transaction::error::ParseOutPointError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::ParseOutPointError]
+#[non_exhaustive] pub enum bitcoin_primitives::transaction::TxInDecoderError
+pub bitcoin_primitives::transaction::TxInDecoderError::PreviousOutput(bitcoin_primitives::transaction::error::OutPointDecoderError)
+pub bitcoin_primitives::transaction::TxInDecoderError::ScriptSig(bitcoin_primitives::script::error::ScriptBufDecoderError)
+pub bitcoin_primitives::transaction::TxInDecoderError::Sequence(bitcoin_units::sequence::error::SequenceDecoderError)
+impl core::clone::Clone for bitcoin_primitives::transaction::error::TxInDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::clone(&self) -> bitcoin_primitives::transaction::error::TxInDecoderError [impl: impl core::clone::Clone for bitcoin_primitives::transaction::error::TxInDecoderError]
+impl core::cmp::Eq for bitcoin_primitives::transaction::error::TxInDecoderError
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::error::TxInDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::eq(&self, other: &bitcoin_primitives::transaction::error::TxInDecoderError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::transaction::error::TxInDecoderError]
+impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::transaction::error::TxInDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::transaction::error::TxInDecoderError]
+impl core::error::Error for bitcoin_primitives::transaction::error::TxInDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)> [impl: impl core::error::Error for bitcoin_primitives::transaction::error::TxInDecoderError]
+impl core::fmt::Debug for bitcoin_primitives::transaction::error::TxInDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::transaction::error::TxInDecoderError]
+impl core::fmt::Display for bitcoin_primitives::transaction::error::TxInDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::transaction::error::TxInDecoderError]
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::error::TxInDecoderError
+impl core::marker::Freeze for bitcoin_primitives::transaction::error::TxInDecoderError
+impl core::marker::Send for bitcoin_primitives::transaction::error::TxInDecoderError
+impl core::marker::Sync for bitcoin_primitives::transaction::error::TxInDecoderError
+impl core::marker::Unpin for bitcoin_primitives::transaction::error::TxInDecoderError
+impl core::marker::UnsafeUnpin for bitcoin_primitives::transaction::error::TxInDecoderError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::error::TxInDecoderError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::error::TxInDecoderError
+impl<T, U> core::convert::Into<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::From<T>
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::Into<T>
+  pub type bitcoin_primitives::transaction::error::TxInDecoderError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::Into<T>]
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::TryFrom<T>
+  pub type bitcoin_primitives::transaction::error::TxInDecoderError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::TryFrom<T>]
+impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone
+  pub type bitcoin_primitives::transaction::error::TxInDecoderError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone]
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone]
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone]
+impl<T> alloc::string::ToString for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::fmt::Display + ?core::marker::Sized
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::fmt::Display + ?core::marker::Sized]
+impl<T> core::any::Any for bitcoin_primitives::transaction::error::TxInDecoderError where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::transaction::error::TxInDecoderError where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::error::TxInDecoderError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::error::TxInDecoderError where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::error::TxInDecoderError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::error::TxInDecoderError where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone
+  pub unsafe fn bitcoin_primitives::transaction::error::TxInDecoderError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxInDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxInDecoderError]
 pub struct bitcoin_primitives::transaction::BlockHashDecoder(_)
 impl bitcoin_primitives::block::BlockHashDecoder
 pub const fn bitcoin_primitives::block::BlockHashDecoder::new() -> Self
@@ -5250,52 +5302,6 @@ impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::TxInDeco
   pub unsafe fn bitcoin_primitives::transaction::TxInDecoder::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::TxInDecoder where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_primitives::transaction::TxInDecoder
   pub fn bitcoin_primitives::transaction::TxInDecoder::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::transaction::TxInDecoder]
-pub struct bitcoin_primitives::transaction::TxInDecoderError(_)
-impl core::clone::Clone for bitcoin_primitives::transaction::error::TxInDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::clone(&self) -> bitcoin_primitives::transaction::error::TxInDecoderError [impl: impl core::clone::Clone for bitcoin_primitives::transaction::error::TxInDecoderError]
-impl core::cmp::Eq for bitcoin_primitives::transaction::error::TxInDecoderError
-impl core::cmp::PartialEq for bitcoin_primitives::transaction::error::TxInDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::eq(&self, other: &bitcoin_primitives::transaction::error::TxInDecoderError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::transaction::error::TxInDecoderError]
-impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::transaction::error::TxInDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::transaction::error::TxInDecoderError]
-impl core::error::Error for bitcoin_primitives::transaction::error::TxInDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)> [impl: impl core::error::Error for bitcoin_primitives::transaction::error::TxInDecoderError]
-impl core::fmt::Debug for bitcoin_primitives::transaction::error::TxInDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::transaction::error::TxInDecoderError]
-impl core::fmt::Display for bitcoin_primitives::transaction::error::TxInDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::transaction::error::TxInDecoderError]
-impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::error::TxInDecoderError
-impl core::marker::Freeze for bitcoin_primitives::transaction::error::TxInDecoderError
-impl core::marker::Send for bitcoin_primitives::transaction::error::TxInDecoderError
-impl core::marker::Sync for bitcoin_primitives::transaction::error::TxInDecoderError
-impl core::marker::Unpin for bitcoin_primitives::transaction::error::TxInDecoderError
-impl core::marker::UnsafeUnpin for bitcoin_primitives::transaction::error::TxInDecoderError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::error::TxInDecoderError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::error::TxInDecoderError
-impl<T, U> core::convert::Into<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::From<T>
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::From<T>]
-impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::Into<T>
-  pub type bitcoin_primitives::transaction::error::TxInDecoderError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::Into<T>]
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::Into<T>]
-impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::TryFrom<T>
-  pub type bitcoin_primitives::transaction::error::TxInDecoderError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::TryFrom<T>]
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::TryFrom<T>]
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone
-  pub type bitcoin_primitives::transaction::error::TxInDecoderError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone]
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone]
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone]
-impl<T> alloc::string::ToString for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::fmt::Display + ?core::marker::Sized
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::fmt::Display + ?core::marker::Sized]
-impl<T> core::any::Any for bitcoin_primitives::transaction::error::TxInDecoderError where T: 'static + ?core::marker::Sized
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::transaction::error::TxInDecoderError where T: 'static + ?core::marker::Sized]
-impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::error::TxInDecoderError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::error::TxInDecoderError where T: ?core::marker::Sized]
-impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::error::TxInDecoderError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::error::TxInDecoderError where T: ?core::marker::Sized]
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone
-  pub unsafe fn bitcoin_primitives::transaction::error::TxInDecoderError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone]
-impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxInDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxInDecoderError]
 pub struct bitcoin_primitives::transaction::TxInEncoder<'e>(_, _)
 impl<'e> bitcoin_consensus_encoding::encode::Encoder for bitcoin_primitives::transaction::TxInEncoder<'e>
   pub fn bitcoin_primitives::transaction::TxInEncoder<'e>::advance(&mut self) -> bitcoin_consensus_encoding::encode::EncoderStatus [impl: impl<'e> bitcoin_consensus_encoding::encode::Encoder for bitcoin_primitives::transaction::TxInEncoder<'e>]

--- a/primitives/api/alloc-only.txt
+++ b/primitives/api/alloc-only.txt
@@ -4036,6 +4036,53 @@ pub type bitcoin_primitives::script::WitnessScript = bitcoin_primitives::script:
 pub type bitcoin_primitives::script::WitnessScriptBuf = bitcoin_primitives::script::ScriptBuf<bitcoin_primitives::script::WitnessScriptTag>
 pub mod bitcoin_primitives::transaction
 pub mod bitcoin_primitives::transaction::error
+#[non_exhaustive] pub enum bitcoin_primitives::transaction::error::TxInDecoderError
+pub bitcoin_primitives::transaction::error::TxInDecoderError::PreviousOutput(bitcoin_primitives::transaction::error::OutPointDecoderError)
+pub bitcoin_primitives::transaction::error::TxInDecoderError::ScriptSig(bitcoin_primitives::script::error::ScriptBufDecoderError)
+pub bitcoin_primitives::transaction::error::TxInDecoderError::Sequence(bitcoin_units::sequence::error::SequenceDecoderError)
+impl core::clone::Clone for bitcoin_primitives::transaction::error::TxInDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::clone(&self) -> bitcoin_primitives::transaction::error::TxInDecoderError [impl: impl core::clone::Clone for bitcoin_primitives::transaction::error::TxInDecoderError]
+impl core::cmp::Eq for bitcoin_primitives::transaction::error::TxInDecoderError
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::error::TxInDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::eq(&self, other: &bitcoin_primitives::transaction::error::TxInDecoderError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::transaction::error::TxInDecoderError]
+impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::transaction::error::TxInDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::transaction::error::TxInDecoderError]
+impl core::fmt::Debug for bitcoin_primitives::transaction::error::TxInDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::transaction::error::TxInDecoderError]
+impl core::fmt::Display for bitcoin_primitives::transaction::error::TxInDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::transaction::error::TxInDecoderError]
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::error::TxInDecoderError
+impl core::marker::Freeze for bitcoin_primitives::transaction::error::TxInDecoderError
+impl core::marker::Send for bitcoin_primitives::transaction::error::TxInDecoderError
+impl core::marker::Sync for bitcoin_primitives::transaction::error::TxInDecoderError
+impl core::marker::Unpin for bitcoin_primitives::transaction::error::TxInDecoderError
+impl core::marker::UnsafeUnpin for bitcoin_primitives::transaction::error::TxInDecoderError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::error::TxInDecoderError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::error::TxInDecoderError
+impl<T, U> core::convert::Into<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::From<T>
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::Into<T>
+  pub type bitcoin_primitives::transaction::error::TxInDecoderError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::Into<T>]
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::TryFrom<T>
+  pub type bitcoin_primitives::transaction::error::TxInDecoderError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::TryFrom<T>]
+impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone
+  pub type bitcoin_primitives::transaction::error::TxInDecoderError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone]
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone]
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone]
+impl<T> alloc::string::ToString for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::fmt::Display + ?core::marker::Sized
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::fmt::Display + ?core::marker::Sized]
+impl<T> core::any::Any for bitcoin_primitives::transaction::error::TxInDecoderError where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::transaction::error::TxInDecoderError where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::error::TxInDecoderError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::error::TxInDecoderError where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::error::TxInDecoderError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::error::TxInDecoderError where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone
+  pub unsafe fn bitcoin_primitives::transaction::error::TxInDecoderError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxInDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxInDecoderError]
 pub struct bitcoin_primitives::transaction::error::OutPointDecoderError(_)
 impl core::clone::Clone for bitcoin_primitives::transaction::error::OutPointDecoderError
   pub fn bitcoin_primitives::transaction::error::OutPointDecoderError::clone(&self) -> bitcoin_primitives::transaction::error::OutPointDecoderError [impl: impl core::clone::Clone for bitcoin_primitives::transaction::error::OutPointDecoderError]
@@ -4124,50 +4171,6 @@ impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::T
   pub unsafe fn bitcoin_primitives::transaction::error::TransactionDecoderError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TransactionDecoderError where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TransactionDecoderError
   pub fn bitcoin_primitives::transaction::error::TransactionDecoderError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TransactionDecoderError]
-pub struct bitcoin_primitives::transaction::error::TxInDecoderError(_)
-impl core::clone::Clone for bitcoin_primitives::transaction::error::TxInDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::clone(&self) -> bitcoin_primitives::transaction::error::TxInDecoderError [impl: impl core::clone::Clone for bitcoin_primitives::transaction::error::TxInDecoderError]
-impl core::cmp::Eq for bitcoin_primitives::transaction::error::TxInDecoderError
-impl core::cmp::PartialEq for bitcoin_primitives::transaction::error::TxInDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::eq(&self, other: &bitcoin_primitives::transaction::error::TxInDecoderError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::transaction::error::TxInDecoderError]
-impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::transaction::error::TxInDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::transaction::error::TxInDecoderError]
-impl core::fmt::Debug for bitcoin_primitives::transaction::error::TxInDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::transaction::error::TxInDecoderError]
-impl core::fmt::Display for bitcoin_primitives::transaction::error::TxInDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::transaction::error::TxInDecoderError]
-impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::error::TxInDecoderError
-impl core::marker::Freeze for bitcoin_primitives::transaction::error::TxInDecoderError
-impl core::marker::Send for bitcoin_primitives::transaction::error::TxInDecoderError
-impl core::marker::Sync for bitcoin_primitives::transaction::error::TxInDecoderError
-impl core::marker::Unpin for bitcoin_primitives::transaction::error::TxInDecoderError
-impl core::marker::UnsafeUnpin for bitcoin_primitives::transaction::error::TxInDecoderError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::error::TxInDecoderError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::error::TxInDecoderError
-impl<T, U> core::convert::Into<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::From<T>
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::From<T>]
-impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::Into<T>
-  pub type bitcoin_primitives::transaction::error::TxInDecoderError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::Into<T>]
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::Into<T>]
-impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::TryFrom<T>
-  pub type bitcoin_primitives::transaction::error::TxInDecoderError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::TryFrom<T>]
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::TryFrom<T>]
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone
-  pub type bitcoin_primitives::transaction::error::TxInDecoderError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone]
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone]
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone]
-impl<T> alloc::string::ToString for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::fmt::Display + ?core::marker::Sized
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::fmt::Display + ?core::marker::Sized]
-impl<T> core::any::Any for bitcoin_primitives::transaction::error::TxInDecoderError where T: 'static + ?core::marker::Sized
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::transaction::error::TxInDecoderError where T: 'static + ?core::marker::Sized]
-impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::error::TxInDecoderError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::error::TxInDecoderError where T: ?core::marker::Sized]
-impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::error::TxInDecoderError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::error::TxInDecoderError where T: ?core::marker::Sized]
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone
-  pub unsafe fn bitcoin_primitives::transaction::error::TxInDecoderError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone]
-impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxInDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxInDecoderError]
 pub struct bitcoin_primitives::transaction::error::TxOutDecoderError(_)
 impl core::clone::Clone for bitcoin_primitives::transaction::error::TxOutDecoderError
   pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::clone(&self) -> bitcoin_primitives::transaction::error::TxOutDecoderError [impl: impl core::clone::Clone for bitcoin_primitives::transaction::error::TxOutDecoderError]
@@ -4256,6 +4259,53 @@ impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::V
   pub unsafe fn bitcoin_primitives::transaction::error::VersionDecoderError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::VersionDecoderError where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::VersionDecoderError
   pub fn bitcoin_primitives::transaction::error::VersionDecoderError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::VersionDecoderError]
+#[non_exhaustive] pub enum bitcoin_primitives::transaction::TxInDecoderError
+pub bitcoin_primitives::transaction::TxInDecoderError::PreviousOutput(bitcoin_primitives::transaction::error::OutPointDecoderError)
+pub bitcoin_primitives::transaction::TxInDecoderError::ScriptSig(bitcoin_primitives::script::error::ScriptBufDecoderError)
+pub bitcoin_primitives::transaction::TxInDecoderError::Sequence(bitcoin_units::sequence::error::SequenceDecoderError)
+impl core::clone::Clone for bitcoin_primitives::transaction::error::TxInDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::clone(&self) -> bitcoin_primitives::transaction::error::TxInDecoderError [impl: impl core::clone::Clone for bitcoin_primitives::transaction::error::TxInDecoderError]
+impl core::cmp::Eq for bitcoin_primitives::transaction::error::TxInDecoderError
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::error::TxInDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::eq(&self, other: &bitcoin_primitives::transaction::error::TxInDecoderError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::transaction::error::TxInDecoderError]
+impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::transaction::error::TxInDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::transaction::error::TxInDecoderError]
+impl core::fmt::Debug for bitcoin_primitives::transaction::error::TxInDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::transaction::error::TxInDecoderError]
+impl core::fmt::Display for bitcoin_primitives::transaction::error::TxInDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::transaction::error::TxInDecoderError]
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::error::TxInDecoderError
+impl core::marker::Freeze for bitcoin_primitives::transaction::error::TxInDecoderError
+impl core::marker::Send for bitcoin_primitives::transaction::error::TxInDecoderError
+impl core::marker::Sync for bitcoin_primitives::transaction::error::TxInDecoderError
+impl core::marker::Unpin for bitcoin_primitives::transaction::error::TxInDecoderError
+impl core::marker::UnsafeUnpin for bitcoin_primitives::transaction::error::TxInDecoderError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::error::TxInDecoderError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::error::TxInDecoderError
+impl<T, U> core::convert::Into<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::From<T>
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::Into<T>
+  pub type bitcoin_primitives::transaction::error::TxInDecoderError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::Into<T>]
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::TryFrom<T>
+  pub type bitcoin_primitives::transaction::error::TxInDecoderError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::TryFrom<T>]
+impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone
+  pub type bitcoin_primitives::transaction::error::TxInDecoderError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone]
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone]
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone]
+impl<T> alloc::string::ToString for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::fmt::Display + ?core::marker::Sized
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::fmt::Display + ?core::marker::Sized]
+impl<T> core::any::Any for bitcoin_primitives::transaction::error::TxInDecoderError where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::transaction::error::TxInDecoderError where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::error::TxInDecoderError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::error::TxInDecoderError where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::error::TxInDecoderError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::error::TxInDecoderError where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone
+  pub unsafe fn bitcoin_primitives::transaction::error::TxInDecoderError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxInDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxInDecoderError]
 pub struct bitcoin_primitives::transaction::BlockHashDecoder(_)
 impl bitcoin_primitives::block::BlockHashDecoder
 pub const fn bitcoin_primitives::block::BlockHashDecoder::new() -> Self
@@ -4874,50 +4924,6 @@ impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::TxInDeco
   pub unsafe fn bitcoin_primitives::transaction::TxInDecoder::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::TxInDecoder where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_primitives::transaction::TxInDecoder
   pub fn bitcoin_primitives::transaction::TxInDecoder::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::transaction::TxInDecoder]
-pub struct bitcoin_primitives::transaction::TxInDecoderError(_)
-impl core::clone::Clone for bitcoin_primitives::transaction::error::TxInDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::clone(&self) -> bitcoin_primitives::transaction::error::TxInDecoderError [impl: impl core::clone::Clone for bitcoin_primitives::transaction::error::TxInDecoderError]
-impl core::cmp::Eq for bitcoin_primitives::transaction::error::TxInDecoderError
-impl core::cmp::PartialEq for bitcoin_primitives::transaction::error::TxInDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::eq(&self, other: &bitcoin_primitives::transaction::error::TxInDecoderError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::transaction::error::TxInDecoderError]
-impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::transaction::error::TxInDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::transaction::error::TxInDecoderError]
-impl core::fmt::Debug for bitcoin_primitives::transaction::error::TxInDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::transaction::error::TxInDecoderError]
-impl core::fmt::Display for bitcoin_primitives::transaction::error::TxInDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::transaction::error::TxInDecoderError]
-impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::error::TxInDecoderError
-impl core::marker::Freeze for bitcoin_primitives::transaction::error::TxInDecoderError
-impl core::marker::Send for bitcoin_primitives::transaction::error::TxInDecoderError
-impl core::marker::Sync for bitcoin_primitives::transaction::error::TxInDecoderError
-impl core::marker::Unpin for bitcoin_primitives::transaction::error::TxInDecoderError
-impl core::marker::UnsafeUnpin for bitcoin_primitives::transaction::error::TxInDecoderError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::error::TxInDecoderError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::error::TxInDecoderError
-impl<T, U> core::convert::Into<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::From<T>
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::From<T>]
-impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::Into<T>
-  pub type bitcoin_primitives::transaction::error::TxInDecoderError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::Into<T>]
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::Into<T>]
-impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::TryFrom<T>
-  pub type bitcoin_primitives::transaction::error::TxInDecoderError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::TryFrom<T>]
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxInDecoderError where U: core::convert::TryFrom<T>]
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone
-  pub type bitcoin_primitives::transaction::error::TxInDecoderError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone]
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone]
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone]
-impl<T> alloc::string::ToString for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::fmt::Display + ?core::marker::Sized
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::fmt::Display + ?core::marker::Sized]
-impl<T> core::any::Any for bitcoin_primitives::transaction::error::TxInDecoderError where T: 'static + ?core::marker::Sized
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::transaction::error::TxInDecoderError where T: 'static + ?core::marker::Sized]
-impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::error::TxInDecoderError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::error::TxInDecoderError where T: ?core::marker::Sized]
-impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::error::TxInDecoderError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::error::TxInDecoderError where T: ?core::marker::Sized]
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone
-  pub unsafe fn bitcoin_primitives::transaction::error::TxInDecoderError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone]
-impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxInDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxInDecoderError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxInDecoderError]
 pub struct bitcoin_primitives::transaction::TxInEncoder<'e>(_, _)
 impl<'e> bitcoin_consensus_encoding::encode::Encoder for bitcoin_primitives::transaction::TxInEncoder<'e>
   pub fn bitcoin_primitives::transaction::TxInEncoder<'e>::advance(&mut self) -> bitcoin_consensus_encoding::encode::EncoderStatus [impl: impl<'e> bitcoin_consensus_encoding::encode::Encoder for bitcoin_primitives::transaction::TxInEncoder<'e>]

--- a/primitives/api/alloc-only.txt
+++ b/primitives/api/alloc-only.txt
@@ -4083,6 +4083,52 @@ impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::T
   pub unsafe fn bitcoin_primitives::transaction::error::TxInDecoderError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxInDecoderError
   pub fn bitcoin_primitives::transaction::error::TxInDecoderError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxInDecoderError]
+#[non_exhaustive] pub enum bitcoin_primitives::transaction::error::TxOutDecoderError
+pub bitcoin_primitives::transaction::error::TxOutDecoderError::Amount(bitcoin_units::amount::error::AmountDecoderError)
+pub bitcoin_primitives::transaction::error::TxOutDecoderError::ScriptPubKey(bitcoin_primitives::script::error::ScriptBufDecoderError)
+impl core::clone::Clone for bitcoin_primitives::transaction::error::TxOutDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::clone(&self) -> bitcoin_primitives::transaction::error::TxOutDecoderError [impl: impl core::clone::Clone for bitcoin_primitives::transaction::error::TxOutDecoderError]
+impl core::cmp::Eq for bitcoin_primitives::transaction::error::TxOutDecoderError
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::error::TxOutDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::eq(&self, other: &bitcoin_primitives::transaction::error::TxOutDecoderError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::transaction::error::TxOutDecoderError]
+impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::transaction::error::TxOutDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::transaction::error::TxOutDecoderError]
+impl core::fmt::Debug for bitcoin_primitives::transaction::error::TxOutDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::transaction::error::TxOutDecoderError]
+impl core::fmt::Display for bitcoin_primitives::transaction::error::TxOutDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::transaction::error::TxOutDecoderError]
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::error::TxOutDecoderError
+impl core::marker::Freeze for bitcoin_primitives::transaction::error::TxOutDecoderError
+impl core::marker::Send for bitcoin_primitives::transaction::error::TxOutDecoderError
+impl core::marker::Sync for bitcoin_primitives::transaction::error::TxOutDecoderError
+impl core::marker::Unpin for bitcoin_primitives::transaction::error::TxOutDecoderError
+impl core::marker::UnsafeUnpin for bitcoin_primitives::transaction::error::TxOutDecoderError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::error::TxOutDecoderError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::error::TxOutDecoderError
+impl<T, U> core::convert::Into<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::From<T>
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::Into<T>
+  pub type bitcoin_primitives::transaction::error::TxOutDecoderError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::Into<T>]
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::TryFrom<T>
+  pub type bitcoin_primitives::transaction::error::TxOutDecoderError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::TryFrom<T>]
+impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone
+  pub type bitcoin_primitives::transaction::error::TxOutDecoderError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone]
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone]
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone]
+impl<T> alloc::string::ToString for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::fmt::Display + ?core::marker::Sized
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::fmt::Display + ?core::marker::Sized]
+impl<T> core::any::Any for bitcoin_primitives::transaction::error::TxOutDecoderError where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::transaction::error::TxOutDecoderError where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::error::TxOutDecoderError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::error::TxOutDecoderError where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::error::TxOutDecoderError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::error::TxOutDecoderError where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone
+  pub unsafe fn bitcoin_primitives::transaction::error::TxOutDecoderError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxOutDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxOutDecoderError]
 pub struct bitcoin_primitives::transaction::error::OutPointDecoderError(_)
 impl core::clone::Clone for bitcoin_primitives::transaction::error::OutPointDecoderError
   pub fn bitcoin_primitives::transaction::error::OutPointDecoderError::clone(&self) -> bitcoin_primitives::transaction::error::OutPointDecoderError [impl: impl core::clone::Clone for bitcoin_primitives::transaction::error::OutPointDecoderError]
@@ -4171,50 +4217,6 @@ impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::T
   pub unsafe fn bitcoin_primitives::transaction::error::TransactionDecoderError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TransactionDecoderError where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TransactionDecoderError
   pub fn bitcoin_primitives::transaction::error::TransactionDecoderError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TransactionDecoderError]
-pub struct bitcoin_primitives::transaction::error::TxOutDecoderError(_)
-impl core::clone::Clone for bitcoin_primitives::transaction::error::TxOutDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::clone(&self) -> bitcoin_primitives::transaction::error::TxOutDecoderError [impl: impl core::clone::Clone for bitcoin_primitives::transaction::error::TxOutDecoderError]
-impl core::cmp::Eq for bitcoin_primitives::transaction::error::TxOutDecoderError
-impl core::cmp::PartialEq for bitcoin_primitives::transaction::error::TxOutDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::eq(&self, other: &bitcoin_primitives::transaction::error::TxOutDecoderError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::transaction::error::TxOutDecoderError]
-impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::transaction::error::TxOutDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::transaction::error::TxOutDecoderError]
-impl core::fmt::Debug for bitcoin_primitives::transaction::error::TxOutDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::transaction::error::TxOutDecoderError]
-impl core::fmt::Display for bitcoin_primitives::transaction::error::TxOutDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::transaction::error::TxOutDecoderError]
-impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::error::TxOutDecoderError
-impl core::marker::Freeze for bitcoin_primitives::transaction::error::TxOutDecoderError
-impl core::marker::Send for bitcoin_primitives::transaction::error::TxOutDecoderError
-impl core::marker::Sync for bitcoin_primitives::transaction::error::TxOutDecoderError
-impl core::marker::Unpin for bitcoin_primitives::transaction::error::TxOutDecoderError
-impl core::marker::UnsafeUnpin for bitcoin_primitives::transaction::error::TxOutDecoderError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::error::TxOutDecoderError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::error::TxOutDecoderError
-impl<T, U> core::convert::Into<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::From<T>
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::From<T>]
-impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::Into<T>
-  pub type bitcoin_primitives::transaction::error::TxOutDecoderError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::Into<T>]
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::Into<T>]
-impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::TryFrom<T>
-  pub type bitcoin_primitives::transaction::error::TxOutDecoderError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::TryFrom<T>]
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::TryFrom<T>]
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone
-  pub type bitcoin_primitives::transaction::error::TxOutDecoderError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone]
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone]
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone]
-impl<T> alloc::string::ToString for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::fmt::Display + ?core::marker::Sized
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::fmt::Display + ?core::marker::Sized]
-impl<T> core::any::Any for bitcoin_primitives::transaction::error::TxOutDecoderError where T: 'static + ?core::marker::Sized
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::transaction::error::TxOutDecoderError where T: 'static + ?core::marker::Sized]
-impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::error::TxOutDecoderError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::error::TxOutDecoderError where T: ?core::marker::Sized]
-impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::error::TxOutDecoderError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::error::TxOutDecoderError where T: ?core::marker::Sized]
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone
-  pub unsafe fn bitcoin_primitives::transaction::error::TxOutDecoderError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone]
-impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxOutDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxOutDecoderError]
 pub struct bitcoin_primitives::transaction::error::VersionDecoderError(_)
 impl core::clone::Clone for bitcoin_primitives::transaction::error::VersionDecoderError
   pub fn bitcoin_primitives::transaction::error::VersionDecoderError::clone(&self) -> bitcoin_primitives::transaction::error::VersionDecoderError [impl: impl core::clone::Clone for bitcoin_primitives::transaction::error::VersionDecoderError]
@@ -4306,6 +4308,52 @@ impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::T
   pub unsafe fn bitcoin_primitives::transaction::error::TxInDecoderError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TxInDecoderError where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxInDecoderError
   pub fn bitcoin_primitives::transaction::error::TxInDecoderError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxInDecoderError]
+#[non_exhaustive] pub enum bitcoin_primitives::transaction::TxOutDecoderError
+pub bitcoin_primitives::transaction::TxOutDecoderError::Amount(bitcoin_units::amount::error::AmountDecoderError)
+pub bitcoin_primitives::transaction::TxOutDecoderError::ScriptPubKey(bitcoin_primitives::script::error::ScriptBufDecoderError)
+impl core::clone::Clone for bitcoin_primitives::transaction::error::TxOutDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::clone(&self) -> bitcoin_primitives::transaction::error::TxOutDecoderError [impl: impl core::clone::Clone for bitcoin_primitives::transaction::error::TxOutDecoderError]
+impl core::cmp::Eq for bitcoin_primitives::transaction::error::TxOutDecoderError
+impl core::cmp::PartialEq for bitcoin_primitives::transaction::error::TxOutDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::eq(&self, other: &bitcoin_primitives::transaction::error::TxOutDecoderError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::transaction::error::TxOutDecoderError]
+impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::transaction::error::TxOutDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::transaction::error::TxOutDecoderError]
+impl core::fmt::Debug for bitcoin_primitives::transaction::error::TxOutDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::transaction::error::TxOutDecoderError]
+impl core::fmt::Display for bitcoin_primitives::transaction::error::TxOutDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::transaction::error::TxOutDecoderError]
+impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::error::TxOutDecoderError
+impl core::marker::Freeze for bitcoin_primitives::transaction::error::TxOutDecoderError
+impl core::marker::Send for bitcoin_primitives::transaction::error::TxOutDecoderError
+impl core::marker::Sync for bitcoin_primitives::transaction::error::TxOutDecoderError
+impl core::marker::Unpin for bitcoin_primitives::transaction::error::TxOutDecoderError
+impl core::marker::UnsafeUnpin for bitcoin_primitives::transaction::error::TxOutDecoderError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::error::TxOutDecoderError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::error::TxOutDecoderError
+impl<T, U> core::convert::Into<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::From<T>
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::Into<T>
+  pub type bitcoin_primitives::transaction::error::TxOutDecoderError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::Into<T>]
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::TryFrom<T>
+  pub type bitcoin_primitives::transaction::error::TxOutDecoderError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::TryFrom<T>]
+impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone
+  pub type bitcoin_primitives::transaction::error::TxOutDecoderError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone]
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone]
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone]
+impl<T> alloc::string::ToString for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::fmt::Display + ?core::marker::Sized
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::fmt::Display + ?core::marker::Sized]
+impl<T> core::any::Any for bitcoin_primitives::transaction::error::TxOutDecoderError where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::transaction::error::TxOutDecoderError where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::error::TxOutDecoderError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::error::TxOutDecoderError where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::error::TxOutDecoderError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::error::TxOutDecoderError where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone
+  pub unsafe fn bitcoin_primitives::transaction::error::TxOutDecoderError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxOutDecoderError
+  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxOutDecoderError]
 pub struct bitcoin_primitives::transaction::BlockHashDecoder(_)
 impl bitcoin_primitives::block::BlockHashDecoder
 pub const fn bitcoin_primitives::block::BlockHashDecoder::new() -> Self
@@ -5058,50 +5106,6 @@ impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::TxOutDec
   pub unsafe fn bitcoin_primitives::transaction::TxOutDecoder::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::TxOutDecoder where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_primitives::transaction::TxOutDecoder
   pub fn bitcoin_primitives::transaction::TxOutDecoder::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::transaction::TxOutDecoder]
-pub struct bitcoin_primitives::transaction::TxOutDecoderError(_)
-impl core::clone::Clone for bitcoin_primitives::transaction::error::TxOutDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::clone(&self) -> bitcoin_primitives::transaction::error::TxOutDecoderError [impl: impl core::clone::Clone for bitcoin_primitives::transaction::error::TxOutDecoderError]
-impl core::cmp::Eq for bitcoin_primitives::transaction::error::TxOutDecoderError
-impl core::cmp::PartialEq for bitcoin_primitives::transaction::error::TxOutDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::eq(&self, other: &bitcoin_primitives::transaction::error::TxOutDecoderError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::transaction::error::TxOutDecoderError]
-impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::transaction::error::TxOutDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::transaction::error::TxOutDecoderError]
-impl core::fmt::Debug for bitcoin_primitives::transaction::error::TxOutDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::transaction::error::TxOutDecoderError]
-impl core::fmt::Display for bitcoin_primitives::transaction::error::TxOutDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::transaction::error::TxOutDecoderError]
-impl core::marker::StructuralPartialEq for bitcoin_primitives::transaction::error::TxOutDecoderError
-impl core::marker::Freeze for bitcoin_primitives::transaction::error::TxOutDecoderError
-impl core::marker::Send for bitcoin_primitives::transaction::error::TxOutDecoderError
-impl core::marker::Sync for bitcoin_primitives::transaction::error::TxOutDecoderError
-impl core::marker::Unpin for bitcoin_primitives::transaction::error::TxOutDecoderError
-impl core::marker::UnsafeUnpin for bitcoin_primitives::transaction::error::TxOutDecoderError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::transaction::error::TxOutDecoderError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::transaction::error::TxOutDecoderError
-impl<T, U> core::convert::Into<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::From<T>
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::From<T>]
-impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::Into<T>
-  pub type bitcoin_primitives::transaction::error::TxOutDecoderError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::Into<T>]
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::Into<T>]
-impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::TryFrom<T>
-  pub type bitcoin_primitives::transaction::error::TxOutDecoderError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::TryFrom<T>]
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::transaction::error::TxOutDecoderError where U: core::convert::TryFrom<T>]
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone
-  pub type bitcoin_primitives::transaction::error::TxOutDecoderError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone]
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone]
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone]
-impl<T> alloc::string::ToString for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::fmt::Display + ?core::marker::Sized
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::fmt::Display + ?core::marker::Sized]
-impl<T> core::any::Any for bitcoin_primitives::transaction::error::TxOutDecoderError where T: 'static + ?core::marker::Sized
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::transaction::error::TxOutDecoderError where T: 'static + ?core::marker::Sized]
-impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::error::TxOutDecoderError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::transaction::error::TxOutDecoderError where T: ?core::marker::Sized]
-impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::error::TxOutDecoderError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::transaction::error::TxOutDecoderError where T: ?core::marker::Sized]
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone
-  pub unsafe fn bitcoin_primitives::transaction::error::TxOutDecoderError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::transaction::error::TxOutDecoderError where T: core::clone::Clone]
-impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxOutDecoderError
-  pub fn bitcoin_primitives::transaction::error::TxOutDecoderError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::transaction::error::TxOutDecoderError]
 pub struct bitcoin_primitives::transaction::TxOutEncoder<'e>(_, _)
 impl<'e> bitcoin_consensus_encoding::encode::Encoder for bitcoin_primitives::transaction::TxOutEncoder<'e>
   pub fn bitcoin_primitives::transaction::TxOutEncoder<'e>::advance(&mut self) -> bitcoin_consensus_encoding::encode::EncoderStatus [impl: impl<'e> bitcoin_consensus_encoding::encode::Encoder for bitcoin_primitives::transaction::TxOutEncoder<'e>]

--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -588,28 +588,16 @@ crate::decoder_newtype! {
     }
 
     fn map_push_bytes_err(err: <HeaderInnerDecoder as encoding::Decoder>::Error) -> HeaderDecoderError {
-        Self::from_inner(err)
+        HeaderDecoderError::from_inner(err)
     }
 
     fn end(
         result: Result<<HeaderInnerDecoder as encoding::Decoder>::Output, <HeaderInnerDecoder as encoding::Decoder>::Error>
     ) -> Result<Header, HeaderDecoderError> {
-        let (version, prev_blockhash, merkle_root, time, bits, nonce) = result.map_err(Self::from_inner)?;
+        let (version, prev_blockhash, merkle_root, time, bits, nonce) =
+            result.map_err(HeaderDecoderError::from_inner)?;
         let nonce = u32::from_le_bytes(nonce);
         Ok(Header { version, prev_blockhash, merkle_root, time, bits, nonce })
-    }
-}
-
-impl HeaderDecoder {
-    fn from_inner(e: <HeaderInnerDecoder as encoding::Decoder>::Error) -> HeaderDecoderError {
-        match e {
-            encoding::Decoder6Error::First(e) => HeaderDecoderError::Version(e),
-            encoding::Decoder6Error::Second(e) => HeaderDecoderError::PrevBlockhash(e),
-            encoding::Decoder6Error::Third(e) => HeaderDecoderError::MerkleRoot(e),
-            encoding::Decoder6Error::Fourth(e) => HeaderDecoderError::Time(e),
-            encoding::Decoder6Error::Fifth(e) => HeaderDecoderError::Bits(e),
-            encoding::Decoder6Error::Sixth(e) => HeaderDecoderError::Nonce(e),
-        }
     }
 }
 
@@ -841,52 +829,30 @@ pub mod error {
         }
     }
 
-    /// An error consensus decoding a `Header`.
-    #[derive(Debug, Clone, PartialEq, Eq)]
-    #[non_exhaustive]
-    pub enum HeaderDecoderError {
-        /// Error while decoding the `version`.
-        Version(VersionDecoderError),
-        /// Error while decoding the `prev_blockhash`.
-        PrevBlockhash(BlockHashDecoderError),
-        /// Error while decoding the `merkle_root`.
-        MerkleRoot(TxMerkleNodeDecoderError),
-        /// Error while decoding the `time`.
-        Time(BlockTimeDecoderError),
-        /// Error while decoding the `bits`.
-        Bits(CompactTargetDecoderError),
-        /// Error while decoding the `nonce`.
-        Nonce(encoding::UnexpectedEofError),
-    }
-
-    impl From<Infallible> for HeaderDecoderError {
-        fn from(never: Infallible) -> Self { match never {} }
-    }
-
-    impl fmt::Display for HeaderDecoderError {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            match *self {
-                Self::Version(ref e) => write_err!(f, "header decoder error"; e),
-                Self::PrevBlockhash(ref e) => write_err!(f, "header decoder error"; e),
-                Self::MerkleRoot(ref e) => write_err!(f, "header decoder error"; e),
-                Self::Time(ref e) => write_err!(f, "header decoder error"; e),
-                Self::Bits(ref e) => write_err!(f, "header decoder error"; e),
-                Self::Nonce(ref e) => write_err!(f, "header decoder error"; e),
-            }
-        }
-    }
-
-    #[cfg(feature = "std")]
-    impl std::error::Error for HeaderDecoderError {
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-            match *self {
-                Self::Version(ref e) => Some(e),
-                Self::PrevBlockhash(ref e) => Some(e),
-                Self::MerkleRoot(ref e) => Some(e),
-                Self::Time(ref e) => Some(e),
-                Self::Bits(ref e) => Some(e),
-                Self::Nonce(ref e) => Some(e),
-            }
+    crate::decoder_error! {
+        /// An error consensus decoding a `Header`.
+        #[derive(Debug, Clone, PartialEq, Eq)]
+        #[non_exhaustive]
+        pub enum HeaderDecoderError from Decoder6<
+            super::VersionDecoder,
+            super::BlockHashDecoder,
+            super::TxMerkleNodeDecoder,
+            super::BlockTimeDecoder,
+            super::CompactTargetDecoder,
+            encoding::ArrayDecoder<4>,
+        > {
+            /// Error while decoding the `version`.
+            version: VersionDecoderError => Version,
+            /// Error while decoding the `prev_blockhash`.
+            prev_blockhash: BlockHashDecoderError => PrevBlockhash,
+            /// Error while decoding the `merkle_root`.
+            merkle_root: TxMerkleNodeDecoderError => MerkleRoot,
+            /// Error while decoding the `time`.
+            time: BlockTimeDecoderError => Time,
+            /// Error while decoding the `bits`.
+            bits: CompactTargetDecoderError => Bits,
+            /// Error while decoding the `nonce`.
+            nonce: encoding::UnexpectedEofError => Nonce,
         }
     }
 

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -146,5 +146,6 @@ pub(crate) fn compact_size_encode(value: usize) -> ArrayVec<u8, 9> {
 #[cfg(feature = "alloc")]
 include!("../include/newtype.rs"); // Explained in `REPO_DIR/docs/README.md`.
 include!("../include/decoder_newtype.rs"); // decoder_newtype! macro
+include!("../include/decoder_error.rs"); // decoder_error! macro
 #[cfg(feature = "alloc")]
 include!("../include/asref_push_bytes.rs"); // impl_asref_push_bytes! macro

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -841,10 +841,14 @@ crate::decoder_newtype! {
         ))
     }
 
+    fn map_push_bytes_err(err: <TxInInnerDecoder as encoding::Decoder>::Error) -> TxInDecoderError {
+        TxInDecoderError::from_inner(err)
+    }
+
     fn end(
         result: Result<<TxInInnerDecoder as encoding::Decoder>::Output, <TxInInnerDecoder as encoding::Decoder>::Error>
     ) -> Result<TxIn, TxInDecoderError> {
-        let (previous_output, script_sig, sequence) = result.map_err(TxInDecoderError)?;
+        let (previous_output, script_sig, sequence) = result.map_err(TxInDecoderError::from_inner)?;
         Ok(TxIn { previous_output, script_sig, sequence, witness: Witness::default() })
     }
 }
@@ -1275,6 +1279,10 @@ pub mod error {
     #[cfg(feature = "alloc")]
     use crate::locktime::absolute::LockTimeDecoderError;
     #[cfg(feature = "alloc")]
+    use crate::script::ScriptBufDecoderError;
+    #[cfg(feature = "alloc")]
+    use crate::sequence::SequenceDecoderError;
+    #[cfg(feature = "alloc")]
     use crate::witness::WitnessDecoderError;
 
     /// An error consensus decoding a `Transaction`.
@@ -1377,27 +1385,23 @@ pub mod error {
         }
     }
 
-    /// An error consensus decoding a `TxIn`.
     #[cfg(feature = "alloc")]
-    #[derive(Debug, Clone, PartialEq, Eq)]
-    pub struct TxInDecoderError(pub(super) <super::TxInInnerDecoder as encoding::Decoder>::Error);
-
-    #[cfg(feature = "alloc")]
-    impl From<Infallible> for TxInDecoderError {
-        fn from(never: Infallible) -> Self { match never {} }
-    }
-
-    #[cfg(feature = "alloc")]
-    impl fmt::Display for TxInDecoderError {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            write_err!(f, "txin decoder error"; self.0)
+    crate::decoder_error! {
+        /// An error consensus decoding a `TxIn`.
+        #[derive(Debug, Clone, PartialEq, Eq)]
+        #[non_exhaustive]
+        pub enum TxInDecoderError from Decoder3<
+            super::OutPointDecoder,
+            super::ScriptSigBufDecoder,
+            super::SequenceDecoder,
+        > {
+            /// Error while decoding the `previous_output`.
+            previous_output: OutPointDecoderError => PreviousOutput,
+            /// Error while decoding the `script_sig`.
+            script_sig: ScriptBufDecoderError => ScriptSig,
+            /// Error while decoding the `sequence`.
+            sequence: SequenceDecoderError => Sequence,
         }
-    }
-
-    #[cfg(feature = "alloc")]
-    #[cfg(feature = "std")]
-    impl std::error::Error for TxInDecoderError {
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
     }
 
     /// An error consensus decoding a `TxOut`.
@@ -3092,7 +3096,7 @@ mod tests {
         assert!(decoder.push_bytes(&mut slice).unwrap().needs_more());
 
         let err = decoder.end().unwrap_err();
-        assert!(matches!(err.0, encoding::Decoder3Error::First(_)));
+        assert!(matches!(err, TxInDecoderError::PreviousOutput(_)));
 
         assert!(!err.to_string().is_empty());
         #[cfg(feature = "std")]
@@ -3113,7 +3117,7 @@ mod tests {
         assert!(decoder.push_bytes(&mut slice).unwrap().needs_more());
 
         let err = decoder.end().unwrap_err();
-        assert!(matches!(err.0, encoding::Decoder3Error::Second(_)));
+        assert!(matches!(err, TxInDecoderError::ScriptSig(_)));
 
         assert!(!err.to_string().is_empty());
         #[cfg(feature = "std")]
@@ -3134,7 +3138,7 @@ mod tests {
         assert!(decoder.push_bytes(&mut slice).unwrap().needs_more());
 
         let err = decoder.end().unwrap_err();
-        assert!(matches!(err.0, encoding::Decoder3Error::Third(_)));
+        assert!(matches!(err, TxInDecoderError::Sequence(_)));
 
         assert!(!err.to_string().is_empty());
         #[cfg(feature = "std")]

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -911,10 +911,14 @@ crate::decoder_newtype! {
         Self(Decoder2::new(AmountDecoder::new(), ScriptPubKeyBufDecoder::new()))
     }
 
+    fn map_push_bytes_err(err: <TxOutInnerDecoder as encoding::Decoder>::Error) -> TxOutDecoderError {
+        TxOutDecoderError::from_inner(err)
+    }
+
     fn end(
         result: Result<<TxOutInnerDecoder as encoding::Decoder>::Output, <TxOutInnerDecoder as encoding::Decoder>::Error>
     ) -> Result<TxOut, TxOutDecoderError> {
-        let (amount, script_pubkey) = result.map_err(TxOutDecoderError)?;
+        let (amount, script_pubkey) = result.map_err(TxOutDecoderError::from_inner)?;
         Ok(TxOut { amount, script_pubkey })
     }
 }
@@ -1277,6 +1281,8 @@ pub mod error {
     #[cfg(feature = "alloc")]
     use super::OutPoint;
     #[cfg(feature = "alloc")]
+    use crate::amount::AmountDecoderError;
+    #[cfg(feature = "alloc")]
     use crate::locktime::absolute::LockTimeDecoderError;
     #[cfg(feature = "alloc")]
     use crate::script::ScriptBufDecoderError;
@@ -1404,26 +1410,20 @@ pub mod error {
         }
     }
 
-    /// An error consensus decoding a `TxOut`.
     #[cfg(feature = "alloc")]
-    #[derive(Debug, Clone, PartialEq, Eq)]
-    pub struct TxOutDecoderError(pub(super) <super::TxOutInnerDecoder as encoding::Decoder>::Error);
-
-    #[cfg(feature = "alloc")]
-    impl From<Infallible> for TxOutDecoderError {
-        fn from(never: Infallible) -> Self { match never {} }
-    }
-
-    #[cfg(feature = "alloc")]
-    impl fmt::Display for TxOutDecoderError {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            write_err!(f, "txout decoder error"; self.0)
+    crate::decoder_error! {
+        /// An error consensus decoding a `TxOut`.
+        #[derive(Debug, Clone, PartialEq, Eq)]
+        #[non_exhaustive]
+        pub enum TxOutDecoderError from Decoder2<
+            super::AmountDecoder,
+            super::ScriptPubKeyBufDecoder,
+        > {
+            /// Error while decoding the `amount`.
+            amount: AmountDecoderError => Amount,
+            /// Error while decoding the `script_pubkey`.
+            script_pubkey: ScriptBufDecoderError => ScriptPubKey,
         }
-    }
-
-    #[cfg(feature = "std")]
-    impl std::error::Error for TxOutDecoderError {
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
     }
 
     /// Error while decoding an `OutPoint`.
@@ -3153,7 +3153,7 @@ mod tests {
         assert!(decoder.push_bytes(&mut slice).unwrap().needs_more());
 
         let err = decoder.end().unwrap_err();
-        assert!(matches!(err.0, encoding::Decoder2Error::First(_)));
+        assert!(matches!(err, TxOutDecoderError::Amount(_)));
 
         assert!(!err.to_string().is_empty());
         #[cfg(feature = "std")]
@@ -3171,7 +3171,7 @@ mod tests {
         assert!(decoder.push_bytes(&mut slice).unwrap().needs_more());
 
         let err = decoder.end().unwrap_err();
-        assert!(matches!(err.0, encoding::Decoder2Error::Second(_)));
+        assert!(matches!(err, TxOutDecoderError::ScriptPubKey(_)));
 
         assert!(!err.to_string().is_empty());
         #[cfg(feature = "std")]


### PR DESCRIPTION
The composite `DecoderN` decoder returns position based errors (`Decoder3Error::Second`, ...); each consuming type hand-writes a named error enum plus `From<Infallible>`, `Display`, `Error`, and a positional `match` to flatten them.

This is already done by hand in `HeaderDecoderError` and `TransactionDecoderError`, and those `Display` impls don't even report which field failed (every arm writes the same `"header decoder error"`). Meanwhile `TxIn` and `TxOut` decoder errors were simply left as raw `DecoderNError` newtypes, so their errors read stuff like "second decoder error".

So decided to add a `macro_rules!` helper, `decoder_error!`. From a `field: ErrorType => Variant` list and the composite decoder, it generates the flat enum, the flattening constructor, `From<Infallible>`, `Display` and `Error`.

It lives in `include/decoder_error.rs` and is pulled into `primitives` with `include!`, the same way `decoder_newtype!` already is, so it stays **private to `primitives`** — per review feedback, let's get some hands-on with the interface before committing to it publicly.

### No new public API surface

Two deliberate choices, since this is a `1.0`-track crate and the API files are checked in:

- **Variants name their error type explicitly** (`bits: CompactTargetDecoderError => Bits`) rather than the macro inferring `<D as Decoder>::Error`. Inference is shorter to write, but the projection is what lands in rustdoc and in `primitives/api/*.txt` — `Bits(<CompactTargetDecoder as Decoder>::Error)` is strictly worse to read than `Bits(CompactTargetDecoderError)`. The two can't drift: the generated code statically asserts each named type really is that decoder's associated error type, so getting one wrong is a compile error pointing at the offending pair.
- **The flattening is a private `from_inner` constructor, not a `From` impl.** A generated `impl From<Decoder6Error<..>>` would publicly commit `primitives` to converting from an encoding-internal positional type, which cuts against keeping this private for now. `from_inner` is `pub(crate)`, so it stays out of the API files entirely.

Net effect on the checked-in API: `HeaderDecoderError` is **unchanged** (same concrete variants, same impls — the commit touches no API file), and `TxIn`/`TxOut` change from opaque newtypes to named enums.

### Converts three errors to use the macro

- `HeaderDecoderError` (the flat `Decoder6`) — variants unchanged, `Display` now reports which field failed instead of a constant string
- `TxInDecoderError` and `TxOutDecoderError` — previously raw newtypes, now named variants `PreviousOutput`/`ScriptSig`/`Sequence` and `Amount`/`ScriptPubKey` in place of `.0` access

### Notes

Arity arms are added as callers need them, one commit at a time — `Decoder6`, then `Decoder3`, then `Decoder2`. `Decoder4` is the only other composite decoder that exists; no error in this crate flattens one yet, so that arm is deliberately left out rather than added speculatively. Adding it later is ~15 lines, and the shared codegen arm it forwards to already handles any arity.

This handles the **flat-single `DecoderN`** case. The nested tower case is left as follow-up: `TransactionDecoderError` can't use the macro as-is, since it's an opaque wrapper over a private inner enum whose variants are mostly not positional at all (`NoOutputs`, `DuplicateInput`, `UnsupportedSegwitFlag`, ...).
