### PR TITLE
units: Add f64 constructors to FeeRate

### DIFF
--- a/bitcoin/src/blockdata/mod.rs
+++ b/bitcoin/src/blockdata/mod.rs
@@ -26,7 +26,7 @@ pub mod fee_rate {
     pub use units::fee_rate::serde;
     // Re-export everything from the [`units::fee_rate`] module.
     #[doc(inline)]
-    pub use units::fee_rate::FeeRate;
+    pub use units::fee_rate::{error, FeeRate, FromFloatError};
 }
 
 /// Provides absolute and relative locktimes.

--- a/units/api/all-features.txt
+++ b/units/api/all-features.txt
@@ -3724,6 +3724,53 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::block::error::TooBigForRel
 impl<T> core::convert::From<T> for bitcoin_units::block::error::TooBigForRelativeHeightError
   pub fn bitcoin_units::block::error::TooBigForRelativeHeightError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::block::error::TooBigForRelativeHeightError]
 pub mod bitcoin_units::fee_rate
+pub mod bitcoin_units::fee_rate::error
+pub struct bitcoin_units::fee_rate::error::FromFloatError(_)
+impl core::clone::Clone for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::clone(&self) -> bitcoin_units::fee_rate::error::FromFloatError [impl: impl core::clone::Clone for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::cmp::Eq for bitcoin_units::fee_rate::error::FromFloatError
+impl core::cmp::PartialEq for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::eq(&self, other: &bitcoin_units::fee_rate::error::FromFloatError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::error::Error for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)> [impl: impl core::error::Error for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::fmt::Debug for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::fmt::Display for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::marker::StructuralPartialEq for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Freeze for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Send for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Sync for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Unpin for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::UnsafeUnpin for bitcoin_units::fee_rate::error::FromFloatError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::fee_rate::error::FromFloatError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::fee_rate::error::FromFloatError
+impl<T, U> core::convert::Into<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::From<T>
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::Into<T>
+  pub type bitcoin_units::fee_rate::error::FromFloatError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::Into<T>]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::TryFrom<T>
+  pub type bitcoin_units::fee_rate::error::FromFloatError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::TryFrom<T>]
+impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone
+  pub type bitcoin_units::fee_rate::error::FromFloatError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone]
+impl<T> alloc::string::ToString for bitcoin_units::fee_rate::error::FromFloatError where T: core::fmt::Display + ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_units::fee_rate::error::FromFloatError where T: core::fmt::Display + ?core::marker::Sized]
+impl<T> core::any::Any for bitcoin_units::fee_rate::error::FromFloatError where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_units::fee_rate::error::FromFloatError where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone
+  pub unsafe fn bitcoin_units::fee_rate::error::FromFloatError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::fee_rate::error::FromFloatError]
 pub mod bitcoin_units::fee_rate::serde
 pub mod bitcoin_units::fee_rate::serde::as_sat_per_kwu_floor
 pub mod bitcoin_units::fee_rate::serde::as_sat_per_kwu_floor::opt
@@ -3860,8 +3907,11 @@ pub const fn bitcoin_units::FeeRate::from_per_kvb(rate: bitcoin_units::Amount) -
 pub const fn bitcoin_units::FeeRate::from_per_kwu(rate: bitcoin_units::Amount) -> bitcoin_units::result::NumOpResult<Self>
 pub const fn bitcoin_units::FeeRate::from_per_vb(rate: bitcoin_units::Amount) -> bitcoin_units::result::NumOpResult<Self>
 pub const fn bitcoin_units::FeeRate::from_sat_per_kvb(sat_kvb: u32) -> Self
+pub fn bitcoin_units::FeeRate::from_sat_per_kvb_f64(sat_kvb: f64) -> core::result::Result<Self, bitcoin_units::fee_rate::error::FromFloatError>
 pub const fn bitcoin_units::FeeRate::from_sat_per_kwu(sat_kwu: u32) -> Self
+pub fn bitcoin_units::FeeRate::from_sat_per_kwu_f64(sat_kwu: f64) -> core::result::Result<Self, bitcoin_units::fee_rate::error::FromFloatError>
 pub const fn bitcoin_units::FeeRate::from_sat_per_vb(sat_vb: u32) -> Self
+pub fn bitcoin_units::FeeRate::from_sat_per_vb_f64(sat_vb: f64) -> core::result::Result<Self, bitcoin_units::fee_rate::error::FromFloatError>
 pub const fn bitcoin_units::FeeRate::mul_by_weight(self, weight: bitcoin_units::Weight) -> bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
 pub const fn bitcoin_units::FeeRate::to_fee(self, weight: bitcoin_units::Weight) -> bitcoin_units::Amount
 pub const fn bitcoin_units::FeeRate::to_sat_per_kvb_ceil(self) -> u64
@@ -4036,6 +4086,52 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::FeeRate where T: core::clo
   pub unsafe fn bitcoin_units::FeeRate::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_units::FeeRate where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_units::FeeRate
   pub fn bitcoin_units::FeeRate::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::FeeRate]
+pub struct bitcoin_units::fee_rate::FromFloatError(_)
+impl core::clone::Clone for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::clone(&self) -> bitcoin_units::fee_rate::error::FromFloatError [impl: impl core::clone::Clone for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::cmp::Eq for bitcoin_units::fee_rate::error::FromFloatError
+impl core::cmp::PartialEq for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::eq(&self, other: &bitcoin_units::fee_rate::error::FromFloatError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::error::Error for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)> [impl: impl core::error::Error for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::fmt::Debug for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::fmt::Display for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::marker::StructuralPartialEq for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Freeze for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Send for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Sync for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Unpin for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::UnsafeUnpin for bitcoin_units::fee_rate::error::FromFloatError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::fee_rate::error::FromFloatError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::fee_rate::error::FromFloatError
+impl<T, U> core::convert::Into<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::From<T>
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::Into<T>
+  pub type bitcoin_units::fee_rate::error::FromFloatError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::Into<T>]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::TryFrom<T>
+  pub type bitcoin_units::fee_rate::error::FromFloatError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::TryFrom<T>]
+impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone
+  pub type bitcoin_units::fee_rate::error::FromFloatError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone]
+impl<T> alloc::string::ToString for bitcoin_units::fee_rate::error::FromFloatError where T: core::fmt::Display + ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_units::fee_rate::error::FromFloatError where T: core::fmt::Display + ?core::marker::Sized]
+impl<T> core::any::Any for bitcoin_units::fee_rate::error::FromFloatError where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_units::fee_rate::error::FromFloatError where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone
+  pub unsafe fn bitcoin_units::fee_rate::error::FromFloatError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::fee_rate::error::FromFloatError]
 pub mod bitcoin_units::locktime
 pub mod bitcoin_units::locktime::absolute
 pub mod bitcoin_units::locktime::absolute::error
@@ -11083,8 +11179,11 @@ pub const fn bitcoin_units::FeeRate::from_per_kvb(rate: bitcoin_units::Amount) -
 pub const fn bitcoin_units::FeeRate::from_per_kwu(rate: bitcoin_units::Amount) -> bitcoin_units::result::NumOpResult<Self>
 pub const fn bitcoin_units::FeeRate::from_per_vb(rate: bitcoin_units::Amount) -> bitcoin_units::result::NumOpResult<Self>
 pub const fn bitcoin_units::FeeRate::from_sat_per_kvb(sat_kvb: u32) -> Self
+pub fn bitcoin_units::FeeRate::from_sat_per_kvb_f64(sat_kvb: f64) -> core::result::Result<Self, bitcoin_units::fee_rate::error::FromFloatError>
 pub const fn bitcoin_units::FeeRate::from_sat_per_kwu(sat_kwu: u32) -> Self
+pub fn bitcoin_units::FeeRate::from_sat_per_kwu_f64(sat_kwu: f64) -> core::result::Result<Self, bitcoin_units::fee_rate::error::FromFloatError>
 pub const fn bitcoin_units::FeeRate::from_sat_per_vb(sat_vb: u32) -> Self
+pub fn bitcoin_units::FeeRate::from_sat_per_vb_f64(sat_vb: f64) -> core::result::Result<Self, bitcoin_units::fee_rate::error::FromFloatError>
 pub const fn bitcoin_units::FeeRate::mul_by_weight(self, weight: bitcoin_units::Weight) -> bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
 pub const fn bitcoin_units::FeeRate::to_fee(self, weight: bitcoin_units::Weight) -> bitcoin_units::Amount
 pub const fn bitcoin_units::FeeRate::to_sat_per_kvb_ceil(self) -> u64

--- a/units/api/all-features.txt
+++ b/units/api/all-features.txt
@@ -3734,6 +3734,53 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::block::error::TooBigForRel
 impl<T> core::convert::From<T> for bitcoin_units::block::error::TooBigForRelativeHeightError
   pub fn bitcoin_units::block::error::TooBigForRelativeHeightError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::block::error::TooBigForRelativeHeightError]
 pub mod bitcoin_units::fee_rate
