### PR TITLE
Add `Debug` impl to `witness::Iter`

### DIFF
--- a/primitives/api/all-features.txt
+++ b/primitives/api/all-features.txt
@@ -5972,6 +5972,8 @@ pub struct bitcoin_primitives::witness::Iter<'a>
 impl core::iter::traits::exact_size::ExactSizeIterator for bitcoin_primitives::witness::Iter<'_>
 impl<'a> core::clone::Clone for bitcoin_primitives::witness::Iter<'a>
   pub fn bitcoin_primitives::witness::Iter<'a>::clone(&self) -> bitcoin_primitives::witness::Iter<'a> [impl: impl<'a> core::clone::Clone for bitcoin_primitives::witness::Iter<'a>]
+impl<'a> core::fmt::Debug for bitcoin_primitives::witness::Iter<'a>
+  pub fn bitcoin_primitives::witness::Iter<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<'a> core::fmt::Debug for bitcoin_primitives::witness::Iter<'a>]
 impl<'a> core::iter::traits::iterator::Iterator for bitcoin_primitives::witness::Iter<'a>
   pub type bitcoin_primitives::witness::Iter<'a>::Item = &'a [u8] [impl: impl<'a> core::iter::traits::iterator::Iterator for bitcoin_primitives::witness::Iter<'a>]
   pub fn bitcoin_primitives::witness::Iter<'a>::next(&mut self) -> core::option::Option<Self::Item> [impl: impl<'a> core::iter::traits::iterator::Iterator for bitcoin_primitives::witness::Iter<'a>]

--- a/primitives/api/alloc-only.txt
+++ b/primitives/api/alloc-only.txt
@@ -5543,6 +5543,8 @@ pub struct bitcoin_primitives::witness::Iter<'a>
 impl core::iter::traits::exact_size::ExactSizeIterator for bitcoin_primitives::witness::Iter<'_>
 impl<'a> core::clone::Clone for bitcoin_primitives::witness::Iter<'a>
   pub fn bitcoin_primitives::witness::Iter<'a>::clone(&self) -> bitcoin_primitives::witness::Iter<'a> [impl: impl<'a> core::clone::Clone for bitcoin_primitives::witness::Iter<'a>]
+impl<'a> core::fmt::Debug for bitcoin_primitives::witness::Iter<'a>
+  pub fn bitcoin_primitives::witness::Iter<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<'a> core::fmt::Debug for bitcoin_primitives::witness::Iter<'a>]
 impl<'a> core::iter::traits::iterator::Iterator for bitcoin_primitives::witness::Iter<'a>
   pub type bitcoin_primitives::witness::Iter<'a>::Item = &'a [u8] [impl: impl<'a> core::iter::traits::iterator::Iterator for bitcoin_primitives::witness::Iter<'a>]
   pub fn bitcoin_primitives::witness::Iter<'a>::next(&mut self) -> core::option::Option<Self::Item> [impl: impl<'a> core::iter::traits::iterator::Iterator for bitcoin_primitives::witness::Iter<'a>]

--- a/primitives/src/witness.rs
+++ b/primitives/src/witness.rs
@@ -612,7 +612,7 @@ impl fmt::UpperHex for Witness {
 }
 
 /// An iterator returning individual witness elements.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Iter<'a> {
     inner: &'a [u8],
     indices_start: usize,


### PR DESCRIPTION
The C-DEBUG API guideline recommends that all public types implement Debug. The witness::Iter type is the only public type in primitives which does not implement Debug, and thus should have a Debug derive added to it.

Add derive(Debug) impl to witness::Iter.