### PR TITLE
units: Remove unnecessary track_caller

### DIFF
--- a/units/src/result.rs
+++ b/units/src/result.rs
@@ -153,7 +153,6 @@ impl<T: fmt::Debug> NumOpResult<T> {
     /// Arguments passed to `unwrap_or` are eagerly evaluated; if you are passing the result of a
     /// function call, it is recommended to use `unwrap_or_else`, which is lazily evaluated.
     #[inline]
-    #[track_caller]
     pub fn unwrap_or(self, default: T) -> T {
         match self {
             Self::Valid(x) => x,
@@ -163,7 +162,6 @@ impl<T: fmt::Debug> NumOpResult<T> {
 
     /// Returns the contained `Valid` value or computes it from a closure.
     #[inline]
-    #[track_caller]
     pub fn unwrap_or_else<F>(self, f: F) -> T
     where
         F: FnOnce() -> T,


### PR DESCRIPTION
I audited `units` with Claude to check for missing usage of `track_caller`. None found but bot did uncover two usages that are unnecessary because the functions don't panic.

Remove unnecessary `track_caller` attributes on functions that do not panic.

Part of #5518