### PR TITLE
Move `new_p2wsh` to `ScriptBuf` with `ScriptHashableTag` bound

### DIFF
--- a/primitives/api/all-features.txt
+++ b/primitives/api/all-features.txt
@@ -3663,7 +3663,6 @@ impl bitcoin_primitives::script::ScriptBuf<bitcoin_primitives::script::ScriptPub
 pub fn bitcoin_primitives::script::ScriptBuf<bitcoin_primitives::script::ScriptPubKeyTag>::new_op_return<T: core::convert::AsRef<bitcoin_primitives::script::PushBytes>>(data: T) -> Self
 pub fn bitcoin_primitives::script::ScriptBuf<bitcoin_primitives::script::ScriptPubKeyTag>::new_p2a() -> Self
 pub fn bitcoin_primitives::script::ScriptBuf<bitcoin_primitives::script::ScriptPubKeyTag>::new_p2sh(script_hash: bitcoin_primitives::script::ScriptHash) -> Self
-pub fn bitcoin_primitives::script::ScriptBuf<bitcoin_primitives::script::ScriptPubKeyTag>::new_p2wsh(script_hash: bitcoin_primitives::script::WScriptHash) -> Self
 impl<T> bitcoin_primitives::script::ScriptBuf<T>
 pub fn bitcoin_primitives::script::ScriptBuf<T>::as_mut_script(&mut self) -> &mut bitcoin_primitives::script::Script<T>
 pub fn bitcoin_primitives::script::ScriptBuf<T>::as_script(&self) -> &bitcoin_primitives::script::Script<T>
@@ -3674,6 +3673,7 @@ pub fn bitcoin_primitives::script::ScriptBuf<T>::from_hex_prefixed(s: &str) -> c
 pub fn bitcoin_primitives::script::ScriptBuf<T>::into_boxed_script(self) -> alloc::boxed::Box<bitcoin_primitives::script::Script<T>>
 pub fn bitcoin_primitives::script::ScriptBuf<T>::into_bytes(self) -> alloc::vec::Vec<u8>
 pub const fn bitcoin_primitives::script::ScriptBuf<T>::new() -> Self
+pub fn bitcoin_primitives::script::ScriptBuf<T>::new_p2wsh(script_hash: bitcoin_primitives::script::WScriptHash) -> Self where T: bitcoin_primitives::script::ScriptHashableTag
 pub fn bitcoin_primitives::script::ScriptBuf<T>::push_opcode(&mut self, data: bitcoin_primitives::opcodes::Opcode)
 pub fn bitcoin_primitives::script::ScriptBuf<T>::push_slice<D: core::convert::AsRef<bitcoin_primitives::script::PushBytes>>(&mut self, data: D)
 pub fn bitcoin_primitives::script::ScriptBuf<T>::push_slice_non_minimal<D: core::convert::AsRef<bitcoin_primitives::script::PushBytes>>(&mut self, data: D)

--- a/primitives/api/alloc-only.txt
+++ b/primitives/api/alloc-only.txt
@@ -3508,7 +3508,6 @@ impl bitcoin_primitives::script::ScriptBuf<bitcoin_primitives::script::ScriptPub
 pub fn bitcoin_primitives::script::ScriptBuf<bitcoin_primitives::script::ScriptPubKeyTag>::new_op_return<T: core::convert::AsRef<bitcoin_primitives::script::PushBytes>>(data: T) -> Self
 pub fn bitcoin_primitives::script::ScriptBuf<bitcoin_primitives::script::ScriptPubKeyTag>::new_p2a() -> Self
 pub fn bitcoin_primitives::script::ScriptBuf<bitcoin_primitives::script::ScriptPubKeyTag>::new_p2sh(script_hash: bitcoin_primitives::script::ScriptHash) -> Self
-pub fn bitcoin_primitives::script::ScriptBuf<bitcoin_primitives::script::ScriptPubKeyTag>::new_p2wsh(script_hash: bitcoin_primitives::script::WScriptHash) -> Self
 impl<T> bitcoin_primitives::script::ScriptBuf<T>
 pub fn bitcoin_primitives::script::ScriptBuf<T>::as_mut_script(&mut self) -> &mut bitcoin_primitives::script::Script<T>
 pub fn bitcoin_primitives::script::ScriptBuf<T>::as_script(&self) -> &bitcoin_primitives::script::Script<T>
