### PR TITLE
Manual weekly update to rustc (to nightly-2026-07-02) on master

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["benches"]
 resolver = "2"
 
 [workspace.metadata.rbmt.toolchains]
-nightly = "nightly-2026-06-26"
+nightly = "nightly-2026-07-02"
 stable = "1.96.0"
 
 [workspace.lints.rust]

--- a/consensus_encoding/api/all-features.txt
+++ b/consensus_encoding/api/all-features.txt
@@ -243,13 +243,13 @@ impl<T> core::convert::From<T> for bitcoin_consensus_encoding::error::Decoder6Er
   pub fn bitcoin_consensus_encoding::error::Decoder6Error<A, B, C, D, E, F>::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_consensus_encoding::error::Decoder6Error<A, B, C, D, E, F>]
 pub enum bitcoin_consensus_encoding::error::ReadError<D>
 pub bitcoin_consensus_encoding::error::ReadError::Decode(D)
-pub bitcoin_consensus_encoding::error::ReadError::Io(std::io::error::Error)
+pub bitcoin_consensus_encoding::error::ReadError::Io(core::io::error::Error)
 impl<D: core::fmt::Debug> core::fmt::Debug for bitcoin_consensus_encoding::error::ReadError<D>
   pub fn bitcoin_consensus_encoding::error::ReadError<D>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<D: core::fmt::Debug> core::fmt::Debug for bitcoin_consensus_encoding::error::ReadError<D>]
 impl<D: core::fmt::Display> core::fmt::Display for bitcoin_consensus_encoding::error::ReadError<D>
   pub fn bitcoin_consensus_encoding::error::ReadError<D>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<D: core::fmt::Display> core::fmt::Display for bitcoin_consensus_encoding::error::ReadError<D>]
-impl<D> core::convert::From<std::io::error::Error> for bitcoin_consensus_encoding::error::ReadError<D>
-  pub fn bitcoin_consensus_encoding::error::ReadError<D>::from(e: std::io::error::Error) -> Self [impl: impl<D> core::convert::From<std::io::error::Error> for bitcoin_consensus_encoding::error::ReadError<D>]
+impl<D> core::convert::From<core::io::error::Error> for bitcoin_consensus_encoding::error::ReadError<D>
+  pub fn bitcoin_consensus_encoding::error::ReadError<D>::from(e: core::io::error::Error) -> Self [impl: impl<D> core::convert::From<core::io::error::Error> for bitcoin_consensus_encoding::error::ReadError<D>]
 impl<D> core::error::Error for bitcoin_consensus_encoding::error::ReadError<D> where D: core::error::Error + 'static
   pub fn bitcoin_consensus_encoding::error::ReadError<D>::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)> [impl: impl<D> core::error::Error for bitcoin_consensus_encoding::error::ReadError<D> where D: core::error::Error + 'static]
 impl<D> core::marker::Freeze for bitcoin_consensus_encoding::error::ReadError<D> where D: core::marker::Freeze
@@ -939,13 +939,13 @@ impl<T> core::convert::From<T> for bitcoin_consensus_encoding::EncoderStatus
   pub fn bitcoin_consensus_encoding::EncoderStatus::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_consensus_encoding::EncoderStatus]
 pub enum bitcoin_consensus_encoding::ReadError<D>
 pub bitcoin_consensus_encoding::ReadError::Decode(D)
-pub bitcoin_consensus_encoding::ReadError::Io(std::io::error::Error)
+pub bitcoin_consensus_encoding::ReadError::Io(core::io::error::Error)
 impl<D: core::fmt::Debug> core::fmt::Debug for bitcoin_consensus_encoding::error::ReadError<D>
   pub fn bitcoin_consensus_encoding::error::ReadError<D>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<D: core::fmt::Debug> core::fmt::Debug for bitcoin_consensus_encoding::error::ReadError<D>]
 impl<D: core::fmt::Display> core::fmt::Display for bitcoin_consensus_encoding::error::ReadError<D>
   pub fn bitcoin_consensus_encoding::error::ReadError<D>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<D: core::fmt::Display> core::fmt::Display for bitcoin_consensus_encoding::error::ReadError<D>]
