### PR TITLE
Manual weekly update to rustc (to nightly-2026-07-17) on master

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ exclude = ["benches"]
 resolver = "2"
 
 [workspace.metadata.rbmt.toolchains]
-nightly = "nightly-2026-07-02"
-stable = "1.97.1"
+nightly = "nightly-2026-07-17"
+stable = "1.96.0"
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "deny", check-cfg = ['cfg(bench)', 'cfg(chacha20_poly1305_fuzz)', 'cfg(fuzzing)', 'cfg(hashes_fuzz)', 'cfg(kani)'] }

--- a/p2p/examples/ping-pong.rs
+++ b/p2p/examples/ping-pong.rs
@@ -71,9 +71,8 @@ fn main() {
                 _ => unimplemented!("{:?}", msg.payload()),
             }
         }
-    } else {
-        eprintln!("failed to open connection");
     }
+    eprintln!("failed to open connection");
 }
 
 fn build_version_message(address: SocketAddr) -> message::NetworkMessage {


### PR DESCRIPTION
Supersedes https://github.com/rust-bitcoin/rust-bitcoin/pull/6578

To fix the CI lint error, a redundant else had to be removed from a p2p example.