### PR TITLE
Manual weekly update to rustc (to nightly-2026-07-10) on master

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["benches"]
 resolver = "2"
 
 [workspace.metadata.rbmt.toolchains]
-nightly = "nightly-2026-07-02"
+nightly = "nightly-2026-07-10"
 stable = "1.96.0"
 
 [workspace.lints.rust]


### PR DESCRIPTION
EDIT: already solved on master

~~Supersedes https://github.com/rust-bitcoin/rust-bitcoin/pull/6520~~

~~Fix a lint late initialization error and regenerate api snapshots for an `std` into `core` api change for `io::error`.~~