### PR TITLE
base58: Replace encoding functions with optional-alloc `Base58CkString`

### DIFF
--- a/base58/src/error.rs
+++ b/base58/src/error.rs
@@ -148,6 +148,45 @@ impl std::error::Error for TooShortError {
     }
 }
 
+/// The input was too long to be encoded into the fixed-size buffer.
+///
+/// Without `alloc` any encoded base58check string must fit in 128 characters.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InputTooLongError(pub(super) InputTooLongErrorInner);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct InputTooLongErrorInner {
+    /// The length of the un-encoded input data in bytes (excluding the 4 checksum bytes).
+    pub(super) input_len: usize,
+}
+
+impl InputTooLongError {
+    /// Returns the length of the input data in bytes (excluding the 4 checksum bytes).
+    pub fn input_length(&self) -> usize { self.0.input_len }
+}
+
+impl From<Infallible> for InputTooLongError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+impl fmt::Display for InputTooLongError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "base58check encoding of {} bytes of data exceeds the 128 character buffer",
+            self.0.input_len
+        )
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for InputTooLongError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        let InputTooLongErrorInner { input_len: _ } = self.0;
+        None
+    }
+}
+
 /// Found an invalid ASCII byte while decoding base58 string.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InvalidCharacterError(pub(super) InvalidCharacterErrorInner);
