### PR TITLE
Backport: Make `SendCmpct` idempotent

### DIFF
--- a/bitcoin/src/p2p/message.rs
+++ b/bitcoin/src/p2p/message.rs
@@ -1029,4 +1029,20 @@ mod test {
         let enc = serialize(&message);
         assert_eq!(data.as_slice(), enc.as_slice());
     }
+
+    #[test]
+    #[rustfmt::skip]
+    fn sendcmpct_v1_network_message_with_invalid_mode_bit() {
+        // Wire data has a non-canonical `send_compact` (0x12 instead of 0x01 or 0).
+        let raw_msg = [
+            0xf9, 0xbe, 0xb4, 0xd9,
+            0x73, 0x65, 0x6e, 0x64, 0x63, 0x6d, 0x70, 0x63, 0x74, 0x00, 0x00, 0x00,
+            0x09, 0x00, 0x00, 0x00,
+            0xf9, 0x9c, 0x95, 0x43,
+            0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x0c, // Mode byte (0x12)
+        ];
+
+        let msg = deserialize::<RawNetworkMessage>(&raw_msg);
+        assert!(msg.is_err());
+    }
 }

--- a/bitcoin/src/p2p/message_compact_blocks.rs
+++ b/bitcoin/src/p2p/message_compact_blocks.rs
@@ -25,7 +25,32 @@ pub struct SendCmpct {
     /// Compact Blocks protocol version number.
     pub version: u64,
 }
-impl_consensus_encoding!(SendCmpct, send_compact, version);
+
+impl crate::consensus::Encodable for SendCmpct {
+    #[inline]
+    fn consensus_encode<R: crate::io::Write + ?Sized>(
+        &self,
+        r: &mut R,
+    ) -> core::result::Result<usize, crate::io::Error> {
+        let mut len = 0;
+        len += self.send_compact.consensus_encode(r)?;
+        len += self.version.consensus_encode(r)?;
+        Ok(len)
+    }
+}
+
+impl crate::consensus::Decodable for SendCmpct {
+    #[inline]
+    fn consensus_decode<R: crate::io::Read + ?Sized>(
+        r: &mut R,
+    ) -> core::result::Result<Self, crate::consensus::encode::Error> {
+        let mut r = r.take(crate::consensus::encode::MAX_VEC_SIZE as u64);
+        Ok(Self {
+            send_compact: crate::consensus::Decodable::consensus_decode(&mut r)?,
+            version: crate::consensus::Decodable::consensus_decode(&mut r)?,
+        })
+    }
+}
 
 #[cfg(feature = "encoding")]
 encoding::encoder_newtype_exact! {

--- a/bitcoin/src/p2p/message_compact_blocks.rs
+++ b/bitcoin/src/p2p/message_compact_blocks.rs
@@ -44,11 +44,15 @@ impl crate::consensus::Decodable for SendCmpct {
     fn consensus_decode<R: crate::io::Read + ?Sized>(
         r: &mut R,
     ) -> core::result::Result<Self, crate::consensus::encode::Error> {
-        let mut r = r.take(crate::consensus::encode::MAX_VEC_SIZE as u64);
-        Ok(Self {
-            send_compact: crate::consensus::Decodable::consensus_decode(&mut r)?,
-            version: crate::consensus::Decodable::consensus_decode(&mut r)?,
-        })
+        let send_compact: u8 = crate::consensus::Decodable::consensus_decode(r)?;
+        let version = crate::consensus::Decodable::consensus_decode(r)?;
+
+        if send_compact == 1 || send_compact == 0 {
+            let send_compact = send_compact != 0;
+            Ok(SendCmpct { send_compact, version })
+        } else {
+            Err(crate::consensus::encode::Error::ParseFailed("first byte was not 0 or 1"))
+        }
     }
 }
 


### PR DESCRIPTION
Backport of #6317

From the spec https://bips.dev/152/

> The "high-bandwidth" mode, which nodes may only enable for a few of their peers, is enabled by setting the first boolean to 1 in a sendcmpct message.

> The "low-bandwidth" mode is enabled by setting the first boolean to 0 in a sendcmpct message

It seems like the spec says that anything besides 1 or 0 is actually an error, though..

Original work by:
- yancy \<github@yancy.lol>
- Abeeujah \<abeeujah@gmail.com>