### PR TITLE
0.32.x: Deprecate branch

### DIFF
--- a/DEPRECATED/README.md
+++ b/DEPRECATED/README.md
@@ -1,0 +1,16 @@
+# Branch Deprecated
+
+Do not patch this branch. The `0.32.x` series of releases spit into
+two after the MSRV bump [0].
+
+- Development of `bitcoin-0.32.10` and onwards is now done on `0.32.xx`.
+- Development of `bitcoin-0.32.100` and onwards is now done on `0.32.xxx`.
+
+So long, and thanks for all the fish.
+
+
+[0] See PRs #6179, #6126, and #6385.
+
+- https://github.com/rust-bitcoin/rust-bitcoin/pull/6179
+- https://github.com/rust-bitcoin/rust-bitcoin/pull/6126
+- https://github.com/rust-bitcoin/rust-bitcoin/pull/6385


### PR DESCRIPTION
Add a file `DEPRECATED/README.md` explaining that this branch is deprecated in favour of `0.32.xx` and `0.32.xxx`.

Close #6495