### PR TITLE
Automated weekly update to rustc (to nightly-2026-07-17) on 0.32.xxx

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["bitcoin", "hashes", "io", "units", "base58"]
 resolver = "2"
 
 [workspace.metadata.rbmt.toolchains]
-nightly = "nightly-2026-03-27"
+nightly = "nightly-2026-07-17"
 stable = "1.91.1"
 
 # Patch secp256k1's dependency on bitcoin_hashes to use our local workspace version.


### PR DESCRIPTION
Automated update to Cargo.toml workspace metadata by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action