### PR TITLE
hashes: Introduce `drain_to_hash` and `encode_to_hash`

### DIFF
--- a/bitcoin/src/crypto/sighash.rs
+++ b/bitcoin/src/crypto/sighash.rs
@@ -450,7 +450,6 @@ impl<R: Borrow<Transaction>> SighashCache<R> {
         // If hash_type & 3 equals SIGHASH_SINGLE:
         //      sha_single_output (32): the SHA256 of the corresponding output in CTxOut format.
         if sighash == TapSighashType::Single {
-            let mut enc = sha256::Hash::engine();
             let txout = self
                 .tx
                 .borrow()
@@ -461,8 +460,7 @@ impl<R: Borrow<Transaction>> SighashCache<R> {
                     outputs_length: self.tx.borrow().outputs.len(),
                 }))
                 .map_err(SigningDataError::Sighash)?;
-            hashes::encode_to_engine(txout, &mut enc);
-            let hash = sha256::Hash::from_engine(enc);
+            let hash = hashes::encode_to_hash::<_, sha256::HashEngine>(txout);
             writer.write_all(&hash.to_byte_array())?;
         }
 

--- a/hashes/api/all-features.txt
+++ b/hashes/api/all-features.txt
@@ -1907,7 +1907,9 @@ pub const bitcoin_hashes::IsByteArray::LEN: usize
 impl<const N: usize> bitcoin_hashes::IsByteArray for [u8; N]
 pub const [u8; N]::LEN: usize
 pub fn bitcoin_hashes::drain_to_engine<T, H>(encoder: &mut T, engine: &mut H) where T: bitcoin_consensus_encoding::encode::Encoder + ?core::marker::Sized, H: bitcoin_hashes::HashEngine
+pub fn bitcoin_hashes::drain_to_hash<T, H>(encoder: &mut T) -> <H as bitcoin_hashes::HashEngine>::Hash where T: bitcoin_consensus_encoding::encode::Encoder + ?core::marker::Sized, H: bitcoin_hashes::HashEngine + core::default::Default
 pub fn bitcoin_hashes::encode_to_engine<T, H>(object: &T, engine: &mut H) where T: bitcoin_consensus_encoding::encode::Encode + ?core::marker::Sized, H: bitcoin_hashes::HashEngine
+pub fn bitcoin_hashes::encode_to_hash<T, H>(obj: &T) -> <H as bitcoin_hashes::HashEngine>::Hash where T: bitcoin_consensus_encoding::encode::Encode + ?core::marker::Sized, H: bitcoin_hashes::HashEngine + core::default::Default
 pub type bitcoin_hashes::HkdfSha256 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha256::Hash>
 pub type bitcoin_hashes::HkdfSha512 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha512::Hash>
 pub type bitcoin_hashes::HmacSha256 = bitcoin_hashes::hmac::Hmac<bitcoin_hashes::sha256::Hash>

--- a/hashes/api/alloc-only.txt
+++ b/hashes/api/alloc-only.txt
@@ -1682,7 +1682,9 @@ pub const bitcoin_hashes::IsByteArray::LEN: usize
 impl<const N: usize> bitcoin_hashes::IsByteArray for [u8; N]
 pub const [u8; N]::LEN: usize
 pub fn bitcoin_hashes::drain_to_engine<T, H>(encoder: &mut T, engine: &mut H) where T: bitcoin_consensus_encoding::encode::Encoder + ?core::marker::Sized, H: bitcoin_hashes::HashEngine
+pub fn bitcoin_hashes::drain_to_hash<T, H>(encoder: &mut T) -> <H as bitcoin_hashes::HashEngine>::Hash where T: bitcoin_consensus_encoding::encode::Encoder + ?core::marker::Sized, H: bitcoin_hashes::HashEngine + core::default::Default
 pub fn bitcoin_hashes::encode_to_engine<T, H>(object: &T, engine: &mut H) where T: bitcoin_consensus_encoding::encode::Encode + ?core::marker::Sized, H: bitcoin_hashes::HashEngine
+pub fn bitcoin_hashes::encode_to_hash<T, H>(obj: &T) -> <H as bitcoin_hashes::HashEngine>::Hash where T: bitcoin_consensus_encoding::encode::Encode + ?core::marker::Sized, H: bitcoin_hashes::HashEngine + core::default::Default
 pub type bitcoin_hashes::HkdfSha256 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha256::Hash>
 pub type bitcoin_hashes::HkdfSha512 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha512::Hash>
 pub type bitcoin_hashes::HmacSha256 = bitcoin_hashes::hmac::Hmac<bitcoin_hashes::sha256::Hash>

