### PR TITLE
units: Add support for satisfaction of parent/child transactions

### DIFF
--- a/units/api/all-features.txt
+++ b/units/api/all-features.txt
@@ -5570,9 +5570,9 @@ pub const fn bitcoin_units::locktime::relative::LockTime::is_block_time(self) ->
 pub fn bitcoin_units::locktime::relative::LockTime::is_implied_by(self, other: Self) -> bool
 pub fn bitcoin_units::locktime::relative::LockTime::is_implied_by_sequence(self, other: bitcoin_units::sequence::Sequence) -> bool
 pub const fn bitcoin_units::locktime::relative::LockTime::is_same_unit(self, other: Self) -> bool
-pub fn bitcoin_units::locktime::relative::LockTime::is_satisfied_by(self, chain_tip_height: bitcoin_units::block::BlockHeight, chain_tip_mtp: bitcoin_units::block::BlockMtp, utxo_mined_at_height: bitcoin_units::block::BlockHeight, utxo_mined_at_mtp: bitcoin_units::block::BlockMtp) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::IsSatisfiedByError>
-pub fn bitcoin_units::locktime::relative::LockTime::is_satisfied_by_height(self, chain_tip: bitcoin_units::block::BlockHeight, utxo_mined_at: bitcoin_units::block::BlockHeight) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError>
-pub fn bitcoin_units::locktime::relative::LockTime::is_satisfied_by_time(self, chain_tip: bitcoin_units::block::BlockMtp, utxo_mined_at: bitcoin_units::block::BlockMtp) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError>
+pub fn bitcoin_units::locktime::relative::LockTime::is_satisfied_by(self, chain_tip_height: bitcoin_units::block::BlockHeight, chain_tip_mtp: bitcoin_units::block::BlockMtp, utxo_mined_at_height: core::option::Option<bitcoin_units::block::BlockHeight>, utxo_mined_at_mtp: core::option::Option<bitcoin_units::block::BlockMtp>) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::IsSatisfiedByError>
+pub fn bitcoin_units::locktime::relative::LockTime::is_satisfied_by_height(self, chain_tip: bitcoin_units::block::BlockHeight, utxo_mined_at: core::option::Option<bitcoin_units::block::BlockHeight>) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError>
+pub fn bitcoin_units::locktime::relative::LockTime::is_satisfied_by_time(self, chain_tip: bitcoin_units::block::BlockMtp, utxo_mined_at: core::option::Option<bitcoin_units::block::BlockMtp>) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError>
 pub fn bitcoin_units::locktime::relative::LockTime::to_consensus_u32(self) -> u32
 pub fn bitcoin_units::locktime::relative::LockTime::to_sequence(self) -> bitcoin_units::sequence::Sequence
 impl core::clone::Clone for bitcoin_units::locktime::relative::LockTime
@@ -5877,7 +5877,7 @@ pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_hex(s: &str) 
 pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_seconds_ceil(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::TimeOverflowError>
 pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_seconds_floor(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::TimeOverflowError>
 pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError>
-pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockMtp, utxo_mined_at: bitcoin_units::block::BlockMtp) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::InvalidTimeError>
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockMtp, utxo_mined_at: core::option::Option<bitcoin_units::block::BlockMtp>) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::InvalidTimeError>
 pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::to_512_second_intervals(self) -> u16
 pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::to_seconds(self) -> u32
 impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOf512Seconds
@@ -5969,7 +5969,7 @@ pub const bitcoin_units::locktime::relative::NumberOfBlocks::ZERO: Self
 pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::from_count(blocks: u16) -> Self
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::PrefixedHexError>
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError>
-pub fn bitcoin_units::locktime::relative::NumberOfBlocks::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockHeight, utxo_mined_at: bitcoin_units::block::BlockHeight) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::InvalidHeightError>
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockHeight, utxo_mined_at: core::option::Option<bitcoin_units::block::BlockHeight>) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::InvalidHeightError>
 pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::to_count(self) -> u16
 impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOfBlocks
   pub fn bitcoin_units::locktime::relative::NumberOfBlocks::clone(&self) -> bitcoin_units::locktime::relative::NumberOfBlocks [impl: impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOfBlocks]
@@ -7619,9 +7619,9 @@ pub const fn bitcoin_units::locktime::relative::LockTime::is_block_time(self) ->
 pub fn bitcoin_units::locktime::relative::LockTime::is_implied_by(self, other: Self) -> bool
 pub fn bitcoin_units::locktime::relative::LockTime::is_implied_by_sequence(self, other: bitcoin_units::sequence::Sequence) -> bool
 pub const fn bitcoin_units::locktime::relative::LockTime::is_same_unit(self, other: Self) -> bool
-pub fn bitcoin_units::locktime::relative::LockTime::is_satisfied_by(self, chain_tip_height: bitcoin_units::block::BlockHeight, chain_tip_mtp: bitcoin_units::block::BlockMtp, utxo_mined_at_height: bitcoin_units::block::BlockHeight, utxo_mined_at_mtp: bitcoin_units::block::BlockMtp) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::IsSatisfiedByError>
-pub fn bitcoin_units::locktime::relative::LockTime::is_satisfied_by_height(self, chain_tip: bitcoin_units::block::BlockHeight, utxo_mined_at: bitcoin_units::block::BlockHeight) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError>
-pub fn bitcoin_units::locktime::relative::LockTime::is_satisfied_by_time(self, chain_tip: bitcoin_units::block::BlockMtp, utxo_mined_at: bitcoin_units::block::BlockMtp) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError>
+pub fn bitcoin_units::locktime::relative::LockTime::is_satisfied_by(self, chain_tip_height: bitcoin_units::block::BlockHeight, chain_tip_mtp: bitcoin_units::block::BlockMtp, utxo_mined_at_height: core::option::Option<bitcoin_units::block::BlockHeight>, utxo_mined_at_mtp: core::option::Option<bitcoin_units::block::BlockMtp>) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::IsSatisfiedByError>
+pub fn bitcoin_units::locktime::relative::LockTime::is_satisfied_by_height(self, chain_tip: bitcoin_units::block::BlockHeight, utxo_mined_at: core::option::Option<bitcoin_units::block::BlockHeight>) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError>
+pub fn bitcoin_units::locktime::relative::LockTime::is_satisfied_by_time(self, chain_tip: bitcoin_units::block::BlockMtp, utxo_mined_at: core::option::Option<bitcoin_units::block::BlockMtp>) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError>
 pub fn bitcoin_units::locktime::relative::LockTime::to_consensus_u32(self) -> u32
 pub fn bitcoin_units::locktime::relative::LockTime::to_sequence(self) -> bitcoin_units::sequence::Sequence
 impl core::clone::Clone for bitcoin_units::locktime::relative::LockTime
