### PR TITLE
units: Add `Weight::to_vb_*` functions, deprecating `to_vbytes_*`

### DIFF
--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -400,7 +400,7 @@ impl TransactionExt for Transaction {
     #[inline]
     fn vsize(&self) -> usize {
         // No overflow because it's computed from data in memory
-        self.weight().to_vbytes_ceil() as usize
+        self.weight().to_vb_ceil() as usize
     }
 
     fn is_explicitly_rbf(&self) -> bool { self.inputs.iter().any(|input| input.sequence.is_rbf()) }

--- a/fuzz/fuzz_targets/units/arbitrary_weight.rs
+++ b/fuzz/fuzz_targets/units/arbitrary_weight.rs
@@ -16,8 +16,8 @@ fn do_test(data: &[u8]) {
         weight.to_wu();
         weight.to_kwu_ceil();
         weight.to_kwu_floor();
-        weight.to_vbytes_ceil();
-        weight.to_vbytes_floor();
+        weight.to_vb_ceil();
+        weight.to_vb_floor();
 
         // Operations that take u64 as the rhs
         for operation in [Weight::checked_mul, Weight::checked_div] {

--- a/units/api/all-features.txt
+++ b/units/api/all-features.txt
@@ -9320,6 +9320,8 @@ pub const fn bitcoin_units::Weight::from_vb_unchecked(vb: u64) -> Self
 pub const fn bitcoin_units::Weight::mul_by_fee_rate(self, fee_rate: bitcoin_units::FeeRate) -> bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
 pub const fn bitcoin_units::Weight::to_kwu_ceil(self) -> u64
 pub const fn bitcoin_units::Weight::to_kwu_floor(self) -> u64
+pub const fn bitcoin_units::Weight::to_vb_ceil(self) -> u64
+pub const fn bitcoin_units::Weight::to_vb_floor(self) -> u64
 pub const fn bitcoin_units::Weight::to_vbytes_ceil(self) -> u64
 pub const fn bitcoin_units::Weight::to_vbytes_floor(self) -> u64
 impl bitcoin_units::Weight
@@ -11747,6 +11749,8 @@ pub const fn bitcoin_units::Weight::from_vb_unchecked(vb: u64) -> Self
 pub const fn bitcoin_units::Weight::mul_by_fee_rate(self, fee_rate: bitcoin_units::FeeRate) -> bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
 pub const fn bitcoin_units::Weight::to_kwu_ceil(self) -> u64
 pub const fn bitcoin_units::Weight::to_kwu_floor(self) -> u64
+pub const fn bitcoin_units::Weight::to_vb_ceil(self) -> u64
+pub const fn bitcoin_units::Weight::to_vb_floor(self) -> u64
 pub const fn bitcoin_units::Weight::to_vbytes_ceil(self) -> u64
 pub const fn bitcoin_units::Weight::to_vbytes_floor(self) -> u64
 impl bitcoin_units::Weight

--- a/units/api/alloc-only.txt
+++ b/units/api/alloc-only.txt
@@ -7565,6 +7565,8 @@ pub const fn bitcoin_units::Weight::from_vb_unchecked(vb: u64) -> Self
 pub const fn bitcoin_units::Weight::mul_by_fee_rate(self, fee_rate: bitcoin_units::FeeRate) -> bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
 pub const fn bitcoin_units::Weight::to_kwu_ceil(self) -> u64
 pub const fn bitcoin_units::Weight::to_kwu_floor(self) -> u64
+pub const fn bitcoin_units::Weight::to_vb_ceil(self) -> u64
+pub const fn bitcoin_units::Weight::to_vb_floor(self) -> u64
 pub const fn bitcoin_units::Weight::to_vbytes_ceil(self) -> u64
 pub const fn bitcoin_units::Weight::to_vbytes_floor(self) -> u64
 impl bitcoin_units::Weight
@@ -9898,6 +9900,8 @@ pub const fn bitcoin_units::Weight::from_vb_unchecked(vb: u64) -> Self
 pub const fn bitcoin_units::Weight::mul_by_fee_rate(self, fee_rate: bitcoin_units::FeeRate) -> bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
 pub const fn bitcoin_units::Weight::to_kwu_ceil(self) -> u64
 pub const fn bitcoin_units::Weight::to_kwu_floor(self) -> u64
+pub const fn bitcoin_units::Weight::to_vb_ceil(self) -> u64
+pub const fn bitcoin_units::Weight::to_vb_floor(self) -> u64
 pub const fn bitcoin_units::Weight::to_vbytes_ceil(self) -> u64
 pub const fn bitcoin_units::Weight::to_vbytes_floor(self) -> u64
 impl bitcoin_units::Weight

--- a/units/api/no-features.txt
+++ b/units/api/no-features.txt
@@ -6721,6 +6721,8 @@ pub const fn bitcoin_units::Weight::from_vb_unchecked(vb: u64) -> Self
 pub const fn bitcoin_units::Weight::mul_by_fee_rate(self, fee_rate: bitcoin_units::FeeRate) -> bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
 pub const fn bitcoin_units::Weight::to_kwu_ceil(self) -> u64
 pub const fn bitcoin_units::Weight::to_kwu_floor(self) -> u64
+pub const fn bitcoin_units::Weight::to_vb_ceil(self) -> u64
+pub const fn bitcoin_units::Weight::to_vb_floor(self) -> u64
 pub const fn bitcoin_units::Weight::to_vbytes_ceil(self) -> u64
 pub const fn bitcoin_units::Weight::to_vbytes_floor(self) -> u64
 impl bitcoin_units::Weight
@@ -8920,6 +8922,8 @@ pub const fn bitcoin_units::Weight::from_vb_unchecked(vb: u64) -> Self
 pub const fn bitcoin_units::Weight::mul_by_fee_rate(self, fee_rate: bitcoin_units::FeeRate) -> bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
 pub const fn bitcoin_units::Weight::to_kwu_ceil(self) -> u64
 pub const fn bitcoin_units::Weight::to_kwu_floor(self) -> u64
+pub const fn bitcoin_units::Weight::to_vb_ceil(self) -> u64
+pub const fn bitcoin_units::Weight::to_vb_floor(self) -> u64
 pub const fn bitcoin_units::Weight::to_vbytes_ceil(self) -> u64
 pub const fn bitcoin_units::Weight::to_vbytes_floor(self) -> u64
 impl bitcoin_units::Weight

--- a/units/src/weight.rs
+++ b/units/src/weight.rs
@@ -428,15 +428,15 @@ mod tests {
 
     #[test]
     fn to_vb_floor() {
-        assert_eq!(Weight::from_wu(8).to_vbytes_floor(), 2);
-        assert_eq!(Weight::from_wu(9).to_vbytes_floor(), 2);
+        assert_eq!(Weight::from_wu(8).to_vb_floor(), 2);
+        assert_eq!(Weight::from_wu(9).to_vb_floor(), 2);
     }
 
     #[test]
     fn to_vb_ceil() {
-        assert_eq!(Weight::from_wu(4).to_vbytes_ceil(), 1);
-        assert_eq!(Weight::from_wu(5).to_vbytes_ceil(), 2);
-        assert_eq!(Weight::MAX.to_vbytes_ceil(), u64::MAX / Weight::WITNESS_SCALE_FACTOR + 1);
+        assert_eq!(Weight::from_wu(4).to_vb_ceil(), 1);
+        assert_eq!(Weight::from_wu(5).to_vb_ceil(), 2);
+        assert_eq!(Weight::MAX.to_vb_ceil(), u64::MAX / Weight::WITNESS_SCALE_FACTOR + 1);
     }
 
     #[test]

--- a/units/src/weight.rs
+++ b/units/src/weight.rs
@@ -120,10 +120,20 @@ impl Weight {
 
     /// Converts to vB rounding down.
     #[inline]
+    pub const fn to_vb_floor(self) -> u64 { self.to_wu() / Self::WITNESS_SCALE_FACTOR }
+
+    /// Converts to vB rounding down.
+    #[inline]
+    #[deprecated(since = "TBD", note = "use `to_vb_floor()` instead")]
     pub const fn to_vbytes_floor(self) -> u64 { self.to_wu() / Self::WITNESS_SCALE_FACTOR }
 
     /// Converts to vB rounding up.
     #[inline]
+    pub const fn to_vb_ceil(self) -> u64 { self.to_wu().div_ceil(Self::WITNESS_SCALE_FACTOR) }
+
+    /// Converts to vB rounding up.
+    #[inline]
+    #[deprecated(since = "TBD", note = "use `to_vbytes_ceil()` instead")]
     pub const fn to_vbytes_ceil(self) -> u64 { self.to_wu().div_ceil(Self::WITNESS_SCALE_FACTOR) }
 
     /// Checked addition.


### PR DESCRIPTION
The Weight type uses from_vb* as the pattern for constructors, but to_vbytes_* for conversion. FeeRate is consistent with to/from_vb*. Before we go to 1.0, Weight's conversion functions should be renamed to keep everything consistent.

Add Weight::to_vb_{floor,ceil} and deprecate Weight::to_vbytes_{floor,ceil}.