### PR TITLE
Change ScriptBuf::default to call ScriptBuf::new

### DIFF
--- a/primitives/src/script/owned.rs
+++ b/primitives/src/script/owned.rs
@@ -294,7 +294,7 @@ impl<T: ScriptHashableTag> ScriptBuf<T> {
 
 // Cannot derive due to generics.
 impl<T> Default for ScriptBuf<T> {
-    fn default() -> Self { Self(PhantomData, Vec::new()) }
+    fn default() -> Self { Self::new() }
 }
 
 impl<T> Deref for ScriptBuf<T> {


### PR DESCRIPTION
According to C-CTOR, for types that implement Default and have a new constructor, the two should have the same behaviour. While ScriptBuf already satisfies this, regressions can be prevented by implementing Default by calling new, rather than repeating the logic.

Adjust ScriptBuf Default impl to call through to ScriptBuf::new.