### PR TITLE
primitives: Add `Hash` derive to `Opcode`

### DIFF
--- a/primitives/api/all-features.txt
+++ b/primitives/api/all-features.txt
@@ -1788,6 +1788,8 @@ impl core::convert::TryFrom<bitcoin_primitives::opcodes::Opcode> for bitcoin_pri
   pub fn bitcoin_primitives::witness_version::WitnessVersion::try_from(opcode: bitcoin_primitives::opcodes::Opcode) -> core::result::Result<Self, Self::Error> [impl: impl core::convert::TryFrom<bitcoin_primitives::opcodes::Opcode> for bitcoin_primitives::witness_version::WitnessVersion]
 impl core::fmt::Debug for bitcoin_primitives::opcodes::Opcode
   pub fn bitcoin_primitives::opcodes::Opcode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::opcodes::Opcode]
+impl core::hash::Hash for bitcoin_primitives::opcodes::Opcode
+  pub fn bitcoin_primitives::opcodes::Opcode::hash<__H: core::hash::Hasher>(&self, state: &mut __H) [impl: impl core::hash::Hash for bitcoin_primitives::opcodes::Opcode]
 impl core::marker::Copy for bitcoin_primitives::opcodes::Opcode
 impl core::marker::StructuralPartialEq for bitcoin_primitives::opcodes::Opcode
 impl core::marker::Freeze for bitcoin_primitives::opcodes::Opcode

--- a/primitives/api/alloc-only.txt
+++ b/primitives/api/alloc-only.txt
@@ -1656,6 +1656,8 @@ impl core::convert::TryFrom<bitcoin_primitives::opcodes::Opcode> for bitcoin_pri
   pub fn bitcoin_primitives::witness_version::WitnessVersion::try_from(opcode: bitcoin_primitives::opcodes::Opcode) -> core::result::Result<Self, Self::Error> [impl: impl core::convert::TryFrom<bitcoin_primitives::opcodes::Opcode> for bitcoin_primitives::witness_version::WitnessVersion]
 impl core::fmt::Debug for bitcoin_primitives::opcodes::Opcode
   pub fn bitcoin_primitives::opcodes::Opcode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::opcodes::Opcode]
+impl core::hash::Hash for bitcoin_primitives::opcodes::Opcode
+  pub fn bitcoin_primitives::opcodes::Opcode::hash<__H: core::hash::Hasher>(&self, state: &mut __H) [impl: impl core::hash::Hash for bitcoin_primitives::opcodes::Opcode]
 impl core::marker::Copy for bitcoin_primitives::opcodes::Opcode
 impl core::marker::StructuralPartialEq for bitcoin_primitives::opcodes::Opcode
 impl core::marker::Freeze for bitcoin_primitives::opcodes::Opcode

--- a/primitives/api/no-features.txt
+++ b/primitives/api/no-features.txt
@@ -1119,6 +1119,8 @@ impl core::convert::TryFrom<bitcoin_primitives::opcodes::Opcode> for bitcoin_pri
   pub fn bitcoin_primitives::witness_version::WitnessVersion::try_from(opcode: bitcoin_primitives::opcodes::Opcode) -> core::result::Result<Self, Self::Error> [impl: impl core::convert::TryFrom<bitcoin_primitives::opcodes::Opcode> for bitcoin_primitives::witness_version::WitnessVersion]
 impl core::fmt::Debug for bitcoin_primitives::opcodes::Opcode
   pub fn bitcoin_primitives::opcodes::Opcode::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_primitives::opcodes::Opcode]
+impl core::hash::Hash for bitcoin_primitives::opcodes::Opcode
+  pub fn bitcoin_primitives::opcodes::Opcode::hash<__H: core::hash::Hasher>(&self, state: &mut __H) [impl: impl core::hash::Hash for bitcoin_primitives::opcodes::Opcode]
 impl core::marker::Copy for bitcoin_primitives::opcodes::Opcode
 impl core::marker::StructuralPartialEq for bitcoin_primitives::opcodes::Opcode
 impl core::marker::Freeze for bitcoin_primitives::opcodes::Opcode

--- a/primitives/src/opcodes.rs
+++ b/primitives/src/opcodes.rs
@@ -22,7 +22,7 @@ use core::fmt;
 ///   Bitcoin Core's `IsPushOnly` considers `OP_RESERVED` to be a "push code", allowing this opcode
 ///   in contexts where only pushes are supposed to be allowed.
 /// </details>
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Opcode {
     code: u8,
 }


### PR DESCRIPTION
The Opcode type implements all of the common traits except for Display, Ord and PartialOrd. The Ord traits are excluded due to no natural ordering and Display due to the current instability in the display format. However Hash has no such restrictions and should be included.

Add Hash derive to Opcode.