### PR TITLE
Release tracking PR: `units 0.5.1`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -89,7 +89,7 @@ dependencies = [
  "bitcoin-network-kind",
  "bitcoin-primitives",
  "bitcoin-taproot-primitives",
- "bitcoin-units 0.5.0",
+ "bitcoin-units 0.5.1",
  "bitcoin_hashes 1.0.0",
  "bitcoinconsensus",
  "hex-conservative 1.1.0",
@@ -214,7 +214,7 @@ dependencies = [
  "bitcoin-internals 0.5.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
- "bitcoin-units 0.5.0",
+ "bitcoin-units 0.5.1",
  "bitcoin_hashes 1.0.0",
  "hex-conservative 1.1.0",
  "serde",
@@ -228,7 +228,7 @@ dependencies = [
  "bincode",
  "bitcoin-consensus-encoding",
  "bitcoin-internals 0.5.0",
- "bitcoin-units 0.5.0",
+ "bitcoin-units 0.5.1",
  "bitcoin_hashes 1.0.0",
  "hex-conservative 1.1.0",
  "serde",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-units"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -88,7 +88,7 @@ dependencies = [
  "bitcoin-network-kind",
  "bitcoin-primitives",
  "bitcoin-taproot-primitives",
- "bitcoin-units 0.5.0",
+ "bitcoin-units 0.5.1",
  "bitcoin_hashes 1.0.0",
  "bitcoinconsensus",
  "hex-conservative 1.1.0",
@@ -213,7 +213,7 @@ dependencies = [
  "bitcoin-internals 0.5.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
- "bitcoin-units 0.5.0",
+ "bitcoin-units 0.5.1",
  "bitcoin_hashes 1.0.0",
  "hex-conservative 1.1.0",
  "serde",
@@ -227,7 +227,7 @@ dependencies = [
  "bincode",
  "bitcoin-consensus-encoding",
  "bitcoin-internals 0.5.0",
- "bitcoin-units 0.5.0",
+ "bitcoin-units 0.5.1",
  "bitcoin_hashes 1.0.0",
  "hex-conservative 1.1.0",
  "serde",
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-units"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -430,7 +430,7 @@ impl TransactionExt for Transaction {
     #[inline]
     fn vsize(&self) -> usize {
         // No overflow because it's computed from data in memory
-        self.weight().to_vbytes_ceil() as usize
+        self.weight().to_vb_ceil() as usize
     }
 
     fn is_explicitly_rbf(&self) -> bool { self.inputs.iter().any(|input| input.sequence.is_rbf()) }

--- a/fuzz/fuzz_targets/units/arbitrary_weight.rs
+++ b/fuzz/fuzz_targets/units/arbitrary_weight.rs
@@ -16,8 +16,8 @@ fn do_test(data: &[u8]) {
         weight.to_wu();
         weight.to_kwu_ceil();
         weight.to_kwu_floor();
-        weight.to_vbytes_ceil();
-        weight.to_vbytes_floor();
+        weight.to_vb_ceil();
+        weight.to_vb_floor();
 
         // Operations that take u64 as the rhs
         for operation in [Weight::checked_mul, Weight::checked_div] {

--- a/units/CHANGELOG.md
+++ b/units/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-08-06
+
+- Add `Weight::to_vb_*` functions, deprecating `to_vbytes_*` [#6678](https://github.com/rust-bitcoin/rust-bitcoin/pull/6678)
+- Add `CompactTarget::to_consensus_u32` [#6683]()
+
 ## [0.5.0] - 2026-06-09
 
 * Remove `_unchecked` hex parsing function [#6292](https://github.com/rust-bitcoin/rust-bitcoin/pull/6292)

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-units"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>", "Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"

--- a/units/api/all-features.txt
+++ b/units/api/all-features.txt
@@ -5025,6 +5025,8 @@ pub const fn bitcoin_units::Weight::from_vb_unchecked(vb: u64) -> Self
 pub const fn bitcoin_units::Weight::mul_by_fee_rate(self, fee_rate: bitcoin_units::FeeRate) -> bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
 pub const fn bitcoin_units::Weight::to_kwu_ceil(self) -> u64
 pub const fn bitcoin_units::Weight::to_kwu_floor(self) -> u64
+pub const fn bitcoin_units::Weight::to_vb_ceil(self) -> u64
+pub const fn bitcoin_units::Weight::to_vb_floor(self) -> u64
 pub const fn bitcoin_units::Weight::to_vbytes_ceil(self) -> u64
 pub const fn bitcoin_units::Weight::to_vbytes_floor(self) -> u64
 pub const fn bitcoin_units::Weight::from_wu(wu: u64) -> Self

--- a/units/api/alloc-only.txt
+++ b/units/api/alloc-only.txt
@@ -3954,6 +3954,8 @@ pub const fn bitcoin_units::Weight::from_vb_unchecked(vb: u64) -> Self
 pub const fn bitcoin_units::Weight::mul_by_fee_rate(self, fee_rate: bitcoin_units::FeeRate) -> bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
 pub const fn bitcoin_units::Weight::to_kwu_ceil(self) -> u64
 pub const fn bitcoin_units::Weight::to_kwu_floor(self) -> u64
+pub const fn bitcoin_units::Weight::to_vb_ceil(self) -> u64
+pub const fn bitcoin_units::Weight::to_vb_floor(self) -> u64
 pub const fn bitcoin_units::Weight::to_vbytes_ceil(self) -> u64
 pub const fn bitcoin_units::Weight::to_vbytes_floor(self) -> u64
 pub const fn bitcoin_units::Weight::from_wu(wu: u64) -> Self

--- a/units/api/no-features.txt
+++ b/units/api/no-features.txt
@@ -3566,6 +3566,8 @@ pub const fn bitcoin_units::Weight::from_vb_unchecked(vb: u64) -> Self
 pub const fn bitcoin_units::Weight::mul_by_fee_rate(self, fee_rate: bitcoin_units::FeeRate) -> bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
 pub const fn bitcoin_units::Weight::to_kwu_ceil(self) -> u64
 pub const fn bitcoin_units::Weight::to_kwu_floor(self) -> u64
+pub const fn bitcoin_units::Weight::to_vb_ceil(self) -> u64
+pub const fn bitcoin_units::Weight::to_vb_floor(self) -> u64
 pub const fn bitcoin_units::Weight::to_vbytes_ceil(self) -> u64
 pub const fn bitcoin_units::Weight::to_vbytes_floor(self) -> u64
 pub const fn bitcoin_units::Weight::from_wu(wu: u64) -> Self

--- a/units/src/weight.rs
+++ b/units/src/weight.rs
@@ -126,10 +126,20 @@ impl Weight {
 
     /// Converts to vB rounding down.
     #[inline]
+    pub const fn to_vb_floor(self) -> u64 { self.to_wu() / Self::WITNESS_SCALE_FACTOR }
+
+    /// Converts to vB rounding down.
+    #[inline]
+    #[deprecated(since = "TBD", note = "use `to_vb_floor()` instead")]
     pub const fn to_vbytes_floor(self) -> u64 { self.to_wu() / Self::WITNESS_SCALE_FACTOR }
 
     /// Converts to vB rounding up.
     #[inline]
+    pub const fn to_vb_ceil(self) -> u64 { self.to_wu().div_ceil(Self::WITNESS_SCALE_FACTOR) }
+
+    /// Converts to vB rounding up.
+    #[inline]
+    #[deprecated(since = "TBD", note = "use `to_vbytes_ceil()` instead")]
     pub const fn to_vbytes_ceil(self) -> u64 { self.to_wu().div_ceil(Self::WITNESS_SCALE_FACTOR) }
 
     /// Checked addition.

--- a/units/src/weight.rs
+++ b/units/src/weight.rs
@@ -446,15 +446,15 @@ mod tests {
 
     #[test]
     fn to_vb_floor() {
-        assert_eq!(Weight::from_wu(8).to_vbytes_floor(), 2);
-        assert_eq!(Weight::from_wu(9).to_vbytes_floor(), 2);
+        assert_eq!(Weight::from_wu(8).to_vb_floor(), 2);
+        assert_eq!(Weight::from_wu(9).to_vb_floor(), 2);
     }
 
     #[test]
     fn to_vb_ceil() {
-        assert_eq!(Weight::from_wu(4).to_vbytes_ceil(), 1);
-        assert_eq!(Weight::from_wu(5).to_vbytes_ceil(), 2);
-        assert_eq!(Weight::MAX.to_vbytes_ceil(), u64::MAX / Weight::WITNESS_SCALE_FACTOR + 1);
+        assert_eq!(Weight::from_wu(4).to_vb_ceil(), 1);
+        assert_eq!(Weight::from_wu(5).to_vb_ceil(), 2);
+        assert_eq!(Weight::MAX.to_vb_ceil(), u64::MAX / Weight::WITNESS_SCALE_FACTOR + 1);
     }
 
     #[test]


### PR DESCRIPTION
Draft because on top of #6685 (and needs #6684 to merge too).

At the risk of getting a bit frantic here I:

1. Had mad sook about Mitch introducing the `deprecated` attribute which would trigger a whole stack release again
2. Calmed down and realised we could still be nice to downstream by putting the deprecation in the last RC 
3. Did #6684 and #6685
4. Pushed up this release PR.

If this lands we can do this again later for any other stuff that we deleted but could have deprecated - like good library devs should. 