### PR TITLE
units: Implement serde traits for absolute locktime types

### DIFF
--- a/units/api/all-features.txt
+++ b/units/api/all-features.txt
@@ -477,8 +477,12 @@ impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::He
 impl core::str::traits::FromStr for bitcoin_units::locktime::absolute::Height
   pub type bitcoin_units::locktime::absolute::Height::Err = bitcoin_units::locktime::absolute::error::ParseHeightError [impl: impl core::str::traits::FromStr for bitcoin_units::locktime::absolute::Height]
   pub fn bitcoin_units::locktime::absolute::Height::from_str(s: &str) -> core::result::Result<Self, Self::Err> [impl: impl core::str::traits::FromStr for bitcoin_units::locktime::absolute::Height]
+impl serde::ser::Serialize for bitcoin_units::locktime::absolute::Height
+  pub fn bitcoin_units::locktime::absolute::Height::serialize<S>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer [impl: impl serde::ser::Serialize for bitcoin_units::locktime::absolute::Height]
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::locktime::absolute::Height
   pub fn bitcoin_units::locktime::absolute::Height::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self> [impl: impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::locktime::absolute::Height]
+impl<'de> serde::de::Deserialize<'de> for bitcoin_units::locktime::absolute::Height
+  pub fn bitcoin_units::locktime::absolute::Height::deserialize<D>(d: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de> [impl: impl<'de> serde::de::Deserialize<'de> for bitcoin_units::locktime::absolute::Height]
 impl core::marker::Freeze for bitcoin_units::locktime::absolute::Height
 impl core::marker::Send for bitcoin_units::locktime::absolute::Height
 impl core::marker::Sync for bitcoin_units::locktime::absolute::Height
@@ -510,6 +514,7 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::absolute::Height
   pub unsafe fn bitcoin_units::locktime::absolute::Height::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::absolute::Height where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_units::locktime::absolute::Height
   pub fn bitcoin_units::locktime::absolute::Height::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::locktime::absolute::Height]
+impl<T> serde::de::DeserializeOwned for bitcoin_units::locktime::absolute::Height where T: for<'de> serde::de::Deserialize<'de>
 pub struct bitcoin_units::absolute::IncompatibleHeightError
 impl bitcoin_units::locktime::absolute::error::IncompatibleHeightError
 pub fn bitcoin_units::locktime::absolute::error::IncompatibleHeightError::incompatible(&self) -> bitcoin_units::locktime::absolute::Height
@@ -791,8 +796,12 @@ impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::Me
 impl core::str::traits::FromStr for bitcoin_units::locktime::absolute::MedianTimePast
   pub type bitcoin_units::locktime::absolute::MedianTimePast::Err = bitcoin_units::locktime::absolute::error::ParseTimeError [impl: impl core::str::traits::FromStr for bitcoin_units::locktime::absolute::MedianTimePast]
   pub fn bitcoin_units::locktime::absolute::MedianTimePast::from_str(s: &str) -> core::result::Result<Self, Self::Err> [impl: impl core::str::traits::FromStr for bitcoin_units::locktime::absolute::MedianTimePast]
+impl serde::ser::Serialize for bitcoin_units::locktime::absolute::MedianTimePast
+  pub fn bitcoin_units::locktime::absolute::MedianTimePast::serialize<S>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer [impl: impl serde::ser::Serialize for bitcoin_units::locktime::absolute::MedianTimePast]
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::locktime::absolute::MedianTimePast
   pub fn bitcoin_units::locktime::absolute::MedianTimePast::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self> [impl: impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::locktime::absolute::MedianTimePast]