@@ -7926,7 +7926,7 @@ pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_hex(s: &str) 
 pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_seconds_ceil(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::TimeOverflowError>
 pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_seconds_floor(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::TimeOverflowError>
 pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError>
-pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockMtp, utxo_mined_at: bitcoin_units::block::BlockMtp) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::InvalidTimeError>
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockMtp, utxo_mined_at: core::option::Option<bitcoin_units::block::BlockMtp>) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::InvalidTimeError>
 pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::to_512_second_intervals(self) -> u16
 pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::to_seconds(self) -> u32
 impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOf512Seconds
@@ -8018,7 +8018,7 @@ pub const bitcoin_units::locktime::relative::NumberOfBlocks::ZERO: Self
 pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::from_count(blocks: u16) -> Self
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::PrefixedHexError>
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError>
-pub fn bitcoin_units::locktime::relative::NumberOfBlocks::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockHeight, utxo_mined_at: bitcoin_units::block::BlockHeight) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::InvalidHeightError>
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockHeight, utxo_mined_at: core::option::Option<bitcoin_units::block::BlockHeight>) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::InvalidHeightError>
 pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::to_count(self) -> u16
 impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOfBlocks
   pub fn bitcoin_units::locktime::relative::NumberOfBlocks::clone(&self) -> bitcoin_units::locktime::relative::NumberOfBlocks [impl: impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOfBlocks]

--- a/units/api/alloc-only.txt
+++ b/units/api/alloc-only.txt
@@ -4504,9 +4504,9 @@ pub const fn bitcoin_units::locktime::relative::LockTime::is_block_time(self) ->
 pub fn bitcoin_units::locktime::relative::LockTime::is_implied_by(self, other: Self) -> bool
 pub fn bitcoin_units::locktime::relative::LockTime::is_implied_by_sequence(self, other: bitcoin_units::sequence::Sequence) -> bool
 pub const fn bitcoin_units::locktime::relative::LockTime::is_same_unit(self, other: Self) -> bool
-pub fn bitcoin_units::locktime::relative::LockTime::is_satisfied_by(self, chain_tip_height: bitcoin_units::block::BlockHeight, chain_tip_mtp: bitcoin_units::block::BlockMtp, utxo_mined_at_height: bitcoin_units::block::BlockHeight, utxo_mined_at_mtp: bitcoin_units::block::BlockMtp) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::IsSatisfiedByError>
-pub fn bitcoin_units::locktime::relative::LockTime::is_satisfied_by_height(self, chain_tip: bitcoin_units::block::BlockHeight, utxo_mined_at: bitcoin_units::block::BlockHeight) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError>
-pub fn bitcoin_units::locktime::relative::LockTime::is_satisfied_by_time(self, chain_tip: bitcoin_units::block::BlockMtp, utxo_mined_at: bitcoin_units::block::BlockMtp) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError>
+pub fn bitcoin_units::locktime::relative::LockTime::is_satisfied_by(self, chain_tip_height: bitcoin_units::block::BlockHeight, chain_tip_mtp: bitcoin_units::block::BlockMtp, utxo_mined_at_height: core::option::Option<bitcoin_units::block::BlockHeight>, utxo_mined_at_mtp: core::option::Option<bitcoin_units::block::BlockMtp>) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::IsSatisfiedByError>
+pub fn bitcoin_units::locktime::relative::LockTime::is_satisfied_by_height(self, chain_tip: bitcoin_units::block::BlockHeight, utxo_mined_at: core::option::Option<bitcoin_units::block::BlockHeight>) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError>
+pub fn bitcoin_units::locktime::relative::LockTime::is_satisfied_by_time(self, chain_tip: bitcoin_units::block::BlockMtp, utxo_mined_at: core::option::Option<bitcoin_units::block::BlockMtp>) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError>
 pub fn bitcoin_units::locktime::relative::LockTime::to_consensus_u32(self) -> u32
 pub fn bitcoin_units::locktime::relative::LockTime::to_sequence(self) -> bitcoin_units::sequence::Sequence
 impl core::clone::Clone for bitcoin_units::locktime::relative::LockTime
@@ -4794,7 +4794,7 @@ pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_hex(s: &str) 
 pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_seconds_ceil(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::TimeOverflowError>
 pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_seconds_floor(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::TimeOverflowError>
 pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError>
-pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockMtp, utxo_mined_at: bitcoin_units::block::BlockMtp) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::InvalidTimeError>
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockMtp, utxo_mined_at: core::option::Option<bitcoin_units::block::BlockMtp>) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::InvalidTimeError>
 pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::to_512_second_intervals(self) -> u16
 pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::to_seconds(self) -> u32
 impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOf512Seconds
@@ -4879,7 +4879,7 @@ pub const bitcoin_units::locktime::relative::NumberOfBlocks::ZERO: Self
 pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::from_count(blocks: u16) -> Self
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::PrefixedHexError>
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError>
-pub fn bitcoin_units::locktime::relative::NumberOfBlocks::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockHeight, utxo_mined_at: bitcoin_units::block::BlockHeight) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::InvalidHeightError>
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockHeight, utxo_mined_at: core::option::Option<bitcoin_units::block::BlockHeight>) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::InvalidHeightError>
 pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::to_count(self) -> u16
 impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOfBlocks
   pub fn bitcoin_units::locktime::relative::NumberOfBlocks::clone(&self) -> bitcoin_units::locktime::relative::NumberOfBlocks [impl: impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOfBlocks]
@@ -6275,9 +6275,9 @@ pub const fn bitcoin_units::locktime::relative::LockTime::is_block_time(self) ->
 pub fn bitcoin_units::locktime::relative::LockTime::is_implied_by(self, other: Self) -> bool
 pub fn bitcoin_units::locktime::relative::LockTime::is_implied_by_sequence(self, other: bitcoin_units::sequence::Sequence) -> bool
 pub const fn bitcoin_units::locktime::relative::LockTime::is_same_unit(self, other: Self) -> bool
