### PR TITLE
Move error types to error submodules

### DIFF
--- a/bitcoin/src/merkle_tree/mod.rs
+++ b/bitcoin/src/merkle_tree/mod.rs
@@ -18,4 +18,10 @@
 #[doc(inline)]
 pub use primitives::merkle_tree::{TxMerkleNodeDecoder, TxMerkleNodeEncoder, TxMerkleNode, WitnessMerkleNode};
 #[doc(no_inline)]
-pub use primitives::merkle_tree::TxMerkleNodeDecoderError;
+pub use self::error::TxMerkleNodeDecoderError;
+
+/// Error types for the merkle tree module.
+pub mod error {
+    #[doc(inline)]
+    pub use primitives::merkle_tree::TxMerkleNodeDecoderError;
+}

--- a/primitives/api/all-features.txt
+++ b/primitives/api/all-features.txt
@@ -1347,6 +1347,53 @@ impl bitcoin_primitives::block::Validation for bitcoin_primitives::block::Unchec
 pub fn bitcoin_primitives::block::compute_merkle_root(transactions: &[bitcoin_primitives::transaction::Transaction]) -> core::option::Option<bitcoin_primitives::merkle_tree::TxMerkleNode>
 pub fn bitcoin_primitives::block::compute_witness_root(transactions: &[bitcoin_primitives::transaction::Transaction]) -> core::option::Option<bitcoin_primitives::merkle_tree::WitnessMerkleNode>
 pub mod bitcoin_primitives::merkle_tree
+pub mod bitcoin_primitives::merkle_tree::error
+pub struct bitcoin_primitives::merkle_tree::error::TxMerkleNodeDecoderError(_)
+impl core::clone::Clone for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::clone(&self) -> bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError [impl: impl core::clone::Clone for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError]
+impl core::cmp::Eq for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+impl core::cmp::PartialEq for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::eq(&self, other: &bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError]
+impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError]
+impl core::error::Error for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)> [impl: impl core::error::Error for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError]
+impl core::fmt::Debug for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError]
+impl core::fmt::Display for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError]
+impl core::marker::StructuralPartialEq for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+impl core::marker::Freeze for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+impl core::marker::Send for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+impl core::marker::Sync for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+impl core::marker::Unpin for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+impl core::marker::UnsafeUnpin for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+impl<T, U> core::convert::Into<U> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where U: core::convert::From<T>
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where U: core::convert::Into<T>
+  pub type bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where U: core::convert::Into<T>]
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where U: core::convert::TryFrom<T>
+  pub type bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where U: core::convert::TryFrom<T>]
+impl<T> alloc::borrow::ToOwned for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where T: core::clone::Clone
+  pub type bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where T: core::clone::Clone]
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where T: core::clone::Clone]
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where T: core::clone::Clone]
+impl<T> alloc::string::ToString for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where T: core::fmt::Display + ?core::marker::Sized
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where T: core::fmt::Display + ?core::marker::Sized]
+impl<T> core::any::Any for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where T: core::clone::Clone
+  pub unsafe fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError]
 pub struct bitcoin_primitives::merkle_tree::TxMerkleNode(_)
 impl bitcoin_primitives::merkle_tree::TxMerkleNode
 pub const fn bitcoin_primitives::merkle_tree::TxMerkleNode::as_byte_array(&self) -> &[u8; 32]

--- a/primitives/api/alloc-only.txt
+++ b/primitives/api/alloc-only.txt
@@ -1255,6 +1255,51 @@ impl bitcoin_primitives::block::Validation for bitcoin_primitives::block::Unchec
 pub fn bitcoin_primitives::block::compute_merkle_root(transactions: &[bitcoin_primitives::transaction::Transaction]) -> core::option::Option<bitcoin_primitives::merkle_tree::TxMerkleNode>
 pub fn bitcoin_primitives::block::compute_witness_root(transactions: &[bitcoin_primitives::transaction::Transaction]) -> core::option::Option<bitcoin_primitives::merkle_tree::WitnessMerkleNode>
 pub mod bitcoin_primitives::merkle_tree
