### PR TITLE
Manual weekly update to rustc (to nightly-2026-07-02) on 0.32.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["bitcoin", "hashes", "io", "units", "base58"]
 resolver = "2"
 
 [workspace.metadata.rbmt.toolchains]
-nightly = "nightly-2026-03-27"
+nightly = "nightly-2026-07-02"
 stable = "1.91.1"
 
 # Patch secp256k1's dependency on bitcoin_hashes to use our local workspace version.

--- a/bitcoin/api/no-features.txt
+++ b/bitcoin/api/no-features.txt
@@ -1007,7 +1007,7 @@ impl<V> core::cmp::PartialOrd for bitcoin::address::Address<V> where V: bitcoin:
   pub fn bitcoin::address::Address<V>::partial_cmp(&self, other: &bitcoin::address::Address<V>) -> core::option::Option<core::cmp::Ordering> [impl: impl<V> core::cmp::PartialOrd for bitcoin::address::Address<V> where V: bitcoin::address::NetworkValidation + core::cmp::PartialOrd]
 impl<V> core::hash::Hash for bitcoin::address::Address<V> where V: bitcoin::address::NetworkValidation + core::hash::Hash
   pub fn bitcoin::address::Address<V>::hash<__H: core::hash::Hasher>(&self, state: &mut __H) [impl: impl<V> core::hash::Hash for bitcoin::address::Address<V> where V: bitcoin::address::NetworkValidation + core::hash::Hash]
-impl<V> core::marker::StructuralPartialEq for bitcoin::address::Address<V> where V: bitcoin::address::NetworkValidation
+impl<V> core::marker::StructuralPartialEq for bitcoin::address::Address<V> where V: bitcoin::address::NetworkValidation + core::cmp::PartialEq
 impl<V> core::marker::Freeze for bitcoin::address::Address<V>
 impl<V> core::marker::Send for bitcoin::address::Address<V>
 impl<V> core::marker::Sync for bitcoin::address::Address<V>
@@ -13325,7 +13325,7 @@ impl<Subtype> core::fmt::Debug for bitcoin::psbt::raw::ProprietaryKey<Subtype> w
   pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<Subtype> core::fmt::Debug for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8> + core::fmt::Debug]
 impl<Subtype> core::hash::Hash for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8> + core::hash::Hash
   pub fn bitcoin::psbt::raw::ProprietaryKey<Subtype>::hash<__H: core::hash::Hasher>(&self, state: &mut __H) [impl: impl<Subtype> core::hash::Hash for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8> + core::hash::Hash]
-impl<Subtype> core::marker::StructuralPartialEq for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8>
+impl<Subtype> core::marker::StructuralPartialEq for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Copy + core::convert::From<u8> + core::convert::Into<u8> + core::cmp::PartialEq
 impl<Subtype> core::marker::Freeze for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Freeze
 impl<Subtype> core::marker::Send for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Send
 impl<Subtype> core::marker::Sync for bitcoin::psbt::raw::ProprietaryKey<Subtype> where Subtype: core::marker::Sync
@@ -16800,7 +16800,7 @@ impl<'u, T> core::fmt::Debug for bitcoin::sighash::Prevouts<'u, T> where T: 'u +
   pub fn bitcoin::sighash::Prevouts<'u, T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<'u, T> core::fmt::Debug for bitcoin::sighash::Prevouts<'u, T> where T: 'u + core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut> + core::fmt::Debug]
 impl<'u, T> core::hash::Hash for bitcoin::sighash::Prevouts<'u, T> where T: 'u + core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut> + core::hash::Hash
   pub fn bitcoin::sighash::Prevouts<'u, T>::hash<__H: core::hash::Hasher>(&self, state: &mut __H) [impl: impl<'u, T> core::hash::Hash for bitcoin::sighash::Prevouts<'u, T> where T: 'u + core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut> + core::hash::Hash]
-impl<'u, T> core::marker::StructuralPartialEq for bitcoin::sighash::Prevouts<'u, T> where T: 'u + core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut>
+impl<'u, T> core::marker::StructuralPartialEq for bitcoin::sighash::Prevouts<'u, T> where T: 'u + core::borrow::Borrow<bitcoin::blockdata::transaction::TxOut> + core::cmp::PartialEq
 impl<'u, T> core::marker::Freeze for bitcoin::sighash::Prevouts<'u, T> where T: core::marker::Freeze
 impl<'u, T> core::marker::Send for bitcoin::sighash::Prevouts<'u, T> where T: core::marker::Send + core::marker::Sync
 impl<'u, T> core::marker::Sync for bitcoin::sighash::Prevouts<'u, T> where T: core::marker::Sync
@@ -18858,12 +18858,12 @@ impl<S: core::clone::Clone> core::clone::Clone for bitcoin::taproot::LeafScript<
 impl<S: core::cmp::Eq> core::cmp::Eq for bitcoin::taproot::LeafScript<S>
 impl<S: core::cmp::PartialEq> core::cmp::PartialEq for bitcoin::taproot::LeafScript<S>
   pub fn bitcoin::taproot::LeafScript<S>::eq(&self, other: &bitcoin::taproot::LeafScript<S>) -> bool [impl: impl<S: core::cmp::PartialEq> core::cmp::PartialEq for bitcoin::taproot::LeafScript<S>]
