### PR TITLE
Automated weekly update to rustc stable (to 1.97.0) on 0.32.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.metadata.rbmt.toolchains]
 nightly = "nightly-2026-03-27"
-stable = "1.91.1"
+stable = "1.97.0"
 
 # Patch secp256k1's dependency on bitcoin_hashes to use our local workspace version.
 # secp256k1 is a dependency of this workspace, but it has a dependency on the


### PR DESCRIPTION
Automated update to Cargo.toml workspace metadata by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action