### PR TITLE
[0.32.xxx] remove stale branch refs and fix push CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@
 on:   # yamllint disable-line rule:truthy
   push:
     branches:
-      - 0.32.x
+      - 0.32.xxx
   pull_request:
 
 name: Continuous integration

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -40,7 +40,7 @@
 #![allow(clippy::needless_question_mark)] // https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
 #![allow(clippy::manual_range_contains)] // More readable than clippy's format.
 #![allow(clippy::needless_borrows_for_generic_args)] // https://github.com/rust-lang/rust-clippy/issues/12454
-// For 0.32.x releases only.
+// For 0.32.xxx releases only.
 #![allow(deprecated)]
 
 // Disable 16-bit support at least for now as we can't guarantee it yet.


### PR DESCRIPTION
The push trigger still lists `0.32.x`, a leftover from the parent branch. CI never runs on pushes to `0.32.xxx`. This commit makes it use the correct branch name and also renames a stale comment's ref to `0.32.x`. Only refs to `0.32.x` left are in the changelogs, which seems justified.