### PR TITLE
0.32.x: Add `consensus_encoding` to BIP157/158 filter message types

### DIFF
--- a/bitcoin/src/bip158.rs
+++ b/bitcoin/src/bip158.rs
@@ -44,6 +44,8 @@ use core::fmt::{self, Display, Formatter};
 
 #[cfg(feature = "arbitrary")]
 use actual_arbitrary::{self as arbitrary, Arbitrary, Unstructured};
+#[cfg(feature = "encoding")]
+use encoding::ArrayRefEncoder;
 use hashes::{sha256d, siphash24, Hash};
 use io::{Read, Write};
 
@@ -68,6 +70,126 @@ hashes::hash_newtype! {
 
 impl_hashencode!(FilterHash);
 impl_hashencode!(FilterHeader);
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// Encoder type for [`FilterHash`].
+    #[derive(Debug, Clone)]
+    pub struct FilterHashEncoder<'e>(ArrayRefEncoder<'e, 32>);
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for FilterHash {
+    type Encoder<'e> = FilterHashEncoder<'e>;
+
+    fn encoder(&self) -> Self::Encoder<'_> {
+        FilterHashEncoder::new(ArrayRefEncoder::without_length_prefix(self.as_byte_array()))
+    }
+}
+
+#[cfg(feature = "encoding")]
+type HashInnerDecoder = encoding::ArrayDecoder<32>;
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// The decoder for the [`FilterHash`] type.
+    #[derive(Debug, Default, Clone)]
+    pub struct FilterHashDecoder(HashInnerDecoder);
+
+    fn end(
+        result: Result<[u8; 32], encoding::UnexpectedEofError>
+    ) -> Result<FilterHash, FilterHashDecoderError> {
+        let arr = result.map_err(FilterHashDecoderError)?;
+        Ok(FilterHash::from_byte_array(arr))
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for FilterHash {
+    type Decoder = FilterHashDecoder;
+}
+
+/// Errors occurring when decoding a [`FilterHash`] message.
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FilterHashDecoderError(
+    pub(crate) <HashInnerDecoder as encoding::Decoder>::Error,
+);
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for FilterHashDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl fmt::Display for FilterHashDecoderError {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+        write_err!(f, "filterhash error"; self.0)
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for FilterHashDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
+}
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// The encoder for the [`FilterHeader`] type.
+    #[derive(Debug, Clone)]
+    pub struct FilterHeaderEncoder<'e>(encoding::ArrayRefEncoder<'e, 32>);
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for FilterHeader {
+    type Encoder<'e> = FilterHeaderEncoder<'e>;
+
+    fn encoder(&self) -> Self::Encoder<'_> {
+        FilterHeaderEncoder::new(encoding::ArrayRefEncoder::without_length_prefix(
+            self.as_byte_array(),
+        ))
+    }
+}
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// Decoder for the [`FilterHeader`] type.
+    #[derive(Debug, Default, Clone)]
+    pub struct FilterHeaderDecoder(HashInnerDecoder);
+
+    fn end(result: Result<[u8; 32], encoding::UnexpectedEofError>) -> Result<FilterHeader, FilterHeaderDecoderError> {
+        Ok(FilterHeader::from_byte_array(result.map_err(FilterHeaderDecoderError)?))
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for FilterHeader {
+    type Decoder = FilterHeaderDecoder;
+}
+
+/// Errors occurring when decoding a [`FilterHeader`] message.
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FilterHeaderDecoderError(
+    pub(crate) <HashInnerDecoder as encoding::Decoder>::Error
+);
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for FilterHeaderDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl fmt::Display for FilterHeaderDecoderError {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+        write_err!(f, "filterheader error"; self.0)
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for FilterHeaderDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
+}
 
 /// Errors for blockfilter.
 #[derive(Debug)]

--- a/bitcoin/src/p2p/message_bloom.rs
+++ b/bitcoin/src/p2p/message_bloom.rs
@@ -5,10 +5,22 @@
 //! This module describes BIP37 Connection Bloom filtering network messages.
 //!
 
+#[cfg(feature = "encoding")]
+use core::convert::Infallible;
+#[cfg(feature = "encoding")]
+use core::fmt;
+#[cfg(feature = "encoding")]
+use encoding::{
+    ArrayDecoder, ArrayEncoder, ByteVecDecoder, BytesEncoder, CompactSizeEncoder, Decoder4,
+    Encoder2, Encoder3,
+};
+
 use io::{Read, Write};
 
 use crate::consensus::{encode, Decodable, Encodable, ReadExt};
 use crate::internal_macros::impl_consensus_encoding;
+#[cfg(feature = "encoding")]
+use crate::internal_macros::write_err;
 
 /// `filterload` message sets the current bloom filter
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -25,6 +37,97 @@ pub struct FilterLoad {
 
 impl_consensus_encoding!(FilterLoad, filter, hash_funcs, tweak, flags);
 
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype! {
+    /// The encoder for the [`FilterLoad`] message.
+    #[derive(Debug, Clone)]
+    pub struct FilterLoadEncoder<'e>(
+        Encoder2<
+            Encoder2<CompactSizeEncoder, BytesEncoder<'e>>,
+            Encoder3<
+                ArrayEncoder<4>,
+                ArrayEncoder<4>,
+                BloomFlagsEncoder<'e>,
+            >,
+        >
+    );
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for FilterLoad {
+    type Encoder<'e> = FilterLoadEncoder<'e>;
+
+    fn encoder(&self) -> Self::Encoder<'_> {
+        FilterLoadEncoder::new(Encoder2::new(
+            Encoder2::new(
+                CompactSizeEncoder::new(self.filter.len()),
+                BytesEncoder::without_length_prefix(&self.filter),
+            ),
+            Encoder3::new(
+                ArrayEncoder::without_length_prefix(self.hash_funcs.to_le_bytes()),
+                ArrayEncoder::without_length_prefix(self.tweak.to_le_bytes()),
+                self.flags.encoder(),
+            ),
+        ))
+    }
+}
+
+#[cfg(feature = "encoding")]
+type FilterLoadInnerDecoder =
+    Decoder4<ByteVecDecoder, ArrayDecoder<4>, ArrayDecoder<4>, BloomFlagsDecoder>;
+
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// The decoder for the [`FilterLoad`] message.
+    #[derive(Debug, Default, Clone)]
+    pub struct FilterLoadDecoder(FilterLoadInnerDecoder);
+
+    fn end(
+        result: Result<
+            <FilterLoadInnerDecoder as encoding::Decoder>::Output,
+            <FilterLoadInnerDecoder as encoding::Decoder>::Error,
+        >
+    ) -> Result<FilterLoad, FilterLoadDecoderError> {
+        let (filter, hash_funcs, tweak, flags) = result.map_err(FilterLoadDecoderError)?;
+        Ok(FilterLoad {
+            filter,
+            hash_funcs: u32::from_le_bytes(hash_funcs),
+            tweak: u32::from_le_bytes(tweak),
+            flags,
+        })
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for FilterLoad {
+    type Decoder = FilterLoadDecoder;
+}
+
+/// An error occurring when decoding a [`FilterLoad`] message.
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FilterLoadDecoderError(
+    pub(crate) <FilterLoadInnerDecoder as encoding::Decoder>::Error,
+);
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for FilterLoadDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl fmt::Display for FilterLoadDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_err!(f, "filterload error"; self.0)
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for FilterLoadDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
+}
+
 /// Bloom filter update flags
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum BloomFlags {
@@ -34,6 +137,93 @@ pub enum BloomFlags {
     All,
     /// Only update the filter with outpoints if it is P2PK or P2MS
     PubkeyOnly,
+}
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// The encoder for [`BloomFlags`].
+    #[derive(Debug, Clone)]
+    pub struct BloomFlagsEncoder<'e>(ArrayEncoder<1>);
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for BloomFlags {
+    type Encoder<'e> = BloomFlagsEncoder<'e>;
+
+    fn encoder(&self) -> Self::Encoder<'_> {
+        BloomFlagsEncoder::new(ArrayEncoder::without_length_prefix([match self {
+            Self::None => 0,
+            Self::All => 1,
+            Self::PubkeyOnly => 2,
+        }]))
+    }
+}
+
+#[cfg(feature = "encoding")]
+type BloomFlagsInnerDecoder = ArrayDecoder<1>;
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// The decoder for [`BloomFlags`].
+    #[derive(Debug, Default, Clone)]
+    pub struct BloomFlagsDecoder(BloomFlagsInnerDecoder);
+
+    fn map_push_bytes_err(err: encoding::UnexpectedEofError) -> BloomFlagsDecoderError {
+        BloomFlagsDecoderError::Decoder(err)
+    }
+
+    fn end(
+        result: Result<[u8; 1], encoding::UnexpectedEofError>
+    ) -> Result<BloomFlags, BloomFlagsDecoderError> {
+        let bloom_flag_arr = result.map_err(BloomFlagsDecoderError::Decoder)?;
+        let bloom_flag = u8::from_le_bytes(bloom_flag_arr);
+        Ok(match bloom_flag {
+            0 => BloomFlags::None,
+            1 => BloomFlags::All,
+            2 => BloomFlags::PubkeyOnly,
+            flag => return Err(BloomFlagsDecoderError::UnknownFlag(flag)),
+        })
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for BloomFlags {
+    type Decoder = BloomFlagsDecoder;
+}
+
+/// An error occurring when decoding a [`BloomFlags`].
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BloomFlagsDecoderError {
+    /// Inner decoder error.
+    Decoder(<BloomFlagsInnerDecoder as encoding::Decoder>::Error),
+    /// The flag is not known.
+    UnknownFlag(u8),
+}
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for BloomFlagsDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl fmt::Display for BloomFlagsDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Decoder(err) => write_err!(f, "bloomflags error"; err),
+            Self::UnknownFlag(flag) => write!(f, "unknown bloomflag {}", flag),
+        }
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for BloomFlagsDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Decoder(err) => Some(err),
+            Self::UnknownFlag(_) => None,
+        }
+    }
 }
 
 impl Encodable for BloomFlags {
@@ -66,3 +256,66 @@ pub struct FilterAdd {
 }
 
 impl_consensus_encoding!(FilterAdd, data);
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// The encoder of the [`FilterAdd`] message.
+    #[derive(Debug, Clone)]
+    pub struct FilterAddEncoder<'e>(Encoder2<CompactSizeEncoder, BytesEncoder<'e>>);
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for FilterAdd {
+    type Encoder<'e> = FilterAddEncoder<'e>;
+
+    fn encoder(&self) -> Self::Encoder<'_> {
+        FilterAddEncoder::new(Encoder2::new(
+            CompactSizeEncoder::new(self.data.len()),
+            BytesEncoder::without_length_prefix(&self.data),
+        ))
+    }
+}
+
+#[cfg(feature = "encoding")]
+type FilterAddInnerDecoder = encoding::ByteVecDecoder;
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// The decoder for the [`FilterAdd`] message.
+    #[derive(Debug, Default, Clone)]
+    pub struct FilterAddDecoder(FilterAddInnerDecoder);
+
+    fn end(
+        result: Result<Vec<u8>, encoding::ByteVecDecoderError>
+    ) -> Result<FilterAdd, FilterAddDecoderError> {
+        let data = result.map_err(FilterAddDecoderError)?;
+        Ok(FilterAdd { data })
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for FilterAdd {
+    type Decoder = FilterAddDecoder;
+}
+
+/// An error decoding a [`FilterAdd`] message.
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FilterAddDecoderError(pub(crate) <FilterAddInnerDecoder as encoding::Decoder>::Error);
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for FilterAddDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl fmt::Display for FilterAddDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_err!(f, "filteradd error"; self.0)
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for FilterAddDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
+}

