### PR TITLE
base58: Remove pub use of `std` types

### DIFF
--- a/base58/src/lib.rs
+++ b/base58/src/lib.rs
@@ -31,13 +31,10 @@ static BASE58_CHARS: &[u8] = b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopq
 pub mod error;
 
 #[cfg(feature = "alloc")]
-#[cfg(not(feature = "std"))]
-pub use alloc::{string::String, vec::Vec};
+use alloc::vec::Vec;
 #[cfg(feature = "alloc")]
 use core::convert::Infallible;
 use core::fmt;
-#[cfg(feature = "std")]
-pub use std::{string::String, vec::Vec};
 
 use hashes::sha256d;
 use internals::array::ArrayExt;


### PR DESCRIPTION
The String type is no longer used anywhere in the public API of base58, as the Base58CkString directly constructs &str types. The Vec type, being from std/alloc, shouldn't be pub re-exported.

Remove String re-export and replace Vec re-export with a use import.