### PR TITLE
units: Remove `From<u16>` from `NumberOfBlocks`

### DIFF
--- a/bitcoin/tests/serde.rs
+++ b/bitcoin/tests/serde.rs
@@ -51,7 +51,7 @@ fn serde_regression_absolute_lock_time_time() {
 
 #[test]
 fn serde_regression_relative_lock_time_height() {
-    let t = relative::LockTime::from(relative::NumberOfBlocks::from(0xCAFE_u16));
+    let t = relative::LockTime::from(relative::NumberOfBlocks::from_height(0xCAFE));
 
     let got = serialize(&t).unwrap();
     let want = include_bytes!("data/serde/relative_lock_time_blocks_bincode") as &[_];

--- a/units/api/all-features.txt
+++ b/units/api/all-features.txt
@@ -5948,8 +5948,6 @@ impl core::convert::From<bitcoin_units::locktime::relative::NumberOfBlocks> for 
   pub fn bitcoin_units::block::BlockHeightInterval::from(h: bitcoin_units::locktime::relative::NumberOfBlocks) -> Self [impl: impl core::convert::From<bitcoin_units::locktime::relative::NumberOfBlocks> for bitcoin_units::block::BlockHeightInterval]
 impl core::convert::From<bitcoin_units::locktime::relative::NumberOfBlocks> for bitcoin_units::locktime::relative::LockTime
   pub fn bitcoin_units::locktime::relative::LockTime::from(h: bitcoin_units::locktime::relative::NumberOfBlocks) -> Self [impl: impl core::convert::From<bitcoin_units::locktime::relative::NumberOfBlocks> for bitcoin_units::locktime::relative::LockTime]
-impl core::convert::From<u16> for bitcoin_units::locktime::relative::NumberOfBlocks
-  pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from(value: u16) -> Self [impl: impl core::convert::From<u16> for bitcoin_units::locktime::relative::NumberOfBlocks]
 impl core::convert::TryFrom<&str> for bitcoin_units::locktime::relative::NumberOfBlocks
   pub type bitcoin_units::locktime::relative::NumberOfBlocks::Error = bitcoin_units::parse_int::error::ParseIntError [impl: impl core::convert::TryFrom<&str> for bitcoin_units::locktime::relative::NumberOfBlocks]
   pub fn bitcoin_units::locktime::relative::NumberOfBlocks::try_from(s: &str) -> core::result::Result<Self, Self::Error> [impl: impl core::convert::TryFrom<&str> for bitcoin_units::locktime::relative::NumberOfBlocks]
@@ -7983,8 +7981,6 @@ impl core::convert::From<bitcoin_units::locktime::relative::NumberOfBlocks> for 
   pub fn bitcoin_units::block::BlockHeightInterval::from(h: bitcoin_units::locktime::relative::NumberOfBlocks) -> Self [impl: impl core::convert::From<bitcoin_units::locktime::relative::NumberOfBlocks> for bitcoin_units::block::BlockHeightInterval]
 impl core::convert::From<bitcoin_units::locktime::relative::NumberOfBlocks> for bitcoin_units::locktime::relative::LockTime
   pub fn bitcoin_units::locktime::relative::LockTime::from(h: bitcoin_units::locktime::relative::NumberOfBlocks) -> Self [impl: impl core::convert::From<bitcoin_units::locktime::relative::NumberOfBlocks> for bitcoin_units::locktime::relative::LockTime]
-impl core::convert::From<u16> for bitcoin_units::locktime::relative::NumberOfBlocks
-  pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from(value: u16) -> Self [impl: impl core::convert::From<u16> for bitcoin_units::locktime::relative::NumberOfBlocks]
 impl core::convert::TryFrom<&str> for bitcoin_units::locktime::relative::NumberOfBlocks
   pub type bitcoin_units::locktime::relative::NumberOfBlocks::Error = bitcoin_units::parse_int::error::ParseIntError [impl: impl core::convert::TryFrom<&str> for bitcoin_units::locktime::relative::NumberOfBlocks]
   pub fn bitcoin_units::locktime::relative::NumberOfBlocks::try_from(s: &str) -> core::result::Result<Self, Self::Error> [impl: impl core::convert::TryFrom<&str> for bitcoin_units::locktime::relative::NumberOfBlocks]

--- a/units/api/alloc-only.txt
+++ b/units/api/alloc-only.txt
@@ -4883,8 +4883,6 @@ impl core::convert::From<bitcoin_units::locktime::relative::NumberOfBlocks> for 
   pub fn bitcoin_units::block::BlockHeightInterval::from(h: bitcoin_units::locktime::relative::NumberOfBlocks) -> Self [impl: impl core::convert::From<bitcoin_units::locktime::relative::NumberOfBlocks> for bitcoin_units::block::BlockHeightInterval]
 impl core::convert::From<bitcoin_units::locktime::relative::NumberOfBlocks> for bitcoin_units::locktime::relative::LockTime
   pub fn bitcoin_units::locktime::relative::LockTime::from(h: bitcoin_units::locktime::relative::NumberOfBlocks) -> Self [impl: impl core::convert::From<bitcoin_units::locktime::relative::NumberOfBlocks> for bitcoin_units::locktime::relative::LockTime]
-impl core::convert::From<u16> for bitcoin_units::locktime::relative::NumberOfBlocks
-  pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from(value: u16) -> Self [impl: impl core::convert::From<u16> for bitcoin_units::locktime::relative::NumberOfBlocks]
 impl core::convert::TryFrom<&str> for bitcoin_units::locktime::relative::NumberOfBlocks
   pub type bitcoin_units::locktime::relative::NumberOfBlocks::Error = bitcoin_units::parse_int::error::ParseIntError [impl: impl core::convert::TryFrom<&str> for bitcoin_units::locktime::relative::NumberOfBlocks]
   pub fn bitcoin_units::locktime::relative::NumberOfBlocks::try_from(s: &str) -> core::result::Result<Self, Self::Error> [impl: impl core::convert::TryFrom<&str> for bitcoin_units::locktime::relative::NumberOfBlocks]
@@ -6654,8 +6652,6 @@ impl core::convert::From<bitcoin_units::locktime::relative::NumberOfBlocks> for 
   pub fn bitcoin_units::block::BlockHeightInterval::from(h: bitcoin_units::locktime::relative::NumberOfBlocks) -> Self [impl: impl core::convert::From<bitcoin_units::locktime::relative::NumberOfBlocks> for bitcoin_units::block::BlockHeightInterval]
 impl core::convert::From<bitcoin_units::locktime::relative::NumberOfBlocks> for bitcoin_units::locktime::relative::LockTime
   pub fn bitcoin_units::locktime::relative::LockTime::from(h: bitcoin_units::locktime::relative::NumberOfBlocks) -> Self [impl: impl core::convert::From<bitcoin_units::locktime::relative::NumberOfBlocks> for bitcoin_units::locktime::relative::LockTime]
-impl core::convert::From<u16> for bitcoin_units::locktime::relative::NumberOfBlocks
-  pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from(value: u16) -> Self [impl: impl core::convert::From<u16> for bitcoin_units::locktime::relative::NumberOfBlocks]
 impl core::convert::TryFrom<&str> for bitcoin_units::locktime::relative::NumberOfBlocks
   pub type bitcoin_units::locktime::relative::NumberOfBlocks::Error = bitcoin_units::parse_int::error::ParseIntError [impl: impl core::convert::TryFrom<&str> for bitcoin_units::locktime::relative::NumberOfBlocks]
   pub fn bitcoin_units::locktime::relative::NumberOfBlocks::try_from(s: &str) -> core::result::Result<Self, Self::Error> [impl: impl core::convert::TryFrom<&str> for bitcoin_units::locktime::relative::NumberOfBlocks]

--- a/units/api/no-features.txt
+++ b/units/api/no-features.txt
@@ -4327,8 +4327,6 @@ impl core::convert::From<bitcoin_units::locktime::relative::NumberOfBlocks> for 
   pub fn bitcoin_units::block::BlockHeightInterval::from(h: bitcoin_units::locktime::relative::NumberOfBlocks) -> Self [impl: impl core::convert::From<bitcoin_units::locktime::relative::NumberOfBlocks> for bitcoin_units::block::BlockHeightInterval]
 impl core::convert::From<bitcoin_units::locktime::relative::NumberOfBlocks> for bitcoin_units::locktime::relative::LockTime
   pub fn bitcoin_units::locktime::relative::LockTime::from(h: bitcoin_units::locktime::relative::NumberOfBlocks) -> Self [impl: impl core::convert::From<bitcoin_units::locktime::relative::NumberOfBlocks> for bitcoin_units::locktime::relative::LockTime]
-impl core::convert::From<u16> for bitcoin_units::locktime::relative::NumberOfBlocks
-  pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from(value: u16) -> Self [impl: impl core::convert::From<u16> for bitcoin_units::locktime::relative::NumberOfBlocks]
 impl core::convert::TryFrom<&str> for bitcoin_units::locktime::relative::NumberOfBlocks
   pub type bitcoin_units::locktime::relative::NumberOfBlocks::Error = bitcoin_units::parse_int::error::ParseIntError [impl: impl core::convert::TryFrom<&str> for bitcoin_units::locktime::relative::NumberOfBlocks]
   pub fn bitcoin_units::locktime::relative::NumberOfBlocks::try_from(s: &str) -> core::result::Result<Self, Self::Error> [impl: impl core::convert::TryFrom<&str> for bitcoin_units::locktime::relative::NumberOfBlocks]
@@ -5874,8 +5872,6 @@ impl core::convert::From<bitcoin_units::locktime::relative::NumberOfBlocks> for 
   pub fn bitcoin_units::block::BlockHeightInterval::from(h: bitcoin_units::locktime::relative::NumberOfBlocks) -> Self [impl: impl core::convert::From<bitcoin_units::locktime::relative::NumberOfBlocks> for bitcoin_units::block::BlockHeightInterval]
 impl core::convert::From<bitcoin_units::locktime::relative::NumberOfBlocks> for bitcoin_units::locktime::relative::LockTime
   pub fn bitcoin_units::locktime::relative::LockTime::from(h: bitcoin_units::locktime::relative::NumberOfBlocks) -> Self [impl: impl core::convert::From<bitcoin_units::locktime::relative::NumberOfBlocks> for bitcoin_units::locktime::relative::LockTime]
-impl core::convert::From<u16> for bitcoin_units::locktime::relative::NumberOfBlocks
-  pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from(value: u16) -> Self [impl: impl core::convert::From<u16> for bitcoin_units::locktime::relative::NumberOfBlocks]
 impl core::convert::TryFrom<&str> for bitcoin_units::locktime::relative::NumberOfBlocks
   pub type bitcoin_units::locktime::relative::NumberOfBlocks::Error = bitcoin_units::parse_int::error::ParseIntError [impl: impl core::convert::TryFrom<&str> for bitcoin_units::locktime::relative::NumberOfBlocks]
   pub fn bitcoin_units::locktime::relative::NumberOfBlocks::try_from(s: &str) -> core::result::Result<Self, Self::Error> [impl: impl core::convert::TryFrom<&str> for bitcoin_units::locktime::relative::NumberOfBlocks]

--- a/units/src/block.rs
+++ b/units/src/block.rs
@@ -308,7 +308,7 @@ impl TryFrom<BlockHeightInterval> for relative::NumberOfBlocks {
     #[inline]
     fn try_from(h: BlockHeightInterval) -> Result<Self, Self::Error> {
         u16::try_from(h.to_u32())
-            .map(Self::from)
+            .map(Self::from_height)
             .map_err(|_| TooBigForRelativeHeightError(h.into()))
     }
 }
@@ -709,7 +709,7 @@ mod tests {
         assert_eq!(interval, 100);
 
         let interval_from_height: BlockHeightInterval =
-            relative::NumberOfBlocks::from(10u16).into();
+            relative::NumberOfBlocks::from_height(10).into();
         assert_eq!(interval_from_height.to_u32(), 10u32);
 
         let invalid_height_greater =

--- a/units/src/locktime/relative/error.rs
+++ b/units/src/locktime/relative/error.rs
@@ -309,7 +309,7 @@ mod tests {
         assert!(e.source().is_none());
 
         // InvalidHeightError - is_satisfied_by with invalid args
-        let blocks = NumberOfBlocks::from(10u16);
+        let blocks = NumberOfBlocks::from_height(10);
         let e = blocks
             .is_satisfied_by(BlockHeight::from_u32(5), BlockHeight::from_u32(10))
             .unwrap_err();

--- a/units/src/locktime/relative/mod.rs
+++ b/units/src/locktime/relative/mod.rs
@@ -449,12 +449,7 @@ impl NumberOfBlocks {
 
 crate::internal_macros::impl_fmt_traits_for_u32_wrapper!(NumberOfBlocks);
 
-impl From<u16> for NumberOfBlocks {
-    #[inline]
-    fn from(value: u16) -> Self { Self(value) }
-}
-
-parse_int::impl_parse_str_from_int_infallible!(NumberOfBlocks, u16, from);
+parse_int::impl_parse_str_from_int_infallible!(NumberOfBlocks, u16, from_height);
 
 impl fmt::Display for NumberOfBlocks {
     #[inline]
@@ -658,8 +653,8 @@ mod tests {
 
     #[test]
     fn parses_correctly_to_height_or_time() {
-        let height1 = NumberOfBlocks::from(10);
-        let height2 = NumberOfBlocks::from(11);
+        let height1 = NumberOfBlocks::from_height(10);
+        let height2 = NumberOfBlocks::from_height(11);
         let time1 = NumberOf512Seconds::from_512_second_intervals(70);
         let time2 = NumberOf512Seconds::from_512_second_intervals(71);
 
@@ -683,12 +678,12 @@ mod tests {
 
     #[test]
     fn height_correctly_implies() {
-        let height = NumberOfBlocks::from(10);
+        let height = NumberOfBlocks::from_height(10);
         let lock_by_height = LockTime::from(height);
 
-        assert!(!lock_by_height.is_implied_by(LockTime::from(NumberOfBlocks::from(9))));
-        assert!(lock_by_height.is_implied_by(LockTime::from(NumberOfBlocks::from(10))));
-        assert!(lock_by_height.is_implied_by(LockTime::from(NumberOfBlocks::from(11))));
+        assert!(!lock_by_height.is_implied_by(LockTime::from(NumberOfBlocks::from_height(9))));
+        assert!(lock_by_height.is_implied_by(LockTime::from(NumberOfBlocks::from_height(10))));
+        assert!(lock_by_height.is_implied_by(LockTime::from(NumberOfBlocks::from_height(11))));
     }
 
     #[test]
@@ -706,7 +701,7 @@ mod tests {
 
     #[test]
     fn sequence_correctly_implies() {
-        let height = NumberOfBlocks::from(10);
+        let height = NumberOfBlocks::from_height(10);
         let time = NumberOf512Seconds::from_512_second_intervals(70);
 
         let lock_by_height = LockTime::from(height);
@@ -729,7 +724,7 @@ mod tests {
     #[test]
     fn incorrect_units_do_not_imply() {
         let time = NumberOf512Seconds::from_512_second_intervals(70);
-        let height = NumberOfBlocks::from(10);
+        let height = NumberOfBlocks::from_height(10);
 
         let lock_by_time = LockTime::from(time);
         assert!(!lock_by_time.is_implied_by(LockTime::from(height)));
@@ -808,7 +803,7 @@ mod tests {
         let lock_by_height = LockTime::from_height(10); // Arbitrary value.
         let err = lock_by_height.is_satisfied_by_time(chain_tip, mined_at).unwrap_err();
 
-        let expected_height = NumberOfBlocks::from(10);
+        let expected_height = NumberOfBlocks::from_height(10);
         assert_eq!(
             err,
             IsSatisfiedByTimeError::Incompatible(IncompatibleTimeError(expected_height))
@@ -847,10 +842,10 @@ mod tests {
         let utxo_height = BlockHeight::from_u32(80);
         let utxo_mtp = BlockMtp::new(utxo_timestamps);
 
-        let lock1 = LockTime::Blocks(NumberOfBlocks::from(10));
+        let lock1 = LockTime::Blocks(NumberOfBlocks::from_height(10));
         assert!(lock1.is_satisfied_by(chain_height, chain_mtp, utxo_height, utxo_mtp).unwrap());
 
-        let lock2 = LockTime::Blocks(NumberOfBlocks::from(21));
+        let lock2 = LockTime::Blocks(NumberOfBlocks::from_height(21));
         assert!(lock2.is_satisfied_by(chain_height, chain_mtp, utxo_height, utxo_mtp).unwrap());
 
         let lock3 = LockTime::Time(NumberOf512Seconds::from_512_second_intervals(10));
@@ -1055,7 +1050,7 @@ mod tests {
         let mined_at = BlockHeight::from_u32(u32::MIN);
         let chain_tip = BlockHeight::from_u32(u32::MAX);
 
-        let block_height = NumberOfBlocks::from(10); // Arbitrary value.
+        let block_height = NumberOfBlocks::from_height(10); // Arbitrary value.
         assert!(block_height.is_satisfied_by(chain_tip, mined_at).unwrap());
     }
 }

--- a/units/src/sequence.rs
+++ b/units/src/sequence.rs
@@ -215,7 +215,7 @@ impl Sequence {
         if self.is_time_locked() {
             Some(LockTime::from(NumberOf512Seconds::from_512_second_intervals(lock_value)))
         } else {
-            Some(LockTime::from(NumberOfBlocks::from(lock_value)))
+            Some(LockTime::from(NumberOfBlocks::from_height(lock_value)))
         }
     }
 


### PR DESCRIPTION
The NumberOfBlocks type has a From\<u16> impl on it, which is used to simplify construction of the type in various tests. However, the from_height constructor already takes a u16 and functions identically. Since the NumberOf512Seconds type has no such From impl, it should be removed from this to reduce the API surface and make the two consistent.

Remove From\<u16> impl from NumberOfBlocks.