+pub mod bitcoin_units::fee_rate::error
+pub struct bitcoin_units::fee_rate::error::FromFloatError(_)
+impl core::clone::Clone for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::clone(&self) -> bitcoin_units::fee_rate::error::FromFloatError [impl: impl core::clone::Clone for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::cmp::Eq for bitcoin_units::fee_rate::error::FromFloatError
+impl core::cmp::PartialEq for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::eq(&self, other: &bitcoin_units::fee_rate::error::FromFloatError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::error::Error for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)> [impl: impl core::error::Error for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::fmt::Debug for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::fmt::Display for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::marker::StructuralPartialEq for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Freeze for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Send for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Sync for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Unpin for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::UnsafeUnpin for bitcoin_units::fee_rate::error::FromFloatError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::fee_rate::error::FromFloatError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::fee_rate::error::FromFloatError
+impl<T, U> core::convert::Into<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::From<T>
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::Into<T>
+  pub type bitcoin_units::fee_rate::error::FromFloatError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::Into<T>]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::TryFrom<T>
+  pub type bitcoin_units::fee_rate::error::FromFloatError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::TryFrom<T>]
+impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone
+  pub type bitcoin_units::fee_rate::error::FromFloatError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone]
+impl<T> alloc::string::ToString for bitcoin_units::fee_rate::error::FromFloatError where T: core::fmt::Display + ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_units::fee_rate::error::FromFloatError where T: core::fmt::Display + ?core::marker::Sized]
+impl<T> core::any::Any for bitcoin_units::fee_rate::error::FromFloatError where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_units::fee_rate::error::FromFloatError where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone
+  pub unsafe fn bitcoin_units::fee_rate::error::FromFloatError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::fee_rate::error::FromFloatError]
 pub mod bitcoin_units::fee_rate::serde
 pub mod bitcoin_units::fee_rate::serde::as_sat_per_kwu_floor
 pub mod bitcoin_units::fee_rate::serde::as_sat_per_kwu_floor::opt
@@ -3870,8 +3917,11 @@ pub const fn bitcoin_units::FeeRate::from_per_kvb(rate: bitcoin_units::Amount) -
 pub const fn bitcoin_units::FeeRate::from_per_kwu(rate: bitcoin_units::Amount) -> bitcoin_units::result::NumOpResult<Self>
 pub const fn bitcoin_units::FeeRate::from_per_vb(rate: bitcoin_units::Amount) -> bitcoin_units::result::NumOpResult<Self>
 pub const fn bitcoin_units::FeeRate::from_sat_per_kvb(sat_kvb: u32) -> Self
+pub fn bitcoin_units::FeeRate::from_sat_per_kvb_f64(sat_kvb: f64) -> core::result::Result<Self, bitcoin_units::fee_rate::error::FromFloatError>
 pub const fn bitcoin_units::FeeRate::from_sat_per_kwu(sat_kwu: u32) -> Self
+pub fn bitcoin_units::FeeRate::from_sat_per_kwu_f64(sat_kwu: f64) -> core::result::Result<Self, bitcoin_units::fee_rate::error::FromFloatError>
 pub const fn bitcoin_units::FeeRate::from_sat_per_vb(sat_vb: u32) -> Self
+pub fn bitcoin_units::FeeRate::from_sat_per_vb_f64(sat_vb: f64) -> core::result::Result<Self, bitcoin_units::fee_rate::error::FromFloatError>
 pub const fn bitcoin_units::FeeRate::mul_by_weight(self, weight: bitcoin_units::Weight) -> bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
 pub const fn bitcoin_units::FeeRate::to_fee(self, weight: bitcoin_units::Weight) -> bitcoin_units::Amount
 pub const fn bitcoin_units::FeeRate::to_sat_per_kvb_ceil(self) -> u64
@@ -4046,6 +4096,52 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::FeeRate where T: core::clo
   pub unsafe fn bitcoin_units::FeeRate::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_units::FeeRate where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_units::FeeRate
   pub fn bitcoin_units::FeeRate::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::FeeRate]
+pub struct bitcoin_units::fee_rate::FromFloatError(_)
+impl core::clone::Clone for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::clone(&self) -> bitcoin_units::fee_rate::error::FromFloatError [impl: impl core::clone::Clone for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::cmp::Eq for bitcoin_units::fee_rate::error::FromFloatError
+impl core::cmp::PartialEq for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::eq(&self, other: &bitcoin_units::fee_rate::error::FromFloatError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::error::Error for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)> [impl: impl core::error::Error for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::fmt::Debug for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::fmt::Display for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::marker::StructuralPartialEq for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Freeze for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Send for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Sync for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Unpin for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::UnsafeUnpin for bitcoin_units::fee_rate::error::FromFloatError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::fee_rate::error::FromFloatError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::fee_rate::error::FromFloatError
+impl<T, U> core::convert::Into<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::From<T>
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::Into<T>
+  pub type bitcoin_units::fee_rate::error::FromFloatError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::Into<T>]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::TryFrom<T>
+  pub type bitcoin_units::fee_rate::error::FromFloatError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::TryFrom<T>]
+impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone
+  pub type bitcoin_units::fee_rate::error::FromFloatError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone]
+impl<T> alloc::string::ToString for bitcoin_units::fee_rate::error::FromFloatError where T: core::fmt::Display + ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_units::fee_rate::error::FromFloatError where T: core::fmt::Display + ?core::marker::Sized]
+impl<T> core::any::Any for bitcoin_units::fee_rate::error::FromFloatError where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_units::fee_rate::error::FromFloatError where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone
+  pub unsafe fn bitcoin_units::fee_rate::error::FromFloatError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::fee_rate::error::FromFloatError]
 pub mod bitcoin_units::locktime
 pub mod bitcoin_units::locktime::absolute
 pub mod bitcoin_units::locktime::absolute::error
@@ -11139,8 +11235,11 @@ pub const fn bitcoin_units::FeeRate::from_per_kvb(rate: bitcoin_units::Amount) -
 pub const fn bitcoin_units::FeeRate::from_per_kwu(rate: bitcoin_units::Amount) -> bitcoin_units::result::NumOpResult<Self>
 pub const fn bitcoin_units::FeeRate::from_per_vb(rate: bitcoin_units::Amount) -> bitcoin_units::result::NumOpResult<Self>
 pub const fn bitcoin_units::FeeRate::from_sat_per_kvb(sat_kvb: u32) -> Self
+pub fn bitcoin_units::FeeRate::from_sat_per_kvb_f64(sat_kvb: f64) -> core::result::Result<Self, bitcoin_units::fee_rate::error::FromFloatError>
 pub const fn bitcoin_units::FeeRate::from_sat_per_kwu(sat_kwu: u32) -> Self
+pub fn bitcoin_units::FeeRate::from_sat_per_kwu_f64(sat_kwu: f64) -> core::result::Result<Self, bitcoin_units::fee_rate::error::FromFloatError>
 pub const fn bitcoin_units::FeeRate::from_sat_per_vb(sat_vb: u32) -> Self
+pub fn bitcoin_units::FeeRate::from_sat_per_vb_f64(sat_vb: f64) -> core::result::Result<Self, bitcoin_units::fee_rate::error::FromFloatError>
 pub const fn bitcoin_units::FeeRate::mul_by_weight(self, weight: bitcoin_units::Weight) -> bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
 pub const fn bitcoin_units::FeeRate::to_fee(self, weight: bitcoin_units::Weight) -> bitcoin_units::Amount
 pub const fn bitcoin_units::FeeRate::to_sat_per_kvb_ceil(self) -> u64

--- a/units/api/alloc-only.txt
+++ b/units/api/alloc-only.txt
@@ -3036,6 +3036,51 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::block::error::TooBigForRel
 impl<T> core::convert::From<T> for bitcoin_units::block::error::TooBigForRelativeHeightError
   pub fn bitcoin_units::block::error::TooBigForRelativeHeightError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::block::error::TooBigForRelativeHeightError]
 pub mod bitcoin_units::fee_rate
+pub mod bitcoin_units::fee_rate::error
+pub struct bitcoin_units::fee_rate::error::FromFloatError(_)
+impl core::clone::Clone for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::clone(&self) -> bitcoin_units::fee_rate::error::FromFloatError [impl: impl core::clone::Clone for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::cmp::Eq for bitcoin_units::fee_rate::error::FromFloatError
+impl core::cmp::PartialEq for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::eq(&self, other: &bitcoin_units::fee_rate::error::FromFloatError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::fmt::Debug for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::fmt::Display for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::marker::StructuralPartialEq for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Freeze for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Send for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Sync for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Unpin for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::UnsafeUnpin for bitcoin_units::fee_rate::error::FromFloatError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::fee_rate::error::FromFloatError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::fee_rate::error::FromFloatError
+impl<T, U> core::convert::Into<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::From<T>
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::Into<T>
+  pub type bitcoin_units::fee_rate::error::FromFloatError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::Into<T>]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::TryFrom<T>
+  pub type bitcoin_units::fee_rate::error::FromFloatError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::TryFrom<T>]
+impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone
+  pub type bitcoin_units::fee_rate::error::FromFloatError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone]
+impl<T> alloc::string::ToString for bitcoin_units::fee_rate::error::FromFloatError where T: core::fmt::Display + ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_units::fee_rate::error::FromFloatError where T: core::fmt::Display + ?core::marker::Sized]
+impl<T> core::any::Any for bitcoin_units::fee_rate::error::FromFloatError where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_units::fee_rate::error::FromFloatError where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone
+  pub unsafe fn bitcoin_units::fee_rate::error::FromFloatError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::fee_rate::error::FromFloatError]
 pub struct bitcoin_units::fee_rate::FeeRate(_)
 impl bitcoin_units::FeeRate
 pub const bitcoin_units::FeeRate::BROADCAST_MIN: Self