-impl<D> core::convert::From<std::io::error::Error> for bitcoin_consensus_encoding::error::ReadError<D>
-  pub fn bitcoin_consensus_encoding::error::ReadError<D>::from(e: std::io::error::Error) -> Self [impl: impl<D> core::convert::From<std::io::error::Error> for bitcoin_consensus_encoding::error::ReadError<D>]
+impl<D> core::convert::From<core::io::error::Error> for bitcoin_consensus_encoding::error::ReadError<D>
+  pub fn bitcoin_consensus_encoding::error::ReadError<D>::from(e: core::io::error::Error) -> Self [impl: impl<D> core::convert::From<core::io::error::Error> for bitcoin_consensus_encoding::error::ReadError<D>]
 impl<D> core::error::Error for bitcoin_consensus_encoding::error::ReadError<D> where D: core::error::Error + 'static
   pub fn bitcoin_consensus_encoding::error::ReadError<D>::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)> [impl: impl<D> core::error::Error for bitcoin_consensus_encoding::error::ReadError<D> where D: core::error::Error + 'static]
 impl<D> core::marker::Freeze for bitcoin_consensus_encoding::error::ReadError<D> where D: core::marker::Freeze
@@ -2246,7 +2246,7 @@ pub fn bitcoin_consensus_encoding::decode_from_slice_unbounded_with<D: bitcoin_c
 pub fn bitcoin_consensus_encoding::decode_from_slice_with<D: bitcoin_consensus_encoding::Decoder + core::default::Default>(bytes: &[u8]) -> core::result::Result<<D as bitcoin_consensus_encoding::Decoder>::Output, bitcoin_consensus_encoding::error::DecodeError<<D as bitcoin_consensus_encoding::Decoder>::Error>>
 pub fn bitcoin_consensus_encoding::drain_to_hex<T>(encoder: T, case: hex_conservative::Case) -> alloc::string::String where T: bitcoin_consensus_encoding::Encoder
 pub fn bitcoin_consensus_encoding::drain_to_vec<T>(encoder: &mut T) -> alloc::vec::Vec<u8> where T: bitcoin_consensus_encoding::Encoder + ?core::marker::Sized
-pub fn bitcoin_consensus_encoding::drain_to_writer<T, W>(encoder: &mut T, writer: W) -> core::result::Result<(), std::io::error::Error> where T: bitcoin_consensus_encoding::Encoder + ?core::marker::Sized, W: std::io::Write
+pub fn bitcoin_consensus_encoding::drain_to_writer<T, W>(encoder: &mut T, writer: W) -> core::result::Result<(), core::io::error::Error> where T: bitcoin_consensus_encoding::Encoder + ?core::marker::Sized, W: std::io::Write
 pub fn bitcoin_consensus_encoding::encode_to_hex<T>(object: &T, case: hex_conservative::Case) -> alloc::string::String where T: bitcoin_consensus_encoding::Encode + ?core::marker::Sized
 pub fn bitcoin_consensus_encoding::encode_to_vec<T>(object: &T) -> alloc::vec::Vec<u8> where T: bitcoin_consensus_encoding::Encode + ?core::marker::Sized
-pub fn bitcoin_consensus_encoding::encode_to_writer<T, W>(object: &T, writer: W) -> core::result::Result<(), std::io::error::Error> where T: bitcoin_consensus_encoding::Encode + ?core::marker::Sized, W: std::io::Write
+pub fn bitcoin_consensus_encoding::encode_to_writer<T, W>(object: &T, writer: W) -> core::result::Result<(), core::io::error::Error> where T: bitcoin_consensus_encoding::Encode + ?core::marker::Sized, W: std::io::Write

--- a/hashes/api/all-features.txt
+++ b/hashes/api/all-features.txt
@@ -111,8 +111,8 @@ impl core::default::Default for bitcoin_hashes::hash160::HashEngine
 impl core::fmt::Debug for bitcoin_hashes::hash160::HashEngine
   pub fn bitcoin_hashes::hash160::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_hashes::hash160::HashEngine]
 impl std::io::Write for bitcoin_hashes::hash160::HashEngine
