### PR TITLE
Add `impl Clone for Box<{custom DST}>`

### DIFF
--- a/primitives/api/all-features.txt
+++ b/primitives/api/all-features.txt
@@ -2306,6 +2306,8 @@ impl core::borrow::Borrow<bitcoin_primitives::script::PushBytes> for bitcoin_pri
   pub fn bitcoin_primitives::script::PushBytesBuf::borrow(&self) -> &bitcoin_primitives::script::PushBytes [impl: impl core::borrow::Borrow<bitcoin_primitives::script::PushBytes> for bitcoin_primitives::script::PushBytesBuf]
 impl core::borrow::BorrowMut<bitcoin_primitives::script::PushBytes> for bitcoin_primitives::script::PushBytesBuf
   pub fn bitcoin_primitives::script::PushBytesBuf::borrow_mut(&mut self) -> &mut bitcoin_primitives::script::PushBytes [impl: impl core::borrow::BorrowMut<bitcoin_primitives::script::PushBytes> for bitcoin_primitives::script::PushBytesBuf]
+impl core::clone::Clone for alloc::boxed::Box<bitcoin_primitives::script::PushBytes>
+  pub fn alloc::boxed::Box<bitcoin_primitives::script::PushBytes>::clone(&self) -> Self [impl: impl core::clone::Clone for alloc::boxed::Box<bitcoin_primitives::script::PushBytes>]
 impl core::cmp::Eq for bitcoin_primitives::script::PushBytes
 impl core::cmp::Ord for bitcoin_primitives::script::PushBytes
   pub fn bitcoin_primitives::script::PushBytes::cmp(&self, other: &bitcoin_primitives::script::PushBytes) -> core::cmp::Ordering [impl: impl core::cmp::Ord for bitcoin_primitives::script::PushBytes]
@@ -3602,6 +3604,8 @@ impl<T> core::borrow::Borrow<bitcoin_primitives::script::Script<T>> for bitcoin_
   pub fn bitcoin_primitives::script::ScriptBuf<T>::borrow(&self) -> &bitcoin_primitives::script::Script<T> [impl: impl<T> core::borrow::Borrow<bitcoin_primitives::script::Script<T>> for bitcoin_primitives::script::ScriptBuf<T>]
 impl<T> core::borrow::BorrowMut<bitcoin_primitives::script::Script<T>> for bitcoin_primitives::script::ScriptBuf<T>
   pub fn bitcoin_primitives::script::ScriptBuf<T>::borrow_mut(&mut self) -> &mut bitcoin_primitives::script::Script<T> [impl: impl<T> core::borrow::BorrowMut<bitcoin_primitives::script::Script<T>> for bitcoin_primitives::script::ScriptBuf<T>]
+impl<T> core::clone::Clone for alloc::boxed::Box<bitcoin_primitives::script::Script<T>>
+  pub fn alloc::boxed::Box<bitcoin_primitives::script::Script<T>>::clone(&self) -> Self [impl: impl<T> core::clone::Clone for alloc::boxed::Box<bitcoin_primitives::script::Script<T>>]
 impl<T> core::convert::AsMut<[u8]> for bitcoin_primitives::script::Script<T>
   pub fn bitcoin_primitives::script::Script<T>::as_mut(&mut self) -> &mut [u8] [impl: impl<T> core::convert::AsMut<[u8]> for bitcoin_primitives::script::Script<T>]
 impl<T> core::convert::AsMut<bitcoin_primitives::script::Script<T>> for bitcoin_primitives::script::Script<T>

