### PR TITLE
units: private Sequence inner field and remove default

### DIFF
--- a/fuzz/fuzz_targets/units/standard_checks.rs
+++ b/fuzz/fuzz_targets/units/standard_checks.rs
@@ -58,11 +58,11 @@ mod fuzz {
     wrap_for_checks!(BlockMtpInterval);
     wrap_for_checks!(NumberOf512Seconds);
     wrap_for_checks!(NumberOfBlocks);
-    wrap_for_checks!(Sequence);
     wrap_for_checks!(SignedAmount);
 
     // Structs that need defaults
     wrap_for_checks!(BlockHeight, super::BlockHeight::MIN);
+    wrap_for_checks!(Sequence, super::Sequence::MAX);
     wrap_for_checks!(BlockMtp, super::BlockMtp::from_u32(1_742_979_600)); // 26 Mar 2025 9:00 UTC
     wrap_for_checks!(BlockTime, super::BlockTime::from(1_742_979_600)); // 26 Mar 2025 9:00 UTC
     wrap_for_checks!(FeeRate, super::FeeRate::BROADCAST_MIN);

--- a/p2p/src/bip152.rs
+++ b/p2p/src/bip152.rs
@@ -852,7 +852,7 @@ mod test {
             inputs: vec![TxIn {
                 previous_output: OutPoint { txid: dummy_txid, vout: 0 },
                 script_sig: ScriptSigBuf::new(),
-                sequence: Sequence(1),
+                sequence: Sequence::from_consensus(1),
                 witness: Witness::new(),
             }],
             outputs: vec![TxOut { amount: Amount::ONE_SAT, script_pubkey: ScriptPubKeyBuf::new() }],

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -337,7 +337,7 @@ fn hash_transaction(tx: &Transaction, uses_segwit_serialization: bool) -> sha256
         enc.input(crate::compact_size_encode(script_sig_bytes.len()).as_slice());
         enc.input(script_sig_bytes);
 
-        enc.input(&input.sequence.0.to_le_bytes());
+        enc.input(&input.sequence.to_consensus_u32().to_le_bytes());
     }
 
     // Encode outputs with leading compact size encoded int.

--- a/primitives/tests/api.rs
+++ b/primitives/tests/api.rs
@@ -207,7 +207,6 @@ struct Default {
     c3: ScriptSigBuf,
     c4: TapScriptBuf,
     c5: WitnessScriptBuf,
-    d: Sequence,
     e: Witness,
 }
 
@@ -431,7 +430,6 @@ fn regression_default() {
         c3: ScriptSigBuf::from_bytes(Vec::new()),
         c4: TapScriptBuf::from_bytes(Vec::new()),
         c5: WitnessScriptBuf::from_bytes(Vec::new()),
-        d: Sequence::MAX,
         e: Witness::new(),
     };
     assert_eq!(got, want);

--- a/units/api/all-features.txt
+++ b/units/api/all-features.txt
@@ -8755,7 +8755,7 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::sequence::error::SequenceD
   pub unsafe fn bitcoin_units::sequence::error::SequenceDecoderError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_units::sequence::error::SequenceDecoderError where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_units::sequence::error::SequenceDecoderError
   pub fn bitcoin_units::sequence::error::SequenceDecoderError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::sequence::error::SequenceDecoderError]
-pub struct bitcoin_units::sequence::Sequence(pub u32)
+pub struct bitcoin_units::sequence::Sequence(_)
 impl bitcoin_units::sequence::Sequence
 pub const bitcoin_units::sequence::Sequence::ENABLE_LOCKTIME_AND_RBF: Self
 pub const bitcoin_units::sequence::Sequence::ENABLE_LOCKTIME_NO_RBF: Self
@@ -11257,7 +11257,7 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::FeeRate where T: core::clo
   pub unsafe fn bitcoin_units::FeeRate::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_units::FeeRate where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_units::FeeRate
   pub fn bitcoin_units::FeeRate::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::FeeRate]
-pub struct bitcoin_units::Sequence(pub u32)
+pub struct bitcoin_units::Sequence(_)
 impl bitcoin_units::sequence::Sequence
 pub const bitcoin_units::sequence::Sequence::ENABLE_LOCKTIME_AND_RBF: Self
 pub const bitcoin_units::sequence::Sequence::ENABLE_LOCKTIME_NO_RBF: Self