-pub fn bitcoin_units::locktime::relative::LockTime::is_satisfied_by(self, chain_tip_height: bitcoin_units::block::BlockHeight, chain_tip_mtp: bitcoin_units::block::BlockMtp, utxo_mined_at_height: bitcoin_units::block::BlockHeight, utxo_mined_at_mtp: bitcoin_units::block::BlockMtp) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::IsSatisfiedByError>
-pub fn bitcoin_units::locktime::relative::LockTime::is_satisfied_by_height(self, chain_tip: bitcoin_units::block::BlockHeight, utxo_mined_at: bitcoin_units::block::BlockHeight) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError>
-pub fn bitcoin_units::locktime::relative::LockTime::is_satisfied_by_time(self, chain_tip: bitcoin_units::block::BlockMtp, utxo_mined_at: bitcoin_units::block::BlockMtp) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError>
+pub fn bitcoin_units::locktime::relative::LockTime::is_satisfied_by(self, chain_tip_height: bitcoin_units::block::BlockHeight, chain_tip_mtp: bitcoin_units::block::BlockMtp, utxo_mined_at_height: core::option::Option<bitcoin_units::block::BlockHeight>, utxo_mined_at_mtp: core::option::Option<bitcoin_units::block::BlockMtp>) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::IsSatisfiedByError>
+pub fn bitcoin_units::locktime::relative::LockTime::is_satisfied_by_height(self, chain_tip: bitcoin_units::block::BlockHeight, utxo_mined_at: core::option::Option<bitcoin_units::block::BlockHeight>) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError>
+pub fn bitcoin_units::locktime::relative::LockTime::is_satisfied_by_time(self, chain_tip: bitcoin_units::block::BlockMtp, utxo_mined_at: core::option::Option<bitcoin_units::block::BlockMtp>) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError>
 pub fn bitcoin_units::locktime::relative::LockTime::to_consensus_u32(self) -> u32
 pub fn bitcoin_units::locktime::relative::LockTime::to_sequence(self) -> bitcoin_units::sequence::Sequence
 impl core::clone::Clone for bitcoin_units::locktime::relative::LockTime
@@ -6565,7 +6565,7 @@ pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_hex(s: &str) 
 pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_seconds_ceil(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::TimeOverflowError>
 pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_seconds_floor(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::TimeOverflowError>
 pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError>
-pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockMtp, utxo_mined_at: bitcoin_units::block::BlockMtp) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::InvalidTimeError>
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockMtp, utxo_mined_at: core::option::Option<bitcoin_units::block::BlockMtp>) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::InvalidTimeError>
 pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::to_512_second_intervals(self) -> u16
 pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::to_seconds(self) -> u32
 impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOf512Seconds
@@ -6650,7 +6650,7 @@ pub const bitcoin_units::locktime::relative::NumberOfBlocks::ZERO: Self
 pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::from_count(blocks: u16) -> Self
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::PrefixedHexError>
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError>
-pub fn bitcoin_units::locktime::relative::NumberOfBlocks::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockHeight, utxo_mined_at: bitcoin_units::block::BlockHeight) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::InvalidHeightError>
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockHeight, utxo_mined_at: core::option::Option<bitcoin_units::block::BlockHeight>) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::InvalidHeightError>
 pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::to_count(self) -> u16
 impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOfBlocks
   pub fn bitcoin_units::locktime::relative::NumberOfBlocks::clone(&self) -> bitcoin_units::locktime::relative::NumberOfBlocks [impl: impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOfBlocks]

--- a/units/api/no-features.txt
+++ b/units/api/no-features.txt
@@ -3996,9 +3996,9 @@ pub const fn bitcoin_units::locktime::relative::LockTime::is_block_time(self) ->
 pub fn bitcoin_units::locktime::relative::LockTime::is_implied_by(self, other: Self) -> bool
 pub fn bitcoin_units::locktime::relative::LockTime::is_implied_by_sequence(self, other: bitcoin_units::sequence::Sequence) -> bool
 pub const fn bitcoin_units::locktime::relative::LockTime::is_same_unit(self, other: Self) -> bool
-pub fn bitcoin_units::locktime::relative::LockTime::is_satisfied_by(self, chain_tip_height: bitcoin_units::block::BlockHeight, chain_tip_mtp: bitcoin_units::block::BlockMtp, utxo_mined_at_height: bitcoin_units::block::BlockHeight, utxo_mined_at_mtp: bitcoin_units::block::BlockMtp) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::IsSatisfiedByError>
-pub fn bitcoin_units::locktime::relative::LockTime::is_satisfied_by_height(self, chain_tip: bitcoin_units::block::BlockHeight, utxo_mined_at: bitcoin_units::block::BlockHeight) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError>
-pub fn bitcoin_units::locktime::relative::LockTime::is_satisfied_by_time(self, chain_tip: bitcoin_units::block::BlockMtp, utxo_mined_at: bitcoin_units::block::BlockMtp) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError>
+pub fn bitcoin_units::locktime::relative::LockTime::is_satisfied_by(self, chain_tip_height: bitcoin_units::block::BlockHeight, chain_tip_mtp: bitcoin_units::block::BlockMtp, utxo_mined_at_height: core::option::Option<bitcoin_units::block::BlockHeight>, utxo_mined_at_mtp: core::option::Option<bitcoin_units::block::BlockMtp>) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::IsSatisfiedByError>
+pub fn bitcoin_units::locktime::relative::LockTime::is_satisfied_by_height(self, chain_tip: bitcoin_units::block::BlockHeight, utxo_mined_at: core::option::Option<bitcoin_units::block::BlockHeight>) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError>
+pub fn bitcoin_units::locktime::relative::LockTime::is_satisfied_by_time(self, chain_tip: bitcoin_units::block::BlockMtp, utxo_mined_at: core::option::Option<bitcoin_units::block::BlockMtp>) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError>
 pub fn bitcoin_units::locktime::relative::LockTime::to_consensus_u32(self) -> u32
 pub fn bitcoin_units::locktime::relative::LockTime::to_sequence(self) -> bitcoin_units::sequence::Sequence
 impl core::clone::Clone for bitcoin_units::locktime::relative::LockTime
