### PR TITLE
primitives: Return block when validation fails

### DIFF
--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -130,7 +130,7 @@ impl BlockCheckedExt for Block<Checked> {
         transactions: Vec<Transaction>,
     ) -> Result<Self, InvalidBlockError> {
         let block = Block::new_unchecked(header, transactions);
-        block.validate()
+        block.validate().map_err(|e| e.0) // e.1 is the block.
     }
 
     fn merkle_root(&self) -> TxMerkleNode { self.header().merkle_root }

--- a/primitives/api/all-features.txt
+++ b/primitives/api/all-features.txt
@@ -487,7 +487,7 @@ pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::c
 pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::compute_witness_commitment(&self, witness_reserved_value: &[u8]) -> core::option::Option<(bitcoin_primitives::merkle_tree::WitnessMerkleNode, bitcoin_primitives::WitnessCommitment)>
 pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::into_parts(self) -> (bitcoin_primitives::block::Header, alloc::vec::Vec<bitcoin_primitives::transaction::Transaction>)
 pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::new_unchecked(header: bitcoin_primitives::block::Header, transactions: alloc::vec::Vec<bitcoin_primitives::transaction::Transaction>) -> Self
-pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::validate(self) -> core::result::Result<bitcoin_primitives::block::Block<bitcoin_primitives::block::Checked>, bitcoin_primitives::block::error::InvalidBlockError>
+pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::validate(self) -> core::result::Result<bitcoin_primitives::block::Block<bitcoin_primitives::block::Checked>, (bitcoin_primitives::block::error::InvalidBlockError, Self)>
 impl<V: bitcoin_primitives::block::Validation> bitcoin_primitives::block::Block<V>
 pub fn bitcoin_primitives::block::Block<V>::block_hash(&self) -> bitcoin_primitives::BlockHash
 impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>
@@ -6752,7 +6752,7 @@ pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::c
 pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::compute_witness_commitment(&self, witness_reserved_value: &[u8]) -> core::option::Option<(bitcoin_primitives::merkle_tree::WitnessMerkleNode, bitcoin_primitives::WitnessCommitment)>
 pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::into_parts(self) -> (bitcoin_primitives::block::Header, alloc::vec::Vec<bitcoin_primitives::transaction::Transaction>)
 pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::new_unchecked(header: bitcoin_primitives::block::Header, transactions: alloc::vec::Vec<bitcoin_primitives::transaction::Transaction>) -> Self
-pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::validate(self) -> core::result::Result<bitcoin_primitives::block::Block<bitcoin_primitives::block::Checked>, bitcoin_primitives::block::error::InvalidBlockError>
+pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::validate(self) -> core::result::Result<bitcoin_primitives::block::Block<bitcoin_primitives::block::Checked>, (bitcoin_primitives::block::error::InvalidBlockError, Self)>
 impl<V: bitcoin_primitives::block::Validation> bitcoin_primitives::block::Block<V>
 pub fn bitcoin_primitives::block::Block<V>::block_hash(&self) -> bitcoin_primitives::BlockHash
 impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>

--- a/primitives/api/alloc-only.txt
+++ b/primitives/api/alloc-only.txt
@@ -470,7 +470,7 @@ pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::c
 pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::compute_witness_commitment(&self, witness_reserved_value: &[u8]) -> core::option::Option<(bitcoin_primitives::merkle_tree::WitnessMerkleNode, bitcoin_primitives::WitnessCommitment)>
 pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::into_parts(self) -> (bitcoin_primitives::block::Header, alloc::vec::Vec<bitcoin_primitives::transaction::Transaction>)
 pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::new_unchecked(header: bitcoin_primitives::block::Header, transactions: alloc::vec::Vec<bitcoin_primitives::transaction::Transaction>) -> Self
-pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::validate(self) -> core::result::Result<bitcoin_primitives::block::Block<bitcoin_primitives::block::Checked>, bitcoin_primitives::block::error::InvalidBlockError>
+pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::validate(self) -> core::result::Result<bitcoin_primitives::block::Block<bitcoin_primitives::block::Checked>, (bitcoin_primitives::block::error::InvalidBlockError, Self)>
 impl<V: bitcoin_primitives::block::Validation> bitcoin_primitives::block::Block<V>
 pub fn bitcoin_primitives::block::Block<V>::block_hash(&self) -> bitcoin_primitives::BlockHash
 impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>