--- a/primitives/api/alloc-only.txt
+++ b/primitives/api/alloc-only.txt
@@ -2168,6 +2168,8 @@ impl core::borrow::Borrow<bitcoin_primitives::script::PushBytes> for bitcoin_pri
   pub fn bitcoin_primitives::script::PushBytesBuf::borrow(&self) -> &bitcoin_primitives::script::PushBytes [impl: impl core::borrow::Borrow<bitcoin_primitives::script::PushBytes> for bitcoin_primitives::script::PushBytesBuf]
 impl core::borrow::BorrowMut<bitcoin_primitives::script::PushBytes> for bitcoin_primitives::script::PushBytesBuf
   pub fn bitcoin_primitives::script::PushBytesBuf::borrow_mut(&mut self) -> &mut bitcoin_primitives::script::PushBytes [impl: impl core::borrow::BorrowMut<bitcoin_primitives::script::PushBytes> for bitcoin_primitives::script::PushBytesBuf]
+impl core::clone::Clone for alloc::boxed::Box<bitcoin_primitives::script::PushBytes>
+  pub fn alloc::boxed::Box<bitcoin_primitives::script::PushBytes>::clone(&self) -> Self [impl: impl core::clone::Clone for alloc::boxed::Box<bitcoin_primitives::script::PushBytes>]
 impl core::cmp::Eq for bitcoin_primitives::script::PushBytes
 impl core::cmp::Ord for bitcoin_primitives::script::PushBytes
   pub fn bitcoin_primitives::script::PushBytes::cmp(&self, other: &bitcoin_primitives::script::PushBytes) -> core::cmp::Ordering [impl: impl core::cmp::Ord for bitcoin_primitives::script::PushBytes]
@@ -3453,6 +3455,8 @@ impl<T> core::borrow::Borrow<bitcoin_primitives::script::Script<T>> for bitcoin_
   pub fn bitcoin_primitives::script::ScriptBuf<T>::borrow(&self) -> &bitcoin_primitives::script::Script<T> [impl: impl<T> core::borrow::Borrow<bitcoin_primitives::script::Script<T>> for bitcoin_primitives::script::ScriptBuf<T>]
 impl<T> core::borrow::BorrowMut<bitcoin_primitives::script::Script<T>> for bitcoin_primitives::script::ScriptBuf<T>
   pub fn bitcoin_primitives::script::ScriptBuf<T>::borrow_mut(&mut self) -> &mut bitcoin_primitives::script::Script<T> [impl: impl<T> core::borrow::BorrowMut<bitcoin_primitives::script::Script<T>> for bitcoin_primitives::script::ScriptBuf<T>]
+impl<T> core::clone::Clone for alloc::boxed::Box<bitcoin_primitives::script::Script<T>>
+  pub fn alloc::boxed::Box<bitcoin_primitives::script::Script<T>>::clone(&self) -> Self [impl: impl<T> core::clone::Clone for alloc::boxed::Box<bitcoin_primitives::script::Script<T>>]
 impl<T> core::convert::AsMut<[u8]> for bitcoin_primitives::script::Script<T>
   pub fn bitcoin_primitives::script::Script<T>::as_mut(&mut self) -> &mut [u8] [impl: impl<T> core::convert::AsMut<[u8]> for bitcoin_primitives::script::Script<T>]
 impl<T> core::convert::AsMut<bitcoin_primitives::script::Script<T>> for bitcoin_primitives::script::Script<T>

--- a/primitives/src/script/borrowed.rs
+++ b/primitives/src/script/borrowed.rs
@@ -105,6 +105,14 @@ impl<T> ToOwned for Script<T> {
     fn to_owned(&self) -> Self::Owned { ScriptBuf::from_bytes(self.to_vec()) }
 }
 
