### PR TITLE
base58: Add `len` and `is_empty` to `Base58CkString`

### DIFF
--- a/base58/src/lib.rs
+++ b/base58/src/lib.rs
@@ -229,6 +229,12 @@ impl Base58CkString {
             Base58CkInner::Large(ref data) => data.slice(),
         }
     }
+
+    /// Returns the number of bytes/ASCII chars in the base58check-encoded string.
+    pub fn len(&self) -> usize { self.as_bytes().len() }
+
+    /// Returns true if the base58check-encoded string is empty.
+    pub fn is_empty(&self) -> bool { self.len() == 0 }
 }
 
 impl AsRef<str> for Base58CkString {

--- a/bitcoin/src/address/mod.rs
+++ b/bitcoin/src/address/mod.rs
@@ -1626,7 +1626,7 @@ mod tests {
         match err {
             Base58Error::InvalidBase58PayloadLength(inner) => {
                 assert_eq!(inner.invalid_base58_payload_length(), 22); // Payload size
-                assert_ne!(inner.invalid_base58_payload_length(), encoded.as_str().len()); // Not string size
+                assert_ne!(inner.invalid_base58_payload_length(), encoded.len()); // Not string size
             }
             other => panic!("unexpected error: {other:?}"),
         }


### PR DESCRIPTION
The Base58CkString type is essentially treated like a string in some cases. While users can cast to a &str with as_str, it is convenient to instead provide len and is_empty functions for the user.

Add len and is_empty methods to the Base58CkString type.