### PR TITLE
primitives: Rename `witness_version` errors

### DIFF
--- a/bitcoin/src/address/error.rs
+++ b/bitcoin/src/address/error.rs
@@ -19,7 +19,7 @@ pub enum FromScriptError {
     /// A witness program error.
     WitnessProgram(witness_program::Error),
     /// A witness version construction error.
-    WitnessVersion(witness_version::TryFromError),
+    WitnessVersion(witness_version::InvalidWitnessVersionError),
 }
 
 impl From<Infallible> for FromScriptError {
@@ -51,8 +51,8 @@ impl From<witness_program::Error> for FromScriptError {
     fn from(e: witness_program::Error) -> Self { Self::WitnessProgram(e) }
 }
 
-impl From<witness_version::TryFromError> for FromScriptError {
-    fn from(e: witness_version::TryFromError) -> Self { Self::WitnessVersion(e) }
+impl From<witness_version::InvalidWitnessVersionError> for FromScriptError {
+    fn from(e: witness_version::InvalidWitnessVersionError) -> Self { Self::WitnessVersion(e) }
 }
 
 /// Address type is either invalid or not supported in rust-bitcoin.
@@ -176,7 +176,7 @@ pub enum Bech32Error {
     /// Parse SegWit Bech32 error.
     ParseBech32(ParseBech32Error),
     /// A witness version conversion/parsing error.
-    WitnessVersion(witness_version::TryFromError),
+    WitnessVersion(witness_version::InvalidWitnessVersionError),
     /// A witness program error.
     WitnessProgram(witness_program::Error),
     /// Tried to parse an unknown HRP.
@@ -211,8 +211,8 @@ impl std::error::Error for Bech32Error {
     }
 }
 
-impl From<witness_version::TryFromError> for Bech32Error {
-    fn from(e: witness_version::TryFromError) -> Self { Self::WitnessVersion(e) }
+impl From<witness_version::InvalidWitnessVersionError> for Bech32Error {
+    fn from(e: witness_version::InvalidWitnessVersionError) -> Self { Self::WitnessVersion(e) }
 }
 
 impl From<witness_program::Error> for Bech32Error {

--- a/bitcoin/src/blockdata/script/witness_version.rs
+++ b/bitcoin/src/blockdata/script/witness_version.rs
@@ -11,7 +11,7 @@ use crate::script::Instruction;
 
 #[rustfmt::skip]            // Keep public re-exports separate.
 #[doc(no_inline)]
-pub use self::error::{FromStrError, TryFromInstructionError, TryFromError};
+pub use self::error::{ParseWitnessVersionError, TryFromInstructionError, InvalidWitnessVersionError};
 
 #[doc(inline)]
 pub use primitives::witness_version::WitnessVersion;
@@ -37,7 +37,7 @@ pub mod error {
 
     #[rustfmt::skip]            // Keep public re-exports separate.
     #[doc(no_inline)]
-    pub use primitives::witness_version::error::{FromStrError, TryFromError};
+    pub use primitives::witness_version::error::{ParseWitnessVersionError, InvalidWitnessVersionError};
 
     /// Error attempting to create a [`WitnessVersion`] from an [`Instruction`]
     ///
@@ -47,7 +47,7 @@ pub mod error {
     #[non_exhaustive]
     pub enum TryFromInstructionError {
         /// Cannot convert OP to a witness version.
-        TryFrom(TryFromError),
+        TryFrom(InvalidWitnessVersionError),
         /// Cannot create a witness version from non-zero data push.
         DataPush,
     }
@@ -76,7 +76,7 @@ pub mod error {
         }
     }
 
-    impl From<TryFromError> for TryFromInstructionError {
-        fn from(e: TryFromError) -> Self { Self::TryFrom(e) }
+    impl From<InvalidWitnessVersionError> for TryFromInstructionError {
+        fn from(e: InvalidWitnessVersionError) -> Self { Self::TryFrom(e) }
     }
 }

--- a/primitives/api/all-features.txt
+++ b/primitives/api/all-features.txt
@@ -1786,7 +1786,7 @@ impl core::convert::From<bitcoin_primitives::witness_version::WitnessVersion> fo
 impl core::convert::From<u8> for bitcoin_primitives::opcodes::Opcode
   pub fn bitcoin_primitives::opcodes::Opcode::from(b: u8) -> Self [impl: impl core::convert::From<u8> for bitcoin_primitives::opcodes::Opcode]
 impl core::convert::TryFrom<bitcoin_primitives::opcodes::Opcode> for bitcoin_primitives::witness_version::WitnessVersion
-  pub type bitcoin_primitives::witness_version::WitnessVersion::Error = bitcoin_primitives::witness_version::error::TryFromError [impl: impl core::convert::TryFrom<bitcoin_primitives::opcodes::Opcode> for bitcoin_primitives::witness_version::WitnessVersion]
+  pub type bitcoin_primitives::witness_version::WitnessVersion::Error = bitcoin_primitives::witness_version::error::InvalidWitnessVersionError [impl: impl core::convert::TryFrom<bitcoin_primitives::opcodes::Opcode> for bitcoin_primitives::witness_version::WitnessVersion]
   pub fn bitcoin_primitives::witness_version::WitnessVersion::try_from(opcode: bitcoin_primitives::opcodes::Opcode) -> core::result::Result<Self, Self::Error> [impl: impl core::convert::TryFrom<bitcoin_primitives::opcodes::Opcode> for bitcoin_primitives::witness_version::WitnessVersion]
 impl core::fmt::Debug for bitcoin_primitives::opcodes::Opcode
   pub fn bitcoin_primitives::opcodes::Opcode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::opcodes::Opcode]
@@ -6374,148 +6374,148 @@ impl<T> core::convert::From<T> for bitcoin_primitives::witness::WitnessEncoder<'
   pub fn bitcoin_primitives::witness::WitnessEncoder<'e>::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::witness::WitnessEncoder<'e>]
 pub mod bitcoin_primitives::witness_version
 pub mod bitcoin_primitives::witness_version::error
-#[non_exhaustive] pub enum bitcoin_primitives::witness_version::error::FromStrError
-pub bitcoin_primitives::witness_version::error::FromStrError::Invalid(bitcoin_primitives::witness_version::error::TryFromError)
-pub bitcoin_primitives::witness_version::error::FromStrError::Unparsable(bitcoin_units::parse_int::error::ParseIntError)
-impl core::clone::Clone for bitcoin_primitives::witness_version::error::FromStrError
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::clone(&self) -> bitcoin_primitives::witness_version::error::FromStrError [impl: impl core::clone::Clone for bitcoin_primitives::witness_version::error::FromStrError]
-impl core::cmp::Eq for bitcoin_primitives::witness_version::error::FromStrError
-impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::FromStrError
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::eq(&self, other: &bitcoin_primitives::witness_version::error::FromStrError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::FromStrError]
-impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::witness_version::error::FromStrError
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::witness_version::error::FromStrError]
-impl core::error::Error for bitcoin_primitives::witness_version::error::FromStrError
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)> [impl: impl core::error::Error for bitcoin_primitives::witness_version::error::FromStrError]
-impl core::fmt::Debug for bitcoin_primitives::witness_version::error::FromStrError
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::witness_version::error::FromStrError]
-impl core::fmt::Display for bitcoin_primitives::witness_version::error::FromStrError
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::witness_version::error::FromStrError]
-impl core::marker::StructuralPartialEq for bitcoin_primitives::witness_version::error::FromStrError
-impl core::marker::Freeze for bitcoin_primitives::witness_version::error::FromStrError
-impl core::marker::Send for bitcoin_primitives::witness_version::error::FromStrError
-impl core::marker::Sync for bitcoin_primitives::witness_version::error::FromStrError
-impl core::marker::Unpin for bitcoin_primitives::witness_version::error::FromStrError
-impl core::marker::UnsafeUnpin for bitcoin_primitives::witness_version::error::FromStrError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness_version::error::FromStrError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness_version::error::FromStrError
-impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::From<T>
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::From<T>]
-impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::Into<T>
-  pub type bitcoin_primitives::witness_version::error::FromStrError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::Into<T>]
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::Into<T>]
-impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::TryFrom<T>
-  pub type bitcoin_primitives::witness_version::error::FromStrError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::TryFrom<T>]
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::TryFrom<T>]
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::FromStrError where T: core::clone::Clone
-  pub type bitcoin_primitives::witness_version::error::FromStrError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::FromStrError where T: core::clone::Clone]
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::FromStrError where T: core::clone::Clone]
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::FromStrError where T: core::clone::Clone]
-impl<T> alloc::string::ToString for bitcoin_primitives::witness_version::error::FromStrError where T: core::fmt::Display + ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_primitives::witness_version::error::FromStrError where T: core::fmt::Display + ?core::marker::Sized]
-impl<T> core::any::Any for bitcoin_primitives::witness_version::error::FromStrError where T: 'static + ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::witness_version::error::FromStrError where T: 'static + ?core::marker::Sized]
-impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::FromStrError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::FromStrError where T: ?core::marker::Sized]
-impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::FromStrError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::FromStrError where T: ?core::marker::Sized]
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::FromStrError where T: core::clone::Clone
-  pub unsafe fn bitcoin_primitives::witness_version::error::FromStrError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::FromStrError where T: core::clone::Clone]
-impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::FromStrError
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::FromStrError]
-pub struct bitcoin_primitives::witness_version::error::TryFromError
-impl bitcoin_primitives::witness_version::error::TryFromError
-pub fn bitcoin_primitives::witness_version::error::TryFromError::invalid_version(&self) -> u8
-impl core::clone::Clone for bitcoin_primitives::witness_version::error::TryFromError
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::clone(&self) -> bitcoin_primitives::witness_version::error::TryFromError [impl: impl core::clone::Clone for bitcoin_primitives::witness_version::error::TryFromError]
-impl core::cmp::Eq for bitcoin_primitives::witness_version::error::TryFromError
-impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::TryFromError
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::eq(&self, other: &bitcoin_primitives::witness_version::error::TryFromError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::TryFromError]
-impl core::error::Error for bitcoin_primitives::witness_version::error::TryFromError
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)> [impl: impl core::error::Error for bitcoin_primitives::witness_version::error::TryFromError]
-impl core::fmt::Debug for bitcoin_primitives::witness_version::error::TryFromError
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::witness_version::error::TryFromError]
-impl core::fmt::Display for bitcoin_primitives::witness_version::error::TryFromError
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::witness_version::error::TryFromError]
-impl core::marker::StructuralPartialEq for bitcoin_primitives::witness_version::error::TryFromError
-impl core::marker::Freeze for bitcoin_primitives::witness_version::error::TryFromError
-impl core::marker::Send for bitcoin_primitives::witness_version::error::TryFromError
-impl core::marker::Sync for bitcoin_primitives::witness_version::error::TryFromError
-impl core::marker::Unpin for bitcoin_primitives::witness_version::error::TryFromError
-impl core::marker::UnsafeUnpin for bitcoin_primitives::witness_version::error::TryFromError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness_version::error::TryFromError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness_version::error::TryFromError
-impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::From<T>
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::From<T>]
-impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::Into<T>
-  pub type bitcoin_primitives::witness_version::error::TryFromError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::Into<T>]
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::Into<T>]
-impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::TryFrom<T>
-  pub type bitcoin_primitives::witness_version::error::TryFromError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::TryFrom<T>]
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::TryFrom<T>]
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::TryFromError where T: core::clone::Clone
-  pub type bitcoin_primitives::witness_version::error::TryFromError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::TryFromError where T: core::clone::Clone]
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::TryFromError where T: core::clone::Clone]
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::TryFromError where T: core::clone::Clone]
-impl<T> alloc::string::ToString for bitcoin_primitives::witness_version::error::TryFromError where T: core::fmt::Display + ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_primitives::witness_version::error::TryFromError where T: core::fmt::Display + ?core::marker::Sized]
-impl<T> core::any::Any for bitcoin_primitives::witness_version::error::TryFromError where T: 'static + ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::witness_version::error::TryFromError where T: 'static + ?core::marker::Sized]
-impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::TryFromError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::TryFromError where T: ?core::marker::Sized]
-impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::TryFromError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::TryFromError where T: ?core::marker::Sized]
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::TryFromError where T: core::clone::Clone
-  pub unsafe fn bitcoin_primitives::witness_version::error::TryFromError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::TryFromError where T: core::clone::Clone]
-impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::TryFromError
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::TryFromError]
-#[non_exhaustive] pub enum bitcoin_primitives::witness_version::FromStrError
-pub bitcoin_primitives::witness_version::FromStrError::Invalid(bitcoin_primitives::witness_version::error::TryFromError)
-pub bitcoin_primitives::witness_version::FromStrError::Unparsable(bitcoin_units::parse_int::error::ParseIntError)
-impl core::clone::Clone for bitcoin_primitives::witness_version::error::FromStrError
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::clone(&self) -> bitcoin_primitives::witness_version::error::FromStrError [impl: impl core::clone::Clone for bitcoin_primitives::witness_version::error::FromStrError]
-impl core::cmp::Eq for bitcoin_primitives::witness_version::error::FromStrError
-impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::FromStrError
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::eq(&self, other: &bitcoin_primitives::witness_version::error::FromStrError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::FromStrError]
-impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::witness_version::error::FromStrError
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::witness_version::error::FromStrError]
-impl core::error::Error for bitcoin_primitives::witness_version::error::FromStrError
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)> [impl: impl core::error::Error for bitcoin_primitives::witness_version::error::FromStrError]
-impl core::fmt::Debug for bitcoin_primitives::witness_version::error::FromStrError
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::witness_version::error::FromStrError]
-impl core::fmt::Display for bitcoin_primitives::witness_version::error::FromStrError
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::witness_version::error::FromStrError]
-impl core::marker::StructuralPartialEq for bitcoin_primitives::witness_version::error::FromStrError
-impl core::marker::Freeze for bitcoin_primitives::witness_version::error::FromStrError
-impl core::marker::Send for bitcoin_primitives::witness_version::error::FromStrError
-impl core::marker::Sync for bitcoin_primitives::witness_version::error::FromStrError
-impl core::marker::Unpin for bitcoin_primitives::witness_version::error::FromStrError
-impl core::marker::UnsafeUnpin for bitcoin_primitives::witness_version::error::FromStrError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness_version::error::FromStrError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness_version::error::FromStrError
-impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::From<T>
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::From<T>]
-impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::Into<T>
-  pub type bitcoin_primitives::witness_version::error::FromStrError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::Into<T>]
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::Into<T>]
-impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::TryFrom<T>
-  pub type bitcoin_primitives::witness_version::error::FromStrError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::TryFrom<T>]
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::TryFrom<T>]
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::FromStrError where T: core::clone::Clone
-  pub type bitcoin_primitives::witness_version::error::FromStrError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::FromStrError where T: core::clone::Clone]
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::FromStrError where T: core::clone::Clone]
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::FromStrError where T: core::clone::Clone]
-impl<T> alloc::string::ToString for bitcoin_primitives::witness_version::error::FromStrError where T: core::fmt::Display + ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_primitives::witness_version::error::FromStrError where T: core::fmt::Display + ?core::marker::Sized]
-impl<T> core::any::Any for bitcoin_primitives::witness_version::error::FromStrError where T: 'static + ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::witness_version::error::FromStrError where T: 'static + ?core::marker::Sized]
-impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::FromStrError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::FromStrError where T: ?core::marker::Sized]
-impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::FromStrError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::FromStrError where T: ?core::marker::Sized]
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::FromStrError where T: core::clone::Clone
-  pub unsafe fn bitcoin_primitives::witness_version::error::FromStrError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::FromStrError where T: core::clone::Clone]
-impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::FromStrError
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::FromStrError]
+#[non_exhaustive] pub enum bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+pub bitcoin_primitives::witness_version::error::ParseWitnessVersionError::Invalid(bitcoin_primitives::witness_version::error::InvalidWitnessVersionError)
+pub bitcoin_primitives::witness_version::error::ParseWitnessVersionError::Unparsable(bitcoin_units::parse_int::error::ParseIntError)
+impl core::clone::Clone for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::clone(&self) -> bitcoin_primitives::witness_version::error::ParseWitnessVersionError [impl: impl core::clone::Clone for bitcoin_primitives::witness_version::error::ParseWitnessVersionError]
+impl core::cmp::Eq for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::eq(&self, other: &bitcoin_primitives::witness_version::error::ParseWitnessVersionError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::ParseWitnessVersionError]
+impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError]
+impl core::error::Error for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)> [impl: impl core::error::Error for bitcoin_primitives::witness_version::error::ParseWitnessVersionError]
+impl core::fmt::Debug for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::witness_version::error::ParseWitnessVersionError]
+impl core::fmt::Display for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::witness_version::error::ParseWitnessVersionError]
+impl core::marker::StructuralPartialEq for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::marker::Freeze for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::marker::Send for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::marker::Sync for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::marker::Unpin for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::marker::UnsafeUnpin for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::From<T>
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::Into<T>
+  pub type bitcoin_primitives::witness_version::error::ParseWitnessVersionError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::Into<T>]
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::TryFrom<T>
+  pub type bitcoin_primitives::witness_version::error::ParseWitnessVersionError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::TryFrom<T>]
+impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: core::clone::Clone
+  pub type bitcoin_primitives::witness_version::error::ParseWitnessVersionError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: core::clone::Clone]
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: core::clone::Clone]
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: core::clone::Clone]
+impl<T> alloc::string::ToString for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: core::fmt::Display + ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: core::fmt::Display + ?core::marker::Sized]
+impl<T> core::any::Any for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: core::clone::Clone
+  pub unsafe fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError]
+pub struct bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::invalid_version(&self) -> u8
+impl core::clone::Clone for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::clone(&self) -> bitcoin_primitives::witness_version::error::InvalidWitnessVersionError [impl: impl core::clone::Clone for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError]
+impl core::cmp::Eq for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::eq(&self, other: &bitcoin_primitives::witness_version::error::InvalidWitnessVersionError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError]
+impl core::error::Error for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)> [impl: impl core::error::Error for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError]
+impl core::fmt::Debug for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError]
+impl core::fmt::Display for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError]
+impl core::marker::StructuralPartialEq for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::marker::Freeze for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::marker::Send for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::marker::Sync for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::marker::Unpin for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::marker::UnsafeUnpin for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::From<T>
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::Into<T>
+  pub type bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::Into<T>]
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::TryFrom<T>
+  pub type bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::TryFrom<T>]
+impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: core::clone::Clone
+  pub type bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: core::clone::Clone]
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: core::clone::Clone]
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: core::clone::Clone]
+impl<T> alloc::string::ToString for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: core::fmt::Display + ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: core::fmt::Display + ?core::marker::Sized]
+impl<T> core::any::Any for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: core::clone::Clone
+  pub unsafe fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError]
+#[non_exhaustive] pub enum bitcoin_primitives::witness_version::ParseWitnessVersionError
+pub bitcoin_primitives::witness_version::ParseWitnessVersionError::Invalid(bitcoin_primitives::witness_version::error::InvalidWitnessVersionError)
+pub bitcoin_primitives::witness_version::ParseWitnessVersionError::Unparsable(bitcoin_units::parse_int::error::ParseIntError)
+impl core::clone::Clone for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::clone(&self) -> bitcoin_primitives::witness_version::error::ParseWitnessVersionError [impl: impl core::clone::Clone for bitcoin_primitives::witness_version::error::ParseWitnessVersionError]
+impl core::cmp::Eq for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::eq(&self, other: &bitcoin_primitives::witness_version::error::ParseWitnessVersionError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::ParseWitnessVersionError]
+impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError]
+impl core::error::Error for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)> [impl: impl core::error::Error for bitcoin_primitives::witness_version::error::ParseWitnessVersionError]
+impl core::fmt::Debug for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::witness_version::error::ParseWitnessVersionError]
+impl core::fmt::Display for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::witness_version::error::ParseWitnessVersionError]
+impl core::marker::StructuralPartialEq for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::marker::Freeze for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::marker::Send for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::marker::Sync for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::marker::Unpin for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::marker::UnsafeUnpin for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::From<T>
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::Into<T>
+  pub type bitcoin_primitives::witness_version::error::ParseWitnessVersionError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::Into<T>]
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::TryFrom<T>
+  pub type bitcoin_primitives::witness_version::error::ParseWitnessVersionError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::TryFrom<T>]
+impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: core::clone::Clone
+  pub type bitcoin_primitives::witness_version::error::ParseWitnessVersionError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: core::clone::Clone]
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: core::clone::Clone]
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: core::clone::Clone]
+impl<T> alloc::string::ToString for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: core::fmt::Display + ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: core::fmt::Display + ?core::marker::Sized]
+impl<T> core::any::Any for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: core::clone::Clone
+  pub unsafe fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError]
 #[repr(u8)] pub enum bitcoin_primitives::witness_version::WitnessVersion
 pub bitcoin_primitives::witness_version::WitnessVersion::V0 = 0
 pub bitcoin_primitives::witness_version::WitnessVersion::V1 = 1
