### PR TITLE
consensus_encoding: Add `Prefixed{Bytes,Slice}Encoder`

### DIFF
--- a/consensus_encoding/api/all-features.txt
+++ b/consensus_encoding/api/all-features.txt
@@ -1888,6 +1888,86 @@ impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::error::Length
   pub unsafe fn bitcoin_consensus_encoding::error::LengthPrefixExceedsMaxError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::error::LengthPrefixExceedsMaxError where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::error::LengthPrefixExceedsMaxError
   pub fn bitcoin_consensus_encoding::error::LengthPrefixExceedsMaxError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_consensus_encoding::error::LengthPrefixExceedsMaxError]
+pub struct bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>(_)
+impl<'sl> bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>
+pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::new(sl: &'sl [u8]) -> Self
+impl bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>]
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>::current_chunk(&self) -> &[u8] [impl: impl bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>]
+impl bitcoin_consensus_encoding::ExactSizeEncoder for bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>::len(&self) -> usize [impl: impl bitcoin_consensus_encoding::ExactSizeEncoder for bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>]
+impl<'sl> core::clone::Clone for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::clone(&self) -> bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> [impl: impl<'sl> core::clone::Clone for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>]
+impl<'sl> core::fmt::Debug for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<'sl> core::fmt::Debug for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>]
+impl<'sl> core::marker::Freeze for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>
+impl<'sl> core::marker::Send for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>
+impl<'sl> core::marker::Sync for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>
+impl<'sl> core::marker::Unpin for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>
+impl<'sl> core::marker::UnsafeUnpin for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>
+impl<'sl> core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>
+impl<'sl> core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>
+impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where U: core::convert::From<T>
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where U: core::convert::Into<T>
+  pub type bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where U: core::convert::Into<T>]
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where U: core::convert::TryFrom<T>
+  pub type bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where U: core::convert::TryFrom<T>]
+impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where T: core::clone::Clone
+  pub type bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where T: core::clone::Clone]
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where T: core::clone::Clone]
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where T: core::clone::Clone]
+impl<T> core::any::Any for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where T: ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where T: ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where T: core::clone::Clone
+  pub unsafe fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>]
+pub struct bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T: bitcoin_consensus_encoding::Encode>(_)
+impl<'e, T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>
+pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::new(sl: &'e [T]) -> Self
+impl<'e, T: bitcoin_consensus_encoding::Encode> core::clone::Clone for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::clone::Clone
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::clone(&self) -> Self [impl: impl<'e, T: bitcoin_consensus_encoding::Encode> core::clone::Clone for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::clone::Clone]
+impl<'e, T: bitcoin_consensus_encoding::Encode> core::fmt::Debug for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::fmt::Debug
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<'e, T: bitcoin_consensus_encoding::Encode> core::fmt::Debug for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::fmt::Debug]
+impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>]
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>::current_chunk(&self) -> &[u8] [impl: impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>]
+impl<'e, T> core::marker::Freeze for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::marker::Freeze
+impl<'e, T> core::marker::Send for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::marker::Send, T: core::marker::Sync
+impl<'e, T> core::marker::Sync for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::marker::Sync, T: core::marker::Sync
+impl<'e, T> core::marker::Unpin for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::marker::Unpin
+impl<'e, T> core::marker::UnsafeUnpin for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::marker::UnsafeUnpin
+impl<'e, T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::panic::unwind_safe::RefUnwindSafe, T: core::panic::unwind_safe::RefUnwindSafe
+impl<'e, T> core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::panic::unwind_safe::UnwindSafe, T: core::panic::unwind_safe::RefUnwindSafe
+impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where U: core::convert::From<T>
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where U: core::convert::Into<T>
+  pub type bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where U: core::convert::Into<T>]
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where U: core::convert::TryFrom<T>
+  pub type bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where U: core::convert::TryFrom<T>]
+impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where T: core::clone::Clone
+  pub type bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where T: core::clone::Clone]
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where T: core::clone::Clone]
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where T: core::clone::Clone]
+impl<T> core::any::Any for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where T: ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where T: ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where T: core::clone::Clone
+  pub unsafe fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>]
 pub struct bitcoin_consensus_encoding::SliceEncoder<'e, T: bitcoin_consensus_encoding::Encode>
 impl<'e, T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::SliceEncoder<'e, T>
 pub fn bitcoin_consensus_encoding::SliceEncoder<'e, T>::without_length_prefix(sl: &'e [T]) -> Self
@@ -2185,6 +2265,9 @@ impl bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::BytesEn
 impl bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::CompactSizeEncoder
   pub fn bitcoin_consensus_encoding::CompactSizeEncoder::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::CompactSizeEncoder]
   pub fn bitcoin_consensus_encoding::CompactSizeEncoder::current_chunk(&self) -> &[u8] [impl: impl bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::CompactSizeEncoder]
+impl bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>]
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>::current_chunk(&self) -> &[u8] [impl: impl bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>]
 impl<A: bitcoin_consensus_encoding::Encoder, B: bitcoin_consensus_encoding::Encoder, C: bitcoin_consensus_encoding::Encoder, D: bitcoin_consensus_encoding::Encoder, E: bitcoin_consensus_encoding::Encoder, F: bitcoin_consensus_encoding::Encoder> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::Encoder6<A, B, C, D, E, F>
   pub fn bitcoin_consensus_encoding::Encoder6<A, B, C, D, E, F>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl<A: bitcoin_consensus_encoding::Encoder, B: bitcoin_consensus_encoding::Encoder, C: bitcoin_consensus_encoding::Encoder, D: bitcoin_consensus_encoding::Encoder, E: bitcoin_consensus_encoding::Encoder, F: bitcoin_consensus_encoding::Encoder> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::Encoder6<A, B, C, D, E, F>]
   pub fn bitcoin_consensus_encoding::Encoder6<A, B, C, D, E, F>::current_chunk(&self) -> &[u8] [impl: impl<A: bitcoin_consensus_encoding::Encoder, B: bitcoin_consensus_encoding::Encoder, C: bitcoin_consensus_encoding::Encoder, D: bitcoin_consensus_encoding::Encoder, E: bitcoin_consensus_encoding::Encoder, F: bitcoin_consensus_encoding::Encoder> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::Encoder6<A, B, C, D, E, F>]
@@ -2197,6 +2280,9 @@ impl<A: bitcoin_consensus_encoding::Encoder, B: bitcoin_consensus_encoding::Enco
 impl<A: bitcoin_consensus_encoding::Encoder, B: bitcoin_consensus_encoding::Encoder> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::Encoder2<A, B>
   pub fn bitcoin_consensus_encoding::Encoder2<A, B>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl<A: bitcoin_consensus_encoding::Encoder, B: bitcoin_consensus_encoding::Encoder> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::Encoder2<A, B>]
   pub fn bitcoin_consensus_encoding::Encoder2<A, B>::current_chunk(&self) -> &[u8] [impl: impl<A: bitcoin_consensus_encoding::Encoder, B: bitcoin_consensus_encoding::Encoder> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::Encoder2<A, B>]
+impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>]
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>::current_chunk(&self) -> &[u8] [impl: impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>]
 impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::SliceEncoder<'_, T>
   pub fn bitcoin_consensus_encoding::SliceEncoder<'_, T>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::SliceEncoder<'_, T>]
   pub fn bitcoin_consensus_encoding::SliceEncoder<'_, T>::current_chunk(&self) -> &[u8] [impl: impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::SliceEncoder<'_, T>]
@@ -2214,6 +2300,8 @@ pub fn bitcoin_consensus_encoding::ExactSizeEncoder::is_empty(&self) -> bool
 pub fn bitcoin_consensus_encoding::ExactSizeEncoder::len(&self) -> usize
 impl bitcoin_consensus_encoding::ExactSizeEncoder for bitcoin_consensus_encoding::CompactSizeEncoder
   pub fn bitcoin_consensus_encoding::CompactSizeEncoder::len(&self) -> usize [impl: impl bitcoin_consensus_encoding::ExactSizeEncoder for bitcoin_consensus_encoding::CompactSizeEncoder]
