### PR TITLE
Automated weekly update to rustc stable (to 1.97.1) on 0.32.xx

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,4 @@ resolver = "2"
 
 [workspace.metadata.rbmt.toolchains]
 nightly = "nightly-2026-03-27"
-stable = "1.91.1"
+stable = "1.97.1"


### PR DESCRIPTION
Automated update to Cargo.toml workspace metadata by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action