### PR TITLE
0.32.x: Add `consensus_encoding` to core p2p message types

### DIFF
--- a/bitcoin/src/p2p/address.rs
+++ b/bitcoin/src/p2p/address.rs
@@ -6,12 +6,16 @@
 //! network addresses in Bitcoin messages.
 //!
 
+#[cfg(feature = "encoding")]
+use core::convert::Infallible;
 use core::{fmt, iter};
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6, ToSocketAddrs};
 
 use io::{Read, Write};
 
 use crate::consensus::encode::{self, Decodable, Encodable, ReadExt, VarInt, WriteExt};
+#[cfg(feature = "encoding")]
+use crate::internal_macros::write_err;
 use crate::p2p::ServiceFlags;
 
 /// A message which can be sent on the Bitcoin network
@@ -26,6 +30,8 @@ pub struct Address {
 }
 
 const ONION: [u16; 3] = [0xFD87, 0xD87E, 0xEB43];
+#[cfg(feature = "encoding")]
+const IPV4_EMBEDDED_IPV6: [u16; 6] = [0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0xFFFF];
 
 impl Address {
     /// Create an address message for a socket
@@ -95,6 +101,20 @@ fn read_be_address<R: Read + ?Sized>(r: &mut R) -> Result<[u16; 8], encode::Erro
     Ok(address)
 }
 
+#[cfg(feature = "encoding")]
+fn address_from_u8(s: [u8; 16]) -> [u16; 8] {
+    [
+        u16::from_be_bytes([s[0], s[1]]),
+        u16::from_be_bytes([s[2], s[3]]),
+        u16::from_be_bytes([s[4], s[5]]),
+        u16::from_be_bytes([s[6], s[7]]),
+        u16::from_be_bytes([s[8], s[9]]),
+        u16::from_be_bytes([s[10], s[11]]),
+        u16::from_be_bytes([s[12], s[13]]),
+        u16::from_be_bytes([s[14], s[15]]),
+    ]
+}
+
 impl fmt::Debug for Address {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let ipv6 = Ipv6Addr::from(self.address);
@@ -119,6 +139,92 @@ impl ToSocketAddrs for Address {
     fn to_socket_addrs(&self) -> Result<Self::Iter, std::io::Error> {
         Ok(iter::once(self.socket_addr()?))
     }
+}
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype! {
+    /// The encoder for the [`Address`] type.
+    #[derive(Debug, Clone)]
+    pub struct AddressEncoder<'e>(
+        encoding::Encoder3<
+            crate::p2p::ServiceFlagsEncoder<'e>,
+            encoding::ArrayEncoder<16>,
+            encoding::ArrayEncoder<2>,
+        >
+    );
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for Address {
+    type Encoder<'e> = AddressEncoder<'e>;
+
+    fn encoder(&self) -> Self::Encoder<'_> {
+        let mut address: [u8; 16] = [0; 16];
+        for (index, value) in self.address.iter().enumerate() {
+            let arr: [u8; 2] = value.to_be_bytes();
+            address[index * 2] = arr[0];
+            address[index * 2 + 1] = arr[1];
+        }
+
+        let enc = encoding::Encoder3::new(
+            self.services.encoder(),
+            encoding::ArrayEncoder::without_length_prefix(address),
+            encoding::ArrayEncoder::without_length_prefix(self.port.to_be_bytes()),
+        );
+
+        AddressEncoder::new(enc)
+    }
+}
+
+#[cfg(feature = "encoding")]
+type AddressInnerDecoder = encoding::Decoder3<
+    crate::p2p::ServiceFlagsDecoder,
+    encoding::ArrayDecoder<16>,
+    encoding::ArrayDecoder<2>,
+>;
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// The Decoder for [`Address`].
+    #[derive(Debug, Default, Clone)]
+    pub struct AddressDecoder(AddressInnerDecoder);
+
+    fn end(
+        result: Result<<AddressInnerDecoder as encoding::Decoder>::Output, <AddressInnerDecoder as encoding::Decoder>::Error>
+    ) -> Result<Address, AddressDecoderError> {
+        let (services, raw_address, port) = result.map_err(AddressDecoderError)?;
+        let address = address_from_u8(raw_address);
+        Ok(Address { services, address, port: u16::from_be_bytes(port) })
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for Address {
+    type Decoder = AddressDecoder;
+}
+
+/// An error decoding an [`Address`].
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AddressDecoderError(
+    pub(crate) <AddressInnerDecoder as encoding::Decoder>::Error
+);
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for AddressDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl fmt::Display for AddressDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write_err!(f, "address decoder error"; self.0)
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for AddressDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
 }
 
 /// Supported networks for use in BIP155 addrv2 message
@@ -243,6 +349,293 @@ impl Decodable for AddrV2 {
     }
 }
 