+impl bitcoin_consensus_encoding::ExactSizeEncoder for bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>::len(&self) -> usize [impl: impl bitcoin_consensus_encoding::ExactSizeEncoder for bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>]
 impl<'sl> bitcoin_consensus_encoding::ExactSizeEncoder for bitcoin_consensus_encoding::BytesEncoder<'sl>
   pub fn bitcoin_consensus_encoding::BytesEncoder<'sl>::len(&self) -> usize [impl: impl<'sl> bitcoin_consensus_encoding::ExactSizeEncoder for bitcoin_consensus_encoding::BytesEncoder<'sl>]
 impl<A, B, C, D, E, F> bitcoin_consensus_encoding::ExactSizeEncoder for bitcoin_consensus_encoding::Encoder6<A, B, C, D, E, F> where A: bitcoin_consensus_encoding::Encoder + bitcoin_consensus_encoding::ExactSizeEncoder, B: bitcoin_consensus_encoding::Encoder + bitcoin_consensus_encoding::ExactSizeEncoder, C: bitcoin_consensus_encoding::Encoder + bitcoin_consensus_encoding::ExactSizeEncoder, D: bitcoin_consensus_encoding::Encoder + bitcoin_consensus_encoding::ExactSizeEncoder, E: bitcoin_consensus_encoding::Encoder + bitcoin_consensus_encoding::ExactSizeEncoder, F: bitcoin_consensus_encoding::Encoder + bitcoin_consensus_encoding::ExactSizeEncoder

--- a/consensus_encoding/api/alloc-only.txt
+++ b/consensus_encoding/api/alloc-only.txt
@@ -1675,6 +1675,86 @@ impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::error::Length
   pub unsafe fn bitcoin_consensus_encoding::error::LengthPrefixExceedsMaxError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::error::LengthPrefixExceedsMaxError where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::error::LengthPrefixExceedsMaxError
   pub fn bitcoin_consensus_encoding::error::LengthPrefixExceedsMaxError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_consensus_encoding::error::LengthPrefixExceedsMaxError]
+pub struct bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>(_)
+impl<'sl> bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>
+pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::new(sl: &'sl [u8]) -> Self
+impl bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>]
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>::current_chunk(&self) -> &[u8] [impl: impl bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>]
+impl bitcoin_consensus_encoding::ExactSizeEncoder for bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>::len(&self) -> usize [impl: impl bitcoin_consensus_encoding::ExactSizeEncoder for bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>]
+impl<'sl> core::clone::Clone for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::clone(&self) -> bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> [impl: impl<'sl> core::clone::Clone for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>]
+impl<'sl> core::fmt::Debug for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<'sl> core::fmt::Debug for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>]
+impl<'sl> core::marker::Freeze for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>
+impl<'sl> core::marker::Send for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>
+impl<'sl> core::marker::Sync for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>
+impl<'sl> core::marker::Unpin for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>
+impl<'sl> core::marker::UnsafeUnpin for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>
+impl<'sl> core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>
+impl<'sl> core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>
+impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where U: core::convert::From<T>
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where U: core::convert::Into<T>
+  pub type bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where U: core::convert::Into<T>]
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where U: core::convert::TryFrom<T>
+  pub type bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where U: core::convert::TryFrom<T>]
+impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where T: core::clone::Clone
+  pub type bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where T: core::clone::Clone]
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where T: core::clone::Clone]
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where T: core::clone::Clone]
+impl<T> core::any::Any for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where T: ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where T: ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where T: core::clone::Clone
+  pub unsafe fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>]
+pub struct bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T: bitcoin_consensus_encoding::Encode>(_)
+impl<'e, T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>
+pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::new(sl: &'e [T]) -> Self
+impl<'e, T: bitcoin_consensus_encoding::Encode> core::clone::Clone for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::clone::Clone
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::clone(&self) -> Self [impl: impl<'e, T: bitcoin_consensus_encoding::Encode> core::clone::Clone for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::clone::Clone]
+impl<'e, T: bitcoin_consensus_encoding::Encode> core::fmt::Debug for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::fmt::Debug
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<'e, T: bitcoin_consensus_encoding::Encode> core::fmt::Debug for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::fmt::Debug]
+impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>]
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>::current_chunk(&self) -> &[u8] [impl: impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>]
+impl<'e, T> core::marker::Freeze for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::marker::Freeze
+impl<'e, T> core::marker::Send for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::marker::Send, T: core::marker::Sync
+impl<'e, T> core::marker::Sync for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::marker::Sync, T: core::marker::Sync
+impl<'e, T> core::marker::Unpin for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::marker::Unpin
+impl<'e, T> core::marker::UnsafeUnpin for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::marker::UnsafeUnpin
+impl<'e, T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::panic::unwind_safe::RefUnwindSafe, T: core::panic::unwind_safe::RefUnwindSafe
+impl<'e, T> core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::panic::unwind_safe::UnwindSafe, T: core::panic::unwind_safe::RefUnwindSafe
+impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where U: core::convert::From<T>
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where U: core::convert::Into<T>
+  pub type bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where U: core::convert::Into<T>]
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where U: core::convert::TryFrom<T>
+  pub type bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where U: core::convert::TryFrom<T>]
+impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where T: core::clone::Clone
+  pub type bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where T: core::clone::Clone]
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where T: core::clone::Clone]
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where T: core::clone::Clone]
+impl<T> core::any::Any for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where T: ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where T: ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where T: core::clone::Clone
+  pub unsafe fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>]
 pub struct bitcoin_consensus_encoding::SliceEncoder<'e, T: bitcoin_consensus_encoding::Encode>
 impl<'e, T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::SliceEncoder<'e, T>
 pub fn bitcoin_consensus_encoding::SliceEncoder<'e, T>::without_length_prefix(sl: &'e [T]) -> Self
@@ -1966,6 +2046,9 @@ impl bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::BytesEn
 impl bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::CompactSizeEncoder
   pub fn bitcoin_consensus_encoding::CompactSizeEncoder::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::CompactSizeEncoder]
   pub fn bitcoin_consensus_encoding::CompactSizeEncoder::current_chunk(&self) -> &[u8] [impl: impl bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::CompactSizeEncoder]
+impl bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>]
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>::current_chunk(&self) -> &[u8] [impl: impl bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>]
 impl<A: bitcoin_consensus_encoding::Encoder, B: bitcoin_consensus_encoding::Encoder, C: bitcoin_consensus_encoding::Encoder, D: bitcoin_consensus_encoding::Encoder, E: bitcoin_consensus_encoding::Encoder, F: bitcoin_consensus_encoding::Encoder> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::Encoder6<A, B, C, D, E, F>
   pub fn bitcoin_consensus_encoding::Encoder6<A, B, C, D, E, F>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl<A: bitcoin_consensus_encoding::Encoder, B: bitcoin_consensus_encoding::Encoder, C: bitcoin_consensus_encoding::Encoder, D: bitcoin_consensus_encoding::Encoder, E: bitcoin_consensus_encoding::Encoder, F: bitcoin_consensus_encoding::Encoder> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::Encoder6<A, B, C, D, E, F>]
   pub fn bitcoin_consensus_encoding::Encoder6<A, B, C, D, E, F>::current_chunk(&self) -> &[u8] [impl: impl<A: bitcoin_consensus_encoding::Encoder, B: bitcoin_consensus_encoding::Encoder, C: bitcoin_consensus_encoding::Encoder, D: bitcoin_consensus_encoding::Encoder, E: bitcoin_consensus_encoding::Encoder, F: bitcoin_consensus_encoding::Encoder> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::Encoder6<A, B, C, D, E, F>]
@@ -1978,6 +2061,9 @@ impl<A: bitcoin_consensus_encoding::Encoder, B: bitcoin_consensus_encoding::Enco
 impl<A: bitcoin_consensus_encoding::Encoder, B: bitcoin_consensus_encoding::Encoder> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::Encoder2<A, B>
   pub fn bitcoin_consensus_encoding::Encoder2<A, B>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl<A: bitcoin_consensus_encoding::Encoder, B: bitcoin_consensus_encoding::Encoder> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::Encoder2<A, B>]
   pub fn bitcoin_consensus_encoding::Encoder2<A, B>::current_chunk(&self) -> &[u8] [impl: impl<A: bitcoin_consensus_encoding::Encoder, B: bitcoin_consensus_encoding::Encoder> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::Encoder2<A, B>]
+impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>]
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>::current_chunk(&self) -> &[u8] [impl: impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>]
 impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::SliceEncoder<'_, T>
   pub fn bitcoin_consensus_encoding::SliceEncoder<'_, T>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::SliceEncoder<'_, T>]
   pub fn bitcoin_consensus_encoding::SliceEncoder<'_, T>::current_chunk(&self) -> &[u8] [impl: impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::SliceEncoder<'_, T>]
@@ -1995,6 +2081,8 @@ pub fn bitcoin_consensus_encoding::ExactSizeEncoder::is_empty(&self) -> bool
 pub fn bitcoin_consensus_encoding::ExactSizeEncoder::len(&self) -> usize
 impl bitcoin_consensus_encoding::ExactSizeEncoder for bitcoin_consensus_encoding::CompactSizeEncoder
   pub fn bitcoin_consensus_encoding::CompactSizeEncoder::len(&self) -> usize [impl: impl bitcoin_consensus_encoding::ExactSizeEncoder for bitcoin_consensus_encoding::CompactSizeEncoder]
+impl bitcoin_consensus_encoding::ExactSizeEncoder for bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>::len(&self) -> usize [impl: impl bitcoin_consensus_encoding::ExactSizeEncoder for bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>]
 impl<'sl> bitcoin_consensus_encoding::ExactSizeEncoder for bitcoin_consensus_encoding::BytesEncoder<'sl>
   pub fn bitcoin_consensus_encoding::BytesEncoder<'sl>::len(&self) -> usize [impl: impl<'sl> bitcoin_consensus_encoding::ExactSizeEncoder for bitcoin_consensus_encoding::BytesEncoder<'sl>]
 impl<A, B, C, D, E, F> bitcoin_consensus_encoding::ExactSizeEncoder for bitcoin_consensus_encoding::Encoder6<A, B, C, D, E, F> where A: bitcoin_consensus_encoding::Encoder + bitcoin_consensus_encoding::ExactSizeEncoder, B: bitcoin_consensus_encoding::Encoder + bitcoin_consensus_encoding::ExactSizeEncoder, C: bitcoin_consensus_encoding::Encoder + bitcoin_consensus_encoding::ExactSizeEncoder, D: bitcoin_consensus_encoding::Encoder + bitcoin_consensus_encoding::ExactSizeEncoder, E: bitcoin_consensus_encoding::Encoder + bitcoin_consensus_encoding::ExactSizeEncoder, F: bitcoin_consensus_encoding::Encoder + bitcoin_consensus_encoding::ExactSizeEncoder

--- a/consensus_encoding/api/no-features.txt
+++ b/consensus_encoding/api/no-features.txt
@@ -1292,6 +1292,78 @@ impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::EncoderByteIt
   pub unsafe fn bitcoin_consensus_encoding::EncoderByteIter<T>::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::EncoderByteIter<T> where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::EncoderByteIter<T>
   pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_consensus_encoding::EncoderByteIter<T>]
+pub struct bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>(_)
+impl<'sl> bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>
+pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::new(sl: &'sl [u8]) -> Self
+impl bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>]
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>::current_chunk(&self) -> &[u8] [impl: impl bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>]
+impl bitcoin_consensus_encoding::ExactSizeEncoder for bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>::len(&self) -> usize [impl: impl bitcoin_consensus_encoding::ExactSizeEncoder for bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>]
+impl<'sl> core::clone::Clone for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::clone(&self) -> bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> [impl: impl<'sl> core::clone::Clone for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>]
+impl<'sl> core::fmt::Debug for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<'sl> core::fmt::Debug for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>]
+impl<'sl> core::marker::Freeze for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>
+impl<'sl> core::marker::Send for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>
+impl<'sl> core::marker::Sync for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>
+impl<'sl> core::marker::Unpin for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>
+impl<'sl> core::marker::UnsafeUnpin for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>
+impl<'sl> core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>
+impl<'sl> core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>
+impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where U: core::convert::From<T>
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where U: core::convert::Into<T>
+  pub type bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where U: core::convert::Into<T>]
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where U: core::convert::TryFrom<T>
+  pub type bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where U: core::convert::TryFrom<T>]
+impl<T> core::any::Any for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where T: ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where T: ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where T: core::clone::Clone
+  pub unsafe fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl> where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>]
+pub struct bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T: bitcoin_consensus_encoding::Encode>(_)
+impl<'e, T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>
+pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::new(sl: &'e [T]) -> Self
+impl<'e, T: bitcoin_consensus_encoding::Encode> core::clone::Clone for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::clone::Clone
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::clone(&self) -> Self [impl: impl<'e, T: bitcoin_consensus_encoding::Encode> core::clone::Clone for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::clone::Clone]
+impl<'e, T: bitcoin_consensus_encoding::Encode> core::fmt::Debug for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::fmt::Debug
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<'e, T: bitcoin_consensus_encoding::Encode> core::fmt::Debug for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::fmt::Debug]
+impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>]
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>::current_chunk(&self) -> &[u8] [impl: impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>]
+impl<'e, T> core::marker::Freeze for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::marker::Freeze
+impl<'e, T> core::marker::Send for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::marker::Send, T: core::marker::Sync
+impl<'e, T> core::marker::Sync for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::marker::Sync, T: core::marker::Sync
+impl<'e, T> core::marker::Unpin for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::marker::Unpin
+impl<'e, T> core::marker::UnsafeUnpin for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::marker::UnsafeUnpin
+impl<'e, T> core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::panic::unwind_safe::RefUnwindSafe, T: core::panic::unwind_safe::RefUnwindSafe
+impl<'e, T> core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::panic::unwind_safe::UnwindSafe, T: core::panic::unwind_safe::RefUnwindSafe
+impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where U: core::convert::From<T>
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where U: core::convert::Into<T>
+  pub type bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where U: core::convert::Into<T>]
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where U: core::convert::TryFrom<T>
+  pub type bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where U: core::convert::TryFrom<T>]
+impl<T> core::any::Any for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where T: ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where T: ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where T: core::clone::Clone
+  pub unsafe fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>]
 pub struct bitcoin_consensus_encoding::SliceEncoder<'e, T: bitcoin_consensus_encoding::Encode>
 impl<'e, T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::SliceEncoder<'e, T>
 pub fn bitcoin_consensus_encoding::SliceEncoder<'e, T>::without_length_prefix(sl: &'e [T]) -> Self
@@ -1466,6 +1538,9 @@ impl bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::BytesEn
 impl bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::CompactSizeEncoder
   pub fn bitcoin_consensus_encoding::CompactSizeEncoder::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::CompactSizeEncoder]
   pub fn bitcoin_consensus_encoding::CompactSizeEncoder::current_chunk(&self) -> &[u8] [impl: impl bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::CompactSizeEncoder]
+impl bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>]
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>::current_chunk(&self) -> &[u8] [impl: impl bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>]
 impl<A: bitcoin_consensus_encoding::Encoder, B: bitcoin_consensus_encoding::Encoder, C: bitcoin_consensus_encoding::Encoder, D: bitcoin_consensus_encoding::Encoder, E: bitcoin_consensus_encoding::Encoder, F: bitcoin_consensus_encoding::Encoder> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::Encoder6<A, B, C, D, E, F>
   pub fn bitcoin_consensus_encoding::Encoder6<A, B, C, D, E, F>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl<A: bitcoin_consensus_encoding::Encoder, B: bitcoin_consensus_encoding::Encoder, C: bitcoin_consensus_encoding::Encoder, D: bitcoin_consensus_encoding::Encoder, E: bitcoin_consensus_encoding::Encoder, F: bitcoin_consensus_encoding::Encoder> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::Encoder6<A, B, C, D, E, F>]
   pub fn bitcoin_consensus_encoding::Encoder6<A, B, C, D, E, F>::current_chunk(&self) -> &[u8] [impl: impl<A: bitcoin_consensus_encoding::Encoder, B: bitcoin_consensus_encoding::Encoder, C: bitcoin_consensus_encoding::Encoder, D: bitcoin_consensus_encoding::Encoder, E: bitcoin_consensus_encoding::Encoder, F: bitcoin_consensus_encoding::Encoder> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::Encoder6<A, B, C, D, E, F>]
