### PR TITLE
Move `builder` script functions to `primitives`

### DIFF
--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -6,9 +6,9 @@ use internals::array::ArrayExt; // For `split_first`.
 
 use super::witness_version::WitnessVersion;
 use super::{
-    Builder, Instruction, InstructionIndices, Instructions, PushBytes, RedeemScript,
-    RedeemScriptSizeError, Script, ScriptHashableTag, ScriptPubKey, ScriptSig, TapScript,
-    WitnessScript, WitnessScriptSizeError,
+    Instruction, InstructionIndices, Instructions, PushBytes, RedeemScript, RedeemScriptSizeError,
+    Script, ScriptHashableTag, ScriptPubKey, ScriptSig, TapScript, WitnessScript,
+    WitnessScriptSizeError,
 };
 use crate::encoding::{Encode, ExactSizeEncoder};
 use crate::key::{LegacyPublicKey, UntweakedPublicKey, WPubkeyHash};
@@ -23,9 +23,6 @@ use crate::{internal_macros, Amount, FeeRate, ScriptPubKeyBuf, ToU64 as _, Witne
 internal_macros::define_extension_trait! {
     /// Extension functionality for the [`Script`] type.
     pub trait ScriptExt<T> impl<T> for Script<T> {
-        /// Constructs a new script builder
-        fn builder() -> Builder<T> { Builder::new() }
-
         /// Counts the sigops for this Script using accurate counting.
         ///
         /// In Bitcoin Core, there are two ways to count sigops, "accurate" and "legacy".

--- a/bitcoin/src/blockdata/script/owned.rs
+++ b/bitcoin/src/blockdata/script/owned.rs
@@ -22,9 +22,6 @@ pub use addresses::ScriptPubKeyBufExt;
 internal_macros::define_extension_trait! {
     /// Extension functionality for the [`ScriptBuf`] type.
     pub trait ScriptBufExt<T> impl<T> for ScriptBuf<T> {
-        /// Constructs a new script builder
-        fn builder() -> Builder<T> { Builder::new() }
-
         /// Adds instructions to push an integer onto the stack.
         ///
         /// Integers are encoded as little-endian signed-magnitude numbers, but there are dedicated

--- a/primitives/api/all-features.txt
+++ b/primitives/api/all-features.txt
@@ -3534,6 +3534,7 @@ pub fn bitcoin_primitives::script::Script<T>::script_hash(&self) -> core::result
 impl<T> bitcoin_primitives::script::Script<T>
 pub const fn bitcoin_primitives::script::Script<T>::as_bytes(&self) -> &[u8]
 pub fn bitcoin_primitives::script::Script<T>::as_mut_bytes(&mut self) -> &mut [u8]
+pub fn bitcoin_primitives::script::Script<T>::builder() -> bitcoin_primitives::script::Builder<T>
 pub fn bitcoin_primitives::script::Script<T>::into_script_buf(self: alloc::boxed::Box<Self>) -> bitcoin_primitives::script::ScriptBuf<T>
 pub const fn bitcoin_primitives::script::Script<T>::is_empty(&self) -> bool
 pub fn bitcoin_primitives::script::Script<T>::is_p2wpkh(&self) -> bool where T: bitcoin_primitives::script::ScriptHashableTag
@@ -3672,6 +3673,7 @@ pub fn bitcoin_primitives::script::ScriptBuf<T>::new_p2wsh(script_hash: bitcoin_
 impl<T> bitcoin_primitives::script::ScriptBuf<T>
 pub fn bitcoin_primitives::script::ScriptBuf<T>::as_mut_script(&mut self) -> &mut bitcoin_primitives::script::Script<T>
 pub fn bitcoin_primitives::script::ScriptBuf<T>::as_script(&self) -> &bitcoin_primitives::script::Script<T>
+pub fn bitcoin_primitives::script::ScriptBuf<T>::builder() -> bitcoin_primitives::script::Builder<T>
 pub fn bitcoin_primitives::script::ScriptBuf<T>::capacity(&self) -> usize
 pub const fn bitcoin_primitives::script::ScriptBuf<T>::from_bytes(bytes: alloc::vec::Vec<u8>) -> Self
 pub fn bitcoin_primitives::script::ScriptBuf<T>::from_hex_no_length_prefix(s: &str) -> core::result::Result<Self, hex_conservative::error::DecodeVariableLengthBytesError>

--- a/primitives/api/alloc-only.txt
+++ b/primitives/api/alloc-only.txt
@@ -3392,6 +3392,7 @@ pub fn bitcoin_primitives::script::Script<T>::script_hash(&self) -> core::result
 impl<T> bitcoin_primitives::script::Script<T>
 pub const fn bitcoin_primitives::script::Script<T>::as_bytes(&self) -> &[u8]
 pub fn bitcoin_primitives::script::Script<T>::as_mut_bytes(&mut self) -> &mut [u8]
+pub fn bitcoin_primitives::script::Script<T>::builder() -> bitcoin_primitives::script::Builder<T>
 pub fn bitcoin_primitives::script::Script<T>::into_script_buf(self: alloc::boxed::Box<Self>) -> bitcoin_primitives::script::ScriptBuf<T>
 pub const fn bitcoin_primitives::script::Script<T>::is_empty(&self) -> bool
 pub fn bitcoin_primitives::script::Script<T>::is_p2wpkh(&self) -> bool where T: bitcoin_primitives::script::ScriptHashableTag
@@ -3517,6 +3518,7 @@ pub fn bitcoin_primitives::script::ScriptBuf<T>::new_p2wsh(script_hash: bitcoin_
 impl<T> bitcoin_primitives::script::ScriptBuf<T>
 pub fn bitcoin_primitives::script::ScriptBuf<T>::as_mut_script(&mut self) -> &mut bitcoin_primitives::script::Script<T>
 pub fn bitcoin_primitives::script::ScriptBuf<T>::as_script(&self) -> &bitcoin_primitives::script::Script<T>
+pub fn bitcoin_primitives::script::ScriptBuf<T>::builder() -> bitcoin_primitives::script::Builder<T>
 pub fn bitcoin_primitives::script::ScriptBuf<T>::capacity(&self) -> usize
 pub const fn bitcoin_primitives::script::ScriptBuf<T>::from_bytes(bytes: alloc::vec::Vec<u8>) -> Self
 pub fn bitcoin_primitives::script::ScriptBuf<T>::into_boxed_script(self) -> alloc::boxed::Box<bitcoin_primitives::script::Script<T>>

--- a/primitives/src/script/borrowed.rs
+++ b/primitives/src/script/borrowed.rs
@@ -17,7 +17,8 @@ use crate::opcodes::all::{OP_CHECKSIG, OP_DUP, OP_EQUAL, OP_EQUALVERIFY, OP_HASH
 use crate::opcodes::{Opcode, OP_PUSHBYTES_2, OP_PUSHBYTES_20, OP_PUSHBYTES_32};
 use crate::prelude::{Box, ToOwned, Vec};
 use crate::script::{
-    RedeemScriptSizeError, ScriptHash, ScriptHashableTag, WScriptHash, WitnessScriptSizeError,
+    Builder, RedeemScriptSizeError, ScriptHash, ScriptHashableTag, WScriptHash,
+    WitnessScriptSizeError,
 };
 use crate::witness_version::WitnessVersion;
 use crate::{ScriptPubKey, WitnessScript};
@@ -188,6 +189,9 @@ impl<T> Script<T> {
     #[inline]
     #[deprecated(since = "1.0.0-rc.0", note = "use `format!(\"{var:x}\")` instead")]
     pub fn to_hex(&self) -> alloc::string::String { alloc::format!("{:x}", self) }
+
+    /// Constructs a new script builder
+    pub fn builder() -> Builder<T> { Builder::new() }
 
     /// Returns witness version of the script, if any.
     ///

--- a/primitives/src/script/owned.rs
+++ b/primitives/src/script/owned.rs
@@ -166,6 +166,9 @@ impl<T> ScriptBuf<T> {
     #[deprecated(since = "1.0.0-rc.0", note = "use `format!(\"{var:x}\")` instead")]
     pub fn to_hex(&self) -> alloc::string::String { alloc::format!("{:x}", self) }
 
+    /// Constructs a new script builder
+    pub fn builder() -> Builder<T> { Builder::new() }
+
     /// Adds a single opcode to the script.
     pub fn push_opcode(&mut self, data: Opcode) { self.as_byte_vec().push(data.to_u8()); }
 


### PR DESCRIPTION
The builder function on ScriptExt and ScriptBufExt provides a shorthand way to get a builder for a script type. With the Builder type moved to primitives, this function can now also be moved.

Move builder functions from ScriptExt and ScriptBufExt to Script<T> and ScriptBuf<T> respectively.