### PR TITLE
consensus_encoding: make distinction in docs about consensus

### DIFF
--- a/consensus_encoding/src/decode/decoders.rs
+++ b/consensus_encoding/src/decode/decoders.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! Primitive decoders.
+//! Primitive and combinator decoder types.
 
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
@@ -141,7 +141,7 @@ impl Decoder for ByteVecDecoder {
     }
 }
 
-/// A decoder that decodes a vector of `T`s.
+/// A decoder for a vector of consensus decodable types.
 ///
 /// The vector encoding must start with the number of items in the vector, encoded as a compact
 /// size.

--- a/consensus_encoding/src/decode/mod.rs
+++ b/consensus_encoding/src/decode/mod.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! Consensus Decoding Traits
-
 pub mod decoders;
 
 #[cfg(feature = "hex")]
@@ -10,7 +8,7 @@ use crate::error::{FromHexError, FromHexErrorInner};
 use crate::ReadError;
 use crate::{DecodeError, UnconsumedError};
 
-/// A Bitcoin object which can be consensus-decoded using a push decoder.
+/// A Bitcoin object which can be consensus decoded using a push decoder.
 ///
 /// To decode something, create a [`Self::Decoder`] and push byte slices into it with
 /// [`Decoder::push_bytes`], then call [`Decoder::end`] to get the result.
@@ -51,7 +49,7 @@ pub trait Decode {
     fn decoder() -> Self::Decoder { Self::Decoder::default() }
 }
 
-/// A push decoder for a consensus-decodable object.
+/// A push decoder that consumes bytes in chunks.
 pub trait Decoder: Sized {
     /// The type that this decoder produces when decoding is complete.
     type Output;
@@ -132,7 +130,7 @@ impl DecoderStatus {
     pub fn is_ready(&self) -> bool { matches!(self, Self::Ready) }
 }
 
-/// Decodes an object from a hex string without heap allocations.
+/// Decodes a consensus decodable type from a hex string without heap allocations.
 ///
 /// # Errors
 ///
@@ -232,7 +230,7 @@ fn decode_from_hex_internal<D: Decoder>(
     }
 }
 
-/// Decodes an object from a byte slice.
+/// Decodes a consensus decodable type from a byte slice.
 ///
 /// # Errors
 ///
@@ -278,7 +276,7 @@ fn decode_from_slice_internal<D: Decoder>(
     }
 }
 
-/// Decodes an object from an unbounded byte slice.
+/// Decodes a consensus decodable type from an unbounded byte slice.
 ///
 /// Unlike [`decode_from_slice`], this function will not error if the slice contains additional
 /// bytes that are not required to decode. Furthermore, the byte slice reference provided to this
@@ -332,7 +330,7 @@ fn decode_from_slice_unbounded_internal<D: Decoder>(
     decoder.end()
 }
 
-/// Decodes an object from a buffered reader.
+/// Decodes a consensus decodable type from a buffered reader.
 ///
 /// # Performance
 ///
@@ -412,7 +410,7 @@ where
     }
 }
 
-/// Decodes an object from an unbuffered reader using a fixed-size buffer.
+/// Decodes a consensus decodable type from an unbuffered reader using a fixed-size buffer.
 ///
 /// For most use cases, prefer [`decode_from_read`] with a [`std::io::BufReader`]. This function is
 /// only needed when you have an unbuffered reader which you cannot wrap. It will probably have
@@ -440,7 +438,7 @@ where
     decode_from_read_unbuffered_with::<T, R, 4096>(reader)
 }
 
-/// Decodes an object from an unbuffered reader using a custom-sized buffer.
+/// Decodes a consensus decodable type from an unbuffered reader using a custom-sized buffer.
 ///
 /// For most use cases, prefer [`decode_from_read`] with a [`std::io::BufReader`]. This function is
 /// only needed when you have an unbuffered reader which you cannot wrap. It will probably have
@@ -493,7 +491,7 @@ where
     decoder.end().map_err(ReadError::Decode)
 }
 
-/// Checks that the given bytes decode to the expected value, panicking if they don't.
+/// Checks that the given bytes decode to the expected consensus decodable value, panicking if they don't.
 ///
 /// This is intended for tests only.
 ///

--- a/consensus_encoding/src/encode/encoders.rs
+++ b/consensus_encoding/src/encode/encoders.rs
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! Collection of "standard encoders".
+//! Primitive and combinator encoder types.
 //!
