### PR TITLE
Release tracking PR: `internals 0.6.0`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -27,7 +27,7 @@ dependencies = [
 name = "base58ck"
 version = "0.4.0"
 dependencies = [
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "bitcoin_hashes 1.0.0",
  "hex-conservative 1.1.0",
 ]
@@ -84,7 +84,7 @@ dependencies = [
  "bitcoin-addresses",
  "bitcoin-consensus-encoding 1.0.0",
  "bitcoin-crypto",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "bitcoin-io 0.5.0",
  "bitcoin-key-expression",
  "bitcoin-network-kind",
@@ -105,7 +105,7 @@ name = "bitcoin-addresses"
 version = "0.0.0"
 dependencies = [
  "bitcoin-crypto",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "bitcoin-primitives",
  "bitcoin-taproot-primitives",
 ]
@@ -118,7 +118,7 @@ version = "0.0.0"
 name = "bitcoin-consensus-encoding"
 version = "1.0.0"
 dependencies = [
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "hex-conservative 1.1.0",
  "serde",
  "serde_json",
@@ -130,7 +130,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2d6094e2a1ba3c93b5a596fe5a10d1a10c3c6e06785cde89f693a044c01aa40"
 dependencies = [
- "bitcoin-internals 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin-internals 0.5.0",
 ]
 
 [[package]]
@@ -139,7 +139,7 @@ version = "0.2.0"
 dependencies = [
  "arbitrary",
  "base58ck 0.4.0",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
  "bitcoin_hashes 1.0.0",
@@ -168,19 +168,19 @@ dependencies = [
 [[package]]
 name = "bitcoin-internals"
 version = "0.5.0"
-dependencies = [
- "bincode",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "bitcoin-internals"
-version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a30a22d1f112dde8e16be7b45c63645dc165cef254f835b3e1e9553e485cfa64"
 dependencies = [
  "hex-conservative 0.3.0",
+]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.6.0"
+dependencies = [
+ "bincode",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -197,7 +197,7 @@ name = "bitcoin-io"
 version = "0.5.0"
 dependencies = [
  "bitcoin-consensus-encoding 1.0.0",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "bitcoin_hashes 1.0.0",
 ]
 
@@ -209,7 +209,7 @@ dependencies = [
  "base58ck 0.4.0",
  "bincode",
  "bitcoin-crypto",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "bitcoin-network-kind",
  "bitcoin_hashes 1.0.0",
  "hex-conservative 1.1.0",
@@ -223,7 +223,7 @@ name = "bitcoin-network-kind"
 version = "1.0.0"
 dependencies = [
  "arbitrary",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "serde",
  "serde_json",
  "serde_test",
@@ -235,7 +235,7 @@ version = "0.1.0"
 dependencies = [
  "arbitrary",
  "bitcoin-consensus-encoding 1.0.0",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
  "bitcoin-units 0.5.0",
@@ -251,7 +251,7 @@ dependencies = [
  "arbitrary",
  "bincode",
  "bitcoin-consensus-encoding 1.0.0",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "bitcoin-units 0.5.0",
  "bitcoin_hashes 1.0.0",
  "hex-conservative 1.1.0",
@@ -271,7 +271,7 @@ version = "0.1.0"
 dependencies = [
  "arbitrary",
  "bitcoin-crypto",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "bitcoin_hashes 1.0.0",
  "secp256k1 0.32.0-beta.2",
  "serde",
@@ -294,7 +294,7 @@ dependencies = [
  "arbitrary",
  "bincode",
  "bitcoin-consensus-encoding 1.0.0",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "serde",
  "serde_json",
  "serde_test",
@@ -326,7 +326,7 @@ version = "1.0.0"
 dependencies = [
  "arbitrary",
  "bitcoin-consensus-encoding 1.0.0",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "cpufeatures",
  "hex-conservative 1.1.0",
  "serde",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -27,7 +27,7 @@ dependencies = [
 name = "base58ck"
 version = "0.4.0"
 dependencies = [
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "bitcoin_hashes 1.0.0",
  "hex-conservative 1.1.0",
 ]
@@ -83,7 +83,7 @@ dependencies = [
  "bitcoin-addresses",
  "bitcoin-consensus-encoding 1.0.0",
  "bitcoin-crypto",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "bitcoin-io 0.5.0",
  "bitcoin-key-expression",
  "bitcoin-network-kind",
@@ -104,7 +104,7 @@ name = "bitcoin-addresses"
 version = "0.0.0"
 dependencies = [
  "bitcoin-crypto",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "bitcoin-primitives",
  "bitcoin-taproot-primitives",
 ]
@@ -117,7 +117,7 @@ version = "0.0.0"
 name = "bitcoin-consensus-encoding"
 version = "1.0.0"
 dependencies = [
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "hex-conservative 1.1.0",
  "serde",
  "serde_json",
@@ -129,7 +129,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2d6094e2a1ba3c93b5a596fe5a10d1a10c3c6e06785cde89f693a044c01aa40"
 dependencies = [
- "bitcoin-internals 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin-internals 0.5.0",
 ]
 
 [[package]]
@@ -138,7 +138,7 @@ version = "0.2.0"
 dependencies = [
  "arbitrary",
  "base58ck 0.4.0",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
  "bitcoin_hashes 1.0.0",
@@ -167,19 +167,19 @@ dependencies = [
 [[package]]
 name = "bitcoin-internals"
 version = "0.5.0"
-dependencies = [
- "bincode",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "bitcoin-internals"
-version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a30a22d1f112dde8e16be7b45c63645dc165cef254f835b3e1e9553e485cfa64"
 dependencies = [
  "hex-conservative 0.3.2",
+]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.6.0"
+dependencies = [
+ "bincode",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -196,7 +196,7 @@ name = "bitcoin-io"
 version = "0.5.0"
 dependencies = [
  "bitcoin-consensus-encoding 1.0.0",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "bitcoin_hashes 1.0.0",
 ]
 
@@ -208,7 +208,7 @@ dependencies = [
  "base58ck 0.4.0",
  "bincode",
  "bitcoin-crypto",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "bitcoin-network-kind",
  "bitcoin_hashes 1.0.0",
  "hex-conservative 1.1.0",
@@ -222,7 +222,7 @@ name = "bitcoin-network-kind"
 version = "1.0.0"
 dependencies = [
  "arbitrary",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "serde",
  "serde_json",
  "serde_test",
@@ -234,7 +234,7 @@ version = "0.1.0"
 dependencies = [
  "arbitrary",
  "bitcoin-consensus-encoding 1.0.0",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
  "bitcoin-units 0.5.0",
@@ -250,7 +250,7 @@ dependencies = [
  "arbitrary",
  "bincode",
  "bitcoin-consensus-encoding 1.0.0",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "bitcoin-units 0.5.0",
  "bitcoin_hashes 1.0.0",
  "hex-conservative 1.1.0",
@@ -264,7 +264,7 @@ version = "0.1.0"
 dependencies = [
  "arbitrary",
  "bitcoin-crypto",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "bitcoin_hashes 1.0.0",
  "secp256k1 0.32.0-beta.2",
  "serde",
@@ -287,7 +287,7 @@ dependencies = [
  "arbitrary",
  "bincode",
  "bitcoin-consensus-encoding 1.0.0",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "serde",
  "serde_json",
  "serde_test",
@@ -310,7 +310,7 @@ version = "1.0.0"
 dependencies = [
  "arbitrary",
  "bitcoin-consensus-encoding 1.0.0",
- "bitcoin-internals 0.5.0",
+ "bitcoin-internals 0.6.0",
  "cpufeatures",
  "hex-conservative 1.1.0",
  "serde",

--- a/addresses/Cargo.toml
+++ b/addresses/Cargo.toml
@@ -20,7 +20,7 @@ alloc = ["crypto/alloc", "internals/alloc", "primitives/alloc", "taproot_primiti
 
 [dependencies]
 crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.2.0", default-features = false, features = [] }
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
 taproot_primitives = { package = "bitcoin-taproot-primitives", path = "../taproot-primitives", version = "0.1.0", default-features = false, features = [] }
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.102.0", default-features = false, features = ["hex"] }
 

--- a/base58/Cargo.toml
+++ b/base58/Cargo.toml
@@ -20,7 +20,7 @@ alloc = ["hashes/alloc", "internals/alloc"]
 
 [dependencies]
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.0.0", default-features = false }
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
 
 [dev-dependencies]
 hex = { package = "hex-conservative", version = "1.1.0" }

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -34,7 +34,7 @@ hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.0.0", de
 key-expression = { package = "bitcoin-key-expression", path = "../key_expression", version = "0.1.0", default-features = false, features = ["alloc"] }
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0", default-features = false, features = ["alloc", "hex"] }
 hex = { package = "hex-conservative", version = "1.1.0", default-features = false, features = ["alloc"] }
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0", features = ["alloc"] }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0", features = ["alloc"] }
 io = { package = "bitcoin-io", path = "../io", version = "0.5.0", default-features = false, features = ["alloc", "hashes"] }
 network = { package = "bitcoin-network-kind", path = "../network", version = "1.0.0", default-features = false, features = ["alloc"]}
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.102.0", default-features = false, features = ["alloc", "hex"] }

--- a/consensus_encoding/Cargo.toml
+++ b/consensus_encoding/Cargo.toml
@@ -21,7 +21,7 @@ alloc = ["internals/alloc", "hex?/alloc", "serde?/alloc"]
 serde = ["alloc", "hex", "dep:serde"]
 
 [dependencies]
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
 
 hex = { package = "hex-conservative", version = "1.1.0", default-features = false, features = [], optional = true }
 serde = { version = "1.0.195", default-features = false, features = ["derive"], optional = true }

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -25,7 +25,7 @@ hex = ["dep:hex", "hashes/hex", "primitives/hex"]
 [dependencies]
 base58 = { package = "base58ck", path = "../base58", version = "0.4.0", default-features = false }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.0.0", default-features = false, features = ["hex"] }
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
 network = { package = "bitcoin-network-kind", path = "../network", version = "1.0.0", default-features = false }
 # This is a temporary dep for the sake of PushBytes impls. This should not be retained for crypto 1.0.
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.102.0", default-features = false, features = [] }

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -23,7 +23,7 @@ serde = ["dep:serde", "hex"]
 small-hash = []
 
 [dependencies]
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0", default-features = false }
 
 arbitrary = { version = "1.4.1", optional = true}

--- a/internals/CHANGELOG.md
+++ b/internals/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-07-07
+
+### Deletions
+
+- Remove unused or single-use types [#6339](https://github.com/rust-bitcoin/rust-bitcoin/pull/6339)
+- Remove the now-unused `hex` dependency [#6490](https://github.com/rust-bitcoin/rust-bitcoin/pull/6490)
+- Remove `internals::compact_size` module [#5374](https://github.com/rust-bitcoin/rust-bitcoin/pull/5374)
+- Remove the unstable `hex-conservative` dependency [#6148](https://github.com/rust-bitcoin/rust-bitcoin/pull/6148)
+- Remove `macros` module [#6340](https://github.com/rust-bitcoin/rust-bitcoin/pull/6340)
+- Move `ToU64` to `bitcoin` [#6362](https://github.com/rust-bitcoin/rust-bitcoin/pull/6362)
+
+### Improvements
+
+- Implement `Serialize`/`Deserialize` for `ArrayVec` [#6099](https://github.com/rust-bitcoin/rust-bitcoin/pull/6099)
+- Implement `ArrayVec::try_push` [#6193](https://github.com/rust-bitcoin/rust-bitcoin/pull/6193)
+- Add `spare_capacity_mut` and `set_len` to `ArrayVec` [#6235](https://github.com/rust-bitcoin/rust-bitcoin/pull/6235)
+
 ## [0.5.0] - 2025-12-05
 
 - Remove `doc_auto_cfg` [#5162](https://github.com/rust-bitcoin/rust-bitcoin/pull/5162)

--- a/internals/Cargo.toml
+++ b/internals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-internals"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>", "The Rust Bitcoin developers"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"

--- a/io/Cargo.toml
+++ b/io/Cargo.toml
@@ -20,7 +20,7 @@ std = ["alloc", "encoding/std", "hashes?/std", "internals/std"]
 alloc = ["encoding/alloc", "hashes?/alloc", "internals/alloc"]
 
 [dependencies]
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0", default-features = false }
 
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.0.0", default-features = false, optional = true }

--- a/key_expression/Cargo.toml
+++ b/key_expression/Cargo.toml
@@ -25,7 +25,7 @@ base58 = { package = "base58ck", path = "../base58", version = "0.4.0", default-
 crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.2.0", default-features = false }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.0.0", default-features = false, features = ["hex"] }
 hex = { package = "hex-conservative", version = "1.1.0", default-features = false, features = ["alloc"] }
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
 network = { package = "bitcoin-network-kind", path = "../network", version = "1.0.0", default-features = false }
 secp256k1 = { version = "0.32.0-beta.2", default-features = false }
 

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -19,7 +19,7 @@ std = ["alloc", "internals/std"]
 alloc = ["internals/alloc", "serde?/alloc"]
 
 [dependencies]
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
 
 arbitrary = { version = "1.4.1", optional = true }
 serde = { version = "1.0.195", default-features = false, features = [ "derive" ], optional = true }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -24,7 +24,7 @@ hex = ["dep:hex", "hashes/hex", "encoding/hex"]
 [dependencies]
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0", default-features = false }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.0.0", default-features = false }
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
 units = { package = "bitcoin-units", path = "../units", version = "0.5.0", default-features = false, features = [ "encoding" ] }
 
 arbitrary = { version = "1.4.1", optional = true }

--- a/taproot-primitives/Cargo.toml
+++ b/taproot-primitives/Cargo.toml
@@ -23,7 +23,7 @@ hex = ["hashes/hex"]
 [dependencies]
 crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.2.0", default-features = false }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.0.0", default-features = false }
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
 
 arbitrary = { version = "1.4.1", optional = true }
 secp256k1 = { version = "0.32.0-beta.2", default-features = false }

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -19,14 +19,14 @@ std = ["alloc", "internals/std", "encoding?/std"]
 alloc = ["internals/alloc", "serde?/alloc", "encoding?/alloc"]
 
 [dependencies]
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0" }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
 
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0", default-features = false, optional = true }
 serde = { version = "1.0.195", default-features = false, features = ["derive"], optional = true }
 arbitrary = { version = "1.4.1", optional = true }
 
 [dev-dependencies]
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.5.0", features = ["test-serde"] }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0", features = ["test-serde"] }
 bincode = "1.3.1"
 serde = { version = "1.0.195", default-features = false, features = ["derive"] }
 serde_test = "1.0.19"


### PR DESCRIPTION
We have removed a ton of stuff, lets release.
 
In preparation add a changelog, bump the version, and update the lock files.