@@ -1478,6 +1553,9 @@ impl<A: bitcoin_consensus_encoding::Encoder, B: bitcoin_consensus_encoding::Enco
 impl<A: bitcoin_consensus_encoding::Encoder, B: bitcoin_consensus_encoding::Encoder> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::Encoder2<A, B>
   pub fn bitcoin_consensus_encoding::Encoder2<A, B>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl<A: bitcoin_consensus_encoding::Encoder, B: bitcoin_consensus_encoding::Encoder> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::Encoder2<A, B>]
   pub fn bitcoin_consensus_encoding::Encoder2<A, B>::current_chunk(&self) -> &[u8] [impl: impl<A: bitcoin_consensus_encoding::Encoder, B: bitcoin_consensus_encoding::Encoder> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::Encoder2<A, B>]
+impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>]
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>::current_chunk(&self) -> &[u8] [impl: impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>]
 impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::SliceEncoder<'_, T>
   pub fn bitcoin_consensus_encoding::SliceEncoder<'_, T>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::SliceEncoder<'_, T>]
   pub fn bitcoin_consensus_encoding::SliceEncoder<'_, T>::current_chunk(&self) -> &[u8] [impl: impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::SliceEncoder<'_, T>]
@@ -1495,6 +1573,8 @@ pub fn bitcoin_consensus_encoding::ExactSizeEncoder::is_empty(&self) -> bool
 pub fn bitcoin_consensus_encoding::ExactSizeEncoder::len(&self) -> usize
 impl bitcoin_consensus_encoding::ExactSizeEncoder for bitcoin_consensus_encoding::CompactSizeEncoder
   pub fn bitcoin_consensus_encoding::CompactSizeEncoder::len(&self) -> usize [impl: impl bitcoin_consensus_encoding::ExactSizeEncoder for bitcoin_consensus_encoding::CompactSizeEncoder]
+impl bitcoin_consensus_encoding::ExactSizeEncoder for bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>
+  pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>::len(&self) -> usize [impl: impl bitcoin_consensus_encoding::ExactSizeEncoder for bitcoin_consensus_encoding::PrefixedBytesEncoder<'_>]
 impl<'sl> bitcoin_consensus_encoding::ExactSizeEncoder for bitcoin_consensus_encoding::BytesEncoder<'sl>
   pub fn bitcoin_consensus_encoding::BytesEncoder<'sl>::len(&self) -> usize [impl: impl<'sl> bitcoin_consensus_encoding::ExactSizeEncoder for bitcoin_consensus_encoding::BytesEncoder<'sl>]
 impl<A, B, C, D, E, F> bitcoin_consensus_encoding::ExactSizeEncoder for bitcoin_consensus_encoding::Encoder6<A, B, C, D, E, F> where A: bitcoin_consensus_encoding::Encoder + bitcoin_consensus_encoding::ExactSizeEncoder, B: bitcoin_consensus_encoding::Encoder + bitcoin_consensus_encoding::ExactSizeEncoder, C: bitcoin_consensus_encoding::Encoder + bitcoin_consensus_encoding::ExactSizeEncoder, D: bitcoin_consensus_encoding::Encoder + bitcoin_consensus_encoding::ExactSizeEncoder, E: bitcoin_consensus_encoding::Encoder + bitcoin_consensus_encoding::ExactSizeEncoder, F: bitcoin_consensus_encoding::Encoder + bitcoin_consensus_encoding::ExactSizeEncoder

--- a/consensus_encoding/examples/encoder.rs
+++ b/consensus_encoding/examples/encoder.rs
@@ -3,7 +3,7 @@
 //! Example of creating an encoder that encodes a slice of encodable objects.
 
 use bitcoin_consensus_encoding as encoding;
-use encoding::{ArrayEncoder, BytesEncoder, CompactSizeEncoder, Encode, Encoder2, SliceEncoder};
+use encoding::{ArrayEncoder, BytesEncoder, Encode, Encoder2, PrefixedSliceEncoder};
 
 fn main() {
     let v = vec![Inner::new(0xcafe_babe), Inner::new(0xdead_beef)];
@@ -29,7 +29,7 @@ impl Adt {
 
 encoding::encoder_newtype! {
     /// The encoder for the [`Adt`] type.
-    pub struct AdtEncoder<'e>(Encoder2<Encoder2<CompactSizeEncoder, SliceEncoder<'e, Inner>>, BytesEncoder<'e>>);
+    pub struct AdtEncoder<'e>(Encoder2<PrefixedSliceEncoder<'e, Inner>, BytesEncoder<'e>>);
 }
 
 impl Encode for Adt {
@@ -39,10 +39,7 @@ impl Encode for Adt {
         Self: 'e;
 
     fn encoder(&self) -> Self::Encoder<'_> {
-        let a = Encoder2::new(
-            CompactSizeEncoder::new(self.v.len()),
-            SliceEncoder::without_length_prefix(&self.v),
-        );
+        let a = PrefixedSliceEncoder::new(&self.v);
         let b = BytesEncoder::without_length_prefix(self.b.as_ref());
 
         AdtEncoder::new(Encoder2::new(a, b))

--- a/consensus_encoding/src/encode/encoders.rs
+++ b/consensus_encoding/src/encode/encoders.rs
@@ -13,6 +13,7 @@
 use core::fmt;
 
 use super::{Encode, Encoder, EncoderStatus, ExactSizeEncoder};
+use crate::CompactSizeEncoder;
 
 /// An encoder for a single byte slice.
 #[derive(Debug, Clone)]
@@ -34,6 +35,34 @@ impl Encoder for BytesEncoder<'_> {
 impl<'sl> ExactSizeEncoder for BytesEncoder<'sl> {
     #[inline]
     fn len(&self) -> usize { self.sl.len() }
+}
+
+/// An encoder for a single byte slice, including a compact size length prefix.
+#[derive(Debug, Clone)]
+pub struct PrefixedBytesEncoder<'sl>(Encoder2<CompactSizeEncoder, BytesEncoder<'sl>>);
+
+impl<'sl> PrefixedBytesEncoder<'sl> {
+    /// Constructs a byte encoder which encodes the given byte slice, with a length prefix.
+    #[inline]
+    pub fn new(sl: &'sl [u8]) -> Self {
+        Self(Encoder2::new(
+            CompactSizeEncoder::new(sl.len()),
+            BytesEncoder::without_length_prefix(sl),
+        ))
+    }
+}
+
+impl Encoder for PrefixedBytesEncoder<'_> {
+    #[inline]
+    fn current_chunk(&self) -> &[u8] { self.0.current_chunk() }
+
+    #[inline]
+    fn advance(&mut self) -> EncoderStatus { self.0.advance() }
+}
+
+impl ExactSizeEncoder for PrefixedBytesEncoder<'_> {
+    #[inline]
+    fn len(&self) -> usize { self.0.len() }
 }
 
 /// An encoder for a single array.
@@ -98,9 +127,7 @@ pub struct SliceEncoder<'e, T: Encode> {
 impl<'e, T: Encode> SliceEncoder<'e, T> {
     /// Constructs an encoder which encodes the slice _without_ adding the length prefix.
     ///
-    /// To encode with a length prefix consider using [`Encoder2`].
-    ///
-    /// E.g, `Encoder2<CompactSizeEncoder, SliceEncoder<'e, Foo>>`.
+    /// To encode with a length prefix, use [`PrefixedSliceEncoder`] instead.
     pub fn without_length_prefix(sl: &'e [T]) -> Self {
         // In this `map` call we cannot remove the closure. Seems to be a bug in the compiler.
         // Perhaps https://github.com/rust-lang/rust/issues/102540 which is 3 years old with
@@ -162,6 +189,44 @@ impl<T: Encode> Encoder for SliceEncoder<'_, T> {
             }
         }
     }
+}
+
+/// An encoder for a list of encodable types, including a length prefix.
+pub struct PrefixedSliceEncoder<'e, T: Encode>(Encoder2<CompactSizeEncoder, SliceEncoder<'e, T>>);
+
+impl<'e, T: Encode> PrefixedSliceEncoder<'e, T> {
+    /// Constructs an encoder which encodes the slice, adding the length prefix.
+    #[inline]
+    pub fn new(sl: &'e [T]) -> Self {
+        Self(Encoder2::new(
+            CompactSizeEncoder::new(sl.len()),
+            SliceEncoder::without_length_prefix(sl),
+        ))
+    }
+}
+
+impl<'e, T: Encode> fmt::Debug for PrefixedSliceEncoder<'e, T>
+where
+    T::Encoder<'e>: fmt::Debug,
+{
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { self.0.fmt(f) }
+}
+
+impl<'e, T: Encode> Clone for PrefixedSliceEncoder<'e, T>
+where
+    T::Encoder<'e>: Clone,
+{
+    #[inline]
+    fn clone(&self) -> Self { Self(self.0.clone()) }
+}
+
+impl<T: Encode> Encoder for PrefixedSliceEncoder<'_, T> {
+    #[inline]
+    fn current_chunk(&self) -> &[u8] { self.0.current_chunk() }
+
+    #[inline]
+    fn advance(&mut self) -> EncoderStatus { self.0.advance() }
 }
 
 /// Helper macro to define an unrolled `EncoderN` composite encoder.