+#[cfg(feature = "encoding")]
+/// The encoder for the [`AddrV2`] type.
+#[derive(Debug, Clone)]
+pub struct AddrV2Encoder<'e> {
+    network: Option<encoding::ArrayEncoder<1>>,
+    size: Option<encoding::CompactSizeEncoder>,
+    bytes4: Option<encoding::ArrayEncoder<4>>,
+    bytes10: Option<encoding::ArrayEncoder<10>>,
+    bytes16: Option<encoding::ArrayEncoder<16>>,
+    bytes32: Option<encoding::ArrayEncoder<32>>,
+    nbytes: Option<encoding::BytesEncoder<'e>>,
+}
+
+#[cfg(feature = "encoding")]
+impl<'e> AddrV2Encoder<'e> {
+    const EMPTY: Self = Self {
+        network: None,
+        size: None,
+        bytes4: None,
+        bytes10: None,
+        bytes16: None,
+        bytes32: None,
+        nbytes: None,
+    };
+
+    fn new(addr: &'e AddrV2) -> Self {
+        match addr {
+            AddrV2::Ipv4(ip) => {
+                let octets = ip.octets();
+                Self {
+                    network: Some(encoding::ArrayEncoder::without_length_prefix([1])),
+                    size: Some(encoding::CompactSizeEncoder::new(4)),
+                    bytes4: Some(encoding::ArrayEncoder::without_length_prefix(octets)),
+                    ..Self::EMPTY
+                }
+            }
+            AddrV2::Ipv6(ip) => {
+                let octets = ip.octets();
+                Self {
+                    network: Some(encoding::ArrayEncoder::without_length_prefix([2])),
+                    size: Some(encoding::CompactSizeEncoder::new(16)),
+                    bytes16: Some(encoding::ArrayEncoder::without_length_prefix(octets)),
+                    ..Self::EMPTY
+                }
+            }
+            AddrV2::TorV2(bytes) => Self {
+                network: Some(encoding::ArrayEncoder::without_length_prefix([3])),
+                size: Some(encoding::CompactSizeEncoder::new(10)),
+                bytes10: Some(encoding::ArrayEncoder::without_length_prefix(*bytes)),
+                ..Self::EMPTY
+            },
+            AddrV2::TorV3(bytes) => Self {
+                network: Some(encoding::ArrayEncoder::without_length_prefix([4])),
+                size: Some(encoding::CompactSizeEncoder::new(32)),
+                bytes32: Some(encoding::ArrayEncoder::without_length_prefix(*bytes)),
+                ..Self::EMPTY
+            },
+            AddrV2::I2p(bytes) => Self {
+                network: Some(encoding::ArrayEncoder::without_length_prefix([5])),
+                size: Some(encoding::CompactSizeEncoder::new(32)),
+                bytes32: Some(encoding::ArrayEncoder::without_length_prefix(*bytes)),
+                ..Self::EMPTY
+            },
+            AddrV2::Cjdns(ip) => {
+                let octets = ip.octets();
+                Self {
+                    network: Some(encoding::ArrayEncoder::without_length_prefix([6])),
+                    size: Some(encoding::CompactSizeEncoder::new(16)),
+                    bytes16: Some(encoding::ArrayEncoder::without_length_prefix(octets)),
+                    ..Self::EMPTY
+                }
+            }
+            AddrV2::Unknown(network, bytes) => Self {
+                network: Some(encoding::ArrayEncoder::without_length_prefix([*network])),
+                size: Some(encoding::CompactSizeEncoder::new(bytes.len())),
+                nbytes: Some(encoding::BytesEncoder::without_length_prefix(bytes.as_slice())),
+                ..Self::EMPTY
+            },
+        }
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encoder for AddrV2Encoder<'_> {
+    fn current_chunk(&self) -> &[u8] {
+        if let Some(network) = &self.network {
+            return network.current_chunk();
+        }
+        if let Some(cs) = &self.size {
+            return cs.current_chunk();
+        }
+        if let Some(b) = &self.bytes4 {
+            return b.current_chunk();
+        }
+        if let Some(b) = &self.bytes10 {
+            return b.current_chunk();
+        }
+        if let Some(b) = &self.bytes16 {
+            return b.current_chunk();
+        }
+        if let Some(b) = &self.bytes32 {
+            return b.current_chunk();
+        }
+        if let Some(b) = &self.nbytes {
+            return b.current_chunk();
+        }
+        &[]
+    }
+
+    fn advance(&mut self) -> encoding::EncoderStatus {
+        if self.network.is_some() && self.network.advance().has_finished() {
+            self.network = None;
+            return encoding::EncoderStatus::HasMore;
+        }
+        if self.size.is_some() && self.size.advance().has_finished() {
+            self.size = None;
+            return encoding::EncoderStatus::HasMore;
+        }
+        if self.bytes4.is_some() && self.bytes4.advance().has_finished() {
+            self.bytes4 = None;
+            return encoding::EncoderStatus::Finished;
+        }
+        if self.bytes10.is_some() && self.bytes10.advance().has_finished() {
+            self.bytes10 = None;
+            return encoding::EncoderStatus::Finished;
+        }
+        if self.bytes16.is_some() && self.bytes16.advance().has_finished() {
+            self.bytes16 = None;
+            return encoding::EncoderStatus::Finished;
+        }
+        if self.bytes32.is_some() && self.bytes32.advance().has_finished() {
+            self.bytes32 = None;
+            return encoding::EncoderStatus::Finished;
+        }
+        if self.nbytes.is_some() && self.nbytes.advance().has_finished() {
+            self.nbytes = None;
+            return encoding::EncoderStatus::Finished;
+        }
+        encoding::EncoderStatus::HasMore
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for AddrV2 {
+    type Encoder<'e> = AddrV2Encoder<'e>;
+
+    fn encoder(&self) -> Self::Encoder<'_> { AddrV2Encoder::new(self) }
+}
+
+#[cfg(feature = "encoding")]
+type AddrV2InnerDecoder = encoding::Decoder2<encoding::ArrayDecoder<1>, encoding::ByteVecDecoder>;
+
+#[cfg(feature = "encoding")]
+/// The decoder for the [`AddrV2`] type.
+#[derive(Debug, Default, Clone)]
+pub struct AddrV2Decoder(AddrV2InnerDecoder);
+
+#[cfg(feature = "encoding")]
+impl AddrV2Decoder {
+    fn to_fixed_size<const N: usize>(bytes: Vec<u8>) -> Result<[u8; N], AddrV2DecoderError> {
+        let len = bytes.len();
+        bytes
+            .try_into()
+            .map_err(|_| AddrV2DecoderError::InvalidAddressLength { expected: N, got: len })
+    }
+
+    fn ipv6_from_bytes(bytes: [u8; 16]) -> Ipv6Addr {
+        let address = address_from_u8(bytes);
+        Ipv6Addr::new(
+            address[0], address[1], address[2], address[3], address[4], address[5], address[6],
+            address[7],
+        )
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decoder for AddrV2Decoder {
+    type Output = AddrV2;
+    type Error = AddrV2DecoderError;
+
+    fn push_bytes(&mut self, bytes: &mut &[u8]) -> Result<encoding::DecoderStatus, Self::Error> {
+        self.0.push_bytes(bytes).map_err(AddrV2DecoderError::Decoder)
+    }
+
+    fn end(self) -> Result<Self::Output, Self::Error> {
+        let (network_id, bytes) = self.0.end().map_err(AddrV2DecoderError::Decoder)?;
+
+        if bytes.len() > 512 {
+            return Err(AddrV2DecoderError::InvalidAddressLength {
+                expected: 512,
+                got: bytes.len(),
+            });
+        }
+
+        match network_id[0] {
+            1 => {
+                let addr = Self::to_fixed_size::<4>(bytes)?;
+                Ok(AddrV2::Ipv4(Ipv4Addr::new(addr[0], addr[1], addr[2], addr[3])))
+            }
+            2 => {
+                let addr = Self::to_fixed_size::<16>(bytes)?;
+                let segments = address_from_u8(addr);
+
+                if segments[0..3] == ONION {
+                    return Err(AddrV2DecoderError::WrappedOnionCat);
+                }
+                if segments[0..6] == IPV4_EMBEDDED_IPV6 {
+                    return Err(AddrV2DecoderError::WrappedIpv4);
+                }
+
+                Ok(AddrV2::Ipv6(Self::ipv6_from_bytes(addr)))
+            }
+            3 => Ok(AddrV2::TorV2(Self::to_fixed_size::<10>(bytes)?)),
+            4 => Ok(AddrV2::TorV3(Self::to_fixed_size::<32>(bytes)?)),
+            5 => Ok(AddrV2::I2p(Self::to_fixed_size::<32>(bytes)?)),
+            6 => {
+                let addr = Self::to_fixed_size::<16>(bytes)?;
+                if addr[0] != 0xFC {
+                    return Err(AddrV2DecoderError::NotCjdns);
+                }
+                Ok(AddrV2::Cjdns(Self::ipv6_from_bytes(addr)))
+            }
+            network_id => Ok(AddrV2::Unknown(network_id, bytes)),
+        }
+    }
+
+    fn read_limit(&self) -> usize { self.0.read_limit() }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for AddrV2 {
+    type Decoder = AddrV2Decoder;
+}
+
+/// An error decoding a [`AddrV2`] message.
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AddrV2DecoderError {
+    /// Inner decoder failure.
+    Decoder(<AddrV2InnerDecoder as encoding::Decoder>::Error),
+    /// The address cannot be decoded given the buffer size.
+    InvalidAddressLength {
+        /// The expected size given the address type.
+        expected: usize,
+        /// Actual size of the buffer.
+        got: usize,
+    },
+    /// Expected CJDNS address but got an invalid mask.
+    NotCjdns,
+    /// `OnionCat` address sent as IPV6 is invalid.
+    WrappedOnionCat,
+    /// Wrapped IPV4 sent as IPV6 is invalid.
+    WrappedIpv4,
+}
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for AddrV2DecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl fmt::Display for AddrV2DecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Decoder(err) => write_err!(f, "addrv2 error"; err),
+            Self::InvalidAddressLength { expected, got } =>
+                write!(f, "invalid length. expected {}, got {}", expected, got),
+            Self::NotCjdns => write!(f, "CJDNS address must start with a reserved byte."),
+            Self::WrappedOnionCat => write!(f, "OnionCat address sent as IPv6 is invalid."),
+            Self::WrappedIpv4 => write!(f, "wrapped IPv4 sent as IPv6 is invalid."),
+        }
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for AddrV2DecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Decoder(err) => Some(err),
+            Self::InvalidAddressLength { .. }
+            | Self::NotCjdns
+            | Self::WrappedOnionCat
+            | Self::WrappedIpv4 => None,
+        }
+    }
+}
+
 /// Address received from BIP155 addrv2 message
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct AddrV2Message {
@@ -299,6 +692,88 @@ impl ToSocketAddrs for AddrV2Message {
     fn to_socket_addrs(&self) -> Result<Self::Iter, std::io::Error> {
         Ok(iter::once(self.socket_addr()?))
     }
+}
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype! {
+    /// The encoder for the [`AddrV2Message`] type.
+    #[derive(Debug, Clone)]
+    pub struct AddrV2MessageEncoder<'e>(
+        encoding::Encoder4<
+            encoding::ArrayEncoder<4>,
+            encoding::CompactSizeEncoder,
+            AddrV2Encoder<'e>,
+            encoding::ArrayEncoder<2>,
+        >
+    );
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for AddrV2Message {
+    type Encoder<'e> = AddrV2MessageEncoder<'e>;
+
+    fn encoder(&self) -> Self::Encoder<'_> {
+        AddrV2MessageEncoder::new(encoding::Encoder4::new(
+            encoding::ArrayEncoder::without_length_prefix(self.time.to_le_bytes()),
+            encoding::CompactSizeEncoder::new_u64(self.services.to_u64()),
+            self.addr.encoder(),
+            encoding::ArrayEncoder::without_length_prefix(self.port.to_be_bytes()),
+        ))
+    }
+}
+
+#[cfg(feature = "encoding")]
+type AddrV2MessageInnerDecoder = encoding::Decoder4<
+    encoding::ArrayDecoder<4>,
+    encoding::CompactSizeU64Decoder,
+    AddrV2Decoder,
+    encoding::ArrayDecoder<2>,
+>;
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// The decoder for the [`AddrV2Message`] type.
+    #[derive(Debug, Default, Clone)]
+    pub struct AddrV2MessageDecoder(AddrV2MessageInnerDecoder);
+
+    fn end(
+        result: Result<<AddrV2MessageInnerDecoder as encoding::Decoder>::Output, <AddrV2MessageInnerDecoder as encoding::Decoder>::Error>
+    ) -> Result<AddrV2Message, AddrV2MessageDecoderError> {
+        let (time, services, addr, port) = result.map_err(AddrV2MessageDecoderError)?;
+        Ok(AddrV2Message {
+            time: u32::from_le_bytes(time),
+            services: ServiceFlags::from(services),
+            addr,
+            port: u16::from_be_bytes(port),
+        })
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for AddrV2Message {
+    type Decoder = AddrV2MessageDecoder;
+}
+
+/// An error decoding an [`AddrV2Message`].
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AddrV2MessageDecoderError(pub(crate) <AddrV2MessageInnerDecoder as encoding::Decoder>::Error);
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for AddrV2MessageDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl fmt::Display for AddrV2MessageDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_err!(f, "addrv2 message error"; self.0)
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for AddrV2MessageDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
 }
 
 #[cfg(test)]

--- a/bitcoin/src/p2p/message.rs
+++ b/bitcoin/src/p2p/message.rs
@@ -13,6 +13,8 @@ use io::{Read, Write};
 
 use crate::blockdata::{block, transaction};
 use crate::consensus::encode::{self, CheckedData, Decodable, Encodable, VarInt};
+#[cfg(feature = "encoding")]
+use crate::internal_macros::write_err;
 use crate::merkle_tree::MerkleBlock;
 use crate::p2p::address::{AddrV2Message, Address};
 use crate::p2p::{
@@ -121,6 +123,85 @@ impl Decodable for CommandString {
         }
 
         Ok(CommandString(Cow::Owned(unsafe { String::from_utf8_unchecked(trimmed.to_vec()) })))
+    }
+}
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// The encoder for the [`CommandString`] type.
+    #[derive(Debug, Clone)]
+    pub struct CommandStringEncoder<'e>(encoding::ArrayEncoder<12>);
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for CommandString {
+    type Encoder<'e> = CommandStringEncoder<'e>;
+
+    fn encoder(&self) -> Self::Encoder<'_> {
+        let mut rawbytes = [0u8; 12];
+        let strbytes = self.0.as_bytes();
+        debug_assert!(strbytes.len() <= 12);
+        rawbytes[..strbytes.len()].copy_from_slice(strbytes);
+        CommandStringEncoder::new(encoding::ArrayEncoder::without_length_prefix(rawbytes))
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for CommandString {
+    type Decoder = CommandStringDecoder;
+}
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// Decoder for [`CommandString`].
+    #[derive(Debug, Default, Clone)]
+    pub struct CommandStringDecoder(encoding::ArrayDecoder<12>);
+
+    fn map_push_bytes_err(err: encoding::UnexpectedEofError) -> CommandStringDecoderError {
+        CommandStringDecoderError::UnexpectedEof(err)
+    }
+
+    fn end(result: Result<[u8; 12], encoding::UnexpectedEofError>) -> Result<CommandString, CommandStringDecoderError> {
+        let rawbytes = result.map_err(CommandStringDecoderError::UnexpectedEof)?;
+        let trimmed =
+            rawbytes.iter().rposition(|&b| b != 0).map_or(&rawbytes[..0], |i| &rawbytes[..=i]);
+
+        if !trimmed.is_ascii() {
+            return Err(CommandStringDecoderError::NotAscii);
+        }
+
+        Ok(CommandString(Cow::Owned(unsafe { String::from_utf8_unchecked(trimmed.to_vec()) })))
+    }
+}
+
+/// Error decoding a [`CommandString`].
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CommandStringDecoderError {
+    /// Unexpected end of data.
+    UnexpectedEof(encoding::UnexpectedEofError),
+    /// Command string contains non-ASCII characters.
+    NotAscii,
+}
+
+#[cfg(feature = "encoding")]
+impl fmt::Display for CommandStringDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::UnexpectedEof(e) => write_err!(f, "unexpected end of data"; e),
+            Self::NotAscii => write!(f, "command string must be ASCII"),
+        }
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for CommandStringDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::UnexpectedEof(e) => Some(e),
+            Self::NotAscii => None,
+        }
     }
 }
 

