### PR TITLE
ci: fix api check PR labeler broken producer

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,13 +66,15 @@ jobs:
       - uses: ./.github/actions/setup-rbmt
       - name: "Run API check"
         id: api_check
-        continue-on-error: true
-        run: cargo rbmt api --baseline ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          set +e
+          cargo rbmt api --baseline ${{ github.event.pull_request.base.sha || github.event.before }}
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
       - name: "Save API diff state"
         if: github.event_name == 'pull_request'
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          EXIT_CODE: ${{ steps.api_check.exit_code }}
+          EXIT_CODE: ${{ steps.api_check.outputs.exit_code }}
         run: |
           echo "$PR_NUMBER" > api-diff
           echo "$EXIT_CODE" >> api-diff


### PR DESCRIPTION
This is the producer part of the fix. The consumer half is #6670 (`master` because its default branch, due to GitHub CI rules). The job failed to get the exit code on 0.32.xxx because the action's syntax was wrong. Now it captures it through `GITHUB_OUTPUT`, like `master` semver check.

Before [this](https://github.com/satsfy/rust-bitcoin/actions/runs/30944936194/job/92112457228) happened:
<img width="1060" height="183" alt="image" src="https://github.com/user-attachments/assets/9bc0e19a-0035-4c97-9cea-fe8424f084f9" />

After [the label works](https://github.com/satsfy/rust-bitcoin/actions/runs/30946443116/job/92117493368):
<img width="495" height="126" alt="image" src="https://github.com/user-attachments/assets/8c9ed212-c67f-4ad2-92f6-0fafac5a5d0f" />