--- a/consensus_encoding/src/lib.rs
+++ b/consensus_encoding/src/lib.rs
@@ -116,7 +116,7 @@ pub use self::decode::{
 #[doc(inline)]
 pub use self::encode::encoders::{
     ArrayEncoder, ArrayRefEncoder, BytesEncoder, Encoder2, Encoder3, Encoder4, Encoder6,
-    SliceEncoder,
+    PrefixedBytesEncoder, PrefixedSliceEncoder, SliceEncoder,
 };
 #[doc(inline)]
 pub use self::encode::{

--- a/consensus_encoding/tests/encode.rs
+++ b/consensus_encoding/tests/encode.rs
@@ -8,7 +8,7 @@ use std::io::{Cursor, Write};
 use bitcoin_consensus_encoding::{
     self as encoding, check_encode, check_encoder, ArrayEncoder, ArrayRefEncoder, BytesEncoder,
     Encode, Encoder, Encoder2, Encoder3, Encoder4, Encoder6, EncoderByteIter, ExactSizeEncoder,
-    SliceEncoder,
+    PrefixedBytesEncoder, PrefixedSliceEncoder, SliceEncoder,
 };
 
 struct TestBytes<'a>(&'a [u8]);
@@ -274,6 +274,39 @@ fn encode_empty_byte_slice_without_prefix() {
 }
 
 #[test]
+fn encode_byte_slice_with_prefix() {
+    // Should have the length prefix chunk, then the byte data, then exhausted.
+    let obj = [1u8, 2, 3];
+    let mut encoder = PrefixedBytesEncoder::new(&obj);
+
+    assert_eq!(encoder.len(), 4);
+    check_encoder(&mut encoder, &[3, 1, 2, 3]);
+}
+
+#[test]
+fn encode_empty_byte_slice_with_prefix() {
+    // Should have a single zero length prefix chunk, then exhausted.
+    let obj = [];
+    let mut encoder = PrefixedBytesEncoder::new(&obj);
+
+    assert_eq!(encoder.len(), 1);
+    check_encoder(&mut encoder, &[0]);
+}
+
+#[cfg(feature = "alloc")]
+#[test]
+fn encode_byte_slice_with_multi_byte_prefix() {
+    // A slice longer than 0xFC bytes takes a 3-byte compact size prefix.
+    let obj = vec![7u8; 0xFD];
+    let mut encoder = PrefixedBytesEncoder::new(&obj);
+
+    assert_eq!(encoder.len(), 3 + 0xFD);
+    let mut expected = vec![0xFD, 0xFD, 0x00];
+    expected.extend_from_slice(&obj);
+    check_encoder(&mut encoder, &expected);
+}
+
+#[test]
 fn encode_slice_with_elements() {
     // Should have the element chunks, then exhausted.
     let slice = &[TestArray([0x34, 0x12, 0x00, 0x00]), TestArray([0x78, 0x56, 0x00, 0x00])];
@@ -298,6 +331,33 @@ fn encode_slice_with_zero_sized_arrays() {
     let mut encoder = SliceEncoder::without_length_prefix(slice);
 
     check_encoder(&mut encoder, &[]);
+}
+
+#[test]
+fn encode_slice_with_prefix() {
+    // Should have the length prefix chunk, then the element chunks, then exhausted.
+    let slice = &[TestArray([0x34, 0x12, 0x00, 0x00]), TestArray([0x78, 0x56, 0x00, 0x00])];
+    let mut encoder = PrefixedSliceEncoder::new(slice);
+
+    check_encoder(&mut encoder, &[0x02, 0x34, 0x12, 0x00, 0x00, 0x78, 0x56, 0x00, 0x00]);
+}
+
+#[test]
+fn encode_empty_slice_with_prefix() {
+    // Should have a single zero length prefix chunk, then exhausted.
+    let slice: &[TestArray<4>] = &[];
+    let mut encoder = PrefixedSliceEncoder::new(slice);
+
+    check_encoder(&mut encoder, &[0x00]);
+}
+
+#[test]
+fn encode_slice_with_prefix_and_zero_sized_arrays() {
+    // The prefix counts elements, not bytes, even when elements encode to nothing.
+    let slice = &[TestArray([]), TestArray([])];
+    let mut encoder = PrefixedSliceEncoder::new(slice);
+
+    check_encoder(&mut encoder, &[0x02]);
 }
 
 #[test]

--- a/p2p/src/bip152.rs
+++ b/p2p/src/bip152.rs
@@ -11,7 +11,7 @@ use core::convert;
 use arbitrary::{Arbitrary, Unstructured};
 use encoding::{
     ArrayDecoder, ArrayEncoder, CompactSizeDecoder, CompactSizeEncoder, Decoder2, Decoder4,
-    Encoder2, Encoder4, SliceEncoder, VecDecoder,
+    Encoder2, Encoder4, PrefixedSliceEncoder, VecDecoder,
 };
 use hashes::{sha256, siphash24, HashEngine};
 use internals::array::ArrayExt as _;
@@ -229,8 +229,8 @@ pub struct HeaderAndShortIds {
 type HeaderAndShortIdsInnerEncoder<'e> = Encoder4<
     HeaderEncoder<'e>,
     ArrayEncoder<8>,
-    Encoder2<CompactSizeEncoder, SliceEncoder<'e, ShortId>>,
-    Encoder2<CompactSizeEncoder, SliceEncoder<'e, PrefilledTransaction>>,
+    PrefixedSliceEncoder<'e, ShortId>,
+    PrefixedSliceEncoder<'e, PrefilledTransaction>,
 >;
 
 encoding::encoder_newtype! {
@@ -251,14 +251,8 @@ impl encoding::Encode for HeaderAndShortIds {
         HeaderAndShortIdsEncoder::new(Encoder4::new(
             self.header.encoder(),
             ArrayEncoder::without_length_prefix(self.nonce.to_le_bytes()),
-            Encoder2::new(
-                CompactSizeEncoder::new(self.short_ids.len()),
-                SliceEncoder::without_length_prefix(&self.short_ids),
-            ),
-            Encoder2::new(
-                CompactSizeEncoder::new(self.prefilled_txs.len()),
-                SliceEncoder::without_length_prefix(&self.prefilled_txs),
-            ),
+            PrefixedSliceEncoder::new(&self.short_ids),
+            PrefixedSliceEncoder::new(&self.prefilled_txs),
         ))
     }
 }
@@ -475,7 +469,7 @@ encoding::encoder_newtype! {
     pub struct BlockTransactionsRequestEncoder<'e>(
         Encoder2<
             BlockHashEncoder<'e>,
-            Encoder2<CompactSizeEncoder, SliceEncoder<'e, Offset>>
+            PrefixedSliceEncoder<'e, Offset>,
         >
     );
 }
@@ -486,10 +480,7 @@ impl encoding::Encode for BlockTransactionsRequest {
     fn encoder(&self) -> Self::Encoder<'_> {
         BlockTransactionsRequestEncoder::new(Encoder2::new(
             self.block_hash.encoder(),
-            Encoder2::new(
-                CompactSizeEncoder::new(self.offsets.len()),
-                SliceEncoder::without_length_prefix(&self.offsets),
-            ),
+            PrefixedSliceEncoder::new(&self.offsets),
         ))
     }
 }
@@ -529,7 +520,7 @@ encoding::encoder_newtype! {
     pub struct BlockTransactionsEncoder<'e>(
         Encoder2<
             BlockHashEncoder<'e>,
-            Encoder2<CompactSizeEncoder, SliceEncoder<'e, Transaction>>
+            PrefixedSliceEncoder<'e, Transaction>
         >
     );
 }
