### PR TITLE
Release tracking PR: `bitcoin-p2p-messages 0.1.0`

### DIFF
--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -25,7 +25,7 @@ hashes = { package = "bitcoin_hashes", version = "1.0.0", path = "../hashes", de
 network = { package = "bitcoin-network-kind", path = "../network", version = "1.0.0", default-features = false }
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.102.0", features = ["hex", "alloc"], default-features = false }
 hex = { package = "hex-conservative", version = "1.1.0", default-features = false, features = ["alloc"] }
-internals = { package = "bitcoin-internals", path = "../internals", default-features = false }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0", default-features = false }
 units = { package = "bitcoin-units", path = "../units", version = "0.5.0", default-features = false }
 
 arbitrary = { version = "1.4.1", optional = true }

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! Rust Bitcoin Peer to Peer Message Types
+//! # Rust Bitcoin Peer to Peer Message Types
 
 #![no_std]
 // Coding conventions.


### PR DESCRIPTION
Get this out the door already. Currently `cargo publish --dry-run --allow-dirty -p bitcoin-p2p-messages` is failing. Raising this to shine some light on the need to release this.

## TODO

https://github.com/rust-bitcoin/rust-bitcoin/pull/6364