-//! These encoders should not be used directly. Instead, when implementing the [`super::Encode`]
-//! trait on a type, you should define a newtype around one or more of these encoders, and pass
-//! through the [`Encoder`] implementation to your newtype. This avoids leaking encoding
-//! implementation details to the users of your type.
+//! These encoders should not be used directly. Instead, you should define a newtype around one or
+//! more of these encoders, and pass through the [`Encoder`] implementation to your newtype. This
+//! avoids leaking encoding implementation details to the users of your type.
 //!
 //! For implementing these newtypes, we provide the [`encoder_newtype`] and
 //! [`encoder_newtype_exact`] macros.
@@ -116,7 +115,7 @@ impl<const N: usize> ExactSizeEncoder for ArrayRefEncoder<'_, N> {
     fn len(&self) -> usize { self.arr.len() }
 }
 
-/// An encoder for a list of encodable types.
+/// An encoder for a list of consensus encodable types.
 pub struct SliceEncoder<'e, T: Encode> {
     /// The list of references to the objects we are encoding.
     sl: &'e [T],
@@ -191,7 +190,7 @@ impl<T: Encode> Encoder for SliceEncoder<'_, T> {
     }
 }
 
-/// An encoder for a list of encodable types, including a length prefix.
+/// An encoder for a list of consensus encodable types, including a length prefix.
 pub struct PrefixedSliceEncoder<'e, T: Encode>(Encoder2<CompactSizeEncoder, SliceEncoder<'e, T>>);
 
 impl<'e, T: Encode> PrefixedSliceEncoder<'e, T> {

--- a/consensus_encoding/src/encode/mod.rs
+++ b/consensus_encoding/src/encode/mod.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! Consensus Encoding Traits
-
 #[cfg(feature = "alloc")]
 #[cfg(feature = "hex")]
 use alloc::string::String;
@@ -10,7 +8,7 @@ use alloc::vec::Vec;
 
 pub mod encoders;
 
-/// A Bitcoin object which can be consensus-encoded.
+/// A Bitcoin object which can be consensus encoded.
 ///
 /// To encode something, use the [`Self::encoder`] method to obtain a [`Self::Encoder`], which will
 /// behave like an iterator yielding byte slices.
@@ -50,7 +48,7 @@ pub trait Encode {
     fn encoder(&self) -> Self::Encoder<'_>;
 }
 
-/// An encoder for a consensus-encodable object.
+/// A pull based encoder that yields bytes in chunks.
 ///
 /// The consumers of a type implementing this encoder trait should generally use it in a loop like
 /// this:
@@ -316,7 +314,7 @@ pub trait ExactSizeEncoder: Encoder {
     fn is_empty(&self) -> bool { self.len() == 0 }
 }
 
-/// Encodes an object into a vector.
+/// Encodes a consensus encodable type into a vector.
 #[cfg(feature = "alloc")]
 pub fn encode_to_vec<T>(object: &T) -> Vec<u8>
 where
@@ -342,7 +340,7 @@ where
     vec
 }
 
-/// Encodes an object into a hex string.
+/// Encodes a consensus encodable type into a hex string.
 #[cfg(feature = "alloc")]
 #[cfg(feature = "hex")]
 pub fn encode_to_hex<T>(object: &T, case: hex::Case) -> String
@@ -364,7 +362,7 @@ where
     hex_iter.flatten().map(char::from).collect()
 }
 
-/// Encodes an object to a standard I/O writer.
+/// Encodes a consensus encodable type to a standard I/O writer.
 ///
 /// # Performance
 ///
@@ -407,7 +405,7 @@ where
     Ok(())
 }
 
-/// Checks that the given `value` encodes to `expected`, panicking if it doesn't.
+/// Checks that a consensus encodable `value` encodes to `expected`, panicking if it doesn't.
 ///
 /// Note that the function does not impose any requirements on chunking - whether the encoded bytes
 /// are returned as a few large chunks or they are many smaller chunks makes no difference (other

--- a/consensus_encoding/src/lib.rs
+++ b/consensus_encoding/src/lib.rs
@@ -2,30 +2,31 @@
 
 //! # Rust Bitcoin Consensus Encoding
 //!
-//! Traits and utilities for encoding and decoding Bitcoin data types in a consensus-consistent way,
-//! using a *sans-I/O* architecture.
+//! Traits and utilities for encoding and decoding Bitcoin data types using a *sans-I/O*
+//! architecture.
 //!
 //! Rather than reading from or writing to [`std::io::Read`]/[`std::io::Write`] traits directly, the
 //! codec types work with byte slices. This keeps codec logic I/O-agnostic, so the same
 //! implementation works in `no_std` environments, sync I/O, async I/O, and hash engines without
 //! duplicating logic or surfacing I/O errors in non-I/O contexts (e.g. when hashing an encoding).
