### PR TITLE
Release tracking PR: `bitcoin-0.34.0-beta`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-crypto"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "arbitrary",
  "base58ck 0.5.0",

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-key-expression"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "arbitrary",
  "base58ck 0.5.0",

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-addresses"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "base58ck 0.5.0",
  "bech32",

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -273,7 +273,7 @@ checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
 
 [[package]]
 name = "bitcoin-taproot-primitives"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "arbitrary",
  "bitcoin-consensus-encoding 1.1.0",

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -74,7 +74,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.33.0-beta"
+version = "0.34.0-beta"
 dependencies = [
  "arbitrary",
  "base58ck 0.5.0",
@@ -161,7 +161,7 @@ version = "0.0.1"
 dependencies = [
  "arbitrary",
  "bitcoin 0.32.102",
- "bitcoin 0.33.0-beta",
+ "bitcoin 0.34.0-beta",
  "bitcoin-consensus-encoding 1.1.0",
  "bitcoin-p2p-messages",
  "libfuzzer-sys",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -208,7 +208,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-key-expression"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "arbitrary",
  "base58ck 0.5.0",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-crypto"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "arbitrary",
  "base58ck 0.5.0",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.33.0-beta"
+version = "0.34.0-beta"
 dependencies = [
  "arbitrary",
  "base58ck 0.5.0",
@@ -160,7 +160,7 @@ version = "0.0.1"
 dependencies = [
  "arbitrary",
  "bitcoin 0.32.102",
- "bitcoin 0.33.0-beta",
+ "bitcoin 0.34.0-beta",
  "bitcoin-consensus-encoding 1.1.0",
  "bitcoin-p2p-messages",
  "libfuzzer-sys",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -266,7 +266,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-taproot-primitives"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "arbitrary",
  "bitcoin-consensus-encoding 1.1.0",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-addresses"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "base58ck 0.5.0",
  "bech32",

--- a/addresses/CHANGELOG.md
+++ b/addresses/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-07-31
+
+* Initial release of the `github.com/rust-bitcoin/rust-bitcoin/addresses` crate as `bitcoin-addresses`.
+
 ## 0.0.0 - Initial dummy release
 
 - Empty crate to reserve the name on crates.io
+
+[Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-addresses-0.1.0...HEAD
+[0.1.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/addresses-0.0.0...bitcoin-addresses-0.1.0

--- a/addresses/Cargo.toml
+++ b/addresses/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-addresses"
-version = "0.0.0"
+version = "0.1.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin"

--- a/addresses/Cargo.toml
+++ b/addresses/Cargo.toml
@@ -24,7 +24,7 @@ bech32 = { version = "0.11.0", default-features = false, features = [] }
 crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.3.0", default-features = false, features = ["hex"] }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.0.0", default-features = false, features = ["hex"] }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
-taproot_primitives = { package = "bitcoin-taproot-primitives", path = "../taproot_primitives", version = "0.1.0", default-features = false, features = [] }
+taproot_primitives = { package = "bitcoin-taproot-primitives", path = "../taproot_primitives", version = "0.2.0", default-features = false, features = [] }
 network = { package = "bitcoin-network-kind", path = "../network", version = "1.0.0", default-features = false, features = []}
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.103.0", default-features = false, features = ["hex"] }
 

--- a/addresses/Cargo.toml
+++ b/addresses/Cargo.toml
@@ -21,7 +21,7 @@ alloc = ["base58/alloc", "bech32/alloc", "crypto/alloc", "hashes/alloc", "intern
 [dependencies]
 base58 = { package = "base58ck", path = "../base58", version = "0.5.0", default-features = false, features = [] }
 bech32 = { version = "0.11.0", default-features = false, features = [] }
-crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.2.0", default-features = false, features = ["hex"] }
+crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.3.0", default-features = false, features = ["hex"] }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.0.0", default-features = false, features = ["hex"] }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
 taproot_primitives = { package = "bitcoin-taproot-primitives", path = "../taproot_primitives", version = "0.1.0", default-features = false, features = [] }

--- a/bitcoin/CHANGELOG.md
+++ b/bitcoin/CHANGELOG.md
@@ -2,6 +2,76 @@
 
 ## [Unreleased]
 
+# 0.34.0-beta - 2026-07-22
+
+Crates smashing continues. The old consensus encoding logic is gone and so is the `psbt` module. See
+the `consensus-enocoding/` crate and [`rust-psbt-v2`](https://crates.io/crates/psbt-v2).
+
+- Remove uses of old encoding traits [#6170](https://github.com/rust-bitcoin/rust-bitcoin/pull/6170)
+- Remove old consensus module [#6389](https://github.com/rust-bitcoin/rust-bitcoin/pull/6389)
+- Remove the unstable hex-conservative dependency [#6148](https://github.com/rust-bitcoin/rust-bitcoin/pull/6148)
+- Delete the psbt module [#6056](https://github.com/rust-bitcoin/rust-bitcoin/pull/6056)
+- Implement `AsRef<PushBytes>` for generic hashes [#6077](https://github.com/rust-bitcoin/rust-bitcoin/pull/6077)
+- Clear pushnum cache on signature operations in sigop count [#6409](https://github.com/rust-bitcoin/rust-bitcoin/pull/6409)
+- Reject non-pushnum opcodes in multisig pattern [#6406](https://github.com/rust-bitcoin/rust-bitcoin/pull/6406)
+- Remove Verification re-exports [#6319](https://github.com/rust-bitcoin/rust-bitcoin/pull/6319)
+- Remove PrivateKeyExt and make PrivateKey::as_inner private [#6345](https://github.com/rust-bitcoin/rust-bitcoin/pull/6345)
+- Fix panic in `sign_message::MessageSignature::from_base64` [#6381](https://github.com/rust-bitcoin/rust-bitcoin/pull/6381)
+- Fix `InstructionIndices::nth` byte position bug [#6382](https://github.com/rust-bitcoin/rust-bitcoin/pull/6382)
+- Witness constructor for P2WSH [#6027](https://github.com/rust-bitcoin/rust-bitcoin/pull/6027)
+- bip158: Reject malformed filter counts [#6220](https://github.com/rust-bitcoin/rust-bitcoin/pull/6220)
+- Add `SerializedLegacyPublicKey` [#6011](https://github.com/rust-bitcoin/rust-bitcoin/pull/6011)
+- Improve secret key conversions [#5961](https://github.com/rust-bitcoin/rust-bitcoin/pull/5961)
+- Derive `Clone` for `SighashCache` [#5939](https://github.com/rust-bitcoin/rust-bitcoin/pull/5939)
+- Move errors to `error` submodules [#5923](https://github.com/rust-bitcoin/rust-bitcoin/pull/5923)
+- Rename public key types [#5879](https://github.com/rust-bitcoin/rust-bitcoin/pull/5879)
+- Add `From` conversion for `PrivateKey` -> `Keypair` [#5740](https://github.com/rust-bitcoin/rust-bitcoin/pull/5740)
+- Reject 65 bytes signature with sighash 0x00 [#5718](https://github.com/rust-bitcoin/rust-bitcoin/pull/5718)
+- Preserve parity for `XOnlyPublicKey` [#5708](https://github.com/rust-bitcoin/rust-bitcoin/pull/5708)
+- Adjust `PublicKey::from_slice` and improve error documentation for key types [#5679](https://github.com/rust-bitcoin/rust-bitcoin/pull/5679)
+- Change `Params::pow_target_spacing` to `u32` [#5656](https://github.com/rust-bitcoin/rust-bitcoin/pull/5656)
+- Change `hex` re-export in bitcoin to stable `hex` [#5640](https://github.com/rust-bitcoin/rust-bitcoin/pull/5640)
+- Fix PSBT key deserialisation byte size [#5625](https://github.com/rust-bitcoin/rust-bitcoin/pull/5625)
+- Add bounds check for non-witness UTXO output index [#5617](https://github.com/rust-bitcoin/rust-bitcoin/pull/5617)
+- Encapsulate the PublicKey and PrivateKey types [#5614](https://github.com/rust-bitcoin/rust-bitcoin/pull/5614)
+- Add note about `Target` maximum values [#5609](https://github.com/rust-bitcoin/rust-bitcoin/pull/5609)
+- Add parity to `XOnlyPublicKey` and adjust API [#5593](https://github.com/rust-bitcoin/rust-bitcoin/pull/5593)
+- Depend on bitcoin-network-kind [#5528](https://github.com/rust-bitcoin/rust-bitcoin/pull/5528)
+- Add `FromStr` to `Target` and `Work` [#5539](https://github.com/rust-bitcoin/rust-bitcoin/pull/5539)
+- Fix `U256::overflowing_mul` [#5501](https://github.com/rust-bitcoin/rust-bitcoin/pull/5501)
+- Fix bug in `Psbt::spend_utxo` when missing output [#5500](https://github.com/rust-bitcoin/rust-bitcoin/pull/5500)
+- Fix unreachable error bug during iteration of funding utxos [#5492](https://github.com/rust-bitcoin/rust-bitcoin/pull/5492)
+
+## Dependency upgrades
+
+New crates: 
+
+- https://crates.io/crates/bitcoin-crypto
+- https://crates.io/crates/bitcoin-addresses
+- https://crates.io/crates/bitcoin-key-expression
+- https://crates.io/crates/bitcoin-network-kind
+
+Dependency upgrades of crates in the `rust-bitcoin` repository:
+
+- `bitcoin-consensus-encoding 1.1.0` [#6538](https://github.com/rust-bitcoin/rust-bitcoin/pull/6538)
+- `bitcoin-primitives 0.103.0` [#6279](https://github.com/rust-bitcoin/rust-bitcoin/pull/6276)
+- `bitcoin-addresses 0.1.0` [#6543](https://github.com/rust-bitcoin/rust-bitcoin/pull/6543) 
+- `bitcoin_hashes 1.1.0` [#6555](https://github.com/rust-bitcoin/rust-bitcoin/pull/6555)
+- `bitcoin-io 0.6.0` [#6544](https://github.com/rust-bitcoin/rust-bitcoin/pull/6544)
+- `bitcoin-internals 0.6.0` [#6491](https://github.com/rust-bitcoin/rust-bitcoin/pull/6491)
+- `bitcoin-network-kind 1.0.0` [#6300](https://github.com/rust-bitcoin/rust-bitcoin/pull/6300)
+- `bitcoin-key-expression 0.1.0` [#6130](https://github.com/rust-bitcoin/rust-bitcoin/pull/6130)
+- `bitcoin-crypto 0.2.0` [#6053](https://github.com/rust-bitcoin/rust-bitcoin/pull/6053)
+
+## BIP-32 work
+
+- Move `bip32` module to `key-expression` crate [#6009]()
+- Make child number a newtype `ChildNumber(u32)` [#6192]()
+- Split relative and absolute bip32 derivation paths [#6232]()
+- validate master key seed length [#6212]()
+- Seed length validation follow-up [#6271]()
+- 
+
 ## [0.33.0-beta] - 2026-02-17
 
 This series of beta releases is meant for two things:

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -39,7 +39,7 @@ io = { package = "bitcoin-io", path = "../io", version = "0.6.0", default-featur
 network = { package = "bitcoin-network-kind", path = "../network", version = "1.0.0", default-features = false, features = ["alloc"]}
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.103.0", default-features = false, features = ["alloc", "hex"] }
 secp256k1 = { version = "0.32.0-beta.2", default-features = false, features = ["alloc"] }
-taproot-primitives = { package = "bitcoin-taproot-primitives", path = "../taproot_primitives", version = "0.1.0", default-features = false, features = ["alloc", "hex"] }
+taproot-primitives = { package = "bitcoin-taproot-primitives", path = "../taproot_primitives", version = "0.2.0", default-features = false, features = ["alloc", "hex"] }
 units = { package = "bitcoin-units", path = "../units", version = "0.5.0", default-features = false, features = ["alloc"] }
 
 arbitrary = { version = "1.4.1", optional = true }

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin"
-version = "0.33.0-beta"
+version = "0.34.0-beta"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -31,7 +31,7 @@ base58 = { package = "base58ck", path = "../base58", version = "0.5.0", default-
 bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
 crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.3.0", default-features = false, features = ["alloc", "hex"] }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.1.0", default-features = false, features = ["alloc", "hex"] }
-key-expression = { package = "bitcoin-key-expression", path = "../key_expression", version = "0.1.0", default-features = false, features = ["alloc"] }
+key-expression = { package = "bitcoin-key-expression", path = "../key_expression", version = "0.2.0", default-features = false, features = ["alloc"] }
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.1.0", default-features = false, features = ["alloc", "hex"] }
 hex = { package = "hex-conservative", version = "1.1.0", default-features = false, features = ["alloc"] }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0", features = ["alloc"] }

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -26,7 +26,7 @@ secp-recovery = ["secp256k1/recovery"]
 arbitrary = ["crypto/arbitrary", "dep:arbitrary", "units/arbitrary", "primitives/arbitrary", "hashes/arbitrary", "key-expression/arbitrary", "secp256k1/arbitrary", "taproot-primitives/arbitrary", "network/arbitrary"]
 
 [dependencies]
-addresses = { package = "bitcoin-addresses", path = "../addresses", version = "0.0.0", default-features = false, features = ["alloc"] }
+addresses = { package = "bitcoin-addresses", path = "../addresses", version = "0.1.0", default-features = false, features = ["alloc"] }
 base58 = { package = "base58ck", path = "../base58", version = "0.5.0", default-features = false, features = ["alloc"] }
 bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
 crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.3.0", default-features = false, features = ["alloc", "hex"] }

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -29,7 +29,7 @@ arbitrary = ["crypto/arbitrary", "dep:arbitrary", "units/arbitrary", "primitives
 addresses = { package = "bitcoin-addresses", path = "../addresses", version = "0.0.0", default-features = false, features = ["alloc"] }
 base58 = { package = "base58ck", path = "../base58", version = "0.5.0", default-features = false, features = ["alloc"] }
 bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
-crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.2.0", default-features = false, features = ["alloc", "hex"] }
+crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.3.0", default-features = false, features = ["alloc", "hex"] }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.1.0", default-features = false, features = ["alloc", "hex"] }
 key-expression = { package = "bitcoin-key-expression", path = "../key_expression", version = "0.1.0", default-features = false, features = ["alloc"] }
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.1.0", default-features = false, features = ["alloc", "hex"] }

--- a/crypto/CHANGELOG.md
+++ b/crypto/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-30
+
+- Remove `PrivateKeyExt` and make `PrivateKey::as_inner` private [#6345](https://github.com/rust-bitcoin/rust-bitcoin/pull/6345)
+- Remove `XOnlyPublicKey::as_inner` and make `to_inner` private for public keys [#5619](https://github.com/rust-bitcoin/rust-bitcoin/pull/5619)
+- Remove Verification re-exports [#6319](https://github.com/rust-bitcoin/rust-bitcoin/pull/6319)
+- Improve sighash errors [#6318](https://github.com/rust-bitcoin/rust-bitcoin/pull/6318)
+- Add `XOnlyPublicKey::verify` [#6261](https://github.com/rust-bitcoin/rust-bitcoin/pull/6261)
+- Extend ECDSA `Signature` [#6260](https://github.com/rust-bitcoin/rust-bitcoin/pull/6260)
+- Split `key::encapsulate` and rename `LegacyPublicKey::to_bytes` [#6238](https://github.com/rust-bitcoin/rust-bitcoin/pull/6238)
+- Introduce new errors to remove `secp256k1::Error` [#6183](https://github.com/rust-bitcoin/rust-bitcoin/pull/6183)
+- Remove alloc feature gate from taproot module [#6155](https://github.com/rust-bitcoin/rust-bitcoin/pull/6155)
+- Add `with_compressedness` to `LegacyPublicKey` [#6119](https://github.com/rust-bitcoin/rust-bitcoin/pull/6119)
+- Clean up key module [#6118](https://github.com/rust-bitcoin/rust-bitcoin/pull/6118)
+- Remove `with_serialized` from `LegacyPublicKey` [#6116](https://github.com/rust-bitcoin/rust-bitcoin/pull/6116)
+- Move `taproot` module to `crypto` [#6097](https://github.com/rust-bitcoin/rust-bitcoin/pull/6097)
+- Gate all usage of `hex-conservative` behind `hex` feature [#6043](https://github.com/rust-bitcoin/rust-bitcoin/pull/6043)
+
 ## [0.2.0] - 2026-04-27
 
 - Re-export types and extern crates [#5858](https://github.com/rust-bitcoin/rust-bitcoin/pull/5858)
@@ -19,5 +36,6 @@
 
 - Empty crate to reserve the name on crates.io
 
-[Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-crypto-0.2.0...HEAD
+[Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-crypto-0.3.0...HEAD
+[0.3.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-crypto-0.2.0...bitcoin-crypto-0.3.0
 [0.2.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-crypto-0.1.0...bitcoin-crypto-0.2.0

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-crypto"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -15,7 +15,7 @@ cargo-fuzz = true
 [dependencies]
 # We shouldn't need an explicit version on the next line, but Andrew's tools
 # choke on it otherwise. See https://github.com/nix-community/crate2nix/issues/373
-bitcoin = { path = "../bitcoin", version = "0.33.0-beta", features = [ "serde", "arbitrary" ] }
+bitcoin = { path = "../bitcoin", version = "0.34.0-beta", features = [ "serde", "arbitrary" ] }
 bitcoin_0_32 = { version = "0.32.102", package = "bitcoin", features = [ "encoding", "serde" ] }
 bitcoin_consensus_encoding = { path = "../consensus_encoding", package = "bitcoin-consensus-encoding" }
 p2p = { path = "../p2p", package = "bitcoin-p2p-messages", features = ["arbitrary"] }

--- a/key_expression/CHANGELOG.md
+++ b/key_expression/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-07-17
+
+- Refactor xpub and xpriv derive functions [#6500](https://github.com/rust-bitcoin/rust-bitcoin/pull/6500)
+- Seed length validation follow-up [#6271](https://github.com/rust-bitcoin/rust-bitcoin/pull/6271)
+- Split up errors [#6396](https://github.com/rust-bitcoin/rust-bitcoin/pull/6396)
+
 ## [0.1.0] - 2026-05-28
 
 - Split relative and absolute `bip32` derivation paths [#6232](https://github.com/rust-bitcoin/rust-bitcoin/pull/6232)
@@ -13,5 +19,6 @@
 
 - Empty crate to reserve the name on crates.io
 
-[Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-key-expression-0.1.0...HEAD
+[Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-key-expression-0.2.0...HEAD
+[0.2.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-key-expression-0.1.0...bitcoin-key-expression-0.2.0
 [0.1.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-key-expression-0.0.0...bitcoin-key-expression-0.1.0

--- a/key_expression/Cargo.toml
+++ b/key_expression/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-key-expression"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin"

--- a/key_expression/Cargo.toml
+++ b/key_expression/Cargo.toml
@@ -22,7 +22,7 @@ arbitrary = ["crypto/arbitrary", "dep:arbitrary", "hashes/arbitrary", "secp256k1
 
 [dependencies]
 base58 = { package = "base58ck", path = "../base58", version = "0.5.0", default-features = false }
-crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.2.0", default-features = false }
+crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.3.0", default-features = false }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.0.0", default-features = false, features = ["hex"] }
 hex = { package = "hex-conservative", version = "1.1.0", default-features = false, features = ["alloc"] }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }

--- a/taproot_primitives/CHANGELOG.md
+++ b/taproot_primitives/CHANGELOG.md
@@ -2,8 +2,15 @@
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-07-17
+
+- Move `TapTweak` to `taproot-primitives` [#6390](https://github.com/rust-bitcoin/rust-bitcoin/pull/6390)
+- Fix bug in `LeafVerison::Future`'s `Display` output [#6222](https://github.com/rust-bitcoin/rust-bitcoin/pull/6222)
+
 ## 0.1.0 - Initial release
 
 - All the hash types and also the `LeafVersion` enum.
 
-[Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-taproot-primitives-0.1.0...HEAD
+[Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-taproot-primitives-0.2.0...HEAD
+[0.2.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-taproot-primitives-0.1.0...bitcoin-taproot-primitives-0.2.0
+

--- a/taproot_primitives/Cargo.toml
+++ b/taproot_primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-taproot-primitives"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin"

--- a/taproot_primitives/Cargo.toml
+++ b/taproot_primitives/Cargo.toml
@@ -21,7 +21,7 @@ arbitrary = ["dep:arbitrary", "crypto/arbitrary", "secp256k1/arbitrary"]
 hex = ["crypto/hex", "encoding/hex", "hashes/hex"]
 
 [dependencies]
-crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.2.0", default-features = false }
+crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.3.0", default-features = false }
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.1.0", default-features = false, features = [] }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.0.0", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }


### PR DESCRIPTION
Its 5 or 6 months (depending how you look at it) since we did the 0.33.0-beta release of `bitcoin`. It would be nice to get our six month release cadence back.

## TODO - backup and release `units 0.6.0` and the cascade of releases that triggers

- https://github.com/rust-bitcoin/rust-bitcoin/pull/6716
- https://github.com/rust-bitcoin/rust-bitcoin/pull/6717
- crypto
- p2p
- https://github.com/rust-bitcoin/rust-bitcoin/pull/6600
- https://github.com/rust-bitcoin/rust-bitcoin/pull/6599
- https://github.com/rust-bitcoin/rust-bitcoin/pull/6543