--- a/bitcoin/src/p2p/message_filter.rs
+++ b/bitcoin/src/p2p/message_filter.rs
@@ -5,9 +5,18 @@
 //! This module describes BIP157 Client Side Block Filtering network messages.
 //!
 
+#[cfg(feature = "encoding")]
+use core::convert::Infallible;
+#[cfg(feature = "encoding")]
+use core::fmt;
+
 use crate::bip158::{FilterHash, FilterHeader};
+#[cfg(feature = "encoding")]
+use crate::bip158::{FilterHeaderDecoder, FilterHeaderEncoder};
 use crate::blockdata::block::BlockHash;
 use crate::internal_macros::impl_consensus_encoding;
+#[cfg(feature = "encoding")]
+use crate::internal_macros::write_err;
 
 /// getcfilters message
 #[derive(PartialEq, Eq, Clone, Debug)]
@@ -21,6 +30,82 @@ pub struct GetCFilters {
 }
 impl_consensus_encoding!(GetCFilters, filter_type, start_height, stop_hash);
 
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// Encoder type for the [`GetCFilters`] message.
+    #[derive(Debug, Clone)]
+    pub struct GetCFiltersEncoder<'e>(
+        encoding::Encoder3<encoding::ArrayEncoder<1>, encoding::ArrayEncoder<4>, crate::blockdata::block::BlockHashEncoder<'e>>
+    );
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for GetCFilters {
+    type Encoder<'e> = GetCFiltersEncoder<'e>;
+
+    fn encoder(&self) -> Self::Encoder<'_> {
+        GetCFiltersEncoder::new(encoding::Encoder3::new(
+            encoding::ArrayEncoder::without_length_prefix(self.filter_type.to_le_bytes()),
+            encoding::ArrayEncoder::without_length_prefix(self.start_height.to_le_bytes()),
+            self.stop_hash.encoder(),
+        ))
+    }
+}
+
+#[cfg(feature = "encoding")]
+type GetCFiltersInnerDecoder = encoding::Decoder3<
+    encoding::ArrayDecoder<1>,
+    encoding::ArrayDecoder<4>,
+    crate::blockdata::block::BlockHashDecoder,
+>;
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// Decoder type for the [`GetCFilters`] message.
+    #[derive(Debug, Default, Clone)]
+    pub struct GetCFiltersDecoder(GetCFiltersInnerDecoder);
+
+    fn end(
+        result: Result<<GetCFiltersInnerDecoder as encoding::Decoder>::Output, <GetCFiltersInnerDecoder as encoding::Decoder>::Error>
+    ) -> Result<GetCFilters, GetCFiltersDecoderError> {
+        let (ty, start_height, stop_hash) = result.map_err(GetCFiltersDecoderError)?;
+        Ok(GetCFilters {
+            filter_type: u8::from_le_bytes(ty),
+            start_height: u32::from_le_bytes(start_height),
+            stop_hash,
+        })
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for GetCFilters {
+    type Decoder = GetCFiltersDecoder;
+}
+
+/// Errors occurring when decoding a [`GetCFilters`] message.
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GetCFiltersDecoderError(
+    pub(crate) <GetCFiltersInnerDecoder as encoding::Decoder>::Error,
+);
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for GetCFiltersDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl fmt::Display for GetCFiltersDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_err!(f, "getcfilters error"; self.0)
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for GetCFiltersDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
+}
+
 /// cfilter message
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub struct CFilter {
@@ -33,6 +118,83 @@ pub struct CFilter {
 }
 impl_consensus_encoding!(CFilter, filter_type, block_hash, filter);
 
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype! {
+    /// Encoder type for a [`CFilter`] message.
+    #[derive(Debug, Clone)]
+    pub struct CFilterEncoder<'e>(
+        encoding::Encoder3<
+            encoding::ArrayEncoder<1>,
+            crate::blockdata::block::BlockHashEncoder<'e>,
+            encoding::Encoder2<encoding::CompactSizeEncoder, encoding::BytesEncoder<'e>>,
+        >
+    );
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for CFilter {
+    type Encoder<'e> = CFilterEncoder<'e>;
+
+    fn encoder(&self) -> Self::Encoder<'_> {
+        CFilterEncoder::new(encoding::Encoder3::new(
+            encoding::ArrayEncoder::without_length_prefix(self.filter_type.to_le_bytes()),
+            self.block_hash.encoder(),
+            encoding::Encoder2::new(
+                encoding::CompactSizeEncoder::new(self.filter.len()),
+                encoding::BytesEncoder::without_length_prefix(&self.filter),
+            ),
+        ))
+    }
+}
+
+#[cfg(feature = "encoding")]
+type CFilterInnerDecoder = encoding::Decoder3<
+    encoding::ArrayDecoder<1>,
+    crate::blockdata::block::BlockHashDecoder,
+    encoding::ByteVecDecoder,
+>;
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// Decoder type for a [`CFilter`] message.
+    #[derive(Debug, Default, Clone)]
+    pub struct CFilterDecoder(CFilterInnerDecoder);
+
+    fn end(
+        result: Result<<CFilterInnerDecoder as encoding::Decoder>::Output, <CFilterInnerDecoder as encoding::Decoder>::Error>
+    ) -> Result<CFilter, CFilterDecoderError> {
+        let (ty, block_hash, filter) = result.map_err(CFilterDecoderError)?;
+        Ok(CFilter { filter_type: u8::from_le_bytes(ty), block_hash, filter })
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for CFilter {
+    type Decoder = CFilterDecoder;
+}
+
+/// Errors occurring when decoding a [`CFilter`] message.
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CFilterDecoderError(pub(crate) <CFilterInnerDecoder as encoding::Decoder>::Error);
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for CFilterDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl fmt::Display for CFilterDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_err!(f, "cfilter error"; self.0)
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for CFilterDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
+}
+
 /// getcfheaders message
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub struct GetCFHeaders {
@@ -44,6 +206,82 @@ pub struct GetCFHeaders {
     pub stop_hash: BlockHash,
 }
 impl_consensus_encoding!(GetCFHeaders, filter_type, start_height, stop_hash);
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// Encoder type for the [`GetCFHeaders`] message.
+    #[derive(Debug, Clone)]
+    pub struct GetCFHeadersEncoder<'e>(
+        encoding::Encoder3<encoding::ArrayEncoder<1>, encoding::ArrayEncoder<4>, crate::blockdata::block::BlockHashEncoder<'e>>
+    );
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for GetCFHeaders {
+    type Encoder<'e> = GetCFHeadersEncoder<'e>;
+
+    fn encoder(&self) -> Self::Encoder<'_> {
+        GetCFHeadersEncoder::new(encoding::Encoder3::new(
+            encoding::ArrayEncoder::without_length_prefix(self.filter_type.to_le_bytes()),
+            encoding::ArrayEncoder::without_length_prefix(self.start_height.to_le_bytes()),
+            self.stop_hash.encoder(),
+        ))
+    }
+}
+
+#[cfg(feature = "encoding")]
+type GetCFHeadersInnerDecoder = encoding::Decoder3<
+    encoding::ArrayDecoder<1>,
+    encoding::ArrayDecoder<4>,
+    crate::blockdata::block::BlockHashDecoder,
+>;
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// Decoder type for the [`GetCFHeaders`] message.
+    #[derive(Debug, Default, Clone)]
+    pub struct GetCFHeadersDecoder(GetCFHeadersInnerDecoder);
+
+    fn end(
+        result: Result<<GetCFHeadersInnerDecoder as encoding::Decoder>::Output, <GetCFHeadersInnerDecoder as encoding::Decoder>::Error>
+    ) -> Result<GetCFHeaders, GetCFHeadersDecoderError> {
+        let (ty, start_height, stop_hash) = result.map_err(GetCFHeadersDecoderError)?;
+        Ok(GetCFHeaders {
+            filter_type: u8::from_le_bytes(ty),
+            start_height: u32::from_le_bytes(start_height),
+            stop_hash,
+        })
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for GetCFHeaders {
+    type Decoder = GetCFHeadersDecoder;
+}
+
+/// Errors occurring when decoding a [`GetCFHeaders`] message.
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GetCFHeadersDecoderError(
+    pub(crate) <GetCFHeadersInnerDecoder as encoding::Decoder>::Error,
+);
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for GetCFHeadersDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl fmt::Display for GetCFHeadersDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_err!(f, "getcfheaders error"; self.0)
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for GetCFHeadersDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
+}
 
 /// cfheaders message
 #[derive(PartialEq, Eq, Clone, Debug)]