--- a/bitcoin/src/p2p/message_network.rs
+++ b/bitcoin/src/p2p/message_network.rs
@@ -6,13 +6,24 @@
 //! capabilities.
 //!
 
+#[cfg(feature = "encoding")]
+use core::convert::Infallible;
+#[cfg(feature = "encoding")]
+use core::fmt;
+
 use hashes::sha256d;
+#[cfg(feature = "encoding")]
+use hashes::Hash as _;
 use io::{Read, Write};
 
 use crate::consensus::{encode, Decodable, Encodable, ReadExt};
 use crate::internal_macros::impl_consensus_encoding;
+#[cfg(feature = "encoding")]
+use crate::internal_macros::write_err;
 use crate::p2p;
 use crate::p2p::address::Address;
+#[cfg(feature = "encoding")]
+use crate::p2p::address::AddressDecoder;
 use crate::p2p::ServiceFlags;
 use crate::prelude::*;
 
@@ -88,6 +99,149 @@ impl_consensus_encoding!(
     relay
 );
 
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype! {
+    /// The encoder for the [`VersionMessage`] type.
+    #[derive(Debug, Clone)]
+    pub struct VersionMessageEncoder<'e>(
+        encoding::Encoder2<
+            encoding::Encoder3<
+                encoding::ArrayEncoder<4>,
+                crate::p2p::ServiceFlagsEncoder<'e>,
+                encoding::ArrayEncoder<8>
+            >,
+            encoding::Encoder6<
+                crate::p2p::address::AddressEncoder<'e>,
+                crate::p2p::address::AddressEncoder<'e>,
+                encoding::ArrayEncoder<8>,
+                encoding::Encoder2<encoding::CompactSizeEncoder, encoding::BytesEncoder<'e>>,
+                encoding::ArrayEncoder<4>,
+                encoding::ArrayEncoder<1>
+            >
+        >
+    );
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for VersionMessage {
+    type Encoder<'e> = VersionMessageEncoder<'e>;
+
+    #[inline]
+    fn encoder(&self) -> Self::Encoder<'_> {
+        VersionMessageEncoder::new(encoding::Encoder2::new(
+            encoding::Encoder3::new(
+                encoding::ArrayEncoder::without_length_prefix(self.version.to_le_bytes()),
+                self.services.encoder(),
+                encoding::ArrayEncoder::without_length_prefix(self.timestamp.to_le_bytes()),
+            ),
+            encoding::Encoder6::new(
+                self.receiver.encoder(),
+                self.sender.encoder(),
+                encoding::ArrayEncoder::without_length_prefix(self.nonce.to_le_bytes()),
+                encoding::Encoder2::new(
+                    encoding::CompactSizeEncoder::new(self.user_agent.len()),
+                    encoding::BytesEncoder::without_length_prefix(self.user_agent.as_bytes()),
+                ),
+                encoding::ArrayEncoder::without_length_prefix(self.start_height.to_le_bytes()),
+                encoding::ArrayEncoder::without_length_prefix([u8::from(self.relay)]),
+            ),
+        ))
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for VersionMessage {
+    type Decoder = VersionMessageDecoder;
+}
+
+#[cfg(feature = "encoding")]
+type VersionMessageInnerDecoder = encoding::Decoder2<
+    encoding::Decoder3<
+        encoding::ArrayDecoder<4>,
+        crate::p2p::ServiceFlagsDecoder,
+        encoding::ArrayDecoder<8>,
+    >,
+    encoding::Decoder6<
+        AddressDecoder,
+        AddressDecoder,
+        encoding::ArrayDecoder<8>,
+        encoding::ByteVecDecoder,
+        encoding::ArrayDecoder<4>,
+        encoding::ArrayDecoder<1>,
+    >,
+>;
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// The Decoder for [`VersionMessage`].
+    #[derive(Debug, Default, Clone)]
+    pub struct VersionMessageDecoder(VersionMessageInnerDecoder);
+
+    fn map_push_bytes_err(
+        err: <VersionMessageInnerDecoder as encoding::Decoder>::Error
+    ) -> VersionMessageDecoderError {
+        VersionMessageDecoderError::Decoder(err)
+    }
+
+    fn end(
+        result: Result<<VersionMessageInnerDecoder as encoding::Decoder>::Output, <VersionMessageInnerDecoder as encoding::Decoder>::Error>
+    ) -> Result<VersionMessage, VersionMessageDecoderError> {
+        let (
+            (version, services, timestamp),
+            (receiver, sender, nonce, user_agent, start_height, relay),
+        ) = result.map_err(VersionMessageDecoderError::Decoder)?;
+        let user_agent = String::from_utf8(user_agent).map_err(|_| VersionMessageDecoderError::InvalidUtf8)?;
+
+        Ok(VersionMessage {
+            version: u32::from_le_bytes(version),
+            services,
+            timestamp: i64::from_le_bytes(timestamp),
+            receiver,
+            sender,
+            nonce: u64::from_le_bytes(nonce),
+            user_agent,
+            start_height: i32::from_le_bytes(start_height),
+            relay: relay[0] != 0,
+        })
+    }
+}
+
+/// Errors occurring when decoding a [`VersionMessage`] message.
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum VersionMessageDecoderError {
+    /// Inner decoder error.
+    Decoder(<VersionMessageInnerDecoder as encoding::Decoder>::Error),
+    /// Invalid UTF-8 in the user agent.
+    InvalidUtf8,
+}
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for VersionMessageDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl fmt::Display for VersionMessageDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Decoder(e) => write_err!(f, "version message decoder error"; e),
+            Self::InvalidUtf8 => write!(f, "invalid utf-8"),
+        }
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for VersionMessageDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Decoder(e) => Some(e),
+            Self::InvalidUtf8 => None,
+        }
+    }
+}
+
 /// message rejection reason as a code
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub enum RejectReason {
@@ -132,6 +286,93 @@ impl Decodable for RejectReason {
     }
 }
 
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// Encoder type for a [`RejectReason`].
+    #[derive(Debug, Clone)]
+    pub struct RejectReasonEncoder<'e>(encoding::ArrayEncoder<1>);
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for RejectReason {
+    type Encoder<'e> = RejectReasonEncoder<'e>;
+
+    fn encoder(&self) -> Self::Encoder<'_> {
+        RejectReasonEncoder::new(encoding::ArrayEncoder::without_length_prefix([*self as u8]))
+    }
+}
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// Decoder type for a [`RejectReason`].
+    #[derive(Debug, Default, Clone)]
+    pub struct RejectReasonDecoder(encoding::ArrayDecoder<1>);
+
+    fn map_push_bytes_err(err: encoding::UnexpectedEofError) -> RejectReasonDecoderError {
+        RejectReasonDecoderError::Decoder(err)
+    }
+
+    fn end(
+        result: Result<[u8; 1], encoding::UnexpectedEofError>
+    ) -> Result<RejectReason, RejectReasonDecoderError> {
+        let code_arr = result.map_err(RejectReasonDecoderError::Decoder)?;
+        let code = u8::from_le_bytes(code_arr);
+        Ok(match code {
+            0x01 => RejectReason::Malformed,
+            0x10 => RejectReason::Invalid,
+            0x11 => RejectReason::Obsolete,
+            0x12 => RejectReason::Duplicate,
+            0x40 => RejectReason::NonStandard,
+            0x41 => RejectReason::Dust,
+            0x42 => RejectReason::Fee,
+            0x43 => RejectReason::Checkpoint,
+            unknown => return Err(RejectReasonDecoderError::UnknownRejectCode(unknown)),
+        })
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for RejectReason {
+    type Decoder = RejectReasonDecoder;
+
+    fn decoder() -> Self::Decoder { RejectReasonDecoder(encoding::ArrayDecoder::new()) }
+}
+
+/// Errors occurring when decoding a [`RejectReason`].
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RejectReasonDecoderError {
+    /// Inner decoder error.
+    Decoder(<encoding::ArrayDecoder<1> as encoding::Decoder>::Error),
+    /// Unknown reject code.
+    UnknownRejectCode(u8),
+}
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for RejectReasonDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl fmt::Display for RejectReasonDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Decoder(e) => write_err!(f, "rejectreason error"; e),
+            Self::UnknownRejectCode(code) => write!(f, "unknown reject code {}", code),
+        }
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for RejectReasonDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Decoder(e) => Some(e),
+            Self::UnknownRejectCode(_) => None,
+        }
+    }
+}
+
 /// Reject message might be sent by peers rejecting one of our messages
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub struct Reject {
@@ -146,6 +387,125 @@ pub struct Reject {
 }
 
 impl_consensus_encoding!(Reject, message, ccode, reason, hash);
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype! {
+    /// Encoder type for a [`Reject`] message.
+    #[derive(Debug, Clone)]
+    pub struct RejectEncoder<'e>(
+        encoding::Encoder4<
+            encoding::Encoder2<encoding::CompactSizeEncoder, encoding::BytesEncoder<'e>>,
+            RejectReasonEncoder<'e>,
+            encoding::Encoder2<encoding::CompactSizeEncoder, encoding::BytesEncoder<'e>>,
+            encoding::ArrayEncoder<32>
+        >
+    );
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for Reject {
+    type Encoder<'e> = RejectEncoder<'e>;
+
+    fn encoder(&self) -> Self::Encoder<'_> {
+        RejectEncoder::new(encoding::Encoder4::new(
+            encoding::Encoder2::new(
+                encoding::CompactSizeEncoder::new(self.message.len()),
+                encoding::BytesEncoder::without_length_prefix(self.message.as_bytes()),
+            ),
+            self.ccode.encoder(),
+            encoding::Encoder2::new(
+                encoding::CompactSizeEncoder::new(self.reason.len()),
+                encoding::BytesEncoder::without_length_prefix(self.reason.as_bytes()),
+            ),
+            encoding::ArrayEncoder::without_length_prefix(self.hash.to_byte_array()),
+        ))
+    }
+}
+
+#[cfg(feature = "encoding")]
+type RejectInnerDecoder = encoding::Decoder4<
+    encoding::ByteVecDecoder,
+    RejectReasonDecoder,
+    encoding::ByteVecDecoder,
+    encoding::ArrayDecoder<32>,
+>;
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// Decoder type for a [`Reject`] message.
+    #[derive(Debug, Default, Clone)]
+    pub struct RejectDecoder(RejectInnerDecoder);
+
+    fn map_push_bytes_err(
+        err: <RejectInnerDecoder as encoding::Decoder>::Error
+    ) -> RejectDecoderError {
+        RejectDecoderError::Decoder(err)
+    }
+
+    fn end(
+        result: Result<<RejectInnerDecoder as encoding::Decoder>::Output, <RejectInnerDecoder as encoding::Decoder>::Error>
+    ) -> Result<Reject, RejectDecoderError> {
+        let (message, ccode, reason, hash) = result.map_err(RejectDecoderError::Decoder)?;
+        let message = String::from_utf8(message).map_err(|_| RejectDecoderError::InvalidUtf8)?;
+        let reason = String::from_utf8(reason).map_err(|_| RejectDecoderError::InvalidUtf8)?;
+
+        Ok(Reject {
+            message: Cow::Owned(message),
+            ccode,
+            reason: Cow::Owned(reason),
+            hash: sha256d::Hash::from_byte_array(hash),
+        })
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for Reject {
+    type Decoder = RejectDecoder;
+
+    fn decoder() -> Self::Decoder {
+        RejectDecoder(encoding::Decoder4::new(
+            encoding::ByteVecDecoder::new(),
+            RejectReason::decoder(),
+            encoding::ByteVecDecoder::new(),
+            encoding::ArrayDecoder::new(),
+        ))
+    }
+}
+
+/// Errors occurring when decoding a [`Reject`].
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RejectDecoderError {
+    /// Inner decoder error.
+    Decoder(<RejectInnerDecoder as encoding::Decoder>::Error),
+    /// Invalid UTF-8.
+    InvalidUtf8,
+}
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for RejectDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl fmt::Display for RejectDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Decoder(e) => write_err!(f, "reject error"; e),
+            Self::InvalidUtf8 => write!(f, "invalid utf-8"),
+        }
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for RejectDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Decoder(e) => Some(e),
+            Self::InvalidUtf8 => None,
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/bitcoin/src/p2p/mod.rs
+++ b/bitcoin/src/p2p/mod.rs
@@ -20,6 +20,8 @@ pub mod message_filter;
 #[cfg(feature = "std")]
 pub mod message_network;
 
