### PR TITLE
Release tracking PR: `addresses 0.1.0`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-crypto"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "arbitrary",
  "base58ck 0.5.0",

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-key-expression"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "arbitrary",
  "base58ck 0.5.0",

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-addresses"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "base58ck 0.5.0",
  "bech32",

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -273,7 +273,7 @@ checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
 
 [[package]]
 name = "bitcoin-taproot-primitives"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "arbitrary",
  "bitcoin-consensus-encoding 1.1.0",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -208,7 +208,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-key-expression"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "arbitrary",
  "base58ck 0.5.0",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-crypto"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "arbitrary",
  "base58ck 0.5.0",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -266,7 +266,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-taproot-primitives"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "arbitrary",
  "bitcoin-consensus-encoding 1.1.0",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-addresses"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "base58ck 0.5.0",
  "bech32",

--- a/addresses/CHANGELOG.md
+++ b/addresses/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-07-31
+
+* Initial release of the `github.com/rust-bitcoin/rust-bitcoin/addresses` crate as `bitcoin-addresses`.
+
 ## 0.0.0 - Initial dummy release
 
 - Empty crate to reserve the name on crates.io
+
+[Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-addresses-0.1.0...HEAD
+[0.1.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/addresses-0.0.0...bitcoin-addresses-0.1.0

--- a/addresses/Cargo.toml
+++ b/addresses/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-addresses"
-version = "0.0.0"
+version = "0.1.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin"

--- a/addresses/Cargo.toml
+++ b/addresses/Cargo.toml
@@ -24,7 +24,7 @@ bech32 = { version = "0.11.0", default-features = false, features = [] }
 crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.3.0", default-features = false, features = ["hex"] }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.0.0", default-features = false, features = ["hex"] }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
-taproot_primitives = { package = "bitcoin-taproot-primitives", path = "../taproot_primitives", version = "0.1.0", default-features = false, features = [] }
+taproot_primitives = { package = "bitcoin-taproot-primitives", path = "../taproot_primitives", version = "0.2.0", default-features = false, features = [] }
 network = { package = "bitcoin-network-kind", path = "../network", version = "1.0.0", default-features = false, features = []}
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.103.0", default-features = false, features = ["hex"] }
 

--- a/addresses/Cargo.toml
+++ b/addresses/Cargo.toml
@@ -21,7 +21,7 @@ alloc = ["base58/alloc", "bech32/alloc", "crypto/alloc", "hashes/alloc", "intern
 [dependencies]
 base58 = { package = "base58ck", path = "../base58", version = "0.5.0", default-features = false, features = [] }
 bech32 = { version = "0.11.0", default-features = false, features = [] }
-crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.2.0", default-features = false, features = ["hex"] }
+crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.3.0", default-features = false, features = ["hex"] }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.0.0", default-features = false, features = ["hex"] }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
 taproot_primitives = { package = "bitcoin-taproot-primitives", path = "../taproot_primitives", version = "0.1.0", default-features = false, features = [] }

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -39,7 +39,7 @@ io = { package = "bitcoin-io", path = "../io", version = "0.6.0", default-featur
 network = { package = "bitcoin-network-kind", path = "../network", version = "1.0.0", default-features = false, features = ["alloc"]}
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.103.0", default-features = false, features = ["alloc", "hex"] }
 secp256k1 = { version = "0.32.0-beta.2", default-features = false, features = ["alloc"] }
-taproot-primitives = { package = "bitcoin-taproot-primitives", path = "../taproot_primitives", version = "0.1.0", default-features = false, features = ["alloc", "hex"] }
+taproot-primitives = { package = "bitcoin-taproot-primitives", path = "../taproot_primitives", version = "0.2.0", default-features = false, features = ["alloc", "hex"] }
 units = { package = "bitcoin-units", path = "../units", version = "0.5.0", default-features = false, features = ["alloc"] }
 
 arbitrary = { version = "1.4.1", optional = true }

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -31,7 +31,7 @@ base58 = { package = "base58ck", path = "../base58", version = "0.5.0", default-
 bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
 crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.3.0", default-features = false, features = ["alloc", "hex"] }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.1.0", default-features = false, features = ["alloc", "hex"] }
-key-expression = { package = "bitcoin-key-expression", path = "../key_expression", version = "0.1.0", default-features = false, features = ["alloc"] }
+key-expression = { package = "bitcoin-key-expression", path = "../key_expression", version = "0.2.0", default-features = false, features = ["alloc"] }
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.1.0", default-features = false, features = ["alloc", "hex"] }
 hex = { package = "hex-conservative", version = "1.1.0", default-features = false, features = ["alloc"] }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0", features = ["alloc"] }

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -26,7 +26,7 @@ secp-recovery = ["secp256k1/recovery"]
 arbitrary = ["crypto/arbitrary", "dep:arbitrary", "units/arbitrary", "primitives/arbitrary", "hashes/arbitrary", "key-expression/arbitrary", "secp256k1/arbitrary", "taproot-primitives/arbitrary", "network/arbitrary"]
 
 [dependencies]
-addresses = { package = "bitcoin-addresses", path = "../addresses", version = "0.0.0", default-features = false, features = ["alloc"] }
+addresses = { package = "bitcoin-addresses", path = "../addresses", version = "0.1.0", default-features = false, features = ["alloc"] }
 base58 = { package = "base58ck", path = "../base58", version = "0.5.0", default-features = false, features = ["alloc"] }
 bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
 crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.3.0", default-features = false, features = ["alloc", "hex"] }

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -29,7 +29,7 @@ arbitrary = ["crypto/arbitrary", "dep:arbitrary", "units/arbitrary", "primitives
 addresses = { package = "bitcoin-addresses", path = "../addresses", version = "0.0.0", default-features = false, features = ["alloc"] }
 base58 = { package = "base58ck", path = "../base58", version = "0.5.0", default-features = false, features = ["alloc"] }
 bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
-crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.2.0", default-features = false, features = ["alloc", "hex"] }
+crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.3.0", default-features = false, features = ["alloc", "hex"] }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.1.0", default-features = false, features = ["alloc", "hex"] }
 key-expression = { package = "bitcoin-key-expression", path = "../key_expression", version = "0.1.0", default-features = false, features = ["alloc"] }
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.1.0", default-features = false, features = ["alloc", "hex"] }

--- a/crypto/CHANGELOG.md
+++ b/crypto/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-30
+
+- Remove `PrivateKeyExt` and make `PrivateKey::as_inner` private [#6345](https://github.com/rust-bitcoin/rust-bitcoin/pull/6345)
+- Remove `XOnlyPublicKey::as_inner` and make `to_inner` private for public keys [#5619](https://github.com/rust-bitcoin/rust-bitcoin/pull/5619)
+- Remove Verification re-exports [#6319](https://github.com/rust-bitcoin/rust-bitcoin/pull/6319)
+- Improve sighash errors [#6318](https://github.com/rust-bitcoin/rust-bitcoin/pull/6318)
+- Add `XOnlyPublicKey::verify` [#6261](https://github.com/rust-bitcoin/rust-bitcoin/pull/6261)
+- Extend ECDSA `Signature` [#6260](https://github.com/rust-bitcoin/rust-bitcoin/pull/6260)
+- Split `key::encapsulate` and rename `LegacyPublicKey::to_bytes` [#6238](https://github.com/rust-bitcoin/rust-bitcoin/pull/6238)
+- Introduce new errors to remove `secp256k1::Error` [#6183](https://github.com/rust-bitcoin/rust-bitcoin/pull/6183)
+- Remove alloc feature gate from taproot module [#6155](https://github.com/rust-bitcoin/rust-bitcoin/pull/6155)
+- Add `with_compressedness` to `LegacyPublicKey` [#6119](https://github.com/rust-bitcoin/rust-bitcoin/pull/6119)
+- Clean up key module [#6118](https://github.com/rust-bitcoin/rust-bitcoin/pull/6118)
+- Remove `with_serialized` from `LegacyPublicKey` [#6116](https://github.com/rust-bitcoin/rust-bitcoin/pull/6116)
+- Move `taproot` module to `crypto` [#6097](https://github.com/rust-bitcoin/rust-bitcoin/pull/6097)
+- Gate all usage of `hex-conservative` behind `hex` feature [#6043](https://github.com/rust-bitcoin/rust-bitcoin/pull/6043)
+
 ## [0.2.0] - 2026-04-27
 
 - Re-export types and extern crates [#5858](https://github.com/rust-bitcoin/rust-bitcoin/pull/5858)
@@ -19,5 +36,6 @@
 
 - Empty crate to reserve the name on crates.io
 
-[Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-crypto-0.2.0...HEAD
+[Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-crypto-0.3.0...HEAD
+[0.3.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-crypto-0.2.0...bitcoin-crypto-0.3.0
 [0.2.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-crypto-0.1.0...bitcoin-crypto-0.2.0

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-crypto"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin"

--- a/key_expression/CHANGELOG.md
+++ b/key_expression/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-07-17
+
+- Refactor xpub and xpriv derive functions [#6500](https://github.com/rust-bitcoin/rust-bitcoin/pull/6500)
+- Seed length validation follow-up [#6271](https://github.com/rust-bitcoin/rust-bitcoin/pull/6271)
+- Split up errors [#6396](https://github.com/rust-bitcoin/rust-bitcoin/pull/6396)
+
 ## [0.1.0] - 2026-05-28
 
 - Split relative and absolute `bip32` derivation paths [#6232](https://github.com/rust-bitcoin/rust-bitcoin/pull/6232)
@@ -13,5 +19,6 @@
 
 - Empty crate to reserve the name on crates.io
 
-[Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-key-expression-0.1.0...HEAD
+[Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-key-expression-0.2.0...HEAD
+[0.2.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-key-expression-0.1.0...bitcoin-key-expression-0.2.0
 [0.1.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-key-expression-0.0.0...bitcoin-key-expression-0.1.0

--- a/key_expression/Cargo.toml
+++ b/key_expression/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-key-expression"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin"

--- a/key_expression/Cargo.toml
+++ b/key_expression/Cargo.toml
@@ -22,7 +22,7 @@ arbitrary = ["crypto/arbitrary", "dep:arbitrary", "hashes/arbitrary", "secp256k1
 
 [dependencies]
 base58 = { package = "base58ck", path = "../base58", version = "0.5.0", default-features = false }
-crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.2.0", default-features = false }
+crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.3.0", default-features = false }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.0.0", default-features = false, features = ["hex"] }
 hex = { package = "hex-conservative", version = "1.1.0", default-features = false, features = ["alloc"] }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }

--- a/taproot_primitives/CHANGELOG.md
+++ b/taproot_primitives/CHANGELOG.md
@@ -2,8 +2,15 @@
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-07-17
+
+- Move `TapTweak` to `taproot-primitives` [#6390](https://github.com/rust-bitcoin/rust-bitcoin/pull/6390)
+- Fix bug in `LeafVerison::Future`'s `Display` output [#6222](https://github.com/rust-bitcoin/rust-bitcoin/pull/6222)
+
 ## 0.1.0 - Initial release
 
 - All the hash types and also the `LeafVersion` enum.
 
-[Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-taproot-primitives-0.1.0...HEAD
+[Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-taproot-primitives-0.2.0...HEAD
+[0.2.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-taproot-primitives-0.1.0...bitcoin-taproot-primitives-0.2.0
+

--- a/taproot_primitives/Cargo.toml
+++ b/taproot_primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-taproot-primitives"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin"

--- a/taproot_primitives/Cargo.toml
+++ b/taproot_primitives/Cargo.toml
@@ -21,7 +21,7 @@ arbitrary = ["dep:arbitrary", "crypto/arbitrary", "secp256k1/arbitrary"]
 hex = ["crypto/hex", "encoding/hex", "hashes/hex"]
 
 [dependencies]
-crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.2.0", default-features = false }
+crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.3.0", default-features = false }
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.1.0", default-features = false, features = [] }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.0.0", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }


### PR DESCRIPTION
In preparation for the initial real release add a changelog entry, bump the version number, and update the lock files.

## TODO

- https://github.com/rust-bitcoin/rust-bitcoin/pull/6597
- https://github.com/rust-bitcoin/rust-bitcoin/pull/6599