### PR TITLE
`0.32.xxx`: Bump consensus_encoding to 1.1 and use prefixed encoders

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -209,18 +209,18 @@ checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.23"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51ef7cd2518ead700af67bf9d1a658d90b6037d77110fd9c0445429d0ba1c6c9"
+checksum = "2de98502f212cfcea8d0bb305bd0f49d7ebdd75b64ba0a68f937d888f4e0d6db"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.0"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab938ebe6f1c82426b5fb82eaf10c3e3028c53deaa3fbe38f5904b37cf4d767"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -305,18 +305,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.130"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.130"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
+checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -345,20 +345,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.60"
+version = "2.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+checksum = "89456b690ff72fddcecf231caedbe615c59480c93358a93dfae7fc29e3ebbf0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.0"
+name = "unicode-ident"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
 
 [[package]]
 name = "wasi"

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -69,21 +69,20 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-consensus-encoding"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2d6094e2a1ba3c93b5a596fe5a10d1a10c3c6e06785cde89f693a044c01aa40"
+checksum = "207311705279250ba465076a1bac4b1ac982855fff73fc5f67e22158ac58cdc9"
 dependencies = [
  "bitcoin-internals",
+ "hex-conservative 1.1.0",
+ "serde",
 ]
 
 [[package]]
 name = "bitcoin-internals"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a30a22d1f112dde8e16be7b45c63645dc165cef254f835b3e1e9553e485cfa64"
-dependencies = [
- "hex-conservative 0.3.0",
-]
+checksum = "d573f4cf32996a8dce612e4348cece65a241f1882ed594047c9ba348e8869fa5"
 
 [[package]]
 name = "bitcoin-io"
@@ -170,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "hex-conservative"
-version = "0.3.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afe881d0527571892c4034822e59bb10c6c991cce6abe8199b6f5cf10766f55"
+checksum = "a7289f6b628ce69fb1a371d0fdcf8ff38cd93ec00e3010eb055d1e044998c8d1"
 dependencies = [
  "arrayvec",
 ]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -68,21 +68,20 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-consensus-encoding"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2d6094e2a1ba3c93b5a596fe5a10d1a10c3c6e06785cde89f693a044c01aa40"
+checksum = "207311705279250ba465076a1bac4b1ac982855fff73fc5f67e22158ac58cdc9"
 dependencies = [
  "bitcoin-internals",
+ "hex-conservative 1.2.0",
+ "serde",
 ]
 
 [[package]]
 name = "bitcoin-internals"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a30a22d1f112dde8e16be7b45c63645dc165cef254f835b3e1e9553e485cfa64"
-dependencies = [
- "hex-conservative 0.3.2",
-]
+checksum = "d573f4cf32996a8dce612e4348cece65a241f1882ed594047c9ba348e8869fa5"
 
 [[package]]
 name = "bitcoin-io"
@@ -163,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "hex-conservative"
-version = "0.3.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830e599c2904b08f0834ee6337d8fe8f0ed4a63b5d9e7a7f49c0ffa06d08d360"
+checksum = "35431185f361ccf3ffc58254628af5f1f5d5f28531da2e02e5d6c82bbc282a10"
 dependencies = [
  "arrayvec",
 ]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -202,18 +202,18 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.63"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -288,18 +288,28 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.156"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "314b5b092c0ade17c00142951e50ced110ec27cea304b1037c6969246c2469a4"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.156"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7e29c4601e36bcec74a223228dce795f4cd3616341a4af93520ca1a837c087d"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -328,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.109"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -50,7 +50,7 @@ ordered = { version = "0.2.0", optional = true }
 bitcoinconsensus = { version = "0.105.0+25.1", default-features = false, optional = true }
 
 # Do NOT use this as a feature! Use the `serde` feature instead.