-  pub fn bitcoin_hashes::hash160::HashEngine::flush(&mut self) -> std::io::error::Result<()> [impl: impl std::io::Write for bitcoin_hashes::hash160::HashEngine]
-  pub fn bitcoin_hashes::hash160::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize> [impl: impl std::io::Write for bitcoin_hashes::hash160::HashEngine]
+  pub fn bitcoin_hashes::hash160::HashEngine::flush(&mut self) -> core::io::error::Result<()> [impl: impl std::io::Write for bitcoin_hashes::hash160::HashEngine]
+  pub fn bitcoin_hashes::hash160::HashEngine::write(&mut self, buf: &[u8]) -> core::io::error::Result<usize> [impl: impl std::io::Write for bitcoin_hashes::hash160::HashEngine]
 impl core::marker::Freeze for bitcoin_hashes::hash160::HashEngine
 impl core::marker::Send for bitcoin_hashes::hash160::HashEngine
 impl core::marker::Sync for bitcoin_hashes::hash160::HashEngine
@@ -362,8 +362,8 @@ impl<T: bitcoin_hashes::HashEngine> bitcoin_hashes::HashEngine for bitcoin_hashe
   pub fn bitcoin_hashes::hmac::HmacEngine<T>::input(&mut self, buf: &[u8]) [impl: impl<T: bitcoin_hashes::HashEngine> bitcoin_hashes::HashEngine for bitcoin_hashes::hmac::HmacEngine<T>]
   pub fn bitcoin_hashes::hmac::HmacEngine<T>::n_bytes_hashed(&self) -> u64 [impl: impl<T: bitcoin_hashes::HashEngine> bitcoin_hashes::HashEngine for bitcoin_hashes::hmac::HmacEngine<T>]
 impl<T: bitcoin_hashes::HashEngine> std::io::Write for bitcoin_hashes::hmac::HmacEngine<T>
-  pub fn bitcoin_hashes::hmac::HmacEngine<T>::flush(&mut self) -> std::io::error::Result<()> [impl: impl<T: bitcoin_hashes::HashEngine> std::io::Write for bitcoin_hashes::hmac::HmacEngine<T>]
-  pub fn bitcoin_hashes::hmac::HmacEngine<T>::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize> [impl: impl<T: bitcoin_hashes::HashEngine> std::io::Write for bitcoin_hashes::hmac::HmacEngine<T>]
+  pub fn bitcoin_hashes::hmac::HmacEngine<T>::flush(&mut self) -> core::io::error::Result<()> [impl: impl<T: bitcoin_hashes::HashEngine> std::io::Write for bitcoin_hashes::hmac::HmacEngine<T>]
+  pub fn bitcoin_hashes::hmac::HmacEngine<T>::write(&mut self, buf: &[u8]) -> core::io::error::Result<usize> [impl: impl<T: bitcoin_hashes::HashEngine> std::io::Write for bitcoin_hashes::hmac::HmacEngine<T>]
 impl<T: core::clone::Clone + bitcoin_hashes::HashEngine> core::clone::Clone for bitcoin_hashes::hmac::HmacEngine<T>
   pub fn bitcoin_hashes::hmac::HmacEngine<T>::clone(&self) -> bitcoin_hashes::hmac::HmacEngine<T> [impl: impl<T: core::clone::Clone + bitcoin_hashes::HashEngine> core::clone::Clone for bitcoin_hashes::hmac::HmacEngine<T>]
 impl<T: core::fmt::Debug + bitcoin_hashes::HashEngine> core::fmt::Debug for bitcoin_hashes::hmac::HmacEngine<T>
