### PR TITLE
units: Add `to_target` conversion to `CompactTarget`

### DIFF
--- a/units/api/all-features.txt
+++ b/units/api/all-features.txt
@@ -6522,6 +6522,7 @@ pub fn bitcoin_units::pow::CompactTarget::from_consensus(bits: u32) -> Self
 pub fn bitcoin_units::pow::CompactTarget::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::PrefixedHexError> where Self: core::marker::Sized
 pub fn bitcoin_units::pow::CompactTarget::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError> where Self: core::marker::Sized
 pub const fn bitcoin_units::pow::CompactTarget::to_consensus(self) -> u32
+pub fn bitcoin_units::pow::CompactTarget::to_target(self) -> bitcoin_units::pow::Target
 impl bitcoin_consensus_encoding::decode::Decode for bitcoin_units::pow::CompactTarget
   pub type bitcoin_units::pow::CompactTarget::Decoder = bitcoin_units::pow::CompactTargetDecoder [impl: impl bitcoin_consensus_encoding::decode::Decode for bitcoin_units::pow::CompactTarget]
 impl bitcoin_consensus_encoding::encode::Encode for bitcoin_units::pow::CompactTarget
@@ -10986,6 +10987,7 @@ pub fn bitcoin_units::pow::CompactTarget::from_consensus(bits: u32) -> Self
 pub fn bitcoin_units::pow::CompactTarget::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::PrefixedHexError> where Self: core::marker::Sized
 pub fn bitcoin_units::pow::CompactTarget::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError> where Self: core::marker::Sized
 pub const fn bitcoin_units::pow::CompactTarget::to_consensus(self) -> u32
+pub fn bitcoin_units::pow::CompactTarget::to_target(self) -> bitcoin_units::pow::Target
 impl bitcoin_consensus_encoding::decode::Decode for bitcoin_units::pow::CompactTarget
   pub type bitcoin_units::pow::CompactTarget::Decoder = bitcoin_units::pow::CompactTargetDecoder [impl: impl bitcoin_consensus_encoding::decode::Decode for bitcoin_units::pow::CompactTarget]
 impl bitcoin_consensus_encoding::encode::Encode for bitcoin_units::pow::CompactTarget

--- a/units/api/alloc-only.txt
+++ b/units/api/alloc-only.txt
@@ -5391,6 +5391,7 @@ pub fn bitcoin_units::pow::CompactTarget::from_consensus(bits: u32) -> Self
 pub fn bitcoin_units::pow::CompactTarget::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::PrefixedHexError> where Self: core::marker::Sized
 pub fn bitcoin_units::pow::CompactTarget::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError> where Self: core::marker::Sized
 pub const fn bitcoin_units::pow::CompactTarget::to_consensus(self) -> u32
+pub fn bitcoin_units::pow::CompactTarget::to_target(self) -> bitcoin_units::pow::Target
 impl core::clone::Clone for bitcoin_units::pow::CompactTarget
   pub fn bitcoin_units::pow::CompactTarget::clone(&self) -> bitcoin_units::pow::CompactTarget [impl: impl core::clone::Clone for bitcoin_units::pow::CompactTarget]
 impl core::cmp::Eq for bitcoin_units::pow::CompactTarget
@@ -9210,6 +9211,7 @@ pub fn bitcoin_units::pow::CompactTarget::from_consensus(bits: u32) -> Self
 pub fn bitcoin_units::pow::CompactTarget::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::PrefixedHexError> where Self: core::marker::Sized
 pub fn bitcoin_units::pow::CompactTarget::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError> where Self: core::marker::Sized
 pub const fn bitcoin_units::pow::CompactTarget::to_consensus(self) -> u32
+pub fn bitcoin_units::pow::CompactTarget::to_target(self) -> bitcoin_units::pow::Target
 impl core::clone::Clone for bitcoin_units::pow::CompactTarget
   pub fn bitcoin_units::pow::CompactTarget::clone(&self) -> bitcoin_units::pow::CompactTarget [impl: impl core::clone::Clone for bitcoin_units::pow::CompactTarget]
 impl core::cmp::Eq for bitcoin_units::pow::CompactTarget