-actual-serde = { package = "serde", version = "1.0.130", default-features = false, features = [ "derive", "alloc" ], optional = true }
+actual-serde = { package = "serde", version = "1.0.195", default-features = false, features = [ "derive", "alloc" ], optional = true }
 
 # Do NOT use this as a feature! Use the `arbitrary` feature instead.
 actual-arbitrary = { package = "arbitrary", version = "1.0.1", optional = true }

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -44,7 +44,7 @@ secp256k1 = { version = "0.29.0", default-features = false, features = ["hashes"
 units = { package = "bitcoin-units", path = "../units", version = "0.1.101", default-features = false, features = ["alloc"] }
 
 base64 = { version = "0.21.3", optional = true }
-encoding = { package = "bitcoin-consensus-encoding", version = "1.0", default-features = false, optional = true }
+encoding = { package = "bitcoin-consensus-encoding", version = "1.1", default-features = false, optional = true }
 ordered = { version = "0.2.0", optional = true }
 # Only use this feature for no-std builds, otherwise use bitcoinconsensus-std.
 bitcoinconsensus = { version = "0.105.0+25.1", default-features = false, optional = true }

--- a/bitcoin/src/bip152.rs
+++ b/bitcoin/src/bip152.rs
@@ -18,7 +18,7 @@ use actual_arbitrary::{self as arbitrary, Arbitrary, Unstructured};
 use encoding::{
     ArrayDecoder, ArrayEncoder, CompactSizeDecoder, CompactSizeDecoderError, CompactSizeEncoder,
     CompactSizeU64Decoder, Decoder, Decoder2, Decoder4, DecoderStatus, Encoder2, Encoder4,
-    EncoderStatus, SliceEncoder, VecDecoder,
+    EncoderStatus, PrefixedSliceEncoder, VecDecoder,
 };
 use hashes::{sha256, siphash24, Hash};
 use io::{Read, Write};
@@ -332,8 +332,8 @@ impl_consensus_encoding!(HeaderAndShortIds, header, nonce, short_ids, prefilled_
 type HeaderAndShortIdsInnerEncoder<'e> = Encoder4<
     HeaderEncoder<'e>,
     ArrayEncoder<8>,
-    Encoder2<CompactSizeEncoder, SliceEncoder<'e, ShortId>>,
-    Encoder2<CompactSizeEncoder, SliceEncoder<'e, PrefilledTransaction>>,
+    PrefixedSliceEncoder<'e, ShortId>,
+    PrefixedSliceEncoder<'e, PrefilledTransaction>,
 >;
 
 #[cfg(feature = "encoding")]
@@ -353,14 +353,8 @@ impl encoding::Encode for HeaderAndShortIds {
         HeaderAndShortIdsEncoder::new(Encoder4::new(
             self.header.encoder(),
             ArrayEncoder::without_length_prefix(self.nonce.to_le_bytes()),
-            Encoder2::new(
-                CompactSizeEncoder::new(self.short_ids.len()),
-                SliceEncoder::without_length_prefix(&self.short_ids),
-            ),
-            Encoder2::new(
-                CompactSizeEncoder::new(self.prefilled_txs.len()),
-                SliceEncoder::without_length_prefix(&self.prefilled_txs),
-            ),
+            PrefixedSliceEncoder::new(&self.short_ids),
+            PrefixedSliceEncoder::new(&self.prefilled_txs),
         ))
     }
 }
@@ -965,7 +959,7 @@ encoding::encoder_newtype! {
     pub struct BlockTransactionsEncoder<'e>(
         Encoder2<
             crate::blockdata::block::BlockHashEncoder<'e>,
-            Encoder2<CompactSizeEncoder, SliceEncoder<'e, Transaction>>
+            PrefixedSliceEncoder<'e, Transaction>
         >
     );
 }
@@ -977,10 +971,7 @@ impl encoding::Encode for BlockTransactions {
     fn encoder(&self) -> Self::Encoder<'_> {
         BlockTransactionsEncoder::new(Encoder2::new(
             self.block_hash.encoder(),
-            Encoder2::new(
-                CompactSizeEncoder::new(self.transactions.len()),
-                SliceEncoder::without_length_prefix(&self.transactions),
-            ),
+            PrefixedSliceEncoder::new(&self.transactions),
         ))
     }
 }

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -14,9 +14,7 @@ use core::fmt;
 #[cfg(feature = "arbitrary")]
 use actual_arbitrary::{self as arbitrary, Arbitrary, Unstructured};
 #[cfg(feature = "encoding")]
