### PR TITLE
primitives: Replace `Block` `PartialEq`/`Eq` derive with manual impl

### DIFF
--- a/primitives/api/all-features.txt
+++ b/primitives/api/all-features.txt
@@ -501,6 +501,9 @@ impl core::str::traits::FromStr for bitcoin_primitives::block::Block<bitcoin_pri
   pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::from_str(s: &str) -> core::result::Result<Self, Self::Err> [impl: impl core::str::traits::FromStr for bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked> where Self: bitcoin_consensus_encoding::decode::Decode]
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::block::Block
   pub fn bitcoin_primitives::block::Block::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self> [impl: impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::block::Block]
+impl<V: bitcoin_primitives::block::Validation> core::cmp::Eq for bitcoin_primitives::block::Block<V>
+impl<V: bitcoin_primitives::block::Validation> core::cmp::PartialEq for bitcoin_primitives::block::Block<V>
+  pub fn bitcoin_primitives::block::Block<V>::eq(&self, other: &Self) -> bool [impl: impl<V: bitcoin_primitives::block::Validation> core::cmp::PartialEq for bitcoin_primitives::block::Block<V>]
 impl<V: bitcoin_primitives::block::Validation> core::fmt::Display for bitcoin_primitives::block::Block<V> where Self: bitcoin_consensus_encoding::encode::Encode
   pub fn bitcoin_primitives::block::Block<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<V: bitcoin_primitives::block::Validation> core::fmt::Display for bitcoin_primitives::block::Block<V> where Self: bitcoin_consensus_encoding::encode::Encode]
 impl<V: bitcoin_primitives::block::Validation> core::fmt::LowerHex for bitcoin_primitives::block::Block<V>
@@ -512,12 +515,8 @@ impl<V> bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::block
   pub fn bitcoin_primitives::block::Block<V>::encoder(&self) -> Self::Encoder [impl: impl<V> bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation]
 impl<V> core::clone::Clone for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::clone::Clone
   pub fn bitcoin_primitives::block::Block<V>::clone(&self) -> bitcoin_primitives::block::Block<V> [impl: impl<V> core::clone::Clone for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::clone::Clone]
-impl<V> core::cmp::Eq for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::cmp::Eq
-impl<V> core::cmp::PartialEq for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::cmp::PartialEq
-  pub fn bitcoin_primitives::block::Block<V>::eq(&self, other: &bitcoin_primitives::block::Block<V>) -> bool [impl: impl<V> core::cmp::PartialEq for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::cmp::PartialEq]
 impl<V> core::fmt::Debug for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::fmt::Debug
   pub fn bitcoin_primitives::block::Block<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<V> core::fmt::Debug for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::fmt::Debug]
-impl<V> core::marker::StructuralPartialEq for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::cmp::PartialEq
 impl<V> core::marker::Freeze for bitcoin_primitives::block::Block<V>
 impl<V> core::marker::Send for bitcoin_primitives::block::Block<V>
 impl<V> core::marker::Sync for bitcoin_primitives::block::Block<V>
@@ -6766,6 +6765,9 @@ impl core::str::traits::FromStr for bitcoin_primitives::block::Block<bitcoin_pri
   pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::from_str(s: &str) -> core::result::Result<Self, Self::Err> [impl: impl core::str::traits::FromStr for bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked> where Self: bitcoin_consensus_encoding::decode::Decode]
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::block::Block
   pub fn bitcoin_primitives::block::Block::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self> [impl: impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::block::Block]
+impl<V: bitcoin_primitives::block::Validation> core::cmp::Eq for bitcoin_primitives::block::Block<V>
+impl<V: bitcoin_primitives::block::Validation> core::cmp::PartialEq for bitcoin_primitives::block::Block<V>
+  pub fn bitcoin_primitives::block::Block<V>::eq(&self, other: &Self) -> bool [impl: impl<V: bitcoin_primitives::block::Validation> core::cmp::PartialEq for bitcoin_primitives::block::Block<V>]
 impl<V: bitcoin_primitives::block::Validation> core::fmt::Display for bitcoin_primitives::block::Block<V> where Self: bitcoin_consensus_encoding::encode::Encode
   pub fn bitcoin_primitives::block::Block<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<V: bitcoin_primitives::block::Validation> core::fmt::Display for bitcoin_primitives::block::Block<V> where Self: bitcoin_consensus_encoding::encode::Encode]
 impl<V: bitcoin_primitives::block::Validation> core::fmt::LowerHex for bitcoin_primitives::block::Block<V>
