### PR TITLE
Use `DebugTuple` for `Builder` debug

### DIFF
--- a/primitives/src/script/builder.rs
+++ b/primitives/src/script/builder.rs
@@ -79,7 +79,9 @@ impl<T> fmt::Display for Builder<T> {
 }
 
 impl<T> fmt::Debug for Builder<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(self, f) }
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_tuple("Builder").field(&self.0).finish()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The Builder Debug impl currently calls through to Display which eventually calls down to Script's Display. For empty scripts, this can render as an empty string. Per the C-DEBUG-NONEMPTY API guideline, all Debug impls should always render something, even for conceptually empty types.

Use DebugTuple in the Builder Debug to render the struct name around the internal content.