### PR TITLE
primitives: update API files

### DIFF
--- a/primitives/api/all-features.txt
+++ b/primitives/api/all-features.txt
@@ -1342,8 +1342,8 @@ impl bitcoin_primitives::block::Validation for bitcoin_primitives::block::Checke
   pub const bitcoin_primitives::block::Checked::IS_CHECKED: bool [impl: impl bitcoin_primitives::block::Validation for bitcoin_primitives::block::Checked]
 impl bitcoin_primitives::block::Validation for bitcoin_primitives::block::Unchecked
   pub const bitcoin_primitives::block::Unchecked::IS_CHECKED: bool [impl: impl bitcoin_primitives::block::Validation for bitcoin_primitives::block::Unchecked]
-pub fn bitcoin_primitives::block::compute_merkle_root(transactions: &[bitcoin_primitives::transaction::Transaction]) -> core::option::Option<bitcoin_primitives::merkle_tree::TxMerkleNode>
-pub fn bitcoin_primitives::block::compute_witness_root(transactions: &[bitcoin_primitives::transaction::Transaction]) -> core::option::Option<bitcoin_primitives::merkle_tree::WitnessMerkleNode>
+pub fn bitcoin_primitives::block::compute_merkle_root<T>(transactions: T) -> core::option::Option<bitcoin_primitives::merkle_tree::TxMerkleNode> where T: core::iter::traits::collect::IntoIterator, <T as core::iter::traits::collect::IntoIterator>::Item: core::borrow::Borrow<bitcoin_primitives::transaction::Transaction>
+pub fn bitcoin_primitives::block::compute_witness_root<T>(transactions: T) -> core::option::Option<bitcoin_primitives::merkle_tree::WitnessMerkleNode> where T: core::iter::traits::collect::IntoIterator, <T as core::iter::traits::collect::IntoIterator>::Item: core::borrow::Borrow<bitcoin_primitives::transaction::Transaction>
 pub mod bitcoin_primitives::merkle_tree
 pub mod bitcoin_primitives::merkle_tree::error
 pub struct bitcoin_primitives::merkle_tree::error::TxMerkleNodeDecoderError(_)
@@ -1398,7 +1398,7 @@ pub const fn bitcoin_primitives::merkle_tree::TxMerkleNode::as_byte_array(&self)
 pub const fn bitcoin_primitives::merkle_tree::TxMerkleNode::from_byte_array(bytes: [u8; 32]) -> Self
 pub const fn bitcoin_primitives::merkle_tree::TxMerkleNode::to_byte_array(self) -> [u8; 32]
 impl bitcoin_primitives::merkle_tree::TxMerkleNode
-pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::calculate_root<I: core::iter::traits::iterator::Iterator<Item = bitcoin_primitives::Txid>>(iter: I) -> core::option::Option<Self>
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::calculate_root<I: core::iter::traits::collect::IntoIterator<Item = bitcoin_primitives::Txid>>(iter: I) -> core::option::Option<Self>
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::combine(&self, other: &Self) -> Self
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::from_leaf(leaf: bitcoin_primitives::Txid) -> Self
 impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::merkle_tree::TxMerkleNode
