### PR TITLE
Adjust Script::witness_version doccomment

### DIFF
--- a/primitives/src/script/borrowed.rs
+++ b/primitives/src/script/borrowed.rs
@@ -187,7 +187,7 @@ impl<T> Script<T> {
     #[deprecated(since = "1.0.0-rc.0", note = "use `format!(\"{var:x}\")` instead")]
     pub fn to_hex(&self) -> alloc::string::String { alloc::format!("{:x}", self) }
 
-    /// Returns witness version of the script, if any, assuming the script is a `scriptPubkey`.
+    /// Returns witness version of the script, if any.
     ///
     /// # Returns
     ///


### PR DESCRIPTION
The doccomment for witness_version starts with "Returns witness version of the script, if any, assuming the script is a scriptPubkey". The "assuming" clause can be dropped since the type system now enforces that this is either a scriptPubKey or a redeemScript.

Remove "assuming the script is a scriptPubkey" from Script::witness_version docs.