### PR TITLE
script: make new_p2wsh available on hashable scripts

### DIFF
--- a/primitives/api/all-features.txt
+++ b/primitives/api/all-features.txt
@@ -3663,7 +3663,8 @@ impl bitcoin_primitives::script::ScriptBuf<bitcoin_primitives::script::ScriptPub
 pub fn bitcoin_primitives::script::ScriptBuf<bitcoin_primitives::script::ScriptPubKeyTag>::new_op_return<T: core::convert::AsRef<bitcoin_primitives::script::PushBytes>>(data: T) -> Self
 pub fn bitcoin_primitives::script::ScriptBuf<bitcoin_primitives::script::ScriptPubKeyTag>::new_p2a() -> Self
 pub fn bitcoin_primitives::script::ScriptBuf<bitcoin_primitives::script::ScriptPubKeyTag>::new_p2sh(script_hash: bitcoin_primitives::script::ScriptHash) -> Self
-pub fn bitcoin_primitives::script::ScriptBuf<bitcoin_primitives::script::ScriptPubKeyTag>::new_p2wsh(script_hash: bitcoin_primitives::script::WScriptHash) -> Self
+impl<T: bitcoin_primitives::script::ScriptHashableTag> bitcoin_primitives::script::ScriptBuf<T>
+pub fn bitcoin_primitives::script::ScriptBuf<T>::new_p2wsh(script_hash: bitcoin_primitives::script::WScriptHash) -> Self
 impl<T> bitcoin_primitives::script::ScriptBuf<T>
 pub fn bitcoin_primitives::script::ScriptBuf<T>::as_mut_script(&mut self) -> &mut bitcoin_primitives::script::Script<T>
 pub fn bitcoin_primitives::script::ScriptBuf<T>::as_script(&self) -> &bitcoin_primitives::script::Script<T>

--- a/primitives/api/alloc-only.txt
+++ b/primitives/api/alloc-only.txt
@@ -3508,7 +3508,8 @@ impl bitcoin_primitives::script::ScriptBuf<bitcoin_primitives::script::ScriptPub
 pub fn bitcoin_primitives::script::ScriptBuf<bitcoin_primitives::script::ScriptPubKeyTag>::new_op_return<T: core::convert::AsRef<bitcoin_primitives::script::PushBytes>>(data: T) -> Self
 pub fn bitcoin_primitives::script::ScriptBuf<bitcoin_primitives::script::ScriptPubKeyTag>::new_p2a() -> Self
 pub fn bitcoin_primitives::script::ScriptBuf<bitcoin_primitives::script::ScriptPubKeyTag>::new_p2sh(script_hash: bitcoin_primitives::script::ScriptHash) -> Self
-pub fn bitcoin_primitives::script::ScriptBuf<bitcoin_primitives::script::ScriptPubKeyTag>::new_p2wsh(script_hash: bitcoin_primitives::script::WScriptHash) -> Self
+impl<T: bitcoin_primitives::script::ScriptHashableTag> bitcoin_primitives::script::ScriptBuf<T>
+pub fn bitcoin_primitives::script::ScriptBuf<T>::new_p2wsh(script_hash: bitcoin_primitives::script::WScriptHash) -> Self
 impl<T> bitcoin_primitives::script::ScriptBuf<T>
 pub fn bitcoin_primitives::script::ScriptBuf<T>::as_mut_script(&mut self) -> &mut bitcoin_primitives::script::Script<T>
 pub fn bitcoin_primitives::script::ScriptBuf<T>::as_script(&self) -> &bitcoin_primitives::script::Script<T>

--- a/primitives/src/script/owned.rs
+++ b/primitives/src/script/owned.rs
@@ -11,7 +11,7 @@ use super::{Script, ScriptBufDecoderError, P2A_PROGRAM};
 use crate::opcodes::all::{OP_1, OP_1NEGATE, OP_EQUAL, OP_HASH160, OP_RETURN};
 use crate::opcodes::{self, Opcode};
 use crate::prelude::{Box, Vec};
-use crate::script::{Builder, PushBytes, ScriptHash, WScriptHash};
+use crate::script::{Builder, PushBytes, ScriptHash, ScriptHashableTag, WScriptHash};
 use crate::witness_version::WitnessVersion;
 use crate::ScriptPubKeyBuf;
 
@@ -275,15 +275,17 @@ impl ScriptPubKeyBuf {
             .into_script()
     }
 
-    /// Generates P2WSH-type of scriptPubkey with a given hash of the redeem script.
-    pub fn new_p2wsh(script_hash: WScriptHash) -> Self {
-        // script hash is 32 bytes long, so it's safe to use `new_witness_program_unchecked` (Segwitv0)
-        super::new_witness_program_unchecked(WitnessVersion::V0, script_hash)
-    }
-
     /// Generates pay to anchor output.
     pub fn new_p2a() -> Self {
         super::new_witness_program_unchecked(WitnessVersion::V1, P2A_PROGRAM)
+    }
+}
+
+impl<T: ScriptHashableTag> ScriptBuf<T> {
+    /// Generates a P2WSH witness program script with a given hash of the witness script.
+    pub fn new_p2wsh(script_hash: WScriptHash) -> Self {
+        // script hash is 32 bytes long, so it's safe to use `new_witness_program_unchecked` (Segwitv0)
+        super::new_witness_program_unchecked(WitnessVersion::V0, script_hash)
     }
 }
 

--- a/primitives/src/script/tests.rs
+++ b/primitives/src/script/tests.rs
@@ -858,6 +858,10 @@ fn new_p2wsh() {
     let mut want = vec![0x00, 0x20];
     want.extend([0x34; 32]);
     assert_eq!(p2wsh.as_bytes(), &want[..]);
+
+    let redeem_script = RedeemScriptBuf::new_p2wsh(wscript_hash);
+    assert!(redeem_script.is_p2wsh());
+    assert_eq!(redeem_script.as_bytes(), &want[..]);
 }
 
 #[test]


### PR DESCRIPTION
Partially addresses #6487.

This moves `new_p2wsh` from the `ScriptPubKeyBuf` inherent impl to
`ScriptBuf<T> where T: ScriptHashableTag`.

This keeps the existing `ScriptPubKeyBuf::new_p2wsh` API working, while also
allowing callers to construct P2WSH witness program scripts as `RedeemScriptBuf`
for P2SH-wrapped P2WSH use cases.

I intentionally left `new_p2wpkh` unchanged in this PR because `WPubkeyHash`
currently lives outside `bitcoin-primitives`, as noted in the issue discussion.
This PR covers the primitives-local part of the issue without adding new
dependencies or broadening the public API surface further.

Testing:
- `cargo test -p bitcoin-primitives script::tests::new_p2wsh`
- `cargo test -p bitcoin-primitives`
- `cargo test -p bitcoin blockdata::script::tests::script_generators`
- `rustfmt --check --edition 2021 primitives/src/script/owned.rs primitives/src/script/tests.rs`