### PR TITLE
Make ToU64 private

### DIFF
--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -266,7 +266,7 @@ pub mod amount {
 ///
 /// This trait exists because [`usize`] doesn't implement `Into<u64>`. We only support 32 and 64 bit
 /// architectures because of consensus code so we can infallibly do the conversion.
-pub trait ToU64 {
+pub(crate) trait ToU64 {
     /// Converts unsigned integer type to a [`u64`].
     fn to_u64(self) -> u64;
 }


### PR DESCRIPTION
The ToU64 trait was moved from internals to bitcoin recently. When moved, it was made public in bitcoin as it was used in the public API of some of the old consensus code. With that consensus code removed, the trait should be made private.

Make ToU64 pub(crate).