+#[cfg(feature = "encoding")]
+use core::convert::Infallible;
 use core::str::FromStr;
 use core::{fmt, ops};
 
@@ -208,6 +210,70 @@ impl Decodable for ServiceFlags {
         Ok(ServiceFlags(Decodable::consensus_decode(r)?))
     }
 }
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// The encoder for the [`ServiceFlags`] type.
+    #[derive(Debug, Clone)]
+    pub struct ServiceFlagsEncoder<'e>(encoding::ArrayEncoder<8>);
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for ServiceFlags {
+    type Encoder<'e> = ServiceFlagsEncoder<'e>;
+    fn encoder(&self) -> Self::Encoder<'_> {
+        ServiceFlagsEncoder::new(encoding::ArrayEncoder::without_length_prefix(
+            self.0.to_le_bytes(),
+        ))
+    }
+}
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// The decoder for the [`ServiceFlags`] type.
+    #[derive(Debug, Clone)]
+    pub struct ServiceFlagsDecoder(encoding::ArrayDecoder<8>);
+
+    /// Constructs a new [`ServiceFlags`] decoder.
+    pub const fn new() -> Self { Self(encoding::ArrayDecoder::new()) }
+
+    fn end(
+        result: Result<[u8; 8], encoding::UnexpectedEofError>
+    ) -> Result<ServiceFlags, ServiceFlagsDecoderError> {
+        let n = u64::from_le_bytes(result.map_err(ServiceFlagsDecoderError)?);
+        Ok(ServiceFlags(n))
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for ServiceFlags {
+    type Decoder = ServiceFlagsDecoder;
+}
+
+/// An error consensus decoding a [`ServiceFlags`].
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServiceFlagsDecoderError(
+    pub(crate) <encoding::ArrayDecoder<8> as encoding::Decoder>::Error
+);
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for ServiceFlagsDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl fmt::Display for ServiceFlagsDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write_err!(f, "serviceflags error"; self.0)
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for ServiceFlagsDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
+}
+
 /// Network magic bytes to identify the cryptocurrency network the message was intended for.
 #[derive(Copy, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
 pub struct Magic([u8; 4]);