--- a/units/api/all-features.txt
+++ b/units/api/all-features.txt
@@ -8808,8 +8808,6 @@ impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::sequence::
 impl core::convert::TryFrom<bitcoin_units::sequence::Sequence> for bitcoin_units::locktime::relative::LockTime
   pub type bitcoin_units::locktime::relative::LockTime::Error = bitcoin_units::locktime::relative::error::DisabledLockTimeError [impl: impl core::convert::TryFrom<bitcoin_units::sequence::Sequence> for bitcoin_units::locktime::relative::LockTime]
   pub fn bitcoin_units::locktime::relative::LockTime::try_from(seq: bitcoin_units::sequence::Sequence) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::DisabledLockTimeError> [impl: impl core::convert::TryFrom<bitcoin_units::sequence::Sequence> for bitcoin_units::locktime::relative::LockTime]
-impl core::default::Default for bitcoin_units::sequence::Sequence
-  pub fn bitcoin_units::sequence::Sequence::default() -> Self [impl: impl core::default::Default for bitcoin_units::sequence::Sequence]
 impl core::fmt::Binary for bitcoin_units::sequence::Sequence
   pub fn bitcoin_units::sequence::Sequence::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Binary for bitcoin_units::sequence::Sequence]
 impl core::fmt::Debug for bitcoin_units::sequence::Sequence
@@ -11312,8 +11310,6 @@ impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::sequence::
 impl core::convert::TryFrom<bitcoin_units::sequence::Sequence> for bitcoin_units::locktime::relative::LockTime
   pub type bitcoin_units::locktime::relative::LockTime::Error = bitcoin_units::locktime::relative::error::DisabledLockTimeError [impl: impl core::convert::TryFrom<bitcoin_units::sequence::Sequence> for bitcoin_units::locktime::relative::LockTime]
   pub fn bitcoin_units::locktime::relative::LockTime::try_from(seq: bitcoin_units::sequence::Sequence) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::DisabledLockTimeError> [impl: impl core::convert::TryFrom<bitcoin_units::sequence::Sequence> for bitcoin_units::locktime::relative::LockTime]
-impl core::default::Default for bitcoin_units::sequence::Sequence
-  pub fn bitcoin_units::sequence::Sequence::default() -> Self [impl: impl core::default::Default for bitcoin_units::sequence::Sequence]
 impl core::fmt::Binary for bitcoin_units::sequence::Sequence
   pub fn bitcoin_units::sequence::Sequence::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Binary for bitcoin_units::sequence::Sequence]
 impl core::fmt::Debug for bitcoin_units::sequence::Sequence

--- a/units/api/alloc-only.txt
+++ b/units/api/alloc-only.txt
@@ -7368,7 +7368,7 @@ impl<T> core::convert::From<T> for bitcoin_units::result::error::NumOpError
   pub fn bitcoin_units::result::error::NumOpError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::result::error::NumOpError]
 pub mod bitcoin_units::sequence
 pub mod bitcoin_units::sequence::error
-pub struct bitcoin_units::sequence::Sequence(pub u32)
+pub struct bitcoin_units::sequence::Sequence(_)
 impl bitcoin_units::sequence::Sequence
 pub const bitcoin_units::sequence::Sequence::ENABLE_LOCKTIME_AND_RBF: Self
 pub const bitcoin_units::sequence::Sequence::ENABLE_LOCKTIME_NO_RBF: Self
@@ -9467,7 +9467,7 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::FeeRate where T: core::clo
   pub unsafe fn bitcoin_units::FeeRate::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_units::FeeRate where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_units::FeeRate
   pub fn bitcoin_units::FeeRate::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::FeeRate]
-pub struct bitcoin_units::Sequence(pub u32)
+pub struct bitcoin_units::Sequence(_)
 impl bitcoin_units::sequence::Sequence
 pub const bitcoin_units::sequence::Sequence::ENABLE_LOCKTIME_AND_RBF: Self
 pub const bitcoin_units::sequence::Sequence::ENABLE_LOCKTIME_NO_RBF: Self