@@ -3051,8 +3096,11 @@ pub const fn bitcoin_units::FeeRate::from_per_kvb(rate: bitcoin_units::Amount) -
 pub const fn bitcoin_units::FeeRate::from_per_kwu(rate: bitcoin_units::Amount) -> bitcoin_units::result::NumOpResult<Self>
 pub const fn bitcoin_units::FeeRate::from_per_vb(rate: bitcoin_units::Amount) -> bitcoin_units::result::NumOpResult<Self>
 pub const fn bitcoin_units::FeeRate::from_sat_per_kvb(sat_kvb: u32) -> Self
+pub fn bitcoin_units::FeeRate::from_sat_per_kvb_f64(sat_kvb: f64) -> core::result::Result<Self, bitcoin_units::fee_rate::error::FromFloatError>
 pub const fn bitcoin_units::FeeRate::from_sat_per_kwu(sat_kwu: u32) -> Self
+pub fn bitcoin_units::FeeRate::from_sat_per_kwu_f64(sat_kwu: f64) -> core::result::Result<Self, bitcoin_units::fee_rate::error::FromFloatError>
 pub const fn bitcoin_units::FeeRate::from_sat_per_vb(sat_vb: u32) -> Self
+pub fn bitcoin_units::FeeRate::from_sat_per_vb_f64(sat_vb: f64) -> core::result::Result<Self, bitcoin_units::fee_rate::error::FromFloatError>
 pub const fn bitcoin_units::FeeRate::mul_by_weight(self, weight: bitcoin_units::Weight) -> bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
 pub const fn bitcoin_units::FeeRate::to_fee(self, weight: bitcoin_units::Weight) -> bitcoin_units::Amount
 pub const fn bitcoin_units::FeeRate::to_sat_per_kvb_ceil(self) -> u64
@@ -3225,6 +3273,50 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::FeeRate where T: core::clo
   pub unsafe fn bitcoin_units::FeeRate::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_units::FeeRate where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_units::FeeRate
   pub fn bitcoin_units::FeeRate::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::FeeRate]
+pub struct bitcoin_units::fee_rate::FromFloatError(_)
+impl core::clone::Clone for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::clone(&self) -> bitcoin_units::fee_rate::error::FromFloatError [impl: impl core::clone::Clone for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::cmp::Eq for bitcoin_units::fee_rate::error::FromFloatError
+impl core::cmp::PartialEq for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::eq(&self, other: &bitcoin_units::fee_rate::error::FromFloatError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::fmt::Debug for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::fmt::Display for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::marker::StructuralPartialEq for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Freeze for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Send for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Sync for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Unpin for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::UnsafeUnpin for bitcoin_units::fee_rate::error::FromFloatError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::fee_rate::error::FromFloatError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::fee_rate::error::FromFloatError
+impl<T, U> core::convert::Into<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::From<T>
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::Into<T>
+  pub type bitcoin_units::fee_rate::error::FromFloatError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::Into<T>]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::TryFrom<T>
+  pub type bitcoin_units::fee_rate::error::FromFloatError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::TryFrom<T>]
+impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone
+  pub type bitcoin_units::fee_rate::error::FromFloatError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone]
+impl<T> alloc::string::ToString for bitcoin_units::fee_rate::error::FromFloatError where T: core::fmt::Display + ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_units::fee_rate::error::FromFloatError where T: core::fmt::Display + ?core::marker::Sized]
+impl<T> core::any::Any for bitcoin_units::fee_rate::error::FromFloatError where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_units::fee_rate::error::FromFloatError where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone
+  pub unsafe fn bitcoin_units::fee_rate::error::FromFloatError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::fee_rate::error::FromFloatError]
 pub mod bitcoin_units::locktime
 pub mod bitcoin_units::locktime::absolute
 pub mod bitcoin_units::locktime::absolute::error
@@ -9295,8 +9387,11 @@ pub const fn bitcoin_units::FeeRate::from_per_kvb(rate: bitcoin_units::Amount) -
 pub const fn bitcoin_units::FeeRate::from_per_kwu(rate: bitcoin_units::Amount) -> bitcoin_units::result::NumOpResult<Self>
 pub const fn bitcoin_units::FeeRate::from_per_vb(rate: bitcoin_units::Amount) -> bitcoin_units::result::NumOpResult<Self>
 pub const fn bitcoin_units::FeeRate::from_sat_per_kvb(sat_kvb: u32) -> Self
+pub fn bitcoin_units::FeeRate::from_sat_per_kvb_f64(sat_kvb: f64) -> core::result::Result<Self, bitcoin_units::fee_rate::error::FromFloatError>
 pub const fn bitcoin_units::FeeRate::from_sat_per_kwu(sat_kwu: u32) -> Self
+pub fn bitcoin_units::FeeRate::from_sat_per_kwu_f64(sat_kwu: f64) -> core::result::Result<Self, bitcoin_units::fee_rate::error::FromFloatError>
 pub const fn bitcoin_units::FeeRate::from_sat_per_vb(sat_vb: u32) -> Self
+pub fn bitcoin_units::FeeRate::from_sat_per_vb_f64(sat_vb: f64) -> core::result::Result<Self, bitcoin_units::fee_rate::error::FromFloatError>
 pub const fn bitcoin_units::FeeRate::mul_by_weight(self, weight: bitcoin_units::Weight) -> bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
 pub const fn bitcoin_units::FeeRate::to_fee(self, weight: bitcoin_units::Weight) -> bitcoin_units::Amount
 pub const fn bitcoin_units::FeeRate::to_sat_per_kvb_ceil(self) -> u64

--- a/units/api/alloc-only.txt
+++ b/units/api/alloc-only.txt
@@ -3036,6 +3036,51 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::block::error::TooBigForRel
 impl<T> core::convert::From<T> for bitcoin_units::block::error::TooBigForRelativeHeightError
   pub fn bitcoin_units::block::error::TooBigForRelativeHeightError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::block::error::TooBigForRelativeHeightError]
 pub mod bitcoin_units::fee_rate
+pub mod bitcoin_units::fee_rate::error
+pub struct bitcoin_units::fee_rate::error::FromFloatError(_)
+impl core::clone::Clone for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::clone(&self) -> bitcoin_units::fee_rate::error::FromFloatError [impl: impl core::clone::Clone for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::cmp::Eq for bitcoin_units::fee_rate::error::FromFloatError
+impl core::cmp::PartialEq for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::eq(&self, other: &bitcoin_units::fee_rate::error::FromFloatError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::fmt::Debug for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::fmt::Display for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::marker::StructuralPartialEq for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Freeze for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Send for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Sync for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Unpin for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::UnsafeUnpin for bitcoin_units::fee_rate::error::FromFloatError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::fee_rate::error::FromFloatError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::fee_rate::error::FromFloatError
+impl<T, U> core::convert::Into<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::From<T>
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::Into<T>
+  pub type bitcoin_units::fee_rate::error::FromFloatError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::Into<T>]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::TryFrom<T>
+  pub type bitcoin_units::fee_rate::error::FromFloatError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::TryFrom<T>]
+impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone
+  pub type bitcoin_units::fee_rate::error::FromFloatError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone]
+impl<T> alloc::string::ToString for bitcoin_units::fee_rate::error::FromFloatError where T: core::fmt::Display + ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_units::fee_rate::error::FromFloatError where T: core::fmt::Display + ?core::marker::Sized]
+impl<T> core::any::Any for bitcoin_units::fee_rate::error::FromFloatError where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_units::fee_rate::error::FromFloatError where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone
+  pub unsafe fn bitcoin_units::fee_rate::error::FromFloatError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::fee_rate::error::FromFloatError]
 pub struct bitcoin_units::fee_rate::FeeRate(_)
 impl bitcoin_units::FeeRate
 pub const bitcoin_units::FeeRate::BROADCAST_MIN: Self
@@ -3051,8 +3096,11 @@ pub const fn bitcoin_units::FeeRate::from_per_kvb(rate: bitcoin_units::Amount) -
 pub const fn bitcoin_units::FeeRate::from_per_kwu(rate: bitcoin_units::Amount) -> bitcoin_units::result::NumOpResult<Self>
 pub const fn bitcoin_units::FeeRate::from_per_vb(rate: bitcoin_units::Amount) -> bitcoin_units::result::NumOpResult<Self>
 pub const fn bitcoin_units::FeeRate::from_sat_per_kvb(sat_kvb: u32) -> Self
