### PR TITLE
hashes: support mutliple tags in one invocation 

### DIFF
--- a/hashes/src/macros.rs
+++ b/hashes/src/macros.rs
@@ -626,6 +626,18 @@ mod test {
         assert_eq!(4, core::mem::align_of::<FunctionScopeHash>());
     }
 
+    #[test]
+    fn multiple_tags_one_invocation() {
+        use crate::sha256t::Tag;
+
+        sha256t_tag! {
+            pub struct FooTag = hash_str("foo");
+            pub struct BarTag = hash_str("bar");
+        }
+
+        assert_ne!(FooTag::MIDSTATE, BarTag::MIDSTATE);
+    }
+
     // NB: This runs with and without `hex` feature enabled, testing different code paths for each.
     #[test]
     #[cfg(feature = "alloc")]

--- a/hashes/src/macros.rs
+++ b/hashes/src/macros.rs
@@ -30,12 +30,14 @@
 /// be a multiple of 64.
 #[macro_export]
 macro_rules! sha256t_tag {
-    ($(#[$($tag_attr:tt)*])* $tag_vis:vis struct $tag:ident = $constructor:tt($($tag_value:tt)+);) => {
+    ($($(#[$($tag_attr:tt)*])* $tag_vis:vis struct $tag:ident = $constructor:tt($($tag_value:tt)+);)+) => {
+        $(
         $crate::sha256t_tag_struct!($tag_vis, $tag, stringify!($tag), $(#[$($tag_attr)*])*);
 
         impl $crate::sha256t::Tag for $tag {
             const MIDSTATE: $crate::sha256::Midstate = $crate::sha256t_tag_constructor!($constructor, $($tag_value)+);
         }
+        )+
     }
 }
 


### PR DESCRIPTION
Currently `sha256t_tag!` macro does not allow creating multiple tags in one invocation, so the macro call has to be repeated for each tag.
Allow multiple tag definitions per call.

Part of https://github.com/rust-bitcoin/rust-bitcoin/issues/6299