-use encoding::{
-    ArrayDecoder, CompactSizeEncoder, Decoder2, Decoder6, Encoder2, SliceEncoder, VecDecoder,
-};
+use encoding::{ArrayDecoder, Decoder2, Decoder6, Encoder2, PrefixedSliceEncoder, VecDecoder};
 use hashes::{sha256d, Hash, HashEngine};
 use io::{Read, Write};
 
@@ -790,17 +788,13 @@ impl Block {
 
 #[cfg(feature = "encoding")]
 impl encoding::Encode for Block {
-    type Encoder<'e> =
-        Encoder2<HeaderEncoder<'e>, Encoder2<CompactSizeEncoder, SliceEncoder<'e, Transaction>>>;
+    type Encoder<'e> = BlockEncoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
-        Encoder2::new(
+        BlockEncoder::new(Encoder2::new(
             self.header.encoder(),
-            Encoder2::new(
-                CompactSizeEncoder::new(self.txdata.len()),
-                SliceEncoder::without_length_prefix(&self.txdata),
-            ),
-        )
+            PrefixedSliceEncoder::new(&self.txdata),
+        ))
     }
 }
 
@@ -814,7 +808,7 @@ encoding::encoder_newtype! {
     /// The encoder for the [`Block`] type.
     #[derive(Debug, Clone)]
     pub struct BlockEncoder<'e>(
-        Encoder2<HeaderEncoder<'e>, Encoder2<CompactSizeEncoder, SliceEncoder<'e, Transaction>>>
+        Encoder2<HeaderEncoder<'e>, PrefixedSliceEncoder<'e, Transaction>>
     );
 }
 

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -19,8 +19,8 @@ use core::{cmp, fmt};
 
 #[cfg(feature = "encoding")]
 use encoding::{
-    ArrayEncoder, BytesEncoder, CompactSizeEncoder, Decoder2, Decoder3, DecoderStatus, Encode as _,
-    Encoder2, Encoder3, Encoder6, EncoderStatus, SliceEncoder, VecDecoder,
+    ArrayEncoder, BytesEncoder, Decoder2, Decoder3, DecoderStatus, Encode as _, Encoder2, Encoder3,
+    Encoder6, EncoderStatus, PrefixedSliceEncoder, VecDecoder,
 };
 use hashes::{sha256d, Hash};
 use io::{Read, Write};