@@ -588,8 +588,8 @@ impl core::default::Default for bitcoin_hashes::ripemd160::HashEngine
 impl core::fmt::Debug for bitcoin_hashes::ripemd160::HashEngine
   pub fn bitcoin_hashes::ripemd160::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_hashes::ripemd160::HashEngine]
 impl std::io::Write for bitcoin_hashes::ripemd160::HashEngine
-  pub fn bitcoin_hashes::ripemd160::HashEngine::flush(&mut self) -> std::io::error::Result<()> [impl: impl std::io::Write for bitcoin_hashes::ripemd160::HashEngine]
-  pub fn bitcoin_hashes::ripemd160::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize> [impl: impl std::io::Write for bitcoin_hashes::ripemd160::HashEngine]
+  pub fn bitcoin_hashes::ripemd160::HashEngine::flush(&mut self) -> core::io::error::Result<()> [impl: impl std::io::Write for bitcoin_hashes::ripemd160::HashEngine]
+  pub fn bitcoin_hashes::ripemd160::HashEngine::write(&mut self, buf: &[u8]) -> core::io::error::Result<usize> [impl: impl std::io::Write for bitcoin_hashes::ripemd160::HashEngine]
 impl core::marker::Freeze for bitcoin_hashes::ripemd160::HashEngine
 impl core::marker::Send for bitcoin_hashes::ripemd160::HashEngine
 impl core::marker::Sync for bitcoin_hashes::ripemd160::HashEngine
@@ -728,8 +728,8 @@ impl core::default::Default for bitcoin_hashes::sha1::HashEngine
 impl core::fmt::Debug for bitcoin_hashes::sha1::HashEngine
   pub fn bitcoin_hashes::sha1::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_hashes::sha1::HashEngine]
 impl std::io::Write for bitcoin_hashes::sha1::HashEngine
-  pub fn bitcoin_hashes::sha1::HashEngine::flush(&mut self) -> std::io::error::Result<()> [impl: impl std::io::Write for bitcoin_hashes::sha1::HashEngine]
-  pub fn bitcoin_hashes::sha1::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize> [impl: impl std::io::Write for bitcoin_hashes::sha1::HashEngine]
+  pub fn bitcoin_hashes::sha1::HashEngine::flush(&mut self) -> core::io::error::Result<()> [impl: impl std::io::Write for bitcoin_hashes::sha1::HashEngine]
+  pub fn bitcoin_hashes::sha1::HashEngine::write(&mut self, buf: &[u8]) -> core::io::error::Result<usize> [impl: impl std::io::Write for bitcoin_hashes::sha1::HashEngine]
 impl core::marker::Freeze for bitcoin_hashes::sha1::HashEngine
 impl core::marker::Send for bitcoin_hashes::sha1::HashEngine
 impl core::marker::Sync for bitcoin_hashes::sha1::HashEngine
@@ -923,8 +923,8 @@ impl core::default::Default for bitcoin_hashes::sha256::HashEngine
 impl core::fmt::Debug for bitcoin_hashes::sha256::HashEngine
   pub fn bitcoin_hashes::sha256::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_hashes::sha256::HashEngine]
 impl std::io::Write for bitcoin_hashes::sha256::HashEngine
-  pub fn bitcoin_hashes::sha256::HashEngine::flush(&mut self) -> std::io::error::Result<()> [impl: impl std::io::Write for bitcoin_hashes::sha256::HashEngine]
-  pub fn bitcoin_hashes::sha256::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize> [impl: impl std::io::Write for bitcoin_hashes::sha256::HashEngine]
+  pub fn bitcoin_hashes::sha256::HashEngine::flush(&mut self) -> core::io::error::Result<()> [impl: impl std::io::Write for bitcoin_hashes::sha256::HashEngine]
+  pub fn bitcoin_hashes::sha256::HashEngine::write(&mut self, buf: &[u8]) -> core::io::error::Result<usize> [impl: impl std::io::Write for bitcoin_hashes::sha256::HashEngine]
 impl core::marker::Freeze for bitcoin_hashes::sha256::HashEngine
 impl core::marker::Send for bitcoin_hashes::sha256::HashEngine
 impl core::marker::Sync for bitcoin_hashes::sha256::HashEngine
