### PR TITLE
Make `Witness` `FromIterator` infallible

### DIFF
--- a/primitives/src/witness.rs
+++ b/primitives/src/witness.rs
@@ -1315,6 +1315,17 @@ mod test {
     }
 
     #[test]
+    fn from_iter_does_not_silently_lose_elements() {
+        let n: usize = 4_000_001;
+        let witness: Witness = core::iter::repeat(&[0u8; 0]).take(n).collect();
+        let len = witness.len();
+        assert_eq!(
+            len, n,
+            "from_iter silently produced a witness with {len} elements (expected {n})"
+        );
+    }
+
+    #[test]
     #[cfg(feature = "hex")]
     fn test_from_hex() {
         let hex_strings = [

--- a/primitives/src/witness.rs
+++ b/primitives/src/witness.rs
@@ -12,8 +12,7 @@ use arbitrary::{Arbitrary, Unstructured};
 #[cfg(doc)]
 use encoding::Decoder4;
 use encoding::{
-    self, BytesEncoder, CompactSizeDecoder, CompactSizeEncoder, Decoder as _, DecoderStatus,
-    Encoder2,
+    self, BytesEncoder, CompactSizeDecoder, CompactSizeEncoder, DecoderStatus, Encoder2,
 };
 #[cfg(feature = "hex")]
 use hex::DecodeVariableLengthBytesError;
@@ -659,30 +658,8 @@ impl<'a> IntoIterator for &'a Witness {
 
 impl<T: AsRef<[u8]>> FromIterator<T> for Witness {
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
-        let mut decoder = WitnessDecoder::new();
-
-        // We can't count the number of witness elements without consuming the iterator.
-        // So instead, we build up the full push_bytes buffer and then push it all at once.
-        // We'll start with a 256 byte buffer to double the initial WitnessDecoder size.
-        let mut buffer = Vec::with_capacity(256);
-        let mut witness_elements = 0;
-
-        // For each witness element, the decoder expects an element length, followed by
-        // the data itself. The iterator's yielded elements do not include the length prefix,
-        // so we add them.
-        for elem in iter {
-            let encoded = crate::compact_size_encode(elem.as_ref().len());
-            buffer.extend_from_slice(encoded.as_slice());
-            buffer.extend_from_slice(elem.as_ref());
-            witness_elements += 1;
-        }
-
-        let witness_count = crate::compact_size_encode(witness_elements);
-        let _ = decoder.push_bytes(&mut witness_count.as_slice());
-
-        let _ = decoder.push_bytes(&mut buffer.as_slice());
-
-        decoder.end().expect("witness_elements in decoder is equal to number of provided elements")
+        let v: Vec<T> = iter.into_iter().collect();
+        Self::from_slice(&v)
     }
 }
 
@@ -1013,7 +990,7 @@ mod test {
 
     use encoding::check_encode;
     #[cfg(feature = "alloc")]
-    use encoding::Decode as _;
+    use encoding::{Decode as _, Decoder as _};
 
     use super::*;
 


### PR DESCRIPTION
The current Witness FromIterator impl uses the WitnessDecoder internally. This was initially done as a means of reducing the allocations needed to construct the type. However, for DoS protection, the WitnessDecoder has various limitations that make it unsuitable for infallible Witness construction. Instead, the old infallible solution should be used, but tweaked to remove the previous per-item allocations from the iterator collection.

Adjust the Witness FromIterator implementation to use a collect and from_slice call to remove the incorrect function beyond the DoS protection limits of the WitnessDecoder.

Closes #6369