### PR TITLE
0.32.xxx: Add `consensus_encoding` to block/compact-block p2p message types

### DIFF
--- a/bitcoin/src/bip152.rs
+++ b/bitcoin/src/bip152.rs
@@ -6,16 +6,29 @@
 //!
 
 use core::convert::Infallible;
+#[cfg(feature = "encoding")]
+use core::fmt::Display;
 use core::{convert, fmt, mem};
 #[cfg(feature = "std")]
 use std::error;
 
 #[cfg(feature = "arbitrary")]
 use actual_arbitrary::{self as arbitrary, Arbitrary, Unstructured};
+#[cfg(feature = "encoding")]
+use encoding::{
+    ArrayDecoder, ArrayEncoder, CompactSizeDecoder, CompactSizeEncoder, Decoder2, Decoder4,
+    Encoder2, Encoder4, SliceEncoder, VecDecoder,
+};
 use hashes::{sha256, siphash24, Hash};
 use io::{Read, Write};
 
+#[cfg(feature = "encoding")]
+use crate::blockdata::block::{BlockHashDecoder, HeaderDecoder, HeaderEncoder};
+#[cfg(feature = "encoding")]
+use crate::blockdata::transaction::{TransactionDecoder, TransactionEncoder};
 use crate::consensus::encode::{self, Decodable, Encodable, VarInt};
+#[cfg(feature = "encoding")]
+use crate::internal_macros::write_err;
 use crate::internal_macros::{impl_array_newtype, impl_bytes_newtype, impl_consensus_encoding};
 use crate::prelude::*;
 use crate::{block, Block, BlockHash, Transaction};
@@ -95,6 +108,88 @@ impl Decodable for PrefilledTransaction {
     }
 }
 
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype! {
+    /// Encoder type for a [`PrefilledTransaction`].
+    #[derive(Debug, Clone)]
+    pub struct PrefilledTransactionEncoder<'e>(Encoder2<CompactSizeEncoder, TransactionEncoder<'e>>);
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for PrefilledTransaction {
+    type Encoder<'e> = PrefilledTransactionEncoder<'e>;
+
+    fn encoder(&self) -> Self::Encoder<'_> {
+        PrefilledTransactionEncoder::new(Encoder2::new(
+            CompactSizeEncoder::new(self.idx as usize),
+            self.tx.encoder(),
+        ))
+    }
+}
+
+#[cfg(feature = "encoding")]
+type PrefilledTransactionInnerDecoder = Decoder2<CompactSizeDecoder, TransactionDecoder>;
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// The decoder for a [`PrefilledTransaction`] message.
+    #[derive(Debug, Default, Clone)]
+    pub struct PrefilledTransactionDecoder(PrefilledTransactionInnerDecoder);
+
+    fn map_push_bytes_err(err: <PrefilledTransactionInnerDecoder as encoding::Decoder>::Error) -> PrefilledTransactionDecoderError {
+        PrefilledTransactionDecoderError::Decoder(err)
+    }
+
+    fn end(
+        result: Result<(usize, Transaction), <PrefilledTransactionInnerDecoder as encoding::Decoder>::Error>
+    ) -> Result<PrefilledTransaction, PrefilledTransactionDecoderError> {
+        let (cs, tx) = result.map_err(PrefilledTransactionDecoderError::Decoder)?;
+        let idx = u16::try_from(cs)
+            .map_err(|_| PrefilledTransactionDecoderError::InvalidIndex(cs))?;
+        Ok(PrefilledTransaction { idx, tx })
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for PrefilledTransaction {
+    type Decoder = PrefilledTransactionDecoder;
+}
+
+/// Errors occurring when decoding a [`PrefilledTransaction`].
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PrefilledTransactionDecoderError {
+    /// Inner decoder error.
+    Decoder(<PrefilledTransactionInnerDecoder as encoding::Decoder>::Error),
+    /// The differential encoding may be no more than 16 bits.
+    InvalidIndex(usize),
+}
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for PrefilledTransactionDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl Display for PrefilledTransactionDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Decoder(d) => write_err!(f, "prefilled transaction error"; d),
+            Self::InvalidIndex(idx) => write!(f, "index overflowed u16 {}", idx),
+        }
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for PrefilledTransactionDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Decoder(d) => Some(d),
+            Self::InvalidIndex(_) => None,
+        }
+    }
+}
+
 /// Short transaction IDs are used to represent a transaction without sending a full 256-bit hash.
 #[derive(PartialEq, Eq, Clone, Copy, Hash, Default, PartialOrd, Ord)]
 pub struct ShortId([u8; 6]);
