### PR TITLE
Backport: units: Add Weight::to_vb_* functions, deprecating to_vbytes_*

### DIFF
--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -430,7 +430,7 @@ impl TransactionExt for Transaction {
     #[inline]
     fn vsize(&self) -> usize {
         // No overflow because it's computed from data in memory
-        self.weight().to_vbytes_ceil() as usize
+        self.weight().to_vb_ceil() as usize
     }
 
     fn is_explicitly_rbf(&self) -> bool { self.inputs.iter().any(|input| input.sequence.is_rbf()) }

--- a/fuzz/fuzz_targets/units/arbitrary_weight.rs
+++ b/fuzz/fuzz_targets/units/arbitrary_weight.rs
@@ -16,8 +16,8 @@ fn do_test(data: &[u8]) {
         weight.to_wu();
         weight.to_kwu_ceil();
         weight.to_kwu_floor();
-        weight.to_vbytes_ceil();
-        weight.to_vbytes_floor();
+        weight.to_vb_ceil();
+        weight.to_vb_floor();
 
         // Operations that take u64 as the rhs
         for operation in [Weight::checked_mul, Weight::checked_div] {

--- a/units/api/all-features.txt
+++ b/units/api/all-features.txt
@@ -5025,6 +5025,8 @@ pub const fn bitcoin_units::Weight::from_vb_unchecked(vb: u64) -> Self
 pub const fn bitcoin_units::Weight::mul_by_fee_rate(self, fee_rate: bitcoin_units::FeeRate) -> bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
 pub const fn bitcoin_units::Weight::to_kwu_ceil(self) -> u64
 pub const fn bitcoin_units::Weight::to_kwu_floor(self) -> u64
+pub const fn bitcoin_units::Weight::to_vb_ceil(self) -> u64
+pub const fn bitcoin_units::Weight::to_vb_floor(self) -> u64
 pub const fn bitcoin_units::Weight::to_vbytes_ceil(self) -> u64
 pub const fn bitcoin_units::Weight::to_vbytes_floor(self) -> u64
 pub const fn bitcoin_units::Weight::from_wu(wu: u64) -> Self

--- a/units/api/alloc-only.txt
+++ b/units/api/alloc-only.txt
@@ -3954,6 +3954,8 @@ pub const fn bitcoin_units::Weight::from_vb_unchecked(vb: u64) -> Self
 pub const fn bitcoin_units::Weight::mul_by_fee_rate(self, fee_rate: bitcoin_units::FeeRate) -> bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
 pub const fn bitcoin_units::Weight::to_kwu_ceil(self) -> u64
 pub const fn bitcoin_units::Weight::to_kwu_floor(self) -> u64
+pub const fn bitcoin_units::Weight::to_vb_ceil(self) -> u64
+pub const fn bitcoin_units::Weight::to_vb_floor(self) -> u64
 pub const fn bitcoin_units::Weight::to_vbytes_ceil(self) -> u64
 pub const fn bitcoin_units::Weight::to_vbytes_floor(self) -> u64
 pub const fn bitcoin_units::Weight::from_wu(wu: u64) -> Self

--- a/units/api/no-features.txt
+++ b/units/api/no-features.txt
@@ -3566,6 +3566,8 @@ pub const fn bitcoin_units::Weight::from_vb_unchecked(vb: u64) -> Self
 pub const fn bitcoin_units::Weight::mul_by_fee_rate(self, fee_rate: bitcoin_units::FeeRate) -> bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
 pub const fn bitcoin_units::Weight::to_kwu_ceil(self) -> u64
 pub const fn bitcoin_units::Weight::to_kwu_floor(self) -> u64
+pub const fn bitcoin_units::Weight::to_vb_ceil(self) -> u64
+pub const fn bitcoin_units::Weight::to_vb_floor(self) -> u64
 pub const fn bitcoin_units::Weight::to_vbytes_ceil(self) -> u64
 pub const fn bitcoin_units::Weight::to_vbytes_floor(self) -> u64
 pub const fn bitcoin_units::Weight::from_wu(wu: u64) -> Self

--- a/units/src/weight.rs
+++ b/units/src/weight.rs
@@ -126,10 +126,20 @@ impl Weight {
 
     /// Converts to vB rounding down.
     #[inline]
+    pub const fn to_vb_floor(self) -> u64 { self.to_wu() / Self::WITNESS_SCALE_FACTOR }
+
+    /// Converts to vB rounding down.
+    #[inline]
+    #[deprecated(since = "TBD", note = "use `to_vb_floor()` instead")]
     pub const fn to_vbytes_floor(self) -> u64 { self.to_wu() / Self::WITNESS_SCALE_FACTOR }
 
     /// Converts to vB rounding up.
     #[inline]
+    pub const fn to_vb_ceil(self) -> u64 { self.to_wu().div_ceil(Self::WITNESS_SCALE_FACTOR) }
+
+    /// Converts to vB rounding up.
+    #[inline]
+    #[deprecated(since = "TBD", note = "use `to_vbytes_ceil()` instead")]
     pub const fn to_vbytes_ceil(self) -> u64 { self.to_wu().div_ceil(Self::WITNESS_SCALE_FACTOR) }
 
     /// Checked addition.

--- a/units/src/weight.rs
+++ b/units/src/weight.rs
@@ -446,15 +446,15 @@ mod tests {
 
     #[test]
     fn to_vb_floor() {
-        assert_eq!(Weight::from_wu(8).to_vbytes_floor(), 2);
-        assert_eq!(Weight::from_wu(9).to_vbytes_floor(), 2);
+        assert_eq!(Weight::from_wu(8).to_vb_floor(), 2);
+        assert_eq!(Weight::from_wu(9).to_vb_floor(), 2);
     }
 
     #[test]
     fn to_vb_ceil() {
-        assert_eq!(Weight::from_wu(4).to_vbytes_ceil(), 1);
-        assert_eq!(Weight::from_wu(5).to_vbytes_ceil(), 2);
-        assert_eq!(Weight::MAX.to_vbytes_ceil(), u64::MAX / Weight::WITNESS_SCALE_FACTOR + 1);
+        assert_eq!(Weight::from_wu(4).to_vb_ceil(), 1);
+        assert_eq!(Weight::from_wu(5).to_vb_ceil(), 2);
+        assert_eq!(Weight::MAX.to_vb_ceil(), u64::MAX / Weight::WITNESS_SCALE_FACTOR + 1);
     }
 
     #[test]


### PR DESCRIPTION
Backport #6678. Same idea as #6684. 