### PR TITLE
primitives: Add fmt traits for `WitnessVersion`

### DIFF
--- a/primitives/api/all-features.txt
+++ b/primitives/api/all-features.txt
@@ -6559,10 +6559,18 @@ impl core::convert::TryFrom<bitcoin_primitives::opcodes::Opcode> for bitcoin_pri
 impl core::convert::TryFrom<u8> for bitcoin_primitives::witness_version::WitnessVersion
   pub type bitcoin_primitives::witness_version::WitnessVersion::Error = bitcoin_primitives::witness_version::error::InvalidWitnessVersionError [impl: impl core::convert::TryFrom<u8> for bitcoin_primitives::witness_version::WitnessVersion]
   pub fn bitcoin_primitives::witness_version::WitnessVersion::try_from(no: u8) -> core::result::Result<Self, Self::Error> [impl: impl core::convert::TryFrom<u8> for bitcoin_primitives::witness_version::WitnessVersion]
+impl core::fmt::Binary for bitcoin_primitives::witness_version::WitnessVersion
+  pub fn bitcoin_primitives::witness_version::WitnessVersion::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Binary for bitcoin_primitives::witness_version::WitnessVersion]
 impl core::fmt::Debug for bitcoin_primitives::witness_version::WitnessVersion
   pub fn bitcoin_primitives::witness_version::WitnessVersion::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::witness_version::WitnessVersion]
 impl core::fmt::Display for bitcoin_primitives::witness_version::WitnessVersion
   pub fn bitcoin_primitives::witness_version::WitnessVersion::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::witness_version::WitnessVersion]
+impl core::fmt::LowerHex for bitcoin_primitives::witness_version::WitnessVersion
+  pub fn bitcoin_primitives::witness_version::WitnessVersion::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::LowerHex for bitcoin_primitives::witness_version::WitnessVersion]
+impl core::fmt::Octal for bitcoin_primitives::witness_version::WitnessVersion
+  pub fn bitcoin_primitives::witness_version::WitnessVersion::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Octal for bitcoin_primitives::witness_version::WitnessVersion]
+impl core::fmt::UpperHex for bitcoin_primitives::witness_version::WitnessVersion
+  pub fn bitcoin_primitives::witness_version::WitnessVersion::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::UpperHex for bitcoin_primitives::witness_version::WitnessVersion]
 impl core::hash::Hash for bitcoin_primitives::witness_version::WitnessVersion
   pub fn bitcoin_primitives::witness_version::WitnessVersion::hash<__H: core::hash::Hasher>(&self, state: &mut __H) [impl: impl core::hash::Hash for bitcoin_primitives::witness_version::WitnessVersion]
 impl core::marker::Copy for bitcoin_primitives::witness_version::WitnessVersion

--- a/primitives/api/alloc-only.txt
+++ b/primitives/api/alloc-only.txt
@@ -6106,10 +6106,18 @@ impl core::convert::TryFrom<bitcoin_primitives::opcodes::Opcode> for bitcoin_pri
 impl core::convert::TryFrom<u8> for bitcoin_primitives::witness_version::WitnessVersion
   pub type bitcoin_primitives::witness_version::WitnessVersion::Error = bitcoin_primitives::witness_version::error::InvalidWitnessVersionError [impl: impl core::convert::TryFrom<u8> for bitcoin_primitives::witness_version::WitnessVersion]
   pub fn bitcoin_primitives::witness_version::WitnessVersion::try_from(no: u8) -> core::result::Result<Self, Self::Error> [impl: impl core::convert::TryFrom<u8> for bitcoin_primitives::witness_version::WitnessVersion]
+impl core::fmt::Binary for bitcoin_primitives::witness_version::WitnessVersion
+  pub fn bitcoin_primitives::witness_version::WitnessVersion::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Binary for bitcoin_primitives::witness_version::WitnessVersion]
 impl core::fmt::Debug for bitcoin_primitives::witness_version::WitnessVersion
   pub fn bitcoin_primitives::witness_version::WitnessVersion::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::witness_version::WitnessVersion]
 impl core::fmt::Display for bitcoin_primitives::witness_version::WitnessVersion
   pub fn bitcoin_primitives::witness_version::WitnessVersion::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::witness_version::WitnessVersion]
+impl core::fmt::LowerHex for bitcoin_primitives::witness_version::WitnessVersion
+  pub fn bitcoin_primitives::witness_version::WitnessVersion::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::LowerHex for bitcoin_primitives::witness_version::WitnessVersion]
+impl core::fmt::Octal for bitcoin_primitives::witness_version::WitnessVersion
+  pub fn bitcoin_primitives::witness_version::WitnessVersion::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Octal for bitcoin_primitives::witness_version::WitnessVersion]
+impl core::fmt::UpperHex for bitcoin_primitives::witness_version::WitnessVersion
+  pub fn bitcoin_primitives::witness_version::WitnessVersion::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::UpperHex for bitcoin_primitives::witness_version::WitnessVersion]
 impl core::hash::Hash for bitcoin_primitives::witness_version::WitnessVersion
   pub fn bitcoin_primitives::witness_version::WitnessVersion::hash<__H: core::hash::Hasher>(&self, state: &mut __H) [impl: impl core::hash::Hash for bitcoin_primitives::witness_version::WitnessVersion]
 impl core::marker::Copy for bitcoin_primitives::witness_version::WitnessVersion