+impl<S: core::cmp::PartialEq> core::marker::StructuralPartialEq for bitcoin::taproot::LeafScript<S>
 impl<S: core::fmt::Debug> core::fmt::Debug for bitcoin::taproot::LeafScript<S>
   pub fn bitcoin::taproot::LeafScript<S>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<S: core::fmt::Debug> core::fmt::Debug for bitcoin::taproot::LeafScript<S>]
 impl<S: core::hash::Hash> core::hash::Hash for bitcoin::taproot::LeafScript<S>
   pub fn bitcoin::taproot::LeafScript<S>::hash<__H: core::hash::Hasher>(&self, state: &mut __H) [impl: impl<S: core::hash::Hash> core::hash::Hash for bitcoin::taproot::LeafScript<S>]
 impl<S: core::marker::Copy> core::marker::Copy for bitcoin::taproot::LeafScript<S>
-impl<S> core::marker::StructuralPartialEq for bitcoin::taproot::LeafScript<S>
 impl<S> core::marker::Freeze for bitcoin::taproot::LeafScript<S> where S: core::marker::Freeze
 impl<S> core::marker::Send for bitcoin::taproot::LeafScript<S> where S: core::marker::Send
 impl<S> core::marker::Sync for bitcoin::taproot::LeafScript<S> where S: core::marker::Sync
@@ -21888,7 +21888,7 @@ impl<V> core::cmp::PartialOrd for bitcoin::address::Address<V> where V: bitcoin:
   pub fn bitcoin::address::Address<V>::partial_cmp(&self, other: &bitcoin::address::Address<V>) -> core::option::Option<core::cmp::Ordering> [impl: impl<V> core::cmp::PartialOrd for bitcoin::address::Address<V> where V: bitcoin::address::NetworkValidation + core::cmp::PartialOrd]
 impl<V> core::hash::Hash for bitcoin::address::Address<V> where V: bitcoin::address::NetworkValidation + core::hash::Hash
   pub fn bitcoin::address::Address<V>::hash<__H: core::hash::Hasher>(&self, state: &mut __H) [impl: impl<V> core::hash::Hash for bitcoin::address::Address<V> where V: bitcoin::address::NetworkValidation + core::hash::Hash]
-impl<V> core::marker::StructuralPartialEq for bitcoin::address::Address<V> where V: bitcoin::address::NetworkValidation
+impl<V> core::marker::StructuralPartialEq for bitcoin::address::Address<V> where V: bitcoin::address::NetworkValidation + core::cmp::PartialEq
 impl<V> core::marker::Freeze for bitcoin::address::Address<V>
 impl<V> core::marker::Send for bitcoin::address::Address<V>
 impl<V> core::marker::Sync for bitcoin::address::Address<V>

--- a/bitcoin/examples/bip32.rs
+++ b/bitcoin/examples/bip32.rs
@@ -20,7 +20,7 @@ fn main() {
 
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
-        eprintln!("not enough arguments. usage: {} <hex-encoded 32-byte seed>", &args[0]);
+        eprintln!("not enough arguments. usage: {} <hex-encoded 32-byte seed>", args[0]);
         process::exit(1);
     }
 

