### PR TITLE
primitives: Add track_caller

### DIFF
--- a/primitives/src/script/borrowed.rs
+++ b/primitives/src/script/borrowed.rs
@@ -361,6 +361,7 @@ macro_rules! delegate_index {
                 type Output = Self;
 
                 #[inline]
+                #[track_caller]
                 fn index(&self, index: $type) -> &Self::Output {
                     Self::from_bytes(&self.as_bytes()[index])
                 }


### PR DESCRIPTION
Audit `primitives` with Claude for missing instances of `track_caller`. Just one found.

Add `track_caller` to the macro defined `index` function.