### PR TITLE
ci: disable fail-fast in weekly rustc update crons

### DIFF
--- a/.github/workflows/cron-weekly-update-nightly.yml
+++ b/.github/workflows/cron-weekly-update-nightly.yml
@@ -22,7 +22,7 @@ jobs:
           ref: ${{ matrix.branch }}
           persist-credentials: false
       - name: Install cargo-rbmt
-        run: cargo install --git https://github.com/rust-bitcoin/rust-bitcoin-maintainer-tools.git --rev $(cat rbmt-version) cargo-rbmt
+        run: cargo install --locked cargo-rbmt@"$(grep '^rbmt.version' Cargo.toml | cut -d'"' -f2)"
       - name: Update nightly toolchain in Cargo.toml
         run: |
           cargo rbmt toolchains --update-nightly

--- a/.github/workflows/cron-weekly-update-nightly.yml
+++ b/.github/workflows/cron-weekly-update-nightly.yml
@@ -13,6 +13,7 @@ jobs:
       id-token: write
       pull-requests: write
     strategy:
+      fail-fast: false
       matrix:
         # Update toolchain on master and LTS branches.
         branch: [master, 0.32.xxx, 0.32.xx]

--- a/.github/workflows/cron-weekly-update-stable.yml
+++ b/.github/workflows/cron-weekly-update-stable.yml
@@ -21,7 +21,7 @@ jobs:
           ref: ${{ matrix.branch }}
           persist-credentials: false
       - name: Install cargo-rbmt
-        run: cargo install --git https://github.com/rust-bitcoin/rust-bitcoin-maintainer-tools.git --rev $(cat rbmt-version) cargo-rbmt
+        run: cargo install --locked cargo-rbmt@"$(grep '^rbmt.version' Cargo.toml | cut -d'"' -f2)"
       - name: Update stable toolchain in Cargo.toml
         run: |
           cargo rbmt toolchains --update-stable

--- a/.github/workflows/cron-weekly-update-stable.yml
+++ b/.github/workflows/cron-weekly-update-stable.yml
@@ -12,6 +12,7 @@ jobs:
       contents: write
       pull-requests: write
     strategy:
+      fail-fast: false
       matrix:
         # Update toolchain on master and LTS branches.
         branch: [master, 0.32.xxx, 0.32.xx]


### PR DESCRIPTION
Note that nightly and stable rustc updates have broken:
- https://github.com/rust-bitcoin/rust-bitcoin/actions/workflows/cron-weekly-update-stable.yml
- https://github.com/rust-bitcoin/rust-bitcoin/actions/workflows/cron-weekly-update-nightly.yml

Because of `fail-fast`, a broken 0.32.xxx job takes the master and 0.32.xx updates down with it. This PR makes each branch succeed or fail on its own.

The cargo-rbmt install issue this PR originally also addressed was fixed on master by the shared setup-rbmt action, so that part is gone.
