### PR TITLE
Remove hex dep from internals

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -170,7 +170,6 @@ name = "bitcoin-internals"
 version = "0.5.0"
 dependencies = [
  "bincode",
- "hex-conservative 1.1.0",
  "serde",
  "serde_json",
 ]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -169,7 +169,6 @@ name = "bitcoin-internals"
 version = "0.5.0"
 dependencies = [
  "bincode",
- "hex-conservative 1.1.0",
  "serde",
  "serde_json",
 ]

--- a/addresses/Cargo.toml
+++ b/addresses/Cargo.toml
@@ -20,7 +20,7 @@ alloc = ["crypto/alloc", "internals/alloc", "primitives/alloc", "taproot_primiti
 
 [dependencies]
 crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.2.0", default-features = false, features = [] }
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0", features = ["hex"] }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
 taproot_primitives = { package = "bitcoin-taproot-primitives", path = "../taproot-primitives", version = "0.1.0", default-features = false, features = [] }
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.102.0", default-features = false, features = ["hex"] }
 

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -34,7 +34,7 @@ hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.0.0", de
 key-expression = { package = "bitcoin-key-expression", path = "../key_expression", version = "0.1.0", default-features = false, features = ["alloc"] }
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0", default-features = false, features = ["alloc", "hex"] }
 hex = { package = "hex-conservative", version = "1.1.0", default-features = false, features = ["alloc"] }
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0", features = ["alloc", "hex"] }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0", features = ["alloc"] }
 io = { package = "bitcoin-io", path = "../io", version = "0.5.0", default-features = false, features = ["alloc", "hashes"] }
 network = { package = "bitcoin-network-kind", path = "../network", version = "1.0.0", default-features = false, features = ["alloc"]}
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.102.0", default-features = false, features = ["alloc", "hex"] }

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -20,12 +20,12 @@ rand = ["secp256k1/rand"]
 alloc = ["base58/alloc", "hashes/alloc", "hex?/alloc", "internals/alloc", "network/alloc", "primitives/alloc", "secp256k1/alloc", "serde?/alloc"]
 serde = ["dep:serde", "hashes/serde", "internals/serde", "secp256k1/serde"]
 arbitrary = ["dep:arbitrary", "secp256k1/arbitrary"]
-hex = ["dep:hex", "hashes/hex", "internals/hex", "primitives/hex"]
+hex = ["dep:hex", "hashes/hex", "primitives/hex"]
 
 [dependencies]
 base58 = { package = "base58ck", path = "../base58", version = "0.4.0", default-features = false }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.0.0", default-features = false, features = ["hex"] }
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0", features = ["hex"] }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
 network = { package = "bitcoin-network-kind", path = "../network", version = "1.0.0", default-features = false }
 # This is a temporary dep for the sake of PushBytes impls. This should not be retained for crypto 1.0.
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.102.0", default-features = false, features = [] }

--- a/internals/Cargo.toml
+++ b/internals/Cargo.toml
@@ -16,13 +16,12 @@ exclude = ["api", "tests", "contrib"]
 
 [features]
 default = []
-std = ["alloc", "hex?/std"]
-alloc = ["hex?/alloc"]
+std = ["alloc"]
+alloc = []
 
 test-serde = ["serde", "dep:serde_json", "dep:bincode"]
 
 [dependencies]
-hex = { package = "hex-conservative", version = "1.1.0", default-features = false, optional = true }
 serde = { version = "1.0.195", default-features = false, optional = true }
 
 # Behind the test-serde feature.

--- a/key_expression/Cargo.toml
+++ b/key_expression/Cargo.toml
@@ -25,7 +25,7 @@ base58 = { package = "base58ck", path = "../base58", version = "0.4.0", default-
 crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.2.0", default-features = false }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.0.0", default-features = false, features = ["hex"] }
 hex = { package = "hex-conservative", version = "1.1.0", default-features = false, features = ["alloc"] }
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0", features = ["hex"] }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
 network = { package = "bitcoin-network-kind", path = "../network", version = "1.0.0", default-features = false }
 secp256k1 = { version = "0.32.0-beta.2", default-features = false }
 

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -19,7 +19,7 @@ std = ["alloc", "hashes/std", "hex?/std", "internals/std", "units/std"]
 alloc = ["hashes/alloc", "hex?/alloc", "internals/alloc", "units/alloc"]
 serde = ["dep:serde", "encoding/serde", "hashes/serde", "internals/serde", "units/serde", "alloc", "hex"]
 arbitrary = ["dep:arbitrary", "units/arbitrary"]
-hex = ["dep:hex", "hashes/hex", "internals/hex", "encoding/hex"]
+hex = ["dep:hex", "hashes/hex", "encoding/hex"]
 
 [dependencies]
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0", default-features = false }


### PR DESCRIPTION
The `hex` dep is no longer used in `internals` (since #6339).

Remove it.