### PR TITLE
Remove unfixable TODO

### DIFF
--- a/bitcoin/src/consensus/mod.rs
+++ b/bitcoin/src/consensus/mod.rs
@@ -151,7 +151,7 @@ impl<E: fmt::Debug> std::error::Error for DecodeError<E> {
         match *self {
             TooManyBytes => None,
             Consensus(ref e) => Some(e),
-            Other(_) => None, // TODO: Is this correct?
+            Other(_) => None,
         }
     }
 }


### PR DESCRIPTION
The fix requires adding trait bounds to `E` which is a breaking change so we cannot fix this TODO on the `0.32.xxx` branch. Drop it.