### PR TITLE
primitives: Use dedicated encoder newtypes for TxIn and TxOut encoding

### DIFF
--- a/primitives/api/all-features.txt
+++ b/primitives/api/all-features.txt
@@ -411,7 +411,7 @@ pub fn bitcoin_primitives::block::Block<V>::fmt(&self, f: &mut core::fmt::Format
 impl<V: bitcoin_primitives::block::Validation> core::fmt::LowerHex for bitcoin_primitives::block::Block<V>
 impl<V: bitcoin_primitives::block::Validation> core::fmt::UpperHex for bitcoin_primitives::block::Block<V>
 impl<V> bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation
-pub type bitcoin_primitives::block::Block<V>::Encoder<'e> where Self: 'e = bitcoin_consensus_encoding::encode::encoders::Encoder2<bitcoin_primitives::block::HeaderEncoder<'e>, bitcoin_consensus_encoding::encode::encoders::Encoder2<bitcoin_consensus_encoding::compact_size::CompactSizeEncoder, bitcoin_consensus_encoding::encode::encoders::SliceEncoder<'e, bitcoin_primitives::transaction::Transaction>>>
+pub type bitcoin_primitives::block::Block<V>::Encoder<'e> where Self: 'e = bitcoin_primitives::block::BlockEncoder<'e>
 pub fn bitcoin_primitives::block::Block<V>::encoder(&self) -> Self::Encoder
 impl<V> core::clone::Clone for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::clone::Clone
 pub fn bitcoin_primitives::block::Block<V>::clone(&self) -> bitcoin_primitives::block::Block<V>
@@ -4293,7 +4293,7 @@ pub const bitcoin_primitives::transaction::TxIn::EMPTY_COINBASE: Self
 impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::transaction::TxIn
 pub type bitcoin_primitives::transaction::TxIn::Decoder = bitcoin_primitives::transaction::TxInDecoder
 impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::transaction::TxIn
-pub type bitcoin_primitives::transaction::TxIn::Encoder<'e> where Self: 'e = bitcoin_consensus_encoding::encode::encoders::Encoder3<bitcoin_primitives::transaction::OutPointEncoder<'e>, bitcoin_primitives::script::ScriptEncoder<'e>, bitcoin_units::sequence::SequenceEncoder<'e>>
+pub type bitcoin_primitives::transaction::TxIn::Encoder<'e> where Self: 'e = bitcoin_primitives::transaction::TxInEncoder<'e>
 pub fn bitcoin_primitives::transaction::TxIn::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::transaction::TxIn
 pub fn bitcoin_primitives::transaction::TxIn::clone(&self) -> bitcoin_primitives::transaction::TxIn
@@ -4430,7 +4430,7 @@ pub bitcoin_primitives::transaction::TxOut::script_pubkey: bitcoin_primitives::s
 impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::transaction::TxOut
 pub type bitcoin_primitives::transaction::TxOut::Decoder = bitcoin_primitives::transaction::TxOutDecoder
 impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::transaction::TxOut
-pub type bitcoin_primitives::transaction::TxOut::Encoder<'e> where Self: 'e = bitcoin_consensus_encoding::encode::encoders::Encoder2<bitcoin_units::amount::unsigned::AmountEncoder<'e>, bitcoin_primitives::script::ScriptEncoder<'e>>
+pub type bitcoin_primitives::transaction::TxOut::Encoder<'e> where Self: 'e = bitcoin_primitives::transaction::TxOutEncoder<'e>
 pub fn bitcoin_primitives::transaction::TxOut::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::transaction::TxOut
 pub fn bitcoin_primitives::transaction::TxOut::clone(&self) -> bitcoin_primitives::transaction::TxOut

--- a/primitives/api/alloc-only.txt
+++ b/primitives/api/alloc-only.txt
@@ -389,7 +389,7 @@ pub fn bitcoin_primitives::BlockHash::from(block: &bitcoin_primitives::block::Bl
 impl core::convert::From<bitcoin_primitives::block::Block> for bitcoin_primitives::BlockHash
 pub fn bitcoin_primitives::BlockHash::from(block: bitcoin_primitives::block::Block) -> Self
 impl<V> bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation
-pub type bitcoin_primitives::block::Block<V>::Encoder<'e> where Self: 'e = bitcoin_consensus_encoding::encode::encoders::Encoder2<bitcoin_primitives::block::HeaderEncoder<'e>, bitcoin_consensus_encoding::encode::encoders::Encoder2<bitcoin_consensus_encoding::compact_size::CompactSizeEncoder, bitcoin_consensus_encoding::encode::encoders::SliceEncoder<'e, bitcoin_primitives::transaction::Transaction>>>
+pub type bitcoin_primitives::block::Block<V>::Encoder<'e> where Self: 'e = bitcoin_primitives::block::BlockEncoder<'e>
 pub fn bitcoin_primitives::block::Block<V>::encoder(&self) -> Self::Encoder
 impl<V> core::clone::Clone for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::clone::Clone
 pub fn bitcoin_primitives::block::Block<V>::clone(&self) -> bitcoin_primitives::block::Block<V>
@@ -4026,7 +4026,7 @@ pub const bitcoin_primitives::transaction::TxIn::EMPTY_COINBASE: Self
 impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::transaction::TxIn
 pub type bitcoin_primitives::transaction::TxIn::Decoder = bitcoin_primitives::transaction::TxInDecoder
 impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::transaction::TxIn
-pub type bitcoin_primitives::transaction::TxIn::Encoder<'e> where Self: 'e = bitcoin_consensus_encoding::encode::encoders::Encoder3<bitcoin_primitives::transaction::OutPointEncoder<'e>, bitcoin_primitives::script::ScriptEncoder<'e>, bitcoin_units::sequence::SequenceEncoder<'e>>
+pub type bitcoin_primitives::transaction::TxIn::Encoder<'e> where Self: 'e = bitcoin_primitives::transaction::TxInEncoder<'e>
 pub fn bitcoin_primitives::transaction::TxIn::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::transaction::TxIn
 pub fn bitcoin_primitives::transaction::TxIn::clone(&self) -> bitcoin_primitives::transaction::TxIn
@@ -4161,7 +4161,7 @@ pub bitcoin_primitives::transaction::TxOut::script_pubkey: bitcoin_primitives::s
 impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::transaction::TxOut
 pub type bitcoin_primitives::transaction::TxOut::Decoder = bitcoin_primitives::transaction::TxOutDecoder
 impl bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::transaction::TxOut
-pub type bitcoin_primitives::transaction::TxOut::Encoder<'e> where Self: 'e = bitcoin_consensus_encoding::encode::encoders::Encoder2<bitcoin_units::amount::unsigned::AmountEncoder<'e>, bitcoin_primitives::script::ScriptEncoder<'e>>
+pub type bitcoin_primitives::transaction::TxOut::Encoder<'e> where Self: 'e = bitcoin_primitives::transaction::TxOutEncoder<'e>
 pub fn bitcoin_primitives::transaction::TxOut::encoder(&self) -> Self::Encoder
 impl core::clone::Clone for bitcoin_primitives::transaction::TxOut
 pub fn bitcoin_primitives::transaction::TxOut::clone(&self) -> bitcoin_primitives::transaction::TxOut

--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -327,18 +327,18 @@ where
     V: Validation,
 {
     type Encoder<'e>
-        = Encoder2<HeaderEncoder<'e>, Encoder2<CompactSizeEncoder, SliceEncoder<'e, Transaction>>>
+        = BlockEncoder<'e>
     where
         Self: 'e;
 
     fn encoder(&self) -> Self::Encoder<'_> {
-        Encoder2::new(
+        BlockEncoder::new(Encoder2::new(
             self.header.encoder(),
             Encoder2::new(
                 CompactSizeEncoder::new(self.transactions.len()),
                 SliceEncoder::without_length_prefix(&self.transactions),
             ),
-        )
+        ))
     }
 }
 

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -763,16 +763,16 @@ encoding::encoder_newtype_exact! {
 #[cfg(feature = "alloc")]
 impl encoding::Encode for TxIn {
     type Encoder<'e>
-        = Encoder3<OutPointEncoder<'e>, ScriptEncoder<'e>, SequenceEncoder<'e>>
+        = TxInEncoder<'e>
     where
         Self: 'e;
 
     fn encoder(&self) -> Self::Encoder<'_> {
-        Encoder3::new(
+        TxInEncoder::new(Encoder3::new(
             self.previous_output.encoder(),
             self.script_sig.encoder(),
             self.sequence.encoder(),
-        )
+        ))
     }
 }
 

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -890,12 +890,12 @@ encoding::encoder_newtype_exact! {
 #[cfg(feature = "alloc")]
 impl encoding::Encode for TxOut {
     type Encoder<'e>
-        = Encoder2<AmountEncoder<'e>, ScriptEncoder<'e>>
+        = TxOutEncoder<'e>
     where
         Self: 'e;
 
     fn encoder(&self) -> Self::Encoder<'_> {
-        Encoder2::new(self.amount.encoder(), self.script_pubkey.encoder())
+        TxOutEncoder::new(Encoder2::new(self.amount.encoder(), self.script_pubkey.encoder()))
     }
 }
 


### PR DESCRIPTION
Both `TxIn` and `TxOut` were not using their encoding newtype in their `Encoding` implementation, this PR addresses that and updates:

- 84d3c67e67e64e3ed14906ef6d4266b55d41a683 `TxIn` encoding to use `TxInEncoder`.
- e63f26dd4a760392f755bdf2ca2a21c4ad8837ae `TxOut` encoding to use `TxOutEncoder`.
- f6c0e6330c950727bd28a3e711eb610ca56540bc `Block` encoding to use `BlockEncoder`.
- 43dc19b439be2a699df6f41b5e3b1c83f28763bf Update API files

closes #6419 