+pub mod bitcoin_primitives::merkle_tree::error
+pub struct bitcoin_primitives::merkle_tree::error::TxMerkleNodeDecoderError(_)
+impl core::clone::Clone for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::clone(&self) -> bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError [impl: impl core::clone::Clone for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError]
+impl core::cmp::Eq for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+impl core::cmp::PartialEq for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::eq(&self, other: &bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError]
+impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError]
+impl core::fmt::Debug for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError]
+impl core::fmt::Display for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError]
+impl core::marker::StructuralPartialEq for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+impl core::marker::Freeze for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+impl core::marker::Send for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+impl core::marker::Sync for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+impl core::marker::Unpin for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+impl core::marker::UnsafeUnpin for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+impl<T, U> core::convert::Into<U> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where U: core::convert::From<T>
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where U: core::convert::Into<T>
+  pub type bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where U: core::convert::Into<T>]
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where U: core::convert::TryFrom<T>
+  pub type bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where U: core::convert::TryFrom<T>]
+impl<T> alloc::borrow::ToOwned for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where T: core::clone::Clone
+  pub type bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where T: core::clone::Clone]
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where T: core::clone::Clone]
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where T: core::clone::Clone]
+impl<T> alloc::string::ToString for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where T: core::fmt::Display + ?core::marker::Sized
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where T: core::fmt::Display + ?core::marker::Sized]
+impl<T> core::any::Any for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where T: core::clone::Clone
+  pub unsafe fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError]
 pub struct bitcoin_primitives::merkle_tree::TxMerkleNode(_)
 impl bitcoin_primitives::merkle_tree::TxMerkleNode
 pub const fn bitcoin_primitives::merkle_tree::TxMerkleNode::as_byte_array(&self) -> &[u8; 32]

--- a/primitives/api/no-features.txt
+++ b/primitives/api/no-features.txt
@@ -746,6 +746,45 @@ impl<T> core::clone::CloneToUninit for bitcoin_primitives::WitnessCommitment whe
 impl<T> core::convert::From<T> for bitcoin_primitives::WitnessCommitment
   pub fn bitcoin_primitives::WitnessCommitment::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::WitnessCommitment]
 pub mod bitcoin_primitives::merkle_tree
+pub mod bitcoin_primitives::merkle_tree::error
+pub struct bitcoin_primitives::merkle_tree::error::TxMerkleNodeDecoderError(_)
+impl core::clone::Clone for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::clone(&self) -> bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError [impl: impl core::clone::Clone for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError]
+impl core::cmp::Eq for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+impl core::cmp::PartialEq for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::eq(&self, other: &bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError]
+impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError]
+impl core::fmt::Debug for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError]
+impl core::fmt::Display for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError]
+impl core::marker::StructuralPartialEq for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+impl core::marker::Freeze for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+impl core::marker::Send for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+impl core::marker::Sync for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+impl core::marker::Unpin for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+impl core::marker::UnsafeUnpin for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+impl<T, U> core::convert::Into<U> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where U: core::convert::From<T>
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where U: core::convert::Into<T>
+  pub type bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where U: core::convert::Into<T>]
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where U: core::convert::TryFrom<T>
+  pub type bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where U: core::convert::TryFrom<T>]
+impl<T> core::any::Any for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where T: core::clone::Clone
+  pub unsafe fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError
+  pub fn bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::merkle_tree::TxMerkleNodeDecoderError]
 pub struct bitcoin_primitives::merkle_tree::TxMerkleNode(_)
 impl bitcoin_primitives::merkle_tree::TxMerkleNode
 pub const fn bitcoin_primitives::merkle_tree::TxMerkleNode::as_byte_array(&self) -> &[u8; 32]

