### PR TITLE
hashes: fix unusable HKDF alias 

### DIFF
--- a/hashes/api/all-features.txt
+++ b/hashes/api/all-features.txt
@@ -1910,8 +1910,8 @@ pub fn bitcoin_hashes::drain_to_engine<T, H>(encoder: &mut T, engine: &mut H) wh
 pub fn bitcoin_hashes::drain_to_hash<T, H>(encoder: &mut T) -> <H as bitcoin_hashes::HashEngine>::Hash where T: bitcoin_consensus_encoding::encode::Encoder + ?core::marker::Sized, H: bitcoin_hashes::HashEngine + core::default::Default
 pub fn bitcoin_hashes::encode_to_engine<T, H>(object: &T, engine: &mut H) where T: bitcoin_consensus_encoding::encode::Encode + ?core::marker::Sized, H: bitcoin_hashes::HashEngine
 pub fn bitcoin_hashes::encode_to_hash<T, H>(obj: &T) -> <H as bitcoin_hashes::HashEngine>::Hash where T: bitcoin_consensus_encoding::encode::Encode + ?core::marker::Sized, H: bitcoin_hashes::HashEngine + core::default::Default
-pub type bitcoin_hashes::HkdfSha256 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha256::Hash>
-pub type bitcoin_hashes::HkdfSha512 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha512::Hash>
+pub type bitcoin_hashes::HkdfSha256 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha256::HashEngine>
+pub type bitcoin_hashes::HkdfSha512 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha512::HashEngine>
 pub type bitcoin_hashes::HmacSha256 = bitcoin_hashes::hmac::Hmac<bitcoin_hashes::sha256::Hash>
 pub type bitcoin_hashes::HmacSha512 = bitcoin_hashes::hmac::Hmac<bitcoin_hashes::sha512::Hash>
 pub type bitcoin_hashes::Sha256t<T> = bitcoin_hashes::sha256t::Hash<T>

--- a/hashes/api/alloc-only.txt
+++ b/hashes/api/alloc-only.txt
@@ -1685,8 +1685,8 @@ pub fn bitcoin_hashes::drain_to_engine<T, H>(encoder: &mut T, engine: &mut H) wh
 pub fn bitcoin_hashes::drain_to_hash<T, H>(encoder: &mut T) -> <H as bitcoin_hashes::HashEngine>::Hash where T: bitcoin_consensus_encoding::encode::Encoder + ?core::marker::Sized, H: bitcoin_hashes::HashEngine + core::default::Default
 pub fn bitcoin_hashes::encode_to_engine<T, H>(object: &T, engine: &mut H) where T: bitcoin_consensus_encoding::encode::Encode + ?core::marker::Sized, H: bitcoin_hashes::HashEngine
 pub fn bitcoin_hashes::encode_to_hash<T, H>(obj: &T) -> <H as bitcoin_hashes::HashEngine>::Hash where T: bitcoin_consensus_encoding::encode::Encode + ?core::marker::Sized, H: bitcoin_hashes::HashEngine + core::default::Default
-pub type bitcoin_hashes::HkdfSha256 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha256::Hash>
-pub type bitcoin_hashes::HkdfSha512 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha512::Hash>
+pub type bitcoin_hashes::HkdfSha256 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha256::HashEngine>
+pub type bitcoin_hashes::HkdfSha512 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha512::HashEngine>
 pub type bitcoin_hashes::HmacSha256 = bitcoin_hashes::hmac::Hmac<bitcoin_hashes::sha256::Hash>
 pub type bitcoin_hashes::HmacSha512 = bitcoin_hashes::hmac::Hmac<bitcoin_hashes::sha512::Hash>
 pub type bitcoin_hashes::Sha256t<T> = bitcoin_hashes::sha256t::Hash<T>

--- a/hashes/api/no-features.txt
+++ b/hashes/api/no-features.txt
@@ -1562,8 +1562,8 @@ pub fn bitcoin_hashes::drain_to_engine<T, H>(encoder: &mut T, engine: &mut H) wh
 pub fn bitcoin_hashes::drain_to_hash<T, H>(encoder: &mut T) -> <H as bitcoin_hashes::HashEngine>::Hash where T: bitcoin_consensus_encoding::encode::Encoder + ?core::marker::Sized, H: bitcoin_hashes::HashEngine + core::default::Default
 pub fn bitcoin_hashes::encode_to_engine<T, H>(object: &T, engine: &mut H) where T: bitcoin_consensus_encoding::encode::Encode + ?core::marker::Sized, H: bitcoin_hashes::HashEngine
 pub fn bitcoin_hashes::encode_to_hash<T, H>(obj: &T) -> <H as bitcoin_hashes::HashEngine>::Hash where T: bitcoin_consensus_encoding::encode::Encode + ?core::marker::Sized, H: bitcoin_hashes::HashEngine + core::default::Default
-pub type bitcoin_hashes::HkdfSha256 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha256::Hash>
-pub type bitcoin_hashes::HkdfSha512 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha512::Hash>
+pub type bitcoin_hashes::HkdfSha256 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha256::HashEngine>
+pub type bitcoin_hashes::HkdfSha512 = bitcoin_hashes::hkdf::Hkdf<bitcoin_hashes::sha512::HashEngine>
 pub type bitcoin_hashes::HmacSha256 = bitcoin_hashes::hmac::Hmac<bitcoin_hashes::sha256::Hash>
 pub type bitcoin_hashes::HmacSha512 = bitcoin_hashes::hmac::Hmac<bitcoin_hashes::sha512::Hash>
 pub type bitcoin_hashes::Sha256t<T> = bitcoin_hashes::sha256t::Hash<T>

--- a/hashes/src/lib.rs
+++ b/hashes/src/lib.rs
@@ -158,11 +158,11 @@ pub type HmacSha256 = Hmac<sha256::Hash>;
 /// HMAC-SHA-512: Type alias for the [`Hmac<Sha512>`] type.
 pub type HmacSha512 = Hmac<sha512::Hash>;
 
-/// HKDF-HMAC-SHA-256: Type alias for the [`Hkdf<Sha256>`] type.
-pub type HkdfSha256 = Hkdf<sha256::Hash>;
+/// HKDF-HMAC-SHA-256: Type alias for the [`Hkdf<sha256::HashEngine>`] type.
+pub type HkdfSha256 = Hkdf<sha256::HashEngine>;
 
-/// HKDF-HMAC-SHA-512: Type alias for the [`Hkdf<Sha512>`] type.
-pub type HkdfSha512 = Hkdf<sha512::Hash>;
+/// HKDF-HMAC-SHA-512: Type alias for the [`Hkdf<sha512::HashEngine>`] type.
+pub type HkdfSha512 = Hkdf<sha512::HashEngine>;
 
 /// A hashing engine which bytes can be serialized into.
 pub trait HashEngine: Clone {


### PR DESCRIPTION
In https://github.com/rust-bitcoin/rust-bitcoin/pull/4085 we reparameterized `Hkdf` to use `HashEngine` instead of the _old_ `GeneralHash`, but missed updating the `HkdfSha256` and HkdfSha512 aliases.

This PR points the aliases at `HashEngine`.