### PR TITLE
fuzz: Fix stale script

### DIFF
--- a/fuzz/generate-files.sh
+++ b/fuzz/generate-files.sh
@@ -103,10 +103,10 @@ $(for name in $(cargo fuzz list); do echo "          $name,"; done)
     steps:
       - name: Install test dependencies
         run: sudo apt-get update -y && sudo apt-get install -y binutils-dev libunwind8-dev libcurl4-openssl-dev libelf-dev libdw-dev cmake gcc libiberty-dev
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/cache@a7833574556fa59680c1b7cb190c1735db73ebf0 # v5.0.0
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: cache-fuzz
         with:
           path: |
@@ -136,7 +136,7 @@ $(for name in $(cargo fuzz list); do echo "          $name,"; done)
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0


### PR DESCRIPTION
The `generate-files.sh` script is stale. Update it using the contents of `fuzz/Cargo.toml` so that running script produces no changes.