+pub fn bitcoin_units::FeeRate::from_sat_per_kvb_f64(sat_kvb: f64) -> core::result::Result<Self, bitcoin_units::fee_rate::error::FromFloatError>
 pub const fn bitcoin_units::FeeRate::from_sat_per_kwu(sat_kwu: u32) -> Self
+pub fn bitcoin_units::FeeRate::from_sat_per_kwu_f64(sat_kwu: f64) -> core::result::Result<Self, bitcoin_units::fee_rate::error::FromFloatError>
 pub const fn bitcoin_units::FeeRate::from_sat_per_vb(sat_vb: u32) -> Self
+pub fn bitcoin_units::FeeRate::from_sat_per_vb_f64(sat_vb: f64) -> core::result::Result<Self, bitcoin_units::fee_rate::error::FromFloatError>
 pub const fn bitcoin_units::FeeRate::mul_by_weight(self, weight: bitcoin_units::Weight) -> bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
 pub const fn bitcoin_units::FeeRate::to_fee(self, weight: bitcoin_units::Weight) -> bitcoin_units::Amount
 pub const fn bitcoin_units::FeeRate::to_sat_per_kvb_ceil(self) -> u64
@@ -3225,6 +3273,50 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::FeeRate where T: core::clo
   pub unsafe fn bitcoin_units::FeeRate::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_units::FeeRate where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_units::FeeRate
   pub fn bitcoin_units::FeeRate::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::FeeRate]
+pub struct bitcoin_units::fee_rate::FromFloatError(_)
+impl core::clone::Clone for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::clone(&self) -> bitcoin_units::fee_rate::error::FromFloatError [impl: impl core::clone::Clone for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::cmp::Eq for bitcoin_units::fee_rate::error::FromFloatError
+impl core::cmp::PartialEq for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::eq(&self, other: &bitcoin_units::fee_rate::error::FromFloatError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::fmt::Debug for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::fmt::Display for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::marker::StructuralPartialEq for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Freeze for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Send for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Sync for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Unpin for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::UnsafeUnpin for bitcoin_units::fee_rate::error::FromFloatError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::fee_rate::error::FromFloatError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::fee_rate::error::FromFloatError
+impl<T, U> core::convert::Into<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::From<T>
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::Into<T>
+  pub type bitcoin_units::fee_rate::error::FromFloatError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::Into<T>]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::TryFrom<T>
+  pub type bitcoin_units::fee_rate::error::FromFloatError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::TryFrom<T>]
+impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone
+  pub type bitcoin_units::fee_rate::error::FromFloatError::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone]
+impl<T> alloc::string::ToString for bitcoin_units::fee_rate::error::FromFloatError where T: core::fmt::Display + ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::to_string(&self) -> alloc::string::String [impl: impl<T> alloc::string::ToString for bitcoin_units::fee_rate::error::FromFloatError where T: core::fmt::Display + ?core::marker::Sized]
+impl<T> core::any::Any for bitcoin_units::fee_rate::error::FromFloatError where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_units::fee_rate::error::FromFloatError where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone
+  pub unsafe fn bitcoin_units::fee_rate::error::FromFloatError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::fee_rate::error::FromFloatError]
 pub mod bitcoin_units::locktime
 pub mod bitcoin_units::locktime::absolute
 pub mod bitcoin_units::locktime::absolute::error
@@ -9311,8 +9403,11 @@ pub const fn bitcoin_units::FeeRate::from_per_kvb(rate: bitcoin_units::Amount) -
 pub const fn bitcoin_units::FeeRate::from_per_kwu(rate: bitcoin_units::Amount) -> bitcoin_units::result::NumOpResult<Self>
 pub const fn bitcoin_units::FeeRate::from_per_vb(rate: bitcoin_units::Amount) -> bitcoin_units::result::NumOpResult<Self>
 pub const fn bitcoin_units::FeeRate::from_sat_per_kvb(sat_kvb: u32) -> Self
+pub fn bitcoin_units::FeeRate::from_sat_per_kvb_f64(sat_kvb: f64) -> core::result::Result<Self, bitcoin_units::fee_rate::error::FromFloatError>
 pub const fn bitcoin_units::FeeRate::from_sat_per_kwu(sat_kwu: u32) -> Self
+pub fn bitcoin_units::FeeRate::from_sat_per_kwu_f64(sat_kwu: f64) -> core::result::Result<Self, bitcoin_units::fee_rate::error::FromFloatError>
 pub const fn bitcoin_units::FeeRate::from_sat_per_vb(sat_vb: u32) -> Self
+pub fn bitcoin_units::FeeRate::from_sat_per_vb_f64(sat_vb: f64) -> core::result::Result<Self, bitcoin_units::fee_rate::error::FromFloatError>
 pub const fn bitcoin_units::FeeRate::mul_by_weight(self, weight: bitcoin_units::Weight) -> bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
 pub const fn bitcoin_units::FeeRate::to_fee(self, weight: bitcoin_units::Weight) -> bitcoin_units::Amount
 pub const fn bitcoin_units::FeeRate::to_sat_per_kvb_ceil(self) -> u64

--- a/units/api/no-features.txt
+++ b/units/api/no-features.txt
@@ -2700,6 +2700,45 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::block::error::TooBigForRel
 impl<T> core::convert::From<T> for bitcoin_units::block::error::TooBigForRelativeHeightError
   pub fn bitcoin_units::block::error::TooBigForRelativeHeightError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::block::error::TooBigForRelativeHeightError]
 pub mod bitcoin_units::fee_rate
+pub mod bitcoin_units::fee_rate::error
+pub struct bitcoin_units::fee_rate::error::FromFloatError(_)
+impl core::clone::Clone for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::clone(&self) -> bitcoin_units::fee_rate::error::FromFloatError [impl: impl core::clone::Clone for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::cmp::Eq for bitcoin_units::fee_rate::error::FromFloatError
+impl core::cmp::PartialEq for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::eq(&self, other: &bitcoin_units::fee_rate::error::FromFloatError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::fmt::Debug for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::fmt::Display for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::marker::StructuralPartialEq for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Freeze for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Send for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Sync for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Unpin for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::UnsafeUnpin for bitcoin_units::fee_rate::error::FromFloatError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::fee_rate::error::FromFloatError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::fee_rate::error::FromFloatError
+impl<T, U> core::convert::Into<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::From<T>
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::Into<T>
+  pub type bitcoin_units::fee_rate::error::FromFloatError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::Into<T>]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::TryFrom<T>
+  pub type bitcoin_units::fee_rate::error::FromFloatError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::TryFrom<T>]
+impl<T> core::any::Any for bitcoin_units::fee_rate::error::FromFloatError where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_units::fee_rate::error::FromFloatError where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone
+  pub unsafe fn bitcoin_units::fee_rate::error::FromFloatError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::fee_rate::error::FromFloatError]
 pub struct bitcoin_units::fee_rate::FeeRate(_)
 impl bitcoin_units::FeeRate
 pub const bitcoin_units::FeeRate::BROADCAST_MIN: Self
@@ -2715,8 +2754,11 @@ pub const fn bitcoin_units::FeeRate::from_per_kvb(rate: bitcoin_units::Amount) -
 pub const fn bitcoin_units::FeeRate::from_per_kwu(rate: bitcoin_units::Amount) -> bitcoin_units::result::NumOpResult<Self>
 pub const fn bitcoin_units::FeeRate::from_per_vb(rate: bitcoin_units::Amount) -> bitcoin_units::result::NumOpResult<Self>
 pub const fn bitcoin_units::FeeRate::from_sat_per_kvb(sat_kvb: u32) -> Self
+pub fn bitcoin_units::FeeRate::from_sat_per_kvb_f64(sat_kvb: f64) -> core::result::Result<Self, bitcoin_units::fee_rate::error::FromFloatError>
 pub const fn bitcoin_units::FeeRate::from_sat_per_kwu(sat_kwu: u32) -> Self
+pub fn bitcoin_units::FeeRate::from_sat_per_kwu_f64(sat_kwu: f64) -> core::result::Result<Self, bitcoin_units::fee_rate::error::FromFloatError>
 pub const fn bitcoin_units::FeeRate::from_sat_per_vb(sat_vb: u32) -> Self
+pub fn bitcoin_units::FeeRate::from_sat_per_vb_f64(sat_vb: f64) -> core::result::Result<Self, bitcoin_units::fee_rate::error::FromFloatError>
 pub const fn bitcoin_units::FeeRate::mul_by_weight(self, weight: bitcoin_units::Weight) -> bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
 pub const fn bitcoin_units::FeeRate::to_fee(self, weight: bitcoin_units::Weight) -> bitcoin_units::Amount
 pub const fn bitcoin_units::FeeRate::to_sat_per_kvb_ceil(self) -> u64
@@ -2885,6 +2927,44 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::FeeRate where T: core::clo
   pub unsafe fn bitcoin_units::FeeRate::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_units::FeeRate where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_units::FeeRate
   pub fn bitcoin_units::FeeRate::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::FeeRate]
