### PR TITLE
units: Add `Div` and `DivAssign` for `NonZero` to `Amount` types

### DIFF
--- a/units/api/all-features.txt
+++ b/units/api/all-features.txt
@@ -1834,6 +1834,10 @@ impl core::ops::arith::Div<u64> for &bitcoin_units::Amount
 impl core::ops::arith::Div<u64> for bitcoin_units::Amount
   pub type bitcoin_units::Amount::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Div<u64> for bitcoin_units::Amount]
   pub fn bitcoin_units::Amount::div(self, rhs: u64) -> Self::Output [impl: impl core::ops::arith::Div<u64> for bitcoin_units::Amount]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount
+  pub fn bitcoin_units::Amount::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount
+  pub fn bitcoin_units::Amount::div_assign(&mut self, rhs: core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount]
 impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64
   pub type u64::Output = <u64 as core::ops::arith::Mul<bitcoin_units::Amount>>::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64]
   pub fn u64::mul(self, rhs: &bitcoin_units::Amount) -> Self::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64]
@@ -2669,6 +2673,10 @@ impl core::ops::arith::Div<i64> for &bitcoin_units::SignedAmount
 impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount
   pub type bitcoin_units::SignedAmount::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> [impl: impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount]
   pub fn bitcoin_units::SignedAmount::div(self, rhs: i64) -> Self::Output [impl: impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount
+  pub fn bitcoin_units::SignedAmount::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount
+  pub fn bitcoin_units::SignedAmount::div_assign(&mut self, rhs: core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount]
 impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64
   pub type i64::Output = <i64 as core::ops::arith::Mul<bitcoin_units::SignedAmount>>::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64]
   pub fn i64::mul(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64]
