### PR TITLE
#6460 follow-up: Adjust docs

### DIFF
--- a/addresses/src/lib.rs
+++ b/addresses/src/lib.rs
@@ -73,7 +73,6 @@ pub trait ScriptPubKeyBufExt: sealed::Sealed {
 
 #[cfg(feature = "alloc")]
 impl ScriptPubKeyBufExt for ScriptPubKeyBuf {
-    /// Generates P2PK-type of scriptPubkey.
     fn new_p2pk(pubkey: LegacyPublicKey) -> Self {
         Builder::new()
             .push_slice(pubkey.serialize())
@@ -91,8 +90,6 @@ impl ScriptPubKeyBufExt for ScriptPubKeyBuf {
             .into_script()
     }
 
-    /// Generates P2TR for script spending path using an internal public key and some optional
-    /// script tree Merkle root.
     fn new_p2tr<K: Into<UntweakedPublicKey>>(
         internal_key: K,
         merkle_root: Option<TapNodeHash>,
@@ -103,13 +100,11 @@ impl ScriptPubKeyBufExt for ScriptPubKeyBuf {
         new_witness_program_unchecked(WitnessVersion::V1, output_key.serialize())
     }
 
-    /// Generates P2TR for key spending path for a known [`TweakedPublicKey`].
     fn new_p2tr_tweaked(output_key: TweakedPublicKey) -> Self {
         // output key is 32 bytes long, so it's safe to use `new_witness_program_unchecked` (Segwitv1)
         new_witness_program_unchecked(WitnessVersion::V1, output_key.serialize())
     }
 
-    /// Generates P2WSH-type of scriptPubkey with a given [`WitnessProgram`].
     fn new_witness_program(witness_program: &WitnessProgram) -> Self {
         Builder::new()
             .push_opcode(witness_program.version().into())

--- a/addresses/src/lib.rs
+++ b/addresses/src/lib.rs
@@ -120,6 +120,7 @@ mod sealed {
 }
 
 /// Generates P2WSH-type of scriptPubkey with a given [`WitnessVersion`] and the program bytes.
+///
 /// Does not do any checks on version or program length.
 ///
 /// Convenience method used by `new_p2a`, `new_p2wpkh`, `new_p2wsh`, `new_p2tr`, and `new_p2tr_tweaked`.

--- a/addresses/src/lib.rs
+++ b/addresses/src/lib.rs
@@ -123,6 +123,7 @@ mod sealed {
 /// Does not do any checks on version or program length.
 ///
 /// Convenience method used by `new_p2a`, `new_p2wpkh`, `new_p2wsh`, `new_p2tr`, and `new_p2tr_tweaked`.
+// This function is duplicated in bitcoin and primitives. If you make any changes, please update all three.
 #[cfg(feature = "alloc")]
 fn new_witness_program_unchecked<T: AsRef<PushBytes>, Tg>(
     version: WitnessVersion,

--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -205,6 +205,7 @@ fn opcode_to_verify(opcode: Option<Opcode>) -> Option<Opcode> {
 /// Does not do any checks on version or program length.
 ///
 /// Convenience method used by `new_p2a`, `new_p2wpkh`, `new_p2wsh`, `new_p2tr`, and `new_p2tr_tweaked`.
+// This function is duplicated in addresses and primitives. If you make any changes, please update all three.
 pub(crate) fn new_witness_program_unchecked<T: AsRef<PushBytes>, Tg>(
     version: WitnessVersion,
     program: T,

--- a/bitcoin/src/blockdata/script/mod.rs
+++ b/bitcoin/src/blockdata/script/mod.rs
@@ -202,6 +202,7 @@ fn opcode_to_verify(opcode: Option<Opcode>) -> Option<Opcode> {
 }
 
 /// Generates P2WSH-type of scriptPubkey with a given [`WitnessVersion`] and the program bytes.
+///
 /// Does not do any checks on version or program length.
 ///
 /// Convenience method used by `new_p2a`, `new_p2wpkh`, `new_p2wsh`, `new_p2tr`, and `new_p2tr_tweaked`.

--- a/primitives/src/script/mod.rs
+++ b/primitives/src/script/mod.rs
@@ -97,6 +97,7 @@ pub(crate) const P2A_PROGRAM: [u8; 2] = [78, 115];
 /// Does not do any checks on version or program length.
 ///
 /// Convenience method used by `new_p2a`, `new_p2wpkh`, `new_p2wsh`, `new_p2tr`, and `new_p2tr_tweaked`.
+// This function is duplicated in addresses and bitcoin. If you make any changes, please update all three.
 pub(crate) fn new_witness_program_unchecked<T: AsRef<PushBytes>, Tg>(
     version: WitnessVersion,
     program: T,

--- a/primitives/src/script/mod.rs
+++ b/primitives/src/script/mod.rs
@@ -94,6 +94,7 @@ pub const MAX_WITNESS_SCRIPT_SIZE: usize = 10_000;
 pub(crate) const P2A_PROGRAM: [u8; 2] = [78, 115];
 
 /// Generates P2WSH-type of scriptPubkey with a given [`WitnessVersion`] and the program bytes.
+///
 /// Does not do any checks on version or program length.
 ///
 /// Convenience method used by `new_p2a`, `new_p2wpkh`, `new_p2wsh`, `new_p2tr`, and `new_p2tr_tweaked`.


### PR DESCRIPTION
Follow-up to #6460 with some docs changes.

- Patch 1 removes the useless docs on the function impls for ScriptPubKeyBufExt impl.
- Patch 2 adds comments to the three new_witness_program_unchecked copies with a reminder to keep them in sync.
- Patch 3 adds empty lines under the heading lines in the doccomments of each instance of new_witness_program_unchecked.