--- a/primitives/src/merkle_tree.rs
+++ b/primitives/src/merkle_tree.rs
@@ -16,10 +16,11 @@ use hashes::{sha256d, HashEngine};
 #[cfg(not(feature = "alloc"))]
 use internals::array_vec::ArrayVec;
 
+#[doc(no_inline)]
+pub use self::error::TxMerkleNodeDecoderError;
 #[doc(inline)]
 pub use crate::hash_types::{
-    TxMerkleNode, TxMerkleNodeDecoder, TxMerkleNodeDecoderError, TxMerkleNodeEncoder,
-    WitnessMerkleNode,
+    TxMerkleNode, TxMerkleNodeDecoder, TxMerkleNodeEncoder, WitnessMerkleNode,
 };
 use crate::hash_types::{Txid, Wtxid};
 use crate::transaction::TxIdentifier;
@@ -192,6 +193,12 @@ impl MerkleNode for WitnessMerkleNode {
         let nodes: Vec<[u8; 32]> = iter.map(Wtxid::to_byte_array).collect();
         calculate_root_batched(nodes).map(Self::from_byte_array)
     }
+}
+
+/// Error types for the merkle tree module.
+pub mod error {
+    #[doc(inline)]
+    pub use crate::hash_types::TxMerkleNodeDecoderError;
 }
 
 #[cfg(test)]

