### PR TITLE
units: Add `RemAssign` to `NumOpResult<Amount/SignedAmount>`

### DIFF
--- a/units/api/all-features.txt
+++ b/units/api/all-features.txt
@@ -8495,6 +8495,14 @@ impl core::ops::arith::Rem<u64> for &bitcoin_units::result::NumOpResult<bitcoin_
 impl core::ops::arith::Rem<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Rem<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::rem(self, modulus: u64) -> Self::Output [impl: impl core::ops::arith::Rem<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::RemAssign<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::rem_assign(&mut self, rhs: &i64) [impl: impl core::ops::arith::RemAssign<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::RemAssign<&u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::rem_assign(&mut self, rhs: &u64) [impl: impl core::ops::arith::RemAssign<&u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::RemAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::rem_assign(&mut self, rhs: i64) [impl: impl core::ops::arith::RemAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::RemAssign<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::rem_assign(&mut self, rhs: u64) [impl: impl core::ops::arith::RemAssign<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::Sub<&bitcoin_units::result::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount
   pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Sub<bitcoin_units::result::NumOpResult<bitcoin_units::Amount>>>::Output [impl: impl core::ops::arith::Sub<&bitcoin_units::result::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount]
   pub fn bitcoin_units::Amount::sub(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>) -> Self::Output [impl: impl core::ops::arith::Sub<&bitcoin_units::result::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount]
@@ -9851,6 +9859,14 @@ impl core::ops::arith::Rem<u64> for &bitcoin_units::result::NumOpResult<bitcoin_
 impl core::ops::arith::Rem<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Rem<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::rem(self, modulus: u64) -> Self::Output [impl: impl core::ops::arith::Rem<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::RemAssign<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::rem_assign(&mut self, rhs: &i64) [impl: impl core::ops::arith::RemAssign<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::RemAssign<&u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::rem_assign(&mut self, rhs: &u64) [impl: impl core::ops::arith::RemAssign<&u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::RemAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::rem_assign(&mut self, rhs: i64) [impl: impl core::ops::arith::RemAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::RemAssign<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::rem_assign(&mut self, rhs: u64) [impl: impl core::ops::arith::RemAssign<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::Sub<&bitcoin_units::result::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount
   pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Sub<bitcoin_units::result::NumOpResult<bitcoin_units::Amount>>>::Output [impl: impl core::ops::arith::Sub<&bitcoin_units::result::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount]
   pub fn bitcoin_units::Amount::sub(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>) -> Self::Output [impl: impl core::ops::arith::Sub<&bitcoin_units::result::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount]

--- a/units/api/alloc-only.txt
+++ b/units/api/alloc-only.txt
@@ -7118,6 +7118,14 @@ impl core::ops::arith::Rem<u64> for &bitcoin_units::result::NumOpResult<bitcoin_
 impl core::ops::arith::Rem<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Rem<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::rem(self, modulus: u64) -> Self::Output [impl: impl core::ops::arith::Rem<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::RemAssign<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::rem_assign(&mut self, rhs: &i64) [impl: impl core::ops::arith::RemAssign<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::RemAssign<&u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::rem_assign(&mut self, rhs: &u64) [impl: impl core::ops::arith::RemAssign<&u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::RemAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::rem_assign(&mut self, rhs: i64) [impl: impl core::ops::arith::RemAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::RemAssign<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::rem_assign(&mut self, rhs: u64) [impl: impl core::ops::arith::RemAssign<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::Sub<&bitcoin_units::result::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount
   pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Sub<bitcoin_units::result::NumOpResult<bitcoin_units::Amount>>>::Output [impl: impl core::ops::arith::Sub<&bitcoin_units::result::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount]
   pub fn bitcoin_units::Amount::sub(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>) -> Self::Output [impl: impl core::ops::arith::Sub<&bitcoin_units::result::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount]
@@ -8089,6 +8097,14 @@ impl core::ops::arith::Rem<u64> for &bitcoin_units::result::NumOpResult<bitcoin_
 impl core::ops::arith::Rem<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Rem<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::rem(self, modulus: u64) -> Self::Output [impl: impl core::ops::arith::Rem<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::RemAssign<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::rem_assign(&mut self, rhs: &i64) [impl: impl core::ops::arith::RemAssign<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::RemAssign<&u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::rem_assign(&mut self, rhs: &u64) [impl: impl core::ops::arith::RemAssign<&u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::RemAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::rem_assign(&mut self, rhs: i64) [impl: impl core::ops::arith::RemAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::RemAssign<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::rem_assign(&mut self, rhs: u64) [impl: impl core::ops::arith::RemAssign<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::Sub<&bitcoin_units::result::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount
   pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Sub<bitcoin_units::result::NumOpResult<bitcoin_units::Amount>>>::Output [impl: impl core::ops::arith::Sub<&bitcoin_units::result::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount]
   pub fn bitcoin_units::Amount::sub(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>) -> Self::Output [impl: impl core::ops::arith::Sub<&bitcoin_units::result::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount]

--- a/units/api/no-features.txt
+++ b/units/api/no-features.txt
@@ -6308,6 +6308,14 @@ impl core::ops::arith::Rem<u64> for &bitcoin_units::result::NumOpResult<bitcoin_
 impl core::ops::arith::Rem<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Rem<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::rem(self, modulus: u64) -> Self::Output [impl: impl core::ops::arith::Rem<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::RemAssign<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::rem_assign(&mut self, rhs: &i64) [impl: impl core::ops::arith::RemAssign<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::RemAssign<&u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::rem_assign(&mut self, rhs: &u64) [impl: impl core::ops::arith::RemAssign<&u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::RemAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::rem_assign(&mut self, rhs: i64) [impl: impl core::ops::arith::RemAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::RemAssign<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::rem_assign(&mut self, rhs: u64) [impl: impl core::ops::arith::RemAssign<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::Sub<&bitcoin_units::result::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount
   pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Sub<bitcoin_units::result::NumOpResult<bitcoin_units::Amount>>>::Output [impl: impl core::ops::arith::Sub<&bitcoin_units::result::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount]
   pub fn bitcoin_units::Amount::sub(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>) -> Self::Output [impl: impl core::ops::arith::Sub<&bitcoin_units::result::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount]
@@ -7233,6 +7241,14 @@ impl core::ops::arith::Rem<u64> for &bitcoin_units::result::NumOpResult<bitcoin_
 impl core::ops::arith::Rem<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Rem<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::rem(self, modulus: u64) -> Self::Output [impl: impl core::ops::arith::Rem<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::RemAssign<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::rem_assign(&mut self, rhs: &i64) [impl: impl core::ops::arith::RemAssign<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::RemAssign<&u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::rem_assign(&mut self, rhs: &u64) [impl: impl core::ops::arith::RemAssign<&u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::RemAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::rem_assign(&mut self, rhs: i64) [impl: impl core::ops::arith::RemAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::RemAssign<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::rem_assign(&mut self, rhs: u64) [impl: impl core::ops::arith::RemAssign<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::Sub<&bitcoin_units::result::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount
   pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Sub<bitcoin_units::result::NumOpResult<bitcoin_units::Amount>>>::Output [impl: impl core::ops::arith::Sub<&bitcoin_units::result::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount]
   pub fn bitcoin_units::Amount::sub(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>) -> Self::Output [impl: impl core::ops::arith::Sub<&bitcoin_units::result::NumOpResult<bitcoin_units::Amount>> for bitcoin_units::Amount]

--- a/units/src/amount/result.rs
+++ b/units/src/amount/result.rs
@@ -9,7 +9,8 @@ use NumOpResult as R;
 
 use super::{Amount, SignedAmount};
 use crate::internal_macros::{
-    impl_add_assign_for_results, impl_div_assign, impl_mul_assign, impl_sub_assign_for_results,
+    impl_add_assign_for_results, impl_div_assign, impl_mul_assign, impl_rem_assign,
+    impl_sub_assign_for_results,
 };
 use crate::result::{MathOp, NumOpError, NumOpResult, OptionExt};
 
@@ -199,6 +200,8 @@ impl_mul_assign!(NumOpResult<Amount>, u64);
 impl_mul_assign!(NumOpResult<SignedAmount>, i64);
 impl_div_assign!(NumOpResult<Amount>, u64);
 impl_div_assign!(NumOpResult<SignedAmount>, i64);
+impl_rem_assign!(NumOpResult<Amount>, u64);
+impl_rem_assign!(NumOpResult<SignedAmount>, i64);
 
 impl_add_assign_for_results!(Amount);
 impl_add_assign_for_results!(SignedAmount);

--- a/units/src/amount/result.rs
+++ b/units/src/amount/result.rs
@@ -405,6 +405,41 @@ mod tests {
     }
 
     #[test]
+    fn test_rem_assign_amount() {
+        let sat = Amount::from_sat_u32(50);
+        let mut res = sat + sat;
+        res %= 30_u64;
+        assert_eq!(res, NumOpResult::Valid(Amount::from_sat_u32(10)));
+
+        res %= &4_u64;
+        assert_eq!(res, NumOpResult::Valid(Amount::from_sat_u32(2)));
+
+        res %= 0_u64;
+        assert_eq!(res, NumOpResult::Error(NumOpError::while_doing(MathOp::Rem)));
+
+        res %= 5_u64;
+        assert_eq!(res, NumOpResult::Error(NumOpError::while_doing(MathOp::Rem)));
+    }
+
+    #[test]
+    fn test_rem_assign_signed_amount() {
+        let ssat = SignedAmount::from_sat_i32(-50);
+
+        let mut res = ssat + ssat;
+        res %= 30_i64;
+        assert_eq!(res, NumOpResult::Valid(SignedAmount::from_sat_i32(-10)));
+
+        res %= &4_i64;
+        assert_eq!(res, NumOpResult::Valid(SignedAmount::from_sat_i32(-2)));
+
+        res %= 0_i64;
+        assert_eq!(res, NumOpResult::Error(NumOpError::while_doing(MathOp::Rem)));
+
+        res %= 5_i64;
+        assert_eq!(res, NumOpResult::Error(NumOpError::while_doing(MathOp::Rem)));
+    }
+
+    #[test]
     fn test_op_assign_amount_error() {
         let mut res: NumOpResult<Amount> = NumOpResult::Error(NumOpError::while_doing(MathOp::Add));
 

--- a/units/src/internal_macros.rs
+++ b/units/src/internal_macros.rs
@@ -191,6 +191,22 @@ macro_rules! impl_div_assign {
 }
 pub(crate) use impl_div_assign;
 
+/// Implement `ops::RemAssign` for `$ty` divided by `$rhs` and `&$rhs`.
+macro_rules! impl_rem_assign {
+    ($ty:ty, $rhs:ident) => {
+        impl core::ops::RemAssign<$rhs> for $ty {
+            #[inline]
+            fn rem_assign(&mut self, rhs: $rhs) { *self = *self % rhs }
+        }
+
+        impl core::ops::RemAssign<&$rhs> for $ty {
+            #[inline]
+            fn rem_assign(&mut self, rhs: &$rhs) { *self = *self % *rhs }
+        }
+    };
+}
+pub(crate) use impl_rem_assign;
+
 /// Implements Lower/UpperHex, Octal and Binary for a new-type `$ty`.
 ///
 /// This macro can be used on raw new-types (e.g. `BlockHeight`), or those encapsulated


### PR DESCRIPTION
Currently, the Amount and SignedAmount types implement Rem<i64/u64>. So that operations can be chained on the NumOpResult types, RemAssign should also be introduced on them with the same semantics, i.e. impl RemAssign<i64/u64> for NumOpResult<Amount/SignedAmount>.

Add RemAssign impls for NumOpResult<Amount/SignedAmount> by i64/u64.

Closes #4031