### PR TITLE
primitives: Drop `WitnessCommitment::GENESIS_PREVIOUS_BLOCK_HASH`

### DIFF
--- a/primitives/api/all-features.txt
+++ b/primitives/api/all-features.txt
@@ -1263,8 +1263,6 @@ impl<T> core::convert::From<T> for bitcoin_primitives::block::VersionEncoder<'e>
   pub fn bitcoin_primitives::block::VersionEncoder<'e>::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::block::VersionEncoder<'e>]
 pub struct bitcoin_primitives::block::WitnessCommitment(_)
 impl bitcoin_primitives::WitnessCommitment
-pub const bitcoin_primitives::WitnessCommitment::GENESIS_PREVIOUS_BLOCK_HASH: Self
-impl bitcoin_primitives::WitnessCommitment
 pub const fn bitcoin_primitives::WitnessCommitment::as_byte_array(&self) -> &[u8; 32]
 pub const fn bitcoin_primitives::WitnessCommitment::from_byte_array(bytes: [u8; 32]) -> Self
 pub const fn bitcoin_primitives::WitnessCommitment::to_byte_array(self) -> [u8; 32]
@@ -7612,8 +7610,6 @@ impl<T> core::convert::From<T> for bitcoin_primitives::witness::Witness
   pub fn bitcoin_primitives::witness::Witness::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::witness::Witness]
 impl<T> serde::de::DeserializeOwned for bitcoin_primitives::witness::Witness where T: for<'de> serde::de::Deserialize<'de>
 pub struct bitcoin_primitives::WitnessCommitment(_)
-impl bitcoin_primitives::WitnessCommitment
-pub const bitcoin_primitives::WitnessCommitment::GENESIS_PREVIOUS_BLOCK_HASH: Self
 impl bitcoin_primitives::WitnessCommitment
 pub const fn bitcoin_primitives::WitnessCommitment::as_byte_array(&self) -> &[u8; 32]
 pub const fn bitcoin_primitives::WitnessCommitment::from_byte_array(bytes: [u8; 32]) -> Self

--- a/primitives/api/alloc-only.txt
+++ b/primitives/api/alloc-only.txt
@@ -1189,8 +1189,6 @@ impl<T> core::convert::From<T> for bitcoin_primitives::block::VersionEncoder<'e>
   pub fn bitcoin_primitives::block::VersionEncoder<'e>::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::block::VersionEncoder<'e>]
 pub struct bitcoin_primitives::block::WitnessCommitment(_)
 impl bitcoin_primitives::WitnessCommitment
-pub const bitcoin_primitives::WitnessCommitment::GENESIS_PREVIOUS_BLOCK_HASH: Self
-impl bitcoin_primitives::WitnessCommitment
 pub const fn bitcoin_primitives::WitnessCommitment::as_byte_array(&self) -> &[u8; 32]
 pub const fn bitcoin_primitives::WitnessCommitment::from_byte_array(bytes: [u8; 32]) -> Self
 pub const fn bitcoin_primitives::WitnessCommitment::to_byte_array(self) -> [u8; 32]
@@ -7038,8 +7036,6 @@ impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness::Witness wher
 impl<T> core::convert::From<T> for bitcoin_primitives::witness::Witness
   pub fn bitcoin_primitives::witness::Witness::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::witness::Witness]
 pub struct bitcoin_primitives::WitnessCommitment(_)
-impl bitcoin_primitives::WitnessCommitment
-pub const bitcoin_primitives::WitnessCommitment::GENESIS_PREVIOUS_BLOCK_HASH: Self
 impl bitcoin_primitives::WitnessCommitment
 pub const fn bitcoin_primitives::WitnessCommitment::as_byte_array(&self) -> &[u8; 32]
 pub const fn bitcoin_primitives::WitnessCommitment::from_byte_array(bytes: [u8; 32]) -> Self

--- a/primitives/api/no-features.txt
+++ b/primitives/api/no-features.txt
@@ -692,8 +692,6 @@ impl<T> core::convert::From<T> for bitcoin_primitives::block::VersionEncoder<'e>
   pub fn bitcoin_primitives::block::VersionEncoder<'e>::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::block::VersionEncoder<'e>]
 pub struct bitcoin_primitives::block::WitnessCommitment(_)
 impl bitcoin_primitives::WitnessCommitment
-pub const bitcoin_primitives::WitnessCommitment::GENESIS_PREVIOUS_BLOCK_HASH: Self
-impl bitcoin_primitives::WitnessCommitment
 pub const fn bitcoin_primitives::WitnessCommitment::as_byte_array(&self) -> &[u8; 32]
 pub const fn bitcoin_primitives::WitnessCommitment::from_byte_array(bytes: [u8; 32]) -> Self
 pub const fn bitcoin_primitives::WitnessCommitment::to_byte_array(self) -> [u8; 32]
@@ -2400,8 +2398,6 @@ impl<T> core::clone::CloneToUninit for bitcoin_primitives::Txid where T: core::c
 impl<T> core::convert::From<T> for bitcoin_primitives::Txid
   pub fn bitcoin_primitives::Txid::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::Txid]
 pub struct bitcoin_primitives::WitnessCommitment(_)
-impl bitcoin_primitives::WitnessCommitment
-pub const bitcoin_primitives::WitnessCommitment::GENESIS_PREVIOUS_BLOCK_HASH: Self
 impl bitcoin_primitives::WitnessCommitment
 pub const fn bitcoin_primitives::WitnessCommitment::as_byte_array(&self) -> &[u8; 32]
 pub const fn bitcoin_primitives::WitnessCommitment::from_byte_array(bytes: [u8; 32]) -> Self

--- a/primitives/src/hash_types/witness_commitment.rs
+++ b/primitives/src/hash_types/witness_commitment.rs
@@ -15,11 +15,6 @@ pub struct WitnessCommitment(sha256d::Hash);
 
 super::impl_debug!(WitnessCommitment);
 
-impl WitnessCommitment {
-    /// Dummy hash used as the previous blockhash of the genesis block.
-    pub const GENESIS_PREVIOUS_BLOCK_HASH: Self = Self::from_byte_array([0; 32]);
-}
-
 // The new hash wrapper type.
 type HashType = WitnessCommitment;
 // The inner hash type from `hashes`.


### PR DESCRIPTION
The GENESIS_PREVIOUS_BLOCK_HASH const on WitnessCommitment doesn't appear to have a use, and is likely copied from the BlockHash type. As such, it should be removed before the 1.0.

Remove WitnessCommitment::GENESIS_PREVIOUS_BLOCK_HASH const.