### PR TITLE
units: Make `Sum` impl generic for `Signed`/`Amount` -> `NumOpResult`

### DIFF
--- a/units/api/all-features.txt
+++ b/units/api/all-features.txt
@@ -8232,10 +8232,6 @@ impl core::convert::From<bitcoin_units::Amount> for bitcoin_units::result::NumOp
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::from(a: bitcoin_units::Amount) -> Self [impl: impl core::convert::From<bitcoin_units::Amount> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::convert::From<bitcoin_units::SignedAmount> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::from(a: bitcoin_units::SignedAmount) -> Self [impl: impl core::convert::From<bitcoin_units::SignedAmount> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
-impl core::iter::traits::accum::Sum for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
-  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = Self> [impl: impl core::iter::traits::accum::Sum for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
-impl core::iter::traits::accum::Sum for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
-  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = Self> [impl: impl core::iter::traits::accum::Sum for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::Add<&bitcoin_units::result::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount
   pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Add<bitcoin_units::result::NumOpResult<bitcoin_units::Amount>>>::Output [impl: impl core::ops::arith::Add<&bitcoin_units::result::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount]
   pub fn bitcoin_units::Amount::add(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>) -> Self::Output [impl: impl core::ops::arith::Add<&bitcoin_units::result::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount]
@@ -8580,6 +8576,10 @@ impl<T: core::cmp::Eq> core::cmp::Eq for bitcoin_units::result::NumOpResult<T>
 impl<T: core::cmp::PartialEq> core::cmp::PartialEq for bitcoin_units::result::NumOpResult<T>
   pub fn bitcoin_units::result::NumOpResult<T>::eq(&self, other: &bitcoin_units::result::NumOpResult<T>) -> bool [impl: impl<T: core::cmp::PartialEq> core::cmp::PartialEq for bitcoin_units::result::NumOpResult<T>]
 impl<T: core::cmp::PartialEq> core::marker::StructuralPartialEq for bitcoin_units::result::NumOpResult<T>
+impl<T: core::convert::Into<Self>> core::iter::traits::accum::Sum<T> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = T> [impl: impl<T: core::convert::Into<Self>> core::iter::traits::accum::Sum<T> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl<T: core::convert::Into<Self>> core::iter::traits::accum::Sum<T> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = T> [impl: impl<T: core::convert::Into<Self>> core::iter::traits::accum::Sum<T> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl<T: core::fmt::Debug> core::fmt::Debug for bitcoin_units::result::NumOpResult<T>
   pub fn bitcoin_units::result::NumOpResult<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<T: core::fmt::Debug> core::fmt::Debug for bitcoin_units::result::NumOpResult<T>]
 impl<T: core::marker::Copy> core::marker::Copy for bitcoin_units::result::NumOpResult<T>
@@ -9590,10 +9590,6 @@ impl core::convert::From<bitcoin_units::Amount> for bitcoin_units::result::NumOp
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::from(a: bitcoin_units::Amount) -> Self [impl: impl core::convert::From<bitcoin_units::Amount> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::convert::From<bitcoin_units::SignedAmount> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::from(a: bitcoin_units::SignedAmount) -> Self [impl: impl core::convert::From<bitcoin_units::SignedAmount> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
-impl core::iter::traits::accum::Sum for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
-  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = Self> [impl: impl core::iter::traits::accum::Sum for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
-impl core::iter::traits::accum::Sum for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
-  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = Self> [impl: impl core::iter::traits::accum::Sum for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::Add<&bitcoin_units::result::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount
   pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Add<bitcoin_units::result::NumOpResult<bitcoin_units::Amount>>>::Output [impl: impl core::ops::arith::Add<&bitcoin_units::result::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount]
   pub fn bitcoin_units::Amount::add(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>) -> Self::Output [impl: impl core::ops::arith::Add<&bitcoin_units::result::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount]
@@ -9938,6 +9934,10 @@ impl<T: core::cmp::Eq> core::cmp::Eq for bitcoin_units::result::NumOpResult<T>
 impl<T: core::cmp::PartialEq> core::cmp::PartialEq for bitcoin_units::result::NumOpResult<T>
   pub fn bitcoin_units::result::NumOpResult<T>::eq(&self, other: &bitcoin_units::result::NumOpResult<T>) -> bool [impl: impl<T: core::cmp::PartialEq> core::cmp::PartialEq for bitcoin_units::result::NumOpResult<T>]
 impl<T: core::cmp::PartialEq> core::marker::StructuralPartialEq for bitcoin_units::result::NumOpResult<T>
+impl<T: core::convert::Into<Self>> core::iter::traits::accum::Sum<T> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = T> [impl: impl<T: core::convert::Into<Self>> core::iter::traits::accum::Sum<T> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl<T: core::convert::Into<Self>> core::iter::traits::accum::Sum<T> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = T> [impl: impl<T: core::convert::Into<Self>> core::iter::traits::accum::Sum<T> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl<T: core::fmt::Debug> core::fmt::Debug for bitcoin_units::result::NumOpResult<T>
   pub fn bitcoin_units::result::NumOpResult<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<T: core::fmt::Debug> core::fmt::Debug for bitcoin_units::result::NumOpResult<T>]
 impl<T: core::marker::Copy> core::marker::Copy for bitcoin_units::result::NumOpResult<T>

--- a/units/api/alloc-only.txt
+++ b/units/api/alloc-only.txt
@@ -6895,10 +6895,6 @@ impl core::convert::From<bitcoin_units::Amount> for bitcoin_units::result::NumOp
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::from(a: bitcoin_units::Amount) -> Self [impl: impl core::convert::From<bitcoin_units::Amount> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::convert::From<bitcoin_units::SignedAmount> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::from(a: bitcoin_units::SignedAmount) -> Self [impl: impl core::convert::From<bitcoin_units::SignedAmount> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
-impl core::iter::traits::accum::Sum for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
-  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = Self> [impl: impl core::iter::traits::accum::Sum for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
-impl core::iter::traits::accum::Sum for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
-  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = Self> [impl: impl core::iter::traits::accum::Sum for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::Add<&bitcoin_units::result::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount
   pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Add<bitcoin_units::result::NumOpResult<bitcoin_units::Amount>>>::Output [impl: impl core::ops::arith::Add<&bitcoin_units::result::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount]
   pub fn bitcoin_units::Amount::add(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>) -> Self::Output [impl: impl core::ops::arith::Add<&bitcoin_units::result::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount]
@@ -7241,6 +7237,10 @@ impl<T: core::cmp::Eq> core::cmp::Eq for bitcoin_units::result::NumOpResult<T>
 impl<T: core::cmp::PartialEq> core::cmp::PartialEq for bitcoin_units::result::NumOpResult<T>
   pub fn bitcoin_units::result::NumOpResult<T>::eq(&self, other: &bitcoin_units::result::NumOpResult<T>) -> bool [impl: impl<T: core::cmp::PartialEq> core::cmp::PartialEq for bitcoin_units::result::NumOpResult<T>]
 impl<T: core::cmp::PartialEq> core::marker::StructuralPartialEq for bitcoin_units::result::NumOpResult<T>
+impl<T: core::convert::Into<Self>> core::iter::traits::accum::Sum<T> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = T> [impl: impl<T: core::convert::Into<Self>> core::iter::traits::accum::Sum<T> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl<T: core::convert::Into<Self>> core::iter::traits::accum::Sum<T> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = T> [impl: impl<T: core::convert::Into<Self>> core::iter::traits::accum::Sum<T> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl<T: core::fmt::Debug> core::fmt::Debug for bitcoin_units::result::NumOpResult<T>
   pub fn bitcoin_units::result::NumOpResult<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<T: core::fmt::Debug> core::fmt::Debug for bitcoin_units::result::NumOpResult<T>]
 impl<T: core::marker::Copy> core::marker::Copy for bitcoin_units::result::NumOpResult<T>
@@ -7868,10 +7868,6 @@ impl core::convert::From<bitcoin_units::Amount> for bitcoin_units::result::NumOp
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::from(a: bitcoin_units::Amount) -> Self [impl: impl core::convert::From<bitcoin_units::Amount> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::convert::From<bitcoin_units::SignedAmount> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::from(a: bitcoin_units::SignedAmount) -> Self [impl: impl core::convert::From<bitcoin_units::SignedAmount> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
-impl core::iter::traits::accum::Sum for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
-  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = Self> [impl: impl core::iter::traits::accum::Sum for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
-impl core::iter::traits::accum::Sum for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
-  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = Self> [impl: impl core::iter::traits::accum::Sum for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::Add<&bitcoin_units::result::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount
   pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Add<bitcoin_units::result::NumOpResult<bitcoin_units::Amount>>>::Output [impl: impl core::ops::arith::Add<&bitcoin_units::result::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount]
   pub fn bitcoin_units::Amount::add(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>) -> Self::Output [impl: impl core::ops::arith::Add<&bitcoin_units::result::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount]
@@ -8214,6 +8210,10 @@ impl<T: core::cmp::Eq> core::cmp::Eq for bitcoin_units::result::NumOpResult<T>
 impl<T: core::cmp::PartialEq> core::cmp::PartialEq for bitcoin_units::result::NumOpResult<T>
   pub fn bitcoin_units::result::NumOpResult<T>::eq(&self, other: &bitcoin_units::result::NumOpResult<T>) -> bool [impl: impl<T: core::cmp::PartialEq> core::cmp::PartialEq for bitcoin_units::result::NumOpResult<T>]
 impl<T: core::cmp::PartialEq> core::marker::StructuralPartialEq for bitcoin_units::result::NumOpResult<T>
+impl<T: core::convert::Into<Self>> core::iter::traits::accum::Sum<T> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = T> [impl: impl<T: core::convert::Into<Self>> core::iter::traits::accum::Sum<T> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl<T: core::convert::Into<Self>> core::iter::traits::accum::Sum<T> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = T> [impl: impl<T: core::convert::Into<Self>> core::iter::traits::accum::Sum<T> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl<T: core::fmt::Debug> core::fmt::Debug for bitcoin_units::result::NumOpResult<T>
   pub fn bitcoin_units::result::NumOpResult<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<T: core::fmt::Debug> core::fmt::Debug for bitcoin_units::result::NumOpResult<T>]
 impl<T: core::marker::Copy> core::marker::Copy for bitcoin_units::result::NumOpResult<T>

--- a/units/api/no-features.txt
+++ b/units/api/no-features.txt
@@ -6085,10 +6085,6 @@ impl core::convert::From<bitcoin_units::Amount> for bitcoin_units::result::NumOp
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::from(a: bitcoin_units::Amount) -> Self [impl: impl core::convert::From<bitcoin_units::Amount> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::convert::From<bitcoin_units::SignedAmount> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::from(a: bitcoin_units::SignedAmount) -> Self [impl: impl core::convert::From<bitcoin_units::SignedAmount> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
-impl core::iter::traits::accum::Sum for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
-  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = Self> [impl: impl core::iter::traits::accum::Sum for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
-impl core::iter::traits::accum::Sum for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
-  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = Self> [impl: impl core::iter::traits::accum::Sum for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::Add<&bitcoin_units::result::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount
   pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Add<bitcoin_units::result::NumOpResult<bitcoin_units::Amount>>>::Output [impl: impl core::ops::arith::Add<&bitcoin_units::result::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount]
   pub fn bitcoin_units::Amount::add(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>) -> Self::Output [impl: impl core::ops::arith::Add<&bitcoin_units::result::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount]
@@ -6431,6 +6427,10 @@ impl<T: core::cmp::Eq> core::cmp::Eq for bitcoin_units::result::NumOpResult<T>
 impl<T: core::cmp::PartialEq> core::cmp::PartialEq for bitcoin_units::result::NumOpResult<T>
   pub fn bitcoin_units::result::NumOpResult<T>::eq(&self, other: &bitcoin_units::result::NumOpResult<T>) -> bool [impl: impl<T: core::cmp::PartialEq> core::cmp::PartialEq for bitcoin_units::result::NumOpResult<T>]
 impl<T: core::cmp::PartialEq> core::marker::StructuralPartialEq for bitcoin_units::result::NumOpResult<T>
+impl<T: core::convert::Into<Self>> core::iter::traits::accum::Sum<T> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = T> [impl: impl<T: core::convert::Into<Self>> core::iter::traits::accum::Sum<T> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl<T: core::convert::Into<Self>> core::iter::traits::accum::Sum<T> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = T> [impl: impl<T: core::convert::Into<Self>> core::iter::traits::accum::Sum<T> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl<T: core::fmt::Debug> core::fmt::Debug for bitcoin_units::result::NumOpResult<T>
   pub fn bitcoin_units::result::NumOpResult<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<T: core::fmt::Debug> core::fmt::Debug for bitcoin_units::result::NumOpResult<T>]
 impl<T: core::marker::Copy> core::marker::Copy for bitcoin_units::result::NumOpResult<T>
@@ -7012,10 +7012,6 @@ impl core::convert::From<bitcoin_units::Amount> for bitcoin_units::result::NumOp
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::from(a: bitcoin_units::Amount) -> Self [impl: impl core::convert::From<bitcoin_units::Amount> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::convert::From<bitcoin_units::SignedAmount> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::from(a: bitcoin_units::SignedAmount) -> Self [impl: impl core::convert::From<bitcoin_units::SignedAmount> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
-impl core::iter::traits::accum::Sum for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
-  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = Self> [impl: impl core::iter::traits::accum::Sum for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
-impl core::iter::traits::accum::Sum for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
-  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = Self> [impl: impl core::iter::traits::accum::Sum for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::Add<&bitcoin_units::result::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount
   pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Add<bitcoin_units::result::NumOpResult<bitcoin_units::Amount>>>::Output [impl: impl core::ops::arith::Add<&bitcoin_units::result::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount]
   pub fn bitcoin_units::Amount::add(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>) -> Self::Output [impl: impl core::ops::arith::Add<&bitcoin_units::result::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount]
@@ -7358,6 +7354,10 @@ impl<T: core::cmp::Eq> core::cmp::Eq for bitcoin_units::result::NumOpResult<T>
 impl<T: core::cmp::PartialEq> core::cmp::PartialEq for bitcoin_units::result::NumOpResult<T>
   pub fn bitcoin_units::result::NumOpResult<T>::eq(&self, other: &bitcoin_units::result::NumOpResult<T>) -> bool [impl: impl<T: core::cmp::PartialEq> core::cmp::PartialEq for bitcoin_units::result::NumOpResult<T>]
 impl<T: core::cmp::PartialEq> core::marker::StructuralPartialEq for bitcoin_units::result::NumOpResult<T>
+impl<T: core::convert::Into<Self>> core::iter::traits::accum::Sum<T> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = T> [impl: impl<T: core::convert::Into<Self>> core::iter::traits::accum::Sum<T> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl<T: core::convert::Into<Self>> core::iter::traits::accum::Sum<T> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::sum<I>(iter: I) -> Self where I: core::iter::traits::iterator::Iterator<Item = T> [impl: impl<T: core::convert::Into<Self>> core::iter::traits::accum::Sum<T> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl<T: core::fmt::Debug> core::fmt::Debug for bitcoin_units::result::NumOpResult<T>
   pub fn bitcoin_units::result::NumOpResult<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<T: core::fmt::Debug> core::fmt::Debug for bitcoin_units::result::NumOpResult<T>]
 impl<T: core::marker::Copy> core::marker::Copy for bitcoin_units::result::NumOpResult<T>

--- a/units/src/amount/result.rs
+++ b/units/src/amount/result.rs
@@ -214,12 +214,12 @@ impl ops::Neg for SignedAmount {
     }
 }
 
-impl core::iter::Sum<Self> for NumOpResult<Amount> {
+impl<T: Into<Self>> core::iter::Sum<T> for NumOpResult<Amount> {
     fn sum<I>(iter: I) -> Self
     where
-        I: Iterator<Item = Self>,
+        I: Iterator<Item = T>,
     {
-        iter.fold(Self::Valid(Amount::ZERO), |acc, amount| match (acc, amount) {
+        iter.fold(Self::Valid(Amount::ZERO), |acc, amount| match (acc, amount.into()) {
             (Self::Valid(lhs), Self::Valid(rhs)) => lhs + rhs,
             (_, _) => Self::Error(NumOpError::while_doing(MathOp::Add)),
         })
@@ -237,12 +237,12 @@ impl<'a> core::iter::Sum<&'a Self> for NumOpResult<Amount> {
     }
 }
 
-impl core::iter::Sum<Self> for NumOpResult<SignedAmount> {
+impl<T: Into<Self>> core::iter::Sum<T> for NumOpResult<SignedAmount> {
     fn sum<I>(iter: I) -> Self
     where
-        I: Iterator<Item = Self>,
+        I: Iterator<Item = T>,
     {
-        iter.fold(Self::Valid(SignedAmount::ZERO), |acc, amount| match (acc, amount) {
+        iter.fold(Self::Valid(SignedAmount::ZERO), |acc, amount| match (acc, amount.into()) {
             (Self::Valid(lhs), Self::Valid(rhs)) => lhs + rhs,
             (_, _) => Self::Error(NumOpError::while_doing(MathOp::Add)),
         })

--- a/units/src/amount/result.rs
+++ b/units/src/amount/result.rs
@@ -264,6 +264,18 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_sum_amounts() {
+        let amounts = [
+            Amount::from_sat_u32(100),
+            Amount::from_sat_u32(200),
+            Amount::from_sat_u32(300),
+        ];
+
+        let sum: NumOpResult<Amount> = amounts.into_iter().sum();
+        assert_eq!(sum, NumOpResult::Valid(Amount::from_sat_u32(600)));
+    }
+
+    #[test]
     fn test_sum_amount_results() {
         let amounts = [
             NumOpResult::Valid(Amount::from_sat_u32(100)),
@@ -297,6 +309,18 @@ mod tests {
 
         let sum: NumOpResult<Amount> = amounts.into_iter().sum();
         assert!(matches!(sum, NumOpResult::Error(_)));
+    }
+
+    #[test]
+    fn test_sum_signed_amounts() {
+        let amounts = [
+            SignedAmount::from_sat_i32(100),
+            SignedAmount::from_sat_i32(-50),
+            SignedAmount::from_sat_i32(200),
+        ];
+
+        let sum: NumOpResult<SignedAmount> = amounts.into_iter().sum();
+        assert_eq!(sum, NumOpResult::Valid(SignedAmount::from_sat_i32(250)));
     }
 
     #[test]


### PR DESCRIPTION
The current Sum implementations relating to Amount/SignedAmount only permit users to sum NumOpResults into a NumOpResult. Since users are far more likely to begin with an Amount/SignedAmount iterator, the Sum impl should instead be generic over the source of NumOpResult<Amount> allowing both summing NumOpResult<Amount> and Amount into a
NumOpResult.

Make Sum on NumOpResult<Amount/SignedAmount> generic to permit summing over Amount and SignedAmount also.