### PR TITLE
consensus_encoding: Loosen `serde_as_consensus` trait bounds

### DIFF
--- a/consensus_encoding/api/all-features.txt
+++ b/consensus_encoding/api/all-features.txt
@@ -601,13 +601,13 @@ impl<T> core::convert::From<T> for bitcoin_consensus_encoding::error::VecDecoder
   pub fn bitcoin_consensus_encoding::error::VecDecoderError<Err>::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_consensus_encoding::error::VecDecoderError<Err>]
 pub mod bitcoin_consensus_encoding::serde_as_consensus
 pub mod bitcoin_consensus_encoding::serde_as_consensus::opt
-pub fn bitcoin_consensus_encoding::serde_as_consensus::opt::deserialize<'d, T, D>(d: D) -> core::result::Result<core::option::Option<T>, <D as serde::de::Deserializer>::Error> where T: bitcoin_consensus_encoding::Encode + bitcoin_consensus_encoding::Decode, D: serde::de::Deserializer<'d>
-pub fn bitcoin_consensus_encoding::serde_as_consensus::opt::serialize<T, S>(t: &core::option::Option<T>, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where T: bitcoin_consensus_encoding::Encode + bitcoin_consensus_encoding::Decode, S: serde::ser::Serializer
+pub fn bitcoin_consensus_encoding::serde_as_consensus::opt::deserialize<'d, T, D>(d: D) -> core::result::Result<core::option::Option<T>, <D as serde::de::Deserializer>::Error> where T: bitcoin_consensus_encoding::Decode, D: serde::de::Deserializer<'d>
+pub fn bitcoin_consensus_encoding::serde_as_consensus::opt::serialize<T, S>(t: &core::option::Option<T>, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where T: bitcoin_consensus_encoding::Encode, S: serde::ser::Serializer
 pub mod bitcoin_consensus_encoding::serde_as_consensus::vec
-pub fn bitcoin_consensus_encoding::serde_as_consensus::vec::deserialize<'d, T, D>(d: D) -> core::result::Result<alloc::vec::Vec<T>, <D as serde::de::Deserializer>::Error> where T: bitcoin_consensus_encoding::Encode + bitcoin_consensus_encoding::Decode, D: serde::de::Deserializer<'d>
-pub fn bitcoin_consensus_encoding::serde_as_consensus::vec::serialize<T, S>(v: &[T], s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where T: bitcoin_consensus_encoding::Encode + bitcoin_consensus_encoding::Decode, S: serde::ser::Serializer
-pub fn bitcoin_consensus_encoding::serde_as_consensus::deserialize<'d, T, D>(d: D) -> core::result::Result<T, <D as serde::de::Deserializer>::Error> where T: bitcoin_consensus_encoding::Encode + bitcoin_consensus_encoding::Decode, D: serde::de::Deserializer<'d>
-pub fn bitcoin_consensus_encoding::serde_as_consensus::serialize<T, S>(value: &T, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where T: bitcoin_consensus_encoding::Encode + bitcoin_consensus_encoding::Decode, S: serde::ser::Serializer
+pub fn bitcoin_consensus_encoding::serde_as_consensus::vec::deserialize<'d, T, D>(d: D) -> core::result::Result<alloc::vec::Vec<T>, <D as serde::de::Deserializer>::Error> where T: bitcoin_consensus_encoding::Decode, D: serde::de::Deserializer<'d>
+pub fn bitcoin_consensus_encoding::serde_as_consensus::vec::serialize<T, S>(v: &[T], s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where T: bitcoin_consensus_encoding::Encode, S: serde::ser::Serializer
+pub fn bitcoin_consensus_encoding::serde_as_consensus::deserialize<'d, T, D>(d: D) -> core::result::Result<T, <D as serde::de::Deserializer>::Error> where T: bitcoin_consensus_encoding::Decode, D: serde::de::Deserializer<'d>
+pub fn bitcoin_consensus_encoding::serde_as_consensus::serialize<T, S>(value: &T, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where T: bitcoin_consensus_encoding::Encode, S: serde::ser::Serializer
 pub macro bitcoin_consensus_encoding::encoder_newtype!
 pub macro bitcoin_consensus_encoding::encoder_newtype_exact!
 pub enum bitcoin_consensus_encoding::DecodeError<Err>

--- a/consensus_encoding/src/serde_as_consensus.rs
+++ b/consensus_encoding/src/serde_as_consensus.rs
@@ -28,7 +28,7 @@ use crate::{Decode, Encode, Encoder as _};
 /// * `S` - The serializer type
 pub fn serialize<T, S>(value: &T, s: S) -> Result<S::Ok, S::Error>
 where
-    T: Encode + Decode,
+    T: Encode,
     S: Serializer,
 {
     if s.is_human_readable() {
@@ -62,7 +62,7 @@ where
 /// * `D` - The deserializer type
 pub fn deserialize<'d, T, D>(d: D) -> Result<T, D::Error>
 where
-    T: Encode + Decode,
+    T: Decode,
     D: Deserializer<'d>,
 {
     if d.is_human_readable() {
@@ -79,7 +79,7 @@ where
 
         impl<'de, T> serde::de::Visitor<'de> for BytesVisitor<T>
         where
-            T: Encode + Decode,
+            T: Decode,
         {
             type Value = T;
 
@@ -161,12 +161,12 @@ pub mod opt {
     #[allow(clippy::ref_option)] // API forced by serde.
     pub fn serialize<T, S>(t: &Option<T>, s: S) -> Result<S::Ok, S::Error>
     where
-        T: Encode + Decode,
+        T: Encode,
         S: Serializer,
     {
         struct AsConsensus<'a, T>(&'a T);
 
-        impl<T: Encode + Decode> serde::Serialize for AsConsensus<'_, T> {
+        impl<T: Encode> serde::Serialize for AsConsensus<'_, T> {
             fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
                 super::serialize(self.0, s)
             }
@@ -180,14 +180,14 @@ pub mod opt {
 
     pub fn deserialize<'d, T, D>(d: D) -> Result<Option<T>, D::Error>
     where
-        T: Encode + Decode,
+        T: Decode,
         D: Deserializer<'d>,
     {
         struct OptVisitor<X>(PhantomData<X>);
 
         impl<'de, X> de::Visitor<'de> for OptVisitor<X>
         where
-            X: Encode + Decode,
+            X: Decode,
         {
             type Value = Option<X>;
 
@@ -266,12 +266,12 @@ pub mod vec {
 
     pub fn serialize<T, S>(v: &[T], s: S) -> Result<S::Ok, S::Error>
     where
-        T: Encode + Decode,
+        T: Encode,
         S: Serializer,
     {
         struct AsConsensus<'a, T>(&'a T);
 
-        impl<T: Encode + Decode> serde::Serialize for AsConsensus<'_, T> {
+        impl<T: Encode> serde::Serialize for AsConsensus<'_, T> {
             fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
                 super::serialize(self.0, s)
             }
@@ -282,14 +282,14 @@ pub mod vec {
 
     pub fn deserialize<'d, T, D>(d: D) -> Result<Vec<T>, D::Error>
     where
-        T: Encode + Decode,
+        T: Decode,
         D: Deserializer<'d>,
     {
         struct VecVisitor<X>(PhantomData<X>);
 
         impl<'de, X> de::Visitor<'de> for VecVisitor<X>
         where
-            X: Encode + Decode,
+            X: Decode,
         {
             type Value = Vec<X>;
 
@@ -305,7 +305,7 @@ pub mod vec {
 
                 impl<'de, X> de::Deserialize<'de> for Wrap<X>
                 where
-                    X: Encode + Decode,
+                    X: Decode,
                 {
                     fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
                         super::deserialize::<X, D>(d).map(Wrap)


### PR DESCRIPTION
The trait bounds in serde_as_consensus currently require Encode + Decode for either serialize or deserialize. In the case of types which can be Encoded but not Decoded (e.g. primitives' Block<Checked>) these over-constrained bounds prevent serde serialisation, or vice-versa.

While this code has been released, removing trait bounds is not breaking as it loosens the requirements on the type. That is, any Encode + Decode type is also Encode alone or Decode alone.

Loosen trait bounds in serde_as_consensus to only Encode or Decode as needed for each function.