### PR TITLE
primitives: Seal `PushBytesErrorReport`

### DIFF
--- a/primitives/api/all-features.txt
+++ b/primitives/api/all-features.txt
@@ -4211,7 +4211,7 @@ impl<T> core::convert::From<T> for bitcoin_primitives::script::WitnessScriptSize
   pub fn bitcoin_primitives::script::WitnessScriptSizeError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::script::WitnessScriptSizeError]
 pub const bitcoin_primitives::script::MAX_REDEEM_SCRIPT_SIZE: usize
 pub const bitcoin_primitives::script::MAX_WITNESS_SCRIPT_SIZE: usize
-pub trait bitcoin_primitives::script::PushBytesErrorReport
+pub trait bitcoin_primitives::script::PushBytesErrorReport: bitcoin_primitives::script::push_bytes::sealed::Sealed
 pub fn bitcoin_primitives::script::PushBytesErrorReport::input_len(&self) -> usize
 impl bitcoin_primitives::script::PushBytesErrorReport for bitcoin_primitives::script::PushBytesError
   pub fn bitcoin_primitives::script::PushBytesError::input_len(&self) -> usize [impl: impl bitcoin_primitives::script::PushBytesErrorReport for bitcoin_primitives::script::PushBytesError]

--- a/primitives/api/alloc-only.txt
+++ b/primitives/api/alloc-only.txt
@@ -4000,7 +4000,7 @@ impl<T> core::convert::From<T> for bitcoin_primitives::script::WitnessScriptSize
   pub fn bitcoin_primitives::script::WitnessScriptSizeError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::script::WitnessScriptSizeError]
 pub const bitcoin_primitives::script::MAX_REDEEM_SCRIPT_SIZE: usize
 pub const bitcoin_primitives::script::MAX_WITNESS_SCRIPT_SIZE: usize
-pub trait bitcoin_primitives::script::PushBytesErrorReport
+pub trait bitcoin_primitives::script::PushBytesErrorReport: bitcoin_primitives::script::push_bytes::sealed::Sealed
 pub fn bitcoin_primitives::script::PushBytesErrorReport::input_len(&self) -> usize
 impl bitcoin_primitives::script::PushBytesErrorReport for bitcoin_primitives::script::PushBytesError
   pub fn bitcoin_primitives::script::PushBytesError::input_len(&self) -> usize [impl: impl bitcoin_primitives::script::PushBytesErrorReport for bitcoin_primitives::script::PushBytesError]

--- a/primitives/src/script/push_bytes.rs
+++ b/primitives/src/script/push_bytes.rs
@@ -358,7 +358,7 @@ crate::impl_asref_push_bytes! {
 ///
 /// This should not be needed by general public, except as an additional bound on `TryFrom` when
 /// converting to `WitnessProgram`.
-pub trait PushBytesErrorReport {
+pub trait PushBytesErrorReport: sealed::Sealed {
     /// How many bytes the input had.
     fn input_len(&self) -> usize;
 }
@@ -366,6 +366,12 @@ pub trait PushBytesErrorReport {
 impl PushBytesErrorReport for core::convert::Infallible {
     #[inline]
     fn input_len(&self) -> usize { match *self {} }
+}
+
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for super::PushBytesError {}
+    impl Sealed for core::convert::Infallible {}
 }
 
 #[doc(no_inline)]


### PR DESCRIPTION
The PushBytesErrorReport trait is intended to provide an accessor for the input length during a push bytes construction failure. Since this should only be defined for the PushBytesError and Infallible, it should be sealed.

Seal PushBytesErrorReport.