### PR TITLE
units: Make `Weight % Weight` return `Weight`

### DIFF
--- a/units/api/all-features.txt
+++ b/units/api/all-features.txt
@@ -9445,7 +9445,7 @@ impl core::ops::arith::Mul<u64> for bitcoin_units::Weight
 impl core::ops::arith::MulAssign<u64> for bitcoin_units::Weight
   pub fn bitcoin_units::Weight::mul_assign(&mut self, rhs: u64) [impl: impl core::ops::arith::MulAssign<u64> for bitcoin_units::Weight]
 impl core::ops::arith::Rem for bitcoin_units::Weight
-  pub type bitcoin_units::Weight::Output = u64 [impl: impl core::ops::arith::Rem for bitcoin_units::Weight]
+  pub type bitcoin_units::Weight::Output = bitcoin_units::Weight [impl: impl core::ops::arith::Rem for bitcoin_units::Weight]
   pub fn bitcoin_units::Weight::rem(self, rhs: bitcoin_units::Weight) -> Self::Output [impl: impl core::ops::arith::Rem for bitcoin_units::Weight]
 impl core::ops::arith::Rem<&bitcoin_units::Weight> for bitcoin_units::Weight
   pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Rem>::Output [impl: impl core::ops::arith::Rem<&bitcoin_units::Weight> for bitcoin_units::Weight]
@@ -11873,7 +11873,7 @@ impl core::ops::arith::Mul<u64> for bitcoin_units::Weight
 impl core::ops::arith::MulAssign<u64> for bitcoin_units::Weight
   pub fn bitcoin_units::Weight::mul_assign(&mut self, rhs: u64) [impl: impl core::ops::arith::MulAssign<u64> for bitcoin_units::Weight]
 impl core::ops::arith::Rem for bitcoin_units::Weight
-  pub type bitcoin_units::Weight::Output = u64 [impl: impl core::ops::arith::Rem for bitcoin_units::Weight]
+  pub type bitcoin_units::Weight::Output = bitcoin_units::Weight [impl: impl core::ops::arith::Rem for bitcoin_units::Weight]
   pub fn bitcoin_units::Weight::rem(self, rhs: bitcoin_units::Weight) -> Self::Output [impl: impl core::ops::arith::Rem for bitcoin_units::Weight]
 impl core::ops::arith::Rem<&bitcoin_units::Weight> for bitcoin_units::Weight
   pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Rem>::Output [impl: impl core::ops::arith::Rem<&bitcoin_units::Weight> for bitcoin_units::Weight]

--- a/units/api/alloc-only.txt
+++ b/units/api/alloc-only.txt
@@ -7730,7 +7730,7 @@ impl core::ops::arith::Mul<u64> for bitcoin_units::Weight
 impl core::ops::arith::MulAssign<u64> for bitcoin_units::Weight
   pub fn bitcoin_units::Weight::mul_assign(&mut self, rhs: u64) [impl: impl core::ops::arith::MulAssign<u64> for bitcoin_units::Weight]
 impl core::ops::arith::Rem for bitcoin_units::Weight
-  pub type bitcoin_units::Weight::Output = u64 [impl: impl core::ops::arith::Rem for bitcoin_units::Weight]
+  pub type bitcoin_units::Weight::Output = bitcoin_units::Weight [impl: impl core::ops::arith::Rem for bitcoin_units::Weight]
   pub fn bitcoin_units::Weight::rem(self, rhs: bitcoin_units::Weight) -> Self::Output [impl: impl core::ops::arith::Rem for bitcoin_units::Weight]
 impl core::ops::arith::Rem<&bitcoin_units::Weight> for bitcoin_units::Weight
   pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Rem>::Output [impl: impl core::ops::arith::Rem<&bitcoin_units::Weight> for bitcoin_units::Weight]
@@ -10064,7 +10064,7 @@ impl core::ops::arith::Mul<u64> for bitcoin_units::Weight
 impl core::ops::arith::MulAssign<u64> for bitcoin_units::Weight
   pub fn bitcoin_units::Weight::mul_assign(&mut self, rhs: u64) [impl: impl core::ops::arith::MulAssign<u64> for bitcoin_units::Weight]
 impl core::ops::arith::Rem for bitcoin_units::Weight
-  pub type bitcoin_units::Weight::Output = u64 [impl: impl core::ops::arith::Rem for bitcoin_units::Weight]
+  pub type bitcoin_units::Weight::Output = bitcoin_units::Weight [impl: impl core::ops::arith::Rem for bitcoin_units::Weight]
   pub fn bitcoin_units::Weight::rem(self, rhs: bitcoin_units::Weight) -> Self::Output [impl: impl core::ops::arith::Rem for bitcoin_units::Weight]
 impl core::ops::arith::Rem<&bitcoin_units::Weight> for bitcoin_units::Weight
   pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Rem>::Output [impl: impl core::ops::arith::Rem<&bitcoin_units::Weight> for bitcoin_units::Weight]

