### PR TITLE
Release tracking PR: `consensus-encoding 1.1.0`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -62,7 +62,7 @@ checksum = "8ed8ccb78a9ff7a6fbb90e2fb9b8588b4a9928d49d8af3cb789108a84ea6b0ce"
 dependencies = [
  "base58ck 0.1.101",
  "bech32",
- "bitcoin-consensus-encoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin-consensus-encoding 1.0.0",
  "bitcoin-io 0.1.101",
  "bitcoin-units 0.1.101",
  "bitcoin_hashes 0.14.101",
@@ -82,7 +82,7 @@ dependencies = [
  "bech32",
  "bincode",
  "bitcoin-addresses",
- "bitcoin-consensus-encoding 1.0.0",
+ "bitcoin-consensus-encoding 1.1.0",
  "bitcoin-crypto",
  "bitcoin-internals 0.6.0",
  "bitcoin-io 0.5.0",
@@ -117,20 +117,20 @@ version = "0.0.0"
 [[package]]
 name = "bitcoin-consensus-encoding"
 version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2d6094e2a1ba3c93b5a596fe5a10d1a10c3c6e06785cde89f693a044c01aa40"
+dependencies = [
+ "bitcoin-internals 0.5.0",
+]
+
+[[package]]
+name = "bitcoin-consensus-encoding"
+version = "1.1.0"
 dependencies = [
  "bitcoin-internals 0.6.0",
  "hex-conservative 1.1.0",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "bitcoin-consensus-encoding"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2d6094e2a1ba3c93b5a596fe5a10d1a10c3c6e06785cde89f693a044c01aa40"
-dependencies = [
- "bitcoin-internals 0.5.0",
 ]
 
 [[package]]
@@ -156,7 +156,7 @@ dependencies = [
  "arbitrary",
  "bitcoin 0.32.101",
  "bitcoin 0.33.0-beta",
- "bitcoin-consensus-encoding 1.0.0",
+ "bitcoin-consensus-encoding 1.1.0",
  "bitcoin-p2p-messages",
  "libfuzzer-sys",
  "serde",
@@ -189,14 +189,14 @@ version = "0.1.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb5de036369d1ac59d3c1819ebc4d850f89466f5401c571a285b6ed564a4cb78"
 dependencies = [
- "bitcoin-consensus-encoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin-consensus-encoding 1.0.0",
 ]
 
 [[package]]
 name = "bitcoin-io"
 version = "0.5.0"
 dependencies = [
- "bitcoin-consensus-encoding 1.0.0",
+ "bitcoin-consensus-encoding 1.1.0",
  "bitcoin-internals 0.6.0",
  "bitcoin_hashes 1.0.0",
 ]
@@ -234,7 +234,7 @@ name = "bitcoin-p2p-messages"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "bitcoin-consensus-encoding 1.0.0",
+ "bitcoin-consensus-encoding 1.1.0",
  "bitcoin-internals 0.6.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
@@ -250,7 +250,7 @@ version = "0.102.0"
 dependencies = [
  "arbitrary",
  "bincode",
- "bitcoin-consensus-encoding 1.0.0",
+ "bitcoin-consensus-encoding 1.1.0",
  "bitcoin-internals 0.6.0",
  "bitcoin-units 0.5.0",
  "bitcoin_hashes 1.0.0",
@@ -283,7 +283,7 @@ version = "0.1.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cb95693f371d089a4b5b6fc41c6f3ea6e01ee8c15388335dfac8ea685173b51"
 dependencies = [
- "bitcoin-consensus-encoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin-consensus-encoding 1.0.0",
  "serde",
 ]
 
@@ -293,7 +293,7 @@ version = "0.5.0"
 dependencies = [
  "arbitrary",
  "bincode",
- "bitcoin-consensus-encoding 1.0.0",
+ "bitcoin-consensus-encoding 1.1.0",
  "bitcoin-internals 0.6.0",
  "serde",
  "serde_json",
@@ -325,7 +325,7 @@ name = "bitcoin_hashes"
 version = "1.0.0"
 dependencies = [
  "arbitrary",
- "bitcoin-consensus-encoding 1.0.0",
+ "bitcoin-consensus-encoding 1.1.0",
  "bitcoin-internals 0.6.0",
  "cpufeatures",
  "hex-conservative 1.1.0",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -61,7 +61,7 @@ checksum = "8ed8ccb78a9ff7a6fbb90e2fb9b8588b4a9928d49d8af3cb789108a84ea6b0ce"
 dependencies = [
  "base58ck 0.1.101",
  "bech32",
- "bitcoin-consensus-encoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin-consensus-encoding 1.0.0",
  "bitcoin-io 0.1.101",
  "bitcoin-units 0.1.101",
  "bitcoin_hashes 0.14.101",
@@ -81,7 +81,7 @@ dependencies = [
  "bech32",
  "bincode",
  "bitcoin-addresses",
- "bitcoin-consensus-encoding 1.0.0",
+ "bitcoin-consensus-encoding 1.1.0",
  "bitcoin-crypto",
  "bitcoin-internals 0.6.0",
  "bitcoin-io 0.5.0",
@@ -116,20 +116,20 @@ version = "0.0.0"
 [[package]]
 name = "bitcoin-consensus-encoding"
 version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2d6094e2a1ba3c93b5a596fe5a10d1a10c3c6e06785cde89f693a044c01aa40"
+dependencies = [
+ "bitcoin-internals 0.5.0",
+]
+
+[[package]]
+name = "bitcoin-consensus-encoding"
+version = "1.1.0"
 dependencies = [
  "bitcoin-internals 0.6.0",
  "hex-conservative 1.1.0",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "bitcoin-consensus-encoding"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2d6094e2a1ba3c93b5a596fe5a10d1a10c3c6e06785cde89f693a044c01aa40"
-dependencies = [
- "bitcoin-internals 0.5.0",
 ]
 
 [[package]]
@@ -155,7 +155,7 @@ dependencies = [
  "arbitrary",
  "bitcoin 0.32.101",
  "bitcoin 0.33.0-beta",
- "bitcoin-consensus-encoding 1.0.0",
+ "bitcoin-consensus-encoding 1.1.0",
  "bitcoin-p2p-messages",
  "libfuzzer-sys",
  "serde",
@@ -188,14 +188,14 @@ version = "0.1.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb5de036369d1ac59d3c1819ebc4d850f89466f5401c571a285b6ed564a4cb78"
 dependencies = [
- "bitcoin-consensus-encoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin-consensus-encoding 1.0.0",
 ]
 
 [[package]]
 name = "bitcoin-io"
 version = "0.5.0"
 dependencies = [
- "bitcoin-consensus-encoding 1.0.0",
+ "bitcoin-consensus-encoding 1.1.0",
  "bitcoin-internals 0.6.0",
  "bitcoin_hashes 1.0.0",
 ]
@@ -233,7 +233,7 @@ name = "bitcoin-p2p-messages"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "bitcoin-consensus-encoding 1.0.0",
+ "bitcoin-consensus-encoding 1.1.0",
  "bitcoin-internals 0.6.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
@@ -249,7 +249,7 @@ version = "0.102.0"
 dependencies = [
  "arbitrary",
  "bincode",
- "bitcoin-consensus-encoding 1.0.0",
+ "bitcoin-consensus-encoding 1.1.0",
  "bitcoin-internals 0.6.0",
  "bitcoin-units 0.5.0",
  "bitcoin_hashes 1.0.0",
@@ -276,7 +276,7 @@ version = "0.1.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cb95693f371d089a4b5b6fc41c6f3ea6e01ee8c15388335dfac8ea685173b51"
 dependencies = [
- "bitcoin-consensus-encoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin-consensus-encoding 1.0.0",
  "serde",
 ]
 
@@ -286,7 +286,7 @@ version = "0.5.0"
 dependencies = [
  "arbitrary",
  "bincode",
- "bitcoin-consensus-encoding 1.0.0",
+ "bitcoin-consensus-encoding 1.1.0",
  "bitcoin-internals 0.6.0",
  "serde",
  "serde_json",
@@ -309,7 +309,7 @@ name = "bitcoin_hashes"
 version = "1.0.0"
 dependencies = [
  "arbitrary",
- "bitcoin-consensus-encoding 1.0.0",
+ "bitcoin-consensus-encoding 1.1.0",
  "bitcoin-internals 0.6.0",
  "cpufeatures",
  "hex-conservative 1.1.0",

--- a/consensus_encoding/CHANGELOG.md
+++ b/consensus_encoding/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-07-14
+
+- Add `PrefixedBytesEncoder` and `PrefixedSliceEncoder` [#6476](https://github.com/rust-bitcoin/rust-bitcoin/pull/6476)
+- Introduce functions to decode from `Decoder` types [#6213](https://github.com/rust-bitcoin/rust-bitcoin/pull/6213)
+- Rename `_with` decoder functions [#6477](https://github.com/rust-bitcoin/rust-bitcoin/pull/6477)
+- Add `ExactSizeEncoder` impl for `Option<T: ExactSizeEncoder>` [#6422](https://github.com/rust-bitcoin/rust-bitcoin/pull/6422)
+- Add hex encoding/decoding support [#6296](https://github.com/rust-bitcoin/rust-bitcoin/pull/6296)
+  - Add `decode_from_hex_with` [#6454](https://github.com/rust-bitcoin/rust-bitcoin/pull/6454)
+- Move `serde_as_consensus` to `consensus_encoding` [#6395](https://github.com/rust-bitcoin/rust-bitcoin/pull/6395)
+  - Clean up `serde_as_consensus` docs [#6453](https://github.com/rust-bitcoin/rust-bitcoin/pull/6453)
+  - Adjust `ConsensusHex` impl in `serde_as_consensus` [#6438](https://github.com/rust-bitcoin/rust-bitcoin/pull/6438)
+- Always enable `alloc` for `serde` [#6415](https://github.com/rust-bitcoin/rust-bitcoin/pull/6415)
+- Fix buffer bug in `decode_from_read_unbuffered_with` [#6380](https://github.com/rust-bitcoin/rust-bitcoin/pull/6380)
+
 ## [1.0.0] - 2026-05-22
 
 Props to the team, our first `1.0` release from this repository. That
@@ -81,6 +95,7 @@ around but the work got done. Props to him for many of the ideas.
 
 Empty crate to reserve the name on crates.io
 
-[Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-consensus-encoding-1.0.0...HEAD
+[Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-consensus-encoding-1.1.0...HEAD
+[1.1.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-consensus-encoding-1.0.0...bitcoin-consensus-encoding-1.1.0
 [1.0.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-consensus-encoding-0.2.0...bitcoin-consensus-encoding-1.0.0
 [0.2.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-consensus-encoding-0.1.0...bitcoin-consensus-encoding-0.2.0

--- a/consensus_encoding/Cargo.toml
+++ b/consensus_encoding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-consensus-encoding"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>", "Nick Johnson <nick@yonson.dev>", "Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 homepage = "https://rust-bitcoin.org/"


### PR DESCRIPTION
In preparation for release add a changelog entry, bump the version, and update the lock files.

This is a post-1.0 release so we need to be careful here team. Please spend some time reviewing the output of:

  `git diff bitcoin-consensus-encoding-1.0.0 consensus_encoding`

With careful eye for API design choices, things that might make maintenance harder etc.

Thanks

Close: #6448