### PR TITLE
Add `Extend` impl to `Witness`

### DIFF
--- a/primitives/api/all-features.txt
+++ b/primitives/api/all-features.txt
@@ -6140,6 +6140,8 @@ impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<bitcoin_primitives::wit
   pub fn alloc::sync::Arc<[T]>::eq(&self, rhs: &bitcoin_primitives::witness::Witness) -> bool [impl: impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<bitcoin_primitives::witness::Witness> for alloc::sync::Arc<[T]>]
 impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<bitcoin_primitives::witness::Witness> for alloc::vec::Vec<T>
   pub fn alloc::vec::Vec<T>::eq(&self, rhs: &bitcoin_primitives::witness::Witness) -> bool [impl: impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<bitcoin_primitives::witness::Witness> for alloc::vec::Vec<T>]
+impl<T: core::convert::AsRef<[u8]>> core::iter::traits::collect::Extend<T> for bitcoin_primitives::witness::Witness
+  pub fn bitcoin_primitives::witness::Witness::extend<I: core::iter::traits::collect::IntoIterator<Item = T>>(&mut self, iter: I) [impl: impl<T: core::convert::AsRef<[u8]>> core::iter::traits::collect::Extend<T> for bitcoin_primitives::witness::Witness]
 impl<T: core::convert::AsRef<[u8]>> core::iter::traits::collect::FromIterator<T> for bitcoin_primitives::witness::Witness
   pub fn bitcoin_primitives::witness::Witness::from_iter<I: core::iter::traits::collect::IntoIterator<Item = T>>(iter: I) -> Self [impl: impl<T: core::convert::AsRef<[u8]>> core::iter::traits::collect::FromIterator<T> for bitcoin_primitives::witness::Witness]
 impl<const N: usize, T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<&[T; N]> for bitcoin_primitives::witness::Witness
@@ -7508,6 +7510,8 @@ impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<bitcoin_primitives::wit
   pub fn alloc::sync::Arc<[T]>::eq(&self, rhs: &bitcoin_primitives::witness::Witness) -> bool [impl: impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<bitcoin_primitives::witness::Witness> for alloc::sync::Arc<[T]>]
 impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<bitcoin_primitives::witness::Witness> for alloc::vec::Vec<T>
   pub fn alloc::vec::Vec<T>::eq(&self, rhs: &bitcoin_primitives::witness::Witness) -> bool [impl: impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<bitcoin_primitives::witness::Witness> for alloc::vec::Vec<T>]
+impl<T: core::convert::AsRef<[u8]>> core::iter::traits::collect::Extend<T> for bitcoin_primitives::witness::Witness
+  pub fn bitcoin_primitives::witness::Witness::extend<I: core::iter::traits::collect::IntoIterator<Item = T>>(&mut self, iter: I) [impl: impl<T: core::convert::AsRef<[u8]>> core::iter::traits::collect::Extend<T> for bitcoin_primitives::witness::Witness]
 impl<T: core::convert::AsRef<[u8]>> core::iter::traits::collect::FromIterator<T> for bitcoin_primitives::witness::Witness
   pub fn bitcoin_primitives::witness::Witness::from_iter<I: core::iter::traits::collect::IntoIterator<Item = T>>(iter: I) -> Self [impl: impl<T: core::convert::AsRef<[u8]>> core::iter::traits::collect::FromIterator<T> for bitcoin_primitives::witness::Witness]
 impl<const N: usize, T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<&[T; N]> for bitcoin_primitives::witness::Witness

--- a/primitives/api/alloc-only.txt
+++ b/primitives/api/alloc-only.txt
@@ -5698,6 +5698,8 @@ impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<bitcoin_primitives::wit
   pub fn alloc::sync::Arc<[T]>::eq(&self, rhs: &bitcoin_primitives::witness::Witness) -> bool [impl: impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<bitcoin_primitives::witness::Witness> for alloc::sync::Arc<[T]>]
 impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<bitcoin_primitives::witness::Witness> for alloc::vec::Vec<T>
   pub fn alloc::vec::Vec<T>::eq(&self, rhs: &bitcoin_primitives::witness::Witness) -> bool [impl: impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<bitcoin_primitives::witness::Witness> for alloc::vec::Vec<T>]