+pub struct bitcoin_units::fee_rate::FromFloatError(_)
+impl core::clone::Clone for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::clone(&self) -> bitcoin_units::fee_rate::error::FromFloatError [impl: impl core::clone::Clone for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::cmp::Eq for bitcoin_units::fee_rate::error::FromFloatError
+impl core::cmp::PartialEq for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::eq(&self, other: &bitcoin_units::fee_rate::error::FromFloatError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::fmt::Debug for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::fmt::Display for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::marker::StructuralPartialEq for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Freeze for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Send for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Sync for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Unpin for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::UnsafeUnpin for bitcoin_units::fee_rate::error::FromFloatError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::fee_rate::error::FromFloatError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::fee_rate::error::FromFloatError
+impl<T, U> core::convert::Into<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::From<T>
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::Into<T>
+  pub type bitcoin_units::fee_rate::error::FromFloatError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::Into<T>]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::TryFrom<T>
+  pub type bitcoin_units::fee_rate::error::FromFloatError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::TryFrom<T>]
+impl<T> core::any::Any for bitcoin_units::fee_rate::error::FromFloatError where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_units::fee_rate::error::FromFloatError where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone
+  pub unsafe fn bitcoin_units::fee_rate::error::FromFloatError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::fee_rate::error::FromFloatError]
 pub mod bitcoin_units::locktime
 pub mod bitcoin_units::locktime::absolute
 pub mod bitcoin_units::locktime::absolute::error
@@ -8367,8 +8447,11 @@ pub const fn bitcoin_units::FeeRate::from_per_kvb(rate: bitcoin_units::Amount) -
 pub const fn bitcoin_units::FeeRate::from_per_kwu(rate: bitcoin_units::Amount) -> bitcoin_units::result::NumOpResult<Self>
 pub const fn bitcoin_units::FeeRate::from_per_vb(rate: bitcoin_units::Amount) -> bitcoin_units::result::NumOpResult<Self>
 pub const fn bitcoin_units::FeeRate::from_sat_per_kvb(sat_kvb: u32) -> Self
+pub fn bitcoin_units::FeeRate::from_sat_per_kvb_f64(sat_kvb: f64) -> core::result::Result<Self, bitcoin_units::fee_rate::error::FromFloatError>
 pub const fn bitcoin_units::FeeRate::from_sat_per_kwu(sat_kwu: u32) -> Self
+pub fn bitcoin_units::FeeRate::from_sat_per_kwu_f64(sat_kwu: f64) -> core::result::Result<Self, bitcoin_units::fee_rate::error::FromFloatError>
 pub const fn bitcoin_units::FeeRate::from_sat_per_vb(sat_vb: u32) -> Self
+pub fn bitcoin_units::FeeRate::from_sat_per_vb_f64(sat_vb: f64) -> core::result::Result<Self, bitcoin_units::fee_rate::error::FromFloatError>
 pub const fn bitcoin_units::FeeRate::mul_by_weight(self, weight: bitcoin_units::Weight) -> bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
 pub const fn bitcoin_units::FeeRate::to_fee(self, weight: bitcoin_units::Weight) -> bitcoin_units::Amount
 pub const fn bitcoin_units::FeeRate::to_sat_per_kvb_ceil(self) -> u64

--- a/units/api/no-features.txt
+++ b/units/api/no-features.txt
@@ -2700,6 +2700,45 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::block::error::TooBigForRel
 impl<T> core::convert::From<T> for bitcoin_units::block::error::TooBigForRelativeHeightError
   pub fn bitcoin_units::block::error::TooBigForRelativeHeightError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::block::error::TooBigForRelativeHeightError]
 pub mod bitcoin_units::fee_rate
+pub mod bitcoin_units::fee_rate::error
+pub struct bitcoin_units::fee_rate::error::FromFloatError(_)
+impl core::clone::Clone for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::clone(&self) -> bitcoin_units::fee_rate::error::FromFloatError [impl: impl core::clone::Clone for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::cmp::Eq for bitcoin_units::fee_rate::error::FromFloatError
+impl core::cmp::PartialEq for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::eq(&self, other: &bitcoin_units::fee_rate::error::FromFloatError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::fmt::Debug for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::fmt::Display for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::marker::StructuralPartialEq for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Freeze for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Send for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Sync for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Unpin for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::UnsafeUnpin for bitcoin_units::fee_rate::error::FromFloatError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::fee_rate::error::FromFloatError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::fee_rate::error::FromFloatError
+impl<T, U> core::convert::Into<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::From<T>
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::Into<T>
+  pub type bitcoin_units::fee_rate::error::FromFloatError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::Into<T>]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::TryFrom<T>
+  pub type bitcoin_units::fee_rate::error::FromFloatError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::TryFrom<T>]
+impl<T> core::any::Any for bitcoin_units::fee_rate::error::FromFloatError where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_units::fee_rate::error::FromFloatError where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone
+  pub unsafe fn bitcoin_units::fee_rate::error::FromFloatError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::fee_rate::error::FromFloatError]
 pub struct bitcoin_units::fee_rate::FeeRate(_)
 impl bitcoin_units::FeeRate
 pub const bitcoin_units::FeeRate::BROADCAST_MIN: Self
@@ -2715,8 +2754,11 @@ pub const fn bitcoin_units::FeeRate::from_per_kvb(rate: bitcoin_units::Amount) -
 pub const fn bitcoin_units::FeeRate::from_per_kwu(rate: bitcoin_units::Amount) -> bitcoin_units::result::NumOpResult<Self>
 pub const fn bitcoin_units::FeeRate::from_per_vb(rate: bitcoin_units::Amount) -> bitcoin_units::result::NumOpResult<Self>
 pub const fn bitcoin_units::FeeRate::from_sat_per_kvb(sat_kvb: u32) -> Self
+pub fn bitcoin_units::FeeRate::from_sat_per_kvb_f64(sat_kvb: f64) -> core::result::Result<Self, bitcoin_units::fee_rate::error::FromFloatError>
 pub const fn bitcoin_units::FeeRate::from_sat_per_kwu(sat_kwu: u32) -> Self
+pub fn bitcoin_units::FeeRate::from_sat_per_kwu_f64(sat_kwu: f64) -> core::result::Result<Self, bitcoin_units::fee_rate::error::FromFloatError>
 pub const fn bitcoin_units::FeeRate::from_sat_per_vb(sat_vb: u32) -> Self
+pub fn bitcoin_units::FeeRate::from_sat_per_vb_f64(sat_vb: f64) -> core::result::Result<Self, bitcoin_units::fee_rate::error::FromFloatError>
 pub const fn bitcoin_units::FeeRate::mul_by_weight(self, weight: bitcoin_units::Weight) -> bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
 pub const fn bitcoin_units::FeeRate::to_fee(self, weight: bitcoin_units::Weight) -> bitcoin_units::Amount
 pub const fn bitcoin_units::FeeRate::to_sat_per_kvb_ceil(self) -> u64
@@ -2885,6 +2927,44 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::FeeRate where T: core::clo
   pub unsafe fn bitcoin_units::FeeRate::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_units::FeeRate where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_units::FeeRate
   pub fn bitcoin_units::FeeRate::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::FeeRate]
+pub struct bitcoin_units::fee_rate::FromFloatError(_)
+impl core::clone::Clone for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::clone(&self) -> bitcoin_units::fee_rate::error::FromFloatError [impl: impl core::clone::Clone for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::cmp::Eq for bitcoin_units::fee_rate::error::FromFloatError
+impl core::cmp::PartialEq for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::eq(&self, other: &bitcoin_units::fee_rate::error::FromFloatError) -> bool [impl: impl core::cmp::PartialEq for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::convert::From<core::convert::Infallible> for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::from(never: core::convert::Infallible) -> Self [impl: impl core::convert::From<core::convert::Infallible> for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::fmt::Debug for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::fmt::Display for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_units::fee_rate::error::FromFloatError]
+impl core::marker::StructuralPartialEq for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Freeze for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Send for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Sync for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::Unpin for bitcoin_units::fee_rate::error::FromFloatError
+impl core::marker::UnsafeUnpin for bitcoin_units::fee_rate::error::FromFloatError
+impl core::panic::unwind_safe::RefUnwindSafe for bitcoin_units::fee_rate::error::FromFloatError
+impl core::panic::unwind_safe::UnwindSafe for bitcoin_units::fee_rate::error::FromFloatError
+impl<T, U> core::convert::Into<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::From<T>
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::Into<T>
+  pub type bitcoin_units::fee_rate::error::FromFloatError::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::Into<T>]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::TryFrom<T>
+  pub type bitcoin_units::fee_rate::error::FromFloatError::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_units::fee_rate::error::FromFloatError where U: core::convert::TryFrom<T>]
+impl<T> core::any::Any for bitcoin_units::fee_rate::error::FromFloatError where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_units::fee_rate::error::FromFloatError where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_units::fee_rate::error::FromFloatError where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone
+  pub unsafe fn bitcoin_units::fee_rate::error::FromFloatError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_units::fee_rate::error::FromFloatError where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_units::fee_rate::error::FromFloatError
+  pub fn bitcoin_units::fee_rate::error::FromFloatError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::fee_rate::error::FromFloatError]
 pub mod bitcoin_units::locktime
 pub mod bitcoin_units::locktime::absolute
 pub mod bitcoin_units::locktime::absolute::error
