### PR TITLE
bitcoin: Enable alloc and hex in encoding dep

### DIFF
--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -44,7 +44,7 @@ secp256k1 = { version = "0.29.0", default-features = false, features = ["hashes"
 units = { package = "bitcoin-units", path = "../units", version = "0.1.101", default-features = false, features = ["alloc"] }
 
 base64 = { version = "0.21.3", optional = true }
-encoding = { package = "bitcoin-consensus-encoding", version = "1.1", default-features = false, optional = true }
+encoding = { package = "bitcoin-consensus-encoding", version = "1.1", default-features = false, features = ["alloc", "hex"], optional = true }
 ordered = { version = "0.2.0", optional = true }
 # Only use this feature for no-std builds, otherwise use bitcoinconsensus-std.
 bitcoinconsensus = { version = "0.105.0+25.1", default-features = false, optional = true }
@@ -106,3 +106,8 @@ exact_features = [
 
 [package.metadata.rbmt.prerelease]
 enabled = true
+
+[package.metadata.rbmt.lint]
+allowed_duplicates = [
+    "hex-conservative",
+]


### PR DESCRIPTION
The `consensus-encoding` dependency does not have the `hex` or `alloc` optional features enabled. On `master` we do have these enabled.

Enabling them gives downstream users access to feature gated functions from `encoding` that they may expect to see (for example `bitcoin::consensus::encode_to_hex`).