@@ -6777,12 +6779,8 @@ impl<V> bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::block
   pub fn bitcoin_primitives::block::Block<V>::encoder(&self) -> Self::Encoder [impl: impl<V> bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation]
 impl<V> core::clone::Clone for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::clone::Clone
   pub fn bitcoin_primitives::block::Block<V>::clone(&self) -> bitcoin_primitives::block::Block<V> [impl: impl<V> core::clone::Clone for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::clone::Clone]
-impl<V> core::cmp::Eq for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::cmp::Eq
-impl<V> core::cmp::PartialEq for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::cmp::PartialEq
-  pub fn bitcoin_primitives::block::Block<V>::eq(&self, other: &bitcoin_primitives::block::Block<V>) -> bool [impl: impl<V> core::cmp::PartialEq for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::cmp::PartialEq]
 impl<V> core::fmt::Debug for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::fmt::Debug
   pub fn bitcoin_primitives::block::Block<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<V> core::fmt::Debug for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::fmt::Debug]
-impl<V> core::marker::StructuralPartialEq for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::cmp::PartialEq
 impl<V> core::marker::Freeze for bitcoin_primitives::block::Block<V>
 impl<V> core::marker::Send for bitcoin_primitives::block::Block<V>
 impl<V> core::marker::Sync for bitcoin_primitives::block::Block<V>

--- a/primitives/api/alloc-only.txt
+++ b/primitives/api/alloc-only.txt
@@ -479,17 +479,16 @@ impl core::convert::From<&bitcoin_primitives::block::Block> for bitcoin_primitiv
   pub fn bitcoin_primitives::BlockHash::from(block: &bitcoin_primitives::block::Block) -> Self [impl: impl core::convert::From<&bitcoin_primitives::block::Block> for bitcoin_primitives::BlockHash]
 impl core::convert::From<bitcoin_primitives::block::Block> for bitcoin_primitives::BlockHash
   pub fn bitcoin_primitives::BlockHash::from(block: bitcoin_primitives::block::Block) -> Self [impl: impl core::convert::From<bitcoin_primitives::block::Block> for bitcoin_primitives::BlockHash]
+impl<V: bitcoin_primitives::block::Validation> core::cmp::Eq for bitcoin_primitives::block::Block<V>
+impl<V: bitcoin_primitives::block::Validation> core::cmp::PartialEq for bitcoin_primitives::block::Block<V>
+  pub fn bitcoin_primitives::block::Block<V>::eq(&self, other: &Self) -> bool [impl: impl<V: bitcoin_primitives::block::Validation> core::cmp::PartialEq for bitcoin_primitives::block::Block<V>]
 impl<V> bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation
   pub type bitcoin_primitives::block::Block<V>::Encoder<'e> where Self: 'e = bitcoin_primitives::block::BlockEncoder<'e> [impl: impl<V> bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation]
   pub fn bitcoin_primitives::block::Block<V>::encoder(&self) -> Self::Encoder [impl: impl<V> bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation]
 impl<V> core::clone::Clone for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::clone::Clone
   pub fn bitcoin_primitives::block::Block<V>::clone(&self) -> bitcoin_primitives::block::Block<V> [impl: impl<V> core::clone::Clone for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::clone::Clone]
-impl<V> core::cmp::Eq for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::cmp::Eq
-impl<V> core::cmp::PartialEq for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::cmp::PartialEq
-  pub fn bitcoin_primitives::block::Block<V>::eq(&self, other: &bitcoin_primitives::block::Block<V>) -> bool [impl: impl<V> core::cmp::PartialEq for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::cmp::PartialEq]
 impl<V> core::fmt::Debug for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::fmt::Debug
   pub fn bitcoin_primitives::block::Block<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<V> core::fmt::Debug for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::fmt::Debug]