@@ -8351,8 +8431,11 @@ pub const fn bitcoin_units::FeeRate::from_per_kvb(rate: bitcoin_units::Amount) -
 pub const fn bitcoin_units::FeeRate::from_per_kwu(rate: bitcoin_units::Amount) -> bitcoin_units::result::NumOpResult<Self>
 pub const fn bitcoin_units::FeeRate::from_per_vb(rate: bitcoin_units::Amount) -> bitcoin_units::result::NumOpResult<Self>
 pub const fn bitcoin_units::FeeRate::from_sat_per_kvb(sat_kvb: u32) -> Self
+pub fn bitcoin_units::FeeRate::from_sat_per_kvb_f64(sat_kvb: f64) -> core::result::Result<Self, bitcoin_units::fee_rate::error::FromFloatError>
 pub const fn bitcoin_units::FeeRate::from_sat_per_kwu(sat_kwu: u32) -> Self
+pub fn bitcoin_units::FeeRate::from_sat_per_kwu_f64(sat_kwu: f64) -> core::result::Result<Self, bitcoin_units::fee_rate::error::FromFloatError>
 pub const fn bitcoin_units::FeeRate::from_sat_per_vb(sat_vb: u32) -> Self
+pub fn bitcoin_units::FeeRate::from_sat_per_vb_f64(sat_vb: f64) -> core::result::Result<Self, bitcoin_units::fee_rate::error::FromFloatError>
 pub const fn bitcoin_units::FeeRate::mul_by_weight(self, weight: bitcoin_units::Weight) -> bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
 pub const fn bitcoin_units::FeeRate::to_fee(self, weight: bitcoin_units::Weight) -> bitcoin_units::Amount
 pub const fn bitcoin_units::FeeRate::to_sat_per_kvb_ceil(self) -> u64