+impl<T: core::convert::AsRef<[u8]>> core::iter::traits::collect::Extend<T> for bitcoin_primitives::witness::Witness
+  pub fn bitcoin_primitives::witness::Witness::extend<I: core::iter::traits::collect::IntoIterator<Item = T>>(&mut self, iter: I) [impl: impl<T: core::convert::AsRef<[u8]>> core::iter::traits::collect::Extend<T> for bitcoin_primitives::witness::Witness]
 impl<T: core::convert::AsRef<[u8]>> core::iter::traits::collect::FromIterator<T> for bitcoin_primitives::witness::Witness
   pub fn bitcoin_primitives::witness::Witness::from_iter<I: core::iter::traits::collect::IntoIterator<Item = T>>(iter: I) -> Self [impl: impl<T: core::convert::AsRef<[u8]>> core::iter::traits::collect::FromIterator<T> for bitcoin_primitives::witness::Witness]
 impl<const N: usize, T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<&[T; N]> for bitcoin_primitives::witness::Witness
@@ -6937,6 +6939,8 @@ impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<bitcoin_primitives::wit
   pub fn alloc::sync::Arc<[T]>::eq(&self, rhs: &bitcoin_primitives::witness::Witness) -> bool [impl: impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<bitcoin_primitives::witness::Witness> for alloc::sync::Arc<[T]>]
 impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<bitcoin_primitives::witness::Witness> for alloc::vec::Vec<T>
   pub fn alloc::vec::Vec<T>::eq(&self, rhs: &bitcoin_primitives::witness::Witness) -> bool [impl: impl<T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<bitcoin_primitives::witness::Witness> for alloc::vec::Vec<T>]
+impl<T: core::convert::AsRef<[u8]>> core::iter::traits::collect::Extend<T> for bitcoin_primitives::witness::Witness
+  pub fn bitcoin_primitives::witness::Witness::extend<I: core::iter::traits::collect::IntoIterator<Item = T>>(&mut self, iter: I) [impl: impl<T: core::convert::AsRef<[u8]>> core::iter::traits::collect::Extend<T> for bitcoin_primitives::witness::Witness]
 impl<T: core::convert::AsRef<[u8]>> core::iter::traits::collect::FromIterator<T> for bitcoin_primitives::witness::Witness
   pub fn bitcoin_primitives::witness::Witness::from_iter<I: core::iter::traits::collect::IntoIterator<Item = T>>(iter: I) -> Self [impl: impl<T: core::convert::AsRef<[u8]>> core::iter::traits::collect::FromIterator<T> for bitcoin_primitives::witness::Witness]
 impl<const N: usize, T: core::borrow::Borrow<[u8]>> core::cmp::PartialEq<&[T; N]> for bitcoin_primitives::witness::Witness

--- a/primitives/src/witness.rs
+++ b/primitives/src/witness.rs
@@ -686,6 +686,12 @@ impl<T: AsRef<[u8]>> FromIterator<T> for Witness {
     }
 }
 
+impl<T: AsRef<[u8]>> Extend<T> for Witness {
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        iter.into_iter().for_each(|elem| self.push(elem));
+    }
+}
+
 // Serde keep backward compatibility with old Vec<Vec<u8>> format
 #[cfg(feature = "serde")]
 impl serde::Serialize for Witness {
@@ -1319,6 +1325,13 @@ mod test {
         for item in &data {
             witness2.push(item);
         }
+        assert_eq!(witness1, witness2);
+        assert_eq!(witness1.len(), witness2.len());
+        assert_eq!(witness1.to_vec(), witness2.to_vec());
+
+        // Test that extend works the same as manually pushing
+        let mut witness2 = Witness::new();
+        witness2.extend(&data);
         assert_eq!(witness1, witness2);
         assert_eq!(witness1.len(), witness2.len());
         assert_eq!(witness1.to_vec(), witness2.to_vec());


### PR DESCRIPTION
Per the C-COLLECT API guideline, any collection type that implements FromIterator should also implement Extend. Since the Witness type already has the push method, and FromIterator impl, it is clearly intended to be usable like a collection and should thus also have Extend.

Add Extend impl to Witness.