@@ -1168,8 +1168,8 @@ impl core::default::Default for bitcoin_hashes::sha256d::HashEngine
 impl core::fmt::Debug for bitcoin_hashes::sha256d::HashEngine
   pub fn bitcoin_hashes::sha256d::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_hashes::sha256d::HashEngine]
 impl std::io::Write for bitcoin_hashes::sha256d::HashEngine
-  pub fn bitcoin_hashes::sha256d::HashEngine::flush(&mut self) -> std::io::error::Result<()> [impl: impl std::io::Write for bitcoin_hashes::sha256d::HashEngine]
-  pub fn bitcoin_hashes::sha256d::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize> [impl: impl std::io::Write for bitcoin_hashes::sha256d::HashEngine]
+  pub fn bitcoin_hashes::sha256d::HashEngine::flush(&mut self) -> core::io::error::Result<()> [impl: impl std::io::Write for bitcoin_hashes::sha256d::HashEngine]
+  pub fn bitcoin_hashes::sha256d::HashEngine::write(&mut self, buf: &[u8]) -> core::io::error::Result<usize> [impl: impl std::io::Write for bitcoin_hashes::sha256d::HashEngine]
 impl core::marker::Freeze for bitcoin_hashes::sha256d::HashEngine
 impl core::marker::Send for bitcoin_hashes::sha256d::HashEngine
 impl core::marker::Sync for bitcoin_hashes::sha256d::HashEngine
@@ -1299,8 +1299,8 @@ impl<T: bitcoin_hashes::sha256t::Tag> core::clone::Clone for bitcoin_hashes::sha
 impl<T: bitcoin_hashes::sha256t::Tag> core::default::Default for bitcoin_hashes::sha256t::HashEngine<T>
   pub fn bitcoin_hashes::sha256t::HashEngine<T>::default() -> Self [impl: impl<T: bitcoin_hashes::sha256t::Tag> core::default::Default for bitcoin_hashes::sha256t::HashEngine<T>]
 impl<T: bitcoin_hashes::sha256t::Tag> std::io::Write for bitcoin_hashes::sha256t::HashEngine<T>
-  pub fn bitcoin_hashes::sha256t::HashEngine<T>::flush(&mut self) -> std::io::error::Result<()> [impl: impl<T: bitcoin_hashes::sha256t::Tag> std::io::Write for bitcoin_hashes::sha256t::HashEngine<T>]
-  pub fn bitcoin_hashes::sha256t::HashEngine<T>::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize> [impl: impl<T: bitcoin_hashes::sha256t::Tag> std::io::Write for bitcoin_hashes::sha256t::HashEngine<T>]
+  pub fn bitcoin_hashes::sha256t::HashEngine<T>::flush(&mut self) -> core::io::error::Result<()> [impl: impl<T: bitcoin_hashes::sha256t::Tag> std::io::Write for bitcoin_hashes::sha256t::HashEngine<T>]
+  pub fn bitcoin_hashes::sha256t::HashEngine<T>::write(&mut self, buf: &[u8]) -> core::io::error::Result<usize> [impl: impl<T: bitcoin_hashes::sha256t::Tag> std::io::Write for bitcoin_hashes::sha256t::HashEngine<T>]
 impl<T: core::fmt::Debug> core::fmt::Debug for bitcoin_hashes::sha256t::HashEngine<T>
   pub fn bitcoin_hashes::sha256t::HashEngine<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<T: core::fmt::Debug> core::fmt::Debug for bitcoin_hashes::sha256t::HashEngine<T>]
 impl<T> core::marker::Freeze for bitcoin_hashes::sha256t::HashEngine<T>
