### PR TITLE
units: Split Div/Rem into distinct variants

### DIFF
--- a/units/api/all-features.txt
+++ b/units/api/all-features.txt
@@ -8189,10 +8189,12 @@ impl<T> core::convert::From<T> for bitcoin_units::result::error::NumOpError
   pub fn bitcoin_units::result::error::NumOpError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::result::error::NumOpError]
 #[non_exhaustive] pub enum bitcoin_units::result::MathOp
 pub bitcoin_units::result::MathOp::Add
-pub bitcoin_units::result::MathOp::Div
+pub bitcoin_units::result::MathOp::DivByZero
+pub bitcoin_units::result::MathOp::DivOverflow
 pub bitcoin_units::result::MathOp::Mul
 pub bitcoin_units::result::MathOp::Neg
-pub bitcoin_units::result::MathOp::Rem
+pub bitcoin_units::result::MathOp::RemByZero
+pub bitcoin_units::result::MathOp::RemOverflow
 pub bitcoin_units::result::MathOp::Sub
 impl bitcoin_units::result::MathOp
 pub fn bitcoin_units::result::MathOp::is_addition(self) -> bool

--- a/units/api/all-features.txt
+++ b/units/api/all-features.txt
@@ -8205,10 +8205,12 @@ impl<T> core::convert::From<T> for bitcoin_units::result::error::NumOpError
   pub fn bitcoin_units::result::error::NumOpError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::result::error::NumOpError]
 #[non_exhaustive] pub enum bitcoin_units::result::MathOp
 pub bitcoin_units::result::MathOp::Add
-pub bitcoin_units::result::MathOp::Div
+pub bitcoin_units::result::MathOp::DivByZero
+pub bitcoin_units::result::MathOp::DivOverflow
 pub bitcoin_units::result::MathOp::Mul
 pub bitcoin_units::result::MathOp::Neg
-pub bitcoin_units::result::MathOp::Rem
+pub bitcoin_units::result::MathOp::RemByZero
+pub bitcoin_units::result::MathOp::RemOverflow
 pub bitcoin_units::result::MathOp::Sub
 impl bitcoin_units::result::MathOp
 pub fn bitcoin_units::result::MathOp::is_addition(self) -> bool

--- a/units/api/alloc-only.txt
+++ b/units/api/alloc-only.txt
@@ -6814,10 +6814,12 @@ impl<T> core::convert::From<T> for bitcoin_units::result::error::NumOpError
   pub fn bitcoin_units::result::error::NumOpError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::result::error::NumOpError]
 #[non_exhaustive] pub enum bitcoin_units::result::MathOp
 pub bitcoin_units::result::MathOp::Add
-pub bitcoin_units::result::MathOp::Div
+pub bitcoin_units::result::MathOp::DivByZero
+pub bitcoin_units::result::MathOp::DivOverflow
 pub bitcoin_units::result::MathOp::Mul
 pub bitcoin_units::result::MathOp::Neg
-pub bitcoin_units::result::MathOp::Rem
+pub bitcoin_units::result::MathOp::RemByZero
+pub bitcoin_units::result::MathOp::RemOverflow
 pub bitcoin_units::result::MathOp::Sub
 impl bitcoin_units::result::MathOp
 pub fn bitcoin_units::result::MathOp::is_addition(self) -> bool

--- a/units/api/alloc-only.txt
+++ b/units/api/alloc-only.txt
@@ -6826,10 +6826,12 @@ impl<T> core::convert::From<T> for bitcoin_units::result::error::NumOpError
   pub fn bitcoin_units::result::error::NumOpError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::result::error::NumOpError]
 #[non_exhaustive] pub enum bitcoin_units::result::MathOp
 pub bitcoin_units::result::MathOp::Add
-pub bitcoin_units::result::MathOp::Div
+pub bitcoin_units::result::MathOp::DivByZero
+pub bitcoin_units::result::MathOp::DivOverflow
 pub bitcoin_units::result::MathOp::Mul
 pub bitcoin_units::result::MathOp::Neg
-pub bitcoin_units::result::MathOp::Rem
+pub bitcoin_units::result::MathOp::RemByZero
+pub bitcoin_units::result::MathOp::RemOverflow
 pub bitcoin_units::result::MathOp::Sub
 impl bitcoin_units::result::MathOp
 pub fn bitcoin_units::result::MathOp::is_addition(self) -> bool

