### PR TITLE
consensus_encoding: Flatten Nested Error Constructors

### DIFF
--- a/consensus_encoding/src/compact_size.rs
+++ b/consensus_encoding/src/compact_size.rs
@@ -278,14 +278,16 @@ fn compact_size_decode_u64(buf: &ArrayVec<u8, 9>) -> Result<u64, CompactSizeDeco
     use CompactSizeDecoderErrorInner as E;
 
     fn arr<const N: usize>(slice: &[u8]) -> Result<[u8; N], CompactSizeDecoderError> {
-        slice.try_into().map_err(|_| {
-            CompactSizeDecoderError(E::UnexpectedEof { required: N, received: slice.len() })
-        })
+        slice
+            .try_into()
+            .map_err(|_| E::UnexpectedEof { required: N, received: slice.len() })
+            .map_err(CompactSizeDecoderError)
     }
 
     let (first, payload) = buf
         .split_first()
-        .ok_or(CompactSizeDecoderError(E::UnexpectedEof { required: 1, received: 0 }))?;
+        .ok_or(E::UnexpectedEof { required: 1, received: 0 })
+        .map_err(CompactSizeDecoderError)?;
 
     match *first {
         PREFIX_U64 => {

--- a/consensus_encoding/src/compact_size.rs
+++ b/consensus_encoding/src/compact_size.rs
@@ -173,22 +173,13 @@ impl Decoder for CompactSizeDecoder {
 
         let dec_value = compact_size_decode_u64(&self.buf)?;
 
-        // This error is returned if dec_value is outside of the usize range, or
-        // if it is above the given limit.
-        let make_err = || {
-            CompactSizeDecoderError(E::ValueExceedsLimit(LengthPrefixExceedsMaxError {
-                value: dec_value,
+        match usize::try_from(dec_value) {
+            Ok(nsize) if nsize <= self.limit => Ok(nsize),
+            _ => Err(CompactSizeDecoderError(E::ValueExceedsLimit(LengthPrefixExceedsMaxError {
                 limit: self.limit,
-            }))
-        };
-
-        usize::try_from(dec_value).map_err(|_| make_err()).and_then(|nsize| {
-            if nsize > self.limit {
-                Err(make_err())
-            } else {
-                Ok(nsize)
-            }
-        })
+                value: dec_value,
+            }))),
+        }
     }
 
     fn read_limit(&self) -> usize { compact_size_read_limit(&self.buf) }

--- a/consensus_encoding/src/decode/decoders.rs
+++ b/consensus_encoding/src/decode/decoders.rs
@@ -123,19 +123,15 @@ impl Decoder for ByteVecDecoder {
         use ByteVecDecoderError as E;
         use ByteVecDecoderErrorInner as Inner;
 
-        if let Some(ref prefix_decoder) = self.prefix_decoder {
-            return Err(E(Inner::UnexpectedEof(UnexpectedEofError {
-                missing: prefix_decoder.read_limit(),
-            })));
-        }
-
-        if self.bytes_written == self.bytes_expected {
-            Ok(self.buffer)
+        let missing = if let Some(ref prefix_decoder) = self.prefix_decoder {
+            prefix_decoder.read_limit()
+        } else if self.bytes_written != self.bytes_expected {
+            self.bytes_expected - self.bytes_written
         } else {
-            Err(E(Inner::UnexpectedEof(UnexpectedEofError {
-                missing: self.bytes_expected - self.bytes_written,
-            })))
-        }
+            return Ok(self.buffer);
+        };
+
+        Err(E(Inner::UnexpectedEof(UnexpectedEofError { missing })))
     }
 
     fn read_limit(&self) -> usize {
@@ -284,19 +280,16 @@ impl<T: Decode> Decoder for VecDecoder<T> {
     fn end(self) -> Result<Self::Output, Self::Error> {
         use VecDecoderErrorInner as E;
 
-        if let Some(ref prefix_decoder) = self.prefix_decoder {
-            return Err(VecDecoderError(E::UnexpectedEof(UnexpectedEofError {
-                missing: prefix_decoder.read_limit(),
-            })));
-        }
-
-        if self.buffer.len() == self.length {
-            Ok(self.buffer)
+        let len = self.buffer.len();
+        let missing = if let Some(prefix_decoder) = self.prefix_decoder {
+            prefix_decoder.read_limit()
+        } else if len != self.length {
+            self.length - len
         } else {
-            Err(VecDecoderError(E::UnexpectedEof(UnexpectedEofError {
-                missing: self.length - self.buffer.len(),
-            })))
-        }
+            return Ok(self.buffer);
+        };
+
+        Err(VecDecoderError(E::UnexpectedEof(UnexpectedEofError { missing })))
     }
 
     fn read_limit(&self) -> usize {

--- a/consensus_encoding/src/decode/mod.rs
+++ b/consensus_encoding/src/decode/mod.rs
@@ -166,6 +166,7 @@ pub fn decode_from_hex_with_decoder<D: Decoder + Default>(
 }
 
 #[cfg(feature = "hex")]
+#[allow(clippy::unnecessary_map_on_constructor)]
 fn decode_from_hex_internal<D: Decoder>(
     hex: &str,
     mut decoder: D,
@@ -187,12 +188,15 @@ fn decode_from_hex_internal<D: Decoder>(
             while !to_flush.is_empty() {
                 if decoder
                     .push_bytes(&mut to_flush)
-                    .map_err(|e| FromHexError(FromHexErrorInner::Decode(DecodeError::Parse(e))))?
+                    .map_err(DecodeError::Parse)
+                    .map_err(FromHexErrorInner::Decode)
+                    .map_err(FromHexError)?
                     .is_ready()
                 {
-                    return Err(FromHexError(FromHexErrorInner::Decode(DecodeError::Unconsumed(
-                        UnconsumedError(),
-                    ))));
+                    return Err(UnconsumedError())
+                        .map_err(DecodeError::Unconsumed)
+                        .map_err(FromHexErrorInner::Decode)
+                        .map_err(FromHexError);
                 }
             }
             index = 0;
@@ -205,7 +209,9 @@ fn decode_from_hex_internal<D: Decoder>(
     while !to_flush.is_empty() {
         if decoder
             .push_bytes(&mut to_flush)
-            .map_err(|e| FromHexError(FromHexErrorInner::Decode(DecodeError::Parse(e))))?
+            .map_err(DecodeError::Parse)
+            .map_err(FromHexErrorInner::Decode)
+            .map_err(FromHexError)?
             .is_ready()
         {
             break;
@@ -213,9 +219,16 @@ fn decode_from_hex_internal<D: Decoder>(
     }
 
     if to_flush.is_empty() {
-        decoder.end().map_err(|e| FromHexError(FromHexErrorInner::Decode(DecodeError::Parse(e))))
+        decoder
+            .end()
+            .map_err(DecodeError::Parse)
+            .map_err(FromHexErrorInner::Decode)
+            .map_err(FromHexError)
     } else {
-        Err(FromHexError(FromHexErrorInner::Decode(DecodeError::Unconsumed(UnconsumedError()))))
+        Err(UnconsumedError())
+            .map_err(DecodeError::Unconsumed)
+            .map_err(FromHexErrorInner::Decode)
+            .map_err(FromHexError)
     }
 }
 

--- a/consensus_encoding/src/encode/mod.rs
+++ b/consensus_encoding/src/encode/mod.rs
@@ -474,26 +474,13 @@ pub fn check_encoder<T: Encoder + ?Sized>(encoder: &mut T, mut expected: &[u8]) 
 }
 
 impl<T: Encoder> Encoder for Option<T> {
-    fn current_chunk(&self) -> &[u8] {
-        match self {
-            Some(encoder) => encoder.current_chunk(),
-            None => &[],
-        }
-    }
+    fn current_chunk(&self) -> &[u8] { self.as_ref().map_or(&[], Encoder::current_chunk) }
 
     fn advance(&mut self) -> EncoderStatus {
-        match self {
-            Some(encoder) => encoder.advance(),
-            None => EncoderStatus::Finished,
-        }
+        self.as_mut().map_or(EncoderStatus::Finished, Encoder::advance)
     }
 }
 
 impl<T: ExactSizeEncoder> ExactSizeEncoder for Option<T> {
-    fn len(&self) -> usize {
-        match self {
-            Some(encoder) => encoder.len(),
-            None => 0,
-        }
-    }
+    fn len(&self) -> usize { self.as_ref().map_or(0, T::len) }
 }


### PR DESCRIPTION
- Patch 1: Deduplicates error path in decoder end method impls.
- Patch 2: Flattens error constructors crate wide.
- Patch 3: Uses combinators in place of match statements for Option<T> Encoder and ExactSizeIterator impls.

References #6539 