@@ -147,6 +242,71 @@ impl Decodable for ShortId {
     }
 }
 
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// Encoder type for a [`ShortId`].
+    #[derive(Debug, Clone)]
+    pub struct ShortIdEncoder<'e>(ArrayEncoder<6>);
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for ShortId {
+    type Encoder<'e> = ShortIdEncoder<'e>;
+
+    fn encoder(&self) -> Self::Encoder<'_> {
+        ShortIdEncoder::new(ArrayEncoder::without_length_prefix(self.to_bytes()))
+    }
+}
+
+#[cfg(feature = "encoding")]
+type ShortIdInnerDecoder = ArrayDecoder<6>;
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// Decoder type for a [`ShortId`].
+    #[derive(Debug, Clone)]
+    pub struct ShortIdDecoder(ShortIdInnerDecoder);
+
+    /// Constructs a new [`ShortId`] decoder.
+    pub const fn new() -> Self { Self(ArrayDecoder::new()) }
+
+    fn end(
+        result: Result<[u8; 6], <ShortIdInnerDecoder as encoding::Decoder>::Error>
+    ) -> Result<ShortId, ShortIdDecoderError> {
+        let arr = result.map_err(ShortIdDecoderError)?;
+        Ok(ShortId(arr))
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for ShortId {
+    type Decoder = ShortIdDecoder;
+}
+
+/// Errors occurring when decoding a [`ShortId`].
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShortIdDecoderError(
+    pub(crate) <ShortIdInnerDecoder as encoding::Decoder>::Error
+);
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for ShortIdDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl Display for ShortIdDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_err!(f, "shortid error"; self.0)
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for ShortIdDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
+}
+
 /// A structure to relay a block header, short IDs, and a select few transactions.
 ///
 /// A [HeaderAndShortIds] structure is used to relay a block header, the short
@@ -166,6 +326,112 @@ pub struct HeaderAndShortIds {
     pub prefilled_txs: Vec<PrefilledTransaction>,
 }
 impl_consensus_encoding!(HeaderAndShortIds, header, nonce, short_ids, prefilled_txs);