-impl<V> core::marker::StructuralPartialEq for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::cmp::PartialEq
 impl<V> core::marker::Freeze for bitcoin_primitives::block::Block<V>
 impl<V> core::marker::Send for bitcoin_primitives::block::Block<V>
 impl<V> core::marker::Sync for bitcoin_primitives::block::Block<V>
@@ -6306,17 +6305,16 @@ impl core::convert::From<&bitcoin_primitives::block::Block> for bitcoin_primitiv
   pub fn bitcoin_primitives::BlockHash::from(block: &bitcoin_primitives::block::Block) -> Self [impl: impl core::convert::From<&bitcoin_primitives::block::Block> for bitcoin_primitives::BlockHash]
 impl core::convert::From<bitcoin_primitives::block::Block> for bitcoin_primitives::BlockHash
   pub fn bitcoin_primitives::BlockHash::from(block: bitcoin_primitives::block::Block) -> Self [impl: impl core::convert::From<bitcoin_primitives::block::Block> for bitcoin_primitives::BlockHash]
+impl<V: bitcoin_primitives::block::Validation> core::cmp::Eq for bitcoin_primitives::block::Block<V>
+impl<V: bitcoin_primitives::block::Validation> core::cmp::PartialEq for bitcoin_primitives::block::Block<V>
+  pub fn bitcoin_primitives::block::Block<V>::eq(&self, other: &Self) -> bool [impl: impl<V: bitcoin_primitives::block::Validation> core::cmp::PartialEq for bitcoin_primitives::block::Block<V>]
 impl<V> bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation
   pub type bitcoin_primitives::block::Block<V>::Encoder<'e> where Self: 'e = bitcoin_primitives::block::BlockEncoder<'e> [impl: impl<V> bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation]
   pub fn bitcoin_primitives::block::Block<V>::encoder(&self) -> Self::Encoder [impl: impl<V> bitcoin_consensus_encoding::encode::Encode for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation]
 impl<V> core::clone::Clone for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::clone::Clone
   pub fn bitcoin_primitives::block::Block<V>::clone(&self) -> bitcoin_primitives::block::Block<V> [impl: impl<V> core::clone::Clone for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::clone::Clone]
-impl<V> core::cmp::Eq for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::cmp::Eq
-impl<V> core::cmp::PartialEq for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::cmp::PartialEq
-  pub fn bitcoin_primitives::block::Block<V>::eq(&self, other: &bitcoin_primitives::block::Block<V>) -> bool [impl: impl<V> core::cmp::PartialEq for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::cmp::PartialEq]
 impl<V> core::fmt::Debug for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::fmt::Debug
   pub fn bitcoin_primitives::block::Block<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<V> core::fmt::Debug for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::fmt::Debug]
-impl<V> core::marker::StructuralPartialEq for bitcoin_primitives::block::Block<V> where V: bitcoin_primitives::block::Validation + core::cmp::PartialEq
 impl<V> core::marker::Freeze for bitcoin_primitives::block::Block<V>
 impl<V> core::marker::Send for bitcoin_primitives::block::Block<V>
 impl<V> core::marker::Sync for bitcoin_primitives::block::Block<V>