--- a/bitcoin/tests/psbt-sign-taproot.rs
+++ b/bitcoin/tests/psbt-sign-taproot.rs
@@ -339,7 +339,7 @@ fn create_psbt_for_taproot_script_path_spend(
 fn finalize_psbt_for_script_path_spend(mut psbt: Psbt) -> Psbt {
     psbt.inputs.iter_mut().for_each(|input| {
         let mut script_witness: Witness = Witness::new();
-        for (_, signature) in input.tap_script_sigs.iter() {
+        for signature in input.tap_script_sigs.values() {
             script_witness.push(signature.to_vec());
         }
         for (control_block, (script, _)) in input.tap_scripts.iter() {

--- a/hashes/api/all-features.txt
+++ b/hashes/api/all-features.txt
@@ -128,7 +128,6 @@ impl<T: bitcoin_hashes::Hash> core::fmt::Display for bitcoin_hashes::hmac::Hmac<
   pub fn bitcoin_hashes::hmac::Hmac<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<T: bitcoin_hashes::Hash> core::fmt::Display for bitcoin_hashes::hmac::Hmac<T>]
 impl<T: bitcoin_hashes::Hash> core::fmt::LowerHex for bitcoin_hashes::hmac::Hmac<T>
   pub fn bitcoin_hashes::hmac::Hmac<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<T: bitcoin_hashes::Hash> core::fmt::LowerHex for bitcoin_hashes::hmac::Hmac<T>]
-impl<T: bitcoin_hashes::Hash> core::marker::StructuralPartialEq for bitcoin_hashes::hmac::Hmac<T>
 impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::Range<usize>> for bitcoin_hashes::hmac::Hmac<T>
   pub type bitcoin_hashes::hmac::Hmac<T>::Output = [u8] [impl: impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::Range<usize>> for bitcoin_hashes::hmac::Hmac<T>]
   pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: core::ops::range::Range<usize>) -> &[u8] [impl: impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::Range<usize>> for bitcoin_hashes::hmac::Hmac<T>]
@@ -151,6 +150,7 @@ impl<T: core::cmp::Ord + bitcoin_hashes::Hash> core::cmp::Ord for bitcoin_hashes
   pub fn bitcoin_hashes::hmac::Hmac<T>::cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::cmp::Ordering [impl: impl<T: core::cmp::Ord + bitcoin_hashes::Hash> core::cmp::Ord for bitcoin_hashes::hmac::Hmac<T>]
 impl<T: core::cmp::PartialEq + bitcoin_hashes::Hash> core::cmp::PartialEq for bitcoin_hashes::hmac::Hmac<T>
   pub fn bitcoin_hashes::hmac::Hmac<T>::eq(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> bool [impl: impl<T: core::cmp::PartialEq + bitcoin_hashes::Hash> core::cmp::PartialEq for bitcoin_hashes::hmac::Hmac<T>]
+impl<T: core::cmp::PartialEq + bitcoin_hashes::Hash> core::marker::StructuralPartialEq for bitcoin_hashes::hmac::Hmac<T>
 impl<T: core::cmp::PartialOrd + bitcoin_hashes::Hash> core::cmp::PartialOrd for bitcoin_hashes::hmac::Hmac<T>
   pub fn bitcoin_hashes::hmac::Hmac<T>::partial_cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::option::Option<core::cmp::Ordering> [impl: impl<T: core::cmp::PartialOrd + bitcoin_hashes::Hash> core::cmp::PartialOrd for bitcoin_hashes::hmac::Hmac<T>]
 impl<T: core::hash::Hash + bitcoin_hashes::Hash> core::hash::Hash for bitcoin_hashes::hmac::Hmac<T>
@@ -206,8 +206,8 @@ impl<T: bitcoin_hashes::Hash> bitcoin_io::Write for bitcoin_hashes::hmac::HmacEn
 impl<T: bitcoin_hashes::Hash> core::default::Default for bitcoin_hashes::hmac::HmacEngine<T>
   pub fn bitcoin_hashes::hmac::HmacEngine<T>::default() -> Self [impl: impl<T: bitcoin_hashes::Hash> core::default::Default for bitcoin_hashes::hmac::HmacEngine<T>]
 impl<T: bitcoin_hashes::Hash> std::io::Write for bitcoin_hashes::hmac::HmacEngine<T>
-  pub fn bitcoin_hashes::hmac::HmacEngine<T>::flush(&mut self) -> std::io::error::Result<()> [impl: impl<T: bitcoin_hashes::Hash> std::io::Write for bitcoin_hashes::hmac::HmacEngine<T>]
-  pub fn bitcoin_hashes::hmac::HmacEngine<T>::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize> [impl: impl<T: bitcoin_hashes::Hash> std::io::Write for bitcoin_hashes::hmac::HmacEngine<T>]
+  pub fn bitcoin_hashes::hmac::HmacEngine<T>::flush(&mut self) -> core::io::error::Result<()> [impl: impl<T: bitcoin_hashes::Hash> std::io::Write for bitcoin_hashes::hmac::HmacEngine<T>]
+  pub fn bitcoin_hashes::hmac::HmacEngine<T>::write(&mut self, buf: &[u8]) -> core::io::error::Result<usize> [impl: impl<T: bitcoin_hashes::Hash> std::io::Write for bitcoin_hashes::hmac::HmacEngine<T>]
 impl<T: core::clone::Clone + bitcoin_hashes::Hash> core::clone::Clone for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::clone::Clone
   pub fn bitcoin_hashes::hmac::HmacEngine<T>::clone(&self) -> bitcoin_hashes::hmac::HmacEngine<T> [impl: impl<T: core::clone::Clone + bitcoin_hashes::Hash> core::clone::Clone for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::clone::Clone]
 impl<T> core::marker::Freeze for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::marker::Freeze
@@ -376,8 +376,8 @@ impl core::clone::Clone for bitcoin_hashes::ripemd160::HashEngine
 impl core::default::Default for bitcoin_hashes::ripemd160::HashEngine
   pub fn bitcoin_hashes::ripemd160::HashEngine::default() -> Self [impl: impl core::default::Default for bitcoin_hashes::ripemd160::HashEngine]
 impl std::io::Write for bitcoin_hashes::ripemd160::HashEngine
-  pub fn bitcoin_hashes::ripemd160::HashEngine::flush(&mut self) -> std::io::error::Result<()> [impl: impl std::io::Write for bitcoin_hashes::ripemd160::HashEngine]
-  pub fn bitcoin_hashes::ripemd160::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize> [impl: impl std::io::Write for bitcoin_hashes::ripemd160::HashEngine]
+  pub fn bitcoin_hashes::ripemd160::HashEngine::flush(&mut self) -> core::io::error::Result<()> [impl: impl std::io::Write for bitcoin_hashes::ripemd160::HashEngine]
+  pub fn bitcoin_hashes::ripemd160::HashEngine::write(&mut self, buf: &[u8]) -> core::io::error::Result<usize> [impl: impl std::io::Write for bitcoin_hashes::ripemd160::HashEngine]
 impl core::marker::Freeze for bitcoin_hashes::ripemd160::HashEngine
 impl core::marker::Send for bitcoin_hashes::ripemd160::HashEngine
 impl core::marker::Sync for bitcoin_hashes::ripemd160::HashEngine
@@ -558,8 +558,8 @@ impl core::clone::Clone for bitcoin_hashes::sha1::HashEngine
 impl core::default::Default for bitcoin_hashes::sha1::HashEngine
   pub fn bitcoin_hashes::sha1::HashEngine::default() -> Self [impl: impl core::default::Default for bitcoin_hashes::sha1::HashEngine]
 impl std::io::Write for bitcoin_hashes::sha1::HashEngine
-  pub fn bitcoin_hashes::sha1::HashEngine::flush(&mut self) -> std::io::error::Result<()> [impl: impl std::io::Write for bitcoin_hashes::sha1::HashEngine]
-  pub fn bitcoin_hashes::sha1::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize> [impl: impl std::io::Write for bitcoin_hashes::sha1::HashEngine]
+  pub fn bitcoin_hashes::sha1::HashEngine::flush(&mut self) -> core::io::error::Result<()> [impl: impl std::io::Write for bitcoin_hashes::sha1::HashEngine]
+  pub fn bitcoin_hashes::sha1::HashEngine::write(&mut self, buf: &[u8]) -> core::io::error::Result<usize> [impl: impl std::io::Write for bitcoin_hashes::sha1::HashEngine]
 impl core::marker::Freeze for bitcoin_hashes::sha1::HashEngine
 impl core::marker::Send for bitcoin_hashes::sha1::HashEngine
 impl core::marker::Sync for bitcoin_hashes::sha1::HashEngine
@@ -705,8 +705,8 @@ impl core::clone::Clone for bitcoin_hashes::sha256::HashEngine
 impl core::default::Default for bitcoin_hashes::sha256::HashEngine
   pub fn bitcoin_hashes::sha256::HashEngine::default() -> Self [impl: impl core::default::Default for bitcoin_hashes::sha256::HashEngine]
 impl std::io::Write for bitcoin_hashes::sha256::HashEngine
-  pub fn bitcoin_hashes::sha256::HashEngine::flush(&mut self) -> std::io::error::Result<()> [impl: impl std::io::Write for bitcoin_hashes::sha256::HashEngine]
-  pub fn bitcoin_hashes::sha256::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize> [impl: impl std::io::Write for bitcoin_hashes::sha256::HashEngine]
+  pub fn bitcoin_hashes::sha256::HashEngine::flush(&mut self) -> core::io::error::Result<()> [impl: impl std::io::Write for bitcoin_hashes::sha256::HashEngine]
+  pub fn bitcoin_hashes::sha256::HashEngine::write(&mut self, buf: &[u8]) -> core::io::error::Result<usize> [impl: impl std::io::Write for bitcoin_hashes::sha256::HashEngine]
 impl core::marker::Freeze for bitcoin_hashes::sha256::HashEngine
 impl core::marker::Send for bitcoin_hashes::sha256::HashEngine
 impl core::marker::Sync for bitcoin_hashes::sha256::HashEngine
@@ -1257,8 +1257,8 @@ impl core::clone::Clone for bitcoin_hashes::sha512::HashEngine
 impl core::default::Default for bitcoin_hashes::sha512::HashEngine
   pub fn bitcoin_hashes::sha512::HashEngine::default() -> Self [impl: impl core::default::Default for bitcoin_hashes::sha512::HashEngine]
 impl std::io::Write for bitcoin_hashes::sha512::HashEngine
-  pub fn bitcoin_hashes::sha512::HashEngine::flush(&mut self) -> std::io::error::Result<()> [impl: impl std::io::Write for bitcoin_hashes::sha512::HashEngine]
-  pub fn bitcoin_hashes::sha512::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize> [impl: impl std::io::Write for bitcoin_hashes::sha512::HashEngine]
+  pub fn bitcoin_hashes::sha512::HashEngine::flush(&mut self) -> core::io::error::Result<()> [impl: impl std::io::Write for bitcoin_hashes::sha512::HashEngine]
+  pub fn bitcoin_hashes::sha512::HashEngine::write(&mut self, buf: &[u8]) -> core::io::error::Result<usize> [impl: impl std::io::Write for bitcoin_hashes::sha512::HashEngine]
 impl core::marker::Freeze for bitcoin_hashes::sha512::HashEngine
 impl core::marker::Send for bitcoin_hashes::sha512::HashEngine
 impl core::marker::Sync for bitcoin_hashes::sha512::HashEngine
@@ -1547,8 +1547,8 @@ impl core::default::Default for bitcoin_hashes::siphash24::HashEngine
 impl core::fmt::Debug for bitcoin_hashes::siphash24::HashEngine
   pub fn bitcoin_hashes::siphash24::HashEngine::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_hashes::siphash24::HashEngine]
 impl std::io::Write for bitcoin_hashes::siphash24::HashEngine
-  pub fn bitcoin_hashes::siphash24::HashEngine::flush(&mut self) -> std::io::error::Result<()> [impl: impl std::io::Write for bitcoin_hashes::siphash24::HashEngine]
-  pub fn bitcoin_hashes::siphash24::HashEngine::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize> [impl: impl std::io::Write for bitcoin_hashes::siphash24::HashEngine]
+  pub fn bitcoin_hashes::siphash24::HashEngine::flush(&mut self) -> core::io::error::Result<()> [impl: impl std::io::Write for bitcoin_hashes::siphash24::HashEngine]
+  pub fn bitcoin_hashes::siphash24::HashEngine::write(&mut self, buf: &[u8]) -> core::io::error::Result<usize> [impl: impl std::io::Write for bitcoin_hashes::siphash24::HashEngine]
 impl core::marker::Freeze for bitcoin_hashes::siphash24::HashEngine
 impl core::marker::Send for bitcoin_hashes::siphash24::HashEngine
 impl core::marker::Sync for bitcoin_hashes::siphash24::HashEngine
@@ -1699,7 +1699,6 @@ impl<T: bitcoin_hashes::Hash> core::fmt::Display for bitcoin_hashes::hmac::Hmac<
   pub fn bitcoin_hashes::hmac::Hmac<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<T: bitcoin_hashes::Hash> core::fmt::Display for bitcoin_hashes::hmac::Hmac<T>]
 impl<T: bitcoin_hashes::Hash> core::fmt::LowerHex for bitcoin_hashes::hmac::Hmac<T>
   pub fn bitcoin_hashes::hmac::Hmac<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<T: bitcoin_hashes::Hash> core::fmt::LowerHex for bitcoin_hashes::hmac::Hmac<T>]
-impl<T: bitcoin_hashes::Hash> core::marker::StructuralPartialEq for bitcoin_hashes::hmac::Hmac<T>
 impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::Range<usize>> for bitcoin_hashes::hmac::Hmac<T>
   pub type bitcoin_hashes::hmac::Hmac<T>::Output = [u8] [impl: impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::Range<usize>> for bitcoin_hashes::hmac::Hmac<T>]
   pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: core::ops::range::Range<usize>) -> &[u8] [impl: impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::Range<usize>> for bitcoin_hashes::hmac::Hmac<T>]