--- a/units/api/all-features.txt
+++ b/units/api/all-features.txt
@@ -3752,52 +3752,99 @@ pub fn bitcoin_units::fee_rate::serde::as_sat_per_vb_floor::vec::deserialize<'d,
 pub fn bitcoin_units::fee_rate::serde::as_sat_per_vb_floor::vec::serialize<S: serde::ser::Serializer>(f: &[bitcoin_units::FeeRate], s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
 pub fn bitcoin_units::fee_rate::serde::as_sat_per_vb_floor::deserialize<'d, D: serde::de::Deserializer<'d>>(d: D) -> core::result::Result<bitcoin_units::FeeRate, <D as serde::de::Deserializer>::Error>
 pub fn bitcoin_units::fee_rate::serde::as_sat_per_vb_floor::serialize<S: serde::ser::Serializer>(f: &bitcoin_units::FeeRate, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error>
+pub mod bitcoin_units::fee_rate::serde::error
+#[non_exhaustive] pub struct bitcoin_units::fee_rate::serde::error::OverflowError
+impl core::clone::Clone for bitcoin_units::fee_rate::serde::error::OverflowError
+  pub fn bitcoin_units::fee_rate::serde::error::OverflowError::clone(&self) -> bitcoin_units::fee_rate::serde::error::OverflowError [impl: impl core::clone::Clone for bitcoin_units::fee_rate::serde::error::OverflowError]
+impl core::cmp::Eq for bitcoin_units::fee_rate::serde::error::OverflowError
+impl core::cmp::PartialEq for bitcoin_units::fee_rate::serde::error::OverflowError
+  pub fn bitcoin_units::fee_rate::serde::error::OverflowError::eq(&self, other: &bitcoin_units::fee_rate::serde::error::OverflowError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_units::fee_rate::serde::error::OverflowError]
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::fee_rate::serde::error::OverflowError
+  pub fn bitcoin_units::fee_rate::serde::error::OverflowError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_units::fee_rate::serde::error::OverflowError]
+impl core::error::Error for bitcoin_units::fee_rate::serde::error::OverflowError
+  pub fn bitcoin_units::fee_rate::serde::error::OverflowError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)> [impl: impl core::error::Error for bitcoin_units::fee_rate::serde::error::OverflowError]
+impl core::fmt::Debug for bitcoin_units::fee_rate::serde::error::OverflowError
+  pub fn bitcoin_units::fee_rate::serde::error::OverflowError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_units::fee_rate::serde::error::OverflowError]
+impl core::fmt::Display for bitcoin_units::fee_rate::serde::error::OverflowError
+  pub fn bitcoin_units::fee_rate::serde::error::OverflowError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_units::fee_rate::serde::error::OverflowError]
+impl core::marker::StructuralPartialEq for bitcoin_units::fee_rate::serde::error::OverflowError
+impl core::marker::Freeze for bitcoin_units::fee_rate::serde::error::OverflowError
+impl core::marker::Send for bitcoin_units::fee_rate::serde::error::OverflowError
+impl core::marker::Sync for bitcoin_units::fee_rate::serde::error::OverflowError
+impl core::marker::Unpin for bitcoin_units::fee_rate::serde::error::OverflowError
+impl core::marker::UnsafeUnpin for bitcoin_units::fee_rate::serde::error::OverflowError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::fee_rate::serde::error::OverflowError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::fee_rate::serde::error::OverflowError
+impl<T, U> core::convert::Into<U> for bitcoin_units::fee_rate::serde::error::OverflowError where U: core::convert::From<T>
+  pub fn bitcoin_units::fee_rate::serde::error::OverflowError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_units::fee_rate::serde::error::OverflowError where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::serde::error::OverflowError where U: core::convert::Into<T>
+  pub type bitcoin_units::fee_rate::serde::error::OverflowError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::serde::error::OverflowError where U: core::convert::Into<T>]
+  pub fn bitcoin_units::fee_rate::serde::error::OverflowError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::serde::error::OverflowError where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::serde::error::OverflowError where U: core::convert::TryFrom<T>
+  pub type bitcoin_units::fee_rate::serde::error::OverflowError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::serde::error::OverflowError where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_units::fee_rate::serde::error::OverflowError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::serde::error::OverflowError where U: core::convert::TryFrom<T>]
+impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::serde::error::OverflowError where T: core::clone::Clone
+  pub type bitcoin_units::fee_rate::serde::error::OverflowError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::serde::error::OverflowError where T: core::clone::Clone]
+  pub fn bitcoin_units::fee_rate::serde::error::OverflowError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::serde::error::OverflowError where T: core::clone::Clone]
+  pub fn bitcoin_units::fee_rate::serde::error::OverflowError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::serde::error::OverflowError where T: core::clone::Clone]
+impl<T> alloc::string::ToString for bitcoin_units::fee_rate::serde::error::OverflowError where T: core::fmt::Display + ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::serde::error::OverflowError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_units::fee_rate::serde::error::OverflowError where T: core::fmt::Display + ?core::marker::Sized]
+impl<T> core::any::Any for bitcoin_units::fee_rate::serde::error::OverflowError where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::serde::error::OverflowError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_units::fee_rate::serde::error::OverflowError where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_units::fee_rate::serde::error::OverflowError where T: ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::serde::error::OverflowError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_units::fee_rate::serde::error::OverflowError where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::fee_rate::serde::error::OverflowError where T: ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::serde::error::OverflowError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_units::fee_rate::serde::error::OverflowError where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_units::fee_rate::serde::error::OverflowError where T: core::clone::Clone
+  pub unsafe fn bitcoin_units::fee_rate::serde::error::OverflowError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_units::fee_rate::serde::error::OverflowError where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_units::fee_rate::serde::error::OverflowError
+  pub fn bitcoin_units::fee_rate::serde::error::OverflowError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::fee_rate::serde::error::OverflowError]
 #[non_exhaustive] pub struct bitcoin_units::fee_rate::serde::OverflowError
