### PR TITLE
primitives: Use generic arguments for functions

### DIFF
--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -7,6 +7,8 @@
 //! module describes structures and functions needed to describe
 //! these blocks and the blockchain.
 
+#[cfg(feature = "alloc")]
+use core::borrow::Borrow;
 use core::fmt;
 #[cfg(feature = "alloc")]
 use core::marker::PhantomData;
@@ -385,8 +387,12 @@ crate::decoder_newtype! {
 /// Unless you are certain your transaction list is nonempty and has no duplicates,
 /// you should not unwrap the `Option` returned by this method!
 #[cfg(feature = "alloc")]
-pub fn compute_merkle_root(transactions: &[Transaction]) -> Option<TxMerkleNode> {
-    let hashes = transactions.iter().map(Transaction::compute_txid);
+pub fn compute_merkle_root<T>(transactions: T) -> Option<TxMerkleNode>
+where
+    T: IntoIterator,
+    T::Item: Borrow<Transaction>,
+{
+    let hashes = transactions.into_iter().map(|t| t.borrow().compute_txid());
     TxMerkleNode::calculate_root(hashes)
 }
 
@@ -400,13 +406,17 @@ pub fn compute_merkle_root(transactions: &[Transaction]) -> Option<TxMerkleNode>
 /// Unless you are certain your transaction list is nonempty and has no duplicates,
 /// you should not unwrap the `Option` returned by this method!
 #[cfg(feature = "alloc")]
-pub fn compute_witness_root(transactions: &[Transaction]) -> Option<WitnessMerkleNode> {
-    let hashes = transactions.iter().enumerate().map(|(i, t)| {
+pub fn compute_witness_root<T>(transactions: T) -> Option<WitnessMerkleNode>
+where
+    T: IntoIterator,
+    T::Item: Borrow<Transaction>,
+{
+    let hashes = transactions.into_iter().enumerate().map(|(i, t)| {
         if i == 0 {
             // Replace the first hash with zeroes.
             Wtxid::COINBASE
         } else {
-            t.compute_wtxid()
+            t.borrow().compute_wtxid()
         }
     });
     WitnessMerkleNode::calculate_root(hashes)

--- a/primitives/src/hash_types/transaction_merkle_node.rs
+++ b/primitives/src/hash_types/transaction_merkle_node.rs
@@ -45,8 +45,8 @@ impl TxMerkleNode {
     ///
     /// Unless you are certain your transaction list is nonempty and has no duplicates,
     /// you should not unwrap the `Option` returned by this method!
-    pub fn calculate_root<I: Iterator<Item = Txid>>(iter: I) -> Option<Self> {
-        MerkleNode::calculate_root(iter)
+    pub fn calculate_root<I: IntoIterator<Item = Txid>>(iter: I) -> Option<Self> {
+        MerkleNode::calculate_root(iter.into_iter())
     }
 }
 

--- a/primitives/src/hash_types/witness_merkle_node.rs
+++ b/primitives/src/hash_types/witness_merkle_node.rs
@@ -45,8 +45,8 @@ impl WitnessMerkleNode {
     ///
     /// Unless you are certain your transaction list is nonempty and has no duplicates,
     /// you should not unwrap the `Option` returned by this method!
-    pub fn calculate_root<I: Iterator<Item = Wtxid>>(iter: I) -> Option<Self> {
-        MerkleNode::calculate_root(iter)
+    pub fn calculate_root<I: IntoIterator<Item = Wtxid>>(iter: I) -> Option<Self> {
+        MerkleNode::calculate_root(iter.into_iter())
     }
 }
 

--- a/primitives/src/merkle_tree.rs
+++ b/primitives/src/merkle_tree.rs
@@ -218,7 +218,7 @@ mod tests {
     #[test]
     fn tx_merkle_node_single_leaf() {
         let (leaf, node) = make_leaf_node(1);
-        let root = TxMerkleNode::calculate_root([leaf].into_iter());
+        let root = TxMerkleNode::calculate_root([leaf]);
         assert!(root.is_some(), "Root should exist for a single leaf");
         assert_eq!(root.unwrap(), node, "Root should equal the leaf node");
     }
@@ -229,7 +229,7 @@ mod tests {
         let (leaf2, node2) = make_leaf_node(2);
         let combined = node1.combine(&node2);
 
-        let root = TxMerkleNode::calculate_root([leaf1, leaf2].into_iter());
+        let root = TxMerkleNode::calculate_root([leaf1, leaf2]);
         assert_eq!(
             root.unwrap(),
             combined,
@@ -241,7 +241,7 @@ mod tests {
     fn tx_merkle_node_duplicate_leaves() {
         let leaf = Txid::from_byte_array([3; 32]);
         // Duplicate transaction list should be rejected (CVE 2012‑2459).
-        let root = TxMerkleNode::calculate_root([leaf, leaf].into_iter());
+        let root = TxMerkleNode::calculate_root([leaf, leaf]);
         assert!(root.is_none(), "Duplicate leaves should return None");
     }
 
@@ -275,9 +275,7 @@ mod tests {
         let subtree_cd = subtree_c.combine(&subtree_d);
         let expected = subtree_ab.combine(&subtree_cd);
 
-        let root = TxMerkleNode::calculate_root(
-            [leaf1, leaf2, leaf3, leaf4, leaf5, leaf6, leaf7].into_iter(),
-        );
+        let root = TxMerkleNode::calculate_root([leaf1, leaf2, leaf3, leaf4, leaf5, leaf6, leaf7]);
         assert_eq!(root, Some(expected));
     }
 
@@ -299,7 +297,7 @@ mod tests {
         // Take the final node, which should be the root of the full tree.
         let expected = level.pop().unwrap();
 
-        let root = TxMerkleNode::calculate_root(leaves.into_iter());
+        let root = TxMerkleNode::calculate_root(leaves);
         assert_eq!(root, Some(expected));
     }
 
@@ -386,7 +384,7 @@ mod tests {
     #[test]
     fn witness_merkle_node_single_leaf() {
         let leaf = Wtxid::from_byte_array([1; 32]);
-        let root = WitnessMerkleNode::calculate_root([leaf].into_iter());
+        let root = WitnessMerkleNode::calculate_root([leaf]);
         assert!(root.is_some(), "Root should exist for a single witness leaf");
         let node = WitnessMerkleNode::from_leaf(leaf);
         assert_eq!(root.unwrap(), node, "Root should equal the leaf node");
@@ -395,7 +393,7 @@ mod tests {
     #[test]
     fn witness_merkle_node_duplicate_leaves() {
         let leaf = Wtxid::from_byte_array([2; 32]);
-        let root = WitnessMerkleNode::calculate_root([leaf, leaf].into_iter());
+        let root = WitnessMerkleNode::calculate_root([leaf, leaf]);
         assert!(root.is_none(), "Duplicate witness leaves should return None");
     }
 


### PR DESCRIPTION
While most of primitives uses generic arguments where useful, there are a couple of functions which can be adjusted to use generics to specify argument requirements.

Adjust block::compute_*_root and *MerkleNode::calculate_root functions to use generics in place of slices and types.