### PR TITLE
primitives: Remove `.clone()` call in `check_witness_commitment`

### DIFF
--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -192,8 +192,8 @@ impl Block<Unchecked> {
         }
 
         if self.transactions[0].is_coinbase() {
-            let coinbase = self.transactions[0].clone();
-            if let Some(commitment) = witness_commitment_from_coinbase(&coinbase) {
+            let coinbase = &self.transactions[0];
+            if let Some(commitment) = witness_commitment_from_coinbase(coinbase) {
                 // Witness reserved value is in coinbase input witness.
                 let witness_vec: Vec<_> = coinbase.inputs[0].witness.iter().collect();
                 if witness_vec.len() == 1 && witness_vec[0].len() == 32 {


### PR DESCRIPTION
In Block::check_witness_commitment, clone is used to clone the first transaction in the block. However, this transaction is only used in ways that need a ref. Thus, the clone can be replaced by ref access.

Replace transaction clone with taking a ref in check_witness_commitment.