@@ -6297,7 +6297,7 @@ pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::c
 pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::compute_witness_commitment(&self, witness_reserved_value: &[u8]) -> core::option::Option<(bitcoin_primitives::merkle_tree::WitnessMerkleNode, bitcoin_primitives::WitnessCommitment)>
 pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::into_parts(self) -> (bitcoin_primitives::block::Header, alloc::vec::Vec<bitcoin_primitives::transaction::Transaction>)
 pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::new_unchecked(header: bitcoin_primitives::block::Header, transactions: alloc::vec::Vec<bitcoin_primitives::transaction::Transaction>) -> Self
-pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::validate(self) -> core::result::Result<bitcoin_primitives::block::Block<bitcoin_primitives::block::Checked>, bitcoin_primitives::block::error::InvalidBlockError>
+pub fn bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>::validate(self) -> core::result::Result<bitcoin_primitives::block::Block<bitcoin_primitives::block::Checked>, (bitcoin_primitives::block::error::InvalidBlockError, Self)>
 impl<V: bitcoin_primitives::block::Validation> bitcoin_primitives::block::Block<V>
 pub fn bitcoin_primitives::block::Block<V>::block_hash(&self) -> bitcoin_primitives::BlockHash
 impl bitcoin_consensus_encoding::decode::Decode for bitcoin_primitives::block::Block<bitcoin_primitives::block::Unchecked>

--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -140,21 +140,24 @@ impl Block<Unchecked> {
     /// * The first transaction is not a coinbase transaction.
     /// * The Merkle root of the header does not match the Merkle root of the transaction list.
     /// * The witness commitment in the coinbase does not match the transaction list.
-    pub fn validate(self) -> Result<Block<Checked>, InvalidBlockError> {
+    ///
+    /// If function errors we return the block because `self` is consumed.
+    #[allow(clippy::result_large_err)] // Because of the block.
+    pub fn validate(self) -> Result<Block<Checked>, (InvalidBlockError, Self)> {
         if self.transactions.is_empty() {
-            return Err(InvalidBlockError::NoTransactions);
+            return Err((InvalidBlockError::NoTransactions, self));
         }
 
         if !self.transactions[0].is_coinbase() {
-            return Err(InvalidBlockError::InvalidCoinbase);
+            return Err((InvalidBlockError::InvalidCoinbase, self));
         }
 
         if !self.check_merkle_root() {
-            return Err(InvalidBlockError::InvalidMerkleRoot);
+            return Err((InvalidBlockError::InvalidMerkleRoot, self));
         }
 
         match self.check_witness_commitment() {
-            (false, _) => Err(InvalidBlockError::InvalidWitnessCommitment),
+            (false, _) => Err((InvalidBlockError::InvalidWitnessCommitment, self)),
             (true, witness_root) => {
                 let block = Self::new_unchecked(self.header, self.transactions);
                 Ok(block.assume_checked(witness_root))
@@ -1134,7 +1137,7 @@ mod tests {
         let transactions = Vec::new(); // Empty transactions
 
         let block = Block::new_unchecked(header, transactions);
-        let err = block.validate().unwrap_err();
+        let (err, _block) = block.validate().unwrap_err();
         assert_eq!(err, InvalidBlockError::NoTransactions);
     }
 
@@ -1165,7 +1168,7 @@ mod tests {
         let transactions = vec![non_coinbase_tx];
         let block = Block::new_unchecked(header, transactions);
 
-        let err = block.validate().unwrap_err();
+        let (err, _block) = block.validate().unwrap_err();
         assert_eq!(err, InvalidBlockError::InvalidCoinbase);
     }
 
@@ -1282,7 +1285,8 @@ mod tests {
 
         let block = Block::new_unchecked(header, transactions);
         assert_eq!(block.check_witness_commitment(), (false, None));
-        assert!(matches!(block.validate(), Err(InvalidBlockError::InvalidWitnessCommitment)));
+        let (err, _block) = block.validate().unwrap_err();
+        assert!(matches!(err, InvalidBlockError::InvalidWitnessCommitment));
     }
 
     #[test]
@@ -1754,7 +1758,8 @@ mod tests {
 
         let block = Block::new_unchecked(header, transactions);
         assert_eq!(block.check_witness_commitment(), (false, None));
-        assert!(matches!(block.validate(), Err(InvalidBlockError::InvalidWitnessCommitment)));
+        let (err, _block) = block.validate().unwrap_err();
+        assert!(matches!(err, InvalidBlockError::InvalidWitnessCommitment));
     }
 
     #[test]


### PR DESCRIPTION
`Block::validate` consumes the block so if the function errors its gone. Users might want to use it still after validation fails.

Return `self` as part of a tuple error.