-impl core::clone::Clone for bitcoin_units::fee_rate::serde::OverflowError
-  pub fn bitcoin_units::fee_rate::serde::OverflowError::clone(&self) -> bitcoin_units::fee_rate::serde::OverflowError [impl: impl core::clone::Clone for bitcoin_units::fee_rate::serde::OverflowError]
-impl core::cmp::Eq for bitcoin_units::fee_rate::serde::OverflowError
-impl core::cmp::PartialEq for bitcoin_units::fee_rate::serde::OverflowError
-  pub fn bitcoin_units::fee_rate::serde::OverflowError::eq(&self, other: &bitcoin_units::fee_rate::serde::OverflowError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_units::fee_rate::serde::OverflowError]
-impl core::convert::From<core::convert::Infallible> for bitcoin_units::fee_rate::serde::OverflowError
-  pub fn bitcoin_units::fee_rate::serde::OverflowError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_units::fee_rate::serde::OverflowError]
-impl core::error::Error for bitcoin_units::fee_rate::serde::OverflowError
-  pub fn bitcoin_units::fee_rate::serde::OverflowError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)> [impl: impl core::error::Error for bitcoin_units::fee_rate::serde::OverflowError]
-impl core::fmt::Debug for bitcoin_units::fee_rate::serde::OverflowError
-  pub fn bitcoin_units::fee_rate::serde::OverflowError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_units::fee_rate::serde::OverflowError]
-impl core::fmt::Display for bitcoin_units::fee_rate::serde::OverflowError
-  pub fn bitcoin_units::fee_rate::serde::OverflowError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_units::fee_rate::serde::OverflowError]
-impl core::marker::StructuralPartialEq for bitcoin_units::fee_rate::serde::OverflowError
-impl core::marker::Freeze for bitcoin_units::fee_rate::serde::OverflowError
-impl core::marker::Send for bitcoin_units::fee_rate::serde::OverflowError
-impl core::marker::Sync for bitcoin_units::fee_rate::serde::OverflowError
-impl core::marker::Unpin for bitcoin_units::fee_rate::serde::OverflowError
-impl core::marker::UnsafeUnpin for bitcoin_units::fee_rate::serde::OverflowError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::fee_rate::serde::OverflowError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::fee_rate::serde::OverflowError
-impl<T, U> core::convert::Into<U> for bitcoin_units::fee_rate::serde::OverflowError where U: core::convert::From<T>
-  pub fn bitcoin_units::fee_rate::serde::OverflowError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_units::fee_rate::serde::OverflowError where U: core::convert::From<T>]
-impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::serde::OverflowError where U: core::convert::Into<T>
-  pub type bitcoin_units::fee_rate::serde::OverflowError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::serde::OverflowError where U: core::convert::Into<T>]
-  pub fn bitcoin_units::fee_rate::serde::OverflowError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::serde::OverflowError where U: core::convert::Into<T>]
-impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::serde::OverflowError where U: core::convert::TryFrom<T>
-  pub type bitcoin_units::fee_rate::serde::OverflowError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::serde::OverflowError where U: core::convert::TryFrom<T>]
-  pub fn bitcoin_units::fee_rate::serde::OverflowError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::serde::OverflowError where U: core::convert::TryFrom<T>]
-impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::serde::OverflowError where T: core::clone::Clone
-  pub type bitcoin_units::fee_rate::serde::OverflowError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::serde::OverflowError where T: core::clone::Clone]
-  pub fn bitcoin_units::fee_rate::serde::OverflowError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::serde::OverflowError where T: core::clone::Clone]
-  pub fn bitcoin_units::fee_rate::serde::OverflowError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::serde::OverflowError where T: core::clone::Clone]
-impl<T> alloc::string::ToString for bitcoin_units::fee_rate::serde::OverflowError where T: core::fmt::Display + ?core::marker::Sized
-  pub fn bitcoin_units::fee_rate::serde::OverflowError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_units::fee_rate::serde::OverflowError where T: core::fmt::Display + ?core::marker::Sized]
-impl<T> core::any::Any for bitcoin_units::fee_rate::serde::OverflowError where T: 'static + ?core::marker::Sized
-  pub fn bitcoin_units::fee_rate::serde::OverflowError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_units::fee_rate::serde::OverflowError where T: 'static + ?core::marker::Sized]
-impl<T> core::borrow::Borrow<T> for bitcoin_units::fee_rate::serde::OverflowError where T: ?core::marker::Sized
-  pub fn bitcoin_units::fee_rate::serde::OverflowError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_units::fee_rate::serde::OverflowError where T: ?core::marker::Sized]
-impl<T> core::borrow::BorrowMut<T> for bitcoin_units::fee_rate::serde::OverflowError where T: ?core::marker::Sized
-  pub fn bitcoin_units::fee_rate::serde::OverflowError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_units::fee_rate::serde::OverflowError where T: ?core::marker::Sized]
-impl<T> core::clone::CloneToUninit for bitcoin_units::fee_rate::serde::OverflowError where T: core::clone::Clone
-  pub unsafe fn bitcoin_units::fee_rate::serde::OverflowError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_units::fee_rate::serde::OverflowError where T: core::clone::Clone]
-impl<T> core::convert::From<T> for bitcoin_units::fee_rate::serde::OverflowError
-  pub fn bitcoin_units::fee_rate::serde::OverflowError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::fee_rate::serde::OverflowError]
+impl core::clone::Clone for bitcoin_units::fee_rate::serde::error::OverflowError
+  pub fn bitcoin_units::fee_rate::serde::error::OverflowError::clone(&self) -> bitcoin_units::fee_rate::serde::error::OverflowError [impl: impl core::clone::Clone for bitcoin_units::fee_rate::serde::error::OverflowError]
+impl core::cmp::Eq for bitcoin_units::fee_rate::serde::error::OverflowError
+impl core::cmp::PartialEq for bitcoin_units::fee_rate::serde::error::OverflowError
+  pub fn bitcoin_units::fee_rate::serde::error::OverflowError::eq(&self, other: &bitcoin_units::fee_rate::serde::error::OverflowError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_units::fee_rate::serde::error::OverflowError]
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::fee_rate::serde::error::OverflowError
+  pub fn bitcoin_units::fee_rate::serde::error::OverflowError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_units::fee_rate::serde::error::OverflowError]
+impl core::error::Error for bitcoin_units::fee_rate::serde::error::OverflowError
+  pub fn bitcoin_units::fee_rate::serde::error::OverflowError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)> [impl: impl core::error::Error for bitcoin_units::fee_rate::serde::error::OverflowError]
+impl core::fmt::Debug for bitcoin_units::fee_rate::serde::error::OverflowError
+  pub fn bitcoin_units::fee_rate::serde::error::OverflowError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_units::fee_rate::serde::error::OverflowError]
+impl core::fmt::Display for bitcoin_units::fee_rate::serde::error::OverflowError
+  pub fn bitcoin_units::fee_rate::serde::error::OverflowError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_units::fee_rate::serde::error::OverflowError]
+impl core::marker::StructuralPartialEq for bitcoin_units::fee_rate::serde::error::OverflowError
+impl core::marker::Freeze for bitcoin_units::fee_rate::serde::error::OverflowError
+impl core::marker::Send for bitcoin_units::fee_rate::serde::error::OverflowError
+impl core::marker::Sync for bitcoin_units::fee_rate::serde::error::OverflowError
+impl core::marker::Unpin for bitcoin_units::fee_rate::serde::error::OverflowError
+impl core::marker::UnsafeUnpin for bitcoin_units::fee_rate::serde::error::OverflowError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::fee_rate::serde::error::OverflowError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::fee_rate::serde::error::OverflowError
+impl<T, U> core::convert::Into<U> for bitcoin_units::fee_rate::serde::error::OverflowError where U: core::convert::From<T>
+  pub fn bitcoin_units::fee_rate::serde::error::OverflowError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_units::fee_rate::serde::error::OverflowError where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::serde::error::OverflowError where U: core::convert::Into<T>
+  pub type bitcoin_units::fee_rate::serde::error::OverflowError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::serde::error::OverflowError where U: core::convert::Into<T>]
+  pub fn bitcoin_units::fee_rate::serde::error::OverflowError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::serde::error::OverflowError where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::serde::error::OverflowError where U: core::convert::TryFrom<T>
+  pub type bitcoin_units::fee_rate::serde::error::OverflowError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::serde::error::OverflowError where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_units::fee_rate::serde::error::OverflowError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::serde::error::OverflowError where U: core::convert::TryFrom<T>]
+impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::serde::error::OverflowError where T: core::clone::Clone
+  pub type bitcoin_units::fee_rate::serde::error::OverflowError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::serde::error::OverflowError where T: core::clone::Clone]
+  pub fn bitcoin_units::fee_rate::serde::error::OverflowError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::serde::error::OverflowError where T: core::clone::Clone]
+  pub fn bitcoin_units::fee_rate::serde::error::OverflowError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::serde::error::OverflowError where T: core::clone::Clone]
+impl<T> alloc::string::ToString for bitcoin_units::fee_rate::serde::error::OverflowError where T: core::fmt::Display + ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::serde::error::OverflowError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_units::fee_rate::serde::error::OverflowError where T: core::fmt::Display + ?core::marker::Sized]
+impl<T> core::any::Any for bitcoin_units::fee_rate::serde::error::OverflowError where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::serde::error::OverflowError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_units::fee_rate::serde::error::OverflowError where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_units::fee_rate::serde::error::OverflowError where T: ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::serde::error::OverflowError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_units::fee_rate::serde::error::OverflowError where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::fee_rate::serde::error::OverflowError where T: ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::serde::error::OverflowError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_units::fee_rate::serde::error::OverflowError where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_units::fee_rate::serde::error::OverflowError where T: core::clone::Clone
+  pub unsafe fn bitcoin_units::fee_rate::serde::error::OverflowError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_units::fee_rate::serde::error::OverflowError where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_units::fee_rate::serde::error::OverflowError
+  pub fn bitcoin_units::fee_rate::serde::error::OverflowError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::fee_rate::serde::error::OverflowError]
 pub struct bitcoin_units::fee_rate::FeeRate(_)
 impl bitcoin_units::FeeRate
 pub const bitcoin_units::FeeRate::BROADCAST_MIN: Self