--- a/units/api/no-features.txt
+++ b/units/api/no-features.txt
@@ -6880,7 +6880,7 @@ impl core::ops::arith::Mul<u64> for bitcoin_units::Weight
 impl core::ops::arith::MulAssign<u64> for bitcoin_units::Weight
   pub fn bitcoin_units::Weight::mul_assign(&mut self, rhs: u64) [impl: impl core::ops::arith::MulAssign<u64> for bitcoin_units::Weight]
 impl core::ops::arith::Rem for bitcoin_units::Weight
-  pub type bitcoin_units::Weight::Output = u64 [impl: impl core::ops::arith::Rem for bitcoin_units::Weight]
+  pub type bitcoin_units::Weight::Output = bitcoin_units::Weight [impl: impl core::ops::arith::Rem for bitcoin_units::Weight]
   pub fn bitcoin_units::Weight::rem(self, rhs: bitcoin_units::Weight) -> Self::Output [impl: impl core::ops::arith::Rem for bitcoin_units::Weight]
 impl core::ops::arith::Rem<&bitcoin_units::Weight> for bitcoin_units::Weight
   pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Rem>::Output [impl: impl core::ops::arith::Rem<&bitcoin_units::Weight> for bitcoin_units::Weight]
@@ -9080,7 +9080,7 @@ impl core::ops::arith::Mul<u64> for bitcoin_units::Weight
 impl core::ops::arith::MulAssign<u64> for bitcoin_units::Weight
   pub fn bitcoin_units::Weight::mul_assign(&mut self, rhs: u64) [impl: impl core::ops::arith::MulAssign<u64> for bitcoin_units::Weight]
 impl core::ops::arith::Rem for bitcoin_units::Weight
-  pub type bitcoin_units::Weight::Output = u64 [impl: impl core::ops::arith::Rem for bitcoin_units::Weight]
+  pub type bitcoin_units::Weight::Output = bitcoin_units::Weight [impl: impl core::ops::arith::Rem for bitcoin_units::Weight]
   pub fn bitcoin_units::Weight::rem(self, rhs: bitcoin_units::Weight) -> Self::Output [impl: impl core::ops::arith::Rem for bitcoin_units::Weight]
 impl core::ops::arith::Rem<&bitcoin_units::Weight> for bitcoin_units::Weight
   pub type bitcoin_units::Weight::Output = <bitcoin_units::Weight as core::ops::arith::Rem>::Output [impl: impl core::ops::arith::Rem<&bitcoin_units::Weight> for bitcoin_units::Weight]

--- a/units/src/weight.rs
+++ b/units/src/weight.rs
@@ -233,9 +233,9 @@ crate::internal_macros::impl_op_for_references! {
         fn rem(self, rhs: u64) -> Self::Output { Weight::from_wu(self.to_wu() % rhs) }
     }
     impl ops::Rem<Weight> for Weight {
-        type Output = u64;
+        type Output = Weight;
 
-        fn rem(self, rhs: Weight) -> Self::Output { self.to_wu() % rhs.to_wu() }
+        fn rem(self, rhs: Weight) -> Self::Output { Weight::from_wu(self.to_wu() % rhs.to_wu()) }
     }
     impl ops::Div<NonZeroU64> for Weight {
         type Output = Weight;
@@ -550,7 +550,7 @@ mod tests {
         let weight3 = Weight::from_wu(3);
 
         let remainder = weight10 % weight3;
-        assert_eq!(remainder, 1);
+        assert_eq!(remainder, Weight::from_wu(1));
 
         let remainder = weight10 % 3;
         assert_eq!(remainder, Weight::from_wu(1));

--- a/units/src/weight.rs
+++ b/units/src/weight.rs
@@ -564,6 +564,16 @@ mod tests {
     }
 
     #[test]
+    fn weight_algebra() {
+        let a = Weight::from_wu(700);
+        let b = Weight::from_wu(300);
+        let d = a / b;
+        let r = a % b;
+
+        assert_eq!(a, d * b + r);
+    }
+
+    #[test]
     fn iter_sum() {
         let values = [
             Weight::from_wu(10),


### PR DESCRIPTION
The Rem<Weight> for Weight op currently returns a u64. A remainder type should always match the type itself, as the leftover after a division is logically a sub-portion of the original quantity, and thus its type.

Adjust Rem<Weight> for Weight impl to return Weight instead of u64.