+
+#[cfg(feature = "encoding")]
+type HeaderAndShortIdsInnerEncoder<'e> = Encoder4<
+    HeaderEncoder<'e>,
+    ArrayEncoder<8>,
+    Encoder2<CompactSizeEncoder, SliceEncoder<'e, ShortId>>,
+    Encoder2<CompactSizeEncoder, SliceEncoder<'e, PrefilledTransaction>>,
+>;
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype! {
+    /// Encoder type for a [`HeaderAndShortIds`] message.
+    #[derive(Debug, Clone)]
+    pub struct HeaderAndShortIdsEncoder<'e>(
+        HeaderAndShortIdsInnerEncoder<'e>
+    );
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for HeaderAndShortIds {
+    type Encoder<'e> = HeaderAndShortIdsEncoder<'e>;
+
+    fn encoder(&self) -> Self::Encoder<'_> {
+        HeaderAndShortIdsEncoder::new(Encoder4::new(
+            self.header.encoder(),
+            ArrayEncoder::without_length_prefix(self.nonce.to_le_bytes()),
+            Encoder2::new(
+                CompactSizeEncoder::new(self.short_ids.len()),
+                SliceEncoder::without_length_prefix(&self.short_ids),
+            ),
+            Encoder2::new(
+                CompactSizeEncoder::new(self.prefilled_txs.len()),
+                SliceEncoder::without_length_prefix(&self.prefilled_txs),
+            ),
+        ))
+    }
+}
+
+#[cfg(feature = "encoding")]
+type HeaderAndShortIdsInnerDecoder =
+    Decoder4<HeaderDecoder, ArrayDecoder<8>, VecDecoder<ShortId>, VecDecoder<PrefilledTransaction>>;
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// Decoder type for the [`HeaderAndShortIds`] message.
+    #[derive(Debug, Default, Clone)]
+    pub struct HeaderAndShortIdsDecoder(HeaderAndShortIdsInnerDecoder);
+
+    fn map_push_bytes_err(err: <HeaderAndShortIdsInnerDecoder as encoding::Decoder>::Error) -> HeaderAndShortIdsDecoderError {
+        HeaderAndShortIdsDecoderError::Decoder(err)
+    }
+
+    fn end(
+        result: Result<
+            <HeaderAndShortIdsInnerDecoder as encoding::Decoder>::Output,
+            <HeaderAndShortIdsInnerDecoder as encoding::Decoder>::Error
+        >
+    ) -> Result<HeaderAndShortIds, HeaderAndShortIdsDecoderError> {
+        let (header, nonce, short_ids, prefilled_txs) = result.map_err(HeaderAndShortIdsDecoderError::Decoder)?;
+        let overflow_check = short_ids.len().checked_add(prefilled_txs.len()).ok_or(HeaderAndShortIdsDecoderError::IndexOverflow)?;
+        if overflow_check > u16::MAX.into() {
+            return Err(HeaderAndShortIdsDecoderError::IndexOverflow);
+        }
+        Ok(HeaderAndShortIds { header, nonce: u64::from_le_bytes(nonce), short_ids, prefilled_txs })
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for HeaderAndShortIds {
+    type Decoder = HeaderAndShortIdsDecoder;
+}
+
+/// Errors occurring when decoding a [`HeaderAndShortIds`] message.
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HeaderAndShortIdsDecoderError {
+    /// Inner decoder error.
+    Decoder(<HeaderAndShortIdsInnerDecoder as encoding::Decoder>::Error),
+    /// Block indexes overflowed.
+    IndexOverflow,
+}
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for HeaderAndShortIdsDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl Display for HeaderAndShortIdsDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Decoder(d) => write_err!(f, "headerandshortids error"; d),
+            Self::IndexOverflow => write!(f, "block index overflowed"),
+        }
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for HeaderAndShortIdsDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Decoder(d) => Some(d),
+            Self::IndexOverflow => None,
+        }
+    }
+}
 
 impl HeaderAndShortIds {
     /// Create a new [HeaderAndShortIds] from a full block.
@@ -352,6 +618,79 @@ pub struct BlockTransactions {
     pub transactions: Vec<Transaction>,
 }
 impl_consensus_encoding!(BlockTransactions, block_hash, transactions);
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype! {
+    /// Encoder type for a [`BlockTransactions`].
+    #[derive(Debug, Clone)]
+    pub struct BlockTransactionsEncoder<'e>(
+        Encoder2<
+            crate::blockdata::block::BlockHashEncoder<'e>,
+            Encoder2<CompactSizeEncoder, SliceEncoder<'e, Transaction>>
+        >
+    );
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for BlockTransactions {
+    type Encoder<'e> = BlockTransactionsEncoder<'e>;
+
+    fn encoder(&self) -> Self::Encoder<'_> {
+        BlockTransactionsEncoder::new(Encoder2::new(
+            self.block_hash.encoder(),
+            Encoder2::new(
+                CompactSizeEncoder::new(self.transactions.len()),
+                SliceEncoder::without_length_prefix(&self.transactions),
+            ),
+        ))
+    }
+}
+
+#[cfg(feature = "encoding")]
+type BlockTransactionsInnerDecoder = Decoder2<BlockHashDecoder, VecDecoder<Transaction>>;
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// Decoder type for a [`BlockTransactions`] message.
+    #[derive(Debug, Default, Clone)]
+    pub struct BlockTransactionsDecoder(BlockTransactionsInnerDecoder);
+
+    fn end(
+        result: Result<(BlockHash, Vec<Transaction>), <BlockTransactionsInnerDecoder as encoding::Decoder>::Error>
+    ) -> Result<BlockTransactions, BlockTransactionsDecoderError> {
+        let (block_hash, transactions) = result.map_err(BlockTransactionsDecoderError)?;
+        Ok(BlockTransactions { block_hash, transactions })
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for BlockTransactions {
+    type Decoder = BlockTransactionsDecoder;
+}
+
+/// Errors occurring when decoding a [`BlockTransactions`].
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlockTransactionsDecoderError(
+    pub(crate) <BlockTransactionsInnerDecoder as encoding::Decoder>::Error,
+);
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for BlockTransactionsDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl Display for BlockTransactionsDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_err!(f, "blocktxn error"; self.0)
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for BlockTransactionsDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
+}
 
 impl BlockTransactions {
     /// Construct a [BlockTransactions] from a [BlockTransactionsRequest] and

--- a/bitcoin/src/p2p/message_blockdata.rs
+++ b/bitcoin/src/p2p/message_blockdata.rs
@@ -13,10 +13,15 @@ use hashes::{sha256d, Hash as _};
 use io::{Read, Write};
 
 use crate::blockdata::block::BlockHash;
+#[cfg(feature = "encoding")]
+use crate::blockdata::block::{BlockHashDecoder, BlockHashEncoder};
 use crate::blockdata::transaction::{Txid, Wtxid};
 use crate::consensus::encode::{self, Decodable, Encodable};
 #[cfg(feature = "encoding")]
-use encoding::{ArrayDecoder, ArrayEncoder, Decoder2, Encoder2};
+use encoding::{
+    ArrayDecoder, ArrayEncoder, CompactSizeEncoder, Decoder2, Decoder3, Encoder2, Encoder3,
+    SliceEncoder, VecDecoder,
+};
 use crate::internal_macros::impl_consensus_encoding;
 #[cfg(feature = "encoding")]
 use crate::internal_macros::write_err;
@@ -252,6 +257,149 @@ impl GetHeadersMessage {
 }
 
 impl_consensus_encoding!(GetHeadersMessage, version, locator_hashes, stop_hash);
+
+#[cfg(feature = "encoding")]
+type GetBlocksOrHeadersInnerEncoder<'e> =
+    Encoder3<ArrayEncoder<4>, Encoder2<CompactSizeEncoder, SliceEncoder<'e, BlockHash>>, BlockHashEncoder<'e>>;
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype! {
+    /// The encoder for [`GetBlocksMessage`].
+    #[derive(Debug, Clone)]
+    pub struct GetBlocksEncoder<'e>(GetBlocksOrHeadersInnerEncoder<'e>);
+}
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype! {
+    /// The encoder for [`GetHeadersMessage`].
+    #[derive(Debug, Clone)]
+    pub struct GetHeadersEncoder<'e>(GetBlocksOrHeadersInnerEncoder<'e>);
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for GetHeadersMessage {
+    type Encoder<'e> = GetHeadersEncoder<'e>;
+
+    fn encoder(&self) -> Self::Encoder<'_> {
+        GetHeadersEncoder::new(Encoder3::new(
+            ArrayEncoder::without_length_prefix(self.version.to_le_bytes()),
+            Encoder2::new(
+                CompactSizeEncoder::new(self.locator_hashes.len()),
+                SliceEncoder::without_length_prefix(&self.locator_hashes),
+            ),
+            self.stop_hash.encoder(),
+        ))
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for GetBlocksMessage {
+    type Encoder<'e> = GetBlocksEncoder<'e>;
+
+    fn encoder(&self) -> Self::Encoder<'_> {
+        GetBlocksEncoder::new(Encoder3::new(
+            ArrayEncoder::without_length_prefix(self.version.to_le_bytes()),
+            Encoder2::new(
+                CompactSizeEncoder::new(self.locator_hashes.len()),
+                SliceEncoder::without_length_prefix(&self.locator_hashes),
+            ),
+            self.stop_hash.encoder(),
+        ))
+    }
+}
+
+#[cfg(feature = "encoding")]
+type GetBlocksOrHeadersInnerDecoder =
+    Decoder3<ArrayDecoder<4>, VecDecoder<BlockHash>, BlockHashDecoder>;
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// Decoder type for [`GetBlocksMessage`].
+    #[derive(Debug, Default, Clone)]
+    pub struct GetBlocksMessageDecoder(GetBlocksOrHeadersInnerDecoder);
+
+    fn end(
+        result: Result<([u8; 4], Vec<BlockHash>, BlockHash), <GetBlocksOrHeadersInnerDecoder as encoding::Decoder>::Error>
+    ) -> Result<GetBlocksMessage, GetBlocksMessageDecoderError> {
+        let (version, locator_hashes, stop_hash) =
+            result.map_err(GetBlocksMessageDecoderError)?;
+        Ok(GetBlocksMessage { version: u32::from_le_bytes(version), locator_hashes, stop_hash })
+    }
+}
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// Decoder type for [`GetHeadersMessage`].
+    #[derive(Debug, Default, Clone)]
+    pub struct GetHeadersMessageDecoder(GetBlocksOrHeadersInnerDecoder);
+
+    fn end(
+        result: Result<([u8; 4], Vec<BlockHash>, BlockHash), <GetBlocksOrHeadersInnerDecoder as encoding::Decoder>::Error>
+    ) -> Result<GetHeadersMessage, GetHeadersMessageDecoderError> {
+        let (version, locator_hashes, stop_hash) =
+            result.map_err(GetHeadersMessageDecoderError)?;
+        Ok(GetHeadersMessage { version: u32::from_le_bytes(version), locator_hashes, stop_hash })
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for GetBlocksMessage {
+    type Decoder = GetBlocksMessageDecoder;
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for GetHeadersMessage {
+    type Decoder = GetHeadersMessageDecoder;
+}
+
+/// An error consensus decoding a [`GetBlocksMessage`].
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GetBlocksMessageDecoderError(
+    pub(crate) <GetBlocksOrHeadersInnerDecoder as encoding::Decoder>::Error,
+);
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for GetBlocksMessageDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl core::fmt::Display for GetBlocksMessageDecoderError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write_err!(f, "getblocks decoder error"; self.0)
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for GetBlocksMessageDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
+}
+
+
+/// An error consensus decoding a [`GetHeadersMessage`].
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GetHeadersMessageDecoderError(
+    pub(crate) <GetBlocksOrHeadersInnerDecoder as encoding::Decoder>::Error,
+);
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for GetHeadersMessageDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl core::fmt::Display for GetHeadersMessageDecoderError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write_err!(f, "getheaders decoder error"; self.0)
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for GetHeadersMessageDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
+}
 
 #[cfg(test)]
 mod tests {

--- a/bitcoin/src/p2p/message_blockdata.rs
+++ b/bitcoin/src/p2p/message_blockdata.rs
@@ -6,13 +6,20 @@
 //! Bitcoin data (blocks and transactions) around.
 //!
 
+#[cfg(feature = "encoding")]
+use core::convert::Infallible;
+
 use hashes::{sha256d, Hash as _};
 use io::{Read, Write};
 
 use crate::blockdata::block::BlockHash;
 use crate::blockdata::transaction::{Txid, Wtxid};
 use crate::consensus::encode::{self, Decodable, Encodable};
+#[cfg(feature = "encoding")]
+use encoding::{ArrayDecoder, ArrayEncoder, Decoder2, Encoder2};
 use crate::internal_macros::impl_consensus_encoding;
+#[cfg(feature = "encoding")]
+use crate::internal_macros::write_err;
 use crate::p2p;
 
 /// An inventory item.
@@ -113,6 +120,91 @@ impl Decodable for Inventory {
             tp => Inventory::Unknown { inv_type: tp, hash: Decodable::consensus_decode(r)? },
         })
     }