@@ -1443,8 +1443,8 @@ impl core::default::Default for bitcoin_hashes::sha384::HashEngine
 impl core::fmt::Debug for bitcoin_hashes::sha384::HashEngine
   pub fn bitcoin_hashes::sha384::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_hashes::sha384::HashEngine]
 impl std::io::Write for bitcoin_hashes::sha384::HashEngine
-  pub fn bitcoin_hashes::sha384::HashEngine::flush(&mut self) -> std::io::error::Result<()> [impl: impl std::io::Write for bitcoin_hashes::sha384::HashEngine]
-  pub fn bitcoin_hashes::sha384::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize> [impl: impl std::io::Write for bitcoin_hashes::sha384::HashEngine]
+  pub fn bitcoin_hashes::sha384::HashEngine::flush(&mut self) -> core::io::error::Result<()> [impl: impl std::io::Write for bitcoin_hashes::sha384::HashEngine]
+  pub fn bitcoin_hashes::sha384::HashEngine::write(&mut self, buf: &[u8]) -> core::io::error::Result<usize> [impl: impl std::io::Write for bitcoin_hashes::sha384::HashEngine]
 impl core::marker::Freeze for bitcoin_hashes::sha384::HashEngine
 impl core::marker::Send for bitcoin_hashes::sha384::HashEngine
 impl core::marker::Sync for bitcoin_hashes::sha384::HashEngine
@@ -1581,8 +1581,8 @@ impl core::default::Default for bitcoin_hashes::sha3_256::HashEngine
 impl core::fmt::Debug for bitcoin_hashes::sha3_256::HashEngine
   pub fn bitcoin_hashes::sha3_256::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_hashes::sha3_256::HashEngine]
 impl std::io::Write for bitcoin_hashes::sha3_256::HashEngine
-  pub fn bitcoin_hashes::sha3_256::HashEngine::flush(&mut self) -> std::io::error::Result<()> [impl: impl std::io::Write for bitcoin_hashes::sha3_256::HashEngine]
-  pub fn bitcoin_hashes::sha3_256::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize> [impl: impl std::io::Write for bitcoin_hashes::sha3_256::HashEngine]
+  pub fn bitcoin_hashes::sha3_256::HashEngine::flush(&mut self) -> core::io::error::Result<()> [impl: impl std::io::Write for bitcoin_hashes::sha3_256::HashEngine]
+  pub fn bitcoin_hashes::sha3_256::HashEngine::write(&mut self, buf: &[u8]) -> core::io::error::Result<usize> [impl: impl std::io::Write for bitcoin_hashes::sha3_256::HashEngine]
 impl core::marker::Freeze for bitcoin_hashes::sha3_256::HashEngine
 impl core::marker::Send for bitcoin_hashes::sha3_256::HashEngine
 impl core::marker::Sync for bitcoin_hashes::sha3_256::HashEngine
@@ -1721,8 +1721,8 @@ impl core::default::Default for bitcoin_hashes::sha512::HashEngine
 impl core::fmt::Debug for bitcoin_hashes::sha512::HashEngine
   pub fn bitcoin_hashes::sha512::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_hashes::sha512::HashEngine]
 impl std::io::Write for bitcoin_hashes::sha512::HashEngine
-  pub fn bitcoin_hashes::sha512::HashEngine::flush(&mut self) -> std::io::error::Result<()> [impl: impl std::io::Write for bitcoin_hashes::sha512::HashEngine]
-  pub fn bitcoin_hashes::sha512::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize> [impl: impl std::io::Write for bitcoin_hashes::sha512::HashEngine]
+  pub fn bitcoin_hashes::sha512::HashEngine::flush(&mut self) -> core::io::error::Result<()> [impl: impl std::io::Write for bitcoin_hashes::sha512::HashEngine]
+  pub fn bitcoin_hashes::sha512::HashEngine::write(&mut self, buf: &[u8]) -> core::io::error::Result<usize> [impl: impl std::io::Write for bitcoin_hashes::sha512::HashEngine]
 impl core::marker::Freeze for bitcoin_hashes::sha512::HashEngine
 impl core::marker::Send for bitcoin_hashes::sha512::HashEngine
 impl core::marker::Sync for bitcoin_hashes::sha512::HashEngine