+//! This crate only supports deterministic encoding and will never support types like floats whose
+//! encoding is non-deterministic or platform-dependent.
 //!
 //! *Consensus* encoding is the canonical byte representation of Bitcoin data types used across the
-//! peer-to-peer network and transaction serialization. This crate only supports deterministic
-//! encoding and will never support types like floats whose encoding is non-deterministic or
-//! platform-dependent.
+//! peer-to-peer network and transaction serialization. Bitcoin types which support consensus
+//! encoding implement the [`Encode`] and [`Decode`] traits.
 //!
 //! # Encoding
 //!
-//! Types implement [`Encode`] to produce an [`Encoder`], which yields encoded bytes in chunks
-//! via [`Encoder::current_chunk`] and [`Encoder::advance`]. The caller drives the process by
-//! pulling chunks until `advance` returns [`EncoderStatus::Finished`].
+//! Consensus encodable types implement [`Encode`] to produce an [`Encoder`], which yields encoded
+//! bytes in chunks via [`Encoder::current_chunk`] and [`Encoder::advance`]. The caller drives the
+//! process by pulling chunks until `advance` returns [`EncoderStatus::Finished`].
 //!
 //! # Decoding
 //!
-//! Types implement [`Decode`] to produce a [`Decoder`], which consumes bytes via
-//! [`Decoder::push_bytes`] until it signals completion by returning `Ok(DecoderStatus::Ready)`. The
-//! caller then calls [`Decoder::end`] to obtain the decoded value.
+//! Consensus encodable types implement [`Decode`] to produce a [`Decoder`], which consumes bytes
+//! via [`Decoder::push_bytes`] until it signals completion by returning `Ok(DecoderStatus::Ready)`.
+//! The caller then calls [`Decoder::end`] to obtain the decoded value.
 //!
 //! Unlike encoding, decoding is fallible. Both `push_bytes` and `end` return `Result`. I/O errors
 //! are handled by the caller, keeping the codec logic I/O-agnostic.
@@ -33,7 +34,8 @@
 //! # Drivers
 //!
 //! This crate provides free functions which drive codecs for common I/O interfaces. On the decoding
-//! side we provide:
+//! side we provide functions which take a consensus encodable type parameter `T: Decode` to select
+//! the output type's associated decoder.
 //!
 //! * [`decode_from_read`]: Decode from a stdlib buffered reader.
 //! * [`decode_from_read_unbuffered`]: Decode from a stdlib unbuffered reader (4k buffer on stack).
@@ -42,22 +44,24 @@
 //! * [`decode_from_slice_unbounded`]: Slice can contain additional data after decoding completes.
 //! * [`decode_from_hex`]: Decode from a hex string without heap allocations.
 //!
-//! Each function above takes a type parameter `T: Decode` to select the output type and its
-//! associated decoder. The following variants instead accept a [`Decoder`] type directly,
-//! instantiated with [`Default`], and can be used when the output type does not implement [`Decode`]:
+//! The following variants instead accept an agnostic [`Decoder`] type directly, instantiated with
+//! [`Default`], and can be used when the output type does not implement [`Decode`]:
 //!
 //! * [`decode_from_read_with_decoder`]: Counterpart to [`decode_from_read`].
 //! * [`decode_from_slice_with_decoder`]: Counterpart to [`decode_from_slice`].
 //! * [`decode_from_slice_unbounded_with_decoder`]: Counterpart to [`decode_from_slice_unbounded`].
 //! * [`decode_from_hex_with_decoder`]: Counterpart to [`decode_from_hex`].
 //!
-//! And on the encoding side we provide:
+//! And on the encoding side we provide similar functions for consensus encodable types.
 //!
 //! * [`encode_to_writer`]: Encode to a stdlib writer.
-//! * [`drain_to_writer`]: Drain an encoder to a stdlib writer.
 //! * [`encode_to_vec`]: Encode to the heap.
-//! * [`drain_to_vec`]: Drain an encoder to the heap.
 //! * [`encode_to_hex`]: Encode to a hex string.
+//!
+//! As well as variants for agnostic [`Encoder`] types.
+//!
+//! * [`drain_to_writer`]: Drain an encoder to a stdlib writer.
+//! * [`drain_to_vec`]: Drain an encoder to the heap.
 //! * [`drain_to_hex`]: Drain an encoder to a hex string.
 //!
 //! # Feature Flags


### PR DESCRIPTION
Over in rust-psbt we have been debating how to integrate encoding. I took a pass at the docs to help me with a distinction, but I think helpful no matter which way we head in rust-psbt. The line I try to make clearer here is that `Encode`/`Decode` are tied to onchain consensus encoding types. Where as the lower-level `Encoder`/`Decoder` traits are agnostic, and could potentially be helpful in rust-psbt.