### PR TITLE
[0.32.xxx] ci: exclude msrv+recent test to sidestep MSRV breaking dependencies

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,9 @@ jobs:
       matrix:
         toolchain: [stable, msrv]
         dep: [minimal, recent]
+        exclude:
+          - toolchain: msrv
+            dep: recent
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:


### PR DESCRIPTION
We are running into an issue in #6550 where we are bumping `bitcoin-consensus-encoding` to 1.1.0. It pulls in a higher version of `serde` which bumps up the version of `proc-macro2`. The test on msrv with recent dependencies fails.

```bash
error: package `proc-macro2 v1.0.106` cannot be built because it requires rustc 1.68 or newer, while the currently active rustc version is 1.60.0
```

Maintaining a low MSRV (currently 1.60.0) with multiple lockfiles can be difficult without the v3 cargo resolver which is MSRV-aware. The v2 resolver pulls in dependencies which have a higher MSRV. Instead of hand holding the Cargo-recent.lock file, we exclude testing the msrv with recent dependencies. We still test the msrv with minimal dependencies, while not as thorough, it shows that it is at least possible to run the code with the MSRV.

If we are cool with this, I'll forward port to `master`.