+impl<'de> serde::de::Deserialize<'de> for bitcoin_units::locktime::absolute::MedianTimePast
+  pub fn bitcoin_units::locktime::absolute::MedianTimePast::deserialize<D>(d: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de> [impl: impl<'de> serde::de::Deserialize<'de> for bitcoin_units::locktime::absolute::MedianTimePast]
 impl core::marker::Freeze for bitcoin_units::locktime::absolute::MedianTimePast
 impl core::marker::Send for bitcoin_units::locktime::absolute::MedianTimePast
 impl core::marker::Sync for bitcoin_units::locktime::absolute::MedianTimePast
@@ -824,6 +833,7 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::absolute::Median
   pub unsafe fn bitcoin_units::locktime::absolute::MedianTimePast::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::absolute::MedianTimePast where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_units::locktime::absolute::MedianTimePast
   pub fn bitcoin_units::locktime::absolute::MedianTimePast::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::locktime::absolute::MedianTimePast]
+impl<T> serde::de::DeserializeOwned for bitcoin_units::locktime::absolute::MedianTimePast where T: for<'de> serde::de::Deserialize<'de>
 pub struct bitcoin_units::absolute::ParseHeightError(_)
 impl core::clone::Clone for bitcoin_units::locktime::absolute::error::ParseHeightError
   pub fn bitcoin_units::locktime::absolute::error::ParseHeightError::clone(&self) -> bitcoin_units::locktime::absolute::error::ParseHeightError [impl: impl core::clone::Clone for bitcoin_units::locktime::absolute::error::ParseHeightError]
@@ -4512,8 +4522,12 @@ impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::He
 impl core::str::traits::FromStr for bitcoin_units::locktime::absolute::Height
   pub type bitcoin_units::locktime::absolute::Height::Err = bitcoin_units::locktime::absolute::error::ParseHeightError [impl: impl core::str::traits::FromStr for bitcoin_units::locktime::absolute::Height]
   pub fn bitcoin_units::locktime::absolute::Height::from_str(s: &str) -> core::result::Result<Self, Self::Err> [impl: impl core::str::traits::FromStr for bitcoin_units::locktime::absolute::Height]
+impl serde::ser::Serialize for bitcoin_units::locktime::absolute::Height
+  pub fn bitcoin_units::locktime::absolute::Height::serialize<S>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer [impl: impl serde::ser::Serialize for bitcoin_units::locktime::absolute::Height]
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::locktime::absolute::Height
   pub fn bitcoin_units::locktime::absolute::Height::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self> [impl: impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::locktime::absolute::Height]
+impl<'de> serde::de::Deserialize<'de> for bitcoin_units::locktime::absolute::Height
+  pub fn bitcoin_units::locktime::absolute::Height::deserialize<D>(d: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de> [impl: impl<'de> serde::de::Deserialize<'de> for bitcoin_units::locktime::absolute::Height]
 impl core::marker::Freeze for bitcoin_units::locktime::absolute::Height
 impl core::marker::Send for bitcoin_units::locktime::absolute::Height
 impl core::marker::Sync for bitcoin_units::locktime::absolute::Height
@@ -4545,6 +4559,7 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::absolute::Height
   pub unsafe fn bitcoin_units::locktime::absolute::Height::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::absolute::Height where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_units::locktime::absolute::Height
   pub fn bitcoin_units::locktime::absolute::Height::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::locktime::absolute::Height]
+impl<T> serde::de::DeserializeOwned for bitcoin_units::locktime::absolute::Height where T: for<'de> serde::de::Deserialize<'de>
 pub struct bitcoin_units::locktime::absolute::IncompatibleHeightError
 impl bitcoin_units::locktime::absolute::error::IncompatibleHeightError
 pub fn bitcoin_units::locktime::absolute::error::IncompatibleHeightError::incompatible(&self) -> bitcoin_units::locktime::absolute::Height