--- a/units/src/fee_rate/serde.rs
+++ b/units/src/fee_rate/serde.rs
@@ -23,8 +23,8 @@
 //! }
 //! ```
 
-use core::convert::Infallible;
-use core::fmt;
+#[doc(no_inline)]
+pub use self::error::OverflowError;
 
 pub mod as_sat_per_kwu_floor {
     //! Serialize and deserialize [`FeeRate`] denominated in satoshis per 1000 weight units.
@@ -406,26 +406,32 @@ pub mod as_sat_per_vb_ceil {
     }
 }
 
-/// Overflow occurred while deserializing fee rate per virtual byte.
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[non_exhaustive]
-pub struct OverflowError;
+/// Error types for fee rate serde handling.
+pub mod error {
+    use core::convert::Infallible;
+    use core::fmt;
 
-impl From<Infallible> for OverflowError {
-    fn from(never: Infallible) -> Self { match never {} }
-}
+    /// Overflow occurred while deserializing fee rate per virtual byte.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[non_exhaustive]
+    pub struct OverflowError;
 
-impl fmt::Display for OverflowError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "overflow occurred while deserializing fee rate per virtual byte")
+    impl From<Infallible> for OverflowError {
+        fn from(never: Infallible) -> Self { match never {} }
     }
-}
 
-#[cfg(feature = "std")]
-impl std::error::Error for OverflowError {
-    #[inline]
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        let Self {} = self;
-        None
+    impl fmt::Display for OverflowError {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "overflow occurred while deserializing fee rate per virtual byte")
+        }
+    }
+
+    #[cfg(feature = "std")]
+    impl std::error::Error for OverflowError {
+        #[inline]
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            let Self {} = self;
+            None
+        }
     }
 }


### PR DESCRIPTION
In the crates, all error types should be defined within error submodules and then re-exported no_inline in the main module. Currently, we have two error types that do not follow this pattern in units and primitives.

Move error types to error submodules and re-export no_inline.