@@ -6548,10 +6548,10 @@ impl core::cmp::PartialOrd for bitcoin_primitives::witness_version::WitnessVersi
 impl core::convert::From<bitcoin_primitives::witness_version::WitnessVersion> for bitcoin_primitives::opcodes::Opcode
   pub fn bitcoin_primitives::opcodes::Opcode::from(version: bitcoin_primitives::witness_version::WitnessVersion) -> Self [impl: impl core::convert::From<bitcoin_primitives::witness_version::WitnessVersion> for bitcoin_primitives::opcodes::Opcode]
 impl core::convert::TryFrom<bitcoin_primitives::opcodes::Opcode> for bitcoin_primitives::witness_version::WitnessVersion
-  pub type bitcoin_primitives::witness_version::WitnessVersion::Error = bitcoin_primitives::witness_version::error::TryFromError [impl: impl core::convert::TryFrom<bitcoin_primitives::opcodes::Opcode> for bitcoin_primitives::witness_version::WitnessVersion]
+  pub type bitcoin_primitives::witness_version::WitnessVersion::Error = bitcoin_primitives::witness_version::error::InvalidWitnessVersionError [impl: impl core::convert::TryFrom<bitcoin_primitives::opcodes::Opcode> for bitcoin_primitives::witness_version::WitnessVersion]
   pub fn bitcoin_primitives::witness_version::WitnessVersion::try_from(opcode: bitcoin_primitives::opcodes::Opcode) -> core::result::Result<Self, Self::Error> [impl: impl core::convert::TryFrom<bitcoin_primitives::opcodes::Opcode> for bitcoin_primitives::witness_version::WitnessVersion]
 impl core::convert::TryFrom<u8> for bitcoin_primitives::witness_version::WitnessVersion