@@ -59,6 +297,91 @@ pub struct CFHeaders {
 }
 impl_consensus_encoding!(CFHeaders, filter_type, stop_hash, previous_filter_header, filter_hashes);
 
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype! {
+    /// Encoder type for a [`CFHeaders`] message.
+    #[derive(Debug, Clone)]
+    pub struct CFHeadersEncoder<'e>(
+        encoding::Encoder4<
+            encoding::ArrayEncoder<1>,
+            crate::blockdata::block::BlockHashEncoder<'e>,
+            FilterHeaderEncoder<'e>,
+            encoding::Encoder2<encoding::CompactSizeEncoder, encoding::SliceEncoder<'e, FilterHash>>,
+        >
+    );
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for CFHeaders {
+    type Encoder<'e> = CFHeadersEncoder<'e>;
+
+    fn encoder(&self) -> Self::Encoder<'_> {
+        CFHeadersEncoder::new(encoding::Encoder4::new(
+            encoding::ArrayEncoder::without_length_prefix(self.filter_type.to_le_bytes()),
+            self.stop_hash.encoder(),
+            self.previous_filter_header.encoder(),
+            encoding::Encoder2::new(
+                encoding::CompactSizeEncoder::new(self.filter_hashes.len()),
+                encoding::SliceEncoder::without_length_prefix(&self.filter_hashes),
+            ),
+        ))
+    }
+}
+
+#[cfg(feature = "encoding")]
+type CFHeadersInnerDecoder = encoding::Decoder4<
+    encoding::ArrayDecoder<1>,
+    crate::blockdata::block::BlockHashDecoder,
+    FilterHeaderDecoder,
+    encoding::VecDecoder<FilterHash>,
+>;
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// Decoder type for a [`CFHeaders`] message.
+    #[derive(Debug, Default, Clone)]
+    pub struct CFHeadersDecoder(CFHeadersInnerDecoder);
+
+    fn end(
+        result: Result<<CFHeadersInnerDecoder as encoding::Decoder>::Output, <CFHeadersInnerDecoder as encoding::Decoder>::Error>
+    ) -> Result<CFHeaders, CFHeadersDecoderError> {
+        let (ty, stop_hash, previous_filter_header, filter_hashes) = result.map_err(CFHeadersDecoderError)?;
+        Ok(CFHeaders {
+            filter_type: u8::from_le_bytes(ty),
+            stop_hash,
+            previous_filter_header,
+            filter_hashes,
+        })
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for CFHeaders {
+    type Decoder = CFHeadersDecoder;
+}
+
+/// Errors occurring when decoding a [`CFHeaders`] message.
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CFHeadersDecoderError(pub(crate) <CFHeadersInnerDecoder as encoding::Decoder>::Error);
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for CFHeadersDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl fmt::Display for CFHeadersDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_err!(f, "cfheaders error"; self.0)
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for CFHeadersDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
+}
+
 /// getcfcheckpt message
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub struct GetCFCheckpt {
@@ -68,6 +391,74 @@ pub struct GetCFCheckpt {
     pub stop_hash: BlockHash,
 }
 impl_consensus_encoding!(GetCFCheckpt, filter_type, stop_hash);
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// Encoder type for the [`GetCFCheckpt`] message.
+    #[derive(Debug, Clone)]
+    pub struct GetCFCheckptEncoder<'e>(
+        encoding::Encoder2<encoding::ArrayEncoder<1>, crate::blockdata::block::BlockHashEncoder<'e>>
+    );
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for GetCFCheckpt {
+    type Encoder<'e> = GetCFCheckptEncoder<'e>;
+
+    fn encoder(&self) -> Self::Encoder<'_> {
+        GetCFCheckptEncoder::new(encoding::Encoder2::new(
+            encoding::ArrayEncoder::without_length_prefix(self.filter_type.to_le_bytes()),
+            self.stop_hash.encoder(),
+        ))
+    }
+}
+
+#[cfg(feature = "encoding")]
+type GetCFCheckptInnerDecoder =
+    encoding::Decoder2<encoding::ArrayDecoder<1>, crate::blockdata::block::BlockHashDecoder>;
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// Decoder type for a [`GetCFCheckpt`] message.
+    #[derive(Debug, Default, Clone)]
+    pub struct GetCFCheckptDecoder(GetCFCheckptInnerDecoder);
+
+    fn end(
+        result: Result<<GetCFCheckptInnerDecoder as encoding::Decoder>::Output, <GetCFCheckptInnerDecoder as encoding::Decoder>::Error>
+    ) -> Result<GetCFCheckpt, GetCFCheckptDecoderError> {
+        let (ty, stop_hash) = result.map_err(GetCFCheckptDecoderError)?;
+        Ok(GetCFCheckpt { filter_type: u8::from_le_bytes(ty), stop_hash })
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for GetCFCheckpt {
+    type Decoder = GetCFCheckptDecoder;
+}
+
+/// Errors occurring when decoding a [`GetCFCheckpt`] message.
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GetCFCheckptDecoderError(
+    pub(crate) <GetCFCheckptInnerDecoder as encoding::Decoder>::Error,
+);
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for GetCFCheckptDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl fmt::Display for GetCFCheckptDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_err!(f, "getcfcheckpt error"; self.0)
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for GetCFCheckptDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
+}
 
 /// cfcheckpt message
 #[derive(PartialEq, Eq, Clone, Debug)]
