### PR TITLE
Release tracking PR: `bitcoin 0.32.11`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.10"
+version = "0.32.11"
 dependencies = [
  "arbitrary",
  "base58ck 0.1.0",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.10"
+version = "0.32.11"
 dependencies = [
  "arbitrary",
  "base58ck 0.1.0",

--- a/bitcoin/CHANGELOG.md
+++ b/bitcoin/CHANGELOG.md
@@ -1,6 +1,5 @@
 # 0.32.10 - 2026-04-23
 
-
 - Fix bug in `LeafVerison::Future`'s `Display` output [#6208](https://github.com/rust-bitcoin/rust-bitcoin/pull/6208)
 - Manually revert `VarInt` range check [#6182](https://github.com/rust-bitcoin/rust-bitcoin/pull/6182)
 - Backport - p2p: Add a hash value to `Inventory`'s `Error` variant [#6147](https://github.com/rust-bitcoin/rust-bitcoin/pull/6147)

--- a/bitcoin/CHANGELOG.md
+++ b/bitcoin/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.32.11 - 2026-07-14
+
+- Backport: Make `SendCmpct` idempotent [#6527](https://github.com/rust-bitcoin/rust-bitcoin/pull/6527)
+
 # 0.32.10 - 2026-04-23
 
 - Fix bug in `LeafVerison::Future`'s `Display` output [#6208](https://github.com/rust-bitcoin/rust-bitcoin/pull/6208)

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin"
-version = "0.32.10"
+version = "0.32.11"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"

--- a/bitcoin/src/consensus/mod.rs
+++ b/bitcoin/src/consensus/mod.rs
@@ -151,7 +151,7 @@ impl<E: fmt::Debug> std::error::Error for DecodeError<E> {
         match *self {
             TooManyBytes => None,
             Consensus(ref e) => Some(e),
-            Other(_) => None, // TODO: Is this correct?
+            Other(_) => None,
         }
     }
 }


### PR DESCRIPTION
In preparation for release add a changelog entry, bump the version number, and update the lock files.
