### PR TITLE
consensus_encoding: add `Decoder::early_end` method with default implementation

### DIFF
--- a/consensus_encoding/api/all-features.txt
+++ b/consensus_encoding/api/all-features.txt
@@ -980,6 +980,7 @@ impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_e
   pub type bitcoin_consensus_encoding::ArrayDecoder<N>::Error = bitcoin_consensus_encoding::error::UnexpectedEofError [impl: impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ArrayDecoder<N>]
   pub type bitcoin_consensus_encoding::ArrayDecoder<N>::Output = [u8; N] [impl: impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ArrayDecoder<N>]
   pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::end(self) -> core::result::Result<Self::Output, Self::Error> [impl: impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ArrayDecoder<N>]
+  pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::end_early(self) -> Self::Error [impl: impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ArrayDecoder<N>]
   pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error> [impl: impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ArrayDecoder<N>]
   pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::read_limit(&self) -> usize [impl: impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ArrayDecoder<N>]
 impl<const N: usize> core::clone::Clone for bitcoin_consensus_encoding::ArrayDecoder<N>
@@ -2197,6 +2198,7 @@ pub trait bitcoin_consensus_encoding::Decoder: core::marker::Sized
 pub type bitcoin_consensus_encoding::Decoder::Error
 pub type bitcoin_consensus_encoding::Decoder::Output
 pub fn bitcoin_consensus_encoding::Decoder::end(self) -> core::result::Result<Self::Output, Self::Error>
+pub fn bitcoin_consensus_encoding::Decoder::end_early(self) -> Self::Error
 pub fn bitcoin_consensus_encoding::Decoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error>
 pub fn bitcoin_consensus_encoding::Decoder::read_limit(&self) -> usize
 impl bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ByteVecDecoder
@@ -2251,6 +2253,7 @@ impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_e
   pub type bitcoin_consensus_encoding::ArrayDecoder<N>::Error = bitcoin_consensus_encoding::error::UnexpectedEofError [impl: impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ArrayDecoder<N>]
   pub type bitcoin_consensus_encoding::ArrayDecoder<N>::Output = [u8; N] [impl: impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ArrayDecoder<N>]
   pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::end(self) -> core::result::Result<Self::Output, Self::Error> [impl: impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ArrayDecoder<N>]
+  pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::end_early(self) -> Self::Error [impl: impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ArrayDecoder<N>]
   pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error> [impl: impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ArrayDecoder<N>]
   pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::read_limit(&self) -> usize [impl: impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ArrayDecoder<N>]
 pub trait bitcoin_consensus_encoding::Encode

--- a/consensus_encoding/api/alloc-only.txt
+++ b/consensus_encoding/api/alloc-only.txt
@@ -819,6 +819,7 @@ impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_e
   pub type bitcoin_consensus_encoding::ArrayDecoder<N>::Error = bitcoin_consensus_encoding::error::UnexpectedEofError [impl: impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ArrayDecoder<N>]
   pub type bitcoin_consensus_encoding::ArrayDecoder<N>::Output = [u8; N] [impl: impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ArrayDecoder<N>]
   pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::end(self) -> core::result::Result<Self::Output, Self::Error> [impl: impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ArrayDecoder<N>]
+  pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::end_early(self) -> Self::Error [impl: impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ArrayDecoder<N>]
   pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error> [impl: impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ArrayDecoder<N>]
   pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::read_limit(&self) -> usize [impl: impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ArrayDecoder<N>]
 impl<const N: usize> core::clone::Clone for bitcoin_consensus_encoding::ArrayDecoder<N>
@@ -1978,6 +1979,7 @@ pub trait bitcoin_consensus_encoding::Decoder: core::marker::Sized
 pub type bitcoin_consensus_encoding::Decoder::Error
 pub type bitcoin_consensus_encoding::Decoder::Output
 pub fn bitcoin_consensus_encoding::Decoder::end(self) -> core::result::Result<Self::Output, Self::Error>
+pub fn bitcoin_consensus_encoding::Decoder::end_early(self) -> Self::Error
 pub fn bitcoin_consensus_encoding::Decoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error>
 pub fn bitcoin_consensus_encoding::Decoder::read_limit(&self) -> usize
 impl bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ByteVecDecoder
@@ -2032,6 +2034,7 @@ impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_e
   pub type bitcoin_consensus_encoding::ArrayDecoder<N>::Error = bitcoin_consensus_encoding::error::UnexpectedEofError [impl: impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ArrayDecoder<N>]
   pub type bitcoin_consensus_encoding::ArrayDecoder<N>::Output = [u8; N] [impl: impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ArrayDecoder<N>]
   pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::end(self) -> core::result::Result<Self::Output, Self::Error> [impl: impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ArrayDecoder<N>]
+  pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::end_early(self) -> Self::Error [impl: impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ArrayDecoder<N>]
   pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error> [impl: impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ArrayDecoder<N>]
   pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::read_limit(&self) -> usize [impl: impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ArrayDecoder<N>]
 pub trait bitcoin_consensus_encoding::Encode

--- a/consensus_encoding/api/no-features.txt
+++ b/consensus_encoding/api/no-features.txt
@@ -639,6 +639,7 @@ impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_e
   pub type bitcoin_consensus_encoding::ArrayDecoder<N>::Error = bitcoin_consensus_encoding::error::UnexpectedEofError [impl: impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ArrayDecoder<N>]
   pub type bitcoin_consensus_encoding::ArrayDecoder<N>::Output = [u8; N] [impl: impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ArrayDecoder<N>]
   pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::end(self) -> core::result::Result<Self::Output, Self::Error> [impl: impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ArrayDecoder<N>]