@@ -3517,6 +3516,7 @@ pub const fn bitcoin_primitives::script::ScriptBuf<T>::from_bytes(bytes: alloc::
 pub fn bitcoin_primitives::script::ScriptBuf<T>::into_boxed_script(self) -> alloc::boxed::Box<bitcoin_primitives::script::Script<T>>
 pub fn bitcoin_primitives::script::ScriptBuf<T>::into_bytes(self) -> alloc::vec::Vec<u8>
 pub const fn bitcoin_primitives::script::ScriptBuf<T>::new() -> Self
+pub fn bitcoin_primitives::script::ScriptBuf<T>::new_p2wsh(script_hash: bitcoin_primitives::script::WScriptHash) -> Self where T: bitcoin_primitives::script::ScriptHashableTag
 pub fn bitcoin_primitives::script::ScriptBuf<T>::push_opcode(&mut self, data: bitcoin_primitives::opcodes::Opcode)
 pub fn bitcoin_primitives::script::ScriptBuf<T>::push_slice<D: core::convert::AsRef<bitcoin_primitives::script::PushBytes>>(&mut self, data: D)
 pub fn bitcoin_primitives::script::ScriptBuf<T>::push_slice_non_minimal<D: core::convert::AsRef<bitcoin_primitives::script::PushBytes>>(&mut self, data: D)

--- a/primitives/src/script/owned.rs
+++ b/primitives/src/script/owned.rs
@@ -11,7 +11,7 @@ use super::{Script, ScriptBufDecoderError, P2A_PROGRAM};
 use crate::opcodes::all::{OP_1, OP_1NEGATE, OP_EQUAL, OP_HASH160, OP_RETURN};
 use crate::opcodes::{self, Opcode};
 use crate::prelude::{Box, Vec};
-use crate::script::{Builder, PushBytes, ScriptHash, WScriptHash};
+use crate::script::{Builder, PushBytes, ScriptHash, ScriptHashableTag, WScriptHash};
 use crate::witness_version::WitnessVersion;
 use crate::ScriptPubKeyBuf;
 
@@ -84,6 +84,15 @@ impl<T> ScriptBuf<T> {
     pub fn from_hex_no_length_prefix(s: &str) -> Result<Self, hex::DecodeVariableLengthBytesError> {
         let v = hex::decode_to_vec(s)?;
         Ok(Self::from_bytes(v))
+    }
+
+    /// Generates P2WSH-type of scriptPubkey with a given hash of the redeem script.
+    pub fn new_p2wsh(script_hash: WScriptHash) -> Self
+    where
+        T: ScriptHashableTag,
+    {
+        // script hash is 32 bytes long, so it's safe to use `new_witness_program_unchecked` (Segwitv0)
+        super::new_witness_program_unchecked(WitnessVersion::V0, script_hash)
     }
 
     /// Returns a reference to unsized script.
@@ -273,12 +282,6 @@ impl ScriptPubKeyBuf {
             .push_slice(script_hash)
             .push_opcode(OP_EQUAL)
             .into_script()
-    }
-
-    /// Generates P2WSH-type of scriptPubkey with a given hash of the redeem script.
-    pub fn new_p2wsh(script_hash: WScriptHash) -> Self {
-        // script hash is 32 bytes long, so it's safe to use `new_witness_program_unchecked` (Segwitv0)
-        super::new_witness_program_unchecked(WitnessVersion::V0, script_hash)
     }
 
     /// Generates pay to anchor output.


### PR DESCRIPTION
The new_p2wsh function currently resides on ScriptPubKeyBuf, which bounds its use to ScriptPubKey, but prevents users from creating a P2SH-wrapped P2WSH script. Instead, it should be bounded on ScriptHashableTag, and thus moved to the main impl ScriptBuf<T> block.

Move new_p2wsh function from ScriptPubKeyBuf to ScriptBuf<T> impl block, bounding on ScriptHashableTag.