@@ -1611,7 +1611,7 @@ pub const fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::as_byte_array(&
 pub const fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::from_byte_array(bytes: [u8; 32]) -> Self
 pub const fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::to_byte_array(self) -> [u8; 32]
 impl bitcoin_primitives::merkle_tree::WitnessMerkleNode
-pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::calculate_root<I: core::iter::traits::iterator::Iterator<Item = bitcoin_primitives::Wtxid>>(iter: I) -> core::option::Option<Self>
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::calculate_root<I: core::iter::traits::collect::IntoIterator<Item = bitcoin_primitives::Wtxid>>(iter: I) -> core::option::Option<Self>
 pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::combine(&self, other: &Self) -> Self
 pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::from_leaf(leaf: bitcoin_primitives::Wtxid) -> Self
 impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::merkle_tree::WitnessMerkleNode

--- a/primitives/api/alloc-only.txt
+++ b/primitives/api/alloc-only.txt
@@ -1250,8 +1250,8 @@ impl bitcoin_primitives::block::Validation for bitcoin_primitives::block::Checke
   pub const bitcoin_primitives::block::Checked::IS_CHECKED: bool [impl: impl bitcoin_primitives::block::Validation for bitcoin_primitives::block::Checked]
 impl bitcoin_primitives::block::Validation for bitcoin_primitives::block::Unchecked
   pub const bitcoin_primitives::block::Unchecked::IS_CHECKED: bool [impl: impl bitcoin_primitives::block::Validation for bitcoin_primitives::block::Unchecked]
-pub fn bitcoin_primitives::block::compute_merkle_root(transactions: &[bitcoin_primitives::transaction::Transaction]) -> core::option::Option<bitcoin_primitives::merkle_tree::TxMerkleNode>
-pub fn bitcoin_primitives::block::compute_witness_root(transactions: &[bitcoin_primitives::transaction::Transaction]) -> core::option::Option<bitcoin_primitives::merkle_tree::WitnessMerkleNode>
+pub fn bitcoin_primitives::block::compute_merkle_root<T>(transactions: T) -> core::option::Option<bitcoin_primitives::merkle_tree::TxMerkleNode> where T: core::iter::traits::collect::IntoIterator, <T as core::iter::traits::collect::IntoIterator>::Item: core::borrow::Borrow<bitcoin_primitives::transaction::Transaction>
+pub fn bitcoin_primitives::block::compute_witness_root<T>(transactions: T) -> core::option::Option<bitcoin_primitives::merkle_tree::WitnessMerkleNode> where T: core::iter::traits::collect::IntoIterator, <T as core::iter::traits::collect::IntoIterator>::Item: core::borrow::Borrow<bitcoin_primitives::transaction::Transaction>
 pub mod bitcoin_primitives::merkle_tree
 pub mod bitcoin_primitives::merkle_tree::error
 pub struct bitcoin_primitives::merkle_tree::error::TxMerkleNodeDecoderError(_)
@@ -1304,7 +1304,7 @@ pub const fn bitcoin_primitives::merkle_tree::TxMerkleNode::as_byte_array(&self)
 pub const fn bitcoin_primitives::merkle_tree::TxMerkleNode::from_byte_array(bytes: [u8; 32]) -> Self
 pub const fn bitcoin_primitives::merkle_tree::TxMerkleNode::to_byte_array(self) -> [u8; 32]
 impl bitcoin_primitives::merkle_tree::TxMerkleNode
-pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::calculate_root<I: core::iter::traits::iterator::Iterator<Item = bitcoin_primitives::Txid>>(iter: I) -> core::option::Option<Self>
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::calculate_root<I: core::iter::traits::collect::IntoIterator<Item = bitcoin_primitives::Txid>>(iter: I) -> core::option::Option<Self>
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::combine(&self, other: &Self) -> Self
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::from_leaf(leaf: bitcoin_primitives::Txid) -> Self
 impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::merkle_tree::TxMerkleNode
@@ -1497,7 +1497,7 @@ pub const fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::as_byte_array(&
 pub const fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::from_byte_array(bytes: [u8; 32]) -> Self
 pub const fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::to_byte_array(self) -> [u8; 32]
 impl bitcoin_primitives::merkle_tree::WitnessMerkleNode
-pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::calculate_root<I: core::iter::traits::iterator::Iterator<Item = bitcoin_primitives::Wtxid>>(iter: I) -> core::option::Option<Self>
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::calculate_root<I: core::iter::traits::collect::IntoIterator<Item = bitcoin_primitives::Wtxid>>(iter: I) -> core::option::Option<Self>
 pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::combine(&self, other: &Self) -> Self
 pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::from_leaf(leaf: bitcoin_primitives::Wtxid) -> Self
 impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::merkle_tree::WitnessMerkleNode

--- a/primitives/api/no-features.txt
+++ b/primitives/api/no-features.txt
@@ -789,7 +789,7 @@ pub const fn bitcoin_primitives::merkle_tree::TxMerkleNode::as_byte_array(&self)
 pub const fn bitcoin_primitives::merkle_tree::TxMerkleNode::from_byte_array(bytes: [u8; 32]) -> Self
 pub const fn bitcoin_primitives::merkle_tree::TxMerkleNode::to_byte_array(self) -> [u8; 32]
 impl bitcoin_primitives::merkle_tree::TxMerkleNode
-pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::calculate_root<I: core::iter::traits::iterator::Iterator<Item = bitcoin_primitives::Txid>>(iter: I) -> core::option::Option<Self>
+pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::calculate_root<I: core::iter::traits::collect::IntoIterator<Item = bitcoin_primitives::Txid>>(iter: I) -> core::option::Option<Self>
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::combine(&self, other: &Self) -> Self
 pub fn bitcoin_primitives::merkle_tree::TxMerkleNode::from_leaf(leaf: bitcoin_primitives::Txid) -> Self
 impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::merkle_tree::TxMerkleNode
@@ -964,7 +964,7 @@ pub const fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::as_byte_array(&
 pub const fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::from_byte_array(bytes: [u8; 32]) -> Self
 pub const fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::to_byte_array(self) -> [u8; 32]
 impl bitcoin_primitives::merkle_tree::WitnessMerkleNode
-pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::calculate_root<I: core::iter::traits::iterator::Iterator<Item = bitcoin_primitives::Wtxid>>(iter: I) -> core::option::Option<Self>
+pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::calculate_root<I: core::iter::traits::collect::IntoIterator<Item = bitcoin_primitives::Wtxid>>(iter: I) -> core::option::Option<Self>
 pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::combine(&self, other: &Self) -> Self
 pub fn bitcoin_primitives::merkle_tree::WitnessMerkleNode::from_leaf(leaf: bitcoin_primitives::Wtxid) -> Self
 impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::merkle_tree::WitnessMerkleNode


### PR DESCRIPTION
Looks like files got out of sync on master. Alternative to this fix, could push on the cargo-rbmt@0.5.1 upgrade where we drop the API files: https://github.com/rust-bitcoin/rust-bitcoin/pull/6547