@@ -543,10 +534,7 @@ impl encoding::Encode for BlockTransactions {
     fn encoder(&self) -> Self::Encoder<'_> {
         BlockTransactionsEncoder::new(Encoder2::new(
             self.block_hash.encoder(),
-            Encoder2::new(
-                CompactSizeEncoder::new(self.transactions.len()),
-                SliceEncoder::without_length_prefix(&self.transactions),
-            ),
+            PrefixedSliceEncoder::new(&self.transactions),
         ))
     }
 }

--- a/p2p/src/merkle_tree.rs
+++ b/p2p/src/merkle_tree.rs
@@ -16,7 +16,7 @@ use alloc::vec::Vec;
 use arbitrary::{Arbitrary, Unstructured};
 use encoding::{
     ArrayDecoder, ArrayEncoder, ByteVecDecoder, CompactSizeEncoder, Decoder2, Decoder3, Encoder2,
-    Encoder3, EncoderStatus, SliceEncoder, VecDecoder,
+    Encoder3, EncoderStatus, PrefixedSliceEncoder, VecDecoder,
 };
 use primitives::block::{self, Block, Checked, Header, HeaderDecoder, HeaderEncoder};
 use primitives::merkle_tree::TxMerkleNode;
@@ -473,7 +473,7 @@ encoding::encoder_newtype! {
     pub struct PartialMerkleTreeEncoder<'e>(
         Encoder3<
             ArrayEncoder<4>,
-            Encoder2<CompactSizeEncoder, SliceEncoder<'e, TxMerkleNode>>,
+            PrefixedSliceEncoder<'e, TxMerkleNode>,
             Encoder2<CompactSizeEncoder, BitVecEncoder>,
         >
     );
@@ -485,10 +485,7 @@ impl encoding::Encode for PartialMerkleTree {
     fn encoder(&self) -> Self::Encoder<'_> {
         PartialMerkleTreeEncoder::new(Encoder3::new(
             ArrayEncoder::without_length_prefix(self.num_transactions.to_le_bytes()),
-            Encoder2::new(
-                CompactSizeEncoder::new(self.hashes.len()),
-                SliceEncoder::without_length_prefix(&self.hashes),
-            ),
+            PrefixedSliceEncoder::new(&self.hashes),
             Encoder2::new(
                 CompactSizeEncoder::new(self.bits.len().div_ceil(8)),
                 BitVecEncoder::new(&self.bits),

--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -13,8 +13,8 @@ use core::{fmt, mem};
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
 use encoding::{
-    self, ArrayDecoder, ArrayEncoder, BytesEncoder, CompactSizeEncoder, Decoder2, Encoder2,
-    EncoderStatus, SliceEncoder, VecDecoder, VecDecoderError,
+    self, ArrayDecoder, ArrayEncoder, BytesEncoder, Decoder2, Encoder2, EncoderStatus,
+    PrefixedSliceEncoder, VecDecoder, VecDecoderError,
 };
 use hashes::{sha256d, HashEngine};
 use primitives::block::{self, Header, HeaderDecoder, HeaderEncoder};
@@ -298,20 +298,17 @@ pub struct InventoryPayload(pub Vec<message_blockdata::Inventory>);
 encoding::encoder_newtype! {
     /// The encoder for an [`InventoryPayload`].
     #[derive(Debug, Clone)]
-    pub struct InventoryPayloadEncoder<'e>(Encoder2<CompactSizeEncoder, SliceEncoder<'e, message_blockdata::Inventory>>);
+    pub struct InventoryPayloadEncoder<'e>(PrefixedSliceEncoder<'e, message_blockdata::Inventory>);
 }
 
 impl encoding::Encode for InventoryPayload {
     type Encoder<'e>
-        = Encoder2<CompactSizeEncoder, SliceEncoder<'e, message_blockdata::Inventory>>
+        = InventoryPayloadEncoder<'e>
     where
         Self: 'e;
 
     fn encoder(&self) -> Self::Encoder<'_> {
-        Encoder2::new(
-            CompactSizeEncoder::new(self.0.len()),
-            SliceEncoder::without_length_prefix(&self.0),
-        )
+        InventoryPayloadEncoder::new(PrefixedSliceEncoder::new(&self.0))
     }
 }
 
@@ -340,17 +337,14 @@ pub struct AddrPayload(pub Vec<AddrV1Message>);
 encoding::encoder_newtype! {
     /// The encoder for an [`AddrPayload`].
     #[derive(Debug, Clone)]
-    pub struct AddrPayloadEncoder<'e>(Encoder2<CompactSizeEncoder, SliceEncoder<'e, AddrV1Message>>);
+    pub struct AddrPayloadEncoder<'e>(PrefixedSliceEncoder<'e, AddrV1Message>);
 }
 
 impl encoding::Encode for AddrPayload {
     type Encoder<'e> = AddrPayloadEncoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
-        AddrPayloadEncoder::new(Encoder2::new(
-            CompactSizeEncoder::new(self.0.len()),
-            SliceEncoder::without_length_prefix(&self.0),
-        ))
+        AddrPayloadEncoder::new(PrefixedSliceEncoder::new(&self.0))
     }
 }
 
@@ -379,20 +373,17 @@ pub struct AddrV2Payload(pub Vec<AddrV2Message>);
 encoding::encoder_newtype! {
     /// The encoder for an [`AddrV2Payload`].
     #[derive(Debug, Clone)]
-    pub struct AddrV2PayloadEncoder<'e>(Encoder2<CompactSizeEncoder, SliceEncoder<'e, AddrV2Message>>);
+    pub struct AddrV2PayloadEncoder<'e>(PrefixedSliceEncoder<'e, AddrV2Message>);
 }
 
 impl encoding::Encode for AddrV2Payload {
     type Encoder<'e>
-        = Encoder2<CompactSizeEncoder, SliceEncoder<'e, AddrV2Message>>
+        = AddrV2PayloadEncoder<'e>
     where
         Self: 'e;
 
     fn encoder(&self) -> Self::Encoder<'_> {
-        Encoder2::new(
-            CompactSizeEncoder::new(self.0.len()),
-            SliceEncoder::without_length_prefix(&self.0),
-        )
+        AddrV2PayloadEncoder::new(PrefixedSliceEncoder::new(&self.0))
     }
 }
 
@@ -1603,17 +1594,14 @@ impl HeadersMessage {
 encoding::encoder_newtype! {
     /// The encoder type for a [`HeadersMessage`].
     #[derive(Debug, Clone)]
-    pub struct HeadersMessageEncoder<'e>(Encoder2<CompactSizeEncoder, SliceEncoder<'e, NetworkHeader>>);
+    pub struct HeadersMessageEncoder<'e>(PrefixedSliceEncoder<'e, NetworkHeader>);
 }
 
 impl encoding::Encode for HeadersMessage {
     type Encoder<'e> = HeadersMessageEncoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
-        HeadersMessageEncoder::new(Encoder2::new(
-            CompactSizeEncoder::new(self.0.len()),
-            SliceEncoder::without_length_prefix(&self.0),
-        ))
+        HeadersMessageEncoder::new(PrefixedSliceEncoder::new(&self.0))
     }
 }
 

--- a/p2p/src/message_blockdata.rs
+++ b/p2p/src/message_blockdata.rs
@@ -10,8 +10,8 @@ use alloc::vec::Vec;
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
 use encoding::{
-    ArrayDecoder, ArrayEncoder, CompactSizeEncoder, Decoder2, Decoder3, Encoder2, Encoder3,
-    SliceEncoder, VecDecoder,
+    ArrayDecoder, ArrayEncoder, Decoder2, Decoder3, Encoder2, Encoder3, PrefixedSliceEncoder,
+    VecDecoder,
 };
 use primitives::block::{BlockHashDecoder, BlockHashEncoder};
 use primitives::transaction::{Txid, Wtxid};
