### PR TITLE
Add gitignore for Cargo.lock.backup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ fuzz/coverage
 
 # Local tooling
 .maintainer-tools
+Cargo.lock.backup


### PR DESCRIPTION
Created by `cargo rbmt`, lets just ignore it.