### PR TITLE
units: Add documentation field to Cargo.toml

### DIFF
--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>", "Tobin C. Harding <me@t
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"
 homepage = "https://rust-bitcoin.org"
+documentation = "https://docs.rs/bitcoin-units"
 description = "Basic Bitcoin numeric units such as amount"
 categories = ["cryptography::cryptocurrencies"]
 keywords = ["bitcoin", "newtypes", "no-std"]


### PR DESCRIPTION
Add the `documentation` field to `Cargo.toml` to satisfy the C-METADATA API guideline.

Related issue #3632