--- a/units/api/no-features.txt
+++ b/units/api/no-features.txt
@@ -4767,6 +4767,7 @@ pub fn bitcoin_units::pow::CompactTarget::from_consensus(bits: u32) -> Self
 pub fn bitcoin_units::pow::CompactTarget::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::PrefixedHexError> where Self: core::marker::Sized
 pub fn bitcoin_units::pow::CompactTarget::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError> where Self: core::marker::Sized
 pub const fn bitcoin_units::pow::CompactTarget::to_consensus(self) -> u32
+pub fn bitcoin_units::pow::CompactTarget::to_target(self) -> bitcoin_units::pow::Target
 impl core::clone::Clone for bitcoin_units::pow::CompactTarget
   pub fn bitcoin_units::pow::CompactTarget::clone(&self) -> bitcoin_units::pow::CompactTarget [impl: impl core::clone::Clone for bitcoin_units::pow::CompactTarget]
 impl core::cmp::Eq for bitcoin_units::pow::CompactTarget
@@ -8278,6 +8279,7 @@ pub fn bitcoin_units::pow::CompactTarget::from_consensus(bits: u32) -> Self
 pub fn bitcoin_units::pow::CompactTarget::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::PrefixedHexError> where Self: core::marker::Sized
 pub fn bitcoin_units::pow::CompactTarget::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError> where Self: core::marker::Sized
 pub const fn bitcoin_units::pow::CompactTarget::to_consensus(self) -> u32
+pub fn bitcoin_units::pow::CompactTarget::to_target(self) -> bitcoin_units::pow::Target
 impl core::clone::Clone for bitcoin_units::pow::CompactTarget
   pub fn bitcoin_units::pow::CompactTarget::clone(&self) -> bitcoin_units::pow::CompactTarget [impl: impl core::clone::Clone for bitcoin_units::pow::CompactTarget]
 impl core::cmp::Eq for bitcoin_units::pow::CompactTarget

--- a/units/src/pow.rs
+++ b/units/src/pow.rs
@@ -257,6 +257,11 @@ impl CompactTarget {
     #[inline]
     pub const fn to_consensus(self) -> u32 { self.0 }
 
+    /// Computes the [`Target`] value from this compact representation.
+    ///
+    /// ref: <https://developer.bitcoin.org/reference/block_chain.html#target-nbits>
+    pub fn to_target(self) -> Target { Target::from_compact(self) }
+
     /// Constructs a new `CompactTarget` from a prefixed hex string.
     ///
     /// # Errors
@@ -1322,7 +1327,7 @@ mod tests {
     fn work_overflowing_subtraction_panics() { let _ = Work(U256::ZERO) - Work(U256::ONE); }
 
     #[test]
-    fn target_from_compact() {
+    fn compact_to_target() {
         // (nBits, target)
         let tests = [
             (0x0100_3456_u32, 0x00_u64), // High bit set.
@@ -1339,20 +1344,20 @@ mod tests {
 
         for (n_bits, target) in tests {
             let want = Target(U256::from(target));
-            let got = Target::from_compact(CompactTarget::from_consensus(n_bits));
+            let got = CompactTarget::from_consensus(n_bits).to_target();
             assert_eq!(got, want);
         }
     }
 
     #[test]
-    fn target_from_compact_overflow_boundaries() {
+    fn compact_to_target_overflow_boundaries() {
         let tests = [
             (0x2100_FFFF_u32, Target(U256::from(0xFFFF_u32) << 240)),
             (0x2200_00FF_u32, Target(U256::from(0xFF_u32) << 248)),
         ];
 
         for (n_bits, want) in tests {
-            let got = Target::from_compact(CompactTarget::from_consensus(n_bits));
+            let got = CompactTarget::from_consensus(n_bits).to_target();
             assert_eq!(got, want);
         }
     }


### PR DESCRIPTION
According to C-CONV-SPECIFIC, conversion methods should prefer to/as/into over from, as it allows chaining. Due to CompactTarget being stabilised before Target, Target currently has methods for converting both to and from CompactTarget. Instead, a method for converting a CompactTarget to a Target should exist on the CompactTarget.

Add to_target conversion method to CompactTarget and adjust test cases to use it to kill mutants.