### PR TITLE
Standardize api test policies

### DIFF
--- a/consensus_encoding/tests/api.rs
+++ b/consensus_encoding/tests/api.rs
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! Test the API surface of `consensus_encoding`.
+//! Test the API surface (not functionality) of `bitcoin-consensus-encoding`.
 //!
-//! The point of these tests is to check the API surface as opposed to test the API functionality.
-//!
-//! ref: <https://rust-lang.github.io/api-guidelines/about.html>
+//! See [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/about.html) and the [rust-bitcoin policies](../../docs/policy.md).
 
 #![allow(dead_code)]
 #![allow(unused_imports)]
@@ -153,9 +151,10 @@ struct Errors {
     h: UnexpectedEofError,
 }
 
+/// C-DEBUG-NONEMPTY: Tests that `ReadError` has non-empty Debug.
 #[test]
 #[cfg(feature = "std")]
-fn api_can_call_debug_on_read_error() {
+fn c_debug_nonempty_read_error() {
     use std::io::{BufReader, Cursor};
 
     let s = String::new();
@@ -166,9 +165,9 @@ fn api_can_call_debug_on_read_error() {
     assert!(!debug.is_empty()); // We don't check this for other errors.
 }
 
-// `Debug` representation is never empty (C-DEBUG-NONEMPTY).
+/// C-DEBUG-NONEMPTY: Tests that all public non-error types have non-empty Debug.
 #[test]
-fn api_all_non_error_types_have_non_empty_debug() {
+fn c_debug_nonempty() {
     static ARR: [u8; 4] = [0u8; 4];
 
     let debug = format!("{:?}", ArrayDecoder::<4>::default());
@@ -213,8 +212,9 @@ fn api_all_non_error_types_have_non_empty_debug() {
     }
 }
 
+/// C-SEND-SYNC: Tests that all public types implement `Send` + `Sync`.
 #[test]
-fn all_types_implement_send_sync() {
+fn c_send_sync() {
     fn assert_send<T: Send>() {}
     fn assert_sync<T: Sync>() {}
 
@@ -227,8 +227,9 @@ fn all_types_implement_send_sync() {
     assert_sync::<Errors>();
 }
 
+/// C-GOOD-ERR: Tests that all public error types implement Display.
 #[test]
-fn api_all_error_types_implement_display() {
+fn c_good_err_display() {
     fn assert_display<T: fmt::Display>() {}
 
     #[cfg(feature = "std")]
@@ -245,8 +246,23 @@ fn api_all_error_types_implement_display() {
     assert_display::<UnexpectedEofError>();
 }
 
+/// C-OBJECT: Tests that traits are object-safe where appropriate.
 #[test]
-fn api_all_error_types_implement_from_infallible() {
+fn c_object() {
+    // If this builds then traits are dyn compatible.
+    struct Traits {
+        a: Box<dyn encoding::Encoder>,
+        b: Box<dyn encoding::ExactSizeEncoder>,
+    }
+    // The following traits are not dyn compatible:
+    // - `Encode`: has a GAT (`type Encoder<'e>`)
+    // - `Decode`: has an associated type (`type Decoder`)
+    // - `Decoder`: has a `Sized` bound
+}
+
+/// P-ERROR-INFALLIBLE: Tests that error types implement `From<Infallible>`.
+#[test]
+fn p_error_infallible() {
     fn assert_from_infallible<T: From<Infallible>>() {}
 
     assert_from_infallible::<DecodeError<UnexpectedEofError>>();
@@ -259,17 +275,4 @@ fn api_all_error_types_implement_from_infallible() {
     #[cfg(feature = "alloc")]
     assert_from_infallible::<VecDecoderError<UnexpectedEofError>>();
     assert_from_infallible::<UnexpectedEofError>();
-}
-
-#[test]
-fn dyn_compatible() {
-    // If this builds then traits are dyn compatible.
-    struct Traits {
-        a: Box<dyn encoding::Encoder>,
-        b: Box<dyn encoding::ExactSizeEncoder>,
-    }
-    // The following traits are not dyn compatible:
-    // - `Encode`: has a GAT (`type Encoder<'e>`)
-    // - `Decode`: has an associated type (`type Decoder`)
-    // - `Decoder`: has a `Sized` bound
 }

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -1,10 +1,34 @@
-# Coding policy for the rust-bitcoin repository
+# Coding Policy for `rust-bitcoin`
 
 We have various `rust-bitcoin` specific coding styles and conventions that are
 grouped here loosely under the term 'policy'. These are things we try to adhere
 to but that you should not need to worry too much about if you are a new
 contributor. Think of this as a place to collect group knowledge that exists in
 the various PRs over the last few years.
+
+## Table of Contents
+
+- [Import statements](#import-statements)
+- [Re-exports](#re-exports)
+  - [pub extern crates](#pub-extern-crates)
+  - [Special treatment of `bitcoin`, `primitives`, `units`](#special-treatment-of-bitcoin-primitives-units)
+  - [Usage of re-exports](#usage-of-re-exports)
+- [Consistent Exports (P-CONSISTENT-EXPORTS)](#consistent-exports-p-consistent-exports)
+- [Return `Self`](#return-self)
+- [Errors](#errors)
+  - [`From<Infallible>` (P-ERROR-INFALLIBLE)](#frominfallible-p-error-infallible)
+- [`expect` messages](#expect-messages)
+- [Rustdocs](#rustdocs)
+  - [Links](#links)
+  - [Examples](#examples)
+- [Derives](#derives)
+- [Attributes](#attributes)
+- [BIP References](#bip-references)
+  - [Exceptions](#exceptions)
+- [Arbitrary Implementations (P-ARBITRARY)](#arbitrary-implementations-p-arbitrary)
+- [Decoder Implementations (P-DECODERS)](#decoder-implementations-p-decoders)
+- [Default Values (P-DEFAULT-CHANGE)](#default-values-p-default-change)
+- [Licensing](#licensing)
 
 ## Import statements
 
@@ -124,6 +148,10 @@ policy is to use types from the highest crate available i.e `use crate::Foo` not
 
 This is enforced by CI.
 
+## Consistent Exports (P-CONSISTENT-EXPORTS)
+
+Root package exports and module exports should remain consistent in stable crates. Once a type, function, or module is publicly exported, removing or changing its visibility in a later version is a breaking change. Carefully consider what should be part of the public API.
+
 ## Return `Self`
 
 Use `Self` as the return type instead of naming the type. When constructing the return value use
@@ -180,9 +208,9 @@ More specifically an error should
 - implement Display using `write_err!()` macro if a variant contains an inner error source.
 - have `Error` suffix on error types (structs and enums).
 - not have `Error` suffix on enum variants.
-- call `internals::impl_from_infallible!`.
 - implement `std::error::Error` if they are public (feature gated on "std").
 - have messages in lower case, except for proper nouns and variable names.
+- implement `From<Infallible>` (more on that below).
 
 ```rust
 /// Documentation for the `Error` type.
@@ -195,12 +223,19 @@ pub enum Error {
     B,
 }
 
-internals::impl_from_infallible!(Error);
-
+impl From<Infallible> for Error {
+    fn from(never: Infallible) -> Self { match never {} }
+}
 ```
 
 All errors that live in an `error` module (eg, `foo/error.rs`) and appear in a public function in
 `foo` module should be available from `foo` i.e., should be re-exported from `foo/mod.rs`.
+
+### `From<Infallible>` (P-ERROR-INFALLIBLE)
+
+All public error types should implement `From<Infallible>` to allow callers to seamlessly convert an operation that can never fail into one that is structurally designed to handle errors.
+
+[`Infallible`](https://doc.rust-lang.org/std/convert/enum.Infallible.html) is a "temporary" (years long) type system hack which should hopefully be replaced in the future by [a rust language feature](https://github.com/rust-lang/rfcs/blob/master/text/1216-bang-type.md). Implementing `Infallible` on rust-bitcoin errors allows callers to take advantage now and avoid orphan rule issues.
 
 ## `expect` messages
 
@@ -376,6 +411,21 @@ When referring to Bitcoin Improvement Proposals (BIPs) in documentation, comment
 Module names, function names, variable names, and file names must keep their existing lowercase/underscore format. Do not rename them to match the formal BIP style:
 - Module names: `bip32`, `bip152` (keep lowercase)
 - Function names: `bip32_derivation`, `bip_341_tests` (keep existing format)
+
+## Arbitrary Implementations (P-ARBITRARY)
+
+Public types should implement the `Arbitrary` trait when a package has an `arbitrary` feature. This ensures helpful fuzz types for users to fuzz their own types built on the primitives exported by rust-bitcoin.
+
+## Decoder Implementations (P-DECODERS)
+
+Public decoder types defined with `bitcoin-consensus-encoding` follow standard conventions to ensure consistent API design for encoding/decoding infrastructure across the library.
+
+1. **`Default`** - Decoders should have a default constructor.
+2. **`new()` method** - Decoders should provide an explicit `new()` constructor method.
+
+## Default Values (P-DEFAULT-CHANGE)
+
+Default values should not change between versions, as this is a breaking change.
 
 ## Licensing
 

--- a/hashes/tests/api.rs
+++ b/hashes/tests/api.rs
@@ -1,16 +1,17 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! Test the API surface of `hashes`.
+//! Test the API surface (not functionality) of `bitcoin_hashes`.
 //!
-//! The point of these tests is to check the API surface as opposed to test the API functionality.
-//!
-//! ref: <https://rust-lang.github.io/api-guidelines/about.html>
+//! See [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/about.html) and the [rust-bitcoin policies](../../docs/policy.md).
 
 #![allow(dead_code)]
 #![allow(unused_imports)]
 #![allow(deprecated)]
 // Exclude lints we don't think are valuable.
 #![allow(clippy::uninlined_format_args)] // Allow `format!("{}", x)` instead of enforcing `format!("{x}")`
+
+#[cfg(feature = "arbitrary")]
+use arbitrary::Arbitrary;
 
 // Import using module style e.g., `sha256::Hash`.
 use bitcoin_hashes::{
@@ -170,25 +171,9 @@ struct Errors {
     c: sha256::MidstateError,
 }
 
+/// C-DEBUG-NONEMPTY: Tests that all public non-error types have non-empty Debug.
 #[test]
-fn api_can_use_modules_from_crate_root() {
-    use bitcoin_hashes::{
-        hash160, hkdf, hmac, muhash, ripemd160, sha1, sha256, sha256d, sha256t, sha384, sha512,
-        sha512_256, siphash24,
-    };
-}
-
-#[test]
-fn api_can_use_alias_from_crate_root() {
-    use bitcoin_hashes::{
-        Hash160, Hkdf, Hmac, MuHash, Ripemd160, Sha1, Sha256, Sha256d, Sha256t, Sha384, Sha512,
-        Sha512_256, Siphash24,
-    };
-}
-
-// `Debug` representation is never empty (C-DEBUG-NONEMPTY).
-#[test]
-fn api_all_non_error_types_have_non_empty_debug() {
+fn c_debug_nonempty() {
     macro_rules! check_debug {
         ($t:tt; $($field:tt),* $(,)?) => {
             $(
@@ -213,9 +198,9 @@ fn api_all_non_error_types_have_non_empty_debug() {
     check_debug!(t; a);
 }
 
-// Public error `Debug` representation is never empty (C-DEBUG-NONEMPTY).
+/// C-DEBUG-NONEMPTY: Tests that all public error types have non-empty Debug.
 #[test]
-fn api_all_public_error_types_have_non_empty_debug() {
+fn c_debug_nonempty_errors() {
     // HKDF is capped at 255 output blocks, so one byte past that limit must error.
     let mut okm = vec![0_u8; 255 * 32 + 1];
     let err = Hkdf::<sha256::HashEngine>::new(&[], &[]).expand(&[], &mut okm).unwrap_err();
@@ -229,8 +214,9 @@ fn api_all_public_error_types_have_non_empty_debug() {
     assert!(!debug.is_empty());
 }
 
+/// C-SEND-SYNC: Tests that all public types implement `Send` + `Sync`.
 #[test]
-fn all_types_implement_send_sync() {
+fn c_send_sync() {
     fn assert_send<T: Send>() {}
     fn assert_sync<T: Sync>() {}
 
@@ -249,19 +235,19 @@ fn all_types_implement_send_sync() {
     assert_sync::<Errors>();
 }
 
-// Error types should implement `std::error::Error` (C-GOOD-ERR).
+/// C-GOOD-ERR: Tests that all public error types implement [`std::error::Error`].
 #[cfg(feature = "std")]
 #[test]
-fn all_error_types_implement_error() {
+fn c_good_err_error() {
     fn assert_error<T: std::error::Error>() {}
 
     assert_error::<hkdf::MaxLengthError>();
     assert_error::<sha256::MidstateError>();
 }
 
-// This is for documentation and so anyone can play with these if they want.
+/// C-OBJECT: Tests that traits are object-safe where appropriate.
 #[test]
-fn dyn_compatible() {
+fn c_object() {
     // use bitcoin_hashes::{sha256t, HashEngine, Hash, IsByteArray};
 
     // struct Traits {
@@ -271,4 +257,49 @@ fn dyn_compatible() {
     //     c: Box<dyn IsByteArray>,
     //     d: Box<dyn sha256t::Tag>,
     // }
+}
+
+/// C-SERDE: Tests that serde traits are implemented where expected.
+#[test]
+#[cfg(feature = "serde")]
+fn c_serde() {
+    fn assert_serde<T: serde::Serialize + for<'de> serde::Deserialize<'de>>() {}
+
+    assert_serde::<Sha256>();
+    assert_serde::<Sha256d>();
+    assert_serde::<Hash160>();
+    assert_serde::<Ripemd160>();
+    assert_serde::<Sha1>();
+    assert_serde::<Sha384>();
+    assert_serde::<Sha512>();
+    assert_serde::<Sha512_256>();
+    assert_serde::<Sha3_256>();
+}
+
+/// P-CONSISTENT-EXPORTS: Tests that modules are exported from the crate root.
+#[test]
+fn p_consistent_exports_modules() {
+    use bitcoin_hashes::{
+        hash160, hkdf, hmac, muhash, ripemd160, sha1, sha256, sha256d, sha256t, sha384, sha512,
+        sha512_256, siphash24,
+    };
+}
+
+/// P-CONSISTENT-EXPORTS: Tests that type aliases are exported from the crate root.
+#[test]
+fn p_consistent_exports_aliases() {
+    use bitcoin_hashes::{
+        Hash160, Hkdf, Hmac, MuHash, Ripemd160, Sha1, Sha256, Sha256d, Sha256t, Sha384, Sha512,
+        Sha512_256, Siphash24,
+    };
+}
+
+/// P-ARBITRARY: Tests that public types implement `Arbitrary`.
+#[test]
+#[cfg(feature = "arbitrary")]
+fn p_arbitrary() {
+    fn assert_arbitrary<T: for<'a> Arbitrary<'a>>() {}
+
+    assert_arbitrary::<Sha256>();
+    assert_arbitrary::<Sha256d>();
 }

--- a/io/tests/api.rs
+++ b/io/tests/api.rs
@@ -1,8 +1,6 @@
-//! Test the API surface of `io`.
+//! Test the API surface (not functionality) of `bitcoin-io`.
 //!
-//! The point of these tests is to check the API surface as opposed to test the API functionality.
-//!
-//! ref: <https://rust-lang.github.io/api-guidelines/about.html>
+//! See [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/about.html) and the [rust-bitcoin policies](../../docs/policy.md).
 
 #![allow(dead_code)]
 #![allow(unused_imports)]
@@ -108,9 +106,9 @@ struct Errors {
     a: io::Error,
 }
 
-// `Debug` representation is never empty (C-DEBUG-NONEMPTY).
+/// C-DEBUG-NONEMPTY: Tests that all public non-error types have non-empty Debug.
 #[test]
-fn api_all_non_error_types_have_non_empty_debug() {
+fn c_debug_nonempty() {
     let t = Types::new();
 
     let debug = format!("{:?}", t.a.a);
@@ -129,8 +127,9 @@ fn api_all_non_error_types_have_non_empty_debug() {
     assert!(!debug.is_empty());
 }
 
+/// C-SEND-SYNC: Tests that all public types implement `Send` + `Sync`.
 #[test]
-fn all_non_error_types_implement_send_sync() {
+fn c_send_sync() {
     fn assert_send<T: Send>() {}
     fn assert_sync<T: Sync>() {}
 
@@ -143,8 +142,9 @@ fn all_non_error_types_implement_send_sync() {
     assert_sync::<Errors>();
 }
 
+/// C-OBJECT: Tests that traits are object-safe where appropriate.
 #[test]
-fn dyn_compatible() {
+fn c_object() {
     // Sanity check, these are all dyn compatible.
     struct StdlibTraits {
         p: Box<dyn std::io::Read>,

--- a/network/tests/api.rs
+++ b/network/tests/api.rs
@@ -1,16 +1,17 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! Test the API surface of `bitcoin-network-kind`.
+//! Test the API surface (not functionality) of `bitcoin-network-kind`.
 //!
-//! The point of these tests is to check the API surface as opposed to test the API functionality.
-//!
-//! See [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/about.html).
+//! See [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/about.html) and the [rust-bitcoin policies](../../docs/policy.md).
 
 #![allow(dead_code)]
 #![allow(unused_imports)]
 
 use core::fmt;
 use core::str::FromStr;
+
+#[cfg(feature = "arbitrary")]
+use arbitrary::Arbitrary;
 
 use bitcoin_network_kind::{Network, NetworkKind, ParseNetworkError, TestnetVersion};
 
@@ -41,7 +42,7 @@ impl Errors {
 
 /// C-SEND-SYNC: Tests that all public types implement `Send` + `Sync`.
 #[test]
-fn api_all_types_implement_send_sync() {
+fn c_send_sync() {
     fn is_send_sync<T: Send + Sync>() {}
 
     is_send_sync::<Enums>();
@@ -50,7 +51,7 @@ fn api_all_types_implement_send_sync() {
 
 /// C-DEBUG-NONEMPTY: Tests that all public types have non-empty Debug.
 #[test]
-fn api_all_types_have_non_empty_debug() {
+fn c_debug_nonempty() {
     let enums = Enums::new();
     let errors = Errors::new();
 
@@ -62,7 +63,7 @@ fn api_all_types_have_non_empty_debug() {
 
 /// C-GOOD-ERR: Tests that all public error types implement Display.
 #[test]
-fn api_all_error_types_implement_display() {
+fn c_good_err_display() {
     fn assert_display<T: fmt::Display>() {}
 
     assert_display::<ParseNetworkError>();
@@ -71,7 +72,7 @@ fn api_all_error_types_implement_display() {
 /// C-GOOD-ERR: Tests that all public error types implement [`std::error::Error`].
 #[test]
 #[cfg(feature = "std")]
-fn api_all_error_types_implement_error() {
+fn c_good_err_error() {
     fn assert_error<T: std::error::Error>() {}
 
     assert_error::<ParseNetworkError>();
@@ -79,7 +80,7 @@ fn api_all_error_types_implement_error() {
 
 /// C-CONV-TRAITS: Tests that conversion traits are implemented where expected.
 #[test]
-fn api_conversion_traits_implemented() {
+fn c_conv_traits() {
     fn assert_from<T: From<U>, U>() {}
     fn assert_fromstr<T: FromStr>() {}
     fn assert_asref_self<T: AsRef<T>>() {}
@@ -92,9 +93,18 @@ fn api_conversion_traits_implemented() {
 /// C-SERDE: Tests that serde traits are implemented where expected.
 #[test]
 #[cfg(feature = "serde")]
-fn api_serde_traits_implemented() {
+fn c_serde() {
     fn assert_serde<T: serde::Serialize + for<'de> serde::Deserialize<'de>>() {}
 
     assert_serde::<NetworkKind>();
     assert_serde::<Network>();
+}
+
+/// P-ARBITRARY: Tests that public types implement `Arbitrary`.
+#[test]
+#[cfg(feature = "arbitrary")]
+fn p_arbitrary() {
+    fn assert_arbitrary<T: for<'a> Arbitrary<'a>>() {}
+
+    assert_arbitrary::<NetworkKind>();
 }

--- a/primitives/tests/api.rs
+++ b/primitives/tests/api.rs
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! Test the API surface of `primitives`.
+//! Test the API surface (not functionality) of `bitcoin-primitives`.
 //!
-//! The point of these tests is to check the API surface as opposed to test the API functionality.
-//!
-//! ref: <https://rust-lang.github.io/api-guidelines/about.html>
+//! See [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/about.html) and the [rust-bitcoin policies](../../docs/policy.md).
 
 #![allow(dead_code)]
 #![allow(unused_imports)]
@@ -198,7 +196,7 @@ struct Default {
 }
 
 /// A struct that includes all public decoder types.
-#[derive(Default)] // All decoders implement `Default`.
+#[derive(Default)] // All decoders implement `Default` (P-DECODERS).
 struct Decoders {
     a: block::BlockDecoder,
     b: block::BlockHashDecoder,
@@ -228,107 +226,9 @@ struct Errors {
     g: script::WitnessScriptSizeError,
 }
 
+/// C-DEBUG-NONEMPTY: Tests that all public non-error types have non-empty Debug.
 #[test]
-fn api_can_use_units_modules_from_crate_root() {
-    use bitcoin_primitives::{amount, block, fee_rate, locktime, weight};
-}
-
-#[test]
-fn api_can_use_units_types_from_crate_root() {
-    use bitcoin_primitives::{
-        Amount, BlockHeight, BlockHeightInterval, BlockMtp, BlockMtpInterval, BlockTime, FeeRate,
-        NumOpResult, Sequence, SignedAmount, Weight,
-    };
-}
-
-#[test]
-fn api_can_use_all_units_types_from_module_amount() {
-    use bitcoin_primitives::amount::{
-        Amount, Denomination, Display, OutOfRangeError, ParseAmountError, ParseDenominationError,
-        ParseError, SignedAmount,
-    };
-}
-
-#[test]
-fn api_can_use_all_units_types_from_module_amount_error() {
-    use bitcoin_primitives::amount::error::{
-        InputTooLargeError, InvalidCharacterError, MissingDenominationError, MissingDigitsError,
-        OutOfRangeError, ParseAmountError, ParseDenominationError, ParseError,
-        PossiblyConfusingDenominationError, TooPreciseError, UnknownDenominationError,
-    };
-}
-
-#[test]
-fn api_can_use_modules_from_crate_root() {
-    use bitcoin_primitives::{
-        amount, block, fee_rate, locktime, merkle_tree, parse_int, pow, result, script, sequence,
-        time, transaction, weight, witness,
-    };
-}
-
-#[test]
-fn api_can_use_types_from_crate_root() {
-    use bitcoin_primitives::{
-        Block, BlockChecked, BlockHash, BlockHeader, BlockUnchecked, BlockValidation, BlockVersion,
-        CompactTarget, OutPoint, RedeemScript, RedeemScriptBuf, ScriptPubKey, ScriptPubKeyBuf,
-        ScriptSig, ScriptSigBuf, Sequence, TapScript, TapScriptBuf, Transaction,
-        TransactionVersion, TxIn, TxOut, Txid, Witness, WitnessCommitment, WitnessScript,
-        WitnessScriptBuf, Wtxid,
-    };
-}
-
-#[test]
-fn api_can_use_all_types_from_module_locktime() {
-    use bitcoin_primitives::locktime::relative::error::{
-        DisabledLockTimeError, InvalidHeightError, InvalidTimeError,
-    };
-    use bitcoin_primitives::locktime::relative::LockTime;
-    use bitcoin_primitives::locktime::{absolute, relative};
-}
-
-#[test]
-fn api_can_use_all_types_from_module_script() {
-    use bitcoin_primitives::script::{
-        RedeemScriptSizeError, ScriptBufDecoder, ScriptBufDecoderError, ScriptEncoder, ScriptHash,
-        ScriptPubKey, ScriptPubKeyBuf, ScriptSig, ScriptSigBuf, WScriptHash,
-        WitnessScriptSizeError,
-    };
-}
-
-#[test]
-fn api_can_use_all_types_from_module_block() {
-    use bitcoin_primitives::block::{
-        BlockDecoder, BlockDecoderError, BlockEncoder, BlockHashDecoder, BlockHashDecoderError,
-        BlockHashEncoder, HeaderDecoder, HeaderEncoder, VersionDecoder, VersionDecoderError,
-        VersionEncoder,
-    };
-}
-
-#[test]
-fn api_can_use_all_types_from_module_merkle_tree() {
-    use bitcoin_primitives::merkle_tree::{
-        TxMerkleNodeDecoder, TxMerkleNodeDecoderError, TxMerkleNodeEncoder,
-    };
-}
-
-#[test]
-fn api_can_use_all_types_from_module_transaction() {
-    use bitcoin_primitives::transaction::{
-        OutPointDecoder, OutPointDecoderError, OutPointEncoder, TransactionDecoder,
-        TransactionDecoderError, TransactionEncoder, TxInDecoder, TxInDecoderError, TxInEncoder,
-        TxOutDecoder, TxOutDecoderError, TxOutEncoder, VersionDecoder, VersionDecoderError,
-        VersionEncoder,
-    };
-}
-
-#[test]
-fn api_can_use_all_types_from_module_witness() {
-    use bitcoin_primitives::witness::{WitnessDecoder, WitnessDecoderError, WitnessEncoder};
-}
-
-// `Debug` representation is never empty (C-DEBUG-NONEMPTY).
-#[test]
-fn api_all_non_error_types_have_non_empty_debug() {
+fn c_debug_nonempty() {
     macro_rules! check_debug {
         ($($t:expr);* $(;)?) => {
             $(
@@ -386,8 +286,9 @@ fn api_all_non_error_types_have_non_empty_debug() {
     };
 }
 
+/// C-SEND-SYNC: Tests that all public types implement `Send` + `Sync`.
 #[test]
-fn all_types_implement_send_sync() {
+fn c_send_sync() {
     fn assert_send<T: Send>() {}
     fn assert_sync<T: Sync>() {}
 
@@ -402,8 +303,47 @@ fn all_types_implement_send_sync() {
     assert_sync::<Errors>();
 }
 
+/// C-OBJECT: Tests that traits are object-safe where appropriate.
 #[test]
-fn regression_default() {
+fn c_object() {
+    // If this builds then traits are dyn compatible.
+    struct Traits {
+        // These traits are explicitly not dyn compatible.
+        // a: Box<dyn block::Validation>,
+    }
+}
+
+/// C-GOOD-ERR: Tests that all public error types implement Display.
+#[test]
+fn c_good_err_display() {
+    use core::fmt;
+
+    fn assert_display<T: fmt::Display>() {}
+
+    assert_display::<transaction::ParseOutPointError>();
+    assert_display::<relative::error::DisabledLockTimeError>();
+    assert_display::<relative::error::IsSatisfiedByError>();
+    assert_display::<relative::error::IsSatisfiedByHeightError>();
+    assert_display::<relative::error::IsSatisfiedByTimeError>();
+    assert_display::<script::RedeemScriptSizeError>();
+    assert_display::<script::WitnessScriptSizeError>();
+}
+
+/// C-SERDE: Tests that serde traits are implemented where expected.
+#[test]
+#[cfg(feature = "serde")]
+fn c_serde() {
+    fn assert_serde<T: serde::Serialize + for<'de> serde::Deserialize<'de>>() {}
+
+    assert_serde::<block::Version>();
+    assert_serde::<transaction::Version>();
+    assert_serde::<OutPoint>();
+    assert_serde::<Witness>();
+}
+
+/// P-DEFAULT-CHANGE: Tests regression for Default implementation values.
+#[test]
+fn p_default_change() {
     let got: Default = Default::default();
     let want = Default {
         a: block::Version::NO_SOFT_FORK_SIGNALLING,
@@ -423,11 +363,9 @@ fn regression_default() {
     assert_eq!(got, want);
 }
 
+/// P-DECODERS: Tests that decoders implement a constructor method.
 #[test]
-fn decoders_implement_default() { let _ = Decoders::default(); }
-
-#[test]
-fn decoders_implement_new() {
+fn p_decoders_implement_new() {
     let _ = block::BlockDecoder::new();
     let _ = block::BlockHashDecoder::new();
     let _ = block::HeaderDecoder::new();
@@ -443,6 +381,112 @@ fn decoders_implement_new() {
     let _ = witness::WitnessDecoder::new();
 }
 
+/// P-CONSISTENT-EXPORTS: Tests that units modules can be used from the crate root.
 #[test]
-// The only trait in this crate is `block::Validation` and it is not dyn compatible.
-fn dyn_compatible() {}
+fn p_consistent_exports_units_modules() {
+    use bitcoin_primitives::{amount, block, fee_rate, locktime, weight};
+}
+
+/// P-CONSISTENT-EXPORTS: Tests that units type aliases can be used from the crate root.
+#[test]
+fn p_consistent_exports_units_types() {
+    use bitcoin_primitives::{
+        Amount, BlockHeight, BlockHeightInterval, BlockMtp, BlockMtpInterval, BlockTime, FeeRate,
+        NumOpResult, Sequence, SignedAmount, Weight,
+    };
+}
+
+/// P-CONSISTENT-EXPORTS: Tests that all units types can be imported from the `amount` module.
+#[test]
+fn p_consistent_exports_units_amount() {
+    use bitcoin_primitives::amount::{
+        Amount, Denomination, Display, OutOfRangeError, ParseAmountError, ParseDenominationError,
+        ParseError, SignedAmount,
+    };
+}
+
+/// P-CONSISTENT-EXPORTS: Tests that all units types can be imported from the `amount::error` module.
+#[test]
+fn p_consistent_exports_units_amount_error() {
+    use bitcoin_primitives::amount::error::{
+        InputTooLargeError, InvalidCharacterError, MissingDenominationError, MissingDigitsError,
+        OutOfRangeError, ParseAmountError, ParseDenominationError, ParseError,
+        PossiblyConfusingDenominationError, TooPreciseError, UnknownDenominationError,
+    };
+}
+
+/// P-CONSISTENT-EXPORTS: Tests that modules can be used from the crate root.
+#[test]
+fn p_consistent_exports_crate_modules() {
+    use bitcoin_primitives::{
+        amount, block, fee_rate, locktime, merkle_tree, parse_int, pow, result, script, sequence,
+        time, transaction, weight, witness,
+    };
+}
+
+/// P-CONSISTENT-EXPORTS: Tests that type aliases can be used from the crate root.
+#[test]
+fn p_consistent_exports_crate_types() {
+    use bitcoin_primitives::{
+        Block, BlockChecked, BlockHash, BlockHeader, BlockUnchecked, BlockValidation, BlockVersion,
+        CompactTarget, OutPoint, RedeemScript, RedeemScriptBuf, ScriptPubKey, ScriptPubKeyBuf,
+        ScriptSig, ScriptSigBuf, Sequence, TapScript, TapScriptBuf, Transaction,
+        TransactionVersion, TxIn, TxOut, Txid, Witness, WitnessCommitment, WitnessScript,
+        WitnessScriptBuf, Wtxid,
+    };
+}
+
+/// P-CONSISTENT-EXPORTS: Tests that all types can be imported from the `locktime` module.
+#[test]
+fn p_consistent_exports_locktime() {
+    use bitcoin_primitives::locktime::relative::error::{
+        DisabledLockTimeError, InvalidHeightError, InvalidTimeError,
+    };
+    use bitcoin_primitives::locktime::relative::LockTime;
+    use bitcoin_primitives::locktime::{absolute, relative};
+}
+
+/// P-CONSISTENT-EXPORTS: Tests that all types can be imported from the `script` module.
+#[test]
+fn p_consistent_exports_script() {
+    use bitcoin_primitives::script::{
+        RedeemScriptSizeError, ScriptBufDecoder, ScriptBufDecoderError, ScriptEncoder, ScriptHash,
+        ScriptPubKey, ScriptPubKeyBuf, ScriptSig, ScriptSigBuf, WScriptHash,
+        WitnessScriptSizeError,
+    };
+}
+
+/// P-CONSISTENT-EXPORTS: Tests that all types can be imported from the `block` module.
+#[test]
+fn p_consistent_exports_block() {
+    use bitcoin_primitives::block::{
+        BlockDecoder, BlockDecoderError, BlockEncoder, BlockHashDecoder, BlockHashDecoderError,
+        BlockHashEncoder, HeaderDecoder, HeaderEncoder, VersionDecoder, VersionDecoderError,
+        VersionEncoder,
+    };
+}
+
+/// P-CONSISTENT-EXPORTS: Tests that all types can be imported from the `merkle_tree` module.
+#[test]
+fn p_consistent_exports_merkle_tree() {
+    use bitcoin_primitives::merkle_tree::{
+        TxMerkleNodeDecoder, TxMerkleNodeDecoderError, TxMerkleNodeEncoder,
+    };
+}
+
+/// P-CONSISTENT-EXPORTS: Tests that all types can be imported from the `transaction` module.
+#[test]
+fn p_consistent_exports_transaction() {
+    use bitcoin_primitives::transaction::{
+        OutPointDecoder, OutPointDecoderError, OutPointEncoder, TransactionDecoder,
+        TransactionDecoderError, TransactionEncoder, TxInDecoder, TxInDecoderError, TxInEncoder,
+        TxOutDecoder, TxOutDecoderError, TxOutEncoder, VersionDecoder, VersionDecoderError,
+        VersionEncoder,
+    };
+}
+
+/// P-CONSISTENT-EXPORTS: Tests that all types can be imported from the `witness` module.
+#[test]
+fn p_consistent_exports_witness() {
+    use bitcoin_primitives::witness::{WitnessDecoder, WitnessDecoderError, WitnessEncoder};
+}

--- a/units/tests/api.rs
+++ b/units/tests/api.rs
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! Test the API surface of `units`.
+//! Test the API surface (not functionality) of `bitcoin-units`.
 //!
-//! The point of these tests is to check the API surface as opposed to test the API functionality.
-//!
-//! ref: <https://rust-lang.github.io/api-guidelines/about.html>
+//! See [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/about.html) and the [rust-bitcoin policies](../../docs/policy.md).
 
 #![allow(dead_code)]
 #![allow(unused_imports)]
@@ -165,7 +163,7 @@ struct Errors {
 }
 
 /// A struct that includes all public decoder types.
-#[derive(Default)] // All decoders implement `Default`.
+#[derive(Default)] // All decoders implement `Default` (P-DECODERS).
 #[cfg(feature = "encoding")]
 struct Decoders {
     a: amount::AmountDecoder,
@@ -188,127 +186,9 @@ struct DecoderErrors {
     e: time::BlockTimeDecoderError,
 }
 
+/// C-DEBUG-NONEMPTY: Tests that all public non-error types have non-empty Debug.
 #[test]
-fn api_can_use_modules_from_crate_root() {
-    use bitcoin_units::{
-        amount, block, fee_rate, locktime, parse_int, pow, result, sequence, time, weight,
-    };
-}
-
-#[test]
-fn api_can_use_types_from_crate_root() {
-    use bitcoin_units::{
-        Amount, BlockHeight, BlockHeightInterval, BlockMtp, BlockMtpInterval, BlockTime,
-        CompactTarget, FeeRate, NumOpResult, Sequence, SignedAmount, Weight,
-    };
-}
-
-#[test]
-fn api_can_use_all_types_from_module_amount() {
-    use bitcoin_units::amount::{
-        Amount, Denomination, Display, OutOfRangeError, ParseAmountError, ParseDenominationError,
-        ParseError, SignedAmount,
-    };
-    #[cfg(feature = "encoding")]
-    use bitcoin_units::amount::{AmountDecoder, AmountDecoderError, AmountEncoder};
-}
-
-#[test]
-fn api_can_use_all_types_from_module_amount_error() {
-    use bitcoin_units::amount::error::{
-        BadPositionError, InputTooLargeError, InvalidCharacterError, MissingDenominationError,
-        MissingDigitsError, OutOfRangeError, ParseAmountError, ParseDenominationError, ParseError,
-        PossiblyConfusingDenominationError, TooPreciseError, UnknownDenominationError,
-    };
-}
-
-#[test]
-fn api_can_use_all_types_from_module_block() {
-    use bitcoin_units::block::{
-        BlockHeight, BlockHeightInterval, BlockMtp, BlockMtpInterval, TooBigForRelativeHeightError,
-    };
-    #[cfg(feature = "encoding")]
-    use bitcoin_units::block::{BlockHeightDecoder, BlockHeightDecoderError, BlockHeightEncoder};
-}
-
-#[test]
-fn api_can_use_all_types_from_module_sequence() {
-    use bitcoin_units::sequence::Sequence;
-    #[cfg(feature = "encoding")]
-    use bitcoin_units::sequence::{SequenceDecoder, SequenceDecoderError, SequenceEncoder};
-}
-
-#[test]
-fn api_can_use_all_types_from_module_fee_rate() {
-    #[cfg(feature = "serde")]
-    use bitcoin_units::fee_rate::serde::OverflowError;
-    use bitcoin_units::fee_rate::FeeRate;
-}
-
-#[test]
-fn api_can_use_all_types_from_module_locktime_absolute() {
-    #[cfg(feature = "encoding")]
-    use bitcoin_units::locktime::absolute::error::LockTimeDecoderError as _;
-    use bitcoin_units::locktime::absolute::error::{
-        ConversionError as _, IncompatibleHeightError as _, IncompatibleTimeError as _,
-        ParseHeightError as _, ParseTimeError as _,
-    };
-    use bitcoin_units::locktime::absolute::{
-        ConversionError, IncompatibleHeightError, IncompatibleTimeError, ParseHeightError,
-        ParseTimeError,
-    };
-    #[cfg(feature = "encoding")]
-    use bitcoin_units::locktime::absolute::{
-        LockTimeDecoder, LockTimeDecoderError, LockTimeEncoder,
-    };
-}
-
-#[test]
-fn api_can_use_all_types_from_module_locktime_relative() {
-    use bitcoin_units::locktime::relative::error::{
-        DisabledLockTimeError as _, InvalidHeightError as _, InvalidTimeError as _,
-        TimeOverflowError as _,
-    };
-    use bitcoin_units::locktime::relative::{
-        DisabledLockTimeError, InvalidHeightError, InvalidTimeError, NumberOf512Seconds,
-        NumberOfBlocks, TimeOverflowError,
-    };
-}
-
-#[test]
-fn api_can_use_all_types_from_module_parse() {
-    use bitcoin_units::parse_int::{ParseIntError, PrefixedHexError, UnprefixedHexError};
-}
-
-#[test]
-fn api_can_use_all_types_from_module_result() {
-    use bitcoin_units::result::{MathOp, NumOpError, NumOpResult};
-}
-
-#[test]
-fn api_can_use_all_types_from_module_pow() {
-    use bitcoin_units::pow::CompactTarget;
-    #[cfg(feature = "encoding")]
-    use bitcoin_units::pow::{
-        CompactTargetDecoder, CompactTargetDecoderError, CompactTargetEncoder,
-    };
-}
-
-#[test]
-fn api_can_use_all_types_from_module_time() {
-    use bitcoin_units::time::BlockTime;
-    #[cfg(feature = "encoding")]
-    use bitcoin_units::time::{BlockTimeDecoder, BlockTimeDecoderError, BlockTimeEncoder};
-}
-
-#[test]
-fn api_can_use_all_types_from_module_weight() {
-    use bitcoin_units::weight::Weight;
-}
-
-// `Debug` representation is never empty (C-DEBUG-NONEMPTY).
-#[test]
-fn api_all_non_error_types_have_non_empty_debug() {
+fn c_debug_nonempty() {
     let t = Types::new();
 
     let debug = format!("{:?}", t.a.a);
@@ -356,6 +236,82 @@ fn api_all_non_error_types_have_non_empty_debug() {
     assert!(!debug.is_empty());
 }
 
+/// C-SEND-SYNC: Tests that all public types implement `Send` + `Sync`.
+#[test]
+fn c_send_sync() {
+    fn assert_send<T: Send>() {}
+    fn assert_sync<T: Sync>() {}
+
+    //  Types are `Send` and `Sync` where possible (C-SEND-SYNC).
+    assert_send::<Types>();
+    assert_sync::<Types>();
+
+    // Error types should implement the Send and Sync traits (C-GOOD-ERR).
+    assert_send::<Errors>();
+    assert_sync::<Errors>();
+}
+
+/// C-GOOD-ERR: Tests that all public error types implement Display.
+#[test]
+fn c_good_err_display() {
+    use core::fmt;
+
+    fn assert_display<T: fmt::Display>() {}
+
+    assert_display::<amount::error::InputTooLargeError>();
+    assert_display::<amount::error::InvalidCharacterError>();
+    assert_display::<amount::error::MissingDenominationError>();
+    assert_display::<amount::error::MissingDigitsError>();
+    assert_display::<amount::error::OutOfRangeError>();
+    assert_display::<amount::error::ParseAmountError>();
+    assert_display::<amount::error::ParseDenominationError>();
+    assert_display::<amount::error::ParseError>();
+    assert_display::<amount::error::PossiblyConfusingDenominationError>();
+    assert_display::<amount::error::TooPreciseError>();
+    assert_display::<amount::error::UnknownDenominationError>();
+    assert_display::<block::TooBigForRelativeHeightError>();
+    #[cfg(feature = "serde")]
+    assert_display::<fee_rate::serde::OverflowError>();
+    assert_display::<locktime::absolute::ConversionError>();
+    assert_display::<locktime::absolute::ParseHeightError>();
+    assert_display::<locktime::absolute::ParseTimeError>();
+    assert_display::<locktime::relative::InvalidHeightError>();
+    assert_display::<locktime::relative::InvalidTimeError>();
+    assert_display::<locktime::relative::TimeOverflowError>();
+    assert_display::<parse_int::ParseIntError>();
+    assert_display::<parse_int::PrefixedHexError>();
+    assert_display::<parse_int::UnprefixedHexError>();
+    #[cfg(feature = "encoding")]
+    assert_display::<pow::CompactTargetDecoderError>();
+    assert_display::<result::NumOpError>();
+}
+
+/// C-OBJECT: Tests that traits are object-safe where appropriate.
+#[test]
+fn c_object() {
+    // If this builds then traits are dyn compatible.
+    struct Traits {
+        // These traits are explicitly not dyn compatible.
+        // b: Box<dyn amount::serde::SerdeAmount>,
+        // c: Box<dyn amount::serde::SerdeAmountForOpt>,
+        // d: Box<dyn parse::Integer>, // Because of core::num::ParseIntError
+    }
+}
+
+/// C-SERDE: Tests that serde traits are implemented where expected.
+#[test]
+#[cfg(feature = "serde")]
+fn c_serde() {
+    fn assert_serde<T: serde::Serialize + for<'de> serde::Deserialize<'de>>() {}
+
+    assert_serde::<BlockHeight>();
+    assert_serde::<BlockHeightInterval>();
+    assert_serde::<BlockMtp>();
+    assert_serde::<BlockMtpInterval>();
+    assert_serde::<Weight>();
+    assert_serde::<Sequence>();
+}
+
 macro_rules! assert_format_matches {
     ($type:expr, $num:expr) => {
         let got = format!("{:o}", $type);
@@ -375,8 +331,10 @@ macro_rules! assert_format_matches {
         assert_eq!(got, want);
     };
 }
+
+/// C-NEWTYPE: Newtype wrappers format identically to their inner types, maintaining transparency.
 #[test]
-fn api_all_wrapper_types_fmt_as_inner() {
+fn c_newtype_transparent_format() {
     // Confirm that for a set of pseudo-random numbers, formatting is equivalent to the inner value
     let mut rand_num = 10;
     for _ in 0..50 {
@@ -412,22 +370,141 @@ fn api_all_wrapper_types_fmt_as_inner() {
     }
 }
 
+/// P-CONSISTENT-EXPORTS: Tests that modules are exported from the crate root.
 #[test]
-fn all_types_implement_send_sync() {
-    fn assert_send<T: Send>() {}
-    fn assert_sync<T: Sync>() {}
-
-    //  Types are `Send` and `Sync` where possible (C-SEND-SYNC).
-    assert_send::<Types>();
-    assert_sync::<Types>();
-
-    // Error types should implement the Send and Sync traits (C-GOOD-ERR).
-    assert_send::<Errors>();
-    assert_sync::<Errors>();
+fn p_consistent_exports_crate_modules() {
+    use bitcoin_units::{
+        amount, block, fee_rate, locktime, parse_int, pow, result, sequence, time, weight,
+    };
 }
 
+/// P-CONSISTENT-EXPORTS: Tests that type aliases are exported from the crate root.
 #[test]
-fn regression_default() {
+fn p_consistent_exports_crate_types() {
+    use bitcoin_units::{
+        Amount, BlockHeight, BlockHeightInterval, BlockMtp, BlockMtpInterval, BlockTime,
+        CompactTarget, FeeRate, NumOpResult, Sequence, SignedAmount, Weight,
+    };
+}
+
+/// P-CONSISTENT-EXPORTS: Tests that all types can be imported from the `amount` module.
+#[test]
+fn p_consistent_exports_amount() {
+    use bitcoin_units::amount::{
+        Amount, Denomination, Display, OutOfRangeError, ParseAmountError, ParseDenominationError,
+        ParseError, SignedAmount,
+    };
+    #[cfg(feature = "encoding")]
+    use bitcoin_units::amount::{AmountDecoder, AmountDecoderError, AmountEncoder};
+}
+
+/// P-CONSISTENT-EXPORTS: Tests that all types can be imported from the `amount::error` module.
+#[test]
+fn p_consistent_exports_amount_error() {
+    use bitcoin_units::amount::error::{
+        BadPositionError, InputTooLargeError, InvalidCharacterError, MissingDenominationError,
+        MissingDigitsError, OutOfRangeError, ParseAmountError, ParseDenominationError, ParseError,
+        PossiblyConfusingDenominationError, TooPreciseError, UnknownDenominationError,
+    };
+}
+
+/// P-CONSISTENT-EXPORTS: Tests that all types can be imported from the `block` module.
+#[test]
+fn p_consistent_exports_block() {
+    use bitcoin_units::block::{
+        BlockHeight, BlockHeightInterval, BlockMtp, BlockMtpInterval, TooBigForRelativeHeightError,
+    };
+    #[cfg(feature = "encoding")]
+    use bitcoin_units::block::{BlockHeightDecoder, BlockHeightDecoderError, BlockHeightEncoder};
+}
+
+/// P-CONSISTENT-EXPORTS: Tests that all types can be imported from the `sequence` module.
+#[test]
+fn p_consistent_exports_sequence() {
+    use bitcoin_units::sequence::Sequence;
+    #[cfg(feature = "encoding")]
+    use bitcoin_units::sequence::{SequenceDecoder, SequenceDecoderError, SequenceEncoder};
+}
+
+/// P-CONSISTENT-EXPORTS: Tests that all types can be imported from the `fee_rate` module.
+#[test]
+fn p_consistent_exports_fee_rate() {
+    #[cfg(feature = "serde")]
+    use bitcoin_units::fee_rate::serde::OverflowError;
+    use bitcoin_units::fee_rate::FeeRate;
+}
+
+/// P-CONSISTENT-EXPORTS: Tests that all types can be imported from the `locktime::absolute` module.
+#[test]
+fn p_consistent_exports_locktime_absolute() {
+    #[cfg(feature = "encoding")]
+    use bitcoin_units::locktime::absolute::error::LockTimeDecoderError as _;
+    use bitcoin_units::locktime::absolute::error::{
+        ConversionError as _, IncompatibleHeightError as _, IncompatibleTimeError as _,
+        ParseHeightError as _, ParseTimeError as _,
+    };
+    use bitcoin_units::locktime::absolute::{
+        ConversionError, IncompatibleHeightError, IncompatibleTimeError, ParseHeightError,
+        ParseTimeError,
+    };
+    #[cfg(feature = "encoding")]
+    use bitcoin_units::locktime::absolute::{
+        LockTimeDecoder, LockTimeDecoderError, LockTimeEncoder,
+    };
+}
+
+/// P-CONSISTENT-EXPORTS: Tests that all types can be imported from the `locktime::relative` module.
+#[test]
+fn p_consistent_exports_locktime_relative() {
+    use bitcoin_units::locktime::relative::error::{
+        DisabledLockTimeError as _, InvalidHeightError as _, InvalidTimeError as _,
+        TimeOverflowError as _,
+    };
+    use bitcoin_units::locktime::relative::{
+        DisabledLockTimeError, InvalidHeightError, InvalidTimeError, NumberOf512Seconds,
+        NumberOfBlocks, TimeOverflowError,
+    };
+}
+
+/// P-CONSISTENT-EXPORTS: Tests that all types can be imported from the `parse_int` module.
+#[test]
+fn p_consistent_exports_parse() {
+    use bitcoin_units::parse_int::{ParseIntError, PrefixedHexError, UnprefixedHexError};
+}
+
+/// P-CONSISTENT-EXPORTS: Tests that all types can be imported from the `result` module.
+#[test]
+fn p_consistent_exports_result() {
+    use bitcoin_units::result::{MathOp, NumOpError, NumOpResult};
+}
+
+/// P-CONSISTENT-EXPORTS: Tests that all types can be imported from the `pow` module.
+#[test]
+fn p_consistent_exports_pow() {
+    use bitcoin_units::pow::CompactTarget;
+    #[cfg(feature = "encoding")]
+    use bitcoin_units::pow::{
+        CompactTargetDecoder, CompactTargetDecoderError, CompactTargetEncoder,
+    };
+}
+
+/// P-CONSISTENT-EXPORTS: Tests that all types can be imported from the `time` module.
+#[test]
+fn p_consistent_exports_time() {
+    use bitcoin_units::time::BlockTime;
+    #[cfg(feature = "encoding")]
+    use bitcoin_units::time::{BlockTimeDecoder, BlockTimeDecoderError, BlockTimeEncoder};
+}
+
+/// P-CONSISTENT-EXPORTS: Tests that all types can be imported from the `weight` module.
+#[test]
+fn p_consistent_exports_weight() {
+    use bitcoin_units::weight::Weight;
+}
+
+/// P-DEFAULT-CHANGE: Tests regression for Default implementation values.
+#[test]
+fn p_default_change() {
     let got: Default = Default::default();
     let want = Default {
         a: Amount::ZERO,
@@ -441,24 +518,10 @@ fn regression_default() {
     assert_eq!(got, want);
 }
 
-#[test]
-fn dyn_compatible() {
-    // If this builds then traits are dyn compatible.
-    struct Traits {
-        // These traits are explicitly not dyn compatible.
-        // b: Box<dyn amount::serde::SerdeAmount>,
-        // c: Box<dyn amount::serde::SerdeAmountForOpt>,
-        // d: Box<dyn parse::Integer>, // Because of core::num::ParseIntError
-    }
-}
-
+/// P-DECODERS: Tests that decoders implement a constructor method.
 #[test]
 #[cfg(feature = "encoding")]
-fn decoders_implement_default() { let _ = Decoders::default(); }
-
-#[test]
-#[cfg(feature = "encoding")]
-fn decoders_implement_new() {
+fn p_decoders_implement_new() {
     let _ = amount::AmountDecoder::new();
     let _ = block::BlockHeightDecoder::new();
     let _ = locktime::absolute::LockTimeDecoder::new();


### PR DESCRIPTION
In the first commit I document 5 rust-bitcoin policies, which I give a `P-*` name similar style to the `C-*` rust API guidelines. In the following six commits I standardize a package to the new convention where each test covers a `C-*` convention or a `P-*` policy. Conventions are tested before policies. No tests were removed, but some were extended with `C-SERDE` and `P-ARBITRARY` tests.

I am hoping the consistency makes it easier for us and LLMs to spot gaps, and the 1:1 names make it easy to look up why we are testing something.

Closes #6291 