--- a/units/api/no-features.txt
+++ b/units/api/no-features.txt
@@ -6010,10 +6010,12 @@ impl<T> core::convert::From<T> for bitcoin_units::result::error::NumOpError
   pub fn bitcoin_units::result::error::NumOpError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::result::error::NumOpError]
 #[non_exhaustive] pub enum bitcoin_units::result::MathOp
 pub bitcoin_units::result::MathOp::Add
-pub bitcoin_units::result::MathOp::Div
+pub bitcoin_units::result::MathOp::DivByZero
+pub bitcoin_units::result::MathOp::DivOverflow
 pub bitcoin_units::result::MathOp::Mul
 pub bitcoin_units::result::MathOp::Neg
-pub bitcoin_units::result::MathOp::Rem
+pub bitcoin_units::result::MathOp::RemByZero
+pub bitcoin_units::result::MathOp::RemOverflow
 pub bitcoin_units::result::MathOp::Sub
 impl bitcoin_units::result::MathOp
 pub fn bitcoin_units::result::MathOp::is_addition(self) -> bool

--- a/units/api/no-features.txt
+++ b/units/api/no-features.txt
@@ -6022,10 +6022,12 @@ impl<T> core::convert::From<T> for bitcoin_units::result::error::NumOpError
   pub fn bitcoin_units::result::error::NumOpError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_units::result::error::NumOpError]
 #[non_exhaustive] pub enum bitcoin_units::result::MathOp
 pub bitcoin_units::result::MathOp::Add
-pub bitcoin_units::result::MathOp::Div
+pub bitcoin_units::result::MathOp::DivByZero
+pub bitcoin_units::result::MathOp::DivOverflow
 pub bitcoin_units::result::MathOp::Mul
 pub bitcoin_units::result::MathOp::Neg
-pub bitcoin_units::result::MathOp::Rem
+pub bitcoin_units::result::MathOp::RemByZero
+pub bitcoin_units::result::MathOp::RemOverflow
 pub bitcoin_units::result::MathOp::Sub
 impl bitcoin_units::result::MathOp
 pub fn bitcoin_units::result::MathOp::is_addition(self) -> bool

