### PR TITLE
Release tracking PR: `base58ck 0.5.0`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "base58ck"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bitcoin-internals 0.6.0",
  "bitcoin_hashes 1.1.0",
@@ -77,7 +77,7 @@ name = "bitcoin"
 version = "0.33.0-beta"
 dependencies = [
  "arbitrary",
- "base58ck 0.4.0",
+ "base58ck 0.5.0",
  "base64",
  "bech32",
  "bincode",
@@ -104,7 +104,7 @@ dependencies = [
 name = "bitcoin-addresses"
 version = "0.0.0"
 dependencies = [
- "base58ck 0.4.0",
+ "base58ck 0.5.0",
  "bech32",
  "bitcoin-crypto",
  "bitcoin-internals 0.6.0",
@@ -144,7 +144,7 @@ name = "bitcoin-crypto"
 version = "0.2.0"
 dependencies = [
  "arbitrary",
- "base58ck 0.4.0",
+ "base58ck 0.5.0",
  "bitcoin-internals 0.6.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
@@ -212,7 +212,7 @@ name = "bitcoin-key-expression"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "base58ck 0.4.0",
+ "base58ck 0.5.0",
  "bincode",
  "bitcoin-crypto",
  "bitcoin-internals 0.6.0",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "base58ck"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bitcoin-internals 0.6.0",
  "bitcoin_hashes 1.1.0",
@@ -76,7 +76,7 @@ name = "bitcoin"
 version = "0.33.0-beta"
 dependencies = [
  "arbitrary",
- "base58ck 0.4.0",
+ "base58ck 0.5.0",
  "base64",
  "bech32",
  "bincode",
@@ -103,7 +103,7 @@ dependencies = [
 name = "bitcoin-addresses"
 version = "0.0.0"
 dependencies = [
- "base58ck 0.4.0",
+ "base58ck 0.5.0",
  "bech32",
  "bitcoin-crypto",
  "bitcoin-internals 0.6.0",
@@ -143,7 +143,7 @@ name = "bitcoin-crypto"
 version = "0.2.0"
 dependencies = [
  "arbitrary",
- "base58ck 0.4.0",
+ "base58ck 0.5.0",
  "bitcoin-internals 0.6.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
@@ -211,7 +211,7 @@ name = "bitcoin-key-expression"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "base58ck 0.4.0",
+ "base58ck 0.5.0",
  "bincode",
  "bitcoin-crypto",
  "bitcoin-internals 0.6.0",

--- a/addresses/Cargo.toml
+++ b/addresses/Cargo.toml
@@ -19,7 +19,7 @@ std = ["alloc", "base58/std", "bech32/std", "crypto/std", "hashes/std", "interna
 alloc = ["base58/alloc", "bech32/alloc", "crypto/alloc", "hashes/alloc", "internals/alloc", "network/alloc", "primitives/alloc", "serde/alloc", "taproot_primitives/alloc"]
 
 [dependencies]
-base58 = { package = "base58ck", path = "../base58", version = "0.4.0", default-features = false, features = [] }
+base58 = { package = "base58ck", path = "../base58", version = "0.5.0", default-features = false, features = [] }
 bech32 = { version = "0.11.0", default-features = false, features = [] }
 crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.2.0", default-features = false, features = ["hex"] }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.0.0", default-features = false, features = ["hex"] }

--- a/base58/CHANGELOG.md
+++ b/base58/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-08-03
+
+- Replace encoding functions with optional-alloc `Base58CkString` [6505](https://github.com/rust-bitcoin/rust-bitcoin/pull/6505)
+- Upgrade to stable `bitcoin_hashes` dependency
+
 ## [0.4.0] - 2025-01-08
 
 - Update to latest `hashes 0.20.0`
@@ -40,7 +45,8 @@
 Initial release of the `base58ck` crate. This crate was cut out of
 `rust-bitcoin` and cleaned up for release as a separate crate.
 
-[Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/base58ck-0.4.0...HEAD
+[Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/base58ck-0.5.0...HEAD
+[0.5.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/base58ck-0.4.0...base58ck-0.5.0
 [0.4.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/base58ck-0.3.0...base58ck-0.4.0
 [0.3.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/base58ck-0.2.0...base58ck-0.3.0
 [0.2.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/base58ck-0.1.100...base58ck-0.2.0

--- a/base58/Cargo.toml
+++ b/base58/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base58ck"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -27,7 +27,7 @@ arbitrary = ["crypto/arbitrary", "dep:arbitrary", "units/arbitrary", "primitives
 
 [dependencies]
 addresses = { package = "bitcoin-addresses", path = "../addresses", version = "0.0.0", default-features = false, features = ["alloc"] }
-base58 = { package = "base58ck", path = "../base58", version = "0.4.0", default-features = false, features = ["alloc"] }
+base58 = { package = "base58ck", path = "../base58", version = "0.5.0", default-features = false, features = ["alloc"] }
 bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
 crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.2.0", default-features = false, features = ["alloc", "hex"] }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.1.0", default-features = false, features = ["alloc", "hex"] }

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -23,7 +23,7 @@ arbitrary = ["dep:arbitrary", "secp256k1/arbitrary"]
 hex = ["dep:hex", "hashes/hex", "primitives/hex"]
 
 [dependencies]
-base58 = { package = "base58ck", path = "../base58", version = "0.4.0", default-features = false }
+base58 = { package = "base58ck", path = "../base58", version = "0.5.0", default-features = false }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.0.0", default-features = false, features = ["hex"] }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
 network = { package = "bitcoin-network-kind", path = "../network", version = "1.0.0", default-features = false }

--- a/key_expression/Cargo.toml
+++ b/key_expression/Cargo.toml
@@ -21,7 +21,7 @@ serde = ["dep:serde", "hashes/serde", "internals/serde", "secp256k1/serde"]
 arbitrary = ["crypto/arbitrary", "dep:arbitrary", "hashes/arbitrary", "secp256k1/arbitrary", "network/arbitrary"]
 
 [dependencies]
-base58 = { package = "base58ck", path = "../base58", version = "0.4.0", default-features = false }
+base58 = { package = "base58ck", path = "../base58", version = "0.5.0", default-features = false }
 crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.2.0", default-features = false }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.0.0", default-features = false, features = ["hex"] }
 hex = { package = "hex-conservative", version = "1.1.0", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
In preparation for release add a changelog entry, bump the version, and update the lock files.