-  pub type bitcoin_primitives::witness_version::WitnessVersion::Error = bitcoin_primitives::witness_version::error::TryFromError [impl: impl core::convert::TryFrom<u8> for bitcoin_primitives::witness_version::WitnessVersion]
+  pub type bitcoin_primitives::witness_version::WitnessVersion::Error = bitcoin_primitives::witness_version::error::InvalidWitnessVersionError [impl: impl core::convert::TryFrom<u8> for bitcoin_primitives::witness_version::WitnessVersion]
   pub fn bitcoin_primitives::witness_version::WitnessVersion::try_from(no: u8) -> core::result::Result<Self, Self::Error> [impl: impl core::convert::TryFrom<u8> for bitcoin_primitives::witness_version::WitnessVersion]
 impl core::fmt::Debug for bitcoin_primitives::witness_version::WitnessVersion
   pub fn bitcoin_primitives::witness_version::WitnessVersion::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::witness_version::WitnessVersion]
@@ -6562,7 +6562,7 @@ impl core::hash::Hash for bitcoin_primitives::witness_version::WitnessVersion
 impl core::marker::Copy for bitcoin_primitives::witness_version::WitnessVersion
 impl core::marker::StructuralPartialEq for bitcoin_primitives::witness_version::WitnessVersion
 impl core::str::traits::FromStr for bitcoin_primitives::witness_version::WitnessVersion
-  pub type bitcoin_primitives::witness_version::WitnessVersion::Err = bitcoin_primitives::witness_version::error::FromStrError [impl: impl core::str::traits::FromStr for bitcoin_primitives::witness_version::WitnessVersion]
+  pub type bitcoin_primitives::witness_version::WitnessVersion::Err = bitcoin_primitives::witness_version::error::ParseWitnessVersionError [impl: impl core::str::traits::FromStr for bitcoin_primitives::witness_version::WitnessVersion]
   pub fn bitcoin_primitives::witness_version::WitnessVersion::from_str(s: &str) -> core::result::Result<Self, Self::Err> [impl: impl core::str::traits::FromStr for bitcoin_primitives::witness_version::WitnessVersion]
 impl core::marker::Freeze for bitcoin_primitives::witness_version::WitnessVersion
 impl core::marker::Send for bitcoin_primitives::witness_version::WitnessVersion
@@ -6595,52 +6595,52 @@ impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::Witn
   pub unsafe fn bitcoin_primitives::witness_version::WitnessVersion::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::WitnessVersion where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::WitnessVersion
   pub fn bitcoin_primitives::witness_version::WitnessVersion::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::WitnessVersion]
-pub struct bitcoin_primitives::witness_version::TryFromError
-impl bitcoin_primitives::witness_version::error::TryFromError
-pub fn bitcoin_primitives::witness_version::error::TryFromError::invalid_version(&self) -> u8
-impl core::clone::Clone for bitcoin_primitives::witness_version::error::TryFromError
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::clone(&self) -> bitcoin_primitives::witness_version::error::TryFromError [impl: impl core::clone::Clone for bitcoin_primitives::witness_version::error::TryFromError]
-impl core::cmp::Eq for bitcoin_primitives::witness_version::error::TryFromError
-impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::TryFromError
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::eq(&self, other: &bitcoin_primitives::witness_version::error::TryFromError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::TryFromError]
-impl core::error::Error for bitcoin_primitives::witness_version::error::TryFromError
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)> [impl: impl core::error::Error for bitcoin_primitives::witness_version::error::TryFromError]
-impl core::fmt::Debug for bitcoin_primitives::witness_version::error::TryFromError
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::witness_version::error::TryFromError]
-impl core::fmt::Display for bitcoin_primitives::witness_version::error::TryFromError
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::witness_version::error::TryFromError]
-impl core::marker::StructuralPartialEq for bitcoin_primitives::witness_version::error::TryFromError
-impl core::marker::Freeze for bitcoin_primitives::witness_version::error::TryFromError
-impl core::marker::Send for bitcoin_primitives::witness_version::error::TryFromError
-impl core::marker::Sync for bitcoin_primitives::witness_version::error::TryFromError
-impl core::marker::Unpin for bitcoin_primitives::witness_version::error::TryFromError
-impl core::marker::UnsafeUnpin for bitcoin_primitives::witness_version::error::TryFromError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness_version::error::TryFromError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness_version::error::TryFromError
-impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::From<T>
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::From<T>]
-impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::Into<T>
-  pub type bitcoin_primitives::witness_version::error::TryFromError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::Into<T>]
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::Into<T>]
-impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::TryFrom<T>
-  pub type bitcoin_primitives::witness_version::error::TryFromError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::TryFrom<T>]
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::TryFrom<T>]
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::TryFromError where T: core::clone::Clone
-  pub type bitcoin_primitives::witness_version::error::TryFromError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::TryFromError where T: core::clone::Clone]
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::TryFromError where T: core::clone::Clone]
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::TryFromError where T: core::clone::Clone]
-impl<T> alloc::string::ToString for bitcoin_primitives::witness_version::error::TryFromError where T: core::fmt::Display + ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_primitives::witness_version::error::TryFromError where T: core::fmt::Display + ?core::marker::Sized]
-impl<T> core::any::Any for bitcoin_primitives::witness_version::error::TryFromError where T: 'static + ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::witness_version::error::TryFromError where T: 'static + ?core::marker::Sized]
-impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::TryFromError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::TryFromError where T: ?core::marker::Sized]
-impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::TryFromError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::TryFromError where T: ?core::marker::Sized]
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::TryFromError where T: core::clone::Clone
-  pub unsafe fn bitcoin_primitives::witness_version::error::TryFromError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::TryFromError where T: core::clone::Clone]
-impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::TryFromError
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::TryFromError]
+pub struct bitcoin_primitives::witness_version::InvalidWitnessVersionError
+impl bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::invalid_version(&self) -> u8
+impl core::clone::Clone for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::clone(&self) -> bitcoin_primitives::witness_version::error::InvalidWitnessVersionError [impl: impl core::clone::Clone for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError]
+impl core::cmp::Eq for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::eq(&self, other: &bitcoin_primitives::witness_version::error::InvalidWitnessVersionError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError]
+impl core::error::Error for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)> [impl: impl core::error::Error for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError]
+impl core::fmt::Debug for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError]
+impl core::fmt::Display for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError]
+impl core::marker::StructuralPartialEq for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::marker::Freeze for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::marker::Send for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::marker::Sync for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::marker::Unpin for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::marker::UnsafeUnpin for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::From<T>
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::Into<T>
+  pub type bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::Into<T>]
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::TryFrom<T>
+  pub type bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::TryFrom<T>]
+impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: core::clone::Clone
+  pub type bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: core::clone::Clone]
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: core::clone::Clone]
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: core::clone::Clone]
+impl<T> alloc::string::ToString for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: core::fmt::Display + ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: core::fmt::Display + ?core::marker::Sized]
+impl<T> core::any::Any for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: core::clone::Clone
+  pub unsafe fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError]
 pub enum bitcoin_primitives::BlockChecked
 impl bitcoin_primitives::block::Validation for bitcoin_primitives::block::Checked
   pub const bitcoin_primitives::block::Checked::IS_CHECKED: bool [impl: impl bitcoin_primitives::block::Validation for bitcoin_primitives::block::Checked]

--- a/primitives/api/alloc-only.txt
+++ b/primitives/api/alloc-only.txt
@@ -1654,7 +1654,7 @@ impl core::convert::From<bitcoin_primitives::witness_version::WitnessVersion> fo
 impl core::convert::From<u8> for bitcoin_primitives::opcodes::Opcode
   pub fn bitcoin_primitives::opcodes::Opcode::from(b: u8) -> Self [impl: impl core::convert::From<u8> for bitcoin_primitives::opcodes::Opcode]
 impl core::convert::TryFrom<bitcoin_primitives::opcodes::Opcode> for bitcoin_primitives::witness_version::WitnessVersion