@@ -1861,8 +1861,8 @@ impl core::default::Default for bitcoin_hashes::sha512_256::HashEngine
 impl core::fmt::Debug for bitcoin_hashes::sha512_256::HashEngine
   pub fn bitcoin_hashes::sha512_256::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_hashes::sha512_256::HashEngine]
 impl std::io::Write for bitcoin_hashes::sha512_256::HashEngine
-  pub fn bitcoin_hashes::sha512_256::HashEngine::flush(&mut self) -> std::io::error::Result<()> [impl: impl std::io::Write for bitcoin_hashes::sha512_256::HashEngine]
-  pub fn bitcoin_hashes::sha512_256::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize> [impl: impl std::io::Write for bitcoin_hashes::sha512_256::HashEngine]
+  pub fn bitcoin_hashes::sha512_256::HashEngine::flush(&mut self) -> core::io::error::Result<()> [impl: impl std::io::Write for bitcoin_hashes::sha512_256::HashEngine]
+  pub fn bitcoin_hashes::sha512_256::HashEngine::write(&mut self, buf: &[u8]) -> core::io::error::Result<usize> [impl: impl std::io::Write for bitcoin_hashes::sha512_256::HashEngine]
 impl core::marker::Freeze for bitcoin_hashes::sha512_256::HashEngine
 impl core::marker::Send for bitcoin_hashes::sha512_256::HashEngine
 impl core::marker::Sync for bitcoin_hashes::sha512_256::HashEngine
@@ -2000,8 +2000,8 @@ impl core::clone::Clone for bitcoin_hashes::siphash24::HashEngine
 impl core::fmt::Debug for bitcoin_hashes::siphash24::HashEngine
   pub fn bitcoin_hashes::siphash24::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_hashes::siphash24::HashEngine]
 impl std::io::Write for bitcoin_hashes::siphash24::HashEngine
-  pub fn bitcoin_hashes::siphash24::HashEngine::flush(&mut self) -> std::io::error::Result<()> [impl: impl std::io::Write for bitcoin_hashes::siphash24::HashEngine]
-  pub fn bitcoin_hashes::siphash24::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize> [impl: impl std::io::Write for bitcoin_hashes::siphash24::HashEngine]
+  pub fn bitcoin_hashes::siphash24::HashEngine::flush(&mut self) -> core::io::error::Result<()> [impl: impl std::io::Write for bitcoin_hashes::siphash24::HashEngine]
+  pub fn bitcoin_hashes::siphash24::HashEngine::write(&mut self, buf: &[u8]) -> core::io::error::Result<usize> [impl: impl std::io::Write for bitcoin_hashes::siphash24::HashEngine]
 impl core::marker::Freeze for bitcoin_hashes::siphash24::HashEngine
 impl core::marker::Send for bitcoin_hashes::siphash24::HashEngine
 impl core::marker::Sync for bitcoin_hashes::siphash24::HashEngine
@@ -2247,8 +2247,8 @@ impl<T: bitcoin_hashes::HashEngine> bitcoin_hashes::HashEngine for bitcoin_hashe
   pub fn bitcoin_hashes::hmac::HmacEngine<T>::input(&mut self, buf: &[u8]) [impl: impl<T: bitcoin_hashes::HashEngine> bitcoin_hashes::HashEngine for bitcoin_hashes::hmac::HmacEngine<T>]
   pub fn bitcoin_hashes::hmac::HmacEngine<T>::n_bytes_hashed(&self) -> u64 [impl: impl<T: bitcoin_hashes::HashEngine> bitcoin_hashes::HashEngine for bitcoin_hashes::hmac::HmacEngine<T>]
 impl<T: bitcoin_hashes::HashEngine> std::io::Write for bitcoin_hashes::hmac::HmacEngine<T>