@@ -8313,6 +8321,12 @@ impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::We
 impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>>>::Output [impl: impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::Weight>) -> Self::Output [impl: impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::Div<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output [impl: impl core::ops::arith::Div<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &i64) -> Self::Output [impl: impl core::ops::arith::Div<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -8355,6 +8369,18 @@ impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Wei
 impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::FeeRate> [impl: impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: bitcoin_units::result::NumOpResult<bitcoin_units::Weight>) -> Self::Output [impl: impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::Div<i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output [impl: impl core::ops::arith::Div<i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: i64) -> Self::Output [impl: impl core::ops::arith::Div<i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -8367,10 +8393,18 @@ impl core::ops::arith::Div<u64> for &bitcoin_units::result::NumOpResult<bitcoin_
 impl core::ops::arith::Div<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Div<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: u64) -> Self::Output [impl: impl core::ops::arith::Div<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::DivAssign<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: &i64) [impl: impl core::ops::arith::DivAssign<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::DivAssign<&u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: &u64) [impl: impl core::ops::arith::DivAssign<&u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::DivAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: i64) [impl: impl core::ops::arith::DivAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::DivAssign<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
@@ -8559,6 +8593,12 @@ impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_un
 impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>>>::Output [impl: impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::Weight>) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output [impl: impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &i64) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -9669,6 +9709,12 @@ impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::We
 impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>>>::Output [impl: impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::Weight>) -> Self::Output [impl: impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::Div<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output [impl: impl core::ops::arith::Div<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &i64) -> Self::Output [impl: impl core::ops::arith::Div<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -9711,6 +9757,18 @@ impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Wei
 impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::FeeRate> [impl: impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: bitcoin_units::result::NumOpResult<bitcoin_units::Weight>) -> Self::Output [impl: impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::Div<i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output [impl: impl core::ops::arith::Div<i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: i64) -> Self::Output [impl: impl core::ops::arith::Div<i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -9723,10 +9781,18 @@ impl core::ops::arith::Div<u64> for &bitcoin_units::result::NumOpResult<bitcoin_
 impl core::ops::arith::Div<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Div<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: u64) -> Self::Output [impl: impl core::ops::arith::Div<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::DivAssign<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: &i64) [impl: impl core::ops::arith::DivAssign<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::DivAssign<&u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: &u64) [impl: impl core::ops::arith::DivAssign<&u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::DivAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: i64) [impl: impl core::ops::arith::DivAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::DivAssign<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
@@ -9915,6 +9981,12 @@ impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_un
 impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>>>::Output [impl: impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::Weight>) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output [impl: impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &i64) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -10212,6 +10284,10 @@ impl core::ops::arith::Div<u64> for &bitcoin_units::Amount
 impl core::ops::arith::Div<u64> for bitcoin_units::Amount
   pub type bitcoin_units::Amount::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Div<u64> for bitcoin_units::Amount]
   pub fn bitcoin_units::Amount::div(self, rhs: u64) -> Self::Output [impl: impl core::ops::arith::Div<u64> for bitcoin_units::Amount]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount
+  pub fn bitcoin_units::Amount::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount
+  pub fn bitcoin_units::Amount::div_assign(&mut self, rhs: core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount]
 impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64
   pub type u64::Output = <u64 as core::ops::arith::Mul<bitcoin_units::Amount>>::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64]
   pub fn u64::mul(self, rhs: &bitcoin_units::Amount) -> Self::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64]
@@ -11527,6 +11603,10 @@ impl core::ops::arith::Div<i64> for &bitcoin_units::SignedAmount
 impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount
   pub type bitcoin_units::SignedAmount::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> [impl: impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount]
   pub fn bitcoin_units::SignedAmount::div(self, rhs: i64) -> Self::Output [impl: impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount
+  pub fn bitcoin_units::SignedAmount::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount
+  pub fn bitcoin_units::SignedAmount::div_assign(&mut self, rhs: core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount]
 impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64
   pub type i64::Output = <i64 as core::ops::arith::Mul<bitcoin_units::SignedAmount>>::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64]
   pub fn i64::mul(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64]

--- a/units/api/all-features.txt
+++ b/units/api/all-features.txt
@@ -1834,6 +1834,10 @@ impl core::ops::arith::Div<u64> for &bitcoin_units::Amount
 impl core::ops::arith::Div<u64> for bitcoin_units::Amount
   pub type bitcoin_units::Amount::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Div<u64> for bitcoin_units::Amount]
   pub fn bitcoin_units::Amount::div(self, rhs: u64) -> Self::Output [impl: impl core::ops::arith::Div<u64> for bitcoin_units::Amount]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount
+  pub fn bitcoin_units::Amount::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount
+  pub fn bitcoin_units::Amount::div_assign(&mut self, rhs: core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount]
 impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64
   pub type u64::Output = <u64 as core::ops::arith::Mul<bitcoin_units::Amount>>::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64]
   pub fn u64::mul(self, rhs: &bitcoin_units::Amount) -> Self::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64]
@@ -2669,6 +2673,10 @@ impl core::ops::arith::Div<i64> for &bitcoin_units::SignedAmount
 impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount
   pub type bitcoin_units::SignedAmount::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> [impl: impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount]
   pub fn bitcoin_units::SignedAmount::div(self, rhs: i64) -> Self::Output [impl: impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount
+  pub fn bitcoin_units::SignedAmount::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount
+  pub fn bitcoin_units::SignedAmount::div_assign(&mut self, rhs: core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount]
 impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64
   pub type i64::Output = <i64 as core::ops::arith::Mul<bitcoin_units::SignedAmount>>::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64]
   pub fn i64::mul(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64]
@@ -8314,6 +8322,12 @@ impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::We
 impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>>>::Output [impl: impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::Weight>) -> Self::Output [impl: impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::Div<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output [impl: impl core::ops::arith::Div<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &i64) -> Self::Output [impl: impl core::ops::arith::Div<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -8356,6 +8370,18 @@ impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Wei
 impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::FeeRate> [impl: impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: bitcoin_units::result::NumOpResult<bitcoin_units::Weight>) -> Self::Output [impl: impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::Div<i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output [impl: impl core::ops::arith::Div<i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: i64) -> Self::Output [impl: impl core::ops::arith::Div<i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -8368,10 +8394,18 @@ impl core::ops::arith::Div<u64> for &bitcoin_units::result::NumOpResult<bitcoin_
 impl core::ops::arith::Div<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Div<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: u64) -> Self::Output [impl: impl core::ops::arith::Div<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::DivAssign<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: &i64) [impl: impl core::ops::arith::DivAssign<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::DivAssign<&u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: &u64) [impl: impl core::ops::arith::DivAssign<&u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::DivAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: i64) [impl: impl core::ops::arith::DivAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::DivAssign<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
@@ -8568,6 +8602,12 @@ impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_un
 impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>>>::Output [impl: impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::Weight>) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output [impl: impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &i64) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -9680,6 +9720,12 @@ impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::We
 impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>>>::Output [impl: impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::Weight>) -> Self::Output [impl: impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::Div<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output [impl: impl core::ops::arith::Div<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &i64) -> Self::Output [impl: impl core::ops::arith::Div<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -9722,6 +9768,18 @@ impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Wei
 impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::FeeRate> [impl: impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: bitcoin_units::result::NumOpResult<bitcoin_units::Weight>) -> Self::Output [impl: impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::Div<i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output [impl: impl core::ops::arith::Div<i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: i64) -> Self::Output [impl: impl core::ops::arith::Div<i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -9734,10 +9792,18 @@ impl core::ops::arith::Div<u64> for &bitcoin_units::result::NumOpResult<bitcoin_
 impl core::ops::arith::Div<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Div<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: u64) -> Self::Output [impl: impl core::ops::arith::Div<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::DivAssign<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: &i64) [impl: impl core::ops::arith::DivAssign<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::DivAssign<&u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: &u64) [impl: impl core::ops::arith::DivAssign<&u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::DivAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: i64) [impl: impl core::ops::arith::DivAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::DivAssign<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
@@ -9934,6 +10000,12 @@ impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_un
 impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>>>::Output [impl: impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::Weight>) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output [impl: impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &i64) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -10231,6 +10303,10 @@ impl core::ops::arith::Div<u64> for &bitcoin_units::Amount
 impl core::ops::arith::Div<u64> for bitcoin_units::Amount
   pub type bitcoin_units::Amount::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Div<u64> for bitcoin_units::Amount]
   pub fn bitcoin_units::Amount::div(self, rhs: u64) -> Self::Output [impl: impl core::ops::arith::Div<u64> for bitcoin_units::Amount]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount
+  pub fn bitcoin_units::Amount::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount
+  pub fn bitcoin_units::Amount::div_assign(&mut self, rhs: core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount]
 impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64
   pub type u64::Output = <u64 as core::ops::arith::Mul<bitcoin_units::Amount>>::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64]
   pub fn u64::mul(self, rhs: &bitcoin_units::Amount) -> Self::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64]
@@ -11547,6 +11623,10 @@ impl core::ops::arith::Div<i64> for &bitcoin_units::SignedAmount
 impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount
   pub type bitcoin_units::SignedAmount::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> [impl: impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount]
   pub fn bitcoin_units::SignedAmount::div(self, rhs: i64) -> Self::Output [impl: impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount
+  pub fn bitcoin_units::SignedAmount::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount
+  pub fn bitcoin_units::SignedAmount::div_assign(&mut self, rhs: core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount]
 impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64
   pub type i64::Output = <i64 as core::ops::arith::Mul<bitcoin_units::SignedAmount>>::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64]
   pub fn i64::mul(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64]

--- a/units/api/alloc-only.txt
+++ b/units/api/alloc-only.txt
@@ -1503,6 +1503,10 @@ impl core::ops::arith::Div<u64> for &bitcoin_units::Amount
 impl core::ops::arith::Div<u64> for bitcoin_units::Amount
   pub type bitcoin_units::Amount::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Div<u64> for bitcoin_units::Amount]
   pub fn bitcoin_units::Amount::div(self, rhs: u64) -> Self::Output [impl: impl core::ops::arith::Div<u64> for bitcoin_units::Amount]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount
+  pub fn bitcoin_units::Amount::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount
+  pub fn bitcoin_units::Amount::div_assign(&mut self, rhs: core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount]
 impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64
   pub type u64::Output = <u64 as core::ops::arith::Mul<bitcoin_units::Amount>>::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64]
   pub fn u64::mul(self, rhs: &bitcoin_units::Amount) -> Self::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64]
@@ -2189,6 +2193,10 @@ impl core::ops::arith::Div<i64> for &bitcoin_units::SignedAmount
 impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount
   pub type bitcoin_units::SignedAmount::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> [impl: impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount]
   pub fn bitcoin_units::SignedAmount::div(self, rhs: i64) -> Self::Output [impl: impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount
+  pub fn bitcoin_units::SignedAmount::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount
+  pub fn bitcoin_units::SignedAmount::div_assign(&mut self, rhs: core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount]
 impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64
   pub type i64::Output = <i64 as core::ops::arith::Mul<bitcoin_units::SignedAmount>>::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64]
   pub fn i64::mul(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64]
@@ -6937,6 +6945,12 @@ impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::We
 impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>>>::Output [impl: impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::Weight>) -> Self::Output [impl: impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::Div<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output [impl: impl core::ops::arith::Div<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &i64) -> Self::Output [impl: impl core::ops::arith::Div<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -6979,6 +6993,18 @@ impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Wei
 impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::FeeRate> [impl: impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: bitcoin_units::result::NumOpResult<bitcoin_units::Weight>) -> Self::Output [impl: impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::Div<i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output [impl: impl core::ops::arith::Div<i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: i64) -> Self::Output [impl: impl core::ops::arith::Div<i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -6991,10 +7017,18 @@ impl core::ops::arith::Div<u64> for &bitcoin_units::result::NumOpResult<bitcoin_
 impl core::ops::arith::Div<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Div<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: u64) -> Self::Output [impl: impl core::ops::arith::Div<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::DivAssign<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: &i64) [impl: impl core::ops::arith::DivAssign<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::DivAssign<&u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: &u64) [impl: impl core::ops::arith::DivAssign<&u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::DivAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: i64) [impl: impl core::ops::arith::DivAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::DivAssign<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
@@ -7189,6 +7223,12 @@ impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_un
 impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>>>::Output [impl: impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::Weight>) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output [impl: impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &i64) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -7918,6 +7958,12 @@ impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::We
 impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>>>::Output [impl: impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::Weight>) -> Self::Output [impl: impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::Div<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output [impl: impl core::ops::arith::Div<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &i64) -> Self::Output [impl: impl core::ops::arith::Div<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -7960,6 +8006,18 @@ impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Wei
 impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::FeeRate> [impl: impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: bitcoin_units::result::NumOpResult<bitcoin_units::Weight>) -> Self::Output [impl: impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::Div<i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output [impl: impl core::ops::arith::Div<i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: i64) -> Self::Output [impl: impl core::ops::arith::Div<i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -7972,10 +8030,18 @@ impl core::ops::arith::Div<u64> for &bitcoin_units::result::NumOpResult<bitcoin_
 impl core::ops::arith::Div<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Div<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: u64) -> Self::Output [impl: impl core::ops::arith::Div<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::DivAssign<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: &i64) [impl: impl core::ops::arith::DivAssign<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::DivAssign<&u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: &u64) [impl: impl core::ops::arith::DivAssign<&u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::DivAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: i64) [impl: impl core::ops::arith::DivAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::DivAssign<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
@@ -8170,6 +8236,12 @@ impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_un
 impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>>>::Output [impl: impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::Weight>) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output [impl: impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &i64) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -8462,6 +8534,10 @@ impl core::ops::arith::Div<u64> for &bitcoin_units::Amount
 impl core::ops::arith::Div<u64> for bitcoin_units::Amount
   pub type bitcoin_units::Amount::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Div<u64> for bitcoin_units::Amount]
   pub fn bitcoin_units::Amount::div(self, rhs: u64) -> Self::Output [impl: impl core::ops::arith::Div<u64> for bitcoin_units::Amount]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount
+  pub fn bitcoin_units::Amount::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount
+  pub fn bitcoin_units::Amount::div_assign(&mut self, rhs: core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount]
 impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64
   pub type u64::Output = <u64 as core::ops::arith::Mul<bitcoin_units::Amount>>::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64]
   pub fn u64::mul(self, rhs: &bitcoin_units::Amount) -> Self::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64]
@@ -9705,6 +9781,10 @@ impl core::ops::arith::Div<i64> for &bitcoin_units::SignedAmount
 impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount
   pub type bitcoin_units::SignedAmount::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> [impl: impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount]
   pub fn bitcoin_units::SignedAmount::div(self, rhs: i64) -> Self::Output [impl: impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount
+  pub fn bitcoin_units::SignedAmount::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount
+  pub fn bitcoin_units::SignedAmount::div_assign(&mut self, rhs: core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount]
 impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64
   pub type i64::Output = <i64 as core::ops::arith::Mul<bitcoin_units::SignedAmount>>::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64]
   pub fn i64::mul(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64]

--- a/units/api/alloc-only.txt
+++ b/units/api/alloc-only.txt
@@ -1503,6 +1503,10 @@ impl core::ops::arith::Div<u64> for &bitcoin_units::Amount
 impl core::ops::arith::Div<u64> for bitcoin_units::Amount
   pub type bitcoin_units::Amount::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Div<u64> for bitcoin_units::Amount]
   pub fn bitcoin_units::Amount::div(self, rhs: u64) -> Self::Output [impl: impl core::ops::arith::Div<u64> for bitcoin_units::Amount]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount
+  pub fn bitcoin_units::Amount::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount
+  pub fn bitcoin_units::Amount::div_assign(&mut self, rhs: core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount]
 impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64
   pub type u64::Output = <u64 as core::ops::arith::Mul<bitcoin_units::Amount>>::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64]
   pub fn u64::mul(self, rhs: &bitcoin_units::Amount) -> Self::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64]
@@ -2189,6 +2193,10 @@ impl core::ops::arith::Div<i64> for &bitcoin_units::SignedAmount
 impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount
   pub type bitcoin_units::SignedAmount::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> [impl: impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount]
   pub fn bitcoin_units::SignedAmount::div(self, rhs: i64) -> Self::Output [impl: impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount
+  pub fn bitcoin_units::SignedAmount::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount
+  pub fn bitcoin_units::SignedAmount::div_assign(&mut self, rhs: core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount]
 impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64
   pub type i64::Output = <i64 as core::ops::arith::Mul<bitcoin_units::SignedAmount>>::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64]
   pub fn i64::mul(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64]
@@ -6936,6 +6944,12 @@ impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::We
 impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>>>::Output [impl: impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::Weight>) -> Self::Output [impl: impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::Div<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output [impl: impl core::ops::arith::Div<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &i64) -> Self::Output [impl: impl core::ops::arith::Div<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -6978,6 +6992,18 @@ impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Wei
 impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::FeeRate> [impl: impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: bitcoin_units::result::NumOpResult<bitcoin_units::Weight>) -> Self::Output [impl: impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::Div<i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output [impl: impl core::ops::arith::Div<i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: i64) -> Self::Output [impl: impl core::ops::arith::Div<i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -6990,10 +7016,18 @@ impl core::ops::arith::Div<u64> for &bitcoin_units::result::NumOpResult<bitcoin_
 impl core::ops::arith::Div<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Div<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: u64) -> Self::Output [impl: impl core::ops::arith::Div<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::DivAssign<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: &i64) [impl: impl core::ops::arith::DivAssign<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::DivAssign<&u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: &u64) [impl: impl core::ops::arith::DivAssign<&u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::DivAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: i64) [impl: impl core::ops::arith::DivAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::DivAssign<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
@@ -7180,6 +7214,12 @@ impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_un
 impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>>>::Output [impl: impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::Weight>) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output [impl: impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &i64) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -7907,6 +7947,12 @@ impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::We
 impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>>>::Output [impl: impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::Weight>) -> Self::Output [impl: impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::Div<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output [impl: impl core::ops::arith::Div<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &i64) -> Self::Output [impl: impl core::ops::arith::Div<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -7949,6 +7995,18 @@ impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Wei
 impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::FeeRate> [impl: impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: bitcoin_units::result::NumOpResult<bitcoin_units::Weight>) -> Self::Output [impl: impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::Div<i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output [impl: impl core::ops::arith::Div<i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: i64) -> Self::Output [impl: impl core::ops::arith::Div<i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -7961,10 +8019,18 @@ impl core::ops::arith::Div<u64> for &bitcoin_units::result::NumOpResult<bitcoin_
 impl core::ops::arith::Div<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Div<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: u64) -> Self::Output [impl: impl core::ops::arith::Div<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::DivAssign<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: &i64) [impl: impl core::ops::arith::DivAssign<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::DivAssign<&u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: &u64) [impl: impl core::ops::arith::DivAssign<&u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::DivAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: i64) [impl: impl core::ops::arith::DivAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::DivAssign<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
@@ -8151,6 +8217,12 @@ impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_un
 impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>>>::Output [impl: impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::Weight>) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output [impl: impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &i64) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -8443,6 +8515,10 @@ impl core::ops::arith::Div<u64> for &bitcoin_units::Amount
 impl core::ops::arith::Div<u64> for bitcoin_units::Amount
   pub type bitcoin_units::Amount::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Div<u64> for bitcoin_units::Amount]
   pub fn bitcoin_units::Amount::div(self, rhs: u64) -> Self::Output [impl: impl core::ops::arith::Div<u64> for bitcoin_units::Amount]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount
+  pub fn bitcoin_units::Amount::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount
+  pub fn bitcoin_units::Amount::div_assign(&mut self, rhs: core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount]
 impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64
   pub type u64::Output = <u64 as core::ops::arith::Mul<bitcoin_units::Amount>>::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64]
   pub fn u64::mul(self, rhs: &bitcoin_units::Amount) -> Self::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64]
@@ -9685,6 +9761,10 @@ impl core::ops::arith::Div<i64> for &bitcoin_units::SignedAmount
 impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount
   pub type bitcoin_units::SignedAmount::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> [impl: impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount]
   pub fn bitcoin_units::SignedAmount::div(self, rhs: i64) -> Self::Output [impl: impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount
+  pub fn bitcoin_units::SignedAmount::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount
+  pub fn bitcoin_units::SignedAmount::div_assign(&mut self, rhs: core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount]
 impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64
   pub type i64::Output = <i64 as core::ops::arith::Mul<bitcoin_units::SignedAmount>>::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64]
   pub fn i64::mul(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64]

--- a/units/api/no-features.txt
+++ b/units/api/no-features.txt
@@ -1317,6 +1317,10 @@ impl core::ops::arith::Div<u64> for &bitcoin_units::Amount
 impl core::ops::arith::Div<u64> for bitcoin_units::Amount
   pub type bitcoin_units::Amount::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Div<u64> for bitcoin_units::Amount]
   pub fn bitcoin_units::Amount::div(self, rhs: u64) -> Self::Output [impl: impl core::ops::arith::Div<u64> for bitcoin_units::Amount]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount
+  pub fn bitcoin_units::Amount::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount
+  pub fn bitcoin_units::Amount::div_assign(&mut self, rhs: core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount]
 impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64
   pub type u64::Output = <u64 as core::ops::arith::Mul<bitcoin_units::Amount>>::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64]
   pub fn u64::mul(self, rhs: &bitcoin_units::Amount) -> Self::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64]
@@ -1931,6 +1935,10 @@ impl core::ops::arith::Div<i64> for &bitcoin_units::SignedAmount
 impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount
   pub type bitcoin_units::SignedAmount::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> [impl: impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount]
   pub fn bitcoin_units::SignedAmount::div(self, rhs: i64) -> Self::Output [impl: impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount
+  pub fn bitcoin_units::SignedAmount::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount
+  pub fn bitcoin_units::SignedAmount::div_assign(&mut self, rhs: core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount]
 impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64
   pub type i64::Output = <i64 as core::ops::arith::Mul<bitcoin_units::SignedAmount>>::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64]
   pub fn i64::mul(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64]
@@ -6126,6 +6134,12 @@ impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::We
 impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>>>::Output [impl: impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::Weight>) -> Self::Output [impl: impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::Div<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output [impl: impl core::ops::arith::Div<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &i64) -> Self::Output [impl: impl core::ops::arith::Div<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -6168,6 +6182,18 @@ impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Wei
 impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::FeeRate> [impl: impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: bitcoin_units::result::NumOpResult<bitcoin_units::Weight>) -> Self::Output [impl: impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::Div<i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output [impl: impl core::ops::arith::Div<i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: i64) -> Self::Output [impl: impl core::ops::arith::Div<i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -6180,10 +6206,18 @@ impl core::ops::arith::Div<u64> for &bitcoin_units::result::NumOpResult<bitcoin_
 impl core::ops::arith::Div<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Div<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: u64) -> Self::Output [impl: impl core::ops::arith::Div<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::DivAssign<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: &i64) [impl: impl core::ops::arith::DivAssign<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::DivAssign<&u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: &u64) [impl: impl core::ops::arith::DivAssign<&u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::DivAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: i64) [impl: impl core::ops::arith::DivAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::DivAssign<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
@@ -6370,6 +6404,12 @@ impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_un
 impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>>>::Output [impl: impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::Weight>) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output [impl: impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &i64) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -7051,6 +7091,12 @@ impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::We
 impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>>>::Output [impl: impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::Weight>) -> Self::Output [impl: impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::Div<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output [impl: impl core::ops::arith::Div<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &i64) -> Self::Output [impl: impl core::ops::arith::Div<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -7093,6 +7139,18 @@ impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Wei
 impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::FeeRate> [impl: impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: bitcoin_units::result::NumOpResult<bitcoin_units::Weight>) -> Self::Output [impl: impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::Div<i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output [impl: impl core::ops::arith::Div<i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: i64) -> Self::Output [impl: impl core::ops::arith::Div<i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -7105,10 +7163,18 @@ impl core::ops::arith::Div<u64> for &bitcoin_units::result::NumOpResult<bitcoin_
 impl core::ops::arith::Div<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Div<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: u64) -> Self::Output [impl: impl core::ops::arith::Div<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::DivAssign<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: &i64) [impl: impl core::ops::arith::DivAssign<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::DivAssign<&u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: &u64) [impl: impl core::ops::arith::DivAssign<&u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::DivAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: i64) [impl: impl core::ops::arith::DivAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::DivAssign<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
@@ -7295,6 +7361,12 @@ impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_un
 impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>>>::Output [impl: impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::Weight>) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output [impl: impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &i64) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -7577,6 +7649,10 @@ impl core::ops::arith::Div<u64> for &bitcoin_units::Amount
 impl core::ops::arith::Div<u64> for bitcoin_units::Amount
   pub type bitcoin_units::Amount::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Div<u64> for bitcoin_units::Amount]
   pub fn bitcoin_units::Amount::div(self, rhs: u64) -> Self::Output [impl: impl core::ops::arith::Div<u64> for bitcoin_units::Amount]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount
+  pub fn bitcoin_units::Amount::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount
+  pub fn bitcoin_units::Amount::div_assign(&mut self, rhs: core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount]
 impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64
   pub type u64::Output = <u64 as core::ops::arith::Mul<bitcoin_units::Amount>>::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64]
   pub fn u64::mul(self, rhs: &bitcoin_units::Amount) -> Self::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64]
@@ -8719,6 +8795,10 @@ impl core::ops::arith::Div<i64> for &bitcoin_units::SignedAmount
 impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount
   pub type bitcoin_units::SignedAmount::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> [impl: impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount]
   pub fn bitcoin_units::SignedAmount::div(self, rhs: i64) -> Self::Output [impl: impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount
+  pub fn bitcoin_units::SignedAmount::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount
+  pub fn bitcoin_units::SignedAmount::div_assign(&mut self, rhs: core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount]
 impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64
   pub type i64::Output = <i64 as core::ops::arith::Mul<bitcoin_units::SignedAmount>>::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64]
   pub fn i64::mul(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64]

--- a/units/api/no-features.txt
+++ b/units/api/no-features.txt
@@ -1317,6 +1317,10 @@ impl core::ops::arith::Div<u64> for &bitcoin_units::Amount
 impl core::ops::arith::Div<u64> for bitcoin_units::Amount
   pub type bitcoin_units::Amount::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Div<u64> for bitcoin_units::Amount]
   pub fn bitcoin_units::Amount::div(self, rhs: u64) -> Self::Output [impl: impl core::ops::arith::Div<u64> for bitcoin_units::Amount]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount
+  pub fn bitcoin_units::Amount::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount
+  pub fn bitcoin_units::Amount::div_assign(&mut self, rhs: core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount]
 impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64
   pub type u64::Output = <u64 as core::ops::arith::Mul<bitcoin_units::Amount>>::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64]
   pub fn u64::mul(self, rhs: &bitcoin_units::Amount) -> Self::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64]
@@ -1931,6 +1935,10 @@ impl core::ops::arith::Div<i64> for &bitcoin_units::SignedAmount
 impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount
   pub type bitcoin_units::SignedAmount::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> [impl: impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount]
   pub fn bitcoin_units::SignedAmount::div(self, rhs: i64) -> Self::Output [impl: impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount
+  pub fn bitcoin_units::SignedAmount::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount
+  pub fn bitcoin_units::SignedAmount::div_assign(&mut self, rhs: core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount]
 impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64
   pub type i64::Output = <i64 as core::ops::arith::Mul<bitcoin_units::SignedAmount>>::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64]
   pub fn i64::mul(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64]
@@ -6127,6 +6135,12 @@ impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::We
 impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>>>::Output [impl: impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::Weight>) -> Self::Output [impl: impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::Div<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output [impl: impl core::ops::arith::Div<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &i64) -> Self::Output [impl: impl core::ops::arith::Div<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -6169,6 +6183,18 @@ impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Wei
 impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::FeeRate> [impl: impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: bitcoin_units::result::NumOpResult<bitcoin_units::Weight>) -> Self::Output [impl: impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::Div<i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output [impl: impl core::ops::arith::Div<i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: i64) -> Self::Output [impl: impl core::ops::arith::Div<i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -6181,10 +6207,18 @@ impl core::ops::arith::Div<u64> for &bitcoin_units::result::NumOpResult<bitcoin_
 impl core::ops::arith::Div<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Div<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: u64) -> Self::Output [impl: impl core::ops::arith::Div<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::DivAssign<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: &i64) [impl: impl core::ops::arith::DivAssign<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::DivAssign<&u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: &u64) [impl: impl core::ops::arith::DivAssign<&u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::DivAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: i64) [impl: impl core::ops::arith::DivAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::DivAssign<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
@@ -6379,6 +6413,12 @@ impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_un
 impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>>>::Output [impl: impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::Weight>) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output [impl: impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &i64) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -7062,6 +7102,12 @@ impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::We
 impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>>>::Output [impl: impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::Weight>) -> Self::Output [impl: impl core::ops::arith::Div<&bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl core::ops::arith::Div<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::Div<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output [impl: impl core::ops::arith::Div<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &i64) -> Self::Output [impl: impl core::ops::arith::Div<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -7104,6 +7150,18 @@ impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Wei
 impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::FeeRate> [impl: impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: bitcoin_units::result::NumOpResult<bitcoin_units::Weight>) -> Self::Output [impl: impl core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl core::ops::arith::Div<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::Div<i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output [impl: impl core::ops::arith::Div<i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: i64) -> Self::Output [impl: impl core::ops::arith::Div<i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -7116,10 +7174,18 @@ impl core::ops::arith::Div<u64> for &bitcoin_units::result::NumOpResult<bitcoin_
 impl core::ops::arith::Div<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Div<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: u64) -> Self::Output [impl: impl core::ops::arith::Div<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::DivAssign<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: &i64) [impl: impl core::ops::arith::DivAssign<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::DivAssign<&u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: &u64) [impl: impl core::ops::arith::DivAssign<&u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div_assign(&mut self, rhs: core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl core::ops::arith::DivAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div_assign(&mut self, rhs: i64) [impl: impl core::ops::arith::DivAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::DivAssign<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
@@ -7314,6 +7380,12 @@ impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_un
 impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub type &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<bitcoin_units::result::NumOpResult<bitcoin_units::Weight>>>::Output [impl: impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
   pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &bitcoin_units::result::NumOpResult<bitcoin_units::Weight>) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a bitcoin_units::result::NumOpResult<bitcoin_units::Weight>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<core::num::nonzero::NonZero<i64>>>::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &core::num::nonzero::NonZeroI64) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<i64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::Amount> as core::ops::arith::Div<core::num::nonzero::NonZero<u64>>>::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::div(self, rhs: &core::num::nonzero::NonZeroU64) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a core::num::nonzero::NonZero<u64>> for &bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
 impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Div<i64>>::Output [impl: impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::div(self, rhs: &i64) -> Self::Output [impl: impl<'a> core::ops::arith::Div<&'a i64> for &bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -7596,6 +7668,10 @@ impl core::ops::arith::Div<u64> for &bitcoin_units::Amount
 impl core::ops::arith::Div<u64> for bitcoin_units::Amount
   pub type bitcoin_units::Amount::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Div<u64> for bitcoin_units::Amount]
   pub fn bitcoin_units::Amount::div(self, rhs: u64) -> Self::Output [impl: impl core::ops::arith::Div<u64> for bitcoin_units::Amount]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount
+  pub fn bitcoin_units::Amount::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount
+  pub fn bitcoin_units::Amount::div_assign(&mut self, rhs: core::num::nonzero::NonZeroU64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<u64>> for bitcoin_units::Amount]
 impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64
   pub type u64::Output = <u64 as core::ops::arith::Mul<bitcoin_units::Amount>>::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64]
   pub fn u64::mul(self, rhs: &bitcoin_units::Amount) -> Self::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::Amount> for u64]
@@ -8739,6 +8815,10 @@ impl core::ops::arith::Div<i64> for &bitcoin_units::SignedAmount
 impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount
   pub type bitcoin_units::SignedAmount::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> [impl: impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount]
   pub fn bitcoin_units::SignedAmount::div(self, rhs: i64) -> Self::Output [impl: impl core::ops::arith::Div<i64> for bitcoin_units::SignedAmount]
+impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount
+  pub fn bitcoin_units::SignedAmount::div_assign(&mut self, rhs: &core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<&core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount]
+impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount
+  pub fn bitcoin_units::SignedAmount::div_assign(&mut self, rhs: core::num::nonzero::NonZeroI64) [impl: impl core::ops::arith::DivAssign<core::num::nonzero::NonZero<i64>> for bitcoin_units::SignedAmount]
 impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64
   pub type i64::Output = <i64 as core::ops::arith::Mul<bitcoin_units::SignedAmount>>::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64]
   pub fn i64::mul(self, rhs: &bitcoin_units::SignedAmount) -> Self::Output [impl: impl core::ops::arith::Mul<&bitcoin_units::SignedAmount> for i64]

--- a/units/src/amount/result.rs
+++ b/units/src/amount/result.rs
@@ -102,6 +102,11 @@ crate::internal_macros::impl_op_for_references! {
 
         fn div(self, rhs: NonZeroU64) -> Self::Output { Self::from_sat(self.to_sat() / rhs.get()).expect("construction after division cannot fail") }
     }
+    impl ops::Div<NonZeroU64> for NumOpResult<Amount> {
+        type Output = NumOpResult<Amount>;
+
+        fn div(self, rhs: NonZeroU64) -> Self::Output { self.map(|lhs| lhs / rhs) }
+    }
     impl ops::Rem<u64> for Amount {
         type Output = NumOpResult<Amount>;
 
@@ -183,6 +188,11 @@ crate::internal_macros::impl_op_for_references! {
 
         fn div(self, rhs: NonZeroI64) -> Self::Output { Self::from_sat(self.to_sat() / rhs.get()).expect("construction after division cannot fail") }
     }
+    impl ops::Div<NonZeroI64> for NumOpResult<SignedAmount> {
+        type Output = NumOpResult<SignedAmount>;
+
+        fn div(self, rhs: NonZeroI64) -> Self::Output { self.map(|lhs| lhs / rhs) }
+    }
     impl ops::Rem<i64> for SignedAmount {
         type Output = NumOpResult<SignedAmount>;
 
@@ -199,6 +209,10 @@ impl_mul_assign!(NumOpResult<Amount>, u64);
 impl_mul_assign!(NumOpResult<SignedAmount>, i64);
 impl_div_assign!(NumOpResult<Amount>, u64);
 impl_div_assign!(NumOpResult<SignedAmount>, i64);
+impl_div_assign!(Amount, NonZeroU64);
+impl_div_assign!(SignedAmount, NonZeroI64);
+impl_div_assign!(NumOpResult<Amount>, NonZeroU64);
+impl_div_assign!(NumOpResult<SignedAmount>, NonZeroI64);
 
 impl_add_assign_for_results!(Amount);
 impl_add_assign_for_results!(SignedAmount);

--- a/units/src/amount/result.rs
+++ b/units/src/amount/result.rs
@@ -416,6 +416,49 @@ mod tests {
     }
 
     #[test]
+    fn test_div_assign_amount_nonzero() {
+        let mut amount = Amount::from_sat_u32(100);
+        amount /= NonZeroU64::new(12).unwrap();
+        assert_eq!(amount, Amount::from_sat_u32(8));
+
+        // Division truncates towards zero.
+        amount /= NonZeroU64::new(10).unwrap();
+        assert_eq!(amount, Amount::ZERO);
+
+        let mut res = amount + Amount::from_sat_u32(100);
+        res /= NonZeroU64::new(4).unwrap();
+        assert_eq!(res, NumOpResult::Valid(Amount::from_sat_u32(25)));
+
+        // An error result stays an error, keeping the original operation.
+        let mut res: NumOpResult<Amount> = NumOpResult::Error(NumOpError::while_doing(MathOp::Add));
+        res /= NonZeroU64::new(2).unwrap();
+        assert_eq!(res, NumOpResult::Error(NumOpError::while_doing(MathOp::Add)));
+    }
+
+    #[test]
+    fn test_div_assign_signed_amount_nonzero() {
+        let mut ssat = SignedAmount::from_sat_i32(-100);
+        ssat /= NonZeroI64::new(4).unwrap();
+        assert_eq!(ssat, SignedAmount::from_sat_i32(-25));
+
+        ssat /= &NonZeroI64::new(-5).unwrap();
+        assert_eq!(ssat, SignedAmount::from_sat_i32(5));
+
+        // Division truncates towards zero.
+        ssat /= NonZeroI64::new(-10).unwrap();
+        assert_eq!(ssat, SignedAmount::ZERO);
+
+        let mut res = ssat - SignedAmount::from_sat_i32(100);
+        res /= NonZeroI64::new(4).unwrap();
+        assert_eq!(res, NumOpResult::Valid(SignedAmount::from_sat_i32(-25)));
+
+        let mut res: NumOpResult<SignedAmount> =
+            NumOpResult::Error(NumOpError::while_doing(MathOp::Sub));
+        res /= NonZeroI64::new(2).unwrap();
+        assert_eq!(res, NumOpResult::Error(NumOpError::while_doing(MathOp::Sub)));
+    }
+
+    #[test]
     fn test_op_assign_amount_error() {
         let mut res: NumOpResult<Amount> = NumOpResult::Error(NumOpError::while_doing(MathOp::Add));
 

--- a/units/src/amount/result.rs
+++ b/units/src/amount/result.rs
@@ -454,6 +454,49 @@ mod tests {
     }
 
     #[test]
+    fn test_div_assign_amount_nonzero() {
+        let mut amount = Amount::from_sat_u32(100);
+        amount /= NonZeroU64::new(12).unwrap();
+        assert_eq!(amount, Amount::from_sat_u32(8));
+
+        // Division truncates towards zero.
+        amount /= NonZeroU64::new(10).unwrap();
+        assert_eq!(amount, Amount::ZERO);
+
+        let mut res = amount + Amount::from_sat_u32(100);
+        res /= NonZeroU64::new(4).unwrap();
+        assert_eq!(res, NumOpResult::Valid(Amount::from_sat_u32(25)));
+
+        // An error result stays an error, keeping the original operation.
+        let mut res: NumOpResult<Amount> = NumOpResult::Error(NumOpError::while_doing(MathOp::Add));
+        res /= NonZeroU64::new(2).unwrap();
+        assert_eq!(res, NumOpResult::Error(NumOpError::while_doing(MathOp::Add)));
+    }
+
+    #[test]
+    fn test_div_assign_signed_amount_nonzero() {
+        let mut ssat = SignedAmount::from_sat_i32(-100);
+        ssat /= NonZeroI64::new(4).unwrap();
+        assert_eq!(ssat, SignedAmount::from_sat_i32(-25));
+
+        ssat /= &NonZeroI64::new(-5).unwrap();
+        assert_eq!(ssat, SignedAmount::from_sat_i32(5));
+
+        // Division truncates towards zero.
+        ssat /= NonZeroI64::new(-10).unwrap();
+        assert_eq!(ssat, SignedAmount::ZERO);
+
+        let mut res = ssat - SignedAmount::from_sat_i32(100);
+        res /= NonZeroI64::new(4).unwrap();
+        assert_eq!(res, NumOpResult::Valid(SignedAmount::from_sat_i32(-25)));
+
+        let mut res: NumOpResult<SignedAmount> =
+            NumOpResult::Error(NumOpError::while_doing(MathOp::Sub));
+        res /= NonZeroI64::new(2).unwrap();
+        assert_eq!(res, NumOpResult::Error(NumOpError::while_doing(MathOp::Sub)));
+    }
+
+    #[test]
     fn test_op_assign_amount_error() {
         let mut res: NumOpResult<Amount> = NumOpResult::Error(NumOpError::while_doing(MathOp::Add));
 

--- a/units/src/amount/result.rs
+++ b/units/src/amount/result.rs
@@ -103,6 +103,11 @@ crate::internal_macros::impl_op_for_references! {
 
         fn div(self, rhs: NonZeroU64) -> Self::Output { Self::from_sat(self.to_sat() / rhs.get()).expect("construction after division cannot fail") }
     }
+    impl ops::Div<NonZeroU64> for NumOpResult<Amount> {
+        type Output = NumOpResult<Amount>;
+
+        fn div(self, rhs: NonZeroU64) -> Self::Output { self.map(|lhs| lhs / rhs) }
+    }
     impl ops::Rem<u64> for Amount {
         type Output = NumOpResult<Amount>;
 
@@ -184,6 +189,11 @@ crate::internal_macros::impl_op_for_references! {
 
         fn div(self, rhs: NonZeroI64) -> Self::Output { Self::from_sat(self.to_sat() / rhs.get()).expect("construction after division cannot fail") }
     }
+    impl ops::Div<NonZeroI64> for NumOpResult<SignedAmount> {
+        type Output = NumOpResult<SignedAmount>;
+
+        fn div(self, rhs: NonZeroI64) -> Self::Output { self.map(|lhs| lhs / rhs) }
+    }
     impl ops::Rem<i64> for SignedAmount {
         type Output = NumOpResult<SignedAmount>;
 
@@ -200,6 +210,10 @@ impl_mul_assign!(NumOpResult<Amount>, u64);
 impl_mul_assign!(NumOpResult<SignedAmount>, i64);
 impl_div_assign!(NumOpResult<Amount>, u64);
 impl_div_assign!(NumOpResult<SignedAmount>, i64);
+impl_div_assign!(Amount, NonZeroU64);
+impl_div_assign!(SignedAmount, NonZeroI64);
+impl_div_assign!(NumOpResult<Amount>, NonZeroU64);
+impl_div_assign!(NumOpResult<SignedAmount>, NonZeroI64);
 impl_rem_assign!(NumOpResult<Amount>, u64);
 impl_rem_assign!(NumOpResult<SignedAmount>, i64);
 


### PR DESCRIPTION
Currently, Amount and SignedAmount can be divided by NonZeroU64/I64, and in both cases yield their original types due to the infallibility of the operation. In order to mirror Amount ops with NumOpResult and \*Assign ops, Div<NonZero*> impls should be included for NumOpResult, and corresponding DivAssign impls should be added for all types.

Add Div<NonZero\*64> for NumOpResult and DivAssign<NonZero*64> for Amount, SignedAmount and NumOpResult.