+#[cfg(feature = "alloc")]
+impl<T> Clone for Box<Script<T>> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Script::from_boxed_bytes(self.as_bytes().to_owned().into_boxed_slice())
+    }
+}
+
 impl<T> Script<T> {
     /// Constructs a new empty script.
     #[inline]

--- a/primitives/src/script/push_bytes.rs
+++ b/primitives/src/script/push_bytes.rs
@@ -6,6 +6,11 @@ use core::borrow::{Borrow, BorrowMut};
 use core::convert::Infallible;
 use core::ops::{Deref, DerefMut};
 
+#[cfg(feature = "alloc")]
+use alloc::borrow::ToOwned as _;
+#[cfg(feature = "alloc")]
+use alloc::boxed::Box;
+
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
 // This is not the usual re-export, `primitive` here is a code audit thing.
@@ -55,6 +60,11 @@ mod primitive {
             ///
             /// The caller is responsible for checking that the length is less than the 2^32.
             fn from_mut_slice_unchecked(bytes: &mut _) -> &mut Self;
+
+            /// Converts a `Box<[u8]>` into a `Box<PushBytes>` without checking the length.
+            ///
+            /// The caller is responsible for checking that the length is less than 2^32.
+            pub(super) fn from_boxed_slice_unchecked(bytes: Box<_>) -> Box<Self>;
         }
     }
 
@@ -282,6 +292,15 @@ mod primitive {
         type Owned = PushBytesBuf;
 
         fn to_owned(&self) -> Self::Owned { PushBytesBuf(self.0.to_owned()) }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl Clone for Box<PushBytes> {
+    #[inline]
+    fn clone(&self) -> Self {
+        // The invariant (length < 2^32) is maintained because we clone from a valid `PushBytes`.
+        PushBytes::from_boxed_slice_unchecked(self.as_bytes().to_owned().into_boxed_slice())
     }
 }
 

--- a/primitives/tests/api.rs
+++ b/primitives/tests/api.rs
@@ -13,10 +13,12 @@
 #![cfg(feature = "hex")]
 #![cfg(feature = "arbitrary")]
 
+extern crate alloc;
+
 use arbitrary::Arbitrary;
 use bitcoin_primitives::block::{Checked, Unchecked};
 use bitcoin_primitives::script::{
-    self, ScriptHash, ScriptPubKeyBufDecoder, ScriptSigBufDecoder, WScriptHash,
+    self, PushBytes, ScriptHash, ScriptPubKeyBufDecoder, ScriptSigBufDecoder, WScriptHash,
 };
 use bitcoin_primitives::{
     absolute, block, merkle_tree, pow, relative, transaction, witness, OutPoint, RedeemScript,
@@ -125,6 +127,18 @@ struct Clone<'a> {
     h: merkle_tree::WitnessMerkleNode,
     i: pow::CompactTarget,
     // j: &'a Script,
+    #[cfg(feature = "alloc")]
+    j0: alloc::boxed::Box<PushBytes>,
+    #[cfg(feature = "alloc")]
+    j1: alloc::boxed::Box<RedeemScript>,
+    #[cfg(feature = "alloc")]
+    j2: alloc::boxed::Box<ScriptPubKey>,
+    #[cfg(feature = "alloc")]
+    j3: alloc::boxed::Box<ScriptSig>,
+    #[cfg(feature = "alloc")]
+    j4: alloc::boxed::Box<TapScript>,
+    #[cfg(feature = "alloc")]
+    j5: alloc::boxed::Box<WitnessScript>,
     k: ScriptHash,
     l: WScriptHash,
     m1: RedeemScriptBuf,


### PR DESCRIPTION
Disclaimer: while this was AI-assisted, I have fully reviewed the code and it looks correct to me (it's also ridiculously simple).

`Script<T>` and `PushBytes` are unsized types wrapping `[u8]`. The standard library only provides `Clone for Box<T>` where `T: Clone + Sized`, so `Box<Script<T>>` and `Box<PushBytes>` were missing `Clone` implementations.

Add manual `impl<T> Clone for Box<Script<T>>` and `impl Clone for Box<PushBytes>` that clone the underlying bytes and wrap them in new boxed values via `from_boxed_bytes` / `from_boxed_slice_unchecked`.

Also add the corresponding `Box<{Script variant}>` and `Box<PushBytes>` fields to the API test's `Clone` struct (guarded by `#[cfg(feature = "alloc")]`) so that these impls are covered by the compile-time API surface tests.