### PR TITLE
Release tracking PR: `chacha20-poly1305` 0.2.1

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -260,6 +260,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin-private"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
+
+[[package]]
 name = "bitcoin-taproot-primitives"
 version = "0.1.0"
 dependencies = [
@@ -292,6 +298,15 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_test",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
+dependencies = [
+ "bitcoin-private",
 ]
 
 [[package]]
@@ -353,7 +368,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20-poly1305"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "hex-conservative 1.1.0",
 ]
@@ -507,7 +522,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e0cc0f1cf93f4969faf3ea1c7d8a9faed25918d96affa959720823dfe86d4f3"
 dependencies = [
- "bitcoin_hashes 0.14.101",
+ "bitcoin_hashes 0.12.0",
  "secp256k1-sys 0.10.0",
  "serde",
 ]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -351,7 +351,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20-poly1305"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "hex-conservative 1.1.0",
 ]

--- a/chacha20_poly1305/CHANGELOG.md
+++ b/chacha20_poly1305/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-07-28
+
+* Use constant-time equality for Poly1305 tag verification [#6125](https://github.com/rust-bitcoin/rust-bitcoin/pull/6125).
+* Upgrade to the stabilized `hex-conservative` dependency, but no public API changes [#6148](https://github.com/rust-bitcoin/rust-bitcoin/pull/6148).
+
 ## [0.2.0] - 2026-04-03
 
 * Add fuzzing support [#5854](https://github.com/rust-bitcoin/rust-bitcoin/pull/5854).
@@ -21,7 +26,8 @@
 
 * Initial release to create the chacha20-poly1305 crate.
 
-[Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/chacha20-poly1305-0.2.0...HEAD
+[Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/chacha20-poly1305-0.2.1...HEAD
+[0.2.1]: https://github.com/rust-bitcoin/rust-bitcoin/compare/chacha20-poly1305-0.2.0...chacha20-poly1305-0.2.1
 [0.2.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/chacha20-poly1305-0.1.2...chacha20-poly1305-0.2.0
 [0.1.2]: https://github.com/rust-bitcoin/rust-bitcoin/compare/chacha20-poly1305-0.1.1...chacha20-poly1305-0.1.2
 [0.1.1]: https://github.com/rust-bitcoin/rust-bitcoin/compare/chacha20-poly1305-0.1.0...chacha20-poly1305-0.1.1

--- a/chacha20_poly1305/Cargo.toml
+++ b/chacha20_poly1305/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chacha20-poly1305"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Nick Johnson <nick@yonson.dev>", "Robert Netzke <rustaceanrob@protonmail.com>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"


### PR DESCRIPTION
I am not sure why the min version for `bitcoin_hashes` changed for `secp256k1@0.29.0`. The updated value appears to be correct though. Maybe `cargo nightly` got better at understanding the weird constraint on hashes by secp256k1? Looks like it was [a recent change](https://github.com/rust-bitcoin/rust-bitcoin/commit/d75c8544498efad0b24ff59ff0c4701e706de37a), so maybe something just getting fixed.

https://github.com/rust-bitcoin/rust-bitcoin/issues/6593