-  pub type bitcoin_primitives::witness_version::WitnessVersion::Error = bitcoin_primitives::witness_version::error::TryFromError [impl: impl core::convert::TryFrom<bitcoin_primitives::opcodes::Opcode> for bitcoin_primitives::witness_version::WitnessVersion]
+  pub type bitcoin_primitives::witness_version::WitnessVersion::Error = bitcoin_primitives::witness_version::error::InvalidWitnessVersionError [impl: impl core::convert::TryFrom<bitcoin_primitives::opcodes::Opcode> for bitcoin_primitives::witness_version::WitnessVersion]
   pub fn bitcoin_primitives::witness_version::WitnessVersion::try_from(opcode: bitcoin_primitives::opcodes::Opcode) -> core::result::Result<Self, Self::Error> [impl: impl core::convert::TryFrom<bitcoin_primitives::opcodes::Opcode> for bitcoin_primitives::witness_version::WitnessVersion]
 impl core::fmt::Debug for bitcoin_primitives::opcodes::Opcode
   pub fn bitcoin_primitives::opcodes::Opcode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::opcodes::Opcode]
@@ -5927,142 +5927,142 @@ impl<T> core::convert::From<T> for bitcoin_primitives::witness::WitnessEncoder<'
   pub fn bitcoin_primitives::witness::WitnessEncoder<'e>::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::witness::WitnessEncoder<'e>]
 pub mod bitcoin_primitives::witness_version
 pub mod bitcoin_primitives::witness_version::error
-#[non_exhaustive] pub enum bitcoin_primitives::witness_version::error::FromStrError
-pub bitcoin_primitives::witness_version::error::FromStrError::Invalid(bitcoin_primitives::witness_version::error::TryFromError)
-pub bitcoin_primitives::witness_version::error::FromStrError::Unparsable(bitcoin_units::parse_int::error::ParseIntError)
-impl core::clone::Clone for bitcoin_primitives::witness_version::error::FromStrError
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::clone(&self) -> bitcoin_primitives::witness_version::error::FromStrError [impl: impl core::clone::Clone for bitcoin_primitives::witness_version::error::FromStrError]
-impl core::cmp::Eq for bitcoin_primitives::witness_version::error::FromStrError
-impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::FromStrError
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::eq(&self, other: &bitcoin_primitives::witness_version::error::FromStrError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::FromStrError]
-impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::witness_version::error::FromStrError
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::witness_version::error::FromStrError]
-impl core::fmt::Debug for bitcoin_primitives::witness_version::error::FromStrError
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::witness_version::error::FromStrError]
-impl core::fmt::Display for bitcoin_primitives::witness_version::error::FromStrError
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::witness_version::error::FromStrError]
-impl core::marker::StructuralPartialEq for bitcoin_primitives::witness_version::error::FromStrError
-impl core::marker::Freeze for bitcoin_primitives::witness_version::error::FromStrError
-impl core::marker::Send for bitcoin_primitives::witness_version::error::FromStrError
-impl core::marker::Sync for bitcoin_primitives::witness_version::error::FromStrError
-impl core::marker::Unpin for bitcoin_primitives::witness_version::error::FromStrError
-impl core::marker::UnsafeUnpin for bitcoin_primitives::witness_version::error::FromStrError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness_version::error::FromStrError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness_version::error::FromStrError
-impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::From<T>
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::From<T>]
-impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::Into<T>
-  pub type bitcoin_primitives::witness_version::error::FromStrError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::Into<T>]
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::Into<T>]
-impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::TryFrom<T>
-  pub type bitcoin_primitives::witness_version::error::FromStrError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::TryFrom<T>]
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::TryFrom<T>]
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::FromStrError where T: core::clone::Clone
-  pub type bitcoin_primitives::witness_version::error::FromStrError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::FromStrError where T: core::clone::Clone]
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::FromStrError where T: core::clone::Clone]
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::FromStrError where T: core::clone::Clone]
-impl<T> alloc::string::ToString for bitcoin_primitives::witness_version::error::FromStrError where T: core::fmt::Display + ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_primitives::witness_version::error::FromStrError where T: core::fmt::Display + ?core::marker::Sized]
-impl<T> core::any::Any for bitcoin_primitives::witness_version::error::FromStrError where T: 'static + ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::witness_version::error::FromStrError where T: 'static + ?core::marker::Sized]
-impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::FromStrError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::FromStrError where T: ?core::marker::Sized]
-impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::FromStrError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::FromStrError where T: ?core::marker::Sized]
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::FromStrError where T: core::clone::Clone
-  pub unsafe fn bitcoin_primitives::witness_version::error::FromStrError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::FromStrError where T: core::clone::Clone]
-impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::FromStrError
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::FromStrError]
-pub struct bitcoin_primitives::witness_version::error::TryFromError
-impl bitcoin_primitives::witness_version::error::TryFromError
-pub fn bitcoin_primitives::witness_version::error::TryFromError::invalid_version(&self) -> u8
-impl core::clone::Clone for bitcoin_primitives::witness_version::error::TryFromError
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::clone(&self) -> bitcoin_primitives::witness_version::error::TryFromError [impl: impl core::clone::Clone for bitcoin_primitives::witness_version::error::TryFromError]
-impl core::cmp::Eq for bitcoin_primitives::witness_version::error::TryFromError
-impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::TryFromError
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::eq(&self, other: &bitcoin_primitives::witness_version::error::TryFromError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::TryFromError]
-impl core::fmt::Debug for bitcoin_primitives::witness_version::error::TryFromError
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::witness_version::error::TryFromError]
-impl core::fmt::Display for bitcoin_primitives::witness_version::error::TryFromError
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::witness_version::error::TryFromError]
-impl core::marker::StructuralPartialEq for bitcoin_primitives::witness_version::error::TryFromError
-impl core::marker::Freeze for bitcoin_primitives::witness_version::error::TryFromError
-impl core::marker::Send for bitcoin_primitives::witness_version::error::TryFromError
-impl core::marker::Sync for bitcoin_primitives::witness_version::error::TryFromError
-impl core::marker::Unpin for bitcoin_primitives::witness_version::error::TryFromError
-impl core::marker::UnsafeUnpin for bitcoin_primitives::witness_version::error::TryFromError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness_version::error::TryFromError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness_version::error::TryFromError
-impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::From<T>
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::From<T>]
-impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::Into<T>
-  pub type bitcoin_primitives::witness_version::error::TryFromError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::Into<T>]
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::Into<T>]
-impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::TryFrom<T>
-  pub type bitcoin_primitives::witness_version::error::TryFromError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::TryFrom<T>]
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::TryFrom<T>]
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::TryFromError where T: core::clone::Clone
-  pub type bitcoin_primitives::witness_version::error::TryFromError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::TryFromError where T: core::clone::Clone]
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::TryFromError where T: core::clone::Clone]
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::TryFromError where T: core::clone::Clone]
-impl<T> alloc::string::ToString for bitcoin_primitives::witness_version::error::TryFromError where T: core::fmt::Display + ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_primitives::witness_version::error::TryFromError where T: core::fmt::Display + ?core::marker::Sized]
-impl<T> core::any::Any for bitcoin_primitives::witness_version::error::TryFromError where T: 'static + ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::witness_version::error::TryFromError where T: 'static + ?core::marker::Sized]
-impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::TryFromError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::TryFromError where T: ?core::marker::Sized]
-impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::TryFromError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::TryFromError where T: ?core::marker::Sized]
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::TryFromError where T: core::clone::Clone
-  pub unsafe fn bitcoin_primitives::witness_version::error::TryFromError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::TryFromError where T: core::clone::Clone]
-impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::TryFromError
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::TryFromError]
-#[non_exhaustive] pub enum bitcoin_primitives::witness_version::FromStrError
-pub bitcoin_primitives::witness_version::FromStrError::Invalid(bitcoin_primitives::witness_version::error::TryFromError)
-pub bitcoin_primitives::witness_version::FromStrError::Unparsable(bitcoin_units::parse_int::error::ParseIntError)
-impl core::clone::Clone for bitcoin_primitives::witness_version::error::FromStrError
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::clone(&self) -> bitcoin_primitives::witness_version::error::FromStrError [impl: impl core::clone::Clone for bitcoin_primitives::witness_version::error::FromStrError]
-impl core::cmp::Eq for bitcoin_primitives::witness_version::error::FromStrError
-impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::FromStrError
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::eq(&self, other: &bitcoin_primitives::witness_version::error::FromStrError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::FromStrError]
-impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::witness_version::error::FromStrError
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::witness_version::error::FromStrError]
-impl core::fmt::Debug for bitcoin_primitives::witness_version::error::FromStrError
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::witness_version::error::FromStrError]
-impl core::fmt::Display for bitcoin_primitives::witness_version::error::FromStrError
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::witness_version::error::FromStrError]
-impl core::marker::StructuralPartialEq for bitcoin_primitives::witness_version::error::FromStrError
-impl core::marker::Freeze for bitcoin_primitives::witness_version::error::FromStrError
-impl core::marker::Send for bitcoin_primitives::witness_version::error::FromStrError
-impl core::marker::Sync for bitcoin_primitives::witness_version::error::FromStrError
-impl core::marker::Unpin for bitcoin_primitives::witness_version::error::FromStrError
-impl core::marker::UnsafeUnpin for bitcoin_primitives::witness_version::error::FromStrError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness_version::error::FromStrError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness_version::error::FromStrError
-impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::From<T>
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::From<T>]
-impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::Into<T>
-  pub type bitcoin_primitives::witness_version::error::FromStrError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::Into<T>]
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::Into<T>]
-impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::TryFrom<T>
-  pub type bitcoin_primitives::witness_version::error::FromStrError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::TryFrom<T>]
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::TryFrom<T>]
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::FromStrError where T: core::clone::Clone
-  pub type bitcoin_primitives::witness_version::error::FromStrError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::FromStrError where T: core::clone::Clone]
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::FromStrError where T: core::clone::Clone]
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::FromStrError where T: core::clone::Clone]
-impl<T> alloc::string::ToString for bitcoin_primitives::witness_version::error::FromStrError where T: core::fmt::Display + ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_primitives::witness_version::error::FromStrError where T: core::fmt::Display + ?core::marker::Sized]
-impl<T> core::any::Any for bitcoin_primitives::witness_version::error::FromStrError where T: 'static + ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::witness_version::error::FromStrError where T: 'static + ?core::marker::Sized]
-impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::FromStrError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::FromStrError where T: ?core::marker::Sized]
-impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::FromStrError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::FromStrError where T: ?core::marker::Sized]
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::FromStrError where T: core::clone::Clone
-  pub unsafe fn bitcoin_primitives::witness_version::error::FromStrError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::FromStrError where T: core::clone::Clone]
-impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::FromStrError
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::FromStrError]
+#[non_exhaustive] pub enum bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+pub bitcoin_primitives::witness_version::error::ParseWitnessVersionError::Invalid(bitcoin_primitives::witness_version::error::InvalidWitnessVersionError)
+pub bitcoin_primitives::witness_version::error::ParseWitnessVersionError::Unparsable(bitcoin_units::parse_int::error::ParseIntError)
+impl core::clone::Clone for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::clone(&self) -> bitcoin_primitives::witness_version::error::ParseWitnessVersionError [impl: impl core::clone::Clone for bitcoin_primitives::witness_version::error::ParseWitnessVersionError]
+impl core::cmp::Eq for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::eq(&self, other: &bitcoin_primitives::witness_version::error::ParseWitnessVersionError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::ParseWitnessVersionError]
+impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError]
+impl core::fmt::Debug for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::witness_version::error::ParseWitnessVersionError]
+impl core::fmt::Display for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::witness_version::error::ParseWitnessVersionError]
+impl core::marker::StructuralPartialEq for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::marker::Freeze for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::marker::Send for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::marker::Sync for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::marker::Unpin for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::marker::UnsafeUnpin for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::From<T>
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::Into<T>
+  pub type bitcoin_primitives::witness_version::error::ParseWitnessVersionError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::Into<T>]
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::TryFrom<T>
+  pub type bitcoin_primitives::witness_version::error::ParseWitnessVersionError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::TryFrom<T>]
+impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: core::clone::Clone
+  pub type bitcoin_primitives::witness_version::error::ParseWitnessVersionError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: core::clone::Clone]
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: core::clone::Clone]
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: core::clone::Clone]
+impl<T> alloc::string::ToString for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: core::fmt::Display + ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: core::fmt::Display + ?core::marker::Sized]
+impl<T> core::any::Any for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: core::clone::Clone
+  pub unsafe fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError]
+pub struct bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::invalid_version(&self) -> u8
+impl core::clone::Clone for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::clone(&self) -> bitcoin_primitives::witness_version::error::InvalidWitnessVersionError [impl: impl core::clone::Clone for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError]
+impl core::cmp::Eq for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::eq(&self, other: &bitcoin_primitives::witness_version::error::InvalidWitnessVersionError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError]
+impl core::fmt::Debug for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError]
+impl core::fmt::Display for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError]
+impl core::marker::StructuralPartialEq for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::marker::Freeze for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::marker::Send for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::marker::Sync for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::marker::Unpin for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::marker::UnsafeUnpin for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::From<T>
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::Into<T>
+  pub type bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::Into<T>]
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::TryFrom<T>
+  pub type bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::TryFrom<T>]
+impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: core::clone::Clone
+  pub type bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: core::clone::Clone]
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: core::clone::Clone]
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: core::clone::Clone]
+impl<T> alloc::string::ToString for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: core::fmt::Display + ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: core::fmt::Display + ?core::marker::Sized]
+impl<T> core::any::Any for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: core::clone::Clone
+  pub unsafe fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError]
+#[non_exhaustive] pub enum bitcoin_primitives::witness_version::ParseWitnessVersionError
+pub bitcoin_primitives::witness_version::ParseWitnessVersionError::Invalid(bitcoin_primitives::witness_version::error::InvalidWitnessVersionError)
+pub bitcoin_primitives::witness_version::ParseWitnessVersionError::Unparsable(bitcoin_units::parse_int::error::ParseIntError)
+impl core::clone::Clone for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::clone(&self) -> bitcoin_primitives::witness_version::error::ParseWitnessVersionError [impl: impl core::clone::Clone for bitcoin_primitives::witness_version::error::ParseWitnessVersionError]
+impl core::cmp::Eq for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::eq(&self, other: &bitcoin_primitives::witness_version::error::ParseWitnessVersionError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::ParseWitnessVersionError]
+impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError]
+impl core::fmt::Debug for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::witness_version::error::ParseWitnessVersionError]
+impl core::fmt::Display for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::witness_version::error::ParseWitnessVersionError]
+impl core::marker::StructuralPartialEq for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::marker::Freeze for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::marker::Send for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::marker::Sync for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::marker::Unpin for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::marker::UnsafeUnpin for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::From<T>
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::Into<T>
+  pub type bitcoin_primitives::witness_version::error::ParseWitnessVersionError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::Into<T>]
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::TryFrom<T>
+  pub type bitcoin_primitives::witness_version::error::ParseWitnessVersionError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::TryFrom<T>]
+impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: core::clone::Clone
+  pub type bitcoin_primitives::witness_version::error::ParseWitnessVersionError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: core::clone::Clone]
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: core::clone::Clone]
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: core::clone::Clone]
+impl<T> alloc::string::ToString for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: core::fmt::Display + ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: core::fmt::Display + ?core::marker::Sized]
+impl<T> core::any::Any for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: core::clone::Clone
+  pub unsafe fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError]
 #[repr(u8)] pub enum bitcoin_primitives::witness_version::WitnessVersion
 pub bitcoin_primitives::witness_version::WitnessVersion::V0 = 0
 pub bitcoin_primitives::witness_version::WitnessVersion::V1 = 1