@@ -4826,8 +4841,12 @@ impl core::marker::StructuralPartialEq for bitcoin_units::locktime::absolute::Me
 impl core::str::traits::FromStr for bitcoin_units::locktime::absolute::MedianTimePast
   pub type bitcoin_units::locktime::absolute::MedianTimePast::Err = bitcoin_units::locktime::absolute::error::ParseTimeError [impl: impl core::str::traits::FromStr for bitcoin_units::locktime::absolute::MedianTimePast]
   pub fn bitcoin_units::locktime::absolute::MedianTimePast::from_str(s: &str) -> core::result::Result<Self, Self::Err> [impl: impl core::str::traits::FromStr for bitcoin_units::locktime::absolute::MedianTimePast]
+impl serde::ser::Serialize for bitcoin_units::locktime::absolute::MedianTimePast
+  pub fn bitcoin_units::locktime::absolute::MedianTimePast::serialize<S>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer [impl: impl serde::ser::Serialize for bitcoin_units::locktime::absolute::MedianTimePast]
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::locktime::absolute::MedianTimePast
   pub fn bitcoin_units::locktime::absolute::MedianTimePast::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self> [impl: impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::locktime::absolute::MedianTimePast]
+impl<'de> serde::de::Deserialize<'de> for bitcoin_units::locktime::absolute::MedianTimePast
+  pub fn bitcoin_units::locktime::absolute::MedianTimePast::deserialize<D>(d: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de> [impl: impl<'de> serde::de::Deserialize<'de> for bitcoin_units::locktime::absolute::MedianTimePast]
 impl core::marker::Freeze for bitcoin_units::locktime::absolute::MedianTimePast
 impl core::marker::Send for bitcoin_units::locktime::absolute::MedianTimePast
 impl core::marker::Sync for bitcoin_units::locktime::absolute::MedianTimePast
@@ -4859,6 +4878,7 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::absolute::Median
   pub unsafe fn bitcoin_units::locktime::absolute::MedianTimePast::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::absolute::MedianTimePast where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_units::locktime::absolute::MedianTimePast
   pub fn bitcoin_units::locktime::absolute::MedianTimePast::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::locktime::absolute::MedianTimePast]
+impl<T> serde::de::DeserializeOwned for bitcoin_units::locktime::absolute::MedianTimePast where T: for<'de> serde::de::Deserialize<'de>
 pub struct bitcoin_units::locktime::absolute::ParseHeightError(_)
 impl core::clone::Clone for bitcoin_units::locktime::absolute::error::ParseHeightError
   pub fn bitcoin_units::locktime::absolute::error::ParseHeightError::clone(&self) -> bitcoin_units::locktime::absolute::error::ParseHeightError [impl: impl core::clone::Clone for bitcoin_units::locktime::absolute::error::ParseHeightError]
@@ -5892,8 +5912,12 @@ impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::Nu
 impl core::str::traits::FromStr for bitcoin_units::locktime::relative::NumberOf512Seconds
   pub type bitcoin_units::locktime::relative::NumberOf512Seconds::Err = bitcoin_units::parse_int::error::ParseIntError [impl: impl core::str::traits::FromStr for bitcoin_units::locktime::relative::NumberOf512Seconds]
   pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_str(s: &str) -> core::result::Result<Self, Self::Err> [impl: impl core::str::traits::FromStr for bitcoin_units::locktime::relative::NumberOf512Seconds]
+impl serde::ser::Serialize for bitcoin_units::locktime::relative::NumberOf512Seconds
+  pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::serialize<S>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer [impl: impl serde::ser::Serialize for bitcoin_units::locktime::relative::NumberOf512Seconds]
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::locktime::relative::NumberOf512Seconds
   pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self> [impl: impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::locktime::relative::NumberOf512Seconds]
