### PR TITLE
units: Add `CompactTarget::to_consensus_u32`

### DIFF
--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -1075,7 +1075,7 @@ mod tests {
             + header.prev_blockhash.as_byte_array().len()
             + header.merkle_root.as_byte_array().len()
             + header.time.to_u32().to_le_bytes().len()
-            + header.bits.to_consensus().to_le_bytes().len()
+            + header.bits.to_consensus_u32().to_le_bytes().len()
             + header.nonce.to_le_bytes().len();
 
         assert_eq!(header_size, Header::SIZE);

--- a/units/api/all-features.txt
+++ b/units/api/all-features.txt
@@ -6550,6 +6550,7 @@ pub fn bitcoin_units::pow::CompactTarget::from_consensus(bits: u32) -> Self
 pub fn bitcoin_units::pow::CompactTarget::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::PrefixedHexError> where Self: core::marker::Sized
 pub fn bitcoin_units::pow::CompactTarget::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError> where Self: core::marker::Sized
 pub const fn bitcoin_units::pow::CompactTarget::to_consensus(self) -> u32
+pub const fn bitcoin_units::pow::CompactTarget::to_consensus_u32(self) -> u32
 pub fn bitcoin_units::pow::CompactTarget::to_target(self) -> bitcoin_units::pow::Target
 impl bitcoin_consensus_encoding::decode::Decode for bitcoin_units::pow::CompactTarget
   pub type bitcoin_units::pow::CompactTarget::Decoder = bitcoin_units::pow::CompactTargetDecoder [impl: impl bitcoin_consensus_encoding::decode::Decode for bitcoin_units::pow::CompactTarget]
@@ -11021,6 +11022,7 @@ pub fn bitcoin_units::pow::CompactTarget::from_consensus(bits: u32) -> Self
 pub fn bitcoin_units::pow::CompactTarget::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::PrefixedHexError> where Self: core::marker::Sized
 pub fn bitcoin_units::pow::CompactTarget::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError> where Self: core::marker::Sized
 pub const fn bitcoin_units::pow::CompactTarget::to_consensus(self) -> u32
+pub const fn bitcoin_units::pow::CompactTarget::to_consensus_u32(self) -> u32
 pub fn bitcoin_units::pow::CompactTarget::to_target(self) -> bitcoin_units::pow::Target
 impl bitcoin_consensus_encoding::decode::Decode for bitcoin_units::pow::CompactTarget
   pub type bitcoin_units::pow::CompactTarget::Decoder = bitcoin_units::pow::CompactTargetDecoder [impl: impl bitcoin_consensus_encoding::decode::Decode for bitcoin_units::pow::CompactTarget]

--- a/units/api/alloc-only.txt
+++ b/units/api/alloc-only.txt
@@ -5389,6 +5389,7 @@ pub fn bitcoin_units::pow::CompactTarget::from_consensus(bits: u32) -> Self
 pub fn bitcoin_units::pow::CompactTarget::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::PrefixedHexError> where Self: core::marker::Sized
 pub fn bitcoin_units::pow::CompactTarget::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError> where Self: core::marker::Sized
 pub const fn bitcoin_units::pow::CompactTarget::to_consensus(self) -> u32
+pub const fn bitcoin_units::pow::CompactTarget::to_consensus_u32(self) -> u32
 pub fn bitcoin_units::pow::CompactTarget::to_target(self) -> bitcoin_units::pow::Target
 impl core::clone::Clone for bitcoin_units::pow::CompactTarget
   pub fn bitcoin_units::pow::CompactTarget::clone(&self) -> bitcoin_units::pow::CompactTarget [impl: impl core::clone::Clone for bitcoin_units::pow::CompactTarget]
@@ -9205,6 +9206,7 @@ pub fn bitcoin_units::pow::CompactTarget::from_consensus(bits: u32) -> Self
 pub fn bitcoin_units::pow::CompactTarget::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::PrefixedHexError> where Self: core::marker::Sized
 pub fn bitcoin_units::pow::CompactTarget::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError> where Self: core::marker::Sized
 pub const fn bitcoin_units::pow::CompactTarget::to_consensus(self) -> u32
+pub const fn bitcoin_units::pow::CompactTarget::to_consensus_u32(self) -> u32
 pub fn bitcoin_units::pow::CompactTarget::to_target(self) -> bitcoin_units::pow::Target
 impl core::clone::Clone for bitcoin_units::pow::CompactTarget
   pub fn bitcoin_units::pow::CompactTarget::clone(&self) -> bitcoin_units::pow::CompactTarget [impl: impl core::clone::Clone for bitcoin_units::pow::CompactTarget]

--- a/units/api/no-features.txt
+++ b/units/api/no-features.txt
@@ -4765,6 +4765,7 @@ pub fn bitcoin_units::pow::CompactTarget::from_consensus(bits: u32) -> Self
 pub fn bitcoin_units::pow::CompactTarget::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::PrefixedHexError> where Self: core::marker::Sized
 pub fn bitcoin_units::pow::CompactTarget::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError> where Self: core::marker::Sized
 pub const fn bitcoin_units::pow::CompactTarget::to_consensus(self) -> u32
+pub const fn bitcoin_units::pow::CompactTarget::to_consensus_u32(self) -> u32
 pub fn bitcoin_units::pow::CompactTarget::to_target(self) -> bitcoin_units::pow::Target
 impl core::clone::Clone for bitcoin_units::pow::CompactTarget
   pub fn bitcoin_units::pow::CompactTarget::clone(&self) -> bitcoin_units::pow::CompactTarget [impl: impl core::clone::Clone for bitcoin_units::pow::CompactTarget]
@@ -8273,6 +8274,7 @@ pub fn bitcoin_units::pow::CompactTarget::from_consensus(bits: u32) -> Self
 pub fn bitcoin_units::pow::CompactTarget::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::PrefixedHexError> where Self: core::marker::Sized
 pub fn bitcoin_units::pow::CompactTarget::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError> where Self: core::marker::Sized
 pub const fn bitcoin_units::pow::CompactTarget::to_consensus(self) -> u32
+pub const fn bitcoin_units::pow::CompactTarget::to_consensus_u32(self) -> u32
 pub fn bitcoin_units::pow::CompactTarget::to_target(self) -> bitcoin_units::pow::Target
 impl core::clone::Clone for bitcoin_units::pow::CompactTarget
   pub fn bitcoin_units::pow::CompactTarget::clone(&self) -> bitcoin_units::pow::CompactTarget [impl: impl core::clone::Clone for bitcoin_units::pow::CompactTarget]

--- a/units/src/pow.rs
+++ b/units/src/pow.rs
@@ -254,8 +254,13 @@ impl CompactTarget {
     pub fn from_consensus(bits: u32) -> Self { Self(bits) }
 
     /// Returns the consensus encoded `u32` representation of this [`CompactTarget`].
+    #[deprecated(since = "TBD", note = "use 'to_consensus_u32()' instead")]
     #[inline]
     pub const fn to_consensus(self) -> u32 { self.0 }
+
+    /// Returns the consensus encoded `u32` representation of this [`CompactTarget`].
+    #[inline]
+    pub const fn to_consensus_u32(self) -> u32 { self.0 }
 
     /// Computes the [`Target`] value from this compact representation.
     ///

--- a/units/src/pow.rs
+++ b/units/src/pow.rs
@@ -173,7 +173,7 @@ impl Target {
     ///
     /// ref: <https://developer.bitcoin.org/reference/block_chain.html#target-nbits>
     pub fn from_compact(c: CompactTarget) -> Self {
-        let bits = c.to_consensus();
+        let bits = c.to_consensus_u32();
         // This is a floating-point "compact" encoding originally used by
         // OpenSSL, which satoshi put into consensus code, so we're stuck
         // with it. The exponent needs to have 3 subtracted from it, hence
@@ -317,7 +317,7 @@ impl encoding::Encode for CompactTarget {
     #[inline]
     fn encoder(&self) -> Self::Encoder<'_> {
         CompactTargetEncoder::new(encoding::ArrayEncoder::without_length_prefix(
-            self.to_consensus().to_le_bytes(),
+            self.to_consensus_u32().to_le_bytes(),
         ))
     }
 }
@@ -1478,7 +1478,7 @@ mod tests {
         let back = t.to_compact_lossy();
         assert_eq!(back, compact); // From/Into sanity check.
 
-        assert_eq!(back.to_consensus(), consensus);
+        assert_eq!(back.to_consensus_u32(), consensus);
     }
 
     #[test]
@@ -1556,7 +1556,7 @@ mod tests {
         let bits: u32 = 0x1d00_ffff;
         let compact_target =
             encoding::decode_from_slice::<CompactTarget>(&bits.to_le_bytes()).unwrap();
-        assert_eq!(compact_target.to_consensus(), bits);
+        assert_eq!(compact_target.to_consensus_u32(), bits);
     }
 
     #[test]
@@ -1608,7 +1608,7 @@ mod tests {
         assert_eq!(format!("{:#o}", compact_target), "0o3500177777");
         assert_eq!(format!("{:b}", compact_target), "11101000000001111111111111111");
         assert_eq!(format!("{:#b}", compact_target), "0b11101000000001111111111111111");
-        assert_eq!(compact_target.to_consensus(), 0x1d00_ffff);
+        assert_eq!(compact_target.to_consensus_u32(), 0x1d00_ffff);
     }
 
     #[test]


### PR DESCRIPTION
Currently, of all of the types that have from_consensus and to_consensus* functions, only CompactTarget excludes the _u32 suffix on the to_consensus function. In order to have LockTime, Sequence and CompactTarget all use a consistent naming scheme, a to_consensus_u32 function should be used for CompactTarget.

Add CompactTarget::to_consensus_u32 and deprecate CompactTarget::to_consensus.