--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -1759,6 +1759,52 @@ mod tests {
     #[test]
     #[cfg(feature = "alloc")]
     #[cfg(feature = "hex")]
+    fn checked_block_eq_ignores_cached_witness_root() {
+        let mut txin = crate::TxIn::EMPTY_COINBASE;
+        txin.witness.push([11u8; 32]);
+
+        let script_pubkey_bytes = hex::decode_to_array::<38>(
+            "6a24aa21a9ed3cde9e0b9f4ad8f9d0fd66d6b9326cd68597c04fa22ab64b8e455f08d2e31ceb",
+        )
+        .unwrap();
+        let tx1 = Transaction {
+            version: crate::transaction::Version::ONE,
+            lock_time: crate::absolute::LockTime::ZERO,
+            inputs: vec![txin],
+            outputs: vec![crate::TxOut {
+                amount: units::Amount::MIN,
+                script_pubkey: crate::script::ScriptBuf::from_bytes(script_pubkey_bytes.to_vec()),
+            }],
+        };
+        let tx2 = Transaction {
+            version: crate::transaction::Version::ONE,
+            lock_time: crate::absolute::LockTime::ZERO,
+            inputs: vec![crate::TxIn::EMPTY_COINBASE],
+            outputs: vec![crate::TxOut {
+                amount: units::Amount::MIN,
+                script_pubkey: crate::script::ScriptBuf::new(),
+            }],
+        };
+
+        let transactions = vec![tx1, tx2];
+        let mut header = dummy_header();
+        header.merkle_root = compute_merkle_root(&transactions).unwrap();
+        let block = Block::new_unchecked(header, transactions);
+
+        let validated = block.clone().validate().unwrap();
+        assert!(validated.cached_witness_root().is_some());
+        let assumed = block.assume_checked(None);
+        assert!(assumed.cached_witness_root().is_none());
+
+        assert_eq!(validated.header(), assumed.header());
+        assert_eq!(validated.transactions(), assumed.transactions());
+        assert_eq!(encoding::encode_to_vec(&validated), encoding::encode_to_vec(&assumed));
+        assert_eq!(validated, assumed);
+    }
+
+    #[test]
+    #[cfg(feature = "alloc")]
+    #[cfg(feature = "hex")]
     fn block_check_witness_commitment_invalid_witness() {
         let mut txin = crate::TxIn::EMPTY_COINBASE;
         let witness_bytes: [u8; 32] = [11u8; 32];

--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -81,7 +81,7 @@ pub trait Validation: sealed::Validation + Sync + Send + Sized + Unpin {
 ///
 /// * [CBlock definition](https://github.com/bitcoin/bitcoin/blob/345457b542b6a980ccfbc868af0970a6f91d1b82/src/primitives/block.h#L62)
 #[cfg(feature = "alloc")]
-#[derive(PartialEq, Eq, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct Block<V = Unchecked>
 where
     V: Validation,
@@ -251,6 +251,16 @@ impl<V: Validation> Block<V> {
     #[inline]
     pub fn block_hash(&self) -> BlockHash { self.header.block_hash() }
 }
+
+#[cfg(feature = "alloc")]
+impl<V: Validation> PartialEq for Block<V> {
+    fn eq(&self, other: &Self) -> bool {
+        self.header == other.header && self.transactions == other.transactions
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<V: Validation> Eq for Block<V> {}
 
 #[cfg(feature = "alloc")]
 impl From<Block> for BlockHash {
@@ -1712,6 +1722,38 @@ mod tests {
         .unwrap();
         let expected = WitnessMerkleNode::from_byte_array(exp_bytes);
         assert_eq!(result, (true, Some(expected)));
+    }
+
+    #[test]
+    #[cfg(feature = "alloc")]
+    fn block_eq() {
+        let coinbase = Transaction {
+            version: crate::transaction::Version::ONE,
+            lock_time: crate::absolute::LockTime::ZERO,
+            inputs: vec![crate::TxIn::EMPTY_COINBASE],
+            outputs: vec![crate::TxOut {
+                amount: units::Amount::MIN,
+                script_pubkey: crate::script::ScriptBuf::new(),
+            }],
+        };
+
+        let header = dummy_header();
+        let other_header = Header { nonce: header.nonce + 1, ..header };
+
+        assert_eq!(
+            Block::new_unchecked(header, vec![coinbase.clone()]),
+            Block::new_unchecked(header, vec![coinbase.clone()]),
+        );
+
+        assert_ne!(
+            Block::new_unchecked(header, vec![coinbase.clone()]),
+            Block::new_unchecked(other_header, vec![coinbase.clone()]),
+        );
+
+        assert_ne!(
+            Block::new_unchecked(header, vec![coinbase.clone()]),
+            Block::new_unchecked(header, vec![coinbase.clone(), coinbase]),
+        );
     }
 
     #[test]


### PR DESCRIPTION
The PartialEq/Eq derive on Block results in incorrect equality comparisons depending on the method of construction due to the witness_root cache. Instead, equality for Block should be implemented manually, comparing the header and transaction lists only.

Replace PartialEq/Eq derive with manual implementations that correctly compare only the header and transaction lists.