+}
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// The encoder for the [`Inventory`] type.
+    #[derive(Debug, Clone)]
+    pub struct InventoryEncoder<'e>(Encoder2<ArrayEncoder<4>, ArrayEncoder<32>>);
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for Inventory {
+    type Encoder<'e> = InventoryEncoder<'e>;
+
+    fn encoder(&self) -> Self::Encoder<'_> {
+        let (prefix, bytes) = match *self {
+            Self::Error => (0, sha256d::Hash::all_zeros().to_byte_array()),
+            Self::Transaction(t) => (1, t.to_byte_array()),
+            Self::Block(b) => (2, b.to_byte_array()),
+            Self::CompactBlock(b) => (4, b.to_byte_array()),
+            Self::WTx(w) => (5, w.to_byte_array()),
+            Self::WitnessTransaction(t) => (0x4000_0001, t.to_byte_array()),
+            Self::WitnessBlock(b) => (0x4000_0002, b.to_byte_array()),
+            Self::Unknown { inv_type: t, hash: d } => (t, d),
+        };
+        InventoryEncoder::new(Encoder2::new(
+            ArrayEncoder::without_length_prefix(prefix.to_le_bytes()),
+            ArrayEncoder::without_length_prefix(bytes),
+        ))
+    }
+}
+
+#[cfg(feature = "encoding")]
+type InventoryInnerDecoder = Decoder2<ArrayDecoder<4>, ArrayDecoder<32>>;
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// The decoder for the [`Inventory`] type.
+    #[derive(Debug, Default, Clone)]
+    pub struct InventoryDecoder(InventoryInnerDecoder);
+
+    fn end(
+        result: Result<([u8; 4], [u8; 32]), <InventoryInnerDecoder as encoding::Decoder>::Error>
+    ) -> Result<Inventory, InventoryDecoderError> {
+        let (ty, inv) = result.map_err(InventoryDecoderError)?;
+        let inv_type = u32::from_le_bytes(ty);
+        Ok(match inv_type {
+            0 => Self::Output::Unknown { inv_type: 0, hash: inv },
+            1 => Self::Output::Transaction(Txid::from_byte_array(inv)),
+            2 => Self::Output::Block(BlockHash::from_byte_array(inv)),
+            4 => Self::Output::CompactBlock(BlockHash::from_byte_array(inv)),
+            5 => Self::Output::WTx(Wtxid::from_byte_array(inv)),
+            0x4000_0001 => Self::Output::WitnessTransaction(Txid::from_byte_array(inv)),
+            0x4000_0002 => Self::Output::WitnessBlock(BlockHash::from_byte_array(inv)),
+            tp => Self::Output::Unknown { inv_type: tp, hash: inv },
+        })
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for Inventory {
+    type Decoder = InventoryDecoder;
+}
+
+/// An error consensus decoding an [`Inventory`].
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InventoryDecoderError(
+    pub(crate) <InventoryInnerDecoder as encoding::Decoder>::Error,
+);
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for InventoryDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl core::fmt::Display for InventoryDecoderError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write_err!(f, "inventory error"; self.0)
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for InventoryDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
 }
 
 // Some simple messages