+impl<'de> serde::de::Deserialize<'de> for bitcoin_units::locktime::relative::NumberOf512Seconds
+  pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::deserialize<D>(d: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de> [impl: impl<'de> serde::de::Deserialize<'de> for bitcoin_units::locktime::relative::NumberOf512Seconds]
 impl core::marker::Freeze for bitcoin_units::locktime::relative::NumberOf512Seconds
 impl core::marker::Send for bitcoin_units::locktime::relative::NumberOf512Seconds
 impl core::marker::Sync for bitcoin_units::locktime::relative::NumberOf512Seconds
@@ -5925,6 +5949,7 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::Number
   pub unsafe fn bitcoin_units::locktime::relative::NumberOf512Seconds::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::NumberOf512Seconds where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::NumberOf512Seconds
   pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::NumberOf512Seconds]
+impl<T> serde::de::DeserializeOwned for bitcoin_units::locktime::relative::NumberOf512Seconds where T: for<'de> serde::de::Deserialize<'de>
 pub struct bitcoin_units::locktime::relative::NumberOfBlocks(_)
 impl bitcoin_units::locktime::relative::NumberOfBlocks
 pub const bitcoin_units::locktime::relative::NumberOfBlocks::MAX: Self
@@ -5983,8 +6008,12 @@ impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::Nu
 impl core::str::traits::FromStr for bitcoin_units::locktime::relative::NumberOfBlocks
   pub type bitcoin_units::locktime::relative::NumberOfBlocks::Err = bitcoin_units::parse_int::error::ParseIntError [impl: impl core::str::traits::FromStr for bitcoin_units::locktime::relative::NumberOfBlocks]
   pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from_str(s: &str) -> core::result::Result<Self, Self::Err> [impl: impl core::str::traits::FromStr for bitcoin_units::locktime::relative::NumberOfBlocks]
+impl serde::ser::Serialize for bitcoin_units::locktime::relative::NumberOfBlocks
+  pub fn bitcoin_units::locktime::relative::NumberOfBlocks::serialize<S>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer [impl: impl serde::ser::Serialize for bitcoin_units::locktime::relative::NumberOfBlocks]
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::locktime::relative::NumberOfBlocks
   pub fn bitcoin_units::locktime::relative::NumberOfBlocks::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self> [impl: impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::locktime::relative::NumberOfBlocks]
+impl<'de> serde::de::Deserialize<'de> for bitcoin_units::locktime::relative::NumberOfBlocks
+  pub fn bitcoin_units::locktime::relative::NumberOfBlocks::deserialize<D>(d: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de> [impl: impl<'de> serde::de::Deserialize<'de> for bitcoin_units::locktime::relative::NumberOfBlocks]
 impl core::marker::Freeze for bitcoin_units::locktime::relative::NumberOfBlocks
 impl core::marker::Send for bitcoin_units::locktime::relative::NumberOfBlocks
 impl core::marker::Sync for bitcoin_units::locktime::relative::NumberOfBlocks
@@ -6016,6 +6045,7 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::Number
   pub unsafe fn bitcoin_units::locktime::relative::NumberOfBlocks::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::NumberOfBlocks where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::NumberOfBlocks
   pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::NumberOfBlocks]
+impl<T> serde::de::DeserializeOwned for bitcoin_units::locktime::relative::NumberOfBlocks where T: for<'de> serde::de::Deserialize<'de>
 pub struct bitcoin_units::locktime::relative::TimeOverflowError
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::TimeOverflowError
   pub fn bitcoin_units::locktime::relative::error::TimeOverflowError::clone(&self) -> bitcoin_units::locktime::relative::error::TimeOverflowError [impl: impl core::clone::Clone for bitcoin_units::locktime::relative::error::TimeOverflowError]
@@ -7927,8 +7957,12 @@ impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::Nu
 impl core::str::traits::FromStr for bitcoin_units::locktime::relative::NumberOf512Seconds
   pub type bitcoin_units::locktime::relative::NumberOf512Seconds::Err = bitcoin_units::parse_int::error::ParseIntError [impl: impl core::str::traits::FromStr for bitcoin_units::locktime::relative::NumberOf512Seconds]
   pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_str(s: &str) -> core::result::Result<Self, Self::Err> [impl: impl core::str::traits::FromStr for bitcoin_units::locktime::relative::NumberOf512Seconds]