--- a/units/src/fee_rate/mod.rs
+++ b/units/src/fee_rate/mod.rs
@@ -41,6 +41,8 @@ mod encapsulate {
 pub use encapsulate::FeeRate;
 use internals::const_casts;
 
+pub use self::error::FromFloatError;
+
 impl FeeRate {
     /// The zero fee rate.
     ///
@@ -111,6 +113,108 @@ impl FeeRate {
         match rate.checked_mul(1_000) {
             Some(per_mvb) => R::Valid(Self::from_sat_per_mvb(per_mvb.to_sat())),
             None => R::Error(E::while_doing(MathOp::Mul)),
+        }
+    }
+
+    /// Constructs a new [`FeeRate`] from satoshis per 1,000 weight units, expressed as a float.
+    ///
+    /// The value is rounded to the nearest satoshi per 1,000,000 virtual bytes, the internal
+    /// representation of [`FeeRate`].
+    ///
+    /// Please be aware of the risk of using floating-point numbers.
+    ///
+    /// # Errors
+    ///
+    /// If `sat_kwu` is `NaN`, infinite, negative, or too large to be represented.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bitcoin_units::FeeRate;
+    /// let fee_rate = FeeRate::from_sat_per_kwu_f64(25.0)?;
+    /// assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(25));
+    /// # Ok::<_, bitcoin_units::fee_rate::FromFloatError>(())
+    /// ```
+    #[inline]
+    pub fn from_sat_per_kwu_f64(sat_kwu: f64) -> Result<Self, FromFloatError> {
+        Self::from_float(sat_kwu, 4_000.0)
+    }
+
+    /// Constructs a new [`FeeRate`] from satoshis per virtual byte, expressed as a float.
+    ///
+    /// The value is rounded to the nearest satoshi per 1,000,000 virtual bytes, the internal
+    /// representation of [`FeeRate`].
+    ///
+    /// Please be aware of the risk of using floating-point numbers.
+    ///
+    /// # Errors
+    ///
+    /// If `sat_vb` is `NaN`, infinite, negative, or too large to be represented.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bitcoin_units::FeeRate;
+    /// let fee_rate = FeeRate::from_sat_per_vb_f64(0.1)?;
+    /// assert_eq!(fee_rate.to_sat_per_kwu_floor(), 25);
+    /// # Ok::<_, bitcoin_units::fee_rate::FromFloatError>(())
+    /// ```
+    #[inline]
+    pub fn from_sat_per_vb_f64(sat_vb: f64) -> Result<Self, FromFloatError> {
+        Self::from_float(sat_vb, 1_000_000.0)
+    }
+
+    /// Constructs a new [`FeeRate`] from satoshis per kilo virtual bytes (1,000 vbytes),
+    /// expressed as a float.
+    ///
+    /// The value is rounded to the nearest satoshi per 1,000,000 virtual bytes, the internal
+    /// representation of [`FeeRate`].
+    ///
+    /// Please be aware of the risk of using floating-point numbers.
+    ///
+    /// # Errors
+    ///
+    /// If `sat_kvb` is `NaN`, infinite, negative, or too large to be represented.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bitcoin_units::FeeRate;
+    /// let fee_rate = FeeRate::from_sat_per_kvb_f64(11.0)?;
+    /// assert_eq!(fee_rate, FeeRate::from_sat_per_kvb(11));
+    /// # Ok::<_, bitcoin_units::fee_rate::FromFloatError>(())
+    /// ```
+    #[inline]
+    pub fn from_sat_per_kvb_f64(sat_kvb: f64) -> Result<Self, FromFloatError> {
+        Self::from_float(sat_kvb, 1_000.0)
+    }
+
+    fn from_float(value: f64, factor: f64) -> Result<Self, FromFloatError> {
+        use error::FromFloatErrorInner;
+
+        if value.is_nan() {
+            return Err(FromFloatError(FromFloatErrorInner::Nan));
+        }
+        if value.is_infinite() {
+            return Err(FromFloatError(FromFloatErrorInner::Infinite));
+        }
+        if value < 0.0 {
+            return Err(FromFloatError(FromFloatErrorInner::Negative));
+        }
+        let sat_mvb = value * factor;
+        // 2^64, the smallest float that does not fit in a `u64`. Also catches the
+        // multiplication overflowing to infinity.
+        if sat_mvb >= 18_446_744_073_709_551_616.0 {
+            return Err(FromFloatError(FromFloatErrorInner::Overflow));
+        }
+        // Cast truncates the fractional part; rounding is done manually because `f64::round`
+        // is not available in `core`.
+        let floor = sat_mvb as u64;
+        if sat_mvb % 1.0 >= 0.5 {
+            // A nonzero fractional part implies `sat_mvb < 2^53`, so this cannot overflow.
+            Ok(Self::from_sat_per_mvb(floor + 1))
+        } else {
+            Ok(Self::from_sat_per_mvb(floor))
         }
     }
 
@@ -273,6 +377,49 @@ impl<'a> Arbitrary<'a> for FeeRate {
     }
 }
 
+/// Error types for fee rate conversions.
+pub mod error {
+    use core::convert::Infallible;
+    use core::fmt;
+
+    /// Error returned when constructing a [`FeeRate`](super::FeeRate) from a float fails.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct FromFloatError(pub(super) FromFloatErrorInner);
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub(super) enum FromFloatErrorInner {
+        Nan,
+        Infinite,
+        Negative,
+        Overflow,
+    }
+
+    impl From<Infallible> for FromFloatError {
+        fn from(never: Infallible) -> Self { match never {} }
+    }
+
+    impl fmt::Display for FromFloatError {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            use FromFloatErrorInner as E;
+
+            match self.0 {
+                E::Nan => write!(f, "fee rate is NaN"),
+                E::Infinite => write!(f, "fee rate is infinite"),
+                E::Negative => write!(f, "fee rate is negative"),
+                E::Overflow => write!(f, "fee rate is too large"),
+            }
+        }
+    }
+
+    #[cfg(feature = "std")]
+    impl std::error::Error for FromFloatError {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            let Self(_) = self;
+            None
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use core::num::NonZeroU64;
@@ -396,6 +543,76 @@ mod tests {
     fn fee_rate_from_sat_per_kvb() {
         let fee_rate = FeeRate::from_sat_per_kvb(11);
         assert_eq!(fee_rate, FeeRate::from_sat_per_mvb(11_000));
+    }
+
+    #[test]
+    fn fee_rate_from_sat_per_kwu_f64() {
+        let fee_rate = FeeRate::from_sat_per_kwu_f64(0.25).unwrap();
+        assert_eq!(fee_rate, FeeRate::from_sat_per_mvb(1_000));
+
+        let fee_rate = FeeRate::from_sat_per_kwu_f64(250.0).unwrap();
+        assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(250));
+    }
+
+    #[test]
+    fn fee_rate_from_sat_per_vb_f64() {
+        let fee_rate = FeeRate::from_sat_per_vb_f64(0.1).unwrap();
+        assert_eq!(fee_rate, FeeRate::from_sat_per_mvb(100_000));
+
+        let fee_rate = FeeRate::from_sat_per_vb_f64(3.0).unwrap();
+        assert_eq!(fee_rate, FeeRate::from_sat_per_vb(3));
+    }
+
+    #[test]
+    fn fee_rate_from_sat_per_kvb_f64() {
+        let fee_rate = FeeRate::from_sat_per_kvb_f64(2.5).unwrap();
+        assert_eq!(fee_rate, FeeRate::from_sat_per_mvb(2_500));
+
+        let fee_rate = FeeRate::from_sat_per_kvb_f64(11.0).unwrap();
+        assert_eq!(fee_rate, FeeRate::from_sat_per_kvb(11));
+    }
+
+    #[test]
+    fn fee_rate_from_float_rounds_to_nearest() {
+        // 0.4 sat/MvB rounds down, 0.5 and 0.6 sat/MvB round up.
+        assert_eq!(FeeRate::from_sat_per_kvb_f64(0.0004).unwrap(), FeeRate::ZERO);
+        assert_eq!(FeeRate::from_sat_per_kvb_f64(0.0005).unwrap(), FeeRate::from_sat_per_mvb(1));
+        assert_eq!(FeeRate::from_sat_per_kvb_f64(0.0006).unwrap(), FeeRate::from_sat_per_mvb(1));
+        assert_eq!(FeeRate::from_sat_per_vb_f64(-0.0).unwrap(), FeeRate::ZERO);
+    }
+
+    #[test]
+    fn fee_rate_from_float_errors() {
+        use super::error::FromFloatErrorInner;
+
+        assert_eq!(
+            FeeRate::from_sat_per_vb_f64(f64::NAN).unwrap_err(),
+            FromFloatError(FromFloatErrorInner::Nan)
+        );
+        assert_eq!(
+            FeeRate::from_sat_per_vb_f64(f64::INFINITY).unwrap_err(),
+            FromFloatError(FromFloatErrorInner::Infinite)
+        );
+        assert_eq!(
+            FeeRate::from_sat_per_vb_f64(f64::NEG_INFINITY).unwrap_err(),
+            FromFloatError(FromFloatErrorInner::Infinite)
+        );
+        assert_eq!(
+            FeeRate::from_sat_per_vb_f64(-0.1).unwrap_err(),
+            FromFloatError(FromFloatErrorInner::Negative)
+        );
+        assert_eq!(
+            FeeRate::from_sat_per_vb_f64(f64::MAX).unwrap_err(),
+            FromFloatError(FromFloatErrorInner::Overflow)
+        );
+
+        // 18_446_744_073_709 sat/vB is the largest whole sat/vB value that fits, one more
+        // overflows the internal u64 sat/MvB representation.
+        assert!(FeeRate::from_sat_per_vb_f64(18_446_744_073_709.0).is_ok());
+        assert_eq!(
+            FeeRate::from_sat_per_vb_f64(18_446_744_073_710.0).unwrap_err(),
+            FromFloatError(FromFloatErrorInner::Overflow)
+        );
     }
 
     #[test]

--- a/units/src/fee_rate/mod.rs
+++ b/units/src/fee_rate/mod.rs
@@ -41,6 +41,8 @@ mod encapsulate {
 pub use encapsulate::FeeRate;
 use internals::const_casts;
 
+pub use self::error::FromFloatError;
+
 impl FeeRate {
     /// The zero fee rate.
     ///
@@ -111,6 +113,108 @@ impl FeeRate {
         match rate.checked_mul(1_000) {
             Some(per_mvb) => R::Valid(Self::from_sat_per_mvb(per_mvb.to_sat())),
             None => R::Error(E::while_doing(MathOp::Mul)),
+        }
+    }
+
+    /// Constructs a new [`FeeRate`] from satoshis per 1,000 weight units, expressed as a float.
+    ///
+    /// The value is rounded to the nearest satoshi per 1,000,000 virtual bytes, the internal
+    /// representation of [`FeeRate`].
+    ///
+    /// Please be aware of the risk of using floating-point numbers.
+    ///
+    /// # Errors
+    ///
+    /// If `sat_kwu` is `NaN`, infinite, negative, or too large to be represented.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bitcoin_units::FeeRate;
+    /// let fee_rate = FeeRate::from_sat_per_kwu_f64(25.0)?;
+    /// assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(25));
+    /// # Ok::<_, bitcoin_units::fee_rate::FromFloatError>(())
+    /// ```
+    #[inline]
+    pub fn from_sat_per_kwu_f64(sat_kwu: f64) -> Result<Self, FromFloatError> {
+        Self::from_float(sat_kwu, 4_000.0)
+    }
+
+    /// Constructs a new [`FeeRate`] from satoshis per virtual byte, expressed as a float.
+    ///
+    /// The value is rounded to the nearest satoshi per 1,000,000 virtual bytes, the internal
+    /// representation of [`FeeRate`].
+    ///
+    /// Please be aware of the risk of using floating-point numbers.
+    ///
+    /// # Errors
+    ///
+    /// If `sat_vb` is `NaN`, infinite, negative, or too large to be represented.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bitcoin_units::FeeRate;
+    /// let fee_rate = FeeRate::from_sat_per_vb_f64(0.1)?;
+    /// assert_eq!(fee_rate.to_sat_per_kwu_floor(), 25);
+    /// # Ok::<_, bitcoin_units::fee_rate::FromFloatError>(())
+    /// ```
+    #[inline]
+    pub fn from_sat_per_vb_f64(sat_vb: f64) -> Result<Self, FromFloatError> {
+        Self::from_float(sat_vb, 1_000_000.0)
+    }
+
+    /// Constructs a new [`FeeRate`] from satoshis per kilo virtual bytes (1,000 vbytes),
+    /// expressed as a float.
+    ///
+    /// The value is rounded to the nearest satoshi per 1,000,000 virtual bytes, the internal
+    /// representation of [`FeeRate`].
+    ///
+    /// Please be aware of the risk of using floating-point numbers.
+    ///
+    /// # Errors
+    ///
+    /// If `sat_kvb` is `NaN`, infinite, negative, or too large to be represented.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bitcoin_units::FeeRate;
+    /// let fee_rate = FeeRate::from_sat_per_kvb_f64(11.0)?;
+    /// assert_eq!(fee_rate, FeeRate::from_sat_per_kvb(11));
+    /// # Ok::<_, bitcoin_units::fee_rate::FromFloatError>(())
+    /// ```
+    #[inline]
+    pub fn from_sat_per_kvb_f64(sat_kvb: f64) -> Result<Self, FromFloatError> {
+        Self::from_float(sat_kvb, 1_000.0)
+    }
+
+    fn from_float(value: f64, factor: f64) -> Result<Self, FromFloatError> {
+        use error::FromFloatErrorInner;
+
+        if value.is_nan() {
+            return Err(FromFloatError(FromFloatErrorInner::Nan));
+        }
+        if value.is_infinite() {
+            return Err(FromFloatError(FromFloatErrorInner::Infinite));
+        }
+        if value < 0.0 {
+            return Err(FromFloatError(FromFloatErrorInner::Negative));
+        }
+        let sat_mvb = value * factor;
+        // 2^64, the smallest float that does not fit in a `u64`. Also catches the
+        // multiplication overflowing to infinity.
+        if sat_mvb >= 18_446_744_073_709_551_616.0 {
+            return Err(FromFloatError(FromFloatErrorInner::Overflow));
+        }
+        // Cast truncates the fractional part; rounding is done manually because `f64::round`
+        // is not available in `core`.
+        let floor = sat_mvb as u64;
+        if sat_mvb % 1.0 >= 0.5 {
+            // A nonzero fractional part implies `sat_mvb < 2^53`, so this cannot overflow.
+            Ok(Self::from_sat_per_mvb(floor + 1))
+        } else {
+            Ok(Self::from_sat_per_mvb(floor))
         }
     }
 
@@ -281,6 +385,49 @@ impl<'a> Arbitrary<'a> for FeeRate {
     }
 }
 
+/// Error types for fee rate conversions.
+pub mod error {
+    use core::convert::Infallible;
+    use core::fmt;
+
+    /// Error returned when constructing a [`FeeRate`](super::FeeRate) from a float fails.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct FromFloatError(pub(super) FromFloatErrorInner);
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub(super) enum FromFloatErrorInner {
+        Nan,
+        Infinite,
+        Negative,
+        Overflow,
+    }
+
+    impl From<Infallible> for FromFloatError {
+        fn from(never: Infallible) -> Self { match never {} }
+    }
+
+    impl fmt::Display for FromFloatError {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            use FromFloatErrorInner as E;
+
+            match self.0 {
+                E::Nan => write!(f, "fee rate is NaN"),
+                E::Infinite => write!(f, "fee rate is infinite"),
+                E::Negative => write!(f, "fee rate is negative"),
+                E::Overflow => write!(f, "fee rate is too large"),
+            }
+        }
+    }
+
+    #[cfg(feature = "std")]
+    impl std::error::Error for FromFloatError {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            let Self(_) = self;
+            None
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use core::num::NonZeroU64;
@@ -404,6 +551,76 @@ mod tests {
     fn fee_rate_from_sat_per_kvb() {
         let fee_rate = FeeRate::from_sat_per_kvb(11);
         assert_eq!(fee_rate, FeeRate::from_sat_per_mvb(11_000));
+    }
+
+    #[test]
+    fn fee_rate_from_sat_per_kwu_f64() {
+        let fee_rate = FeeRate::from_sat_per_kwu_f64(0.25).unwrap();
+        assert_eq!(fee_rate, FeeRate::from_sat_per_mvb(1_000));
+
+        let fee_rate = FeeRate::from_sat_per_kwu_f64(250.0).unwrap();
+        assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(250));
+    }
+
+    #[test]
+    fn fee_rate_from_sat_per_vb_f64() {
+        let fee_rate = FeeRate::from_sat_per_vb_f64(0.1).unwrap();
+        assert_eq!(fee_rate, FeeRate::from_sat_per_mvb(100_000));
+
+        let fee_rate = FeeRate::from_sat_per_vb_f64(3.0).unwrap();
+        assert_eq!(fee_rate, FeeRate::from_sat_per_vb(3));
+    }
+
+    #[test]
+    fn fee_rate_from_sat_per_kvb_f64() {
+        let fee_rate = FeeRate::from_sat_per_kvb_f64(2.5).unwrap();
+        assert_eq!(fee_rate, FeeRate::from_sat_per_mvb(2_500));
+
+        let fee_rate = FeeRate::from_sat_per_kvb_f64(11.0).unwrap();
+        assert_eq!(fee_rate, FeeRate::from_sat_per_kvb(11));
+    }
+
+    #[test]
+    fn fee_rate_from_float_rounds_to_nearest() {
+        // 0.4 sat/MvB rounds down, 0.5 and 0.6 sat/MvB round up.
+        assert_eq!(FeeRate::from_sat_per_kvb_f64(0.0004).unwrap(), FeeRate::ZERO);
+        assert_eq!(FeeRate::from_sat_per_kvb_f64(0.0005).unwrap(), FeeRate::from_sat_per_mvb(1));
+        assert_eq!(FeeRate::from_sat_per_kvb_f64(0.0006).unwrap(), FeeRate::from_sat_per_mvb(1));
+        assert_eq!(FeeRate::from_sat_per_vb_f64(-0.0).unwrap(), FeeRate::ZERO);
+    }
+
+    #[test]
+    fn fee_rate_from_float_errors() {
+        use super::error::FromFloatErrorInner;
+
+        assert_eq!(
+            FeeRate::from_sat_per_vb_f64(f64::NAN).unwrap_err(),
+            FromFloatError(FromFloatErrorInner::Nan)
+        );
+        assert_eq!(
+            FeeRate::from_sat_per_vb_f64(f64::INFINITY).unwrap_err(),
+            FromFloatError(FromFloatErrorInner::Infinite)
+        );
+        assert_eq!(
+            FeeRate::from_sat_per_vb_f64(f64::NEG_INFINITY).unwrap_err(),
+            FromFloatError(FromFloatErrorInner::Infinite)
+        );
+        assert_eq!(
+            FeeRate::from_sat_per_vb_f64(-0.1).unwrap_err(),
+            FromFloatError(FromFloatErrorInner::Negative)
+        );
+        assert_eq!(
+            FeeRate::from_sat_per_vb_f64(f64::MAX).unwrap_err(),
+            FromFloatError(FromFloatErrorInner::Overflow)
+        );
+
+        // 18_446_744_073_709 sat/vB is the largest whole sat/vB value that fits, one more
+        // overflows the internal u64 sat/MvB representation.
+        assert!(FeeRate::from_sat_per_vb_f64(18_446_744_073_709.0).is_ok());
+        assert_eq!(
+            FeeRate::from_sat_per_vb_f64(18_446_744_073_710.0).unwrap_err(),
+            FromFloatError(FromFloatErrorInner::Overflow)
+        );
     }
 
     #[test]

--- a/units/tests/api.rs
+++ b/units/tests/api.rs
@@ -148,20 +148,21 @@ struct Errors {
     j: amount::error::TooPreciseError,
     k: amount::error::UnknownDenominationError,
     l: block::TooBigForRelativeHeightError,
+    m: fee_rate::FromFloatError,
     #[cfg(feature = "serde")]
-    m: fee_rate::serde::OverflowError,
-    n: locktime::absolute::ConversionError,
-    o: locktime::absolute::ParseHeightError,
-    p: locktime::absolute::ParseTimeError,
-    q: locktime::relative::InvalidHeightError,
-    r: locktime::relative::InvalidTimeError,
-    s: locktime::relative::TimeOverflowError,
-    t: parse_int::ParseIntError,
-    u: parse_int::PrefixedHexError,
-    v: parse_int::UnprefixedHexError,
+    n: fee_rate::serde::OverflowError,
+    o: locktime::absolute::ConversionError,
+    p: locktime::absolute::ParseHeightError,
+    q: locktime::absolute::ParseTimeError,
+    r: locktime::relative::InvalidHeightError,
+    s: locktime::relative::InvalidTimeError,
+    t: locktime::relative::TimeOverflowError,
+    u: parse_int::ParseIntError,
+    v: parse_int::PrefixedHexError,
+    w: parse_int::UnprefixedHexError,
     #[cfg(feature = "encoding")]
-    w: pow::CompactTargetDecoderError,
-    x: result::NumOpError,
+    x: pow::CompactTargetDecoderError,
+    y: result::NumOpError,
 }
 
 /// A struct that includes all public decoder types.
@@ -242,7 +243,7 @@ fn api_can_use_all_types_from_module_sequence() {
 fn api_can_use_all_types_from_module_fee_rate() {
     #[cfg(feature = "serde")]
     use bitcoin_units::fee_rate::serde::OverflowError;
-    use bitcoin_units::fee_rate::FeeRate;
+    use bitcoin_units::fee_rate::{FeeRate, FromFloatError};
 }
 
 #[test]

--- a/units/tests/api.rs
+++ b/units/tests/api.rs
@@ -145,20 +145,21 @@ struct Errors {
     j: amount::error::TooPreciseError,
     k: amount::error::UnknownDenominationError,
     l: block::TooBigForRelativeHeightError,
+    m: fee_rate::FromFloatError,
     #[cfg(feature = "serde")]
-    m: fee_rate::serde::OverflowError,
-    n: locktime::absolute::ConversionError,
-    o: locktime::absolute::ParseHeightError,
-    p: locktime::absolute::ParseTimeError,
-    q: locktime::relative::InvalidHeightError,
-    r: locktime::relative::InvalidTimeError,
-    s: locktime::relative::TimeOverflowError,
-    t: parse_int::ParseIntError,
-    u: parse_int::PrefixedHexError,
-    v: parse_int::UnprefixedHexError,
+    n: fee_rate::serde::OverflowError,
+    o: locktime::absolute::ConversionError,
+    p: locktime::absolute::ParseHeightError,
+    q: locktime::absolute::ParseTimeError,
+    r: locktime::relative::InvalidHeightError,
+    s: locktime::relative::InvalidTimeError,
+    t: locktime::relative::TimeOverflowError,
+    u: parse_int::ParseIntError,
+    v: parse_int::PrefixedHexError,
+    w: parse_int::UnprefixedHexError,
     #[cfg(feature = "encoding")]
-    w: pow::CompactTargetDecoderError,
-    x: result::NumOpError,
+    x: pow::CompactTargetDecoderError,
+    y: result::NumOpError,
 }
 
 /// A struct that includes all public decoder types.
@@ -269,6 +270,7 @@ fn c_good_err_display() {
     assert_display::<amount::error::TooPreciseError>();
     assert_display::<amount::error::UnknownDenominationError>();
     assert_display::<block::TooBigForRelativeHeightError>();
+    assert_display::<fee_rate::FromFloatError>();
     #[cfg(feature = "serde")]
     assert_display::<fee_rate::serde::OverflowError>();
     assert_display::<locktime::absolute::ConversionError>();
@@ -430,7 +432,7 @@ fn p_consistent_exports_sequence() {
 fn p_consistent_exports_fee_rate() {
     #[cfg(feature = "serde")]
     use bitcoin_units::fee_rate::serde::OverflowError;
-    use bitcoin_units::fee_rate::FeeRate;
+    use bitcoin_units::fee_rate::{FeeRate, FromFloatError};
 }
 
 /// P-CONSISTENT-EXPORTS: Tests that all types can be imported from the `locktime::absolute` module.


### PR DESCRIPTION
Applications commonly deal with fractional fee rates such as 0.1 sat/vB, but
`FeeRate` only has integer constructors, so callers have to hand-roll the
float conversion.

Add `from_sat_per_kwu_f64`, `from_sat_per_vb_f64` and `from_sat_per_kvb_f64`,
using the `_f64` suffix suggested in the issue discussion. Values are rounded
to the nearest sat/MvB (the internal representation). NaN, infinite, negative
and overflowing inputs return the new `fee_rate::FromFloatError` type.

The constructors use plain float arithmetic with no feature gate, so they are
also available in `no_std`. They are not `const` because const float
arithmetic requires Rust 1.82 (MSRV is 1.74).

Closes #6439