--- a/units/api/alloc-only.txt
+++ b/units/api/alloc-only.txt
@@ -7416,8 +7416,6 @@ impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::sequence::
 impl core::convert::TryFrom<bitcoin_units::sequence::Sequence> for bitcoin_units::locktime::relative::LockTime
   pub type bitcoin_units::locktime::relative::LockTime::Error = bitcoin_units::locktime::relative::error::DisabledLockTimeError [impl: impl core::convert::TryFrom<bitcoin_units::sequence::Sequence> for bitcoin_units::locktime::relative::LockTime]
   pub fn bitcoin_units::locktime::relative::LockTime::try_from(seq: bitcoin_units::sequence::Sequence) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::DisabledLockTimeError> [impl: impl core::convert::TryFrom<bitcoin_units::sequence::Sequence> for bitcoin_units::locktime::relative::LockTime]
-impl core::default::Default for bitcoin_units::sequence::Sequence
-  pub fn bitcoin_units::sequence::Sequence::default() -> Self [impl: impl core::default::Default for bitcoin_units::sequence::Sequence]
 impl core::fmt::Binary for bitcoin_units::sequence::Sequence
   pub fn bitcoin_units::sequence::Sequence::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Binary for bitcoin_units::sequence::Sequence]
 impl core::fmt::Debug for bitcoin_units::sequence::Sequence
@@ -9517,8 +9515,6 @@ impl core::convert::TryFrom<alloc::string::String> for bitcoin_units::sequence::
 impl core::convert::TryFrom<bitcoin_units::sequence::Sequence> for bitcoin_units::locktime::relative::LockTime
   pub type bitcoin_units::locktime::relative::LockTime::Error = bitcoin_units::locktime::relative::error::DisabledLockTimeError [impl: impl core::convert::TryFrom<bitcoin_units::sequence::Sequence> for bitcoin_units::locktime::relative::LockTime]
   pub fn bitcoin_units::locktime::relative::LockTime::try_from(seq: bitcoin_units::sequence::Sequence) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::DisabledLockTimeError> [impl: impl core::convert::TryFrom<bitcoin_units::sequence::Sequence> for bitcoin_units::locktime::relative::LockTime]
-impl core::default::Default for bitcoin_units::sequence::Sequence
-  pub fn bitcoin_units::sequence::Sequence::default() -> Self [impl: impl core::default::Default for bitcoin_units::sequence::Sequence]
 impl core::fmt::Binary for bitcoin_units::sequence::Sequence
   pub fn bitcoin_units::sequence::Sequence::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Binary for bitcoin_units::sequence::Sequence]
 impl core::fmt::Debug for bitcoin_units::sequence::Sequence

--- a/units/api/no-features.txt
+++ b/units/api/no-features.txt
@@ -6548,7 +6548,7 @@ impl<T> core::convert::From<T> for bitcoin_units::result::error::NumOpError
   pub fn bitcoin_units::result::error::NumOpError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::result::error::NumOpError]
 pub mod bitcoin_units::sequence
 pub mod bitcoin_units::sequence::error
-pub struct bitcoin_units::sequence::Sequence(pub u32)
+pub struct bitcoin_units::sequence::Sequence(_)
 impl bitcoin_units::sequence::Sequence
 pub const bitcoin_units::sequence::Sequence::ENABLE_LOCKTIME_AND_RBF: Self
 pub const bitcoin_units::sequence::Sequence::ENABLE_LOCKTIME_NO_RBF: Self
@@ -8519,7 +8519,7 @@ impl<T> core::clone::CloneToUninit for bitcoin_units::FeeRate where T: core::clo
   pub unsafe fn bitcoin_units::FeeRate::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_units::FeeRate where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_units::FeeRate
   pub fn bitcoin_units::FeeRate::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::FeeRate]
-pub struct bitcoin_units::Sequence(pub u32)
+pub struct bitcoin_units::Sequence(_)
 impl bitcoin_units::sequence::Sequence
 pub const bitcoin_units::sequence::Sequence::ENABLE_LOCKTIME_AND_RBF: Self
 pub const bitcoin_units::sequence::Sequence::ENABLE_LOCKTIME_NO_RBF: Self

