### PR TITLE
Release tracking PR: `hashes 1.1.0`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -28,7 +28,7 @@ name = "base58ck"
 version = "0.4.0"
 dependencies = [
  "bitcoin-internals 0.6.0",
- "bitcoin_hashes 1.0.0",
+ "bitcoin_hashes 1.1.0",
  "hex-conservative 1.1.0",
 ]
 
@@ -91,7 +91,7 @@ dependencies = [
  "bitcoin-primitives",
  "bitcoin-taproot-primitives",
  "bitcoin-units 0.5.0",
- "bitcoin_hashes 1.0.0",
+ "bitcoin_hashes 1.1.0",
  "bitcoinconsensus",
  "hex-conservative 1.1.0",
  "secp256k1 0.32.0-beta.2",
@@ -142,7 +142,7 @@ dependencies = [
  "bitcoin-internals 0.6.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
- "bitcoin_hashes 1.0.0",
+ "bitcoin_hashes 1.1.0",
  "hex-conservative 1.1.0",
  "secp256k1 0.32.0-beta.2",
  "serde",
@@ -198,7 +198,7 @@ version = "0.5.0"
 dependencies = [
  "bitcoin-consensus-encoding 1.1.0",
  "bitcoin-internals 0.6.0",
- "bitcoin_hashes 1.0.0",
+ "bitcoin_hashes 1.1.0",
 ]
 
 [[package]]
@@ -211,7 +211,7 @@ dependencies = [
  "bitcoin-crypto",
  "bitcoin-internals 0.6.0",
  "bitcoin-network-kind",
- "bitcoin_hashes 1.0.0",
+ "bitcoin_hashes 1.1.0",
  "hex-conservative 1.1.0",
  "secp256k1 0.32.0-beta.2",
  "serde",
@@ -239,7 +239,7 @@ dependencies = [
  "bitcoin-network-kind",
  "bitcoin-primitives",
  "bitcoin-units 0.5.0",
- "bitcoin_hashes 1.0.0",
+ "bitcoin_hashes 1.1.0",
  "hex-conservative 1.1.0",
  "serde",
 ]
@@ -253,7 +253,7 @@ dependencies = [
  "bitcoin-consensus-encoding 1.1.0",
  "bitcoin-internals 0.6.0",
  "bitcoin-units 0.5.0",
- "bitcoin_hashes 1.0.0",
+ "bitcoin_hashes 1.1.0",
  "hex-conservative 1.1.0",
  "serde",
  "serde_json",
@@ -272,7 +272,7 @@ dependencies = [
  "arbitrary",
  "bitcoin-crypto",
  "bitcoin-internals 0.6.0",
- "bitcoin_hashes 1.0.0",
+ "bitcoin_hashes 1.1.0",
  "secp256k1 0.32.0-beta.2",
  "serde",
 ]
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "arbitrary",
  "bitcoin-consensus-encoding 1.1.0",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -28,7 +28,7 @@ name = "base58ck"
 version = "0.4.0"
 dependencies = [
  "bitcoin-internals 0.6.0",
- "bitcoin_hashes 1.0.0",
+ "bitcoin_hashes 1.1.0",
  "hex-conservative 1.1.0",
 ]
 
@@ -90,7 +90,7 @@ dependencies = [
  "bitcoin-primitives",
  "bitcoin-taproot-primitives",
  "bitcoin-units 0.5.0",
- "bitcoin_hashes 1.0.0",
+ "bitcoin_hashes 1.1.0",
  "bitcoinconsensus",
  "hex-conservative 1.1.0",
  "secp256k1 0.32.0-beta.2",
@@ -141,7 +141,7 @@ dependencies = [
  "bitcoin-internals 0.6.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
- "bitcoin_hashes 1.0.0",
+ "bitcoin_hashes 1.1.0",
  "hex-conservative 1.1.0",
  "secp256k1 0.32.0-beta.2",
  "serde",
@@ -197,7 +197,7 @@ version = "0.5.0"
 dependencies = [
  "bitcoin-consensus-encoding 1.1.0",
  "bitcoin-internals 0.6.0",
- "bitcoin_hashes 1.0.0",
+ "bitcoin_hashes 1.1.0",
 ]
 
 [[package]]
@@ -210,7 +210,7 @@ dependencies = [
  "bitcoin-crypto",
  "bitcoin-internals 0.6.0",
  "bitcoin-network-kind",
- "bitcoin_hashes 1.0.0",
+ "bitcoin_hashes 1.1.0",
  "hex-conservative 1.1.0",
  "secp256k1 0.32.0-beta.2",
  "serde",
@@ -238,7 +238,7 @@ dependencies = [
  "bitcoin-network-kind",
  "bitcoin-primitives",
  "bitcoin-units 0.5.0",
- "bitcoin_hashes 1.0.0",
+ "bitcoin_hashes 1.1.0",
  "hex-conservative 1.1.0",
  "serde",
 ]
@@ -252,7 +252,7 @@ dependencies = [
  "bitcoin-consensus-encoding 1.1.0",
  "bitcoin-internals 0.6.0",
  "bitcoin-units 0.5.0",
- "bitcoin_hashes 1.0.0",
+ "bitcoin_hashes 1.1.0",
  "hex-conservative 1.1.0",
  "serde",
  "serde_json",
@@ -265,7 +265,7 @@ dependencies = [
  "arbitrary",
  "bitcoin-crypto",
  "bitcoin-internals 0.6.0",
- "bitcoin_hashes 1.0.0",
+ "bitcoin_hashes 1.1.0",
  "secp256k1 0.32.0-beta.2",
  "serde",
 ]
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "arbitrary",
  "bitcoin-consensus-encoding 1.1.0",

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -30,7 +30,7 @@ addresses = { package = "bitcoin-addresses", path = "../addresses", version = "0
 base58 = { package = "base58ck", path = "../base58", version = "0.4.0", default-features = false, features = ["alloc"] }
 bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
 crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.2.0", default-features = false, features = ["alloc", "hex"] }
-hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.0.0", default-features = false, features = ["alloc", "hex"] }
+hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.1.0", default-features = false, features = ["alloc", "hex"] }
 key-expression = { package = "bitcoin-key-expression", path = "../key_expression", version = "0.1.0", default-features = false, features = ["alloc"] }
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0", default-features = false, features = ["alloc", "hex"] }
 hex = { package = "hex-conservative", version = "1.1.0", default-features = false, features = ["alloc"] }

--- a/hashes/CHANGELOG.md
+++ b/hashes/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-07-15
+
+* Add `with_input` method to `HashEngine` for convenient one-shot hashing [#6411](https://github.com/rust-bitcoin/rust-bitcoin/pull/6411)
+* Add `drain_to_hash` and `encode_to_hash` helper functions [#6456](https://github.com/rust-bitcoin/rust-bitcoin/pull/6456)
+* Deprecate `sha256t_tag` macro in favor of direct `sha256t::Tag` implementation [#6465](https://github.com/rust-bitcoin/rust-bitcoin/pull/6465)
+* Fix unusable `HKDF` alias [#6466](https://github.com/rust-bitcoin/rust-bitcoin/pull/6466)
+
 # 1.0.0 - 2026-06-01
 
 * No changes since `v0.21.0`.
@@ -366,7 +373,8 @@ Note that we have stopped re-exporting the `core` crate when compiling without `
 
 * Initial release
 
-[Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin_hashes-1.0.0...HEAD
+[Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin_hashes-1.1.0...HEAD
+[1.1.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin_hashes-1.0.0...bitcoin_hashes-1.1.0
 [1.0.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin_hashes-0.21.0...bitcoin_hashes-1.0.0
 [0.21.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin_hashes-0.20.0...bitcoin_hashes-0.21.0
 [0.20.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin_hashes-0.19.0...bitcoin_hashes-0.20.0

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin_hashes"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin"

--- a/hashes/src/macros.rs
+++ b/hashes/src/macros.rs
@@ -37,7 +37,7 @@
 ///
 /// This macro dates to a time before SHA256 could be computed in a `const` context.
 #[macro_export]
-#[deprecated(since = "TBD", note = "use `sha256t::Tag` instead")]
+#[deprecated(since = "1.1.0", note = "use `sha256t::Tag` instead")]
 macro_rules! sha256t_tag {
     ($(#[$($tag_attr:tt)*])* $tag_vis:vis struct $tag:ident = $constructor:tt($($tag_value:tt)+);) => {
         $crate::sha256t_tag_struct!($tag_vis, $tag, stringify!($tag), $(#[$($tag_attr)*])*);
@@ -576,7 +576,7 @@ macro_rules! impl_serde_traits(
 
 #[cfg(test)]
 mod test {
-    #![allow(deprecated_in_future)]
+    #![allow(deprecated)]
 
     use crate::sha256;
 

--- a/hashes/src/sha256t/mod.rs
+++ b/hashes/src/sha256t/mod.rs
@@ -192,7 +192,7 @@ macro_rules! sha256t_tag_constructor {
 
 #[cfg(test)]
 mod tests {
-    #![allow(deprecated_in_future)]
+    #![allow(deprecated)]
 
     #[cfg(feature = "alloc")]
     #[cfg(feature = "hex")]

--- a/hashes/tests/api.rs
+++ b/hashes/tests/api.rs
@@ -8,7 +8,7 @@
 
 #![allow(dead_code)]
 #![allow(unused_imports)]
-#![allow(deprecated_in_future)]
+#![allow(deprecated)]
 // Exclude lints we don't think are valuable.
 #![allow(clippy::uninlined_format_args)] // Allow `format!("{}", x)` instead of enforcing `format!("{x}")`
 

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -23,7 +23,7 @@ hex = ["dep:hex", "hashes/hex", "encoding/hex"]
 
 [dependencies]
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0", default-features = false }
-hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.0.0", default-features = false }
+hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.1.0", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
 units = { package = "bitcoin-units", path = "../units", version = "0.5.0", default-features = false, features = [ "encoding" ] }
 


### PR DESCRIPTION
Changelog brought to you by a friendly clanker. But there is something non-conventional here that I am not sure is good thing. I only bumped the internal hashes dependency constraints on packages which use the 1.1.0 features, so `bitcoin` and `primitives`. I am kind of surprised the cargo workspace is cool with this, but appears to be so? With that said, are *we* cool with this? Or should I just be consistent and bump everything to 1.1.0 even though some packages could work independently without it. FWIW the `prerelease` task builds and tests a package in isolation on its minimal dependencies, so if we somehow do forget to bump a constraint, that is where we are likely to see a failure.

Closes #6551