+impl serde::ser::Serialize for bitcoin_units::locktime::relative::NumberOf512Seconds
+  pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::serialize<S>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer [impl: impl serde::ser::Serialize for bitcoin_units::locktime::relative::NumberOf512Seconds]
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::locktime::relative::NumberOf512Seconds
   pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self> [impl: impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::locktime::relative::NumberOf512Seconds]
+impl<'de> serde::de::Deserialize<'de> for bitcoin_units::locktime::relative::NumberOf512Seconds
+  pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::deserialize<D>(d: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de> [impl: impl<'de> serde::de::Deserialize<'de> for bitcoin_units::locktime::relative::NumberOf512Seconds]
 impl core::marker::Freeze for bitcoin_units::locktime::relative::NumberOf512Seconds
 impl core::marker::Send for bitcoin_units::locktime::relative::NumberOf512Seconds
 impl core::marker::Sync for bitcoin_units::locktime::relative::NumberOf512Seconds
@@ -7960,6 +7994,7 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::Number
   pub unsafe fn bitcoin_units::locktime::relative::NumberOf512Seconds::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::NumberOf512Seconds where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::NumberOf512Seconds
   pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::NumberOf512Seconds]
+impl<T> serde::de::DeserializeOwned for bitcoin_units::locktime::relative::NumberOf512Seconds where T: for<'de> serde::de::Deserialize<'de>
 pub struct bitcoin_units::relative::NumberOfBlocks(_)
 impl bitcoin_units::locktime::relative::NumberOfBlocks
 pub const bitcoin_units::locktime::relative::NumberOfBlocks::MAX: Self
@@ -8018,8 +8053,12 @@ impl core::marker::StructuralPartialEq for bitcoin_units::locktime::relative::Nu
 impl core::str::traits::FromStr for bitcoin_units::locktime::relative::NumberOfBlocks
   pub type bitcoin_units::locktime::relative::NumberOfBlocks::Err = bitcoin_units::parse_int::error::ParseIntError [impl: impl core::str::traits::FromStr for bitcoin_units::locktime::relative::NumberOfBlocks]
   pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from_str(s: &str) -> core::result::Result<Self, Self::Err> [impl: impl core::str::traits::FromStr for bitcoin_units::locktime::relative::NumberOfBlocks]