--- a/units/src/amount/result.rs
+++ b/units/src/amount/result.rs
@@ -83,7 +83,7 @@ crate::internal_macros::impl_op_for_references! {
     impl ops::Div<u64> for Amount {
         type Output = NumOpResult<Amount>;
 
-        fn div(self, rhs: u64) -> Self::Output { self.checked_div(rhs).valid_or_error(MathOp::Div) }
+        fn div(self, rhs: u64) -> Self::Output { self.checked_div(rhs).valid_or_error(MathOp::DivByZero) }
     }
     impl ops::Div<u64> for NumOpResult<Amount> {
         type Output = NumOpResult<Amount>;
@@ -94,7 +94,7 @@ crate::internal_macros::impl_op_for_references! {
         type Output = NumOpResult<u64>;
 
         fn div(self, rhs: Amount) -> Self::Output {
-            self.to_sat().checked_div(rhs.to_sat()).valid_or_error(MathOp::Div)
+            self.to_sat().checked_div(rhs.to_sat()).valid_or_error(MathOp::DivByZero)
         }
     }
     impl ops::Div<NonZeroU64> for Amount {
@@ -105,7 +105,7 @@ crate::internal_macros::impl_op_for_references! {
     impl ops::Rem<u64> for Amount {
         type Output = NumOpResult<Amount>;
 
-        fn rem(self, modulus: u64) -> Self::Output { self.checked_rem(modulus).valid_or_error(MathOp::Rem) }
+        fn rem(self, modulus: u64) -> Self::Output { self.checked_rem(modulus).valid_or_error(MathOp::RemByZero) }
     }
     impl ops::Rem<u64> for NumOpResult<Amount> {
         type Output = NumOpResult<Amount>;
@@ -164,7 +164,11 @@ crate::internal_macros::impl_op_for_references! {
     impl ops::Div<i64> for SignedAmount {
         type Output = NumOpResult<SignedAmount>;
 
-        fn div(self, rhs: i64) -> Self::Output { self.checked_div(rhs).valid_or_error(MathOp::Div) }
+        fn div(self, rhs: i64) -> Self::Output {
+            // `i64::checked_div` returns `None` only for `rhs == 0` or `self == i64::MIN && rhs == -1`.
+            let op = if rhs == 0 { MathOp::DivByZero } else { MathOp::DivOverflow };
+            self.checked_div(rhs).valid_or_error(op)
+        }
     }
     impl ops::Div<i64> for NumOpResult<SignedAmount> {
         type Output = NumOpResult<SignedAmount>;
@@ -175,7 +179,8 @@ crate::internal_macros::impl_op_for_references! {
         type Output = NumOpResult<i64>;
 
         fn div(self, rhs: SignedAmount) -> Self::Output {
-            self.to_sat().checked_div(rhs.to_sat()).valid_or_error(MathOp::Div)
+            let op = if rhs.to_sat() == 0 { MathOp::DivByZero } else { MathOp::DivOverflow };
+            self.to_sat().checked_div(rhs.to_sat()).valid_or_error(op)
         }
     }
     impl ops::Div<NonZeroI64> for SignedAmount {
@@ -186,7 +191,11 @@ crate::internal_macros::impl_op_for_references! {
     impl ops::Rem<i64> for SignedAmount {
         type Output = NumOpResult<SignedAmount>;
 
-        fn rem(self, modulus: i64) -> Self::Output { self.checked_rem(modulus).valid_or_error(MathOp::Rem) }
+        fn rem(self, modulus: i64) -> Self::Output {
+            // `i64::checked_rem` returns `None` only for `modulus == 0` or `self == i64::MIN && modulus == -1`.
+            let op = if modulus == 0 { MathOp::RemByZero } else { MathOp::RemOverflow };
+            self.checked_rem(modulus).valid_or_error(op)
+        }
     }
     impl ops::Rem<i64> for NumOpResult<SignedAmount> {
         type Output = NumOpResult<SignedAmount>;

--- a/units/src/amount/result.rs
+++ b/units/src/amount/result.rs
@@ -84,7 +84,7 @@ crate::internal_macros::impl_op_for_references! {
     impl ops::Div<u64> for Amount {
         type Output = NumOpResult<Amount>;
 
-        fn div(self, rhs: u64) -> Self::Output { self.checked_div(rhs).valid_or_error(MathOp::Div) }
+        fn div(self, rhs: u64) -> Self::Output { self.checked_div(rhs).valid_or_error(MathOp::DivByZero) }
     }
     impl ops::Div<u64> for NumOpResult<Amount> {
         type Output = NumOpResult<Amount>;
@@ -95,7 +95,7 @@ crate::internal_macros::impl_op_for_references! {
         type Output = NumOpResult<u64>;
 
         fn div(self, rhs: Amount) -> Self::Output {
-            self.to_sat().checked_div(rhs.to_sat()).valid_or_error(MathOp::Div)
+            self.to_sat().checked_div(rhs.to_sat()).valid_or_error(MathOp::DivByZero)
         }
     }
     impl ops::Div<NonZeroU64> for Amount {
@@ -111,7 +111,7 @@ crate::internal_macros::impl_op_for_references! {
     impl ops::Rem<u64> for Amount {
         type Output = NumOpResult<Amount>;
 
-        fn rem(self, modulus: u64) -> Self::Output { self.checked_rem(modulus).valid_or_error(MathOp::Rem) }
+        fn rem(self, modulus: u64) -> Self::Output { self.checked_rem(modulus).valid_or_error(MathOp::RemByZero) }
     }
     impl ops::Rem<u64> for NumOpResult<Amount> {
         type Output = NumOpResult<Amount>;
@@ -170,7 +170,11 @@ crate::internal_macros::impl_op_for_references! {
     impl ops::Div<i64> for SignedAmount {
         type Output = NumOpResult<SignedAmount>;
 
-        fn div(self, rhs: i64) -> Self::Output { self.checked_div(rhs).valid_or_error(MathOp::Div) }
+        fn div(self, rhs: i64) -> Self::Output {
+            // `i64::checked_div` returns `None` only for `rhs == 0` or `self == i64::MIN && rhs == -1`.
+            let op = if rhs == 0 { MathOp::DivByZero } else { MathOp::DivOverflow };
+            self.checked_div(rhs).valid_or_error(op)
+        }
     }
     impl ops::Div<i64> for NumOpResult<SignedAmount> {
         type Output = NumOpResult<SignedAmount>;
@@ -181,7 +185,8 @@ crate::internal_macros::impl_op_for_references! {
         type Output = NumOpResult<i64>;
 
         fn div(self, rhs: SignedAmount) -> Self::Output {
-            self.to_sat().checked_div(rhs.to_sat()).valid_or_error(MathOp::Div)
+            let op = if rhs.to_sat() == 0 { MathOp::DivByZero } else { MathOp::DivOverflow };
+            self.to_sat().checked_div(rhs.to_sat()).valid_or_error(op)
         }
     }
     impl ops::Div<NonZeroI64> for SignedAmount {
@@ -197,7 +202,11 @@ crate::internal_macros::impl_op_for_references! {
     impl ops::Rem<i64> for SignedAmount {
         type Output = NumOpResult<SignedAmount>;
 
-        fn rem(self, modulus: i64) -> Self::Output { self.checked_rem(modulus).valid_or_error(MathOp::Rem) }
+        fn rem(self, modulus: i64) -> Self::Output {
+            // `i64::checked_rem` returns `None` only for `modulus == 0` or `self == i64::MIN && modulus == -1`.
+            let op = if modulus == 0 { MathOp::RemByZero } else { MathOp::RemOverflow };
+            self.checked_rem(modulus).valid_or_error(op)
+        }
     }
     impl ops::Rem<i64> for NumOpResult<SignedAmount> {
         type Output = NumOpResult<SignedAmount>;
@@ -444,10 +453,11 @@ mod tests {
         assert_eq!(res, NumOpResult::Valid(Amount::from_sat_u32(2)));
 
         res %= 0_u64;
-        assert_eq!(res, NumOpResult::Error(NumOpError::while_doing(MathOp::Rem)));
+        assert_eq!(res, NumOpResult::Error(NumOpError::while_doing(MathOp::RemByZero)));
 
         res %= 5_u64;
-        assert_eq!(res, NumOpResult::Error(NumOpError::while_doing(MathOp::Rem)));
+        // Still the previous error.
+        assert_eq!(res, NumOpResult::Error(NumOpError::while_doing(MathOp::RemByZero)));
     }
 
     #[test]
@@ -462,10 +472,11 @@ mod tests {
         assert_eq!(res, NumOpResult::Valid(SignedAmount::from_sat_i32(-2)));
 
         res %= 0_i64;
-        assert_eq!(res, NumOpResult::Error(NumOpError::while_doing(MathOp::Rem)));
+        assert_eq!(res, NumOpResult::Error(NumOpError::while_doing(MathOp::RemByZero)));
 
         res %= 5_i64;
-        assert_eq!(res, NumOpResult::Error(NumOpError::while_doing(MathOp::Rem)));
+        // Still the previous error.
+        assert_eq!(res, NumOpResult::Error(NumOpError::while_doing(MathOp::RemByZero)));
     }
 
     #[test]

--- a/units/src/amount/tests.rs
+++ b/units/src/amount/tests.rs
@@ -193,8 +193,10 @@ fn display_math_op() {
         (MathOp::Add, "add"),
         (MathOp::Sub, "sub"),
         (MathOp::Mul, "mul"),
-        (MathOp::Div, "div"),
-        (MathOp::Rem, "rem"),
+        (MathOp::DivByZero, "div-by-zero"),
+        (MathOp::DivOverflow, "div-overflow"),
+        (MathOp::RemByZero, "rem-by-zero"),
+        (MathOp::RemOverflow, "rem-overflow"),
         (MathOp::Neg, "neg"),
     ];
 
@@ -1625,7 +1627,7 @@ fn checked_rem() {
 fn amount_div_by_weight_floor_error() {
     // Division by zero weight returns error
     let err = sat(100).div_by_weight_floor(Weight::ZERO).unwrap_err();
-    assert_eq!(err, NumOpError::while_doing(MathOp::Div));
+    assert_eq!(err, NumOpError::while_doing(MathOp::DivByZero));
 
     // Overflow case: Amount::MAX * 1000 overflows
     let err = Amount::MAX.div_by_weight_floor(Weight::from_wu(1)).unwrap_err();
@@ -1636,7 +1638,7 @@ fn amount_div_by_weight_floor_error() {
 fn amount_div_by_weight_ceil_error() {
     // Division by zero weight returns error
     let err = sat(100).div_by_weight_ceil(Weight::ZERO).unwrap_err();
-    assert_eq!(err, NumOpError::while_doing(MathOp::Div));
+    assert_eq!(err, NumOpError::while_doing(MathOp::DivByZero));
 
     // Overflow case: Amount::MAX * 1000 overflows
     let err = Amount::MAX.div_by_weight_ceil(Weight::from_wu(1)).unwrap_err();

--- a/units/src/amount/tests.rs
+++ b/units/src/amount/tests.rs
@@ -193,8 +193,10 @@ fn display_math_op() {
         (MathOp::Add, "add"),
         (MathOp::Sub, "sub"),
         (MathOp::Mul, "mul"),
-        (MathOp::Div, "div"),
-        (MathOp::Rem, "rem"),
+        (MathOp::DivByZero, "div (by zero)"),
+        (MathOp::DivOverflow, "div (overflow)"),
+        (MathOp::RemByZero, "rem (by zero)"),
+        (MathOp::RemOverflow, "rem (overflow)"),
         (MathOp::Neg, "neg"),
     ];
 
@@ -1652,7 +1654,7 @@ fn checked_rem() {
 fn amount_div_by_weight_floor_error() {
     // Division by zero weight returns error
     let err = sat(100).div_by_weight_floor(Weight::ZERO).unwrap_err();
-    assert_eq!(err, NumOpError::while_doing(MathOp::Div));
+    assert_eq!(err, NumOpError::while_doing(MathOp::DivByZero));
 
     // Overflow case: Amount::MAX * 1000 overflows
     let err = Amount::MAX.div_by_weight_floor(Weight::from_wu(1)).unwrap_err();
@@ -1663,7 +1665,7 @@ fn amount_div_by_weight_floor_error() {
 fn amount_div_by_weight_ceil_error() {
     // Division by zero weight returns error
     let err = sat(100).div_by_weight_ceil(Weight::ZERO).unwrap_err();
-    assert_eq!(err, NumOpError::while_doing(MathOp::Div));
+    assert_eq!(err, NumOpError::while_doing(MathOp::DivByZero));
 
     // Overflow case: Amount::MAX * 1000 overflows
     let err = Amount::MAX.div_by_weight_ceil(Weight::from_wu(1)).unwrap_err();

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -468,10 +468,10 @@ impl Amount {
                     if let Ok(amount) = Self::from_sat(fee_rate) {
                         return FeeRate::from_per_kwu(amount);
                     },
-                None => return R::Error(E::while_doing(MathOp::Div)),
+                None => return R::Error(E::while_doing(MathOp::DivByZero)),
             }
         }
-        // Use `MathOp::Mul` because `Div` implies div by zero.
+        // Use `MathOp::Mul` because the `DivOverflow` specifically means `i32::MIN / -1`.
         R::Error(E::while_doing(MathOp::Mul))
     }
 
@@ -494,7 +494,7 @@ impl Amount {
     pub const fn div_by_weight_ceil(self, weight: Weight) -> NumOpResult<FeeRate> {
         let wu = weight.to_wu();
         if wu == 0 {
-            return R::Error(E::while_doing(MathOp::Div));
+            return R::Error(E::while_doing(MathOp::DivByZero));
         }
 
         // Mul by 1,000 because we use per/kwu.
@@ -505,7 +505,7 @@ impl Amount {
                 return FeeRate::from_per_kwu(amount);
             }
         }
-        // Use `MathOp::Mul` because `Div` implies div by zero.
+        // Use `MathOp::Mul` because the `DivOverflow` specifically means `i32::MIN / -1`.
         R::Error(E::while_doing(MathOp::Mul))
     }
 
@@ -519,7 +519,7 @@ impl Amount {
         let msats = self.to_sat() * 1_000;
         match msats.checked_div(fee_rate.to_sat_per_kwu_ceil()) {
             Some(wu) => R::Valid(Weight::from_wu(wu)),
-            None => R::Error(E::while_doing(MathOp::Div)),
+            None => R::Error(E::while_doing(MathOp::DivByZero)),
         }
     }
 
@@ -532,7 +532,7 @@ impl Amount {
         let rate = fee_rate.to_sat_per_kwu_ceil();
         // Early return so we do not have to use checked arithmetic below.
         if rate == 0 {
-            return R::Error(E::while_doing(MathOp::Div));
+            return R::Error(E::while_doing(MathOp::DivByZero));
         }
 
         debug_assert!(Self::MAX.to_sat().checked_mul(1_000).is_some());

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -470,10 +470,10 @@ impl Amount {
                     if let Ok(amount) = Self::from_sat(fee_rate) {
                         return FeeRate::from_per_kwu(amount);
                     },
-                None => return R::Error(E::while_doing(MathOp::Div)),
+                None => return R::Error(E::while_doing(MathOp::DivByZero)),
             }
         }
-        // Use `MathOp::Mul` because `Div` implies div by zero.
+        // Use `MathOp::Mul` because the `DivOverflow` specifically means `i32::MIN / -1`.
         R::Error(E::while_doing(MathOp::Mul))
     }
 
@@ -496,7 +496,7 @@ impl Amount {
     pub const fn div_by_weight_ceil(self, weight: Weight) -> NumOpResult<FeeRate> {
         let wu = weight.to_wu();
         if wu == 0 {
-            return R::Error(E::while_doing(MathOp::Div));
+            return R::Error(E::while_doing(MathOp::DivByZero));
         }
 
         // Mul by 1,000 because we use per/kwu.
@@ -507,7 +507,7 @@ impl Amount {
                 return FeeRate::from_per_kwu(amount);
             }
         }
-        // Use `MathOp::Mul` because `Div` implies div by zero.
+        // Use `MathOp::Mul` because the `DivOverflow` specifically means `i32::MIN / -1`.
         R::Error(E::while_doing(MathOp::Mul))
     }
 
@@ -521,7 +521,7 @@ impl Amount {
         let msats = self.to_sat() * 1_000;
         match msats.checked_div(fee_rate.to_sat_per_kwu_ceil()) {
             Some(wu) => R::Valid(Weight::from_wu(wu)),
-            None => R::Error(E::while_doing(MathOp::Div)),
+            None => R::Error(E::while_doing(MathOp::DivByZero)),
         }
     }
 
@@ -534,7 +534,7 @@ impl Amount {
         let rate = fee_rate.to_sat_per_kwu_ceil();
         // Early return so we do not have to use checked arithmetic below.
         if rate == 0 {
-            return R::Error(E::while_doing(MathOp::Div));
+            return R::Error(E::while_doing(MathOp::DivByZero));
         }
 
         debug_assert!(Self::MAX.to_sat().checked_mul(1_000).is_some());

--- a/units/src/result.rs
+++ b/units/src/result.rs
@@ -342,10 +342,14 @@ pub enum MathOp {
     Sub,
     /// Multiplication failed ([`core::ops::Mul`] resulted in an invalid value).
     Mul,
-    /// Division failed ([`core::ops::Div`] attempted div-by-zero).
-    Div,
-    /// Calculating the remainder failed ([`core::ops::Rem`] attempted div-by-zero).
-    Rem,
+    /// Division failed because the divisor was zero ([`core::ops::Div`] attempted div-by-zero).
+    DivByZero,
+    /// Division failed because the result would overflow (e.g. `T::MIN / -1`).
+    DivOverflow,
+    /// Calculating the remainder failed because the divisor was zero ([`core::ops::Rem`] attempted div-by-zero).
+    RemByZero,
+    /// Calculating the remainder failed because the result would overflow (e.g. `T::MIN % -1`).
+    RemOverflow,
     /// Negation failed ([`core::ops::Neg`] resulted in an invalid value).
     Neg,
     /// Stops users from casting this enum to an integer.
@@ -357,12 +361,15 @@ pub enum MathOp {
 impl MathOp {
     /// Returns `true` if this operation error'ed due to overflow.
     pub fn is_overflow(self) -> bool {
-        matches!(self, Self::Add | Self::Sub | Self::Mul | Self::Neg)
+        matches!(
+            self,
+            Self::Add | Self::Sub | Self::Mul | Self::Neg | Self::DivOverflow | Self::RemOverflow
+        )
     }
 
     /// Returns `true` if this operation error'ed due to division by zero.
     #[inline]
-    pub fn is_div_by_zero(self) -> bool { !self.is_overflow() }
+    pub fn is_div_by_zero(self) -> bool { matches!(self, Self::DivByZero | Self::RemByZero) }
 
     /// Returns `true` if this operation error'ed due to addition.
     #[inline]
@@ -387,8 +394,10 @@ impl fmt::Display for MathOp {
             Self::Add => write!(f, "add"),
             Self::Sub => write!(f, "sub"),
             Self::Mul => write!(f, "mul"),
-            Self::Div => write!(f, "div"),
-            Self::Rem => write!(f, "rem"),
+            Self::DivByZero => write!(f, "div (by zero)"),
+            Self::DivOverflow => write!(f, "div (overflow)"),
+            Self::RemByZero => write!(f, "rem (by zero)"),
+            Self::RemOverflow => write!(f, "rem (overflow)"),
             Self::Neg => write!(f, "neg"),
             Self::_DoNotUse(infallible) => match infallible {},
         }
@@ -458,13 +467,15 @@ impl<'a, T: Arbitrary<'a>> Arbitrary<'a> for NumOpResult<T> {
 #[cfg(feature = "arbitrary")]
 impl<'a> Arbitrary<'a> for MathOp {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let choice = u.int_in_range(0..=5)?;
+        let choice = u.int_in_range(0..=7)?;
         match choice {
             0 => Ok(Self::Add),
             1 => Ok(Self::Sub),
             2 => Ok(Self::Mul),
-            3 => Ok(Self::Div),
-            4 => Ok(Self::Rem),
+            3 => Ok(Self::DivByZero),
+            4 => Ok(Self::DivOverflow),
+            5 => Ok(Self::RemByZero),
+            6 => Ok(Self::RemOverflow),
             _ => Ok(Self::Neg),
         }
     }
@@ -486,11 +497,15 @@ mod tests {
         assert!(MathOp::Sub.is_overflow());
         assert!(MathOp::Mul.is_overflow());
         assert!(MathOp::Neg.is_overflow());
-        assert!(!MathOp::Div.is_overflow());
-        assert!(!MathOp::Rem.is_overflow());
+        assert!(MathOp::DivOverflow.is_overflow());
+        assert!(MathOp::RemOverflow.is_overflow());
+        assert!(!MathOp::DivByZero.is_overflow());
+        assert!(!MathOp::RemByZero.is_overflow());
 
-        assert!(MathOp::Div.is_div_by_zero());
-        assert!(MathOp::Rem.is_div_by_zero());
+        assert!(MathOp::DivByZero.is_div_by_zero());
+        assert!(MathOp::RemByZero.is_div_by_zero());
+        assert!(!MathOp::DivOverflow.is_div_by_zero());
+        assert!(!MathOp::RemOverflow.is_div_by_zero());
         assert!(!MathOp::Add.is_div_by_zero());
 
         assert!(MathOp::Add.is_addition());
@@ -500,7 +515,7 @@ mod tests {
         assert!(!MathOp::Add.is_subtraction());
 
         assert!(MathOp::Mul.is_multiplication());
-        assert!(!MathOp::Div.is_multiplication());
+        assert!(!MathOp::DivByZero.is_multiplication());
 
         assert!(MathOp::Neg.is_negation());
         assert!(!MathOp::Add.is_negation());
@@ -572,9 +587,11 @@ mod tests {
             NumOpError::while_doing(MathOp::Add),
             NumOpError::while_doing(MathOp::Sub),
             NumOpError::while_doing(MathOp::Mul),
-            NumOpError::while_doing(MathOp::Div),
+            NumOpError::while_doing(MathOp::DivByZero),
+            NumOpError::while_doing(MathOp::DivOverflow),
             NumOpError::while_doing(MathOp::Neg),
-            NumOpError::while_doing(MathOp::Rem),
+            NumOpError::while_doing(MathOp::RemByZero),
+            NumOpError::while_doing(MathOp::RemOverflow),
         ];
         for err in errs {
             assert_eq!(NumOpResult::<Amount>::Error(err).unwrap_err(), err);

--- a/units/src/result.rs
+++ b/units/src/result.rs
@@ -344,10 +344,14 @@ pub enum MathOp {
     Sub,
     /// Multiplication failed ([`core::ops::Mul`] resulted in an invalid value).
     Mul,
-    /// Division failed ([`core::ops::Div`] attempted div-by-zero).
-    Div,
-    /// Calculating the remainder failed ([`core::ops::Rem`] attempted div-by-zero).
-    Rem,
+    /// Division failed because the divisor was zero ([`core::ops::Div`] attempted div-by-zero).
+    DivByZero,
+    /// Division failed because the result overflowed (e.g. `T::MIN / -1`).
+    DivOverflow,
+    /// Calculating the remainder failed because the divisor was zero ([`core::ops::Rem`] attempted div-by-zero).
+    RemByZero,
+    /// Calculating the remainder failed because the result overflowed (e.g. `T::MIN % -1`).
+    RemOverflow,
     /// Negation failed ([`core::ops::Neg`] resulted in an invalid value).
     Neg,
     /// Stops users from casting this enum to an integer.
@@ -359,12 +363,15 @@ pub enum MathOp {
 impl MathOp {
     /// Returns `true` if this operation error'ed due to overflow.
     pub fn is_overflow(self) -> bool {
-        matches!(self, Self::Add | Self::Sub | Self::Mul | Self::Neg)
+        matches!(
+            self,
+            Self::Add | Self::Sub | Self::Mul | Self::Neg | Self::DivOverflow | Self::RemOverflow
+        )
     }
 
     /// Returns `true` if this operation error'ed due to division by zero.
     #[inline]
-    pub fn is_div_by_zero(self) -> bool { !self.is_overflow() }
+    pub fn is_div_by_zero(self) -> bool { matches!(self, Self::DivByZero | Self::RemByZero) }
 
     /// Returns `true` if this operation error'ed due to addition.
     #[inline]
@@ -389,8 +396,10 @@ impl fmt::Display for MathOp {
             Self::Add => write!(f, "add"),
             Self::Sub => write!(f, "sub"),
             Self::Mul => write!(f, "mul"),
-            Self::Div => write!(f, "div"),
-            Self::Rem => write!(f, "rem"),
+            Self::DivByZero => write!(f, "div-by-zero"),
+            Self::DivOverflow => write!(f, "div-overflow"),
+            Self::RemByZero => write!(f, "rem-by-zero"),
+            Self::RemOverflow => write!(f, "rem-overflow"),
             Self::Neg => write!(f, "neg"),
             Self::_DoNotUse(infallible) => match infallible {},
         }
@@ -460,13 +469,15 @@ impl<'a, T: Arbitrary<'a>> Arbitrary<'a> for NumOpResult<T> {
 #[cfg(feature = "arbitrary")]
 impl<'a> Arbitrary<'a> for MathOp {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let choice = u.int_in_range(0..=5)?;
+        let choice = u.int_in_range(0..=7)?;
         match choice {
             0 => Ok(Self::Add),
             1 => Ok(Self::Sub),
             2 => Ok(Self::Mul),
-            3 => Ok(Self::Div),
-            4 => Ok(Self::Rem),
+            3 => Ok(Self::DivByZero),
+            4 => Ok(Self::DivOverflow),
+            5 => Ok(Self::RemByZero),
+            6 => Ok(Self::RemOverflow),
             _ => Ok(Self::Neg),
         }
     }
@@ -488,11 +499,15 @@ mod tests {
         assert!(MathOp::Sub.is_overflow());
         assert!(MathOp::Mul.is_overflow());
         assert!(MathOp::Neg.is_overflow());
-        assert!(!MathOp::Div.is_overflow());
-        assert!(!MathOp::Rem.is_overflow());
+        assert!(MathOp::DivOverflow.is_overflow());
+        assert!(MathOp::RemOverflow.is_overflow());
+        assert!(!MathOp::DivByZero.is_overflow());
+        assert!(!MathOp::RemByZero.is_overflow());
 
-        assert!(MathOp::Div.is_div_by_zero());
-        assert!(MathOp::Rem.is_div_by_zero());
+        assert!(MathOp::DivByZero.is_div_by_zero());
+        assert!(MathOp::RemByZero.is_div_by_zero());
+        assert!(!MathOp::DivOverflow.is_div_by_zero());
+        assert!(!MathOp::RemOverflow.is_div_by_zero());
         assert!(!MathOp::Add.is_div_by_zero());
 
         assert!(MathOp::Add.is_addition());
@@ -502,7 +517,7 @@ mod tests {
         assert!(!MathOp::Add.is_subtraction());
 
         assert!(MathOp::Mul.is_multiplication());
-        assert!(!MathOp::Div.is_multiplication());
+        assert!(!MathOp::DivByZero.is_multiplication());
 
         assert!(MathOp::Neg.is_negation());
         assert!(!MathOp::Add.is_negation());
@@ -574,9 +589,11 @@ mod tests {
             NumOpError::while_doing(MathOp::Add),
             NumOpError::while_doing(MathOp::Sub),
             NumOpError::while_doing(MathOp::Mul),
-            NumOpError::while_doing(MathOp::Div),
+            NumOpError::while_doing(MathOp::DivByZero),
+            NumOpError::while_doing(MathOp::DivOverflow),
             NumOpError::while_doing(MathOp::Neg),
-            NumOpError::while_doing(MathOp::Rem),
+            NumOpError::while_doing(MathOp::RemByZero),
+            NumOpError::while_doing(MathOp::RemOverflow),
         ];
         for err in errs {
             assert_eq!(NumOpResult::<Amount>::Error(err).unwrap_err(), err);


### PR DESCRIPTION
Division can overflow a signed integer if `T::MIN` is divided by -1

Concretely:

i32::MIN        = -2_147_483_648
i32::MIN / -1   =  2_147_483_648   // but i32::MAX is 2_147_483_647

Split `MathOp::Div` and `MathOp::Rem` into distinct variants.

Fix: #4672