### PR TITLE
`[0.32.xx]` units: backport kani proof fixes to 0.32.xx

### DIFF
--- a/units/src/amount.rs
+++ b/units/src/amount.rs
@@ -1977,10 +1977,15 @@ mod verification {
     // CI it fails, so we need to set it higher.
     #[kani::unwind(4)]
     #[kani::proof]
-    fn u_amount_add_homomorphic() {
+    fn u_amount_homomorphic() {
         let n1 = kani::any::<u64>();
         let n2 = kani::any::<u64>();
-        kani::assume(n1.checked_add(n2).is_some()); // assume we don't overflow in the actual test
+        // Assume we don't overflow in the actual tests.
+        kani::assume(n1.checked_add(n2).is_some()); // Adding u64s doesn't overflow.
+        let a1 = Amount::from_sat(n1);
+        let a2 = Amount::from_sat(n2);
+        kani::assume(a1.checked_add(a2).is_some()); // Adding amounts doesn't overflow.
+
         assert_eq!(Amount::from_sat(n1) + Amount::from_sat(n2), Amount::from_sat(n1 + n2));
 
         let mut amt = Amount::from_sat(n1);
@@ -1994,39 +1999,21 @@ mod verification {
         let mut amt = Amount::from_sat(max);
         amt -= Amount::from_sat(min);
         assert_eq!(amt, Amount::from_sat(max - min));
-
-        assert_eq!(
-            Amount::from_sat(n1).to_signed(),
-            if n1 <= i64::MAX as u64 {
-                Ok(SignedAmount::from_sat(n1.try_into().unwrap()))
-            } else {
-                Err(OutOfRangeError::too_big(true))
-            },
-        );
     }
 
     #[kani::unwind(4)]
     #[kani::proof]
-    fn u_amount_add_homomorphic_checked() {
-        let n1 = kani::any::<u64>();
-        let n2 = kani::any::<u64>();
-        assert_eq!(
-            Amount::from_sat(n1).checked_add(Amount::from_sat(n2)),
-            n1.checked_add(n2).map(Amount::from_sat),
-        );
-        assert_eq!(
-            Amount::from_sat(n1).checked_sub(Amount::from_sat(n2)),
-            n1.checked_sub(n2).map(Amount::from_sat),
-        );
-    }
-
-    #[kani::unwind(4)]
-    #[kani::proof]
-    fn s_amount_add_homomorphic() {
+    fn s_amount_homomorphic() {
         let n1 = kani::any::<i64>();
         let n2 = kani::any::<i64>();
-        kani::assume(n1.checked_add(n2).is_some()); // assume we don't overflow in the actual test
-        kani::assume(n1.checked_sub(n2).is_some()); // assume we don't overflow in the actual test
+        // Assume we don't overflow in the actual tests.
+        kani::assume(n1.checked_add(n2).is_some()); // Adding i64s doesn't overflow.
+        kani::assume(n1.checked_sub(n2).is_some()); // Subbing i64s doesn't overflow.
+        let a1 = SignedAmount::from_sat(n1);
+        let a2 = SignedAmount::from_sat(n2);
+        kani::assume(a1.checked_add(a2).is_some()); // Adding amounts doesn't overflow.
+        kani::assume(a1.checked_sub(a2).is_some()); // Subbing amounts doesn't overflow.
+
         assert_eq!(
             SignedAmount::from_sat(n1) + SignedAmount::from_sat(n2),
             SignedAmount::from_sat(n1 + n2)
@@ -2042,39 +2029,6 @@ mod verification {
         let mut amt = SignedAmount::from_sat(n1);
         amt -= SignedAmount::from_sat(n2);
         assert_eq!(amt, SignedAmount::from_sat(n1 - n2));
-
-        assert_eq!(
-            SignedAmount::from_sat(n1).to_unsigned(),
-            if n1 >= 0 {
-                Ok(Amount::from_sat(n1.try_into().unwrap()))
-            } else {
-                Err(OutOfRangeError { is_signed: true, is_greater_than_max: false })
-            },
-        );
-    }
-
-    #[kani::unwind(4)]
-    #[kani::proof]
-    fn s_amount_add_homomorphic_checked() {
-        let n1 = kani::any::<i64>();
-        let n2 = kani::any::<i64>();
-        assert_eq!(
-            SignedAmount::from_sat(n1).checked_add(SignedAmount::from_sat(n2)),
-            n1.checked_add(n2).map(SignedAmount::from_sat),
-        );
-        assert_eq!(
-            SignedAmount::from_sat(n1).checked_sub(SignedAmount::from_sat(n2)),
-            n1.checked_sub(n2).map(SignedAmount::from_sat),
-        );
-
-        assert_eq!(
-            SignedAmount::from_sat(n1).positive_sub(SignedAmount::from_sat(n2)),
-            if n1 >= 0 && n2 >= 0 && n1 >= n2 {
-                Some(SignedAmount::from_sat(n1 - n2))
-            } else {
-                None
-            },
-        );
     }
 }
 


### PR DESCRIPTION
Copying the backport we did to `0.32.xxx` in 65f1fbfcbb18971fdc60d48a4f57233a9af3f317. We run kani on both LTS branches, so needs to be here as well.