### PR TITLE
Backport: units: Add CompactTarget::to_consensus_u32

### DIFF
--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -1051,7 +1051,7 @@ mod tests {
             + header.prev_blockhash.as_byte_array().len()
             + header.merkle_root.as_byte_array().len()
             + header.time.to_u32().to_le_bytes().len()
-            + header.bits.to_consensus().to_le_bytes().len()
+            + header.bits.to_consensus_u32().to_le_bytes().len()
             + header.nonce.to_le_bytes().len();
 
         assert_eq!(header_size, Header::SIZE);

--- a/units/api/all-features.txt
+++ b/units/api/all-features.txt
@@ -3811,6 +3811,7 @@ pub fn bitcoin_units::pow::CompactTarget::from_consensus(bits: u32) -> Self
 pub fn bitcoin_units::pow::CompactTarget::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::PrefixedHexError> where Self: core::marker::Sized
 pub fn bitcoin_units::pow::CompactTarget::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError> where Self: core::marker::Sized
 pub const fn bitcoin_units::pow::CompactTarget::to_consensus(self) -> u32
+pub const fn bitcoin_units::pow::CompactTarget::to_consensus_u32(self) -> u32
 impl bitcoin_consensus_encoding::decode::Decode for bitcoin_units::pow::CompactTarget
 pub type bitcoin_units::pow::CompactTarget::Decoder = bitcoin_units::pow::CompactTargetDecoder
 impl bitcoin_consensus_encoding::encode::Encode for bitcoin_units::pow::CompactTarget

--- a/units/api/alloc-only.txt
+++ b/units/api/alloc-only.txt
@@ -3134,6 +3134,7 @@ pub fn bitcoin_units::pow::CompactTarget::from_consensus(bits: u32) -> Self
 pub fn bitcoin_units::pow::CompactTarget::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::PrefixedHexError> where Self: core::marker::Sized
 pub fn bitcoin_units::pow::CompactTarget::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError> where Self: core::marker::Sized
 pub const fn bitcoin_units::pow::CompactTarget::to_consensus(self) -> u32
+pub const fn bitcoin_units::pow::CompactTarget::to_consensus_u32(self) -> u32
 impl core::clone::Clone for bitcoin_units::pow::CompactTarget
 pub fn bitcoin_units::pow::CompactTarget::clone(&self) -> bitcoin_units::pow::CompactTarget
 impl core::cmp::Eq for bitcoin_units::pow::CompactTarget

--- a/units/api/no-features.txt
+++ b/units/api/no-features.txt
@@ -2804,6 +2804,7 @@ pub fn bitcoin_units::pow::CompactTarget::from_consensus(bits: u32) -> Self
 pub fn bitcoin_units::pow::CompactTarget::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::PrefixedHexError> where Self: core::marker::Sized
 pub fn bitcoin_units::pow::CompactTarget::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError> where Self: core::marker::Sized
 pub const fn bitcoin_units::pow::CompactTarget::to_consensus(self) -> u32
+pub const fn bitcoin_units::pow::CompactTarget::to_consensus_u32(self) -> u32
 impl core::clone::Clone for bitcoin_units::pow::CompactTarget
 pub fn bitcoin_units::pow::CompactTarget::clone(&self) -> bitcoin_units::pow::CompactTarget
 impl core::cmp::Eq for bitcoin_units::pow::CompactTarget

--- a/units/src/pow.rs
+++ b/units/src/pow.rs
@@ -173,7 +173,7 @@ impl Target {
     ///
     /// ref: <https://developer.bitcoin.org/reference/block_chain.html#target-nbits>
     pub fn from_compact(c: CompactTarget) -> Self {
-        let bits = c.to_consensus();
+        let bits = c.to_consensus_u32();
         // This is a floating-point "compact" encoding originally used by
         // OpenSSL, which satoshi put into consensus code, so we're stuck
         // with it. The exponent needs to have 3 subtracted from it, hence
@@ -308,7 +308,7 @@ impl encoding::Encode for CompactTarget {
     #[inline]
     fn encoder(&self) -> Self::Encoder<'_> {
         CompactTargetEncoder::new(encoding::ArrayEncoder::without_length_prefix(
-            self.to_consensus().to_le_bytes(),
+            self.to_consensus_u32().to_le_bytes(),
         ))
     }
 }
@@ -1452,7 +1452,7 @@ mod tests {
         let back = t.to_compact_lossy();
         assert_eq!(back, compact); // From/Into sanity check.
 
-        assert_eq!(back.to_consensus(), consensus);
+        assert_eq!(back.to_consensus_u32(), consensus);
     }
 
     #[test]
@@ -1530,7 +1530,7 @@ mod tests {
         let bits: u32 = 0x1d00_ffff;
         let compact_target =
             encoding::decode_from_slice::<CompactTarget>(&bits.to_le_bytes()).unwrap();
-        assert_eq!(compact_target.to_consensus(), bits);
+        assert_eq!(compact_target.to_consensus_u32(), bits);
     }
 
     #[test]
@@ -1582,7 +1582,7 @@ mod tests {
         assert_eq!(format!("{:#o}", compact_target), "0o3500177777");
         assert_eq!(format!("{:b}", compact_target), "11101000000001111111111111111");
         assert_eq!(format!("{:#b}", compact_target), "0b11101000000001111111111111111");
-        assert_eq!(compact_target.to_consensus(), 0x1d00_ffff);
+        assert_eq!(compact_target.to_consensus_u32(), 0x1d00_ffff);
     }
 
     #[test]

--- a/units/src/pow.rs
+++ b/units/src/pow.rs
@@ -251,6 +251,11 @@ impl CompactTarget {
 
     /// Returns the consensus encoded `u32` representation of this [`CompactTarget`].
     #[inline]
+    pub const fn to_consensus_u32(self) -> u32 { self.0 }
+
+    /// Returns the consensus encoded `u32` representation of this [`CompactTarget`].
+    #[deprecated(since = "0.5.1", note = "use 'to_consensus_u32()' instead")]
+    #[inline]
     pub const fn to_consensus(self) -> u32 { self.0 }
 
     /// Constructs a new `CompactTarget` from a prefixed hex string.


### PR DESCRIPTION
Backport #6683 so we can release `bitcoin-units 0.5.1` with the sole purpose of putting deprecated stuff in the *last* RC release and not have to do a whole stack of releases again since we are so close to `units 1.0.0`.
