### PR TITLE
units: Fix off-by-one error in satisfied by height

### DIFF
--- a/units/src/locktime/absolute/mod.rs
+++ b/units/src/locktime/absolute/mod.rs
@@ -574,8 +574,9 @@ impl Height {
     #[inline]
     pub fn is_satisfied_by(self, height: Self) -> bool {
         // Use u64 so that there can be no overflow.
+        // The next block will have a height chain tip + 1
         let next_block_height = u64::from(height.to_u32()) + 1;
-        u64::from(self.to_u32()) <= next_block_height
+        u64::from(self.to_u32()) < next_block_height
     }
 }
 
@@ -1035,14 +1036,14 @@ mod tests {
     fn height_is_satisfied_by() {
         let chain_tip = Height::from_u32(100).unwrap();
 
-        // lock is satisfied if transaction can go in the next block (height <= chain_tip + 1).
-        let locktime = Height::from_u32(100).unwrap();
+        // lock is satisfied if transaction can go in the next block (height < chain_tip + 1).
+        let locktime = Height::from_u32(99).unwrap();
         assert!(locktime.is_satisfied_by(chain_tip));
-        let locktime = Height::from_u32(101).unwrap();
+        let locktime = Height::from_u32(100).unwrap();
         assert!(locktime.is_satisfied_by(chain_tip));
 
         // It is not satisfied if the lock height is after the next block.
-        let locktime = Height::from_u32(102).unwrap();
+        let locktime = Height::from_u32(101).unwrap();
         assert!(!locktime.is_satisfied_by(chain_tip));
     }
 

--- a/units/src/locktime/relative/mod.rs
+++ b/units/src/locktime/relative/mod.rs
@@ -440,17 +440,9 @@ impl NumberOfBlocks {
         chain_tip: crate::BlockHeight,
         utxo_mined_at: crate::BlockHeight,
     ) -> Result<bool, InvalidHeightError> {
-        match chain_tip.checked_sub(utxo_mined_at) {
-            Some(diff) => {
-                if diff.to_u32() == u32::MAX {
-                    // Weird but ok none the less - protects against overflow below.
-                    return Ok(true);
-                }
-                // +1 because the next block will have height 1 higher than `chain_tip`.
-                Ok(u32::from(self.to_height()) <= diff.to_u32() + 1)
-            }
-            None => Err(InvalidHeightError { chain_tip, utxo_mined_at }),
-        }
+        chain_tip.checked_sub(utxo_mined_at)
+            .ok_or(InvalidHeightError { chain_tip, utxo_mined_at })
+            .map(|diff| u32::from(self.to_height()) <= diff.to_u32())
     }
 }
 
@@ -857,7 +849,7 @@ mod tests {
         let lock1 = LockTime::Blocks(NumberOfBlocks::from(10));
         assert!(lock1.is_satisfied_by(chain_height, chain_mtp, utxo_height, utxo_mtp).unwrap());
 
-        let lock2 = LockTime::Blocks(NumberOfBlocks::from(21));
+        let lock2 = LockTime::Blocks(NumberOfBlocks::from(20));
         assert!(lock2.is_satisfied_by(chain_height, chain_mtp, utxo_height, utxo_mtp).unwrap());
 
         let lock3 = LockTime::Time(NumberOf512Seconds::from_512_second_intervals(10));
@@ -1018,12 +1010,12 @@ mod tests {
         let height_lock = LockTime::Blocks(NumberOfBlocks(10));
 
         // Test case 1: Satisfaction (current_height >= utxo_height + required)
-        let chain_state1 = BlockHeight::from_u32(89);
+        let chain_state1 = BlockHeight::from_u32(90);
         let utxo_state1 = BlockHeight::from_u32(80);
         assert!(height_lock.is_satisfied_by_height(chain_state1, utxo_state1).unwrap());
 
         // Test case 2: Not satisfied (current_height < utxo_height + required)
-        let chain_state2 = BlockHeight::from_u32(88);
+        let chain_state2 = BlockHeight::from_u32(89);
         let utxo_state2 = BlockHeight::from_u32(80);
         assert!(!height_lock.is_satisfied_by_height(chain_state2, utxo_state2).unwrap());
 


### PR DESCRIPTION
In #6384 we fixed an off-by-one error in the satisfied by time logic. I swear I checked the satisfied by height code at that time but apparently not. While reviewing #6581 I saw the same bug.

The problem is we both +1 to height _and_ use `<=`. Either of these on its own is correct since we know the next block has height one higher and the check is 'lower than the height of the next block'.

The unit boundary test was wrong too.