### PR TITLE
consensus_encoding: Adjust ConsensusHex impl in serde_as_consensus

### DIFF
--- a/consensus_encoding/src/serde_as_consensus.rs
+++ b/consensus_encoding/src/serde_as_consensus.rs
@@ -15,9 +15,10 @@
 use core::fmt;
 use core::marker::PhantomData;
 
+use hex::DisplayHex as _;
 use serde::{de, Deserializer, Serializer};
 
-use crate::{Decode, Encode};
+use crate::{Decode, Encode, Encoder as _};
 
 /// Serializes a type as a consensus-encoded hex string.
 ///
@@ -35,15 +36,13 @@ where
 
         impl<T: Encode> fmt::Display for ConsensusHex<'_, T> {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                let encoder = self.0.encoder();
-                let byte_iter = crate::EncoderByteIter::new(encoder);
-                let iter = hex::BytesToHexIter::new(byte_iter, hex::Case::Lower).flatten();
-
-                for ch in iter {
-                    fmt::Display::fmt(&ch, f)?;
+                let mut encoder = self.0.encoder();
+                loop {
+                    fmt::Display::fmt(&encoder.current_chunk().as_hex(), f)?;
+                    if encoder.advance().has_finished() {
+                        return Ok(());
+                    }
                 }
-
-                Ok(())
             }
         }
 


### PR DESCRIPTION
The ConsensusHex Display impl in serde_as_consensus currently uses the EncoderByteIter. While this functions correctly, it is inefficient as it repeatedly calls current_chunk internally to fetch successive chars as well as writing to the Formatter one char at a time. Instead, the DisplayHex trait can be used to dump entire chunks at a time.

Adjust ConsensusHex Display impl in serde_as_consensus to write using DisplayHex rather than char-by-char with EncoderByteIter.