### PR TITLE
units: Restore the +1 in relative locktime satisfied by height

### DIFF
--- a/units/src/locktime/relative/mod.rs
+++ b/units/src/locktime/relative/mod.rs
@@ -440,9 +440,10 @@ impl NumberOfBlocks {
         chain_tip: crate::BlockHeight,
         utxo_mined_at: crate::BlockHeight,
     ) -> Result<bool, InvalidHeightError> {
-        chain_tip.checked_sub(utxo_mined_at)
+        chain_tip
+            .checked_sub(utxo_mined_at)
             .ok_or(InvalidHeightError { chain_tip, utxo_mined_at })
-            .map(|diff| u32::from(self.to_height()) <= diff.to_u32())
+            .map(|diff| u32::from(self.to_height()).saturating_sub(1) <= diff.to_u32())
     }
 }
 
@@ -849,7 +850,7 @@ mod tests {
         let lock1 = LockTime::Blocks(NumberOfBlocks::from(10));
         assert!(lock1.is_satisfied_by(chain_height, chain_mtp, utxo_height, utxo_mtp).unwrap());
 
-        let lock2 = LockTime::Blocks(NumberOfBlocks::from(20));
+        let lock2 = LockTime::Blocks(NumberOfBlocks::from(21));
         assert!(lock2.is_satisfied_by(chain_height, chain_mtp, utxo_height, utxo_mtp).unwrap());
 
         let lock3 = LockTime::Time(NumberOf512Seconds::from_512_second_intervals(10));
@@ -1010,12 +1011,12 @@ mod tests {
         let height_lock = LockTime::Blocks(NumberOfBlocks(10));
 
         // Test case 1: Satisfaction (current_height >= utxo_height + required)
-        let chain_state1 = BlockHeight::from_u32(90);
+        let chain_state1 = BlockHeight::from_u32(89);
         let utxo_state1 = BlockHeight::from_u32(80);
         assert!(height_lock.is_satisfied_by_height(chain_state1, utxo_state1).unwrap());
 
         // Test case 2: Not satisfied (current_height < utxo_height + required)
-        let chain_state2 = BlockHeight::from_u32(89);
+        let chain_state2 = BlockHeight::from_u32(88);
         let utxo_state2 = BlockHeight::from_u32(80);
         assert!(!height_lock.is_satisfied_by_height(chain_state2, utxo_state2).unwrap());
 
@@ -1024,6 +1025,28 @@ mod tests {
         let chain_state3 = BlockHeight::from_u32(1000);
         let utxo_state3 = BlockHeight::from_u32(80);
         assert!(!max_height_lock.is_satisfied_by_height(chain_state3, utxo_state3).unwrap());
+    }
+
+    #[test]
+    fn satisfied_by_height_boundary() {
+        for n in [0, 2, 5, 9, 20, u16::MAX] {
+            let lock = NumberOfBlocks::from_height(n);
+            let mined_at = BlockHeight::from_u32(100);
+
+            let first_spendable_tip = BlockHeight::from_u32(100 + u32::from(n).saturating_sub(1));
+            assert!(
+                lock.is_satisfied_by(first_spendable_tip, mined_at).unwrap(),
+                "n={n} must be satisfied at tip {first_spendable_tip} ({n} confirmations)"
+            );
+
+            if n > 1 {
+                let too_early = BlockHeight::from_u32(100 + u32::from(n) - 2);
+                assert!(
+                    !lock.is_satisfied_by(too_early, mined_at).unwrap(),
+                    "n={n} must not be satisfied at tip {too_early}"
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
#6582 removed the `+ 1` from the height based relative locktime check. It should be restored.

Absolute and relative locktimes differ in consensus. `CheckFinalTxAtTip` compares `nLockTime` against the next block height, so the absolute half of #6582 is correct. But `CalculateSequenceLocks` computes

    nMinHeight = nCoinHeight + relative - 1

and `EvaluateSequenceLocks` requires `nMinHeight < block.nHeight`. For the next block that reduces to `relative <= diff + 1`, so the UTXO needs `relative` confirmations, not `relative + 1`.

On master every height based relative locktime reads as unsatisfied for one block longer than consensus requires.

Checked against Bitcoin Core v31.1 on regtest, sending version 2 transactions to `testmempoolaccept` at each tip:

    N   utxo height   first tip Core accepts   confirmations
    1   151           151                      1
    2   156           157                      2
    5   162           166                      5
    9   171           179                      9

Core accepts at N confirmations, master requires N + 1. Over 29 (N, tip) pairs there are 4 mismatches on master and 0 with this change. Same result on v28.0. The same check run against the absolute code, untouched here, gives 0 mismatches on master.

The time based path is left alone. `EvaluateSequenceLocks` compares `nMinTime` against the median time past of the chain tip, not of the next block, so it correctly has no `+ 1` (24 pairs with bit 22 set, 0 mismatches on master). A comment records the asymmetry.

Also reverts the three test constants changed by #6582 and adds a boundary test.