--- a/bitcoin/src/p2p/message_compact_blocks.rs
+++ b/bitcoin/src/p2p/message_compact_blocks.rs
@@ -4,8 +4,18 @@
 //! BIP152  Compact Blocks network messages
 //!
 
+#[cfg(feature = "encoding")]
+use core::convert::Infallible;
+#[cfg(feature = "encoding")]
+use core::fmt;
+
+#[cfg(feature = "encoding")]
+use encoding::{ArrayDecoder, ArrayEncoder, Decoder2, Encoder2};
+
 use crate::bip152;
 use crate::internal_macros::impl_consensus_encoding;
+#[cfg(feature = "encoding")]
+use crate::internal_macros::write_err;
 
 /// sendcmpct message
 #[derive(PartialEq, Eq, Clone, Debug, Copy, PartialOrd, Ord, Hash)]
@@ -16,6 +26,72 @@ pub struct SendCmpct {
     pub version: u64,
 }
 impl_consensus_encoding!(SendCmpct, send_compact, version);
+
+#[cfg(feature = "encoding")]
+encoding::encoder_newtype_exact! {
+    /// Encoder type for the [`SendCmpct`] message.
+    #[derive(Debug, Clone)]
+    pub struct SendCmpctEncoder<'e>(Encoder2<ArrayEncoder<1>, ArrayEncoder<8>>);
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Encode for SendCmpct {
+    type Encoder<'e> = SendCmpctEncoder<'e>;
+
+    fn encoder(&self) -> Self::Encoder<'_> {
+        SendCmpctEncoder::new(Encoder2::new(
+            ArrayEncoder::without_length_prefix([u8::from(self.send_compact)]),
+            ArrayEncoder::without_length_prefix(self.version.to_le_bytes()),
+        ))
+    }
+}
+
+#[cfg(feature = "encoding")]
+type SendCmpctInnerDecoder = Decoder2<ArrayDecoder<1>, ArrayDecoder<8>>;
+
+#[cfg(feature = "encoding")]
+crate::decoder_newtype! {
+    /// Decoder type for the [`SendCmpct`] message.
+    #[derive(Debug, Default, Clone)]
+    pub struct SendCmpctDecoder(SendCmpctInnerDecoder);
+
+    fn end(
+        result: Result<([u8; 1], [u8; 8]), <SendCmpctInnerDecoder as encoding::Decoder>::Error>
+    ) -> Result<SendCmpct, SendCmpctDecoderError> {
+        let (send_cmpct, version) = result.map_err(SendCmpctDecoderError)?;
+        let send_compact = u8::from_le_bytes(send_cmpct) != 0;
+        Ok(SendCmpct { send_compact, version: u64::from_le_bytes(version) })
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl encoding::Decode for SendCmpct {
+    type Decoder = SendCmpctDecoder;
+}
+
+/// Errors occurring when decoding a [`SendCmpct`] message.
+#[cfg(feature = "encoding")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SendCmpctDecoderError(
+    pub(crate) <SendCmpctInnerDecoder as encoding::Decoder>::Error
+);
+
+#[cfg(feature = "encoding")]
+impl From<Infallible> for SendCmpctDecoderError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+#[cfg(feature = "encoding")]
+impl fmt::Display for SendCmpctDecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_err!(f, "sendcmpct error"; self.0)
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "std"))]
+impl std::error::Error for SendCmpctDecoderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
+}
 
 /// cmpctblock message
 ///


### PR DESCRIPTION
Add `consensus_encoding` support to `Inventory`, `GetBlocksMessage` and `GetHeadersMessage` (`p2p/message_blockdata.rs`); `PrefilledTransaction`, `ShortId`, `HeaderAndShortIds` and `BlockTransactions` (`bip152.rs`); and `SendCmpct` (`p2p/message_compact_blocks.rs`).

Changes from master are detailed in the commit logs.

I ran the fuzzer locally for 5 min with no errors with valid inputs. The new TransactionDecoder encoding, and on master, rejects invalid inputs that are accepted on the legacy encoding, so these are skipped in the fuzzing. Fuzzing of 0.32.x is currently done on master so it was not added to this PR.