--- a/primitives/api/no-features.txt
+++ b/primitives/api/no-features.txt
@@ -1964,10 +1964,18 @@ impl core::convert::TryFrom<bitcoin_primitives::opcodes::Opcode> for bitcoin_pri
 impl core::convert::TryFrom<u8> for bitcoin_primitives::witness_version::WitnessVersion
   pub type bitcoin_primitives::witness_version::WitnessVersion::Error = bitcoin_primitives::witness_version::error::InvalidWitnessVersionError [impl: impl core::convert::TryFrom<u8> for bitcoin_primitives::witness_version::WitnessVersion]
   pub fn bitcoin_primitives::witness_version::WitnessVersion::try_from(no: u8) -> core::result::Result<Self, Self::Error> [impl: impl core::convert::TryFrom<u8> for bitcoin_primitives::witness_version::WitnessVersion]
+impl core::fmt::Binary for bitcoin_primitives::witness_version::WitnessVersion
+  pub fn bitcoin_primitives::witness_version::WitnessVersion::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Binary for bitcoin_primitives::witness_version::WitnessVersion]
 impl core::fmt::Debug for bitcoin_primitives::witness_version::WitnessVersion
   pub fn bitcoin_primitives::witness_version::WitnessVersion::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::witness_version::WitnessVersion]
 impl core::fmt::Display for bitcoin_primitives::witness_version::WitnessVersion
   pub fn bitcoin_primitives::witness_version::WitnessVersion::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Display for bitcoin_primitives::witness_version::WitnessVersion]
+impl core::fmt::LowerHex for bitcoin_primitives::witness_version::WitnessVersion
+  pub fn bitcoin_primitives::witness_version::WitnessVersion::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::LowerHex for bitcoin_primitives::witness_version::WitnessVersion]
+impl core::fmt::Octal for bitcoin_primitives::witness_version::WitnessVersion
+  pub fn bitcoin_primitives::witness_version::WitnessVersion::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Octal for bitcoin_primitives::witness_version::WitnessVersion]
+impl core::fmt::UpperHex for bitcoin_primitives::witness_version::WitnessVersion
+  pub fn bitcoin_primitives::witness_version::WitnessVersion::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::UpperHex for bitcoin_primitives::witness_version::WitnessVersion]
 impl core::hash::Hash for bitcoin_primitives::witness_version::WitnessVersion
   pub fn bitcoin_primitives::witness_version::WitnessVersion::hash<__H: core::hash::Hasher>(&self, state: &mut __H) [impl: impl core::hash::Hash for bitcoin_primitives::witness_version::WitnessVersion]
 impl core::marker::Copy for bitcoin_primitives::witness_version::WitnessVersion

--- a/primitives/src/witness_version.rs
+++ b/primitives/src/witness_version.rs
@@ -81,6 +81,26 @@ impl fmt::Display for WitnessVersion {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "{}", *self as u8) }
 }
 
+impl fmt::LowerHex for WitnessVersion {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(&self.to_num(), f) }
+}
+
+impl fmt::UpperHex for WitnessVersion {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::UpperHex::fmt(&self.to_num(), f) }
+}
+
+impl fmt::Octal for WitnessVersion {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Octal::fmt(&self.to_num(), f) }
+}
+
+impl fmt::Binary for WitnessVersion {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Binary::fmt(&self.to_num(), f) }
+}
+
 impl FromStr for WitnessVersion {
     type Err = ParseWitnessVersionError;
 

--- a/primitives/src/witness_version.rs
+++ b/primitives/src/witness_version.rs
@@ -233,7 +233,7 @@ pub mod error {
 #[cfg(test)]
 mod tests {
     #[cfg(feature = "alloc")]
-    use alloc::string::ToString;
+    use alloc::format;
 
     use super::*;
     use crate::opcodes::OP_PUSHDATA4;
@@ -248,11 +248,23 @@ mod tests {
 
     #[test]
     #[cfg(feature = "alloc")]
-    fn witness_version_display() {
-        assert_eq!(WitnessVersion::V0.to_string(), "0");
-        assert_eq!(WitnessVersion::V1.to_string(), "1");
-        assert_eq!(WitnessVersion::V10.to_string(), "10");
-        assert_eq!(WitnessVersion::V16.to_string(), "16");
+    fn witness_version_fmt() {
+        assert_eq!(format!("{}", WitnessVersion::V0), "0");
+        assert_eq!(format!("{}", WitnessVersion::V1), "1");
+        assert_eq!(format!("{}", WitnessVersion::V10), "10");
+        assert_eq!(format!("{}", WitnessVersion::V16), "16");
+
+        assert_eq!(format!("{:x}", WitnessVersion::V10), "a");
+        assert_eq!(format!("{:x}", WitnessVersion::V16), "10");
+
+        assert_eq!(format!("{:X}", WitnessVersion::V10), "A");
+        assert_eq!(format!("{:X}", WitnessVersion::V16), "10");
+
+        assert_eq!(format!("{:o}", WitnessVersion::V10), "12");
+        assert_eq!(format!("{:o}", WitnessVersion::V16), "20");
+
+        assert_eq!(format!("{:b}", WitnessVersion::V10), "1010");
+        assert_eq!(format!("{:b}", WitnessVersion::V16), "10000");
     }
 
     #[test]


### PR DESCRIPTION
Per the C-NUM-FMT guideline, number types should have Octal, Binary and Hex formatting. Just as with the block::Version and
transaction::Version types, the WitnessVersion type should also include these trait impls.
Opcode specifically is excluded as its stringify functionality is still unclear.

Add {Lower,Upper}Hex, Binary, and Octal trait impls to WitnessVersion.