@@ -6095,10 +6095,10 @@ impl core::cmp::PartialOrd for bitcoin_primitives::witness_version::WitnessVersi
 impl core::convert::From<bitcoin_primitives::witness_version::WitnessVersion> for bitcoin_primitives::opcodes::Opcode
   pub fn bitcoin_primitives::opcodes::Opcode::from(version: bitcoin_primitives::witness_version::WitnessVersion) -> Self [impl: impl core::convert::From<bitcoin_primitives::witness_version::WitnessVersion> for bitcoin_primitives::opcodes::Opcode]
 impl core::convert::TryFrom<bitcoin_primitives::opcodes::Opcode> for bitcoin_primitives::witness_version::WitnessVersion
-  pub type bitcoin_primitives::witness_version::WitnessVersion::Error = bitcoin_primitives::witness_version::error::TryFromError [impl: impl core::convert::TryFrom<bitcoin_primitives::opcodes::Opcode> for bitcoin_primitives::witness_version::WitnessVersion]
+  pub type bitcoin_primitives::witness_version::WitnessVersion::Error = bitcoin_primitives::witness_version::error::InvalidWitnessVersionError [impl: impl core::convert::TryFrom<bitcoin_primitives::opcodes::Opcode> for bitcoin_primitives::witness_version::WitnessVersion]
   pub fn bitcoin_primitives::witness_version::WitnessVersion::try_from(opcode: bitcoin_primitives::opcodes::Opcode) -> core::result::Result<Self, Self::Error> [impl: impl core::convert::TryFrom<bitcoin_primitives::opcodes::Opcode> for bitcoin_primitives::witness_version::WitnessVersion]
 impl core::convert::TryFrom<u8> for bitcoin_primitives::witness_version::WitnessVersion
-  pub type bitcoin_primitives::witness_version::WitnessVersion::Error = bitcoin_primitives::witness_version::error::TryFromError [impl: impl core::convert::TryFrom<u8> for bitcoin_primitives::witness_version::WitnessVersion]
+  pub type bitcoin_primitives::witness_version::WitnessVersion::Error = bitcoin_primitives::witness_version::error::InvalidWitnessVersionError [impl: impl core::convert::TryFrom<u8> for bitcoin_primitives::witness_version::WitnessVersion]
   pub fn bitcoin_primitives::witness_version::WitnessVersion::try_from(no: u8) -> core::result::Result<Self, Self::Error> [impl: impl core::convert::TryFrom<u8> for bitcoin_primitives::witness_version::WitnessVersion]
 impl core::fmt::Debug for bitcoin_primitives::witness_version::WitnessVersion
   pub fn bitcoin_primitives::witness_version::WitnessVersion::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::witness_version::WitnessVersion]
@@ -6109,7 +6109,7 @@ impl core::hash::Hash for bitcoin_primitives::witness_version::WitnessVersion
 impl core::marker::Copy for bitcoin_primitives::witness_version::WitnessVersion
 impl core::marker::StructuralPartialEq for bitcoin_primitives::witness_version::WitnessVersion
 impl core::str::traits::FromStr for bitcoin_primitives::witness_version::WitnessVersion
-  pub type bitcoin_primitives::witness_version::WitnessVersion::Err = bitcoin_primitives::witness_version::error::FromStrError [impl: impl core::str::traits::FromStr for bitcoin_primitives::witness_version::WitnessVersion]
+  pub type bitcoin_primitives::witness_version::WitnessVersion::Err = bitcoin_primitives::witness_version::error::ParseWitnessVersionError [impl: impl core::str::traits::FromStr for bitcoin_primitives::witness_version::WitnessVersion]
   pub fn bitcoin_primitives::witness_version::WitnessVersion::from_str(s: &str) -> core::result::Result<Self, Self::Err> [impl: impl core::str::traits::FromStr for bitcoin_primitives::witness_version::WitnessVersion]
 impl core::marker::Freeze for bitcoin_primitives::witness_version::WitnessVersion
 impl core::marker::Send for bitcoin_primitives::witness_version::WitnessVersion
@@ -6142,50 +6142,50 @@ impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::Witn
   pub unsafe fn bitcoin_primitives::witness_version::WitnessVersion::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::WitnessVersion where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::WitnessVersion
   pub fn bitcoin_primitives::witness_version::WitnessVersion::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::WitnessVersion]