@@ -1722,6 +1721,7 @@ impl<T: core::cmp::Ord + bitcoin_hashes::Hash> core::cmp::Ord for bitcoin_hashes
   pub fn bitcoin_hashes::hmac::Hmac<T>::cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::cmp::Ordering [impl: impl<T: core::cmp::Ord + bitcoin_hashes::Hash> core::cmp::Ord for bitcoin_hashes::hmac::Hmac<T>]
 impl<T: core::cmp::PartialEq + bitcoin_hashes::Hash> core::cmp::PartialEq for bitcoin_hashes::hmac::Hmac<T>
   pub fn bitcoin_hashes::hmac::Hmac<T>::eq(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> bool [impl: impl<T: core::cmp::PartialEq + bitcoin_hashes::Hash> core::cmp::PartialEq for bitcoin_hashes::hmac::Hmac<T>]
+impl<T: core::cmp::PartialEq + bitcoin_hashes::Hash> core::marker::StructuralPartialEq for bitcoin_hashes::hmac::Hmac<T>
 impl<T: core::cmp::PartialOrd + bitcoin_hashes::Hash> core::cmp::PartialOrd for bitcoin_hashes::hmac::Hmac<T>
   pub fn bitcoin_hashes::hmac::Hmac<T>::partial_cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::option::Option<core::cmp::Ordering> [impl: impl<T: core::cmp::PartialOrd + bitcoin_hashes::Hash> core::cmp::PartialOrd for bitcoin_hashes::hmac::Hmac<T>]
 impl<T: core::hash::Hash + bitcoin_hashes::Hash> core::hash::Hash for bitcoin_hashes::hmac::Hmac<T>
@@ -1777,8 +1777,8 @@ impl<T: bitcoin_hashes::Hash> bitcoin_io::Write for bitcoin_hashes::hmac::HmacEn
 impl<T: bitcoin_hashes::Hash> core::default::Default for bitcoin_hashes::hmac::HmacEngine<T>
   pub fn bitcoin_hashes::hmac::HmacEngine<T>::default() -> Self [impl: impl<T: bitcoin_hashes::Hash> core::default::Default for bitcoin_hashes::hmac::HmacEngine<T>]
 impl<T: bitcoin_hashes::Hash> std::io::Write for bitcoin_hashes::hmac::HmacEngine<T>
-  pub fn bitcoin_hashes::hmac::HmacEngine<T>::flush(&mut self) -> std::io::error::Result<()> [impl: impl<T: bitcoin_hashes::Hash> std::io::Write for bitcoin_hashes::hmac::HmacEngine<T>]
-  pub fn bitcoin_hashes::hmac::HmacEngine<T>::write(&mut self, buf: &[u8]) -> std::io::error::Result<usize> [impl: impl<T: bitcoin_hashes::Hash> std::io::Write for bitcoin_hashes::hmac::HmacEngine<T>]
+  pub fn bitcoin_hashes::hmac::HmacEngine<T>::flush(&mut self) -> core::io::error::Result<()> [impl: impl<T: bitcoin_hashes::Hash> std::io::Write for bitcoin_hashes::hmac::HmacEngine<T>]
+  pub fn bitcoin_hashes::hmac::HmacEngine<T>::write(&mut self, buf: &[u8]) -> core::io::error::Result<usize> [impl: impl<T: bitcoin_hashes::Hash> std::io::Write for bitcoin_hashes::hmac::HmacEngine<T>]
 impl<T: core::clone::Clone + bitcoin_hashes::Hash> core::clone::Clone for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::clone::Clone
   pub fn bitcoin_hashes::hmac::HmacEngine<T>::clone(&self) -> bitcoin_hashes::hmac::HmacEngine<T> [impl: impl<T: core::clone::Clone + bitcoin_hashes::Hash> core::clone::Clone for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::clone::Clone]
 impl<T> core::marker::Freeze for bitcoin_hashes::hmac::HmacEngine<T> where <T as bitcoin_hashes::Hash>::Engine: core::marker::Freeze

--- a/hashes/api/alloc-only.txt
+++ b/hashes/api/alloc-only.txt
@@ -106,7 +106,6 @@ impl<T: bitcoin_hashes::Hash> core::fmt::Display for bitcoin_hashes::hmac::Hmac<
   pub fn bitcoin_hashes::hmac::Hmac<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<T: bitcoin_hashes::Hash> core::fmt::Display for bitcoin_hashes::hmac::Hmac<T>]
 impl<T: bitcoin_hashes::Hash> core::fmt::LowerHex for bitcoin_hashes::hmac::Hmac<T>
   pub fn bitcoin_hashes::hmac::Hmac<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<T: bitcoin_hashes::Hash> core::fmt::LowerHex for bitcoin_hashes::hmac::Hmac<T>]
