### PR TITLE
Move `script_hash` and `wscript_hash` to `primitives`

### DIFF
--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -66,7 +66,7 @@ use crate::script::witness_version::WitnessVersion;
 use crate::script::{
     self, BuilderExt as _, RedeemScriptSizeError, Script, ScriptExt as _, ScriptHash,
     ScriptHashableTag, ScriptPubKey, ScriptPubKeyBuf, ScriptPubKeyBufExt as _, WScriptHash,
-    WitnessScript, WitnessScriptExt as _, WitnessScriptSizeError,
+    WitnessScript, WitnessScriptSizeError,
 };
 use crate::taproot::TapNodeHash;
 

--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -7,8 +7,8 @@ use internals::array::ArrayExt; // For `split_first`.
 use super::witness_version::WitnessVersion;
 use super::{
     Builder, Instruction, InstructionIndices, Instructions, PushBytes, RedeemScript,
-    RedeemScriptSizeError, Script, ScriptHash, ScriptHashableTag, ScriptPubKey, ScriptSig,
-    TapScript, WScriptHash, WitnessScript, WitnessScriptSizeError,
+    RedeemScriptSizeError, Script, ScriptHashableTag, ScriptPubKey, ScriptSig, TapScript,
+    WitnessScript, WitnessScriptSizeError,
 };
 use crate::encoding::{Encode, ExactSizeEncoder};
 use crate::key::{LegacyPublicKey, UntweakedPublicKey, WPubkeyHash};