@@ -1709,14 +1709,8 @@ impl encoding::Encode for Transaction {
 
     fn encoder(&self) -> Self::Encoder<'_> {
         let version = self.version.encoder();
-        let inputs = Encoder2::new(
-            CompactSizeEncoder::new(self.input.len()),
-            SliceEncoder::without_length_prefix(self.input.as_ref()),
-        );
-        let outputs = Encoder2::new(
-            CompactSizeEncoder::new(self.output.len()),
-            SliceEncoder::without_length_prefix(self.output.as_ref()),
-        );
+        let inputs = PrefixedSliceEncoder::new(self.input.as_ref());
+        let outputs = PrefixedSliceEncoder::new(self.output.as_ref());
         let lock_time = self.lock_time.encoder();
 
         if self.uses_segwit_serialization() {
@@ -1745,8 +1739,8 @@ impl encoding::Decode for Transaction {
 type TransactionEncoderInner<'e> = Encoder6<
     VersionEncoder<'e>,
     Option<ArrayEncoder<2>>,
-    Encoder2<CompactSizeEncoder, SliceEncoder<'e, TxIn>>,
-    Encoder2<CompactSizeEncoder, SliceEncoder<'e, TxOut>>,
+    PrefixedSliceEncoder<'e, TxIn>,
+    PrefixedSliceEncoder<'e, TxOut>,
     Option<WitnessesEncoder<'e>>,
     LockTimeEncoder<'e>,
 >;

--- a/bitcoin/src/p2p/message_blockdata.rs
+++ b/bitcoin/src/p2p/message_blockdata.rs
@@ -9,6 +9,11 @@
 #[cfg(feature = "encoding")]
 use core::convert::Infallible;
 
+#[cfg(feature = "encoding")]
+use encoding::{
+    ArrayDecoder, ArrayEncoder, Decoder2, Decoder3, Encoder2, Encoder3, PrefixedSliceEncoder,
+    VecDecoder,
+};
 use hashes::{sha256d, Hash as _};
 use io::{Read, Write};
 
@@ -17,11 +22,6 @@ use crate::blockdata::block::BlockHash;
 use crate::blockdata::block::{BlockHashDecoder, BlockHashEncoder};
 use crate::blockdata::transaction::{Txid, Wtxid};
 use crate::consensus::encode::{self, Decodable, Encodable};
-#[cfg(feature = "encoding")]
-use encoding::{
-    ArrayDecoder, ArrayEncoder, CompactSizeEncoder, Decoder2, Decoder3, Encoder2, Encoder3,
-    SliceEncoder, VecDecoder,
-};
 use crate::internal_macros::impl_consensus_encoding;
 #[cfg(feature = "encoding")]
 use crate::internal_macros::write_err;
@@ -260,7 +260,7 @@ impl_consensus_encoding!(GetHeadersMessage, version, locator_hashes, stop_hash);
 
 #[cfg(feature = "encoding")]
 type GetBlocksOrHeadersInnerEncoder<'e> =
-    Encoder3<ArrayEncoder<4>, Encoder2<CompactSizeEncoder, SliceEncoder<'e, BlockHash>>, BlockHashEncoder<'e>>;
+    Encoder3<ArrayEncoder<4>, PrefixedSliceEncoder<'e, BlockHash>, BlockHashEncoder<'e>>;
 
 #[cfg(feature = "encoding")]
 encoding::encoder_newtype! {
@@ -283,10 +283,7 @@ impl encoding::Encode for GetHeadersMessage {
     fn encoder(&self) -> Self::Encoder<'_> {
         GetHeadersEncoder::new(Encoder3::new(
             ArrayEncoder::without_length_prefix(self.version.to_le_bytes()),
-            Encoder2::new(
-                CompactSizeEncoder::new(self.locator_hashes.len()),
-                SliceEncoder::without_length_prefix(&self.locator_hashes),
-            ),
+            PrefixedSliceEncoder::new(&self.locator_hashes),
             self.stop_hash.encoder(),
         ))
     }
@@ -299,10 +296,7 @@ impl encoding::Encode for GetBlocksMessage {
     fn encoder(&self) -> Self::Encoder<'_> {
         GetBlocksEncoder::new(Encoder3::new(
             ArrayEncoder::without_length_prefix(self.version.to_le_bytes()),
-            Encoder2::new(
-                CompactSizeEncoder::new(self.locator_hashes.len()),
-                SliceEncoder::without_length_prefix(&self.locator_hashes),
-            ),
+            PrefixedSliceEncoder::new(&self.locator_hashes),
             self.stop_hash.encoder(),
         ))
     }

--- a/bitcoin/src/p2p/message_bloom.rs
+++ b/bitcoin/src/p2p/message_bloom.rs
@@ -9,12 +9,11 @@
 use core::convert::Infallible;
 #[cfg(feature = "encoding")]
 use core::fmt;
+
 #[cfg(feature = "encoding")]
 use encoding::{
-    ArrayDecoder, ArrayEncoder, ByteVecDecoder, BytesEncoder, CompactSizeEncoder, Decoder4,
-    Encoder2, Encoder3,
+    ArrayDecoder, ArrayEncoder, ByteVecDecoder, Decoder4, Encoder2, Encoder3, PrefixedBytesEncoder,
 };
-
 use io::{Read, Write};
 
 use crate::consensus::{encode, Decodable, Encodable, ReadExt};
@@ -43,7 +42,7 @@ encoding::encoder_newtype! {
     #[derive(Debug, Clone)]
     pub struct FilterLoadEncoder<'e>(
         Encoder2<
-            Encoder2<CompactSizeEncoder, BytesEncoder<'e>>,
+            PrefixedBytesEncoder<'e>,
             Encoder3<
                 ArrayEncoder<4>,
                 ArrayEncoder<4>,
@@ -59,10 +58,7 @@ impl encoding::Encode for FilterLoad {
 
     fn encoder(&self) -> Self::Encoder<'_> {
         FilterLoadEncoder::new(Encoder2::new(
-            Encoder2::new(
-                CompactSizeEncoder::new(self.filter.len()),
-                BytesEncoder::without_length_prefix(&self.filter),
-            ),
+            PrefixedBytesEncoder::new(&self.filter),
             Encoder3::new(
                 ArrayEncoder::without_length_prefix(self.hash_funcs.to_le_bytes()),
                 ArrayEncoder::without_length_prefix(self.tweak.to_le_bytes()),
@@ -261,7 +257,7 @@ impl_consensus_encoding!(FilterAdd, data);
 encoding::encoder_newtype_exact! {
     /// The encoder of the [`FilterAdd`] message.
     #[derive(Debug, Clone)]
-    pub struct FilterAddEncoder<'e>(Encoder2<CompactSizeEncoder, BytesEncoder<'e>>);
+    pub struct FilterAddEncoder<'e>(PrefixedBytesEncoder<'e>);
 }
 
 #[cfg(feature = "encoding")]
@@ -269,10 +265,7 @@ impl encoding::Encode for FilterAdd {
     type Encoder<'e> = FilterAddEncoder<'e>;
 
     fn encoder(&self) -> Self::Encoder<'_> {
-        FilterAddEncoder::new(Encoder2::new(
-            CompactSizeEncoder::new(self.data.len()),
-            BytesEncoder::without_length_prefix(&self.data),
-        ))
+        FilterAddEncoder::new(PrefixedBytesEncoder::new(&self.data))
     }
 }
 

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -36,7 +36,7 @@ hex = { package = "hex-conservative", version = "0.2.2", default-features = fals
 bitcoin-io = { path = "../io", version = "0.1.101", default-features = false, optional = true }
 # Do NOT use this as a feature! Use the `schemars` feature instead.
 actual-schemars = { package = "schemars", version = "0.8.3", default-features = false, optional = true }
-serde = { version = "1.0.130", default-features = false, optional = true }
+serde = { version = "1.0.195", default-features = false, optional = true }
 
 [dev-dependencies]
 serde_test = "1.0.19"

--- a/io/Cargo.toml
+++ b/io/Cargo.toml
@@ -22,7 +22,7 @@ std = ["alloc", "encoding?/std"]
 alloc = ["encoding?/alloc"]
 
 [dependencies]
-encoding = { package = "bitcoin-consensus-encoding", version = "1.0", default-features = false, optional = true }
+encoding = { package = "bitcoin-consensus-encoding", version = "1.1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -27,7 +27,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 arbitrary = { version = "1.0.1", optional = true }
 encoding = { package = "bitcoin-consensus-encoding", version = "1.0", default-features = false, optional = true }
-serde = { version = "1.0.130", default-features = false, features = ["derive"], optional = true }
+serde = { version = "1.0.195", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 serde_test = "1.0.19"

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -26,7 +26,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 arbitrary = { version = "1.0.1", optional = true }
-encoding = { package = "bitcoin-consensus-encoding", version = "1.0", default-features = false, optional = true }
+encoding = { package = "bitcoin-consensus-encoding", version = "1.1", default-features = false, optional = true }
 serde = { version = "1.0.195", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
With the release of consensus_encoding 1.1.0, the prefixed encoders changes on master can now be backported. As some of the types are not present on 0.32.xxx, this is a subset of the master changes, paired with a bump to the consensus_encoding dep version.

- Patch 1 updates the serde dependency versions.
- Patch 2 bumps the consensus_encoding dep versions to 1.1.0.
- Patch 3 replaces uses of Encoder2<CompactSizeEncoder, Bytes/SliceEncoder> with the corresponding prefixed encoder type.