@@ -4250,7 +4250,7 @@ pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_hex(s: &str) 
 pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_seconds_ceil(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::TimeOverflowError>
 pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_seconds_floor(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::TimeOverflowError>
 pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError>
-pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockMtp, utxo_mined_at: bitcoin_units::block::BlockMtp) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::InvalidTimeError>
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockMtp, utxo_mined_at: core::option::Option<bitcoin_units::block::BlockMtp>) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::InvalidTimeError>
 pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::to_512_second_intervals(self) -> u16
 pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::to_seconds(self) -> u32
 impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOf512Seconds
@@ -4323,7 +4323,7 @@ pub const bitcoin_units::locktime::relative::NumberOfBlocks::ZERO: Self
 pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::from_count(blocks: u16) -> Self
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::PrefixedHexError>
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError>
-pub fn bitcoin_units::locktime::relative::NumberOfBlocks::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockHeight, utxo_mined_at: bitcoin_units::block::BlockHeight) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::InvalidHeightError>
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockHeight, utxo_mined_at: core::option::Option<bitcoin_units::block::BlockHeight>) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::InvalidHeightError>
 pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::to_count(self) -> u16
 impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOfBlocks
   pub fn bitcoin_units::locktime::relative::NumberOfBlocks::clone(&self) -> bitcoin_units::locktime::relative::NumberOfBlocks [impl: impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOfBlocks]
@@ -5543,9 +5543,9 @@ pub const fn bitcoin_units::locktime::relative::LockTime::is_block_time(self) ->
 pub fn bitcoin_units::locktime::relative::LockTime::is_implied_by(self, other: Self) -> bool
 pub fn bitcoin_units::locktime::relative::LockTime::is_implied_by_sequence(self, other: bitcoin_units::sequence::Sequence) -> bool
 pub const fn bitcoin_units::locktime::relative::LockTime::is_same_unit(self, other: Self) -> bool
-pub fn bitcoin_units::locktime::relative::LockTime::is_satisfied_by(self, chain_tip_height: bitcoin_units::block::BlockHeight, chain_tip_mtp: bitcoin_units::block::BlockMtp, utxo_mined_at_height: bitcoin_units::block::BlockHeight, utxo_mined_at_mtp: bitcoin_units::block::BlockMtp) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::IsSatisfiedByError>
-pub fn bitcoin_units::locktime::relative::LockTime::is_satisfied_by_height(self, chain_tip: bitcoin_units::block::BlockHeight, utxo_mined_at: bitcoin_units::block::BlockHeight) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError>
-pub fn bitcoin_units::locktime::relative::LockTime::is_satisfied_by_time(self, chain_tip: bitcoin_units::block::BlockMtp, utxo_mined_at: bitcoin_units::block::BlockMtp) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError>
+pub fn bitcoin_units::locktime::relative::LockTime::is_satisfied_by(self, chain_tip_height: bitcoin_units::block::BlockHeight, chain_tip_mtp: bitcoin_units::block::BlockMtp, utxo_mined_at_height: core::option::Option<bitcoin_units::block::BlockHeight>, utxo_mined_at_mtp: core::option::Option<bitcoin_units::block::BlockMtp>) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::IsSatisfiedByError>
+pub fn bitcoin_units::locktime::relative::LockTime::is_satisfied_by_height(self, chain_tip: bitcoin_units::block::BlockHeight, utxo_mined_at: core::option::Option<bitcoin_units::block::BlockHeight>) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::IsSatisfiedByHeightError>
+pub fn bitcoin_units::locktime::relative::LockTime::is_satisfied_by_time(self, chain_tip: bitcoin_units::block::BlockMtp, utxo_mined_at: core::option::Option<bitcoin_units::block::BlockMtp>) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::IsSatisfiedByTimeError>
 pub fn bitcoin_units::locktime::relative::LockTime::to_consensus_u32(self) -> u32
 pub fn bitcoin_units::locktime::relative::LockTime::to_sequence(self) -> bitcoin_units::sequence::Sequence
 impl core::clone::Clone for bitcoin_units::locktime::relative::LockTime
@@ -5797,7 +5797,7 @@ pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_hex(s: &str) 
 pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_seconds_ceil(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::TimeOverflowError>
 pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_seconds_floor(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::TimeOverflowError>
 pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError>
-pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockMtp, utxo_mined_at: bitcoin_units::block::BlockMtp) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::InvalidTimeError>
+pub fn bitcoin_units::locktime::relative::NumberOf512Seconds::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockMtp, utxo_mined_at: core::option::Option<bitcoin_units::block::BlockMtp>) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::InvalidTimeError>
 pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::to_512_second_intervals(self) -> u16
 pub const fn bitcoin_units::locktime::relative::NumberOf512Seconds::to_seconds(self) -> u32
 impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOf512Seconds
@@ -5870,7 +5870,7 @@ pub const bitcoin_units::locktime::relative::NumberOfBlocks::ZERO: Self
 pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::from_count(blocks: u16) -> Self
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::PrefixedHexError>
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError>
-pub fn bitcoin_units::locktime::relative::NumberOfBlocks::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockHeight, utxo_mined_at: bitcoin_units::block::BlockHeight) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::InvalidHeightError>
+pub fn bitcoin_units::locktime::relative::NumberOfBlocks::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockHeight, utxo_mined_at: core::option::Option<bitcoin_units::block::BlockHeight>) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::InvalidHeightError>
 pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::to_count(self) -> u16
 impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOfBlocks
   pub fn bitcoin_units::locktime::relative::NumberOfBlocks::clone(&self) -> bitcoin_units::locktime::relative::NumberOfBlocks [impl: impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOfBlocks]

