### PR TITLE
Release tracking PR: `bitcoin-io 0.6.0`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -85,7 +85,7 @@ dependencies = [
  "bitcoin-consensus-encoding 1.0.0",
  "bitcoin-crypto",
  "bitcoin-internals 0.6.0",
- "bitcoin-io 0.5.0",
+ "bitcoin-io 0.6.0",
  "bitcoin-key-expression",
  "bitcoin-network-kind",
  "bitcoin-primitives",
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-io"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bitcoin-consensus-encoding 1.0.0",
  "bitcoin-internals 0.6.0",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -84,7 +84,7 @@ dependencies = [
  "bitcoin-consensus-encoding 1.0.0",
  "bitcoin-crypto",
  "bitcoin-internals 0.6.0",
- "bitcoin-io 0.5.0",
+ "bitcoin-io 0.6.0",
  "bitcoin-key-expression",
  "bitcoin-network-kind",
  "bitcoin-primitives",
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-io"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bitcoin-consensus-encoding 1.0.0",
  "bitcoin-internals 0.6.0",

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -35,7 +35,7 @@ key-expression = { package = "bitcoin-key-expression", path = "../key_expression
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0", default-features = false, features = ["alloc", "hex"] }
 hex = { package = "hex-conservative", version = "1.1.0", default-features = false, features = ["alloc"] }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0", features = ["alloc"] }
-io = { package = "bitcoin-io", path = "../io", version = "0.5.0", default-features = false, features = ["alloc", "hashes"] }
+io = { package = "bitcoin-io", path = "../io", version = "0.6.0", default-features = false, features = ["alloc", "hashes"] }
 network = { package = "bitcoin-network-kind", path = "../network", version = "1.0.0", default-features = false, features = ["alloc"]}
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.102.0", default-features = false, features = ["alloc", "hex"] }
 secp256k1 = { version = "0.32.0-beta.2", default-features = false, features = ["alloc"] }

--- a/io/CHANGELOG.md
+++ b/io/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-07-14
+
+* Introduce `encode_to_writer` for bitcoin io `Write` trait [#5214](https://github.com/rust-bitcoin/rust-bitcoin/pull/5214)
+* Fix buffer bug in `decode_from_read_unbuffered_with` [#6379](https://github.com/rust-bitcoin/rust-bitcoin/pull/6379)
+* Introduce functions to decode from `Decoder` types [#6213](https://github.com/rust-bitcoin/rust-bitcoin/pull/6213)
+* Replace gated `no_std` with blanket `no_std` [#5665](https://github.com/rust-bitcoin/rust-bitcoin/pull/5665)
+* Upgrade to `consensus-encoding 1.0.0` [#5999](https://github.com/rust-bitcoin/rust-bitcoin/pull/5999)
+* Upgrade to `bitcoin_hashes 1.0.0` [#6229](https://github.com/rust-bitcoin/rust-bitcoin/pull/6229)
+
 ## [0.5.0] - 2026-01-08
 
 It was found that the `1.0.0-rc.x` releases were troublesome because
@@ -80,7 +89,8 @@ Types:
 
 Empty crate to reserve the name on crates.io
 
-[Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-io-0.5.0...HEAD
+[Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-io-0.6.0...HEAD
+[0.6.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-io-0.5.0...bitcoin-io-0.6.0
 [0.5.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-io-0.4.0-rc.0...bitcoin-io-0.5.0
 [0.4.0-rc.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-io-0.3.0...bitcoin-io-0.4.0-rc.0
 [0.3.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/io-0.2.0...bitcoin-io-0.3.0

--- a/io/Cargo.toml
+++ b/io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-io"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Matt Corallo <birchneutea@mattcorallo.com>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin"


### PR DESCRIPTION
In preparation for release add a changelog entry, bump the version number, and update the lock files.