-impl<T: bitcoin_hashes::Hash> core::marker::StructuralPartialEq for bitcoin_hashes::hmac::Hmac<T>
 impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::Range<usize>> for bitcoin_hashes::hmac::Hmac<T>
   pub type bitcoin_hashes::hmac::Hmac<T>::Output = [u8] [impl: impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::Range<usize>> for bitcoin_hashes::hmac::Hmac<T>]
   pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: core::ops::range::Range<usize>) -> &[u8] [impl: impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::Range<usize>> for bitcoin_hashes::hmac::Hmac<T>]
@@ -129,6 +128,7 @@ impl<T: core::cmp::Ord + bitcoin_hashes::Hash> core::cmp::Ord for bitcoin_hashes
   pub fn bitcoin_hashes::hmac::Hmac<T>::cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::cmp::Ordering [impl: impl<T: core::cmp::Ord + bitcoin_hashes::Hash> core::cmp::Ord for bitcoin_hashes::hmac::Hmac<T>]
 impl<T: core::cmp::PartialEq + bitcoin_hashes::Hash> core::cmp::PartialEq for bitcoin_hashes::hmac::Hmac<T>
   pub fn bitcoin_hashes::hmac::Hmac<T>::eq(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> bool [impl: impl<T: core::cmp::PartialEq + bitcoin_hashes::Hash> core::cmp::PartialEq for bitcoin_hashes::hmac::Hmac<T>]
+impl<T: core::cmp::PartialEq + bitcoin_hashes::Hash> core::marker::StructuralPartialEq for bitcoin_hashes::hmac::Hmac<T>
 impl<T: core::cmp::PartialOrd + bitcoin_hashes::Hash> core::cmp::PartialOrd for bitcoin_hashes::hmac::Hmac<T>
   pub fn bitcoin_hashes::hmac::Hmac<T>::partial_cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::option::Option<core::cmp::Ordering> [impl: impl<T: core::cmp::PartialOrd + bitcoin_hashes::Hash> core::cmp::PartialOrd for bitcoin_hashes::hmac::Hmac<T>]
 impl<T: core::hash::Hash + bitcoin_hashes::Hash> core::hash::Hash for bitcoin_hashes::hmac::Hmac<T>
@@ -1443,7 +1443,6 @@ impl<T: bitcoin_hashes::Hash> core::fmt::Display for bitcoin_hashes::hmac::Hmac<
   pub fn bitcoin_hashes::hmac::Hmac<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<T: bitcoin_hashes::Hash> core::fmt::Display for bitcoin_hashes::hmac::Hmac<T>]
 impl<T: bitcoin_hashes::Hash> core::fmt::LowerHex for bitcoin_hashes::hmac::Hmac<T>
   pub fn bitcoin_hashes::hmac::Hmac<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<T: bitcoin_hashes::Hash> core::fmt::LowerHex for bitcoin_hashes::hmac::Hmac<T>]