-pub struct bitcoin_primitives::witness_version::TryFromError
-impl bitcoin_primitives::witness_version::error::TryFromError
-pub fn bitcoin_primitives::witness_version::error::TryFromError::invalid_version(&self) -> u8
-impl core::clone::Clone for bitcoin_primitives::witness_version::error::TryFromError
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::clone(&self) -> bitcoin_primitives::witness_version::error::TryFromError [impl: impl core::clone::Clone for bitcoin_primitives::witness_version::error::TryFromError]
-impl core::cmp::Eq for bitcoin_primitives::witness_version::error::TryFromError
-impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::TryFromError
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::eq(&self, other: &bitcoin_primitives::witness_version::error::TryFromError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::TryFromError]
-impl core::fmt::Debug for bitcoin_primitives::witness_version::error::TryFromError
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::witness_version::error::TryFromError]
-impl core::fmt::Display for bitcoin_primitives::witness_version::error::TryFromError
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::witness_version::error::TryFromError]
-impl core::marker::StructuralPartialEq for bitcoin_primitives::witness_version::error::TryFromError
-impl core::marker::Freeze for bitcoin_primitives::witness_version::error::TryFromError
-impl core::marker::Send for bitcoin_primitives::witness_version::error::TryFromError
-impl core::marker::Sync for bitcoin_primitives::witness_version::error::TryFromError
-impl core::marker::Unpin for bitcoin_primitives::witness_version::error::TryFromError
-impl core::marker::UnsafeUnpin for bitcoin_primitives::witness_version::error::TryFromError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness_version::error::TryFromError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness_version::error::TryFromError
-impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::From<T>
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::From<T>]
-impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::Into<T>
-  pub type bitcoin_primitives::witness_version::error::TryFromError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::Into<T>]
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::Into<T>]
-impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::TryFrom<T>
-  pub type bitcoin_primitives::witness_version::error::TryFromError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::TryFrom<T>]
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::TryFrom<T>]
-impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::TryFromError where T: core::clone::Clone
-  pub type bitcoin_primitives::witness_version::error::TryFromError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::TryFromError where T: core::clone::Clone]
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::TryFromError where T: core::clone::Clone]
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::TryFromError where T: core::clone::Clone]
-impl<T> alloc::string::ToString for bitcoin_primitives::witness_version::error::TryFromError where T: core::fmt::Display + ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_primitives::witness_version::error::TryFromError where T: core::fmt::Display + ?core::marker::Sized]
-impl<T> core::any::Any for bitcoin_primitives::witness_version::error::TryFromError where T: 'static + ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::witness_version::error::TryFromError where T: 'static + ?core::marker::Sized]
-impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::TryFromError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::TryFromError where T: ?core::marker::Sized]
-impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::TryFromError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::TryFromError where T: ?core::marker::Sized]
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::TryFromError where T: core::clone::Clone
-  pub unsafe fn bitcoin_primitives::witness_version::error::TryFromError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::TryFromError where T: core::clone::Clone]
-impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::TryFromError
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::TryFromError]
+pub struct bitcoin_primitives::witness_version::InvalidWitnessVersionError
+impl bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::invalid_version(&self) -> u8
+impl core::clone::Clone for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::clone(&self) -> bitcoin_primitives::witness_version::error::InvalidWitnessVersionError [impl: impl core::clone::Clone for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError]
+impl core::cmp::Eq for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::eq(&self, other: &bitcoin_primitives::witness_version::error::InvalidWitnessVersionError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError]
+impl core::fmt::Debug for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError]
+impl core::fmt::Display for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError]
+impl core::marker::StructuralPartialEq for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::marker::Freeze for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::marker::Send for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::marker::Sync for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::marker::Unpin for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::marker::UnsafeUnpin for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::From<T>
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::Into<T>
+  pub type bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::Into<T>]
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::TryFrom<T>
+  pub type bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::TryFrom<T>]
+impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: core::clone::Clone
+  pub type bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: core::clone::Clone]
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: core::clone::Clone]
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: core::clone::Clone]
+impl<T> alloc::string::ToString for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: core::fmt::Display + ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: core::fmt::Display + ?core::marker::Sized]
+impl<T> core::any::Any for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: core::clone::Clone
+  pub unsafe fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError]
 pub enum bitcoin_primitives::BlockChecked
 impl bitcoin_primitives::block::Validation for bitcoin_primitives::block::Checked
   pub const bitcoin_primitives::block::Checked::IS_CHECKED: bool [impl: impl bitcoin_primitives::block::Validation for bitcoin_primitives::block::Checked]

--- a/primitives/api/no-features.txt
+++ b/primitives/api/no-features.txt
@@ -1117,7 +1117,7 @@ impl core::convert::From<bitcoin_primitives::witness_version::WitnessVersion> fo
 impl core::convert::From<u8> for bitcoin_primitives::opcodes::Opcode
   pub fn bitcoin_primitives::opcodes::Opcode::from(b: u8) -> Self [impl: impl core::convert::From<u8> for bitcoin_primitives::opcodes::Opcode]
 impl core::convert::TryFrom<bitcoin_primitives::opcodes::Opcode> for bitcoin_primitives::witness_version::WitnessVersion
-  pub type bitcoin_primitives::witness_version::WitnessVersion::Error = bitcoin_primitives::witness_version::error::TryFromError [impl: impl core::convert::TryFrom<bitcoin_primitives::opcodes::Opcode> for bitcoin_primitives::witness_version::WitnessVersion]
+  pub type bitcoin_primitives::witness_version::WitnessVersion::Error = bitcoin_primitives::witness_version::error::InvalidWitnessVersionError [impl: impl core::convert::TryFrom<bitcoin_primitives::opcodes::Opcode> for bitcoin_primitives::witness_version::WitnessVersion]
   pub fn bitcoin_primitives::witness_version::WitnessVersion::try_from(opcode: bitcoin_primitives::opcodes::Opcode) -> core::result::Result<Self, Self::Error> [impl: impl core::convert::TryFrom<bitcoin_primitives::opcodes::Opcode> for bitcoin_primitives::witness_version::WitnessVersion]
 impl core::fmt::Debug for bitcoin_primitives::opcodes::Opcode
   pub fn bitcoin_primitives::opcodes::Opcode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::opcodes::Opcode]
@@ -1811,124 +1811,124 @@ impl<T> core::convert::From<T> for bitcoin_primitives::Wtxid
   pub fn bitcoin_primitives::Wtxid::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::Wtxid]
 pub mod bitcoin_primitives::witness_version
 pub mod bitcoin_primitives::witness_version::error
