### PR TITLE
primitives: Apply the witness item size limit to every element

### DIFF
--- a/primitives/src/witness.rs
+++ b/primitives/src/witness.rs
@@ -418,7 +418,10 @@ impl encoding::Decoder for WitnessDecoder {
                 }
 
                 // Take ownership of the decoder so we can consume it.
-                let decoder = core::mem::take(&mut self.element_length_decoder);
+                let decoder = core::mem::replace(
+                    &mut self.element_length_decoder,
+                    CompactSizeDecoder::new_with_limit(MAX_WITNESS_ITEM_SIZE),
+                );
                 let element_length = decoder.end().map_err(|e| E(Inner::LengthPrefixDecode(e)))?;
 
                 // keep the element length prefix in the content area.
@@ -1850,5 +1853,27 @@ mod test {
         // No massive allocation occurred.
         assert_eq!(dec.content.len(), 5);
         assert!(dec.content.capacity() < 100_000);
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn element_length_limit_applies_to_every_element() {
+        // 4_000_001, which exceeds `MAX_WITNESS_ITEM_SIZE` but is below the default 32MB compact
+        // size limit. It is therefore only rejected if each element gets a correctly limited
+        // decoder, rather than the first one alone.
+        const OVERSIZED: [u8; 5] = [0xFE, 0x01, 0x09, 0x3D, 0x00];
+
+        // As the first element.
+        let mut encoded = vec![0x01];
+        encoded.extend_from_slice(&OVERSIZED);
+        let mut dec = WitnessDecoder::new();
+        assert!(dec.push_bytes(&mut encoded.as_slice()).is_err());
+
+        // And as a later element, which used to be accepted because the length decoder was
+        // replaced with an unlimited-by-comparison default one after the first element.
+        let mut encoded = vec![0x02, 0x00];
+        encoded.extend_from_slice(&OVERSIZED);
+        let mut dec = WitnessDecoder::new();
+        assert!(dec.push_bytes(&mut encoded.as_slice()).is_err());
     }
 }


### PR DESCRIPTION
`WitnessDecoder` is constructed with `CompactSizeDecoder::new_with_limit(MAX_WITNESS_ITEM_SIZE)`, which is 4,000,000. After decoding each element length it calls `mem::take` on that decoder, which puts back `Default`, and `CompactSizeDecoder::default()` is `new()` with the 32MB `MAX_COMPACT_SIZE` limit. So only the first element is bounded by `MAX_WITNESS_ITEM_SIZE`. Every later element gets 33,554,432.

An element between 4,000,001 and 33,554,432 bytes then decodes, but `cast_to_usize_if_valid` caps at 4,000,000 and returns `None`. The resulting `Witness` reports a length it cannot serve:

    witness.len()  = 2
    witness.get(1) = None
    witness.last() = None
    iter().count() = 1

`P2TrSpend::from_witness` dispatches on `len()` and then unwraps `last()`, so this panics. It is reachable from a 4,000,070 byte transaction, which is under the p2p `MAX_MSG_SIZE` of 5,000,000:

    transaction DECODED
    panicked at bitcoin/src/blockdata/witness.rs:184:33: len > 0

The same oversized length as the first element is correctly rejected today, which isolates this to the `mem::take`.

`mem::replace` with a correctly limited decoder fixes it. No valid data is rejected: witness bytes are one weight unit each, so a 4,000,001 byte element cannot fit in a block, and element 0 was already subject to this limit.

The added test fails on master at the later element assertion and passes with the fix.

Unrelated but worth noting: `cast_to_usize_if_valid` hardcodes its own `4_000_000` rather than referencing `MAX_WITNESS_ITEM_SIZE`. The two agreeing is what makes this fix correct. Left alone here, but they could usefully be unified.