-impl<T: bitcoin_hashes::Hash> core::marker::StructuralPartialEq for bitcoin_hashes::hmac::Hmac<T>
 impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::Range<usize>> for bitcoin_hashes::hmac::Hmac<T>
   pub type bitcoin_hashes::hmac::Hmac<T>::Output = [u8] [impl: impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::Range<usize>> for bitcoin_hashes::hmac::Hmac<T>]
   pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: core::ops::range::Range<usize>) -> &[u8] [impl: impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::Range<usize>> for bitcoin_hashes::hmac::Hmac<T>]
@@ -1466,6 +1465,7 @@ impl<T: core::cmp::Ord + bitcoin_hashes::Hash> core::cmp::Ord for bitcoin_hashes
   pub fn bitcoin_hashes::hmac::Hmac<T>::cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::cmp::Ordering [impl: impl<T: core::cmp::Ord + bitcoin_hashes::Hash> core::cmp::Ord for bitcoin_hashes::hmac::Hmac<T>]
 impl<T: core::cmp::PartialEq + bitcoin_hashes::Hash> core::cmp::PartialEq for bitcoin_hashes::hmac::Hmac<T>
   pub fn bitcoin_hashes::hmac::Hmac<T>::eq(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> bool [impl: impl<T: core::cmp::PartialEq + bitcoin_hashes::Hash> core::cmp::PartialEq for bitcoin_hashes::hmac::Hmac<T>]
+impl<T: core::cmp::PartialEq + bitcoin_hashes::Hash> core::marker::StructuralPartialEq for bitcoin_hashes::hmac::Hmac<T>
 impl<T: core::cmp::PartialOrd + bitcoin_hashes::Hash> core::cmp::PartialOrd for bitcoin_hashes::hmac::Hmac<T>
   pub fn bitcoin_hashes::hmac::Hmac<T>::partial_cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::option::Option<core::cmp::Ordering> [impl: impl<T: core::cmp::PartialOrd + bitcoin_hashes::Hash> core::cmp::PartialOrd for bitcoin_hashes::hmac::Hmac<T>]
 impl<T: core::hash::Hash + bitcoin_hashes::Hash> core::hash::Hash for bitcoin_hashes::hmac::Hmac<T>

--- a/hashes/api/no-features.txt
+++ b/hashes/api/no-features.txt
@@ -100,7 +100,6 @@ impl<T: bitcoin_hashes::Hash> core::fmt::Display for bitcoin_hashes::hmac::Hmac<
   pub fn bitcoin_hashes::hmac::Hmac<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<T: bitcoin_hashes::Hash> core::fmt::Display for bitcoin_hashes::hmac::Hmac<T>]
 impl<T: bitcoin_hashes::Hash> core::fmt::LowerHex for bitcoin_hashes::hmac::Hmac<T>
   pub fn bitcoin_hashes::hmac::Hmac<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<T: bitcoin_hashes::Hash> core::fmt::LowerHex for bitcoin_hashes::hmac::Hmac<T>]