-#[non_exhaustive] pub enum bitcoin_primitives::witness_version::error::FromStrError
-pub bitcoin_primitives::witness_version::error::FromStrError::Invalid(bitcoin_primitives::witness_version::error::TryFromError)
-pub bitcoin_primitives::witness_version::error::FromStrError::Unparsable(bitcoin_units::parse_int::error::ParseIntError)
-impl core::clone::Clone for bitcoin_primitives::witness_version::error::FromStrError
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::clone(&self) -> bitcoin_primitives::witness_version::error::FromStrError [impl: impl core::clone::Clone for bitcoin_primitives::witness_version::error::FromStrError]
-impl core::cmp::Eq for bitcoin_primitives::witness_version::error::FromStrError
-impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::FromStrError
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::eq(&self, other: &bitcoin_primitives::witness_version::error::FromStrError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::FromStrError]
-impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::witness_version::error::FromStrError
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::witness_version::error::FromStrError]
-impl core::fmt::Debug for bitcoin_primitives::witness_version::error::FromStrError
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::witness_version::error::FromStrError]
-impl core::fmt::Display for bitcoin_primitives::witness_version::error::FromStrError
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::witness_version::error::FromStrError]
-impl core::marker::StructuralPartialEq for bitcoin_primitives::witness_version::error::FromStrError
-impl core::marker::Freeze for bitcoin_primitives::witness_version::error::FromStrError
-impl core::marker::Send for bitcoin_primitives::witness_version::error::FromStrError
-impl core::marker::Sync for bitcoin_primitives::witness_version::error::FromStrError
-impl core::marker::Unpin for bitcoin_primitives::witness_version::error::FromStrError
-impl core::marker::UnsafeUnpin for bitcoin_primitives::witness_version::error::FromStrError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness_version::error::FromStrError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness_version::error::FromStrError
-impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::From<T>
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::From<T>]
-impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::Into<T>
-  pub type bitcoin_primitives::witness_version::error::FromStrError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::Into<T>]
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::Into<T>]
-impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::TryFrom<T>
-  pub type bitcoin_primitives::witness_version::error::FromStrError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::TryFrom<T>]
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::TryFrom<T>]
-impl<T> core::any::Any for bitcoin_primitives::witness_version::error::FromStrError where T: 'static + ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::witness_version::error::FromStrError where T: 'static + ?core::marker::Sized]
-impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::FromStrError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::FromStrError where T: ?core::marker::Sized]
-impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::FromStrError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::FromStrError where T: ?core::marker::Sized]
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::FromStrError where T: core::clone::Clone
-  pub unsafe fn bitcoin_primitives::witness_version::error::FromStrError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::FromStrError where T: core::clone::Clone]
-impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::FromStrError
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::FromStrError]
-pub struct bitcoin_primitives::witness_version::error::TryFromError
-impl bitcoin_primitives::witness_version::error::TryFromError
-pub fn bitcoin_primitives::witness_version::error::TryFromError::invalid_version(&self) -> u8
-impl core::clone::Clone for bitcoin_primitives::witness_version::error::TryFromError
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::clone(&self) -> bitcoin_primitives::witness_version::error::TryFromError [impl: impl core::clone::Clone for bitcoin_primitives::witness_version::error::TryFromError]
-impl core::cmp::Eq for bitcoin_primitives::witness_version::error::TryFromError
-impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::TryFromError
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::eq(&self, other: &bitcoin_primitives::witness_version::error::TryFromError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::TryFromError]
-impl core::fmt::Debug for bitcoin_primitives::witness_version::error::TryFromError
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::witness_version::error::TryFromError]
-impl core::fmt::Display for bitcoin_primitives::witness_version::error::TryFromError
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::witness_version::error::TryFromError]
-impl core::marker::StructuralPartialEq for bitcoin_primitives::witness_version::error::TryFromError
-impl core::marker::Freeze for bitcoin_primitives::witness_version::error::TryFromError
-impl core::marker::Send for bitcoin_primitives::witness_version::error::TryFromError
-impl core::marker::Sync for bitcoin_primitives::witness_version::error::TryFromError
-impl core::marker::Unpin for bitcoin_primitives::witness_version::error::TryFromError
-impl core::marker::UnsafeUnpin for bitcoin_primitives::witness_version::error::TryFromError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness_version::error::TryFromError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness_version::error::TryFromError
-impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::From<T>
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::From<T>]
-impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::Into<T>
-  pub type bitcoin_primitives::witness_version::error::TryFromError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::Into<T>]
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::Into<T>]
-impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::TryFrom<T>
-  pub type bitcoin_primitives::witness_version::error::TryFromError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::TryFrom<T>]
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::TryFrom<T>]
-impl<T> core::any::Any for bitcoin_primitives::witness_version::error::TryFromError where T: 'static + ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::witness_version::error::TryFromError where T: 'static + ?core::marker::Sized]
-impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::TryFromError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::TryFromError where T: ?core::marker::Sized]
-impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::TryFromError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::TryFromError where T: ?core::marker::Sized]
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::TryFromError where T: core::clone::Clone
-  pub unsafe fn bitcoin_primitives::witness_version::error::TryFromError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::TryFromError where T: core::clone::Clone]
-impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::TryFromError
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::TryFromError]
-#[non_exhaustive] pub enum bitcoin_primitives::witness_version::FromStrError
-pub bitcoin_primitives::witness_version::FromStrError::Invalid(bitcoin_primitives::witness_version::error::TryFromError)
-pub bitcoin_primitives::witness_version::FromStrError::Unparsable(bitcoin_units::parse_int::error::ParseIntError)
-impl core::clone::Clone for bitcoin_primitives::witness_version::error::FromStrError
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::clone(&self) -> bitcoin_primitives::witness_version::error::FromStrError [impl: impl core::clone::Clone for bitcoin_primitives::witness_version::error::FromStrError]
-impl core::cmp::Eq for bitcoin_primitives::witness_version::error::FromStrError
-impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::FromStrError
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::eq(&self, other: &bitcoin_primitives::witness_version::error::FromStrError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::FromStrError]
-impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::witness_version::error::FromStrError
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::witness_version::error::FromStrError]
-impl core::fmt::Debug for bitcoin_primitives::witness_version::error::FromStrError
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::witness_version::error::FromStrError]
-impl core::fmt::Display for bitcoin_primitives::witness_version::error::FromStrError
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::witness_version::error::FromStrError]
-impl core::marker::StructuralPartialEq for bitcoin_primitives::witness_version::error::FromStrError
-impl core::marker::Freeze for bitcoin_primitives::witness_version::error::FromStrError
-impl core::marker::Send for bitcoin_primitives::witness_version::error::FromStrError
-impl core::marker::Sync for bitcoin_primitives::witness_version::error::FromStrError
-impl core::marker::Unpin for bitcoin_primitives::witness_version::error::FromStrError
-impl core::marker::UnsafeUnpin for bitcoin_primitives::witness_version::error::FromStrError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness_version::error::FromStrError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness_version::error::FromStrError
-impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::From<T>
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::From<T>]
-impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::Into<T>
-  pub type bitcoin_primitives::witness_version::error::FromStrError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::Into<T>]
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::Into<T>]
-impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::TryFrom<T>
-  pub type bitcoin_primitives::witness_version::error::FromStrError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::TryFrom<T>]
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::FromStrError where U: core::convert::TryFrom<T>]
-impl<T> core::any::Any for bitcoin_primitives::witness_version::error::FromStrError where T: 'static + ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::witness_version::error::FromStrError where T: 'static + ?core::marker::Sized]
-impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::FromStrError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::FromStrError where T: ?core::marker::Sized]
-impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::FromStrError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::FromStrError where T: ?core::marker::Sized]
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::FromStrError where T: core::clone::Clone
-  pub unsafe fn bitcoin_primitives::witness_version::error::FromStrError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::FromStrError where T: core::clone::Clone]
-impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::FromStrError
-  pub fn bitcoin_primitives::witness_version::error::FromStrError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::FromStrError]
+#[non_exhaustive] pub enum bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+pub bitcoin_primitives::witness_version::error::ParseWitnessVersionError::Invalid(bitcoin_primitives::witness_version::error::InvalidWitnessVersionError)
+pub bitcoin_primitives::witness_version::error::ParseWitnessVersionError::Unparsable(bitcoin_units::parse_int::error::ParseIntError)
+impl core::clone::Clone for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::clone(&self) -> bitcoin_primitives::witness_version::error::ParseWitnessVersionError [impl: impl core::clone::Clone for bitcoin_primitives::witness_version::error::ParseWitnessVersionError]
+impl core::cmp::Eq for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::eq(&self, other: &bitcoin_primitives::witness_version::error::ParseWitnessVersionError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::ParseWitnessVersionError]
+impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError]
+impl core::fmt::Debug for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::witness_version::error::ParseWitnessVersionError]
+impl core::fmt::Display for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::witness_version::error::ParseWitnessVersionError]
+impl core::marker::StructuralPartialEq for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::marker::Freeze for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::marker::Send for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::marker::Sync for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::marker::Unpin for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::marker::UnsafeUnpin for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::From<T>
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::Into<T>
+  pub type bitcoin_primitives::witness_version::error::ParseWitnessVersionError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::Into<T>]
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::TryFrom<T>
+  pub type bitcoin_primitives::witness_version::error::ParseWitnessVersionError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::TryFrom<T>]
+impl<T> core::any::Any for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: core::clone::Clone
+  pub unsafe fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError]
+pub struct bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::invalid_version(&self) -> u8
+impl core::clone::Clone for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::clone(&self) -> bitcoin_primitives::witness_version::error::InvalidWitnessVersionError [impl: impl core::clone::Clone for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError]
+impl core::cmp::Eq for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::eq(&self, other: &bitcoin_primitives::witness_version::error::InvalidWitnessVersionError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError]
+impl core::fmt::Debug for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError]
+impl core::fmt::Display for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError]
+impl core::marker::StructuralPartialEq for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::marker::Freeze for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::marker::Send for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::marker::Sync for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::marker::Unpin for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::marker::UnsafeUnpin for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::From<T>
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::Into<T>
+  pub type bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::Into<T>]
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::TryFrom<T>
+  pub type bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::TryFrom<T>]
+impl<T> core::any::Any for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: core::clone::Clone
+  pub unsafe fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError]
+#[non_exhaustive] pub enum bitcoin_primitives::witness_version::ParseWitnessVersionError
+pub bitcoin_primitives::witness_version::ParseWitnessVersionError::Invalid(bitcoin_primitives::witness_version::error::InvalidWitnessVersionError)
+pub bitcoin_primitives::witness_version::ParseWitnessVersionError::Unparsable(bitcoin_units::parse_int::error::ParseIntError)
+impl core::clone::Clone for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::clone(&self) -> bitcoin_primitives::witness_version::error::ParseWitnessVersionError [impl: impl core::clone::Clone for bitcoin_primitives::witness_version::error::ParseWitnessVersionError]
+impl core::cmp::Eq for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::eq(&self, other: &bitcoin_primitives::witness_version::error::ParseWitnessVersionError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::ParseWitnessVersionError]
+impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError]
+impl core::fmt::Debug for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::witness_version::error::ParseWitnessVersionError]
+impl core::fmt::Display for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::witness_version::error::ParseWitnessVersionError]
+impl core::marker::StructuralPartialEq for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::marker::Freeze for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::marker::Send for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::marker::Sync for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::marker::Unpin for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::marker::UnsafeUnpin for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::From<T>
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::Into<T>
+  pub type bitcoin_primitives::witness_version::error::ParseWitnessVersionError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::Into<T>]
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::TryFrom<T>
+  pub type bitcoin_primitives::witness_version::error::ParseWitnessVersionError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where U: core::convert::TryFrom<T>]
+impl<T> core::any::Any for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: core::clone::Clone
+  pub unsafe fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::ParseWitnessVersionError where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::ParseWitnessVersionError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::ParseWitnessVersionError]
 #[repr(u8)] pub enum bitcoin_primitives::witness_version::WitnessVersion
 pub bitcoin_primitives::witness_version::WitnessVersion::V0 = 0
 pub bitcoin_primitives::witness_version::WitnessVersion::V1 = 1
@@ -1961,10 +1961,10 @@ impl core::cmp::PartialOrd for bitcoin_primitives::witness_version::WitnessVersi
 impl core::convert::From<bitcoin_primitives::witness_version::WitnessVersion> for bitcoin_primitives::opcodes::Opcode
   pub fn bitcoin_primitives::opcodes::Opcode::from(version: bitcoin_primitives::witness_version::WitnessVersion) -> Self [impl: impl core::convert::From<bitcoin_primitives::witness_version::WitnessVersion> for bitcoin_primitives::opcodes::Opcode]
 impl core::convert::TryFrom<bitcoin_primitives::opcodes::Opcode> for bitcoin_primitives::witness_version::WitnessVersion
-  pub type bitcoin_primitives::witness_version::WitnessVersion::Error = bitcoin_primitives::witness_version::error::TryFromError [impl: impl core::convert::TryFrom<bitcoin_primitives::opcodes::Opcode> for bitcoin_primitives::witness_version::WitnessVersion]
+  pub type bitcoin_primitives::witness_version::WitnessVersion::Error = bitcoin_primitives::witness_version::error::InvalidWitnessVersionError [impl: impl core::convert::TryFrom<bitcoin_primitives::opcodes::Opcode> for bitcoin_primitives::witness_version::WitnessVersion]
   pub fn bitcoin_primitives::witness_version::WitnessVersion::try_from(opcode: bitcoin_primitives::opcodes::Opcode) -> core::result::Result<Self, Self::Error> [impl: impl core::convert::TryFrom<bitcoin_primitives::opcodes::Opcode> for bitcoin_primitives::witness_version::WitnessVersion]
 impl core::convert::TryFrom<u8> for bitcoin_primitives::witness_version::WitnessVersion
-  pub type bitcoin_primitives::witness_version::WitnessVersion::Error = bitcoin_primitives::witness_version::error::TryFromError [impl: impl core::convert::TryFrom<u8> for bitcoin_primitives::witness_version::WitnessVersion]
+  pub type bitcoin_primitives::witness_version::WitnessVersion::Error = bitcoin_primitives::witness_version::error::InvalidWitnessVersionError [impl: impl core::convert::TryFrom<u8> for bitcoin_primitives::witness_version::WitnessVersion]
   pub fn bitcoin_primitives::witness_version::WitnessVersion::try_from(no: u8) -> core::result::Result<Self, Self::Error> [impl: impl core::convert::TryFrom<u8> for bitcoin_primitives::witness_version::WitnessVersion]
 impl core::fmt::Debug for bitcoin_primitives::witness_version::WitnessVersion
   pub fn bitcoin_primitives::witness_version::WitnessVersion::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::witness_version::WitnessVersion]