--- a/units/api/no-features.txt
+++ b/units/api/no-features.txt
@@ -6590,8 +6590,6 @@ impl core::convert::TryFrom<&str> for bitcoin_units::sequence::Sequence
 impl core::convert::TryFrom<bitcoin_units::sequence::Sequence> for bitcoin_units::locktime::relative::LockTime
   pub type bitcoin_units::locktime::relative::LockTime::Error = bitcoin_units::locktime::relative::error::DisabledLockTimeError [impl: impl core::convert::TryFrom<bitcoin_units::sequence::Sequence> for bitcoin_units::locktime::relative::LockTime]
   pub fn bitcoin_units::locktime::relative::LockTime::try_from(seq: bitcoin_units::sequence::Sequence) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::DisabledLockTimeError> [impl: impl core::convert::TryFrom<bitcoin_units::sequence::Sequence> for bitcoin_units::locktime::relative::LockTime]
-impl core::default::Default for bitcoin_units::sequence::Sequence
-  pub fn bitcoin_units::sequence::Sequence::default() -> Self [impl: impl core::default::Default for bitcoin_units::sequence::Sequence]
 impl core::fmt::Binary for bitcoin_units::sequence::Sequence
   pub fn bitcoin_units::sequence::Sequence::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Binary for bitcoin_units::sequence::Sequence]
 impl core::fmt::Debug for bitcoin_units::sequence::Sequence
@@ -8563,8 +8561,6 @@ impl core::convert::TryFrom<&str> for bitcoin_units::sequence::Sequence
 impl core::convert::TryFrom<bitcoin_units::sequence::Sequence> for bitcoin_units::locktime::relative::LockTime
   pub type bitcoin_units::locktime::relative::LockTime::Error = bitcoin_units::locktime::relative::error::DisabledLockTimeError [impl: impl core::convert::TryFrom<bitcoin_units::sequence::Sequence> for bitcoin_units::locktime::relative::LockTime]
   pub fn bitcoin_units::locktime::relative::LockTime::try_from(seq: bitcoin_units::sequence::Sequence) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::DisabledLockTimeError> [impl: impl core::convert::TryFrom<bitcoin_units::sequence::Sequence> for bitcoin_units::locktime::relative::LockTime]
-impl core::default::Default for bitcoin_units::sequence::Sequence
-  pub fn bitcoin_units::sequence::Sequence::default() -> Self [impl: impl core::default::Default for bitcoin_units::sequence::Sequence]
 impl core::fmt::Binary for bitcoin_units::sequence::Sequence
   pub fn bitcoin_units::sequence::Sequence::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Binary for bitcoin_units::sequence::Sequence]
 impl core::fmt::Debug for bitcoin_units::sequence::Sequence

--- a/units/src/sequence.rs
+++ b/units/src/sequence.rs
@@ -33,7 +33,7 @@ pub use self::error::SequenceDecoderError;
 /// Bitcoin transaction input sequence number.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Sequence(pub u32);
+pub struct Sequence(u32);
 
 impl Sequence {
     /// The maximum allowable sequence number.

--- a/units/src/sequence.rs
+++ b/units/src/sequence.rs
@@ -228,12 +228,6 @@ impl Sequence {
 
 crate::internal_macros::impl_fmt_traits_for_u32_wrapper!(Sequence);
 
-impl Default for Sequence {
-    /// The default value of sequence is 0xffffffff.
-    #[inline]
-    fn default() -> Self { Self::MAX }
-}
-
 impl From<Sequence> for u32 {
     #[inline]
     fn from(sequence: Sequence) -> Self { sequence.0 }

--- a/units/tests/api.rs
+++ b/units/tests/api.rs
@@ -129,7 +129,6 @@ struct Default {
     d: BlockMtpInterval,
     e: relative::NumberOf512Seconds,
     f: relative::NumberOfBlocks,
-    g: Sequence,
 }
 
 /// A struct that includes all public error types (excl. decode errors).
@@ -436,7 +435,6 @@ fn regression_default() {
         d: BlockMtpInterval::ZERO,
         e: relative::NumberOf512Seconds::ZERO,
         f: relative::NumberOfBlocks::ZERO,
-        g: Sequence::MAX,
     };
     assert_eq!(got, want);
 }


### PR DESCRIPTION
Closes https://github.com/rust-bitcoin/rust-bitcoin/issues/6639

C-STRUCT-PRIVATE API design guideline forbids a struct inner field from being public, which was `Sequence`'s case. This PR makes it private. The value remains accessible through `from_consensus` and `to_consensus_u32`.

The `Sequence` default impl doesn't have a `new()`, which the API guidelines expect, so this PR removes the impl, drops `Sequence` from the `Default` conformance tests and the API snapshots, and gives the fuzz wrapper an explicit default.