### PR TITLE
fuzz: fix ci job, install cargo-fuzz first

### DIFF
--- a/.github/workflows/cron-daily-fuzz.yml
+++ b/.github/workflows/cron-daily-fuzz.yml
@@ -36,8 +36,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6 # stable
         with:
           toolchain: '1.74.0'
+      - name: Install cargo-fuzz
+        run: cargo install --locked --version 0.12.0 cargo-fuzz
       - name: Fuzz shard ${{ matrix.shard_id }}
         working-directory: fuzz
+        shell: bash
         run: |
           shard_targets=($(cargo fuzz list | sort | awk -v shard=${{ matrix.shard_id }} 'BEGIN{i=0} {if (i++ % 16 == shard) print}'))
           for target in "${shard_targets[@]}"; do

--- a/fuzz/fuzz.sh
+++ b/fuzz/fuzz.sh
@@ -79,7 +79,7 @@ while :; do
     if [ "$cycle_mode" = true ]; then
       chrt_cmd='chrt -i 0'
     fi
-    RUSTFLAGS="$RUSTFLAGS $fuzz_rustflags" $chrt_cmd cargo +nightly fuzz run "$targetName" -- -max_total_time="$max_total_time"
+    RUSTFLAGS="${RUSTFLAGS:-} ${fuzz_rustflags}" $chrt_cmd cargo +nightly fuzz run "$targetName" -- -max_total_time="$max_total_time"
 
     echo "Minimizing corpus for target $targetName"
     cargo +nightly fuzz cmin "$targetName"


### PR DESCRIPTION
My bug found by satsfy, need to install `cargo-fuzz` before using it. Also adds an explicit bash shell for set -e fail fast default.