### PR TITLE
Manual weekly update to rustc (to nightly-2026-07-17) on 0.32.xx

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,5 @@ resolver = "2"
 
 [workspace.metadata]
 rbmt.version = "0.5.1"
-rbmt.toolchains.nightly = "nightly-2026-03-27"
+rbmt.toolchains.nightly = "nightly-2026-07-17"
 rbmt.toolchains.stable = "1.97.1"

--- a/bitcoin/examples/bip32.rs
+++ b/bitcoin/examples/bip32.rs
@@ -20,7 +20,7 @@ fn main() {
 
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
-        eprintln!("not enough arguments. usage: {} <hex-encoded 32-byte seed>", &args[0]);
+        eprintln!("not enough arguments. usage: {} <hex-encoded 32-byte seed>", args[0]);
         process::exit(1);
     }
 

--- a/bitcoin/tests/psbt-sign-taproot.rs
+++ b/bitcoin/tests/psbt-sign-taproot.rs
@@ -339,7 +339,7 @@ fn create_psbt_for_taproot_script_path_spend(
 fn finalize_psbt_for_script_path_spend(mut psbt: Psbt) -> Psbt {
     psbt.inputs.iter_mut().for_each(|input| {
         let mut script_witness: Witness = Witness::new();
-        for (_, signature) in input.tap_script_sigs.iter() {
+        for signature in input.tap_script_sigs.values() {
             script_witness.push(signature.to_vec());
         }
         for (control_block, (script, _)) in input.tap_scripts.iter() {

--- a/units/src/amount.rs
+++ b/units/src/amount.rs
@@ -753,15 +753,14 @@ fn fmt_satoshi_in(
     let mut num_after_decimal_point = 0;
     let mut norm_nb_decimals = 0;
     let mut num_before_decimal_point = satoshi;
-    let trailing_decimal_zeros;
     let mut exp = 0;
-    match precision.cmp(&0) {
+    let trailing_decimal_zeros = match precision.cmp(&0) {
         // We add the number of zeroes to the end
         Ordering::Greater => {
             if satoshi > 0 {
                 exp = precision as usize;
             }
-            trailing_decimal_zeros = options.precision.unwrap_or(0);
+            options.precision.unwrap_or(0)
         }
         Ordering::Less => {
             let precision = precision.unsigned_abs();
@@ -780,10 +779,10 @@ fn fmt_satoshi_in(
             }
             // compute requested precision
             let opt_precision = options.precision.unwrap_or(0);
-            trailing_decimal_zeros = opt_precision.saturating_sub(norm_nb_decimals);
+            opt_precision.saturating_sub(norm_nb_decimals)
         }
-        Ordering::Equal => trailing_decimal_zeros = options.precision.unwrap_or(0),
-    }
+        Ordering::Equal => options.precision.unwrap_or(0),
+    };
     let total_decimals = norm_nb_decimals + trailing_decimal_zeros;
     // Compute expected width of the number
     let mut num_width = if total_decimals > 0 {


### PR DESCRIPTION
Supersedes https://github.com/rust-bitcoin/rust-bitcoin/pull/6579

Includes necessary lint fixes. Snapshots are not present in the branch, so the original PR CI snapshot error no longer exists.