-  pub fn bitcoin_hashes::hmac::HmacEngine<T>::flush(&mut self) -> std::io::error::Result<()> [impl: impl<T: bitcoin_hashes::HashEngine> std::io::Write for bitcoin_hashes::hmac::HmacEngine<T>]
-  pub fn bitcoin_hashes::hmac::HmacEngine<T>::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize> [impl: impl<T: bitcoin_hashes::HashEngine> std::io::Write for bitcoin_hashes::hmac::HmacEngine<T>]
+  pub fn bitcoin_hashes::hmac::HmacEngine<T>::flush(&mut self) -> core::io::error::Result<()> [impl: impl<T: bitcoin_hashes::HashEngine> std::io::Write for bitcoin_hashes::hmac::HmacEngine<T>]
+  pub fn bitcoin_hashes::hmac::HmacEngine<T>::write(&mut self, buf: &[u8]) -> core::io::error::Result<usize> [impl: impl<T: bitcoin_hashes::HashEngine> std::io::Write for bitcoin_hashes::hmac::HmacEngine<T>]
 impl<T: core::clone::Clone + bitcoin_hashes::HashEngine> core::clone::Clone for bitcoin_hashes::hmac::HmacEngine<T>
   pub fn bitcoin_hashes::hmac::HmacEngine<T>::clone(&self) -> bitcoin_hashes::hmac::HmacEngine<T> [impl: impl<T: core::clone::Clone + bitcoin_hashes::HashEngine> core::clone::Clone for bitcoin_hashes::hmac::HmacEngine<T>]
 impl<T: core::fmt::Debug + bitcoin_hashes::HashEngine> core::fmt::Debug for bitcoin_hashes::hmac::HmacEngine<T>

--- a/units/src/amount/mod.rs
+++ b/units/src/amount/mod.rs
@@ -461,15 +461,14 @@ fn fmt_satoshi_in(
     let mut num_after_decimal_point = 0;
     let mut norm_nb_decimals = 0;
     let mut num_before_decimal_point = satoshi;
-    let trailing_decimal_zeros;
     let mut exp = 0;
-    match precision.cmp(&0) {
+    let trailing_decimal_zeros = match precision.cmp(&0) {
         // We add the number of zeroes to the end
         Ordering::Greater => {
             if satoshi > 0 {
                 exp = precision as usize; // Cast ok, checked not negative above.
             }
-            trailing_decimal_zeros = options.precision.unwrap_or(0);
+            options.precision.unwrap_or(0)
         }
         Ordering::Less => {
             let precision = precision.unsigned_abs();
@@ -502,10 +501,10 @@ fn fmt_satoshi_in(
             }
             // compute requested precision
             let opt_precision = options.precision.unwrap_or(0);
-            trailing_decimal_zeros = opt_precision.saturating_sub(norm_nb_decimals);
+            opt_precision.saturating_sub(norm_nb_decimals)
         }
-        Ordering::Equal => trailing_decimal_zeros = options.precision.unwrap_or(0),
-    }
+        Ordering::Equal => options.precision.unwrap_or(0),
+    };
     let total_decimals = norm_nb_decimals + trailing_decimal_zeros;
     // Compute expected width of the number
     let mut num_width = if total_decimals > 0 {


### PR DESCRIPTION
Supersedes https://github.com/rust-bitcoin/rust-bitcoin/pull/6463

To fix lint errors, the PR refactors the variable initialization location of `trailing_decimal_zeros` on the `units` `amount`.
To fix api errors, generate the api snapshots with `cargo rbmt api`.