@@ -80,3 +471,80 @@ pub struct CFCheckpt {
     pub filter_headers: Vec<FilterHeader>,
 }
 impl_consensus_encoding!(CFCheckpt, filter_type, stop_hash, filter_headers);
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype! {
+    /// Encoder type for a [`CFCheckpt`] message.
+    #[derive(Debug, Clone)]
+    pub struct CFCheckptEncoder<'e>(
+        encoding::Encoder3<
+            encoding::ArrayEncoder<1>,
+            crate::blockdata::block::BlockHashEncoder<'e>,
+            encoding::Encoder2<encoding::CompactSizeEncoder, encoding::SliceEncoder<'e, FilterHeader>>,
+        >
+    );
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for CFCheckpt {
+    type Encoder<'e> = CFCheckptEncoder<'e>;
+
+    fn encoder(&self) -> Self::Encoder<'_> {
+        CFCheckptEncoder::new(encoding::Encoder3::new(
+            encoding::ArrayEncoder::without_length_prefix(self.filter_type.to_le_bytes()),
+            self.stop_hash.encoder(),
+            encoding::Encoder2::new(
+                encoding::CompactSizeEncoder::new(self.filter_headers.len()),
+                encoding::SliceEncoder::without_length_prefix(&self.filter_headers),
+            ),
+        ))
+    }
+}
+
+#[cfg(feature = "encoding")]
+type CFCheckptInnerDecoder = encoding::Decoder3<
+    encoding::ArrayDecoder<1>,
+    crate::blockdata::block::BlockHashDecoder,
+    encoding::VecDecoder<FilterHeader>,
+>;
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// Decoder type for a [`CFCheckpt`] message.
+    #[derive(Debug, Default, Clone)]
+    pub struct CFCheckptDecoder(CFCheckptInnerDecoder);
+
+    fn end(
+        result: Result<<CFCheckptInnerDecoder as encoding::Decoder>::Output, <CFCheckptInnerDecoder as encoding::Decoder>::Error>
+    ) -> Result<CFCheckpt, CFCheckptDecoderError> {
+        let (ty, stop_hash, filter_headers) = result.map_err(CFCheckptDecoderError)?;
+        Ok(CFCheckpt { filter_type: u8::from_le_bytes(ty), stop_hash, filter_headers })
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for CFCheckpt {
+    type Decoder = CFCheckptDecoder;
+}
+
+/// Errors occurring when decoding a [`CFCheckpt`] message.
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CFCheckptDecoderError(pub(crate) <CFCheckptInnerDecoder as encoding::Decoder>::Error);
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for CFCheckptDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl fmt::Display for CFCheckptDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_err!(f, "cfcheckpt error"; self.0)
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for CFCheckptDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
+}


### PR DESCRIPTION
Add `consensus_encoding` support to the compact block filter (BIP157/158) p2p message types and the related filter hash types.

- Add `consensus_encoding` support to `FilterLoad`, `BloomFlags` and `FilterAdd` (`p2p/message_bloom.rs`); `GetCFilters`, `CFilter`, `GetCFHeaders`, `CFHeaders`, `GetCFCheckpt` and `CFCheckpt` (`p2p/message_filter.rs`); and `FilterHash` and `FilterHeader` (`bip158.rs`).
- Copied from master with minimal changes required, described in the commit logs.
- `FilterHash`/`FilterHeader` are in `bip158.rs` instead of `p2p::message_filter` on master. They also use `ArrayRefEncoder<32>` instead of master's `ArrayEncoder<32>`.

The second commit had assistance by Claude Opus 4.8 to fix the differences to master.

I ran the fuzzer locally for 5 min with no errors. Fuzzing of 0.32.x is currently done on master so it was not added to this PR.