-impl<T: bitcoin_hashes::Hash> core::marker::StructuralPartialEq for bitcoin_hashes::hmac::Hmac<T>
 impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::Range<usize>> for bitcoin_hashes::hmac::Hmac<T>
   pub type bitcoin_hashes::hmac::Hmac<T>::Output = [u8] [impl: impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::Range<usize>> for bitcoin_hashes::hmac::Hmac<T>]
   pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: core::ops::range::Range<usize>) -> &[u8] [impl: impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::Range<usize>> for bitcoin_hashes::hmac::Hmac<T>]
@@ -123,6 +122,7 @@ impl<T: core::cmp::Ord + bitcoin_hashes::Hash> core::cmp::Ord for bitcoin_hashes
   pub fn bitcoin_hashes::hmac::Hmac<T>::cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::cmp::Ordering [impl: impl<T: core::cmp::Ord + bitcoin_hashes::Hash> core::cmp::Ord for bitcoin_hashes::hmac::Hmac<T>]
 impl<T: core::cmp::PartialEq + bitcoin_hashes::Hash> core::cmp::PartialEq for bitcoin_hashes::hmac::Hmac<T>
   pub fn bitcoin_hashes::hmac::Hmac<T>::eq(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> bool [impl: impl<T: core::cmp::PartialEq + bitcoin_hashes::Hash> core::cmp::PartialEq for bitcoin_hashes::hmac::Hmac<T>]
+impl<T: core::cmp::PartialEq + bitcoin_hashes::Hash> core::marker::StructuralPartialEq for bitcoin_hashes::hmac::Hmac<T>
 impl<T: core::cmp::PartialOrd + bitcoin_hashes::Hash> core::cmp::PartialOrd for bitcoin_hashes::hmac::Hmac<T>
   pub fn bitcoin_hashes::hmac::Hmac<T>::partial_cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::option::Option<core::cmp::Ordering> [impl: impl<T: core::cmp::PartialOrd + bitcoin_hashes::Hash> core::cmp::PartialOrd for bitcoin_hashes::hmac::Hmac<T>]
 impl<T: core::hash::Hash + bitcoin_hashes::Hash> core::hash::Hash for bitcoin_hashes::hmac::Hmac<T>
@@ -1329,7 +1329,6 @@ impl<T: bitcoin_hashes::Hash> core::fmt::Display for bitcoin_hashes::hmac::Hmac<
   pub fn bitcoin_hashes::hmac::Hmac<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<T: bitcoin_hashes::Hash> core::fmt::Display for bitcoin_hashes::hmac::Hmac<T>]
 impl<T: bitcoin_hashes::Hash> core::fmt::LowerHex for bitcoin_hashes::hmac::Hmac<T>
   pub fn bitcoin_hashes::hmac::Hmac<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<T: bitcoin_hashes::Hash> core::fmt::LowerHex for bitcoin_hashes::hmac::Hmac<T>]
