### PR TITLE
addresses: Move types as precursors to Address move

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -81,6 +81,7 @@ dependencies = [
  "base64",
  "bech32",
  "bincode",
+ "bitcoin-addresses",
  "bitcoin-consensus-encoding 1.0.0",
  "bitcoin-crypto",
  "bitcoin-internals 0.5.0",
@@ -102,6 +103,12 @@ dependencies = [
 [[package]]
 name = "bitcoin-addresses"
 version = "0.0.0"
+dependencies = [
+ "bitcoin-crypto",
+ "bitcoin-internals 0.5.0",
+ "bitcoin-primitives",
+ "bitcoin-taproot-primitives",
+]
 
 [[package]]
 name = "bitcoin-bip158"

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -80,6 +80,7 @@ dependencies = [
  "base64",
  "bech32",
  "bincode",
+ "bitcoin-addresses",
  "bitcoin-consensus-encoding 1.0.0",
  "bitcoin-crypto",
  "bitcoin-internals 0.5.0",
@@ -101,6 +102,12 @@ dependencies = [
 [[package]]
 name = "bitcoin-addresses"
 version = "0.0.0"
+dependencies = [
+ "bitcoin-crypto",
+ "bitcoin-internals 0.5.0",
+ "bitcoin-primitives",
+ "bitcoin-taproot-primitives",
+]
 
 [[package]]
 name = "bitcoin-bip158"

--- a/addresses/Cargo.toml
+++ b/addresses/Cargo.toml
@@ -15,10 +15,14 @@ exclude = ["tests", "contrib"]
 
 [features]
 default = ["std"]
-std = ["alloc"]
-alloc = []
+std = ["alloc", "crypto/std", "internals/std", "primitives/std", "taproot_primitives/std"]
+alloc = ["crypto/alloc", "internals/alloc", "primitives/alloc", "taproot_primitives/alloc"]
 
 [dependencies]
+crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.2.0", default-features = false, features = [] }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0", features = ["hex"] }
+taproot_primitives = { package = "bitcoin-taproot-primitives", path = "../taproot-primitives", version = "0.1.0", default-features = false, features = [] }
+primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.102.0", default-features = false, features = ["hex"] }
 
 [dev-dependencies]
 

--- a/addresses/src/lib.rs
+++ b/addresses/src/lib.rs
@@ -26,9 +26,94 @@ extern crate std;
 pub mod witness_program;
 
 #[cfg(feature = "alloc")]
-use primitives::script::{Builder, PushBytes, ScriptBuf};
+use crypto::key::{LegacyPublicKey, UntweakedPublicKey, TweakedPublicKey, PubkeyHash};
+#[cfg(feature = "alloc")]
+use primitives::opcodes::all::{OP_CHECKSIG, OP_DUP, OP_EQUALVERIFY, OP_HASH160};
+#[cfg(feature = "alloc")]
+use primitives::script::{Builder, PushBytes, ScriptBuf, ScriptPubKeyBuf};
 #[cfg(feature = "alloc")]
 use primitives::witness_version::WitnessVersion;
+#[cfg(feature = "alloc")]
+use taproot_primitives::{TapNodeHash, TapTweak as _};
+
+#[cfg(feature = "alloc")]
+use witness_program::WitnessProgram;
+
+/// Extension functionality for the [`ScriptPubKeyBuf`] type.
+#[cfg(feature = "alloc")]
+pub trait ScriptPubKeyBufExt: sealed::Sealed {
+    /// Generates P2PK-type of scriptPubkey.
+    fn new_p2pk(pubkey: LegacyPublicKey) -> Self;
+
+    /// Generates P2PKH-type of scriptPubkey.
+    fn new_p2pkh(pubkey_hash: PubkeyHash) -> Self;
+
+    /// Generates P2TR for script spending path using an internal public key and some optional
+    /// script tree Merkle root.
+    fn new_p2tr<K: Into<UntweakedPublicKey>>(
+        internal_key: K,
+        merkle_root: Option<TapNodeHash>,
+    ) -> Self;
+
+    /// Generates P2TR for key spending path for a known [`TweakedPublicKey`].
+    fn new_p2tr_tweaked(output_key: TweakedPublicKey) -> Self;
+
+    /// Generates P2WSH-type of scriptPubkey with a given [`WitnessProgram`].
+    fn new_witness_program(witness_program: &WitnessProgram) -> Self;
+}
+
+#[cfg(feature = "alloc")]
+impl ScriptPubKeyBufExt for ScriptPubKeyBuf {
+    /// Generates P2PK-type of scriptPubkey.
+    fn new_p2pk(pubkey: LegacyPublicKey) -> Self {
+        Builder::new()
+            .push_slice(pubkey.serialize())
+            .push_opcode(OP_CHECKSIG)
+            .into_script()
+    }
+
+    fn new_p2pkh(pubkey_hash: PubkeyHash) -> Self {
+        Builder::new()
+            .push_opcode(OP_DUP)
+            .push_opcode(OP_HASH160)
+            .push_slice(pubkey_hash)
+            .push_opcode(OP_EQUALVERIFY)
+            .push_opcode(OP_CHECKSIG)
+            .into_script()
+    }
+
+    /// Generates P2TR for script spending path using an internal public key and some optional
+    /// script tree Merkle root.
+    fn new_p2tr<K: Into<UntweakedPublicKey>>(
+        internal_key: K,
+        merkle_root: Option<TapNodeHash>,
+    ) -> Self {
+        let internal_key = internal_key.into();
+        let output_key = internal_key.tap_tweak(merkle_root);
+        // output key is 32 bytes long, so it's safe to use `new_witness_program_unchecked` (Segwitv1)
+        new_witness_program_unchecked(WitnessVersion::V1, output_key.serialize())
+    }
+
+    /// Generates P2TR for key spending path for a known [`TweakedPublicKey`].
+    fn new_p2tr_tweaked(output_key: TweakedPublicKey) -> Self {
+        // output key is 32 bytes long, so it's safe to use `new_witness_program_unchecked` (Segwitv1)
+        new_witness_program_unchecked(WitnessVersion::V1, output_key.serialize())
+    }
+
+    /// Generates P2WSH-type of scriptPubkey with a given [`WitnessProgram`].
+    fn new_witness_program(witness_program: &WitnessProgram) -> Self {
+        Builder::new()
+            .push_opcode(witness_program.version().into())
+            .push_slice(witness_program.program())
+            .into_script()
+    }
+}
+
+#[cfg(feature = "alloc")]
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for super::ScriptPubKeyBuf {}
+}
 
 /// Generates P2WSH-type of scriptPubkey with a given [`WitnessVersion`] and the program bytes.
 /// Does not do any checks on version or program length.

--- a/addresses/src/lib.rs
+++ b/addresses/src/lib.rs
@@ -39,6 +39,15 @@ use taproot_primitives::{TapNodeHash, TapTweak as _};
 #[cfg(feature = "alloc")]
 use witness_program::WitnessProgram;
 
+/// Mainnet (bitcoin) pubkey address prefix.
+pub const PUBKEY_ADDRESS_PREFIX_MAIN: u8 = 0; // 0x00
+/// Mainnet (bitcoin) script address prefix.
+pub const SCRIPT_ADDRESS_PREFIX_MAIN: u8 = 5; // 0x05
+/// Test (testnet, signet, regtest) pubkey address prefix.
+pub const PUBKEY_ADDRESS_PREFIX_TEST: u8 = 111; // 0x6f
+/// Test (testnet, signet, regtest) script address prefix.
+pub const SCRIPT_ADDRESS_PREFIX_TEST: u8 = 196; // 0xc4
+
 /// Extension functionality for the [`ScriptPubKeyBuf`] type.
 #[cfg(feature = "alloc")]
 pub trait ScriptPubKeyBufExt: sealed::Sealed {

--- a/addresses/src/lib.rs
+++ b/addresses/src/lib.rs
@@ -21,3 +21,6 @@ extern crate alloc;
 
 #[cfg(feature = "std")]
 extern crate std;
+
+#[cfg(feature = "alloc")]
+pub mod witness_program;

--- a/addresses/src/lib.rs
+++ b/addresses/src/lib.rs
@@ -24,3 +24,24 @@ extern crate std;
 
 #[cfg(feature = "alloc")]
 pub mod witness_program;
+
+#[cfg(feature = "alloc")]
+use primitives::script::{Builder, PushBytes, ScriptBuf};
+#[cfg(feature = "alloc")]
+use primitives::witness_version::WitnessVersion;
+
+/// Generates P2WSH-type of scriptPubkey with a given [`WitnessVersion`] and the program bytes.
+/// Does not do any checks on version or program length.
+///
+/// Convenience method used by `new_p2a`, `new_p2wpkh`, `new_p2wsh`, `new_p2tr`, and `new_p2tr_tweaked`.
+#[cfg(feature = "alloc")]
+fn new_witness_program_unchecked<T: AsRef<PushBytes>, Tg>(
+    version: WitnessVersion,
+    program: T,
+) -> ScriptBuf<Tg> {
+    let program = program.as_ref();
+    debug_assert!(program.len() >= 2 && program.len() <= 40);
+    // In SegWit v0, the program must be either 20 bytes (P2WPKH) or 32 bytes (P2WSH) long.
+    debug_assert!(version != WitnessVersion::V0 || program.len() == 20 || program.len() == 32);
+    Builder::new().push_opcode(version.into()).push_slice(program).into_script()
+}

--- a/addresses/src/witness_program.rs
+++ b/addresses/src/witness_program.rs
@@ -7,13 +7,11 @@
 //!
 //! [BIP-0141]: <https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki>
 
+use crypto::key::{FullPublicKey, TweakedPublicKey, UntweakedPublicKey};
 use internals::array_vec::ArrayVec;
-
-use super::witness_version::WitnessVersion;
-use super::{PushBytes, WScriptHash, WitnessScript, WitnessScriptSizeError};
-use crate::crypto::key::{FullPublicKey, TapTweak, TweakedPublicKey, UntweakedPublicKey};
-use crate::script::WitnessScriptExt as _;
-use crate::taproot::TapNodeHash;
+use primitives::script::{PushBytes, WScriptHash, WitnessScript, WitnessScriptSizeError};
+use primitives::witness_version::WitnessVersion;
+use taproot_primitives::{TapNodeHash, TapTweak as _};
 
 #[rustfmt::skip]            // Keep public re-exports separate.
 #[doc(no_inline)]
@@ -81,7 +79,7 @@ impl WitnessProgram {
 
     /// Constructs a new [`WitnessProgram`] from `script` for a P2WSH output.
     pub fn p2wsh(script: &WitnessScript) -> Result<Self, WitnessScriptSizeError> {
-        script.wscript_hash().map(Self::p2wsh_from_hash)
+        WScriptHash::from_script(script).map(Self::p2wsh_from_hash)
     }
 
     /// Constructs a new [`WitnessProgram`] from `script` for a P2WSH output.

--- a/addresses/src/witness_program.rs
+++ b/addresses/src/witness_program.rs
@@ -41,6 +41,13 @@ pub struct WitnessProgram {
 
 impl WitnessProgram {
     /// Constructs a new witness program, copying the content from the given byte slice.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::InvalidLength`] if the given bytes are shorter than [`MIN_SIZE`], or
+    ///   longer than [`MAX_SIZE`].
+    /// - [`Error::InvalidSegwitV0Length`] if the given version is [`WitnessVersion::V0`] and
+    ///   bytes is not 20 or 32 bytes long.
     pub fn new(version: WitnessVersion, bytes: &[u8]) -> Result<Self, Error> {
         let program_len = bytes.len();
         if program_len < MIN_SIZE || program_len > MAX_SIZE {
@@ -78,6 +85,10 @@ impl WitnessProgram {
     }
 
     /// Constructs a new [`WitnessProgram`] from `script` for a P2WSH output.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the script exceeds 10,000 bytes.
     pub fn p2wsh(script: &WitnessScript) -> Result<Self, WitnessScriptSizeError> {
         WScriptHash::from_script(script).map(Self::p2wsh_from_hash)
     }
@@ -114,6 +125,7 @@ impl WitnessProgram {
     pub fn version(&self) -> WitnessVersion { self.version }
 
     /// Returns the witness program.
+    #[allow(clippy::missing_panics_doc)] // expect panic is unreachable by witness program limit
     pub fn program(&self) -> &PushBytes {
         self.program
             .as_slice()

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -17,7 +17,7 @@ exclude = ["tests", "contrib"]
 # If you change features or optional dependencies in any way please update the "# Cargo features" section in lib.rs as well.
 [features]
 default = [ "std", "secp-recovery" ]
-std = ["base58/std", "bech32/std", "crypto/std", "key-expression/std", "encoding/std", "hashes/std", "hex/std", "internals/std", "io/std", "network/std", "primitives/std", "secp256k1/std", "taproot-primitives/std", "units/std", "base64?/std", "bitcoinconsensus?/std"]
+std = ["addresses/std", "base58/std", "bech32/std", "crypto/std", "key-expression/std", "encoding/std", "hashes/std", "hex/std", "internals/std", "io/std", "network/std", "primitives/std", "secp256k1/std", "taproot-primitives/std", "units/std", "base64?/std", "bitcoinconsensus?/std"]
 rand = ["secp256k1/rand", "crypto/rand"]
 serde = ["base64", "crypto/serde", "dep:serde", "encoding/serde", "hashes/serde", "internals/serde", "key-expression/serde", "network/serde", "primitives/serde", "secp256k1/serde", "taproot-primitives/serde", "units/serde"]
 secp-global-context = ["secp256k1/global-context"]
@@ -26,6 +26,7 @@ secp-recovery = ["secp256k1/recovery"]
 arbitrary = ["crypto/arbitrary", "dep:arbitrary", "units/arbitrary", "primitives/arbitrary", "hashes/arbitrary", "key-expression/arbitrary", "secp256k1/arbitrary", "taproot-primitives/arbitrary", "network/arbitrary"]
 
 [dependencies]
+addresses = { package = "bitcoin-addresses", path = "../addresses", version = "0.0.0", default-features = false, features = ["alloc"] }
 base58 = { package = "base58ck", path = "../base58", version = "0.4.0", default-features = false, features = ["alloc"] }
 bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
 crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.2.0", default-features = false, features = ["alloc", "hex"] }

--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -28,13 +28,13 @@ pub const WITNESS_SCALE_FACTOR: usize = units::weight::WITNESS_SCALE_FACTOR;
 /// The maximum allowed number of signature check operations in a block.
 pub const MAX_BLOCK_SIGOPS_COST: i64 = 80_000;
 /// Mainnet (bitcoin) pubkey address prefix.
-pub const PUBKEY_ADDRESS_PREFIX_MAIN: u8 = 0; // 0x00
+pub const PUBKEY_ADDRESS_PREFIX_MAIN: u8 = addresses::PUBKEY_ADDRESS_PREFIX_MAIN; // 0x00
 /// Mainnet (bitcoin) script address prefix.
-pub const SCRIPT_ADDRESS_PREFIX_MAIN: u8 = 5; // 0x05
+pub const SCRIPT_ADDRESS_PREFIX_MAIN: u8 = addresses::SCRIPT_ADDRESS_PREFIX_MAIN; // 0x05
 /// Test (testnet, signet, regtest) pubkey address prefix.
-pub const PUBKEY_ADDRESS_PREFIX_TEST: u8 = 111; // 0x6f
+pub const PUBKEY_ADDRESS_PREFIX_TEST: u8 = addresses::PUBKEY_ADDRESS_PREFIX_TEST; // 0x6f
 /// Test (testnet, signet, regtest) script address prefix.
-pub const SCRIPT_ADDRESS_PREFIX_TEST: u8 = 196; // 0xc4
+pub const SCRIPT_ADDRESS_PREFIX_TEST: u8 = addresses::SCRIPT_ADDRESS_PREFIX_TEST; // 0xc4
 /// The maximum allowed redeem script size for a P2SH output.
 pub const MAX_REDEEM_SCRIPT_SIZE: usize = primitives::script::MAX_REDEEM_SCRIPT_SIZE; // 520
 /// The maximum allowed redeem script size of the witness script.

--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -52,7 +52,6 @@ mod owned;
 mod push_bytes;
 #[cfg(test)]
 mod tests;
-pub mod witness_program;
 pub mod witness_version;
 
 use io::{BufRead, Write};
@@ -73,6 +72,8 @@ pub use self::{
     owned::{ScriptBufExt, ScriptPubKeyBufExt, ScriptSigBufExt},
     push_bytes::{PushBytes, PushBytesBuf, PushBytesExt, PushBytesErrorReport},
 };
+#[doc(inline)]
+pub use addresses::witness_program;
 #[doc(no_inline)]
 pub use primitives::script::ScriptBufDecoderError;
 #[doc(inline)]

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -5,20 +5,19 @@ use core::ops::Deref;
 
 use super::{
     opcode_to_verify, write_scriptint, Builder, Error, Instruction, PushBytes, ScriptBuf,
-    ScriptExtPriv as _, ScriptPubKeyBuf, ScriptSigBuf, WitnessScript,
+    ScriptExtPriv as _, ScriptSigBuf, WitnessScript,
 };
-use crate::key::{
-    FullPublicKey, LegacyPublicKey, PubkeyHash, TapTweak, TweakedPublicKey, UntweakedPublicKey,
-    WPubkeyHash,
-};
+use crate::key::{FullPublicKey, WPubkeyHash};
 use crate::opcodes::all::*;
 use crate::opcodes::{self, Opcode};
 use crate::prelude::Vec;
-use crate::script::witness_program::WitnessProgram;
 use crate::script::witness_version::WitnessVersion;
 use crate::script::{self, BuilderExt as _};
-use crate::taproot::TapNodeHash;
 use crate::{internal_macros, ToU64 as _};
+
+#[rustfmt::skip] // Keep public re-exports separate.
+#[doc(inline)]
+pub use addresses::ScriptPubKeyBufExt;
 
 internal_macros::define_extension_trait! {
     /// Extension functionality for the [`ScriptBuf`] type.
@@ -120,53 +119,6 @@ internal_macros::define_extension_trait! {
             script::new_witness_program_unchecked(WitnessVersion::V0, pubkey_hash)
         }
 
-    }
-}
-
-crate::internal_macros::define_extension_trait! {
-    /// Extension functionality for the [`ScriptPubKeyBuf`] type.
-    pub trait ScriptPubKeyBufExt impl for ScriptPubKeyBuf {
-        /// Generates P2PK-type of scriptPubkey.
-        fn new_p2pk(pubkey: LegacyPublicKey) -> Self {
-            Builder::new().push_key(pubkey).push_opcode(OP_CHECKSIG).into_script()
-        }
-
-        /// Generates P2PKH-type of scriptPubkey.
-        fn new_p2pkh(pubkey_hash: PubkeyHash) -> Self {
-            Builder::new()
-                .push_opcode(OP_DUP)
-                .push_opcode(OP_HASH160)
-                .push_slice(pubkey_hash)
-                .push_opcode(OP_EQUALVERIFY)
-                .push_opcode(OP_CHECKSIG)
-                .into_script()
-        }
-
-        /// Generates P2TR for script spending path using an internal public key and some optional
-        /// script tree Merkle root.
-        fn new_p2tr<K: Into<UntweakedPublicKey>>(
-            internal_key: K,
-            merkle_root: Option<TapNodeHash>,
-        ) -> Self {
-            let internal_key = internal_key.into();
-            let output_key = internal_key.tap_tweak(merkle_root);
-            // output key is 32 bytes long, so it's safe to use `new_witness_program_unchecked` (Segwitv1)
-            script::new_witness_program_unchecked(WitnessVersion::V1, output_key.serialize())
-        }
-
-        /// Generates P2TR for key spending path for a known [`TweakedPublicKey`].
-        fn new_p2tr_tweaked(output_key: TweakedPublicKey) -> Self {
-            // output key is 32 bytes long, so it's safe to use `new_witness_program_unchecked` (Segwitv1)
-            script::new_witness_program_unchecked(WitnessVersion::V1, output_key.serialize())
-        }
-
-        /// Generates P2WSH-type of scriptPubkey with a given [`WitnessProgram`].
-        fn new_witness_program(witness_program: &WitnessProgram) -> Self {
-            Builder::new()
-                .push_opcode(witness_program.version().into())
-                .push_slice(witness_program.program())
-                .into_script()
-        }
     }
 }
 

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -62,6 +62,7 @@ extern crate std;
 #[cfg(feature = "arbitrary")]
 pub extern crate arbitrary;
 
+pub extern crate addresses;
 pub extern crate base58;
 #[cfg(feature = "base64")]
 pub extern crate base64;


### PR DESCRIPTION
There are a handful of types and functions that need to be moved to addresses before the main Address move. In order to reduce the size of the main PR, these can be moved ahead of time, keeping the final PR as a single split, tweak and move on the main address types.

- Patch 1 moves the WitnessProgram type to addresses.
- Patch 2 copies new_witness_program_unchecked into addresses from bitcoin.
- Patch 3 moves the ScriptPubKeyBufExt extension trait to addresses, adjusting new_p2pk as needed, and re-exports from bitcoin.
- Patch 4 fixes lint errors from the previous three patches.
- Patch 5 moves constants to addresses, and adjusts the definitions in bitcoin to match the imported values.