@@ -143,14 +143,6 @@ internal_macros::define_extension_trait! {
         // These methods only exist for scriptPubKey and redeemScript, as indicated by the
         // where clauses on them.
 
-        /// Returns 160-bit hash of the script for P2SH outputs.
-        #[inline]
-        fn script_hash(&self) -> Result<ScriptHash, RedeemScriptSizeError>
-        where T: ScriptHashableTag
-        {
-            ScriptHash::from_script(self)
-        }
-
         /// Computes the P2SH output corresponding to this redeem script.
         fn to_p2sh(&self) -> Result<ScriptPubKeyBuf, RedeemScriptSizeError>
         where T: ScriptHashableTag
@@ -184,12 +176,6 @@ internal_macros::define_extension_trait! {
 internal_macros::define_extension_trait! {
     /// Extension functionality for the [`WitnessScript`] type.
     pub trait WitnessScriptExt impl for WitnessScript {
-        /// Returns 256-bit hash of the script for P2WSH outputs.
-        #[inline]
-        fn wscript_hash(&self) -> Result<WScriptHash, WitnessScriptSizeError> {
-            WScriptHash::from_script(self)
-        }
-
         /// Computes the P2WSH output corresponding to this witnessScript (aka the "witness redeem
         /// script").
         fn to_p2wsh(&self) -> Result<ScriptPubKeyBuf, WitnessScriptSizeError> {

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -145,8 +145,6 @@ crate::internal_macros::define_extension_trait! {
         ///
         /// [`WitnessExt::p2wsh`]: crate::blockdata::witness::WitnessExt::p2wsh
         fn p2sh_p2wsh(witness_script: &WitnessScript) -> Result<ScriptSigBuf, super::WitnessScriptSizeError> {
-            use super::WitnessScriptExt as _;
-
             let hash = witness_script.wscript_hash()?;
             let redeem_script: super::ScriptPubKeyBuf = Builder::new().push_int_unchecked(0).push_slice(hash).into_script();
             Ok(Builder::new().push_slice(<&PushBytes>::try_from(redeem_script.as_bytes()).expect("redeem script is 34 bytes")).into_script())

--- a/primitives/api/all-features.txt
+++ b/primitives/api/all-features.txt
@@ -3527,6 +3527,10 @@ pub fn bitcoin_primitives::script::Script<bitcoin_primitives::script::ScriptPubK
 pub fn bitcoin_primitives::script::Script<bitcoin_primitives::script::ScriptPubKeyTag>::is_p2pkh(&self) -> bool
 pub fn bitcoin_primitives::script::Script<bitcoin_primitives::script::ScriptPubKeyTag>::is_p2sh(&self) -> bool
 pub fn bitcoin_primitives::script::Script<bitcoin_primitives::script::ScriptPubKeyTag>::is_witness_program(&self) -> bool
+impl bitcoin_primitives::script::Script<bitcoin_primitives::script::WitnessScriptTag>
+pub fn bitcoin_primitives::script::Script<bitcoin_primitives::script::WitnessScriptTag>::wscript_hash(&self) -> core::result::Result<bitcoin_primitives::script::WScriptHash, bitcoin_primitives::script::WitnessScriptSizeError>
+impl<T: bitcoin_primitives::script::ScriptHashableTag> bitcoin_primitives::script::Script<T>
+pub fn bitcoin_primitives::script::Script<T>::script_hash(&self) -> core::result::Result<bitcoin_primitives::script::ScriptHash, bitcoin_primitives::script::RedeemScriptSizeError>
 impl<T> bitcoin_primitives::script::Script<T>
 pub const fn bitcoin_primitives::script::Script<T>::as_bytes(&self) -> &[u8]
 pub fn bitcoin_primitives::script::Script<T>::as_mut_bytes(&mut self) -> &mut [u8]

--- a/primitives/api/alloc-only.txt
+++ b/primitives/api/alloc-only.txt
@@ -3385,6 +3385,10 @@ pub fn bitcoin_primitives::script::Script<bitcoin_primitives::script::ScriptPubK
 pub fn bitcoin_primitives::script::Script<bitcoin_primitives::script::ScriptPubKeyTag>::is_p2pkh(&self) -> bool
 pub fn bitcoin_primitives::script::Script<bitcoin_primitives::script::ScriptPubKeyTag>::is_p2sh(&self) -> bool
 pub fn bitcoin_primitives::script::Script<bitcoin_primitives::script::ScriptPubKeyTag>::is_witness_program(&self) -> bool
+impl bitcoin_primitives::script::Script<bitcoin_primitives::script::WitnessScriptTag>
+pub fn bitcoin_primitives::script::Script<bitcoin_primitives::script::WitnessScriptTag>::wscript_hash(&self) -> core::result::Result<bitcoin_primitives::script::WScriptHash, bitcoin_primitives::script::WitnessScriptSizeError>
+impl<T: bitcoin_primitives::script::ScriptHashableTag> bitcoin_primitives::script::Script<T>
+pub fn bitcoin_primitives::script::Script<T>::script_hash(&self) -> core::result::Result<bitcoin_primitives::script::ScriptHash, bitcoin_primitives::script::RedeemScriptSizeError>
 impl<T> bitcoin_primitives::script::Script<T>
 pub const fn bitcoin_primitives::script::Script<T>::as_bytes(&self) -> &[u8]
 pub fn bitcoin_primitives::script::Script<T>::as_mut_bytes(&mut self) -> &mut [u8]

--- a/primitives/src/script/borrowed.rs
+++ b/primitives/src/script/borrowed.rs
@@ -16,9 +16,11 @@ use super::{ScriptBuf, P2A_PROGRAM};
 use crate::opcodes::all::{OP_CHECKSIG, OP_DUP, OP_EQUAL, OP_EQUALVERIFY, OP_HASH160, OP_RETURN};
 use crate::opcodes::{Opcode, OP_PUSHBYTES_2, OP_PUSHBYTES_20, OP_PUSHBYTES_32};
 use crate::prelude::{Box, ToOwned, Vec};
-use crate::script::ScriptHashableTag;
+use crate::script::{
+    RedeemScriptSizeError, ScriptHash, ScriptHashableTag, WScriptHash, WitnessScriptSizeError,
+};
 use crate::witness_version::WitnessVersion;
-use crate::ScriptPubKey;
+use crate::{ScriptPubKey, WitnessScript};
 
 // Defined in `REPO_DIR/include/newtype.rs`.
 crate::transparent_newtype! {
@@ -286,6 +288,30 @@ impl ScriptPubKey {
     #[inline]
     pub fn is_op_return(&self) -> bool {
         self.as_bytes().first().is_some_and(|&b| b == OP_RETURN.to_u8())
+    }
+}
+
+impl WitnessScript {
+    /// Returns 256-bit hash of the script for P2WSH outputs.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the script exceeds 10,000 bytes.
+    #[inline]
+    pub fn wscript_hash(&self) -> Result<WScriptHash, WitnessScriptSizeError> {
+        WScriptHash::from_script(self)
+    }
+}
+
+impl<T: ScriptHashableTag> Script<T> {
+    /// Returns 160-bit hash of the script for P2SH outputs.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the script exceeds 520 bytes.
+    #[inline]
+    pub fn script_hash(&self) -> Result<ScriptHash, RedeemScriptSizeError> {
+        ScriptHash::from_script(self)
     }
 }
 


### PR DESCRIPTION
The script_hash and wscript_hash functions in Script extension traits currently function the same as the W/ScriptHash::from_script constructors. Until recently, these could not be moved as the prerequisite functionality and types had yet to be moved. With the recent moves of functionality to primitives, these can now be moved.

Move script_hash and wscript_hash to primitives on the base types.