@@ -341,6 +407,66 @@ impl BorrowMut<[u8]> for Magic {
 
 impl BorrowMut<[u8; 4]> for Magic {
     fn borrow_mut(&mut self) -> &mut [u8; 4] { &mut self.0 }
+}
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// The encoder type for network [`Magic`].
+    #[derive(Debug, Clone)]
+    pub struct MagicEncoder<'e>(encoding::ArrayEncoder<4>);
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for Magic {
+    type Encoder<'e> = MagicEncoder<'e>;
+
+    fn encoder(&self) -> Self::Encoder<'_> {
+        MagicEncoder::new(encoding::ArrayEncoder::without_length_prefix(self.0))
+    }
+}
+
+#[cfg(feature = "encoding")]
+type MagicInnerDecoder = encoding::ArrayDecoder<4>;
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// The decoder type for a network [`Magic`].
+    #[derive(Debug, Default, Clone)]
+    pub struct MagicDecoder(MagicInnerDecoder);
+
+    fn end(
+        result: Result<[u8; 4], <MagicInnerDecoder as encoding::Decoder>::Error>
+    ) -> Result<Magic, MagicDecoderError> {
+        let bytes = result.map_err(MagicDecoderError)?;
+        Ok(Magic::from_bytes(bytes))
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for Magic {
+    type Decoder = MagicDecoder;
+}
+
+/// An error consensus decoding a `Magic`.
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MagicDecoderError(pub(crate) <MagicInnerDecoder as encoding::Decoder>::Error);
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for MagicDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl fmt::Display for MagicDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write_err!(f, "magic error"; self.0)
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for MagicDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
 }
 
 /// An error in parsing magic bytes.


### PR DESCRIPTION
Continue implementing `consensus_encoding` on `0.32.x`, adding impls for the core p2p networking types that are the same on master.

- Add `consensus_encoding` support to `ServiceFlags` and `Magic` (`p2p/mod.rs`), `Address`, `AddrV2` and `AddrV2Message` (`p2p/address.rs`), `CommandString` (`p2p/message.rs`), and `VersionMessage`, `RejectReason` and `Reject` (`p2p/message_network.rs`).
- Some changes were necessary, detailed in the commit logs, due to missing types in 0.32.x.

A couple of the commits had assistance by Claude Opus 4.8 to fix the differences to master.

I ran the fuzzer locally for 5 min with no errors. Fuzzing of 0.32.x is currently done on master so it was not added to this PR.