-impl<T: bitcoin_hashes::Hash> core::marker::StructuralPartialEq for bitcoin_hashes::hmac::Hmac<T>
 impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::Range<usize>> for bitcoin_hashes::hmac::Hmac<T>
   pub type bitcoin_hashes::hmac::Hmac<T>::Output = [u8] [impl: impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::Range<usize>> for bitcoin_hashes::hmac::Hmac<T>]
   pub fn bitcoin_hashes::hmac::Hmac<T>::index(&self, index: core::ops::range::Range<usize>) -> &[u8] [impl: impl<T: bitcoin_hashes::Hash> core::ops::index::Index<core::ops::range::Range<usize>> for bitcoin_hashes::hmac::Hmac<T>]
@@ -1352,6 +1351,7 @@ impl<T: core::cmp::Ord + bitcoin_hashes::Hash> core::cmp::Ord for bitcoin_hashes
   pub fn bitcoin_hashes::hmac::Hmac<T>::cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::cmp::Ordering [impl: impl<T: core::cmp::Ord + bitcoin_hashes::Hash> core::cmp::Ord for bitcoin_hashes::hmac::Hmac<T>]
 impl<T: core::cmp::PartialEq + bitcoin_hashes::Hash> core::cmp::PartialEq for bitcoin_hashes::hmac::Hmac<T>
   pub fn bitcoin_hashes::hmac::Hmac<T>::eq(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> bool [impl: impl<T: core::cmp::PartialEq + bitcoin_hashes::Hash> core::cmp::PartialEq for bitcoin_hashes::hmac::Hmac<T>]
+impl<T: core::cmp::PartialEq + bitcoin_hashes::Hash> core::marker::StructuralPartialEq for bitcoin_hashes::hmac::Hmac<T>
 impl<T: core::cmp::PartialOrd + bitcoin_hashes::Hash> core::cmp::PartialOrd for bitcoin_hashes::hmac::Hmac<T>
   pub fn bitcoin_hashes::hmac::Hmac<T>::partial_cmp(&self, other: &bitcoin_hashes::hmac::Hmac<T>) -> core::option::Option<core::cmp::Ordering> [impl: impl<T: core::cmp::PartialOrd + bitcoin_hashes::Hash> core::cmp::PartialOrd for bitcoin_hashes::hmac::Hmac<T>]
 impl<T: core::hash::Hash + bitcoin_hashes::Hash> core::hash::Hash for bitcoin_hashes::hmac::Hmac<T>

--- a/units/src/amount.rs
+++ b/units/src/amount.rs
@@ -753,15 +753,14 @@ fn fmt_satoshi_in(
     let mut num_after_decimal_point = 0;
     let mut norm_nb_decimals = 0;
     let mut num_before_decimal_point = satoshi;
-    let trailing_decimal_zeros;
     let mut exp = 0;
-    match precision.cmp(&0) {
+    let trailing_decimal_zeros = match precision.cmp(&0) {
         // We add the number of zeroes to the end
         Ordering::Greater => {
             if satoshi > 0 {
                 exp = precision as usize;
             }
-            trailing_decimal_zeros = options.precision.unwrap_or(0);
+            options.precision.unwrap_or(0)
         }
         Ordering::Less => {
             let precision = precision.unsigned_abs();
@@ -780,10 +779,10 @@ fn fmt_satoshi_in(
             }
             // compute requested precision
             let opt_precision = options.precision.unwrap_or(0);
-            trailing_decimal_zeros = opt_precision.saturating_sub(norm_nb_decimals);
+            opt_precision.saturating_sub(norm_nb_decimals)
         }
-        Ordering::Equal => trailing_decimal_zeros = options.precision.unwrap_or(0),
-    }
+        Ordering::Equal => options.precision.unwrap_or(0),
+    };
     let total_decimals = norm_nb_decimals + trailing_decimal_zeros;
     // Compute expected width of the number
     let mut num_width = if total_decimals > 0 {


### PR DESCRIPTION
Supersedes https://github.com/rust-bitcoin/rust-bitcoin/pull/6462

Drops a needless borrow in the `bip32` example, iterates `tap_script_sigs` with `values()` in the taproot test, and binds `trailing_decimal_zeros` from the match expression in units amount (borrowed from [cf6c1a5](https://github.com/rust-bitcoin/rust-bitcoin/pull/6492/commits/cf6c1a52b3dba95ac38773c60b5d03286a3e7012)).