--- a/hashes/api/no-features.txt
+++ b/hashes/api/no-features.txt
@@ -1559,7 +1559,9 @@ pub const bitcoin_hashes::IsByteArray::LEN: usize
 impl<const N: usize> bitcoin_hashes::IsByteArray for [u8; N]
 pub const [u8; N]::LEN: usize
 pub fn bitcoin_hashes::drain_to_engine<T, H>(encoder: &mut T, engine: &mut H) where T: bitcoin_consensus_encoding::encode::Encoder + ?core::marker::Sized, H: bitcoin_hashes::HashEngine
+pub fn bitcoin_hashes::drain_to_hash<T, H>(encoder: &mut T) -> <H as bitcoin_hashes::HashEngine>::Hash where T: bitcoin_consensus_encoding::encode::Encoder + ?core::marker::Sized, H: bitcoin_hashes::HashEngine + core::default::Default
 pub fn bitcoin_hashes::encode_to_engine<T, H>(object: &T, engine: &mut H) where T: bitcoin_consensus_encoding::encode::Encode + ?core::marker::Sized, H: bitcoin_hashes::HashEngine
+pub fn bitcoin_hashes::encode_to_hash<T, H>(obj: &T) -> <H as bitcoin_hashes::HashEngine>::Hash where T: bitcoin_consensus_encoding::encode::Encode + ?core::marker::Sized, H: bitcoin_hashes::HashEngine + core::default::Default
 pub type bitcoin_hashes::HkdfSha256 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha256::Hash>
 pub type bitcoin_hashes::HkdfSha512 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha512::Hash>
 pub type bitcoin_hashes::HmacSha256 = bitcoin_hashes::hmac::Hmac<bitcoin_hashes::sha256::Hash>

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -223,6 +223,28 @@ where
     }
 }
 
+/// Encodes an object into a hash value.
+pub fn encode_to_hash<T, H>(obj: &T) -> H::Hash
+where
+    T: encoding::Encode + ?Sized,
+    H: HashEngine + Default,
+{
+    let mut engine = H::default();
+    encode_to_engine(obj, &mut engine);
+    engine.finalize()
+}
+
+/// Drains the output of an [`encoding::Encoder`] into a hash value.
+pub fn drain_to_hash<T, H>(encoder: &mut T) -> H::Hash
+where
+    T: encoding::Encoder + ?Sized,
+    H: HashEngine + Default,
+{
+    let mut engine = H::default();
+    drain_to_engine(encoder, &mut engine);
+    engine.finalize()
+}
+
 /// Trait which applies to hashes of all types.
 pub trait Hash:
     Copy + Clone + PartialEq + Eq + PartialOrd + Ord + hash::Hash + convert::AsRef<[u8]>

--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -16,7 +16,9 @@ use arbitrary::{Arbitrary, Unstructured};
 use encoding::{ArrayDecoder, Decoder6};
 #[cfg(feature = "alloc")]
 use encoding::{CompactSizeEncoder, Decoder2, Encoder2, SliceEncoder, VecDecoder};
-use hashes::{sha256d, HashEngine as _};
+use hashes::sha256d;
+#[cfg(feature = "alloc")]
+use hashes::HashEngine as _;
 
 #[cfg(feature = "hex")]
 use crate::hex_codec::HexPrimitive;
@@ -465,9 +467,8 @@ impl Header {
     /// Returns the block hash.
     // This is the same as `Encodable` but done manually because `Encodable` isn't in `primitives`.
     pub fn block_hash(&self) -> BlockHash {
-        let mut engine = sha256d::Hash::engine();
-        hashes::encode_to_engine(self, &mut engine);
-        BlockHash::from_byte_array(engine.finalize().to_byte_array())
+        let hash = hashes::encode_to_hash::<_, sha256d::HashEngine>(self);
+        BlockHash::from_byte_array(hash.to_byte_array())
     }
 }
 


### PR DESCRIPTION
Currently, the encode_to_engine and drain_to_engine functions require a user to construct an engine, call the function, and then finalise the engine to get a final hash value. This can be simplified to a one-liner with the aid of an encode/drain_to_hash function instead. Some existing uses of the encode_to_engine can also be replaced alongside the introduction of the new functions.

Introduce drain_to_hash and encode_to_hash functions that directly produce a hash value from an Encode/Encoder type.

Closes #6447