@@ -1975,7 +1975,7 @@ impl core::hash::Hash for bitcoin_primitives::witness_version::WitnessVersion
 impl core::marker::Copy for bitcoin_primitives::witness_version::WitnessVersion
 impl core::marker::StructuralPartialEq for bitcoin_primitives::witness_version::WitnessVersion
 impl core::str::traits::FromStr for bitcoin_primitives::witness_version::WitnessVersion
-  pub type bitcoin_primitives::witness_version::WitnessVersion::Err = bitcoin_primitives::witness_version::error::FromStrError [impl: impl core::str::traits::FromStr for bitcoin_primitives::witness_version::WitnessVersion]
+  pub type bitcoin_primitives::witness_version::WitnessVersion::Err = bitcoin_primitives::witness_version::error::ParseWitnessVersionError [impl: impl core::str::traits::FromStr for bitcoin_primitives::witness_version::WitnessVersion]
   pub fn bitcoin_primitives::witness_version::WitnessVersion::from_str(s: &str) -> core::result::Result<Self, Self::Err> [impl: impl core::str::traits::FromStr for bitcoin_primitives::witness_version::WitnessVersion]
 impl core::marker::Freeze for bitcoin_primitives::witness_version::WitnessVersion
 impl core::marker::Send for bitcoin_primitives::witness_version::WitnessVersion
@@ -2002,44 +2002,44 @@ impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::Witn
   pub unsafe fn bitcoin_primitives::witness_version::WitnessVersion::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::WitnessVersion where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::WitnessVersion
   pub fn bitcoin_primitives::witness_version::WitnessVersion::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::WitnessVersion]
-pub struct bitcoin_primitives::witness_version::TryFromError
-impl bitcoin_primitives::witness_version::error::TryFromError
-pub fn bitcoin_primitives::witness_version::error::TryFromError::invalid_version(&self) -> u8
-impl core::clone::Clone for bitcoin_primitives::witness_version::error::TryFromError
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::clone(&self) -> bitcoin_primitives::witness_version::error::TryFromError [impl: impl core::clone::Clone for bitcoin_primitives::witness_version::error::TryFromError]
-impl core::cmp::Eq for bitcoin_primitives::witness_version::error::TryFromError
-impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::TryFromError
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::eq(&self, other: &bitcoin_primitives::witness_version::error::TryFromError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::TryFromError]
-impl core::fmt::Debug for bitcoin_primitives::witness_version::error::TryFromError
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::witness_version::error::TryFromError]
-impl core::fmt::Display for bitcoin_primitives::witness_version::error::TryFromError
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::witness_version::error::TryFromError]
-impl core::marker::StructuralPartialEq for bitcoin_primitives::witness_version::error::TryFromError
-impl core::marker::Freeze for bitcoin_primitives::witness_version::error::TryFromError
-impl core::marker::Send for bitcoin_primitives::witness_version::error::TryFromError
-impl core::marker::Sync for bitcoin_primitives::witness_version::error::TryFromError
-impl core::marker::Unpin for bitcoin_primitives::witness_version::error::TryFromError
-impl core::marker::UnsafeUnpin for bitcoin_primitives::witness_version::error::TryFromError
-impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness_version::error::TryFromError
-impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness_version::error::TryFromError
-impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::From<T>
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::From<T>]
-impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::Into<T>
-  pub type bitcoin_primitives::witness_version::error::TryFromError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::Into<T>]
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::Into<T>]
-impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::TryFrom<T>
-  pub type bitcoin_primitives::witness_version::error::TryFromError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::TryFrom<T>]
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::TryFromError where U: core::convert::TryFrom<T>]
-impl<T> core::any::Any for bitcoin_primitives::witness_version::error::TryFromError where T: 'static + ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::witness_version::error::TryFromError where T: 'static + ?core::marker::Sized]
-impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::TryFromError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::TryFromError where T: ?core::marker::Sized]
-impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::TryFromError where T: ?core::marker::Sized
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::TryFromError where T: ?core::marker::Sized]
-impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::TryFromError where T: core::clone::Clone
-  pub unsafe fn bitcoin_primitives::witness_version::error::TryFromError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::TryFromError where T: core::clone::Clone]
-impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::TryFromError
-  pub fn bitcoin_primitives::witness_version::error::TryFromError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::TryFromError]
+pub struct bitcoin_primitives::witness_version::InvalidWitnessVersionError
+impl bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::invalid_version(&self) -> u8
+impl core::clone::Clone for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::clone(&self) -> bitcoin_primitives::witness_version::error::InvalidWitnessVersionError [impl: impl core::clone::Clone for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError]
+impl core::cmp::Eq for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::eq(&self, other: &bitcoin_primitives::witness_version::error::InvalidWitnessVersionError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError]
+impl core::fmt::Debug for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError]
+impl core::fmt::Display for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError]
+impl core::marker::StructuralPartialEq for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::marker::Freeze for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::marker::Send for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::marker::Sync for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::marker::Unpin for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::marker::UnsafeUnpin for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::From<T>
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::Into<T>
+  pub type bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::Into<T>]
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::TryFrom<T>
+  pub type bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where U: core::convert::TryFrom<T>]
+impl<T> core::any::Any for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: ?core::marker::Sized
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: core::clone::Clone
+  pub unsafe fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
+  pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::error::InvalidWitnessVersionError]
 pub struct bitcoin_primitives::BlockHash(_)
 impl bitcoin_primitives::BlockHash
 pub const bitcoin_primitives::BlockHash::GENESIS_PREVIOUS_BLOCK_HASH: Self

--- a/primitives/src/witness_version.rs
+++ b/primitives/src/witness_version.rs
@@ -19,7 +19,7 @@ use crate::opcodes::{Opcode, OP_PUSHBYTES_0};
 
 #[rustfmt::skip]            // Keep public re-exports separate.
 #[doc(no_inline)]
-pub use self::error::{FromStrError, TryFromError};
+pub use self::error::{ParseWitnessVersionError, InvalidWitnessVersionError};
 
 /// Version of the segregated witness program.
 ///
@@ -82,16 +82,16 @@ impl fmt::Display for WitnessVersion {
 }
 
 impl FromStr for WitnessVersion {
-    type Err = FromStrError;
+    type Err = ParseWitnessVersionError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let version: u8 = parse_int::int_from_str(s).map_err(FromStrError::Unparsable)?;
-        Self::try_from(version).map_err(FromStrError::Invalid)
+        let version: u8 = parse_int::int_from_str(s).map_err(ParseWitnessVersionError::Unparsable)?;
+        Self::try_from(version).map_err(ParseWitnessVersionError::Invalid)
     }
 }
 
 impl TryFrom<u8> for WitnessVersion {
-    type Error = TryFromError;
+    type Error = InvalidWitnessVersionError;
 
     fn try_from(no: u8) -> Result<Self, Self::Error> {
         Ok(match no {
@@ -112,20 +112,20 @@ impl TryFrom<u8> for WitnessVersion {
             14 => Self::V14,
             15 => Self::V15,
             16 => Self::V16,
-            invalid => return Err(TryFromError { invalid }),
+            invalid => return Err(InvalidWitnessVersionError { invalid }),
         })
     }
 }
 
 impl TryFrom<Opcode> for WitnessVersion {
-    type Error = TryFromError;
+    type Error = InvalidWitnessVersionError;
 
     fn try_from(opcode: Opcode) -> Result<Self, Self::Error> {
         match opcode.to_u8() {
             0 => Ok(Self::V0),
             version if version >= OP_1.to_u8() && version <= OP_16.to_u8() =>
                 Self::try_from(version - OP_1.to_u8() + 1),
-            invalid => Err(TryFromError { invalid }),
+            invalid => Err(InvalidWitnessVersionError { invalid }),
         }
     }
 }
@@ -152,18 +152,18 @@ pub mod error {
     /// [`WitnessVersion`]: super::WitnessVersion
     #[derive(Clone, Debug, PartialEq, Eq)]
     #[non_exhaustive]
-    pub enum FromStrError {
+    pub enum ParseWitnessVersionError {
         /// Unable to parse integer from string.
         Unparsable(ParseIntError),
         /// String contained an invalid witness version number.
-        Invalid(TryFromError),
+        Invalid(InvalidWitnessVersionError),
     }
 
-    impl From<Infallible> for FromStrError {
+    impl From<Infallible> for ParseWitnessVersionError {
         fn from(never: Infallible) -> Self { match never {} }
     }
 
-    impl fmt::Display for FromStrError {
+    impl fmt::Display for ParseWitnessVersionError {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             match *self {
                 Self::Unparsable(ref e) => write_err!(f, "integer parse error"; e),
@@ -173,7 +173,7 @@ pub mod error {
     }
 
     #[cfg(feature = "std")]
-    impl std::error::Error for FromStrError {
+    impl std::error::Error for ParseWitnessVersionError {
         fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
             match *self {
                 Self::Unparsable(ref e) => Some(e),
@@ -185,24 +185,24 @@ pub mod error {
     ///
     /// [`WitnessVersion`]: super::WitnessVersion
     #[derive(Clone, Debug, PartialEq, Eq)]
-    pub struct TryFromError {
+    pub struct InvalidWitnessVersionError {
         /// The invalid non-witness version integer.
         pub(super) invalid: u8,
     }
 
-    impl TryFromError {
+    impl InvalidWitnessVersionError {
         /// Returns the invalid non-witness version integer.
         pub fn invalid_version(&self) -> u8 { self.invalid }
     }
 
-    impl fmt::Display for TryFromError {
+    impl fmt::Display for InvalidWitnessVersionError {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             write!(f, "invalid witness script version: {}", self.invalid)
         }
     }
 
     #[cfg(feature = "std")]
-    impl std::error::Error for TryFromError {
+    impl std::error::Error for InvalidWitnessVersionError {
         fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
             let Self { invalid: _ } = self;
             None


### PR DESCRIPTION
The error types in the new primitives::witness_version module follow the traits that they are used within, FromStr and TryFrom. This differs from other such errors. These should be renamed to more closely align with existing naming patterns.

Rename FromStrError to ParseWitnessVersionError and TryFromError to InvalidWitnessVersionError.