+  pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::end_early(self) -> Self::Error [impl: impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ArrayDecoder<N>]
   pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error> [impl: impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ArrayDecoder<N>]
   pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::read_limit(&self) -> usize [impl: impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ArrayDecoder<N>]
 impl<const N: usize> core::clone::Clone for bitcoin_consensus_encoding::ArrayDecoder<N>
@@ -1482,6 +1483,7 @@ pub trait bitcoin_consensus_encoding::Decoder: core::marker::Sized
 pub type bitcoin_consensus_encoding::Decoder::Error
 pub type bitcoin_consensus_encoding::Decoder::Output
 pub fn bitcoin_consensus_encoding::Decoder::end(self) -> core::result::Result<Self::Output, Self::Error>
+pub fn bitcoin_consensus_encoding::Decoder::end_early(self) -> Self::Error
 pub fn bitcoin_consensus_encoding::Decoder::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error>
 pub fn bitcoin_consensus_encoding::Decoder::read_limit(&self) -> usize
 impl bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::CompactSizeDecoder
@@ -1524,6 +1526,7 @@ impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_e
   pub type bitcoin_consensus_encoding::ArrayDecoder<N>::Error = bitcoin_consensus_encoding::error::UnexpectedEofError [impl: impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ArrayDecoder<N>]
   pub type bitcoin_consensus_encoding::ArrayDecoder<N>::Output = [u8; N] [impl: impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ArrayDecoder<N>]
   pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::end(self) -> core::result::Result<Self::Output, Self::Error> [impl: impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ArrayDecoder<N>]
+  pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::end_early(self) -> Self::Error [impl: impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ArrayDecoder<N>]
   pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error> [impl: impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ArrayDecoder<N>]
   pub fn bitcoin_consensus_encoding::ArrayDecoder<N>::read_limit(&self) -> usize [impl: impl<const N: usize> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ArrayDecoder<N>]
 pub trait bitcoin_consensus_encoding::Encode

--- a/consensus_encoding/src/decode/decoders.rs
+++ b/consensus_encoding/src/decode/decoders.rs
@@ -354,6 +354,14 @@ impl<const N: usize> Decoder for ArrayDecoder<N> {
     }
 
     #[inline]
+    fn end_early(self) -> Self::Error {
+        // We must explicitly implement this method because in the case that N == 0,
+        // Self::end() will always succeed, even before any calls to `push_bytes`.
+        // This would cause the default self.end().unwrap() implementation to panic.
+        UnexpectedEofError { missing: N - self.bytes_written }
+    }
+
+    #[inline]
     fn end(self) -> Result<Self::Output, Self::Error> {
         if self.bytes_written == N {
             Ok(self.buffer)

--- a/consensus_encoding/src/decode/mod.rs
+++ b/consensus_encoding/src/decode/mod.rs
@@ -82,6 +82,30 @@ pub trait Decoder: Sized {
     #[track_caller]
     fn push_bytes(&mut self, bytes: &mut &[u8]) -> Result<DecoderStatus, Self::Error>;
 
+    /// Consumes a decoder, assuming that it is incomplete, returning the error that
+    /// would have been returned by an early call to [`Self::end`].
+    ///
+    /// The default implementation is equivalent to `self.end().unwrap_err()`, and
+    /// this implementation should be sufficient for almost all implementors. It must
+    /// be overridden if `self.end()` would succeed even without a call to `psuh_bytes`
+    /// yielding `DecoderStatus::Ready`. An example of such a decoder is `ArrayDecoder::<0>`.
+    ///
+    /// # Panics
+    ///
+    /// May panic if [`Self::push_bytes`] has previously been called, and the most recent
+    /// call returned `Ok(DecoderStatus::Ready)`. (In this case, the caller should call
+    /// [`Self::end`] instead, and handle the correctly-decoded object if one exists.)
+    ///
+    /// May panic if any other method on this trait has previously been called, and an
+    /// error returned.
+    #[track_caller]
+    fn end_early(self) -> Self::Error {
+        match self.end() {
+            Ok(_) => panic!("Decoder::end() suceeded without Decoder::push_bytes returning Ready"),
+            Err(e) => e,
+        }
+    }
+
     /// Completes the decoding process and returns the final result.
     ///
     /// This consumes the decoder and should be called when no more input data is available.
@@ -90,6 +114,8 @@ pub trait Decoder: Sized {
     ///
     /// Returns an error if the decoder has not received sufficient data to complete decoding, or if
     /// the accumulated data is invalid when considered as a complete object.
+    ///
+    /// If [`Self::push_bytes`] has been called 
     ///
     /// # Panics
     ///


### PR DESCRIPTION
Adds a new method `Decoder::early_end` which consumes a decoder and returns an error, as though `end` had been called before the decoding was complete.

This method can be used in `end` implementations for composite decoders. For such decoders, if the user calls `end` early, the implementation must return some sort of error. If it has a sub-decoder which it "knows" has not finished and will therefore yield an error, it could just call `end()` on that sub-decoder and unwrap the error. This new method formalizes the conditions under which this is allowed.

This is non-breaking because there is a default implementation for the new trait method. (It may break code which calls obj.early_end() on an object which implements both `Decoder` and another trait that has an `early_end` method, but this is not considered semver-breaking in Rust.)

Fixes #6534