### PR TITLE
units: Allow -0.0 float for `Amount::from_float_in`

### DIFF
--- a/units/src/amount/tests.rs
+++ b/units/src/amount/tests.rs
@@ -365,6 +365,8 @@ fn floating_point() {
     let f = Amount::from_float_in;
     let sf = SignedAmount::from_float_in;
 
+    assert_eq!(f(0.0, D::Bitcoin), Ok(sat(0)));
+    assert_eq!(f(-0.0, D::Bitcoin), Ok(sat(0)));
     assert_eq!(f(11.22, D::Bitcoin), Ok(sat(1_122_000_000)));
     assert_eq!(sf(-11.22, D::MilliBitcoin), Ok(ssat(-1_122_000)));
     assert_eq!(f(11.22, D::Bit), Ok(sat(1122)));

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -268,6 +268,7 @@ impl Amount {
     #[inline]
     #[cfg(feature = "alloc")]
     pub fn from_float_in(value: f64, denom: Denomination) -> Result<Self, ParseAmountError> {
+        let value = if value == 0.0 { 0.0 } else { value };
         if value < 0.0 {
             return Err(ParseAmountError(ParseAmountErrorInner::OutOfRange(
                 OutOfRangeError::negative(),


### PR DESCRIPTION
The Amount::from_float_in function rejects values < 0.0. With floats, a value can be 0, but have a negative sign. This should still be accepted by the unsigned Amount type, as it is not negative.

Adjust Amount::from_float_in to accept -0.0 as Amount::ZERO.