### PR TITLE
Release tracking PR: `bitcoin 0.32.102`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.101"
+version = "0.32.102"
 dependencies = [
  "arbitrary",
  "base58ck",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.101"
+version = "0.32.102"
 dependencies = [
  "arbitrary",
  "base58ck",

--- a/bitcoin/CHANGELOG.md
+++ b/bitcoin/CHANGELOG.md
@@ -1,8 +1,14 @@
 # unreleased
 
-- Remove mutagen
+# 0.32.101 - 2026-06-24
 
-# 0.32.100 - 2025-05-26
+**Bump the MSRV to Rust 1.60.0**
+
+- Exposes the new stabilized encoding library through the optional `encoding` feature. Note that enabling it bumps the MSRV to 1.74.0.
+
+# 0.32.100 - 2025-05-26 [YANKED]
+
+> This release was yanked because the MSRV bump to 1.74.0 was too aggressive for some users. See version 0.32.101 for a smaller upgrade to 1.60.0.
 
 **Bump the MSRV to Rust 1.74.0**
 

--- a/bitcoin/CHANGELOG.md
+++ b/bitcoin/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 **Bump the MSRV to Rust 1.60.0**
 
-- Exposes the new stabilized encoding library through the optional `encoding` feature. Note that enabling it bumps the MSRV to 1.74.0.
+Exposes the new stabilized encoding library through the optional `encoding` feature. Note that enabling it bumps the MSRV to 1.74.0.
+
+- Remove mutagen [#6337](https://github.com/rust-bitcoin/rust-bitcoin/pull/6337)
+- Use `write!` in `ParseNetwork` and `UnknownAddressType` error displays [#6386](https://github.com/rust-bitcoin/rust-bitcoin/pull/6386)
+- Add `consensus_encoding` to types present in units 1.0 [#6184](https://github.com/rust-bitcoin/rust-bitcoin/pull/6184)
 
 # 0.32.100 - 2025-05-26 [YANKED]
 

--- a/bitcoin/CHANGELOG.md
+++ b/bitcoin/CHANGELOG.md
@@ -1,5 +1,14 @@
 # unreleased
 
+# 0.32.102 - 2026-07-06
+
+- Backport: Make `SendCmpct` idempotent [#6525](https://github.com/rust-bitcoin/rust-bitcoin/pull/6525)
+- Add `consensus_encoding` to block/compact-block p2p message types [#6457](https://github.com/rust-bitcoin/rust-bitcoin/pull/6457)
+- Add `consensus_encoding` support to types in `bitcoin-primitives` [#6333](https://github.com/rust-bitcoin/rust-bitcoin/pull/6333)
+- Add `consensus_encoding` support to core p2p message types [#6443](https://github.com/rust-bitcoin/rust-bitcoin/pull/6443)
+- Add `consensus_encoding` support to BIP157/158 filter message types [#6444](https://github.com/rust-bitcoin/rust-bitcoin/pull/6444)
+- Use `write!` in `ParseNetwork` and `UnknownAddressType` error displays [#6386](https://github.com/rust-bitcoin/rust-bitcoin/pull/6386)
+
 # 0.32.101 - 2026-06-24
 
 **Bump the MSRV to Rust 1.60.0**

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -3,7 +3,7 @@ name = "bitcoin"
 # We jumped to `v0.32.100` when doing the MSRV bump to Rust `1.74`
 # leaving room for a bunch of secuity releases upto this number if
 # needed.
-version = "0.32.101"
+version = "0.32.102"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -1779,7 +1779,7 @@ impl Default for TransactionDecoder {
 }
 
 #[cfg(feature = "encoding")]
-#[allow(clippy::too_many_lines)] // TODO: Can we clean this up?
+#[allow(clippy::too_many_lines)]
 impl encoding::Decoder for TransactionDecoder {
     type Output = Transaction;
     type Error = TransactionDecoderError;

--- a/bitcoin/src/consensus/mod.rs
+++ b/bitcoin/src/consensus/mod.rs
@@ -151,7 +151,7 @@ impl<E: fmt::Debug> std::error::Error for DecodeError<E> {
         match *self {
             TooManyBytes => None,
             Consensus(ref e) => Some(e),
-            Other(_) => None, // TODO: Is this correct?
+            Other(_) => None,
         }
     }
 }

--- a/io/CHANGELOG.md
+++ b/io/CHANGELOG.md
@@ -1,4 +1,12 @@
-# 0.1.100 - 2026-05-26
+# 0.1.101 - 2026-06-24
+
+**Bump the MSRV to Rust 1.60.0**
+
+- Exposes the new stabilized encoding library through the optional `encoding` feature. Note that enabling it bumps the MSRV to 1.74.0.
+
+# 0.1.100 - 2026-05-26 [YANKED]
+
+> This release was yanked because the MSRV bump to 1.74.0 was too aggressive for some users. See version 0.1.101 for a smaller upgrade to 1.60.0.
 
 **Bump the MSRV to Rust 1.74.0**
 


### PR DESCRIPTION
In preparation for release add a changelog entry (thanks Claude), bump the version number, and update the lock files.

The motivation for this release is the addition of new encoding logic for primitive types.