@@ -158,6 +197,7 @@ pub(super) struct InvalidCharacterErrorInner {
 }
 
 impl InvalidCharacterError {
+    #[cfg(feature = "alloc")]
     pub(super) fn new(invalid: u8) -> Self { Self(InvalidCharacterErrorInner { invalid }) }
 
     /// Returns the invalid base58 character.

--- a/base58/src/error.rs
+++ b/base58/src/error.rs
@@ -5,12 +5,15 @@
 use core::convert::Infallible;
 use core::fmt;
 
+#[cfg(feature = "alloc")]
 use internals::write_err;
 
 /// An error occurred during base58 decoding (with checksum).
+#[cfg(feature = "alloc")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Error(pub(super) ErrorInner);
 
+#[cfg(feature = "alloc")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum ErrorInner {
     /// Invalid character while decoding.
@@ -21,6 +24,7 @@ pub(super) enum ErrorInner {
     TooShort(TooShortError),
 }
 
+#[cfg(feature = "alloc")]
 impl Error {
     /// Returns the invalid base58 character, if encountered.
     pub fn invalid_character(&self) -> Option<u8> {
@@ -47,10 +51,12 @@ impl Error {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl From<Infallible> for Error {
     fn from(never: Infallible) -> Self { match never {} }
 }
 
+#[cfg(feature = "alloc")]
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use ErrorInner::{Decode, IncorrectChecksum, TooShort};
@@ -76,18 +82,22 @@ impl std::error::Error for Error {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl From<InvalidCharacterError> for Error {
     fn from(e: InvalidCharacterError) -> Self { Self(ErrorInner::Decode(e)) }
 }
 
+#[cfg(feature = "alloc")]
 impl From<IncorrectChecksumError> for Error {
     fn from(e: IncorrectChecksumError) -> Self { Self(ErrorInner::IncorrectChecksum(e)) }
 }
 
+#[cfg(feature = "alloc")]
 impl From<TooShortError> for Error {
     fn from(e: TooShortError) -> Self { Self(ErrorInner::TooShort(e)) }
 }
 
+#[cfg(feature = "alloc")]
 /// Checksum was not correct.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct IncorrectChecksumError {
@@ -97,10 +107,12 @@ pub(super) struct IncorrectChecksumError {
     pub(super) expected: u32,
 }
 
+#[cfg(feature = "alloc")]
 impl From<Infallible> for IncorrectChecksumError {
     fn from(never: Infallible) -> Self { match never {} }
 }
 
+#[cfg(feature = "alloc")]
 impl fmt::Display for IncorrectChecksumError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
@@ -119,6 +131,7 @@ impl std::error::Error for IncorrectChecksumError {
     }
 }
 
+#[cfg(feature = "alloc")]
 /// The decoded base58 data was too short (require at least 4 bytes for checksum).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct TooShortError {
@@ -126,10 +139,12 @@ pub(super) struct TooShortError {
     pub(super) length: usize,
 }
 
+#[cfg(feature = "alloc")]
 impl From<Infallible> for TooShortError {
     fn from(never: Infallible) -> Self { match never {} }
 }
 
+#[cfg(feature = "alloc")]
 impl fmt::Display for TooShortError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
@@ -188,14 +203,17 @@ impl std::error::Error for InputTooLongError {
 }
 
 /// Found an invalid ASCII byte while decoding base58 string.
+#[cfg(feature = "alloc")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InvalidCharacterError(pub(super) InvalidCharacterErrorInner);
 
+#[cfg(feature = "alloc")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct InvalidCharacterErrorInner {
     pub(super) invalid: u8,
 }
 
+#[cfg(feature = "alloc")]
 impl InvalidCharacterError {
     #[cfg(feature = "alloc")]
     pub(super) fn new(invalid: u8) -> Self { Self(InvalidCharacterErrorInner { invalid }) }
@@ -204,10 +222,12 @@ impl InvalidCharacterError {
     pub fn invalid_character(&self) -> u8 { self.0.invalid }
 }
 
+#[cfg(feature = "alloc")]
 impl From<Infallible> for InvalidCharacterError {
     fn from(never: Infallible) -> Self { match never {} }
 }
 
+#[cfg(feature = "alloc")]
 impl fmt::Display for InvalidCharacterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "invalid base58 character {:#x}", self.0.invalid)

--- a/base58/src/lib.rs
+++ b/base58/src/lib.rs
@@ -412,26 +412,26 @@ mod tests {
     #[test]
     fn base58_encode() {
         // Basics
-        assert_eq!(&encode(&[0][..]), "1");
-        assert_eq!(&encode(&[1][..]), "2");
-        assert_eq!(&encode(&[58][..]), "21");
-        assert_eq!(&encode(&[13, 36][..]), "211");
+        assert_eq!(Base58CkString::encode_unbounded(&[13, 36][..]).as_str(), "7YY3x3vS");
 
         // Leading zeroes
-        assert_eq!(&encode(&[0, 13, 36][..]), "1211");
-        assert_eq!(&encode(&[0, 0, 0, 0, 13, 36][..]), "1111211");
+        assert_eq!(Base58CkString::encode_unbounded(&[0, 13, 36][..]).as_str(), "17YZPJu4L");
+        assert_eq!(
+            Base58CkString::encode_unbounded(&[0, 0, 0, 0, 13, 36][..]).as_str(),
+            "11117YaXDHva"
+        );
 
         // Long input (>128 bytes => has to use heap)
-        let res = encode(
+        let res = Base58CkString::encode_unbounded(
             "BitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBit\
         coinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoinBitcoin"
                 .as_bytes(),
         );
         let exp =
-            "ZqC5ZdfpZRi7fjA8hbhX5pEE96MdH9hEaC1YouxscPtbJF16qVWksHWR4wwvx7MotFcs2ChbJqK8KJ9X\
-        wZznwWn1JFDhhTmGo9v6GjAVikzCsBWZehu7bm22xL8b5zBR5AsBygYRwbFJsNwNkjpyFuDKwmsUTKvkULCvucPJrN5\
-        QUdxpGakhqkZFL7RU4yT";
-        assert_eq!(&res, exp);
+            "4hqMa7U6Kxg4YstWo7KztyYAAkTuhuLWTvrHia8nrgx5eb2E8cf79wD9dBjd4c9STsTTXWZT5pp985vP\
+        nL4MVTQrt4EW5jgAk5Fh81PoF6jjhCyUZY2kZ8iYaM5XpfPkZ6aki57S6oiuVv4cmJz2ou8ssxEKNRJMWjSFL5izLbe\
+        s9rugAdBdrboyHMSAtSNY1Nrb4";
+        assert_eq!(res.as_str(), exp);
 
         // Addresses
         let addr = hex!("00f8917303bfa8ef24f292e8fa1419b20460ba064d");
@@ -472,7 +472,7 @@ mod tests {
         // Check that empty slice passes roundtrip.
         assert_eq!(decode_check(Base58CkString::encode_unbounded(&[]).as_str()), Ok(vec![]));
         // Check that `len > 4` is enforced.
-        assert_eq!(decode_check(&encode(&[1, 2, 3])), Err(TooShortError { length: 3 }.into()));
+        assert_eq!(decode_check("Ldp"), Err(TooShortError { length: 3 }.into()));
     }
 }
 

--- a/base58/src/lib.rs
+++ b/base58/src/lib.rs
@@ -221,7 +221,6 @@ const fn encoded_check_reserve_len(unencoded_len: usize) -> usize {
 trait Buffer: Sized {
     type Err: fmt::Debug;
 
-    fn push(&mut self, val: u8);
     fn try_push(&mut self, val: u8) -> Result<(), Self::Err>;
     fn slice(&self) -> &[u8];
     fn slice_mut(&mut self) -> &mut [u8];
@@ -230,8 +229,6 @@ trait Buffer: Sized {
 #[cfg(feature = "alloc")]
 impl Buffer for Vec<u8> {
     type Err = Infallible;
-
-    fn push(&mut self, val: u8) { Self::push(self, val) }
 
     fn try_push(&mut self, val: u8) -> Result<(), Self::Err> {
         self.push(val);
@@ -245,8 +242,6 @@ impl Buffer for Vec<u8> {
 
 impl<const N: usize> Buffer for ArrayVec<u8, N> {
     type Err = internals::array_vec::error::Error;
-
-    fn push(&mut self, val: u8) { Self::push(self, val) }
 
     fn try_push(&mut self, val: u8) -> Result<(), Self::Err> { self.try_push(val) }
 

--- a/base58/src/lib.rs
+++ b/base58/src/lib.rs
@@ -36,6 +36,7 @@ pub mod error;
 #[cfg(not(feature = "std"))]
 pub use alloc::{string::String, vec::Vec};
 #[cfg(feature = "alloc")]
+use core::convert::Infallible;
 use core::fmt;
 #[cfg(feature = "std")]
 pub use std::{string::String, vec::Vec};
@@ -221,14 +222,24 @@ const fn encoded_check_reserve_len(unencoded_len: usize) -> usize {
 
 #[cfg(feature = "alloc")]
 trait Buffer: Sized {
+    type Err: fmt::Debug;
+
     fn push(&mut self, val: u8);
+    fn try_push(&mut self, val: u8) -> Result<(), Self::Err>;
     fn slice(&self) -> &[u8];
     fn slice_mut(&mut self) -> &mut [u8];
 }
 
 #[cfg(feature = "alloc")]
 impl Buffer for Vec<u8> {
+    type Err = Infallible;
+
     fn push(&mut self, val: u8) { Self::push(self, val) }
+
+    fn try_push(&mut self, val: u8) -> Result<(), Self::Err> {
+        self.push(val);
+        Ok(())
+    }
 
     fn slice(&self) -> &[u8] { self }
 
@@ -237,7 +248,11 @@ impl Buffer for Vec<u8> {
 
 #[cfg(feature = "alloc")]
 impl<const N: usize> Buffer for ArrayVec<u8, N> {
+    type Err = internals::array_vec::error::Error;
+
     fn push(&mut self, val: u8) { Self::push(self, val) }
+
+    fn try_push(&mut self, val: u8) -> Result<(), Self::Err> { self.try_push(val) }
 
     fn slice(&self) -> &[u8] { self.as_slice() }
 

--- a/base58/src/lib.rs
+++ b/base58/src/lib.rs
@@ -2,7 +2,7 @@
 
 //! # Bitcoin Base58 Encoding and Decoding
 //!
-//! This crate can be used in a no-std environment but requires an allocator.
+//! This crate can be used in a no-std environment but requires an allocator for decoding.
 
 #![no_std]
 // Experimental features we need.

--- a/base58/src/lib.rs
+++ b/base58/src/lib.rs
@@ -435,7 +435,10 @@ mod tests {
 
         // Addresses
         let addr = hex!("00f8917303bfa8ef24f292e8fa1419b20460ba064d");
-        assert_eq!(&encode_check(&addr[..]), "1PfJpZsjreyVrqeoAfabrRwwjQyoSQMmHH");
+        assert_eq!(
+            Base58CkString::encode_unbounded(&addr[..]).as_str(),
+            "1PfJpZsjreyVrqeoAfabrRwwjQyoSQMmHH"
+        );
     }
 
     #[test]
@@ -463,11 +466,11 @@ mod tests {
     fn base58_roundtrip() {
         let s = "xprv9wTYmMFdV23N2TdNG573QoEsfRrWKQgWeibmLntzniatZvR9BmLnvSxqu53Kw1UmYPxLgboyZQaXwTCg8MSY3H2EU4pWcQDnRnrVA1xe8fs";
         let v: Vec<u8> = decode_check(s).unwrap();
-        assert_eq!(encode_check(&v[..]), s);
-        assert_eq!(decode_check(&encode_check(&v[..])).ok(), Some(v));
+        assert_eq!(Base58CkString::encode_unbounded(&v[..]).as_str(), s);
+        assert_eq!(decode_check(Base58CkString::encode_unbounded(&v[..]).as_str()).ok(), Some(v));
 
         // Check that empty slice passes roundtrip.
-        assert_eq!(decode_check(&encode_check(&[])), Ok(vec![]));
+        assert_eq!(decode_check(Base58CkString::encode_unbounded(&[]).as_str()), Ok(vec![]));
         // Check that `len > 4` is enforced.
         assert_eq!(decode_check(&encode(&[1, 2, 3])), Err(TooShortError { length: 3 }.into()));
     }
@@ -482,8 +485,8 @@ mod benches {
         let data: alloc::vec::Vec<_> = (0u8..50).collect();
 
         bh.iter(|| {
-            let r = super::encode_check(&data);
-            black_box(&r);
+            let r = super::Base58CkString::encode_unbounded(&data);
+            black_box(r.as_str());
         });
     }
 
@@ -492,8 +495,8 @@ mod benches {
         let data: alloc::vec::Vec<_> = (0u8..78).collect(); // length of xpub
 
         bh.iter(|| {
-            let r = super::encode_check(&data);
-            black_box(&r);
+            let r = super::Base58CkString::encode_unbounded(&data);
+            black_box(r.as_str());
         });
     }
 }

--- a/base58/src/lib.rs
+++ b/base58/src/lib.rs
@@ -26,7 +26,6 @@ extern crate test;
 #[cfg(feature = "std")]
 extern crate std;
 
-#[cfg(feature = "alloc")]
 static BASE58_CHARS: &[u8] = b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 
 #[cfg(feature = "alloc")]
@@ -45,7 +44,6 @@ pub use std::{string::String, vec::Vec};
 use hashes::sha256d;
 #[cfg(feature = "alloc")]
 use internals::array::ArrayExt;
-#[cfg(feature = "alloc")]
 use internals::array_vec::ArrayVec;
 #[allow(unused)] // MSRV polyfill
 #[cfg(feature = "alloc")]
@@ -220,7 +218,6 @@ const fn encoded_check_reserve_len(unencoded_len: usize) -> usize {
     encoded_reserve_len(unencoded_len + 4)
 }
 
-#[cfg(feature = "alloc")]
 trait Buffer: Sized {
     type Err: fmt::Debug;
 
@@ -246,7 +243,6 @@ impl Buffer for Vec<u8> {
     fn slice_mut(&mut self) -> &mut [u8] { self }
 }
 
-#[cfg(feature = "alloc")]
 impl<const N: usize> Buffer for ArrayVec<u8, N> {
     type Err = internals::array_vec::error::Error;
 
@@ -265,6 +261,16 @@ where
     I: Iterator<Item = u8> + Clone,
     W: fmt::Write,
 {
+    // format_iter is only called from within encode_check_to_writer, and always has a sufficiently sized buffer.
+    encode_to_buffer(data, buf).expect("encode_to_buffer is infallible with well-sized buffer");
+
+    let str_slice =
+        core::str::from_utf8(buf.slice()).expect("encode_to_buffer writes ASCII bytes to buf");
+    writer.write_str(str_slice)
+}
+
+// Base58 encode the data in the iterator `data` to the buffer buf as ASCII bytes
+fn encode_to_buffer<I: Iterator<Item = u8>, T: Buffer>(data: I, buf: &mut T) -> Result<(), T::Err> {
     let mut leading_zero_count = 0;
     let mut leading_zeroes = true;
     // Build string in little endian with 0-58 in place of characters...
@@ -283,18 +289,19 @@ where
         }
 
         while carry > 0 {
-            buf.push((carry % 58) as u8); // cast loses data intentionally
+            buf.try_push((carry % 58) as u8)?; // cast loses data intentionally
             carry /= 58;
         }
     }
 
-    // ... then reverse it and convert to chars
+    // ... then reverse it and convert to ASCII
     for _ in 0..leading_zero_count {
-        buf.push(0);
+        buf.try_push(0)?;
     }
 
-    for ch in buf.slice().iter().rev() {
-        writer.write_char(char::from(BASE58_CHARS[usize::from(*ch)]))?;
+    buf.slice_mut().reverse();
+    for ch in buf.slice_mut() {
+        *ch = BASE58_CHARS[usize::from(*ch)];
     }
 
     Ok(())

--- a/base58/src/lib.rs
+++ b/base58/src/lib.rs
@@ -249,60 +249,6 @@ impl fmt::Debug for Base58CkString {
     }
 }
 
-/// Encodes `data` as a base58 string (see also `base58::encode_check()`).
-#[allow(clippy::missing_panics_doc)] // fmt::Write returns Result but String is infallible.
-#[cfg(feature = "alloc")]
-pub fn encode(data: &[u8]) -> String {
-    let reserve_len = encoded_reserve_len(data.len());
-    let mut res = String::with_capacity(reserve_len);
-    if reserve_len <= SHORT_OPT_BUFFER_LEN {
-        format_iter(
-            &mut res,
-            data.iter().copied(),
-            &mut ArrayVec::<u8, SHORT_OPT_BUFFER_LEN>::new(),
-        )
-    } else {
-        format_iter(&mut res, data.iter().copied(), &mut Vec::with_capacity(reserve_len))
-    }
-    .expect("string doesn't error");
-    res
-}
-
-/// Encodes `data` as a base58 string including the checksum.
-///
-/// The checksum is the first four bytes of the `SHA256d` of the data, concatenated onto the end.
-#[allow(clippy::missing_panics_doc)] // fmt::Write returns Result but String is infallible.
-#[cfg(feature = "alloc")]
-pub fn encode_check(data: &[u8]) -> String {
-    let mut res = String::with_capacity(encoded_check_reserve_len(data.len()));
-    encode_check_to_writer(&mut res, data).expect("string doesn't fail");
-    res
-}
-
-/// Encodes a slice as base58, including the checksum, into a formatter.
-///
-/// The checksum is the first four bytes of the `SHA256d` of the data, concatenated onto the end.
-///
-/// # Errors
-///
-/// Returns an error if the formatter fails to write the encoded string.
-#[cfg(feature = "alloc")]
-pub fn encode_check_to_fmt(fmt: &mut fmt::Formatter, data: &[u8]) -> fmt::Result {
-    encode_check_to_writer(fmt, data)
-}
-
-#[cfg(feature = "alloc")]
-fn encode_check_to_writer(fmt: &mut impl fmt::Write, data: &[u8]) -> fmt::Result {
-    let checksum = sha256d::Hash::hash(data);
-    let iter = data.iter().copied().chain(checksum.as_byte_array()[0..4].iter().copied());
-    let reserve_len = encoded_check_reserve_len(data.len());
-    if reserve_len <= SHORT_OPT_BUFFER_LEN {
-        format_iter(fmt, iter, &mut ArrayVec::<u8, SHORT_OPT_BUFFER_LEN>::new())
-    } else {
-        format_iter(fmt, iter, &mut Vec::with_capacity(reserve_len))
-    }
-}
-
 /// Returns the length to reserve when encoding base58 without checksum
 #[cfg(feature = "alloc")]
 const fn encoded_reserve_len(unencoded_len: usize) -> usize {
@@ -346,20 +292,6 @@ impl<const N: usize> Buffer for ArrayVec<u8, N> {
     fn slice(&self) -> &[u8] { self.as_slice() }
 
     fn slice_mut(&mut self) -> &mut [u8] { self.as_mut_slice() }
-}
-
-#[cfg(feature = "alloc")]
-fn format_iter<I, W>(writer: &mut W, data: I, buf: &mut impl Buffer) -> fmt::Result
-where
-    I: Iterator<Item = u8> + Clone,
-    W: fmt::Write,
-{
-    // format_iter is only called from within encode_check_to_writer, and always has a sufficiently sized buffer.
-    encode_to_buffer(data, buf).expect("encode_to_buffer is infallible with well-sized buffer");
-
-    let str_slice =
-        core::str::from_utf8(buf.slice()).expect("encode_to_buffer writes ASCII bytes to buf");
-    writer.write_str(str_slice)
 }
 
 // Base58 encode the data in the iterator `data` to the buffer buf as ASCII bytes

--- a/base58/src/lib.rs
+++ b/base58/src/lib.rs
@@ -28,7 +28,6 @@ extern crate std;
 
 static BASE58_CHARS: &[u8] = b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 
-#[cfg(feature = "alloc")]
 pub mod error;
 
 #[cfg(feature = "alloc")]
@@ -40,7 +39,6 @@ use core::fmt;
 #[cfg(feature = "std")]
 pub use std::{string::String, vec::Vec};
 
-#[cfg(feature = "alloc")]
 use hashes::sha256d;
 #[cfg(feature = "alloc")]
 use internals::array::ArrayExt;
@@ -49,6 +47,8 @@ use internals::array_vec::ArrayVec;
 #[cfg(feature = "alloc")]
 use internals::slice::SliceExt;
 
+#[cfg(not(feature = "alloc"))]
+use crate::error::InputTooLongErrorInner;
 #[cfg(feature = "alloc")]
 use crate::error::{IncorrectChecksumError, TooShortError};
 
@@ -56,6 +56,8 @@ use crate::error::{IncorrectChecksumError, TooShortError};
 #[cfg(feature = "alloc")]
 #[doc(no_inline)]
 pub use self::error::{Error, InvalidCharacterError};
+#[doc(no_inline)]
+pub use self::error::InputTooLongError;
 
 #[rustfmt::skip]
 #[cfg(feature = "alloc")]
@@ -148,8 +150,104 @@ pub fn decode_check(data: &str) -> Result<Vec<u8>, Error> {
     Ok(ret)
 }
 
-#[cfg(feature = "alloc")]
 const SHORT_OPT_BUFFER_LEN: usize = 128;
+
+/// A base58check-encoded string (data followed by a 4 byte `SHA256d` checksum, base58-encoded).
+///
+/// Strings of at most 128 characters can be encoded without allocating. Longer strings can only
+/// be produced when the `alloc` feature is enabled.
+#[derive(Clone, Hash, PartialEq, Eq)]
+pub struct Base58CkString(Base58CkInner);
+
+#[derive(Clone, Hash, PartialEq, Eq)]
+enum Base58CkInner {
+    /// ASCII string of length at most 128 base58 characters (roughly 93 bytes)
+    Small(ArrayVec<u8, SHORT_OPT_BUFFER_LEN>),
+    /// Unbounded string (available with "alloc" only).
+    #[cfg(feature = "alloc")]
+    Large(Vec<u8>),
+}
+
+impl Base58CkString {
+    /// Encodes `data` as a base58check string, including the checksum.
+    ///
+    /// The checksum is the first four bytes of the `SHA256d` of the data, concatenated onto the
+    /// end before encoding.
+    ///
+    /// # Errors
+    ///
+    /// If the `alloc` feature is disabled and `data` encodes to more than 128 base58 characters.
+    /// With `alloc` enabled this function is infallible. If you will only be using this with `alloc`,
+    /// you can alternatively call [`Self::encode_unbounded`].
+    pub fn encode(data: &[u8]) -> Result<Self, InputTooLongError> {
+        #[cfg(feature = "alloc")]
+        {
+            Ok(Self::encode_unbounded(data))
+        }
+        #[cfg(not(feature = "alloc"))]
+        {
+            let mut buf = ArrayVec::<u8, SHORT_OPT_BUFFER_LEN>::new();
+            let checksum = sha256d::Hash::hash(data);
+            let iter = data.iter().copied().chain(checksum.as_byte_array()[0..4].iter().copied());
+
+            encode_to_buffer(iter, &mut buf)
+                .map(|()| Self(Base58CkInner::Small(buf)))
+                .map_err(|_| InputTooLongError(InputTooLongErrorInner { input_len: data.len() }))
+        }
+    }
+
+    /// Encodes `data` of any length as a base58check string.
+    #[allow(clippy::missing_panics_doc)] // encode_to_buffer is infallible in both cases
+    #[cfg(feature = "alloc")]
+    pub fn encode_unbounded(data: &[u8]) -> Self {
+        let checksum = sha256d::Hash::hash(data);
+        let iter = data.iter().copied().chain(checksum.as_byte_array()[0..4].iter().copied());
+        let reserve_len = encoded_check_reserve_len(data.len());
+        if reserve_len <= SHORT_OPT_BUFFER_LEN {
+            let mut buf = ArrayVec::<u8, SHORT_OPT_BUFFER_LEN>::new();
+            encode_to_buffer(iter, &mut buf)
+                .expect("encode_to_buffer is infallible with well-sized ArrayVec buf");
+            Self(Base58CkInner::Small(buf))
+        } else {
+            let mut buf = Vec::with_capacity(reserve_len);
+            encode_to_buffer(iter, &mut buf).expect("encode_to_buffer is infallible with Vec buf");
+            Self(Base58CkInner::Large(buf))
+        }
+    }
+
+    /// Returns the base58check-encoded string.
+    #[allow(clippy::missing_panics_doc)] // Base58 characters are always valid ASCII.
+    pub fn as_str(&self) -> &str {
+        core::str::from_utf8(self.as_bytes()).expect("base58 characters are valid ASCII")
+    }
+
+    /// Returns the base58check-encoded string as ASCII bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        match self.0 {
+            Base58CkInner::Small(ref data) => data.slice(),
+            #[cfg(feature = "alloc")]
+            Base58CkInner::Large(ref data) => data.slice(),
+        }
+    }
+}
+
+impl AsRef<str> for Base58CkString {
+    fn as_ref(&self) -> &str { self.as_str() }
+}
+
+impl AsRef<[u8]> for Base58CkString {
+    fn as_ref(&self) -> &[u8] { self.as_bytes() }
+}
+
+impl fmt::Display for Base58CkString {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { self.as_str().fmt(f) }
+}
+
+impl fmt::Debug for Base58CkString {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_tuple("Base58CkString").field(&self.as_str()).finish()
+    }
+}
 
 /// Encodes `data` as a base58 string (see also `base58::encode_check()`).
 #[allow(clippy::missing_panics_doc)] // fmt::Write returns Result but String is infallible.

--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -195,7 +195,7 @@ impl fmt::Display for AddressInner {
                     NetworkKind::Test => PUBKEY_ADDRESS_PREFIX_TEST,
                 };
                 prefixed[1..].copy_from_slice(hash.as_byte_array());
-                base58::encode_check_to_fmt(fmt, &prefixed[..])
+                base58::Base58CkString::encode_unbounded(&prefixed[..]).fmt(fmt)
             }
             P2sh { hash, network } => {
                 let mut prefixed = [0; 21];
@@ -204,7 +204,7 @@ impl fmt::Display for AddressInner {
                     NetworkKind::Test => SCRIPT_ADDRESS_PREFIX_TEST,
                 };
                 prefixed[1..].copy_from_slice(hash.as_byte_array());
-                base58::encode_check_to_fmt(fmt, &prefixed[..])
+                base58::Base58CkString::encode_unbounded(&prefixed[..]).fmt(fmt)
             }
             Segwit { program, hrp } => {
                 let hrp = hrp.to_hrp();
@@ -1620,13 +1620,13 @@ mod tests {
 
         let mut payload = [0u8; 22]; // Invalid: should be 21
         payload[0] = PUBKEY_ADDRESS_PREFIX_MAIN;
-        let encoded = base58::encode_check(&payload);
+        let encoded = base58::Base58CkString::encode_unbounded(&payload);
 
-        let err = Address::<NetworkUnchecked>::from_base58_str(&encoded).unwrap_err();
+        let err = Address::<NetworkUnchecked>::from_base58_str(encoded.as_str()).unwrap_err();
         match err {
             Base58Error::InvalidBase58PayloadLength(inner) => {
                 assert_eq!(inner.invalid_base58_payload_length(), 22); // Payload size
-                assert_ne!(inner.invalid_base58_payload_length(), encoded.len()); // Not string size
+                assert_ne!(inner.invalid_base58_payload_length(), encoded.as_str().len()); // Not string size
             }
             other => panic!("unexpected error: {other:?}"),
         }

--- a/crypto/src/key.rs
+++ b/crypto/src/key.rs
@@ -1185,11 +1185,11 @@ impl WifKey {
         ret[1..33].copy_from_slice(&self.private_key.as_inner()[..]);
         let privkey = if self.private_key.compressed() {
             ret[33] = 1;
-            base58::encode_check(&ret[..])
+            base58::Base58CkString::encode_unbounded(&ret[..])
         } else {
-            base58::encode_check(&ret[..33])
+            base58::Base58CkString::encode_unbounded(&ret[..33])
         };
-        fmt.write_str(&privkey)
+        fmt.write_str(privkey.as_str())
     }
 
     /// Gets the WIF encoding of this private key.

--- a/key_expression/src/bip32.rs
+++ b/key_expression/src/bip32.rs
@@ -1053,7 +1053,7 @@ impl Xpub {
 
 impl fmt::Display for Xpriv {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        base58::encode_check_to_fmt(fmt, &self.encode()[..])
+        base58::Base58CkString::encode_unbounded(&self.encode()).fmt(fmt)
     }
 }
 
@@ -1075,7 +1075,7 @@ impl FromStr for Xpriv {
 
 impl fmt::Display for Xpub {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        base58::encode_check_to_fmt(fmt, &self.encode()[..])
+        base58::Base58CkString::encode_unbounded(&self.encode()[..]).fmt(fmt)
     }
 }
 


### PR DESCRIPTION
At present, the base58 crate relies on an alloc feature to reliably encode base58. For 1.0, we want to have at least limited no-alloc functionality. A first step for this is to rebuild the encoding functionality to allow users to encode limited length byte arrays to base58, so that at least all Bitcoin related uses can be covered without alloc.

Contributes to #6417