+impl serde::ser::Serialize for bitcoin_units::locktime::relative::NumberOfBlocks
+  pub fn bitcoin_units::locktime::relative::NumberOfBlocks::serialize<S>(&self, s: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer [impl: impl serde::ser::Serialize for bitcoin_units::locktime::relative::NumberOfBlocks]
 impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::locktime::relative::NumberOfBlocks
   pub fn bitcoin_units::locktime::relative::NumberOfBlocks::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self> [impl: impl<'a> arbitrary::Arbitrary<'a> for bitcoin_units::locktime::relative::NumberOfBlocks]
+impl<'de> serde::de::Deserialize<'de> for bitcoin_units::locktime::relative::NumberOfBlocks
+  pub fn bitcoin_units::locktime::relative::NumberOfBlocks::deserialize<D>(d: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de> [impl: impl<'de> serde::de::Deserialize<'de> for bitcoin_units::locktime::relative::NumberOfBlocks]
 impl core::marker::Freeze for bitcoin_units::locktime::relative::NumberOfBlocks
 impl core::marker::Send for bitcoin_units::locktime::relative::NumberOfBlocks
 impl core::marker::Sync for bitcoin_units::locktime::relative::NumberOfBlocks
@@ -8051,6 +8090,7 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::Number
   pub unsafe fn bitcoin_units::locktime::relative::NumberOfBlocks::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_units::locktime::relative::NumberOfBlocks where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::NumberOfBlocks
   pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::locktime::relative::NumberOfBlocks]
+impl<T> serde::de::DeserializeOwned for bitcoin_units::locktime::relative::NumberOfBlocks where T: for<'de> serde::de::Deserialize<'de>
 pub struct bitcoin_units::relative::TimeOverflowError
 impl core::clone::Clone for bitcoin_units::locktime::relative::error::TimeOverflowError
   pub fn bitcoin_units::locktime::relative::error::TimeOverflowError::clone(&self) -> bitcoin_units::locktime::relative::error::TimeOverflowError [impl: impl core::clone::Clone for bitcoin_units::locktime::relative::error::TimeOverflowError]

--- a/units/src/locktime/absolute/mod.rs
+++ b/units/src/locktime/absolute/mod.rs
@@ -13,6 +13,8 @@ use core::fmt;
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
 use internals::error::InputString;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use self::error::ParseError;
 #[cfg(doc)]
@@ -589,6 +591,28 @@ impl fmt::Display for Height {
 
 parse_int::impl_parse_str!(Height, ParseHeightError, parser(Height::from_u32));
 
+#[cfg(feature = "serde")]
+impl Serialize for Height {
+    #[inline]
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        u32::serialize(&self.to_u32(), s)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for Height {
+    #[inline]
+    fn deserialize<D>(d: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Self::from_u32(u32::deserialize(d)?).map_err(serde::de::Error::custom)
+    }
+}
+
 /// The median timestamp of 11 consecutive blocks, representing "the timestamp" of the
 /// final block for locktime-checking purposes.
 ///
@@ -717,6 +741,28 @@ where
         let n = s.as_ref().parse::<i64>().map_err(ParseError::invalid_int(s))?;
         let n = u32::try_from(n).map_err(|_| ParseError::Conversion(n))?;
         f(n).map_err(ParseError::from).map_err(Into::into)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for MedianTimePast {
+    #[inline]
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        u32::serialize(&self.to_u32(), s)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for MedianTimePast {
+    #[inline]
+    fn deserialize<D>(d: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Self::from_u32(u32::deserialize(d)?).map_err(serde::de::Error::custom)
     }
 }
 

--- a/units/src/locktime/relative/mod.rs
+++ b/units/src/locktime/relative/mod.rs
@@ -13,6 +13,8 @@ use core::{convert, fmt};
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
 use internals::const_casts;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::parse_int::{self, PrefixedHexError, UnprefixedHexError};
 #[cfg(doc)]
@@ -459,6 +461,27 @@ impl fmt::Display for NumberOfBlocks {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(&self.0, f) }
 }
+#[cfg(feature = "serde")]
+impl Serialize for NumberOfBlocks {
+    #[inline]
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        u16::serialize(&self.to_height(), s)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for NumberOfBlocks {
+    #[inline]
+    fn deserialize<D>(d: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(Self::from_height(u16::deserialize(d)?))
+    }
+}
 
 /// A relative lock time lock-by-time value.
 ///
@@ -574,6 +597,28 @@ parse_int::impl_parse_str_from_int_infallible!(NumberOf512Seconds, u16, from_512
 impl fmt::Display for NumberOf512Seconds {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(&self.0, f) }
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for NumberOf512Seconds {
+    #[inline]
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        u16::serialize(&self.to_512_second_intervals(), s)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for NumberOf512Seconds {
+    #[inline]
+    fn deserialize<D>(d: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(Self::from_512_second_intervals(u16::deserialize(d)?))
+    }
 }
 
 #[cfg(feature = "arbitrary")]


### PR DESCRIPTION
To satisfy the API guideline [C-SERDE](https://rust-lang.github.io/api-guidelines/interoperability.html#data-structures-implement-serdes-serialize-deserialize-c-serde), data types in a crate must implement serde's `Serialize` and `Deserialize` traits.

Add custom impls for both `absolute` and `relative` lock time subtypes (the `LockTime` types are already done).

Close #6632