--- a/units/src/locktime/relative/error.rs
+++ b/units/src/locktime/relative/error.rs
@@ -311,7 +311,7 @@ mod tests {
         // InvalidHeightError - is_satisfied_by with invalid args
         let blocks = NumberOfBlocks::from_count(10);
         let e = blocks
-            .is_satisfied_by(BlockHeight::from_u32(5), BlockHeight::from_u32(10))
+            .is_satisfied_by(BlockHeight::from_u32(5), Some(BlockHeight::from_u32(10)))
             .unwrap_err();
         assert!(!e.to_string().is_empty());
         #[cfg(feature = "std")]
@@ -319,7 +319,7 @@ mod tests {
 
         // InvalidTimeError - is_satisfied_by with invalid args
         let time = NumberOf512Seconds::from_512_second_intervals(10);
-        let e = time.is_satisfied_by(BlockMtp::from_u32(5), BlockMtp::from_u32(10)).unwrap_err();
+        let e = time.is_satisfied_by(BlockMtp::from_u32(5), Some(BlockMtp::from_u32(10))).unwrap_err();
         assert!(!e.to_string().is_empty());
         #[cfg(feature = "std")]
         assert!(e.source().is_none());
@@ -335,8 +335,8 @@ mod tests {
             .is_satisfied_by(
                 BlockHeight::from_u32(5),
                 BlockMtp::ZERO,
-                BlockHeight::from_u32(10),
-                BlockMtp::ZERO,
+                Some(BlockHeight::from_u32(10)),
+                Some(BlockMtp::ZERO),
             )
             .unwrap_err();
         assert!(!e.to_string().is_empty());
@@ -347,8 +347,8 @@ mod tests {
             .is_satisfied_by(
                 BlockHeight::ZERO,
                 BlockMtp::from_u32(5),
-                BlockHeight::ZERO,
-                BlockMtp::from_u32(10),
+                Some(BlockHeight::ZERO),
+                Some(BlockMtp::from_u32(10)),
             )
             .unwrap_err();
         assert!(!e.to_string().is_empty());
@@ -358,14 +358,14 @@ mod tests {
         // IsSatisfiedByHeightError
         // Incompatible type
         let e = time_lock
-            .is_satisfied_by_height(BlockHeight::from_u32(5), BlockHeight::from_u32(10))
+            .is_satisfied_by_height(BlockHeight::from_u32(5), Some(BlockHeight::from_u32(10)))
             .unwrap_err();
         assert!(!e.to_string().is_empty());
         #[cfg(feature = "std")]
         assert!(e.source().is_some());
         // Satisfaction type
         let e = height_lock
-            .is_satisfied_by_height(BlockHeight::from_u32(5), BlockHeight::from_u32(10))
+            .is_satisfied_by_height(BlockHeight::from_u32(5), Some(BlockHeight::from_u32(10)))
             .unwrap_err();
         assert!(!e.to_string().is_empty());
         #[cfg(feature = "std")]
@@ -374,14 +374,14 @@ mod tests {
         // IsSatisfiedByTimeError
         // Incompatible type
         let e = height_lock
-            .is_satisfied_by_time(BlockMtp::from_u32(5), BlockMtp::from_u32(10))
+            .is_satisfied_by_time(BlockMtp::from_u32(5), Some(BlockMtp::from_u32(10)))
             .unwrap_err();
         assert!(!e.to_string().is_empty());
         #[cfg(feature = "std")]
         assert!(e.source().is_some());
         // Satisfaction type
         let e = time_lock
-            .is_satisfied_by_time(BlockMtp::from_u32(5), BlockMtp::from_u32(10))
+            .is_satisfied_by_time(BlockMtp::from_u32(5), Some(BlockMtp::from_u32(10)))
             .unwrap_err();
         assert!(!e.to_string().is_empty());
         #[cfg(feature = "std")]

--- a/units/src/locktime/relative/mod.rs
+++ b/units/src/locktime/relative/mod.rs
@@ -203,6 +203,13 @@ impl LockTime {
     /// If this function returns true then an output with this locktime can be spent in the next
     /// block.
     ///
+    /// # Arguments
+    ///
+    /// * `chain_tip_height`: The current height of the blockchain.
+    /// * `chain_tip_mtp`: The current MTP (i.e. median of the 11 latest blocks).
+    /// * `utxo_mined_at_height`: `Some` height if mined, `None` if UTXO may go in the next block.
+    /// * `utxo_mined_at_mtp`: `Some` MTP if mined, `None` if UTXO may go in the next block.
+    ///
     /// # Errors
     ///
     /// If `chain_tip` is not _after_ `utxo_mined_at` i.e., if you get the args mixed up.
@@ -211,8 +218,8 @@ impl LockTime {
         self,
         chain_tip_height: BlockHeight,
         chain_tip_mtp: BlockMtp,
-        utxo_mined_at_height: BlockHeight,
-        utxo_mined_at_mtp: BlockMtp,
+        utxo_mined_at_height: Option<BlockHeight>,
+        utxo_mined_at_mtp: Option<BlockMtp>,
     ) -> Result<bool, IsSatisfiedByError> {
         match self {
             Self::Blocks(blocks) => blocks
@@ -226,6 +233,11 @@ impl LockTime {
 
     /// Returns true if an output with this locktime can be spent in the next block.
     ///
+    /// # Arguments
+    ///
+    /// * `chain_tip`: The current height of the blockchain.
+    /// * `utxo_mined_at`: `Some` height if mined, `None` if UTXO may go in the next block.
+    ///
     /// # Errors
     ///
     /// Returns an error if this lock is not lock-by-height.
@@ -233,7 +245,7 @@ impl LockTime {
     pub fn is_satisfied_by_height(
         self,
         chain_tip: BlockHeight,
-        utxo_mined_at: BlockHeight,
+        utxo_mined_at: Option<BlockHeight>,
     ) -> Result<bool, IsSatisfiedByHeightError> {
         match self {
             Self::Blocks(blocks) => blocks
@@ -246,6 +258,11 @@ impl LockTime {
 
     /// Returns true if an output with this locktime can be spent in the next block.
     ///
+    /// # Arguments
+    ///
+    /// * `chain_tip`: The current MTP (i.e. median of the 11 latest blocks).
+    /// * `utxo_mined_at`: `Some` MTP if mined, `None` if UTXO may go in the next block.
+    ///
     /// # Errors
     ///
     /// Returns an error if this lock is not lock-by-time.
@@ -253,7 +270,7 @@ impl LockTime {
     pub fn is_satisfied_by_time(
         self,
         chain_tip: BlockMtp,
-        utxo_mined_at: BlockMtp,
+        utxo_mined_at: Option<BlockMtp>,
     ) -> Result<bool, IsSatisfiedByTimeError> {
         match self {
             Self::Time(time) => time
@@ -437,18 +454,36 @@ impl NumberOfBlocks {
 
     /// Returns true if an output locked by a block count can be spent in the next block.
     ///
+    /// `chain_tip` can be any height from the block prior to `utxo_mined_at` onwards i.e., we
+    /// support a pair of parent/child transactions going into the mempool at the same time.
+    ///
+    /// # Arguments
+    ///
+    /// * `chain_tip`: The current height of the blockchain.
+    /// * `utxo_mined_at`: `Some` height if mined, `None` if UTXO may go in the next block.
+    ///
     /// # Errors
     ///
-    /// If `chain_tip` is not _after_ `utxo_mined_at` i.e., if you get the args mixed up.
+    /// If `chain_tip` is not valid for `utxo_mined_at` i.e., if you get the args mixed up.
     pub fn is_satisfied_by(
         self,
         chain_tip: crate::BlockHeight,
-        utxo_mined_at: crate::BlockHeight,
+        utxo_mined_at: Option<crate::BlockHeight>,
     ) -> Result<bool, InvalidHeightError> {
-        chain_tip
-            .checked_sub(utxo_mined_at)
-            .ok_or(InvalidHeightError { chain_tip, utxo_mined_at })
-            .map(|diff| u32::from(self.to_count()).saturating_sub(1) <= diff.to_u32())
+        match utxo_mined_at {
+            Some(mined_at) => {
+                chain_tip
+                    .checked_sub(mined_at)
+                    .ok_or(InvalidHeightError { chain_tip, utxo_mined_at: mined_at })
+                    .map(|diff| u32::from(self.to_count()).saturating_sub(1) <= diff.to_u32())
+
+            },
+            None => {
+                // We want 0-value relative timelocks to be able to go into transactions in the
+                // mempool if their parent is also in the mempool.
+                Ok(self == Self::ZERO)
+            }
+        }
     }
 }
 
@@ -574,18 +609,32 @@ impl NumberOf512Seconds {
 
     /// Returns true if an output locked by time can be spent in the next block.
     ///
+    /// # Arguments
+    ///
+    /// * `chain_tip_mtp`: The current MTP (i.e. median of the 11 latest blocks).
+    /// * `utxo_mined_at`: `Some` MTP if mined, `None` if UTXO may go in the next block.
+    ///
     /// # Errors
     ///
     /// If `chain_tip` is not _after_ `utxo_mined_at` i.e., if you get the args mixed up.
     pub fn is_satisfied_by(
         self,
         chain_tip: crate::BlockMtp,
-        utxo_mined_at: crate::BlockMtp,
+        utxo_mined_at: Option<crate::BlockMtp>,
     ) -> Result<bool, InvalidTimeError> {
-        chain_tip
-            .checked_sub(utxo_mined_at)
-            .ok_or(InvalidTimeError { chain_tip, utxo_mined_at })
-            .map(|diff| self.to_seconds() <= diff.to_u32())
+        match utxo_mined_at {
+            Some(mined_at) => {
+                chain_tip
+                    .checked_sub(mined_at)
+                    .ok_or(InvalidTimeError { chain_tip, utxo_mined_at: mined_at })
+                    .map(|diff| self.to_seconds() <= diff.to_u32())
+            }
+            None => {
+                // We want 0-value relative timelocks to be able to go into transactions in the
+                // mempool if their parent is also in the mempool.
+                Ok(self == Self::ZERO)
+            }
+        }
     }
 }
 
@@ -818,7 +867,7 @@ mod tests {
         let chain_tip = BlockHeight::from_u32(800_000);
 
         let lock_by_time = LockTime::from_512_second_intervals(70); // Arbitrary value.
-        let err = lock_by_time.is_satisfied_by_height(chain_tip, mined_at).unwrap_err();
+        let err = lock_by_time.is_satisfied_by_height(chain_tip, Some(mined_at)).unwrap_err();
 
         let expected_time = NumberOf512Seconds::from_512_second_intervals(70);
         assert_eq!(
@@ -836,7 +885,7 @@ mod tests {
         let chain_tip = BlockHeight::from_u32(800_000);
 
         let block_count = NumberOfBlocks::from_count(70); // Arbitrary value.
-        let err = block_count.is_satisfied_by(chain_tip, mined_at).unwrap_err();
+        let err = block_count.is_satisfied_by(chain_tip, Some(mined_at)).unwrap_err();
 
         assert!(matches!(err, InvalidHeightError { chain_tip: _, utxo_mined_at: _ }));
     }
@@ -849,7 +898,7 @@ mod tests {
         let chain_tip = BlockMtp::from_u32(1_600_000_000);
 
         let lock_by_height = LockTime::from_block_count(10); // Arbitrary value.
-        let err = lock_by_height.is_satisfied_by_time(chain_tip, mined_at).unwrap_err();
+        let err = lock_by_height.is_satisfied_by_time(chain_tip, Some(mined_at)).unwrap_err();
 
         let expected_height = NumberOfBlocks::from_count(10);
         assert_eq!(
@@ -867,7 +916,7 @@ mod tests {
         let chain_tip = BlockMtp::from_u32(1_600_000_000);
 
         let time_interval = NumberOf512Seconds::from_512_second_intervals(10); // Arbitrary value.
-        let err = time_interval.is_satisfied_by(chain_tip, mined_at).unwrap_err();
+        let err = time_interval.is_satisfied_by(chain_tip, Some(mined_at)).unwrap_err();
 
         assert!(matches!(err, InvalidTimeError { chain_tip: _, utxo_mined_at: _ }));
     }
@@ -891,35 +940,35 @@ mod tests {
         let utxo_mtp = BlockMtp::new(utxo_timestamps);
 
         let lock1 = LockTime::Blocks(NumberOfBlocks::from_count(10));
-        assert!(lock1.is_satisfied_by(chain_height, chain_mtp, utxo_height, utxo_mtp).unwrap());
+        assert!(lock1.is_satisfied_by(chain_height, chain_mtp, Some(utxo_height), Some(utxo_mtp)).unwrap());
 
         let lock2 = LockTime::Blocks(NumberOfBlocks::from_count(21));
-        assert!(lock2.is_satisfied_by(chain_height, chain_mtp, utxo_height, utxo_mtp).unwrap());
+        assert!(lock2.is_satisfied_by(chain_height, chain_mtp, Some(utxo_height), Some(utxo_mtp)).unwrap());
 
         let lock3 = LockTime::Time(NumberOf512Seconds::from_512_second_intervals(10));
-        assert!(lock3.is_satisfied_by(chain_height, chain_mtp, utxo_height, utxo_mtp).unwrap());
+        assert!(lock3.is_satisfied_by(chain_height, chain_mtp, Some(utxo_height), Some(utxo_mtp)).unwrap());
 
         let lock4 = LockTime::Time(NumberOf512Seconds::from_512_second_intervals(20000));
-        assert!(!lock4.is_satisfied_by(chain_height, chain_mtp, utxo_height, utxo_mtp).unwrap());
+        assert!(!lock4.is_satisfied_by(chain_height, chain_mtp, Some(utxo_height), Some(utxo_mtp)).unwrap());
 
         assert!(LockTime::ZERO
-            .is_satisfied_by(chain_height, chain_mtp, utxo_height, utxo_mtp)
+            .is_satisfied_by(chain_height, chain_mtp, Some(utxo_height), Some(utxo_mtp))
             .unwrap());
         assert!(LockTime::from_512_second_intervals(0)
-            .is_satisfied_by(chain_height, chain_mtp, utxo_height, utxo_mtp)
+            .is_satisfied_by(chain_height, chain_mtp, Some(utxo_height), Some(utxo_mtp))
             .unwrap());
 
         let lock6 = LockTime::from_seconds_floor(5000).unwrap();
-        assert!(lock6.is_satisfied_by(chain_height, chain_mtp, utxo_height, utxo_mtp).unwrap());
+        assert!(lock6.is_satisfied_by(chain_height, chain_mtp, Some(utxo_height), Some(utxo_mtp)).unwrap());
 
         let max_height_lock = LockTime::Blocks(NumberOfBlocks::MAX);
         assert!(!max_height_lock
-            .is_satisfied_by(chain_height, chain_mtp, utxo_height, utxo_mtp)
+            .is_satisfied_by(chain_height, chain_mtp, Some(utxo_height), Some(utxo_mtp))
             .unwrap());
 
         let max_time_lock = LockTime::Time(NumberOf512Seconds::MAX);
         assert!(!max_time_lock
-            .is_satisfied_by(chain_height, chain_mtp, utxo_height, utxo_mtp)
+            .is_satisfied_by(chain_height, chain_mtp, Some(utxo_height), Some(utxo_mtp))
             .unwrap());
 
         let max_chain_height = BlockHeight::from_u32(u32::MAX);
@@ -927,10 +976,10 @@ mod tests {
         let max_utxo_height = BlockHeight::MAX;
         let max_utxo_mtp = max_chain_mtp;
         assert!(!max_height_lock
-            .is_satisfied_by(max_chain_height, max_chain_mtp, max_utxo_height, max_utxo_mtp)
+            .is_satisfied_by(max_chain_height, max_chain_mtp, Some(max_utxo_height), Some(max_utxo_mtp))
             .unwrap());
         assert!(!max_time_lock
-            .is_satisfied_by(max_chain_height, max_chain_mtp, max_utxo_height, max_utxo_mtp)
+            .is_satisfied_by(max_chain_height, max_chain_mtp, Some(max_utxo_height), Some(max_utxo_mtp))
             .unwrap());
     }
 
@@ -1029,24 +1078,24 @@ mod tests {
         let time_lock = LockTime::Time(NumberOf512Seconds::from_512_second_intervals(10));
         let chain_state1 = BlockMtp::new(timestamps);
         let utxo_state1 = BlockMtp::new(utxo_timestamps);
-        assert!(time_lock.is_satisfied_by_time(chain_state1, utxo_state1).unwrap());
+        assert!(time_lock.is_satisfied_by_time(chain_state1, Some(utxo_state1)).unwrap());
 
         // Test case 2: Not satisfied (current_mtp < utxo_mtp + required_seconds)
         let chain_state2 = BlockMtp::new(timestamps2);
         let utxo_state2 = BlockMtp::new(utxo_timestamps2);
-        assert!(!time_lock.is_satisfied_by_time(chain_state2, utxo_state2).unwrap());
+        assert!(!time_lock.is_satisfied_by_time(chain_state2, Some(utxo_state2)).unwrap());
 
         // Test case 3: Test with a larger value (100 intervals = 51200 seconds)
         let larger_lock = LockTime::Time(NumberOf512Seconds::from_512_second_intervals(100));
         let chain_state3 = BlockMtp::new(timestamps3);
         let utxo_state3 = BlockMtp::new(utxo_timestamps3);
-        assert!(larger_lock.is_satisfied_by_time(chain_state3, utxo_state3).unwrap());
+        assert!(larger_lock.is_satisfied_by_time(chain_state3, Some(utxo_state3)).unwrap());
 
         // Test case 4: Overflow handling - tests that is_satisfied_by_time handles overflow gracefully
         let max_time_lock = LockTime::Time(NumberOf512Seconds::MAX);
         let chain_state4 = BlockMtp::new(timestamps);
         let utxo_state4 = BlockMtp::new(utxo_timestamps);
-        assert!(!max_time_lock.is_satisfied_by_time(chain_state4, utxo_state4).unwrap());
+        assert!(!max_time_lock.is_satisfied_by_time(chain_state4, Some(utxo_state4)).unwrap());
     }
 
     #[test]
@@ -1056,18 +1105,18 @@ mod tests {
         // Test case 1: Satisfaction (current_height >= utxo_height + required)
         let chain_state1 = BlockHeight::from_u32(89);
         let utxo_state1 = BlockHeight::from_u32(80);
-        assert!(height_lock.is_satisfied_by_height(chain_state1, utxo_state1).unwrap());
+        assert!(height_lock.is_satisfied_by_height(chain_state1, Some(utxo_state1)).unwrap());
 
         // Test case 2: Not satisfied (current_height < utxo_height + required)
         let chain_state2 = BlockHeight::from_u32(88);
         let utxo_state2 = BlockHeight::from_u32(80);
-        assert!(!height_lock.is_satisfied_by_height(chain_state2, utxo_state2).unwrap());
+        assert!(!height_lock.is_satisfied_by_height(chain_state2, Some(utxo_state2)).unwrap());
 
         // Test case 3: Overflow handling - tests that is_satisfied_by_height handles overflow gracefully
         let max_height_lock = LockTime::Blocks(NumberOfBlocks::MAX);
         let chain_state3 = BlockHeight::from_u32(1000);
         let utxo_state3 = BlockHeight::from_u32(80);
-        assert!(!max_height_lock.is_satisfied_by_height(chain_state3, utxo_state3).unwrap());
+        assert!(!max_height_lock.is_satisfied_by_height(chain_state3, Some(utxo_state3)).unwrap());
     }
 
     #[test]
@@ -1078,14 +1127,14 @@ mod tests {
 
             let first_spendable_tip = BlockHeight::from_u32(100 + u32::from(n).saturating_sub(1));
             assert!(
-                lock.is_satisfied_by(first_spendable_tip, mined_at).unwrap(),
+                lock.is_satisfied_by(first_spendable_tip, Some(mined_at)).unwrap(),
                 "n={n} must be satisfied at tip {first_spendable_tip} ({n} confirmations)"
             );
 
             if n > 1 {
                 let too_early = BlockHeight::from_u32(100 + u32::from(n) - 2);
                 assert!(
-                    !lock.is_satisfied_by(too_early, mined_at).unwrap(),
+                    !lock.is_satisfied_by(too_early, Some(mined_at)).unwrap(),
                     "n={n} must not be satisfied at tip {too_early}"
                 );
             }
@@ -1099,6 +1148,6 @@ mod tests {
         let chain_tip = BlockHeight::from_u32(u32::MAX);
 
         let block_height = NumberOfBlocks::from_count(10); // Arbitrary value.
-        assert!(block_height.is_satisfied_by(chain_tip, mined_at).unwrap());
+        assert!(block_height.is_satisfied_by(chain_tip, Some(mined_at)).unwrap());
     }
 }

--- a/units/src/locktime/relative/mod.rs
+++ b/units/src/locktime/relative/mod.rs
@@ -434,14 +434,23 @@ impl NumberOfBlocks {
 
     /// Returns true if an output locked by height can be spent in the next block.
     ///
+    /// `chain_tip` can be any height from the block prior to `utxo_mined_at` onwards i.e., we
+    /// support a pair of parent/child transactions going into the mempool at the same time.
+    ///
     /// # Errors
     ///
-    /// If `chain_tip` is not _after_ `utxo_mined_at` i.e., if you get the args mixed up.
+    /// If `chain_tip` is not valid for `utxo_mined_at` i.e., if you get the args mixed up.
     pub fn is_satisfied_by(
         self,
         chain_tip: crate::BlockHeight,
         utxo_mined_at: crate::BlockHeight,
     ) -> Result<bool, InvalidHeightError> {
+        // We want 0-value relative timelocks to be able to go into transactions in the
+        //  mempool if their parent is also in the mempool.
+        if u64::from(utxo_mined_at.to_u32()) == u64::from(chain_tip.to_u32()) + 1 {
+            return Ok(self.to_height() == 0);
+        }
+
         chain_tip
             .checked_sub(utxo_mined_at)
             .ok_or(InvalidHeightError { chain_tip, utxo_mined_at })

--- a/units/src/locktime/relative/mod.rs
+++ b/units/src/locktime/relative/mod.rs
@@ -1082,6 +1082,16 @@ mod tests {
     }
 
     #[test]
+    fn parent_child_can_be_mined_in_the_same_block() {
+        let height_lock = LockTime::Blocks(NumberOfBlocks(0));
+
+        let chain_state = BlockHeight::from_u32(99);
+        let utxo_state = BlockHeight::from_u32(100);
+
+        assert!(height_lock.is_satisfied_by_height(chain_state, utxo_state).unwrap());
+    }
+
+    #[test]
     fn satisfied_by_height_boundary() {
         for n in [0, 2, 5, 9, 20, u16::MAX] {
             let lock = NumberOfBlocks::from_height(n);

--- a/units/src/locktime/relative/mod.rs
+++ b/units/src/locktime/relative/mod.rs
@@ -1118,6 +1118,41 @@ mod tests {
         let utxo_state3 = BlockHeight::from_u32(80);
         assert!(!max_height_lock.is_satisfied_by_height(chain_state3, Some(utxo_state3)).unwrap());
     }
+    #[test]
+    fn parent_child_can_be_mined_in_the_same_block_lock_by_count_if_zero() {
+        let height_lock = LockTime::Blocks(NumberOfBlocks::ZERO);
+        // Value is meaningless, we only check that lock is ZERO.
+        let chain_state = BlockHeight::from_u32(100);
+
+        assert!(height_lock.is_satisfied_by_height(chain_state, None).unwrap());
+    }
+
+    #[test]
+    fn parent_child_cannot_be_mined_in_the_same_block_lock_by_count_if_non_zero() {
+       let height_lock = LockTime::from_block_count(1);
+        // Value is meaningless, we only check that lock is ZERO.
+        let chain_state = BlockHeight::from_u32(100);
+
+        assert!(!height_lock.is_satisfied_by_height(chain_state, None).unwrap());
+    }
+
+    #[test]
+    fn parent_child_can_be_mined_in_the_same_block_lock_by_time_if_zero() {
+        let height_lock = LockTime::Time(NumberOf512Seconds::ZERO);
+        // Value is meaningless, we only check that lock is ZERO.
+        let chain_state = crate::BlockMtp::from_u32(83_176_862);
+
+        assert!(height_lock.is_satisfied_by_time(chain_state, None).unwrap());
+    }
+
+    #[test]
+    fn parent_child_cannot_be_mined_in_the_same_block_lock_by_time_if_non_zero() {
+       let height_lock = LockTime::from_512_second_intervals(1);
+        // Value is meaningless, we only check that lock is ZERO.
+        let chain_state = crate::BlockMtp::from_u32(83_176_862);
+
+        assert!(!height_lock.is_satisfied_by_time(chain_state, None).unwrap());
+    }
 
     #[test]
     fn satisfied_by_height_boundary() {


### PR DESCRIPTION
This is for relative timelocks. Does not touch absolute timelocks.

We are being overly restrictive by checking chain tip is equal or greater than the utxo mined-at
value (because of `checked_sub`).

If a pair of parent/child transactions hit the mempool together zero-value relative timelocks can
still be satisfied.

In order to support this functionality change the `utxo_mined_at` argument to be an `Option`, with
`None` signifying not-mined-yet. This has a nice advantage of making the arguments harder to mix up.