@@ -179,7 +179,7 @@ impl From<BlockLocator> for Vec<BlockHash> {
     fn from(locator: BlockLocator) -> Self { locator.0 }
 }
 
-type BlockLocatorInnerEncoder<'e> = Encoder2<CompactSizeEncoder, SliceEncoder<'e, BlockHash>>;
+type BlockLocatorInnerEncoder<'e> = PrefixedSliceEncoder<'e, BlockHash>;
 
 encoding::encoder_newtype! {
     /// The encoder for [`BlockLocator`].
@@ -191,10 +191,7 @@ impl encoding::Encode for BlockLocator {
     type Encoder<'e> = BlockLocatorEncoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
-        BlockLocatorEncoder::new(Encoder2::new(
-            CompactSizeEncoder::new(self.0.len()),
-            SliceEncoder::without_length_prefix(&self.0),
-        ))
+        BlockLocatorEncoder::new(PrefixedSliceEncoder::new(&self.0))
     }
 }
 

--- a/p2p/src/message_bloom.rs
+++ b/p2p/src/message_bloom.rs
@@ -9,8 +9,7 @@ use alloc::vec::Vec;
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
 use encoding::{
-    ArrayDecoder, ArrayEncoder, ByteVecDecoder, BytesEncoder, CompactSizeEncoder, Decoder4,
-    Encoder2, Encoder3,
+    ArrayDecoder, ArrayEncoder, ByteVecDecoder, Decoder4, Encoder2, Encoder3, PrefixedBytesEncoder,
 };
 
 #[rustfmt::skip]                // Keep public re-exports separate.
@@ -35,7 +34,7 @@ encoding::encoder_newtype_exact! {
     #[derive(Debug, Clone)]
     pub struct FilterLoadEncoder<'e>(
         Encoder2<
-            Encoder2<CompactSizeEncoder, BytesEncoder<'e>>,
+            PrefixedBytesEncoder<'e>,
             Encoder3<
                 ArrayEncoder<4>,
                 ArrayEncoder<4>,
@@ -50,10 +49,7 @@ impl encoding::Encode for FilterLoad {
 
     fn encoder(&self) -> Self::Encoder<'_> {
         FilterLoadEncoder::new(Encoder2::new(
-            Encoder2::new(
-                CompactSizeEncoder::new(self.filter.len()),
-                BytesEncoder::without_length_prefix(&self.filter),
-            ),
+            PrefixedBytesEncoder::new(&self.filter),
             Encoder3::new(
                 ArrayEncoder::without_length_prefix(self.hash_funcs.to_le_bytes()),
                 ArrayEncoder::without_length_prefix(self.tweak.to_le_bytes()),
@@ -159,17 +155,14 @@ pub struct FilterAdd {
 encoding::encoder_newtype_exact! {
     /// The encoder of the [`FilterAdd`] message.
     #[derive(Debug, Clone)]
-    pub struct FilterAddEncoder<'e>(Encoder2<CompactSizeEncoder, BytesEncoder<'e>>);
+    pub struct FilterAddEncoder<'e>(PrefixedBytesEncoder<'e>);
 }
 
 impl encoding::Encode for FilterAdd {
     type Encoder<'e> = FilterAddEncoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
-        FilterAddEncoder::new(Encoder2::new(
-            CompactSizeEncoder::new(self.data.len()),
-            BytesEncoder::without_length_prefix(&self.data),
-        ))
+        FilterAddEncoder::new(PrefixedBytesEncoder::new(&self.data))
     }
 }
 

--- a/p2p/src/message_filter.rs
+++ b/p2p/src/message_filter.rs
@@ -9,8 +9,8 @@ use alloc::vec::Vec;
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
 use encoding::{
-    ArrayDecoder, ArrayEncoder, ByteVecDecoder, BytesEncoder, CompactSizeEncoder, Decoder2,
-    Decoder3, Decoder4, Encoder2, Encoder3, Encoder4, SliceEncoder, VecDecoder,
+    ArrayDecoder, ArrayEncoder, ByteVecDecoder, Decoder2, Decoder3, Decoder4, Encoder2, Encoder3,
+    Encoder4, PrefixedBytesEncoder, PrefixedSliceEncoder, VecDecoder,
 };
 use hashes::{sha256d, HashEngine};
 use primitives::block::{BlockHashDecoder, BlockHashEncoder};
@@ -191,7 +191,7 @@ encoding::encoder_newtype_exact! {
         Encoder3<
             ArrayEncoder<1>,
             BlockHashEncoder<'e>,
-            Encoder2<CompactSizeEncoder, BytesEncoder<'e>>,
+            PrefixedBytesEncoder<'e>,
         >
     );
 }
@@ -206,10 +206,7 @@ impl encoding::Encode for CFilter {
         CFilterEncoder::new(Encoder3::new(
             ArrayEncoder::without_length_prefix(self.filter_type.to_le_bytes()),
             self.block_hash.encoder(),
-            Encoder2::new(
-                CompactSizeEncoder::new(self.filter.len()),
-                BytesEncoder::without_length_prefix(&self.filter),
-            ),
+            PrefixedBytesEncoder::new(&self.filter),
         ))
     }
 }
@@ -302,7 +299,7 @@ encoding::encoder_newtype! {
             ArrayEncoder<1>,
             BlockHashEncoder<'e>,
             FilterHeaderEncoder<'e>,
-            Encoder2<CompactSizeEncoder, SliceEncoder<'e, FilterHash>>
+            PrefixedSliceEncoder<'e, FilterHash>
         >
     );
 }
@@ -315,10 +312,7 @@ impl encoding::Encode for CFHeaders {
             ArrayEncoder::without_length_prefix(self.filter_type.to_le_bytes()),
             self.stop_hash.encoder(),
             self.previous_filter_header.encoder(),
-            Encoder2::new(
-                CompactSizeEncoder::new(self.filter_hashes.len()),
-                SliceEncoder::without_length_prefix(&self.filter_hashes),
-            ),
+            PrefixedSliceEncoder::new(&self.filter_hashes),
         ))
     }
 }
@@ -415,7 +409,7 @@ encoding::encoder_newtype! {
         Encoder3<
             ArrayEncoder<1>,
             BlockHashEncoder<'e>,
-            Encoder2<CompactSizeEncoder, SliceEncoder<'e, FilterHeader>>
+            PrefixedSliceEncoder<'e, FilterHeader>
         >
     );
 }
@@ -430,10 +424,7 @@ impl encoding::Encode for CFCheckpt {
         CFCheckptEncoder::new(Encoder3::new(
             ArrayEncoder::without_length_prefix(self.filter_type.to_le_bytes()),
             self.stop_hash.encoder(),
-            Encoder2::new(
-                CompactSizeEncoder::new(self.filter_headers.len()),
-                SliceEncoder::without_length_prefix(&self.filter_headers),
-            ),
+            PrefixedSliceEncoder::new(&self.filter_headers),
         ))
     }
 }

--- a/p2p/src/message_network.rs
+++ b/p2p/src/message_network.rs
@@ -13,8 +13,7 @@ use alloc::vec::Vec;
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
 use encoding::{
-    ArrayDecoder, ArrayEncoder, ByteVecDecoder, BytesEncoder, CompactSizeEncoder, Decoder4,
-    Encoder2, Encoder4,
+    ArrayDecoder, ArrayEncoder, ByteVecDecoder, Decoder4, Encoder4, PrefixedBytesEncoder,
 };
 use hashes::sha256d;
 
@@ -199,17 +198,14 @@ pub struct UserAgent {
 encoding::encoder_newtype_exact! {
     /// The encoder for a [`UserAgent`] string.
     #[derive(Debug, Clone)]
-    pub struct UserAgentEncoder<'e>(Encoder2<CompactSizeEncoder, BytesEncoder<'e>>);
+    pub struct UserAgentEncoder<'e>(PrefixedBytesEncoder<'e>);
 }
 
 impl encoding::Encode for UserAgent {
     type Encoder<'e> = UserAgentEncoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
-        UserAgentEncoder::new(Encoder2::new(
-            CompactSizeEncoder::new(self.user_agent.len()),
-            BytesEncoder::without_length_prefix(self.user_agent.as_bytes()),
-        ))
+        UserAgentEncoder::new(PrefixedBytesEncoder::new(self.user_agent.as_bytes()))
     }
 }
 
