### PR TITLE
units: Simplify checked_* ops and serde Option<T> serialization

### DIFF
--- a/units/src/amount/serde.rs
+++ b/units/src/amount/serde.rs
@@ -94,7 +94,7 @@ pub mod as_sat {
         use core::fmt;
         use core::marker::PhantomData;
 
-        use serde::{de, Deserializer, Serializer};
+        use serde::{de, Deserializer, Serialize, Serializer};
 
         use crate::SignedAmount;
 
@@ -104,13 +104,7 @@ pub mod as_sat {
         where
             A: Into<SignedAmount> + Copy,
         {
-            match *a {
-                Some(a) => {
-                    let amount: SignedAmount = a.into();
-                    s.serialize_some(&amount.to_sat())
-                }
-                None => s.serialize_none(),
-            }
+            a.map(Into::into).map(SignedAmount::to_sat).serialize(s)
         }
 
         pub fn deserialize<'d, A, D: Deserializer<'d>>(d: D) -> Result<Option<A>, D::Error>
@@ -171,10 +165,7 @@ pub mod as_sat {
         where
             A: Into<SignedAmount> + Copy,
         {
-            s.collect_seq(a.iter().map(|amount| {
-                let signed_amount: SignedAmount = (*amount).into();
-                signed_amount.to_sat()
-            }))
+            s.collect_seq(a.iter().map(|&amount| amount.into()).map(SignedAmount::to_sat))
         }
 
         pub fn deserialize<'d, A, D: Deserializer<'d>>(d: D) -> Result<Vec<A>, D::Error>
@@ -272,11 +263,8 @@ pub mod as_btc {
         where
             A: Into<SignedAmount> + Copy,
         {
-            match *a {
-                Some(a) => {
-                    let amount: SignedAmount = a.into();
-                    f64::serialize(&amount.to_float_in(Denomination::Bitcoin), s)
-                }
+            match a.map(Into::into).map(|amt| amt.to_float_in(Denomination::Bitcoin)) {
+                Some(a) => f64::serialize(&a, s),
                 None => s.serialize_none(),
             }
         }
@@ -441,11 +429,8 @@ pub mod as_str {
         where
             A: Into<SignedAmount> + Copy,
         {
-            match *a {
-                Some(a) => {
-                    let amount: SignedAmount = a.into();
-                    str::serialize(&amount.to_string_in(Denomination::Bitcoin), s)
-                }
+            match a.map(Into::into).map(|amt| amt.to_string_in(Denomination::Bitcoin)) {
+                Some(a) => str::serialize(&a, s),
                 None => s.serialize_none(),
             }
         }

--- a/units/src/amount/signed.rs
+++ b/units/src/amount/signed.rs
@@ -434,14 +434,9 @@ impl SignedAmount {
     #[inline]
     #[must_use]
     pub const fn checked_add(self, rhs: Self) -> Option<Self> {
-        // No `map()` in const context.
-        match self.to_sat().checked_add(rhs.to_sat()) {
-            Some(res) => match Self::from_sat(res) {
-                Ok(amount) => Some(amount),
-                Err(_) => None,
-            },
-            None => None,
-        }
+        let Some(sat) = self.to_sat().checked_add(rhs.to_sat()) else { return None };
+        let Ok(amount) = Self::from_sat(sat) else { return None };
+        Some(amount)
     }
 
     /// Checked subtraction.
@@ -451,14 +446,9 @@ impl SignedAmount {
     #[inline]
     #[must_use]
     pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
-        // No `map()` in const context.
-        match self.to_sat().checked_sub(rhs.to_sat()) {
-            Some(res) => match Self::from_sat(res) {
-                Ok(amount) => Some(amount),
-                Err(_) => None,
-            },
-            None => None,
-        }
+        let Some(sat) = self.to_sat().checked_sub(rhs.to_sat()) else { return None };
+        let Ok(amount) = Self::from_sat(sat) else { return None };
+        Some(amount)
     }
 
     /// Checked multiplication.
@@ -468,14 +458,9 @@ impl SignedAmount {
     #[inline]
     #[must_use]
     pub const fn checked_mul(self, rhs: i64) -> Option<Self> {
-        // No `map()` in const context.
-        match self.to_sat().checked_mul(rhs) {
-            Some(res) => match Self::from_sat(res) {
-                Ok(amount) => Some(amount),
-                Err(_) => None,
-            },
-            None => None,
-        }
+        let Some(sat) = self.to_sat().checked_mul(rhs) else { return None };
+        let Ok(amount) = Self::from_sat(sat) else { return None };
+        Some(amount)
     }
 
     /// Checked integer division.
@@ -486,14 +471,9 @@ impl SignedAmount {
     #[inline]
     #[must_use]
     pub const fn checked_div(self, rhs: i64) -> Option<Self> {
-        // No `map()` in const context.
-        match self.to_sat().checked_div(rhs) {
-            Some(res) => match Self::from_sat(res) {
-                Ok(amount) => Some(amount),
-                Err(_) => None, // Unreachable because of checked_div above.
-            },
-            None => None,
-        }
+        let Some(sat) = self.to_sat().checked_div(rhs) else { return None };
+        let Ok(amount) = Self::from_sat(sat) else { return None };
+        Some(amount)
     }
 
     /// Checked remainder.
@@ -502,14 +482,9 @@ impl SignedAmount {
     #[inline]
     #[must_use]
     pub const fn checked_rem(self, rhs: i64) -> Option<Self> {
-        // No `map()` in const context.
-        match self.to_sat().checked_rem(rhs) {
-            Some(res) => match Self::from_sat(res) {
-                Ok(amount) => Some(amount),
-                Err(_) => None, // Unreachable because of checked_rem above.
-            },
-            None => None,
-        }
+        let Some(sat) = self.to_sat().checked_rem(rhs) else { return None };
+        let Ok(amount) = Self::from_sat(sat) else { return None };
+        Some(amount)
     }
 
     /// Subtraction that doesn't allow negative [`SignedAmount`]s.

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -383,12 +383,9 @@ impl Amount {
     #[inline]
     #[must_use]
     pub const fn checked_add(self, rhs: Self) -> Option<Self> {
-        // No `map()` in const context.
         // Unchecked add ok, adding two values less than `MAX_MONEY` cannot overflow an `i64`.
-        match Self::from_sat(self.to_sat() + rhs.to_sat()) {
-            Ok(amount) => Some(amount),
-            Err(_) => None,
-        }
+        let Ok(amount) = Self::from_sat(self.to_sat() + rhs.to_sat()) else { return None };
+        Some(amount)
     }
 
     /// Checked subtraction.
@@ -397,14 +394,9 @@ impl Amount {
     #[inline]
     #[must_use]
     pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
-        // No `map()` in const context.
-        match self.to_sat().checked_sub(rhs.to_sat()) {
-            Some(res) => match Self::from_sat(res) {
-                Ok(amount) => Some(amount),
-                Err(_) => None, // Unreachable because of checked_sub above.
-            },
-            None => None,
-        }
+        let Some(sat) = self.to_sat().checked_sub(rhs.to_sat()) else { return None };
+        let Ok(amount) = Self::from_sat(sat) else { return None };
+        Some(amount)
     }
 
     /// Checked multiplication.
@@ -413,14 +405,9 @@ impl Amount {
     #[inline]
     #[must_use]
     pub const fn checked_mul(self, rhs: u64) -> Option<Self> {
-        // No `map()` in const context.
-        match self.to_sat().checked_mul(rhs) {
-            Some(res) => match Self::from_sat(res) {
-                Ok(amount) => Some(amount),
-                Err(_) => None,
-            },
-            None => None,
-        }
+        let Some(sat) = self.to_sat().checked_mul(rhs) else { return None };
+        let Ok(amount) = Self::from_sat(sat) else { return None };
+        Some(amount)
     }
 
     /// Checked integer division.
@@ -431,14 +418,9 @@ impl Amount {
     #[inline]
     #[must_use]
     pub const fn checked_div(self, rhs: u64) -> Option<Self> {
-        // No `map()` in const context.
-        match self.to_sat().checked_div(rhs) {
-            Some(res) => match Self::from_sat(res) {
-                Ok(amount) => Some(amount),
-                Err(_) => None, // Unreachable because of checked_div above.
-            },
-            None => None,
-        }
+        let Some(sat) = self.to_sat().checked_div(rhs) else { return None };
+        let Ok(amount) = Self::from_sat(sat) else { return None };
+        Some(amount)
     }
 
     /// Checked remainder.
@@ -447,14 +429,9 @@ impl Amount {
     #[inline]
     #[must_use]
     pub const fn checked_rem(self, rhs: u64) -> Option<Self> {
-        // No `map()` in const context.
-        match self.to_sat().checked_rem(rhs) {
-            Some(res) => match Self::from_sat(res) {
-                Ok(amount) => Some(amount),
-                Err(_) => None, // Unreachable because of checked_rem above.
-            },
-            None => None,
-        }
+        let Some(sat) = self.to_sat().checked_rem(rhs) else { return None };
+        let Ok(amount) = Self::from_sat(sat) else { return None };
+        Some(amount)
     }
 
     /// Converts to a signed amount.

--- a/units/src/fee_rate/mod.rs
+++ b/units/src/fee_rate/mod.rs
@@ -144,11 +144,8 @@ impl FeeRate {
     #[inline]
     #[must_use]
     pub const fn checked_mul(self, rhs: u64) -> Option<Self> {
-        // No `map()` in const context.
-        match self.to_sat_per_mvb().checked_mul(rhs) {
-            Some(res) => Some(Self::from_sat_per_mvb(res)),
-            None => None,
-        }
+        let Some(sat_mvb) = self.to_sat_per_mvb().checked_mul(rhs) else { return None };
+        Some(Self::from_sat_per_mvb(sat_mvb))
     }
 
     /// Checked division.
@@ -157,11 +154,8 @@ impl FeeRate {
     #[inline]
     #[must_use]
     pub const fn checked_div(self, rhs: u64) -> Option<Self> {
-        // No `map()` in const context.
-        match self.to_sat_per_mvb().checked_div(rhs) {
-            Some(res) => Some(Self::from_sat_per_mvb(res)),
-            None => None,
-        }
+        let Some(sat_mvb) = self.to_sat_per_mvb().checked_div(rhs) else { return None };
+        Some(Self::from_sat_per_mvb(sat_mvb))
     }
 
     /// Checked addition.
@@ -170,11 +164,10 @@ impl FeeRate {
     #[inline]
     #[must_use]
     pub const fn checked_add(self, rhs: Self) -> Option<Self> {
-        // No `map()` in const context.
-        match self.to_sat_per_mvb().checked_add(rhs.to_sat_per_mvb()) {
-            Some(res) => Some(Self::from_sat_per_mvb(res)),
-            None => None,
-        }
+        let Some(sat_mvb) = self.to_sat_per_mvb().checked_add(rhs.to_sat_per_mvb()) else {
+            return None;
+        };
+        Some(Self::from_sat_per_mvb(sat_mvb))
     }
 
     /// Checked subtraction.
@@ -183,11 +176,10 @@ impl FeeRate {
     #[inline]
     #[must_use]
     pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
-        // No `map()` in const context.
-        match self.to_sat_per_mvb().checked_sub(rhs.to_sat_per_mvb()) {
-            Some(res) => Some(Self::from_sat_per_mvb(res)),
-            None => None,
-        }
+        let Some(sat_mvb) = self.to_sat_per_mvb().checked_sub(rhs.to_sat_per_mvb()) else {
+            return None;
+        };
+        Some(Self::from_sat_per_mvb(sat_mvb))
     }
 
     /// Calculates the fee by multiplying this fee rate by weight.

--- a/units/src/fee_rate/serde.rs
+++ b/units/src/fee_rate/serde.rs
@@ -57,17 +57,14 @@ pub mod as_sat_per_kwu_floor {
 
         use core::fmt;
 
-        use serde::{de, Deserializer, Serializer};
+        use serde::{de, Deserializer, Serialize, Serializer};
 
         use crate::FeeRate;
 
         #[inline]
         #[allow(clippy::ref_option)] // API forced by serde.
         pub fn serialize<S: Serializer>(f: &Option<FeeRate>, s: S) -> Result<S::Ok, S::Error> {
-            match *f {
-                Some(f) => s.serialize_some(&f.to_sat_per_kwu_floor()),
-                None => s.serialize_none(),
-            }
+            f.map(FeeRate::to_sat_per_kwu_floor).serialize(s)
         }
 
         pub fn deserialize<'d, D: Deserializer<'d>>(d: D) -> Result<Option<FeeRate>, D::Error> {
@@ -184,17 +181,14 @@ pub mod as_sat_per_vb_floor {
 
         use core::fmt;
 
-        use serde::{de, Deserializer, Serializer};
+        use serde::{de, Deserializer, Serialize, Serializer};
 
         use crate::fee_rate::FeeRate;
 
         #[inline]
         #[allow(clippy::ref_option)] // API forced by serde.
         pub fn serialize<S: Serializer>(f: &Option<FeeRate>, s: S) -> Result<S::Ok, S::Error> {
-            match *f {
-                Some(f) => s.serialize_some(&f.to_sat_per_vb_floor()),
-                None => s.serialize_none(),
-            }
+            f.map(FeeRate::to_sat_per_vb_floor).serialize(s)
         }
 
         pub fn deserialize<'d, D: Deserializer<'d>>(d: D) -> Result<Option<FeeRate>, D::Error> {
@@ -312,17 +306,14 @@ pub mod as_sat_per_vb_ceil {
 
         use core::fmt;
 
-        use serde::{de, Deserializer, Serializer};
+        use serde::{de, Deserializer, Serialize, Serializer};
 
         use crate::fee_rate::FeeRate;
 
         #[inline]
         #[allow(clippy::ref_option)] // API forced by serde.
         pub fn serialize<S: Serializer>(f: &Option<FeeRate>, s: S) -> Result<S::Ok, S::Error> {
-            match *f {
-                Some(f) => s.serialize_some(&f.to_sat_per_vb_ceil()),
-                None => s.serialize_none(),
-            }
+            f.map(FeeRate::to_sat_per_vb_ceil).serialize(s)
         }
 
         pub fn deserialize<'d, D: Deserializer<'d>>(d: D) -> Result<Option<FeeRate>, D::Error> {

--- a/units/src/weight.rs
+++ b/units/src/weight.rs
@@ -65,21 +65,15 @@ impl Weight {
     /// Constructs a new [`Weight`] from kilo weight units returning [`None`] if an overflow occurred.
     #[inline]
     pub const fn from_kwu(wu: u64) -> Option<Self> {
-        // No `map()` in const context.
-        match wu.checked_mul(1000) {
-            Some(wu) => Some(Self::from_wu(wu)),
-            None => None,
-        }
+        let Some(wu) = wu.checked_mul(1000) else { return None };
+        Some(Self::from_wu(wu))
     }
 
     /// Constructs a new [`Weight`] from virtual bytes, returning [`None`] if an overflow occurred.
     #[inline]
     pub const fn from_vb(vb: u64) -> Option<Self> {
-        // No `map()` in const context.
-        match vb.checked_mul(Self::WITNESS_SCALE_FACTOR) {
-            Some(wu) => Some(Self::from_wu(wu)),
-            None => None,
-        }
+        let Some(wu) = vb.checked_mul(Self::WITNESS_SCALE_FACTOR) else { return None };
+        Some(Self::from_wu(wu))
     }
 
     /// Constructs a new [`Weight`] from virtual bytes without an overflow check.
@@ -138,11 +132,8 @@ impl Weight {
     #[inline]
     #[must_use]
     pub const fn checked_add(self, rhs: Self) -> Option<Self> {
-        // No `map()` in const context.
-        match self.to_wu().checked_add(rhs.to_wu()) {
-            Some(wu) => Some(Self::from_wu(wu)),
-            None => None,
-        }
+        let Some(wu) = self.to_wu().checked_add(rhs.to_wu()) else { return None };
+        Some(Self::from_wu(wu))
     }
 
     /// Checked subtraction.
@@ -151,11 +142,8 @@ impl Weight {
     #[inline]
     #[must_use]
     pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
-        // No `map()` in const context.
-        match self.to_wu().checked_sub(rhs.to_wu()) {
-            Some(wu) => Some(Self::from_wu(wu)),
-            None => None,
-        }
+        let Some(wu) = self.to_wu().checked_sub(rhs.to_wu()) else { return None };
+        Some(Self::from_wu(wu))
     }
 
     /// Checked multiplication.
@@ -164,11 +152,8 @@ impl Weight {
     #[inline]
     #[must_use]
     pub const fn checked_mul(self, rhs: u64) -> Option<Self> {
-        // No `map()` in const context.
-        match self.to_wu().checked_mul(rhs) {
-            Some(wu) => Some(Self::from_wu(wu)),
-            None => None,
-        }
+        let Some(wu) = self.to_wu().checked_mul(rhs) else { return None };
+        Some(Self::from_wu(wu))
     }
 
     /// Checked division.
@@ -177,11 +162,8 @@ impl Weight {
     #[inline]
     #[must_use]
     pub const fn checked_div(self, rhs: u64) -> Option<Self> {
-        // No `map()` in const context.
-        match self.to_wu().checked_div(rhs) {
-            Some(wu) => Some(Self::from_wu(wu)),
-            None => None,
-        }
+        let Some(wu) = self.to_wu().checked_div(rhs) else { return None };
+        Some(Self::from_wu(wu))
     }
 
     /// Checked fee rate multiplication.


### PR DESCRIPTION
- Patch 1: Improves Option<T> control flow using `let-else` in const `checked_*` functions.
- Patch 2:  Uses Option combinators in `amount` and `fee_rate` serde modules in place of deref and match statements.