### PR TITLE
Release tracking PR: `primitives 0.103.1`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-primitives"
-version = "0.103.0"
+version = "0.103.1"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-primitives"
-version = "0.103.0"
+version = "0.103.1"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/primitives/CHANGELOG.md
+++ b/primitives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+# [0.103.1] - 2026-08-06
+
+- Explicitly depend on `consensus-encoding 1.1.0`
+
 # [0.103.0] - 2026-07-14
 
 - Move `script_hash` and `wscript_hash` to primitives [#6504](https://github.com/rust-bitcoin/rust-bitcoin/pull/6504)

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -22,7 +22,7 @@ arbitrary = ["dep:arbitrary", "units/arbitrary"]
 hex = ["dep:hex", "hashes/hex", "encoding/hex"]
 
 [dependencies]
-encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0", default-features = false }
+encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.1.0", default-features = false }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.1.0", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
 units = { package = "bitcoin-units", path = "../units", version = "0.5.0", default-features = false, features = [ "encoding" ] }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-primitives"
-version = "0.103.0"
+version = "0.103.1"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>", "Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin"


### PR DESCRIPTION
Explicitly depend on `consensus-encoding 1.1.0`. Found while trying to release `crypto`. 