@@ -470,9 +466,9 @@ encoding::encoder_newtype_exact! {
     #[derive(Debug, Clone)]
     pub struct RejectEncoder<'e>(
         Encoder4<
-            Encoder2<CompactSizeEncoder, BytesEncoder<'e>>,
+            PrefixedBytesEncoder<'e>,
             RejectReasonEncoder<'e>,
-            Encoder2<CompactSizeEncoder, BytesEncoder<'e>>,
+            PrefixedBytesEncoder<'e>,
             ArrayEncoder<32>,
         >
     );
@@ -483,15 +479,9 @@ impl encoding::Encode for Reject {
 
     fn encoder(&self) -> Self::Encoder<'_> {
         RejectEncoder::new(Encoder4::new(
-            Encoder2::new(
-                CompactSizeEncoder::new(self.message.len()),
-                BytesEncoder::without_length_prefix(self.message.as_bytes()),
-            ),
+            PrefixedBytesEncoder::new(self.message.as_bytes()),
             self.ccode.encoder(),
-            Encoder2::new(
-                CompactSizeEncoder::new(self.reason.len()),
-                BytesEncoder::without_length_prefix(self.reason.as_bytes()),
-            ),
+            PrefixedBytesEncoder::new(self.reason.as_bytes()),
             ArrayEncoder::without_length_prefix(self.hash.to_byte_array()),
         ))
     }
@@ -566,18 +556,13 @@ impl Alert {
 encoding::encoder_newtype_exact! {
     /// The encoder type for an [`Alert`] message.
     #[derive(Debug, Clone)]
-    pub struct AlertEncoder<'e>(Encoder2<CompactSizeEncoder, BytesEncoder<'e>>);
+    pub struct AlertEncoder<'e>(PrefixedBytesEncoder<'e>);
 }
 
 impl encoding::Encode for Alert {
     type Encoder<'e> = AlertEncoder<'e>;
 
-    fn encoder(&self) -> Self::Encoder<'_> {
-        AlertEncoder::new(Encoder2::new(
-            CompactSizeEncoder::new(self.0.len()),
-            BytesEncoder::without_length_prefix(&self.0),
-        ))
-    }
+    fn encoder(&self) -> Self::Encoder<'_> { AlertEncoder::new(PrefixedBytesEncoder::new(&self.0)) }
 }
 
 type AlertInnerDecoder = ByteVecDecoder;

--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -15,7 +15,7 @@ use core::marker::PhantomData;
 use arbitrary::{Arbitrary, Unstructured};
 use encoding::{ArrayDecoder, Decoder6};
 #[cfg(feature = "alloc")]
-use encoding::{CompactSizeEncoder, Decoder2, Encoder2, SliceEncoder, VecDecoder};
+use encoding::{Decoder2, Encoder2, PrefixedSliceEncoder, VecDecoder};
 use hashes::sha256d;
 #[cfg(feature = "alloc")]
 use hashes::HashEngine as _;
@@ -336,10 +336,7 @@ where
     fn encoder(&self) -> Self::Encoder<'_> {
         BlockEncoder::new(Encoder2::new(
             self.header.encoder(),
-            Encoder2::new(
-                CompactSizeEncoder::new(self.transactions.len()),
-                SliceEncoder::without_length_prefix(&self.transactions),
-            ),
+            PrefixedSliceEncoder::new(&self.transactions),
         ))
     }
 }
@@ -354,7 +351,7 @@ encoding::encoder_newtype! {
     /// The encoder for the [`Block`] type.
     #[derive(Debug, Clone)]
     pub struct BlockEncoder<'e>(
-        Encoder2<HeaderEncoder<'e>, Encoder2<CompactSizeEncoder, SliceEncoder<'e, Transaction>>>
+        Encoder2<HeaderEncoder<'e>, PrefixedSliceEncoder<'e, Transaction>>
     );
 }
 

--- a/primitives/src/script/borrowed.rs
+++ b/primitives/src/script/borrowed.rs
@@ -10,7 +10,7 @@ use core::ops::{
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
-use encoding::{BytesEncoder, CompactSizeEncoder, Encode, Encoder2};
+use encoding::{Encode, PrefixedBytesEncoder};
 
 use super::{ScriptBuf, P2A_PROGRAM};
 use crate::opcodes::all::{OP_CHECKSIG, OP_DUP, OP_EQUAL, OP_EQUALVERIFY, OP_HASH160, OP_RETURN};
@@ -322,17 +322,14 @@ impl<T> Encode for Script<T> {
         Self: 'e;
 
     fn encoder(&self) -> Self::Encoder<'_> {
-        ScriptEncoder::new(Encoder2::new(
-            CompactSizeEncoder::new(self.as_bytes().len()),
-            BytesEncoder::without_length_prefix(self.as_bytes()),
-        ))
+        ScriptEncoder::new(PrefixedBytesEncoder::new(self.as_bytes()))
     }
 }
 
 encoding::encoder_newtype_exact! {
     /// The encoder for the [`Script<T>`] type.
     #[derive(Debug, Clone)]
-    pub struct ScriptEncoder<'e>(Encoder2<CompactSizeEncoder, BytesEncoder<'e>>);
+    pub struct ScriptEncoder<'e>(PrefixedBytesEncoder<'e>);
 }
 
 #[cfg(feature = "arbitrary")]

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -22,8 +22,8 @@ use encoding::FromHexError;
 use encoding::{ArrayEncoder, BytesEncoder, Encoder2};
 #[cfg(feature = "alloc")]
 use encoding::{
-    CompactSizeEncoder, Decoder2, Decoder3, DecoderStatus, Encode as _, Encoder3, Encoder6,
-    EncoderStatus, SliceEncoder, VecDecoder,
+    Decoder2, Decoder3, DecoderStatus, Encode as _, Encoder3, Encoder6, EncoderStatus,
+    PrefixedSliceEncoder, VecDecoder,
 };
 #[cfg(feature = "alloc")]
 use hashes::sha256d;
@@ -379,14 +379,8 @@ impl encoding::Encode for Transaction {
 
     fn encoder(&self) -> Self::Encoder<'_> {
         let version = self.version.encoder();
-        let inputs = Encoder2::new(
-            CompactSizeEncoder::new(self.inputs.len()),
-            SliceEncoder::without_length_prefix(self.inputs.as_ref()),
-        );
-        let outputs = Encoder2::new(
-            CompactSizeEncoder::new(self.outputs.len()),
-            SliceEncoder::without_length_prefix(self.outputs.as_ref()),
-        );
+        let inputs = PrefixedSliceEncoder::new(self.inputs.as_ref());
+        let outputs = PrefixedSliceEncoder::new(self.outputs.as_ref());
         let lock_time = self.lock_time.encoder();
 
         if self.uses_segwit_serialization() {
@@ -415,8 +409,8 @@ impl encoding::Decode for Transaction {
 type TransactionEncoderInner<'e> = Encoder6<
     VersionEncoder<'e>,
     Option<ArrayEncoder<2>>,
-    Encoder2<CompactSizeEncoder, SliceEncoder<'e, TxIn>>,
-    Encoder2<CompactSizeEncoder, SliceEncoder<'e, TxOut>>,
+    PrefixedSliceEncoder<'e, TxIn>,
+    PrefixedSliceEncoder<'e, TxOut>,
     Option<WitnessesEncoder<'e>>,
     LockTimeEncoder<'e>,
 >;


### PR DESCRIPTION
The BytesEncoder and SliceEncoder types currently write out their contents without any length prefix, using a without_length_prefix constructor. When users need a length prefix, they must instead construct an Encoder2<CompactSizeEncoder, _> to prefix the length. Instead, we can provide prefixed encoders that encode a length prefix as a compact size automatically, simplifying the API for users.

- Patch 1 adds the prefixed encoders
- Patch 2 adds tests to cover mutants.
- Patch 3 updates the API files.
- Patch 4 replaces uses of Encoder2<CompactSizeEncoder, Bytes/SliceEncoder> with the corresponding prefixed encoder type in all of the crates.

Closes #6467