### PR TITLE
units: backport kani proof fixes to 0.32.x

### DIFF
--- a/units/src/amount.rs
+++ b/units/src/amount.rs
@@ -2040,10 +2040,15 @@ mod verification {
     // CI it fails, so we need to set it higher.
     #[kani::unwind(4)]
     #[kani::proof]
-    fn u_amount_add_homomorphic() {
+    fn u_amount_homomorphic() {
         let n1 = kani::any::<u64>();
         let n2 = kani::any::<u64>();
-        kani::assume(n1.checked_add(n2).is_some()); // assume we don't overflow in the actual test
+        // Assume we don't overflow in the actual tests.
+        kani::assume(n1.checked_add(n2).is_some()); // Adding u64s doesn't overflow.
+        let a1 = Amount::from_sat(n1);
+        let a2 = Amount::from_sat(n2);
+        kani::assume(a1.checked_add(a2).is_some()); // Adding amounts doesn't overflow.
+
         assert_eq!(Amount::from_sat(n1) + Amount::from_sat(n2), Amount::from_sat(n1 + n2));
 
         let mut amt = Amount::from_sat(n1);
@@ -2057,39 +2062,21 @@ mod verification {
         let mut amt = Amount::from_sat(max);
         amt -= Amount::from_sat(min);
         assert_eq!(amt, Amount::from_sat(max - min));
-
-        assert_eq!(
-            Amount::from_sat(n1).to_signed(),
-            if n1 <= i64::MAX as u64 {
-                Ok(SignedAmount::from_sat(n1.try_into().unwrap()))
-            } else {
-                Err(OutOfRangeError::too_big(true))
-            },
-        );
     }
 
     #[kani::unwind(4)]
     #[kani::proof]
-    fn u_amount_add_homomorphic_checked() {
-        let n1 = kani::any::<u64>();
-        let n2 = kani::any::<u64>();
-        assert_eq!(
-            Amount::from_sat(n1).checked_add(Amount::from_sat(n2)),
-            n1.checked_add(n2).map(Amount::from_sat),
-        );
-        assert_eq!(
-            Amount::from_sat(n1).checked_sub(Amount::from_sat(n2)),
-            n1.checked_sub(n2).map(Amount::from_sat),
-        );
-    }
-
-    #[kani::unwind(4)]
-    #[kani::proof]
-    fn s_amount_add_homomorphic() {
+    fn s_amount_homomorphic() {
         let n1 = kani::any::<i64>();
         let n2 = kani::any::<i64>();
-        kani::assume(n1.checked_add(n2).is_some()); // assume we don't overflow in the actual test
-        kani::assume(n1.checked_sub(n2).is_some()); // assume we don't overflow in the actual test
+        // Assume we don't overflow in the actual tests.
+        kani::assume(n1.checked_add(n2).is_some()); // Adding i64s doesn't overflow.
+        kani::assume(n1.checked_sub(n2).is_some()); // Subbing i64s doesn't overflow.
+        let a1 = SignedAmount::from_sat(n1);
+        let a2 = SignedAmount::from_sat(n2);
+        kani::assume(a1.checked_add(a2).is_some()); // Adding amounts doesn't overflow.
+        kani::assume(a1.checked_sub(a2).is_some()); // Subbing amounts doesn't overflow.
+
         assert_eq!(
             SignedAmount::from_sat(n1) + SignedAmount::from_sat(n2),
             SignedAmount::from_sat(n1 + n2)
@@ -2105,39 +2092,6 @@ mod verification {
         let mut amt = SignedAmount::from_sat(n1);
         amt -= SignedAmount::from_sat(n2);
         assert_eq!(amt, SignedAmount::from_sat(n1 - n2));
-
-        assert_eq!(
-            SignedAmount::from_sat(n1).to_unsigned(),
-            if n1 >= 0 {
-                Ok(Amount::from_sat(n1.try_into().unwrap()))
-            } else {
-                Err(OutOfRangeError { is_signed: true, is_greater_than_max: false })
-            },
-        );
-    }
-
-    #[kani::unwind(4)]
-    #[kani::proof]
-    fn s_amount_add_homomorphic_checked() {
-        let n1 = kani::any::<i64>();
-        let n2 = kani::any::<i64>();
-        assert_eq!(
-            SignedAmount::from_sat(n1).checked_add(SignedAmount::from_sat(n2)),
-            n1.checked_add(n2).map(SignedAmount::from_sat),
-        );
-        assert_eq!(
-            SignedAmount::from_sat(n1).checked_sub(SignedAmount::from_sat(n2)),
-            n1.checked_sub(n2).map(SignedAmount::from_sat),
-        );
-
-        assert_eq!(
-            SignedAmount::from_sat(n1).positive_sub(SignedAmount::from_sat(n2)),
-            if n1 >= 0 && n2 >= 0 && n1 >= n2 {
-                Some(SignedAmount::from_sat(n1 - n2))
-            } else {
-                None
-            },
-        );
     }
 }
 


### PR DESCRIPTION
We can't match master exactly, that would require backporting more changes to `units` itself. But backporting these two gets 0.32.x proofs working again.

* #2686 -- Rename proofs.
* #3782 -- Cut the amount of proofs from 4 to 2, assume no overflow since we are only proving the homomorphism holds for valid cases.

Fixes https://github.com/rust-bitcoin/rust-bitcoin/issues/6461.