### PR TITLE
primitives: Add serde impls for `WitnessVersion`

### DIFF
--- a/primitives/api/all-features.txt
+++ b/primitives/api/all-features.txt
@@ -6579,6 +6579,10 @@ impl core::marker::StructuralPartialEq for bitcoin_primitives::witness_version::
 impl core::str::traits::FromStr for bitcoin_primitives::witness_version::WitnessVersion
   pub type bitcoin_primitives::witness_version::WitnessVersion::Err = bitcoin_primitives::witness_version::error::ParseWitnessVersionError [impl: impl core::str::traits::FromStr for bitcoin_primitives::witness_version::WitnessVersion]
   pub fn bitcoin_primitives::witness_version::WitnessVersion::from_str(s: &str) -> core::result::Result<Self, Self::Err> [impl: impl core::str::traits::FromStr for bitcoin_primitives::witness_version::WitnessVersion]
+impl serde::ser::Serialize for bitcoin_primitives::witness_version::WitnessVersion
+  pub fn bitcoin_primitives::witness_version::WitnessVersion::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer [impl: impl serde::ser::Serialize for bitcoin_primitives::witness_version::WitnessVersion]
+impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::witness_version::WitnessVersion
+  pub fn bitcoin_primitives::witness_version::WitnessVersion::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de> [impl: impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::witness_version::WitnessVersion]
 impl core::marker::Freeze for bitcoin_primitives::witness_version::WitnessVersion
 impl core::marker::Send for bitcoin_primitives::witness_version::WitnessVersion
 impl core::marker::Sync for bitcoin_primitives::witness_version::WitnessVersion
@@ -6610,6 +6614,7 @@ impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::Witn
   pub unsafe fn bitcoin_primitives::witness_version::WitnessVersion::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_primitives::witness_version::WitnessVersion where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::WitnessVersion
   pub fn bitcoin_primitives::witness_version::WitnessVersion::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_primitives::witness_version::WitnessVersion]
+impl<T> serde::de::DeserializeOwned for bitcoin_primitives::witness_version::WitnessVersion where T: for<'de> serde::de::Deserialize<'de>
 pub struct bitcoin_primitives::witness_version::InvalidWitnessVersionError
 impl bitcoin_primitives::witness_version::error::InvalidWitnessVersionError
 pub fn bitcoin_primitives::witness_version::error::InvalidWitnessVersionError::invalid_version(&self) -> u8

--- a/primitives/src/witness_version.rs
+++ b/primitives/src/witness_version.rs
@@ -160,6 +160,27 @@ impl From<WitnessVersion> for Opcode {
     }
 }
 
+#[cfg(feature = "serde")]
+impl serde::Serialize for WitnessVersion {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_u8(self.to_num())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for WitnessVersion {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let version = u8::deserialize(deserializer)?;
+        Self::try_from(version).map_err(serde::de::Error::custom)
+    }
+}
+
 /// Error types for the segwit version number.
 pub mod error {
     use core::convert::Infallible;

--- a/primitives/src/witness_version.rs
+++ b/primitives/src/witness_version.rs
@@ -314,6 +314,30 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
+    fn witness_version_serde_round_trip() {
+        for version in 0u8..=16 {
+            let wv = WitnessVersion::try_from(version).unwrap();
+
+            let json = serde_json::to_string(&wv).unwrap();
+            assert_eq!(json, format!("{}", version));
+            assert_eq!(serde_json::from_str::<WitnessVersion>(&json).unwrap(), wv);
+
+            let bin = bincode::serialize(&wv).unwrap();
+            assert_eq!(bin, bincode::serialize(&version).unwrap());
+            assert_eq!(bincode::deserialize::<WitnessVersion>(&bin).unwrap(), wv);
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn witness_version_serde_invalid() {
+        assert!(serde_json::from_str::<WitnessVersion>("17").is_err());
+        assert!(serde_json::from_str::<WitnessVersion>("255").is_err());
+        assert!(serde_json::from_str::<WitnessVersion>("-1").is_err());
+    }
+
+    #[test]
     fn witness_version_opcode_round_trip() {
         for version in 0u8..=16 {
             let wv = WitnessVersion::try_from(version).unwrap();


### PR DESCRIPTION
The WitnessVersion type in primitives should have serde trait impls, per the C-SERDE guideline.

Add serde Serialize and Deserialize impls for WitnessVersion.

Contributes to #6630 