### PR TITLE
units: rename locktime height accessors and query methods

### DIFF
--- a/bitcoin/tests/serde.rs
+++ b/bitcoin/tests/serde.rs
@@ -51,7 +51,7 @@ fn serde_regression_absolute_lock_time_time() {
 
 #[test]
 fn serde_regression_relative_lock_time_height() {
-    let t = relative::LockTime::from(relative::NumberOfBlocks::from_height(0xCAFE));
+    let t = relative::LockTime::from(relative::NumberOfBlocks::from_count(0xCAFE));
 
     let got = serialize(&t).unwrap();
     let want = include_bytes!("data/serde/relative_lock_time_blocks_bincode") as &[_];

--- a/units/api/all-features.txt
+++ b/units/api/all-features.txt
@@ -5549,12 +5549,12 @@ impl bitcoin_units::locktime::relative::LockTime
 pub const bitcoin_units::locktime::relative::LockTime::SIZE: usize
 pub const bitcoin_units::locktime::relative::LockTime::ZERO: Self
 pub const fn bitcoin_units::locktime::relative::LockTime::from_512_second_intervals(intervals: u16) -> Self
+pub const fn bitcoin_units::locktime::relative::LockTime::from_block_count(n: u16) -> Self
 pub fn bitcoin_units::locktime::relative::LockTime::from_consensus(n: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::DisabledLockTimeError>
-pub const fn bitcoin_units::locktime::relative::LockTime::from_height(n: u16) -> Self
 pub const fn bitcoin_units::locktime::relative::LockTime::from_seconds_ceil(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::TimeOverflowError>
 pub const fn bitcoin_units::locktime::relative::LockTime::from_seconds_floor(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::TimeOverflowError>
 pub fn bitcoin_units::locktime::relative::LockTime::from_sequence(n: bitcoin_units::sequence::Sequence) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::DisabledLockTimeError>
-pub const fn bitcoin_units::locktime::relative::LockTime::is_block_height(self) -> bool
+pub const fn bitcoin_units::locktime::relative::LockTime::is_block_count(self) -> bool
 pub const fn bitcoin_units::locktime::relative::LockTime::is_block_time(self) -> bool
 pub fn bitcoin_units::locktime::relative::LockTime::is_implied_by(self, other: Self) -> bool
 pub fn bitcoin_units::locktime::relative::LockTime::is_implied_by_sequence(self, other: bitcoin_units::sequence::Sequence) -> bool
@@ -5955,11 +5955,11 @@ impl bitcoin_units::locktime::relative::NumberOfBlocks
 pub const bitcoin_units::locktime::relative::NumberOfBlocks::MAX: Self
 pub const bitcoin_units::locktime::relative::NumberOfBlocks::MIN: Self
 pub const bitcoin_units::locktime::relative::NumberOfBlocks::ZERO: Self
-pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::from_height(blocks: u16) -> Self
+pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::from_count(blocks: u16) -> Self
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::PrefixedHexError>
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError>
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockHeight, utxo_mined_at: bitcoin_units::block::BlockHeight) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::InvalidHeightError>
-pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::to_height(self) -> u16
+pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::to_count(self) -> u16
 impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOfBlocks
   pub fn bitcoin_units::locktime::relative::NumberOfBlocks::clone(&self) -> bitcoin_units::locktime::relative::NumberOfBlocks [impl: impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOfBlocks]
 impl core::cmp::Eq for bitcoin_units::locktime::relative::NumberOfBlocks
@@ -7593,12 +7593,12 @@ impl bitcoin_units::locktime::relative::LockTime
 pub const bitcoin_units::locktime::relative::LockTime::SIZE: usize
 pub const bitcoin_units::locktime::relative::LockTime::ZERO: Self
 pub const fn bitcoin_units::locktime::relative::LockTime::from_512_second_intervals(intervals: u16) -> Self
+pub const fn bitcoin_units::locktime::relative::LockTime::from_block_count(n: u16) -> Self
 pub fn bitcoin_units::locktime::relative::LockTime::from_consensus(n: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::DisabledLockTimeError>
-pub const fn bitcoin_units::locktime::relative::LockTime::from_height(n: u16) -> Self
 pub const fn bitcoin_units::locktime::relative::LockTime::from_seconds_ceil(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::TimeOverflowError>
 pub const fn bitcoin_units::locktime::relative::LockTime::from_seconds_floor(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::TimeOverflowError>
 pub fn bitcoin_units::locktime::relative::LockTime::from_sequence(n: bitcoin_units::sequence::Sequence) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::DisabledLockTimeError>
-pub const fn bitcoin_units::locktime::relative::LockTime::is_block_height(self) -> bool
+pub const fn bitcoin_units::locktime::relative::LockTime::is_block_count(self) -> bool
 pub const fn bitcoin_units::locktime::relative::LockTime::is_block_time(self) -> bool
 pub fn bitcoin_units::locktime::relative::LockTime::is_implied_by(self, other: Self) -> bool
 pub fn bitcoin_units::locktime::relative::LockTime::is_implied_by_sequence(self, other: bitcoin_units::sequence::Sequence) -> bool
@@ -7999,11 +7999,11 @@ impl bitcoin_units::locktime::relative::NumberOfBlocks
 pub const bitcoin_units::locktime::relative::NumberOfBlocks::MAX: Self
 pub const bitcoin_units::locktime::relative::NumberOfBlocks::MIN: Self
 pub const bitcoin_units::locktime::relative::NumberOfBlocks::ZERO: Self
-pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::from_height(blocks: u16) -> Self
+pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::from_count(blocks: u16) -> Self
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::PrefixedHexError>
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError>
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockHeight, utxo_mined_at: bitcoin_units::block::BlockHeight) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::InvalidHeightError>
-pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::to_height(self) -> u16
+pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::to_count(self) -> u16
 impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOfBlocks
   pub fn bitcoin_units::locktime::relative::NumberOfBlocks::clone(&self) -> bitcoin_units::locktime::relative::NumberOfBlocks [impl: impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOfBlocks]
 impl core::cmp::Eq for bitcoin_units::locktime::relative::NumberOfBlocks

--- a/units/api/alloc-only.txt
+++ b/units/api/alloc-only.txt
@@ -4483,12 +4483,12 @@ impl bitcoin_units::locktime::relative::LockTime
 pub const bitcoin_units::locktime::relative::LockTime::SIZE: usize
 pub const bitcoin_units::locktime::relative::LockTime::ZERO: Self
 pub const fn bitcoin_units::locktime::relative::LockTime::from_512_second_intervals(intervals: u16) -> Self
+pub const fn bitcoin_units::locktime::relative::LockTime::from_block_count(n: u16) -> Self
 pub fn bitcoin_units::locktime::relative::LockTime::from_consensus(n: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::DisabledLockTimeError>
-pub const fn bitcoin_units::locktime::relative::LockTime::from_height(n: u16) -> Self
 pub const fn bitcoin_units::locktime::relative::LockTime::from_seconds_ceil(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::TimeOverflowError>
 pub const fn bitcoin_units::locktime::relative::LockTime::from_seconds_floor(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::TimeOverflowError>
 pub fn bitcoin_units::locktime::relative::LockTime::from_sequence(n: bitcoin_units::sequence::Sequence) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::DisabledLockTimeError>
-pub const fn bitcoin_units::locktime::relative::LockTime::is_block_height(self) -> bool
+pub const fn bitcoin_units::locktime::relative::LockTime::is_block_count(self) -> bool
 pub const fn bitcoin_units::locktime::relative::LockTime::is_block_time(self) -> bool
 pub fn bitcoin_units::locktime::relative::LockTime::is_implied_by(self, other: Self) -> bool
 pub fn bitcoin_units::locktime::relative::LockTime::is_implied_by_sequence(self, other: bitcoin_units::sequence::Sequence) -> bool
@@ -4865,11 +4865,11 @@ impl bitcoin_units::locktime::relative::NumberOfBlocks
 pub const bitcoin_units::locktime::relative::NumberOfBlocks::MAX: Self
 pub const bitcoin_units::locktime::relative::NumberOfBlocks::MIN: Self
 pub const bitcoin_units::locktime::relative::NumberOfBlocks::ZERO: Self
-pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::from_height(blocks: u16) -> Self
+pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::from_count(blocks: u16) -> Self
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::PrefixedHexError>
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError>
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockHeight, utxo_mined_at: bitcoin_units::block::BlockHeight) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::InvalidHeightError>
-pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::to_height(self) -> u16
+pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::to_count(self) -> u16
 impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOfBlocks
   pub fn bitcoin_units::locktime::relative::NumberOfBlocks::clone(&self) -> bitcoin_units::locktime::relative::NumberOfBlocks [impl: impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOfBlocks]
 impl core::cmp::Eq for bitcoin_units::locktime::relative::NumberOfBlocks
@@ -6253,12 +6253,12 @@ impl bitcoin_units::locktime::relative::LockTime
 pub const bitcoin_units::locktime::relative::LockTime::SIZE: usize
 pub const bitcoin_units::locktime::relative::LockTime::ZERO: Self
 pub const fn bitcoin_units::locktime::relative::LockTime::from_512_second_intervals(intervals: u16) -> Self
+pub const fn bitcoin_units::locktime::relative::LockTime::from_block_count(n: u16) -> Self
 pub fn bitcoin_units::locktime::relative::LockTime::from_consensus(n: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::DisabledLockTimeError>
-pub const fn bitcoin_units::locktime::relative::LockTime::from_height(n: u16) -> Self
 pub const fn bitcoin_units::locktime::relative::LockTime::from_seconds_ceil(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::TimeOverflowError>
 pub const fn bitcoin_units::locktime::relative::LockTime::from_seconds_floor(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::TimeOverflowError>
 pub fn bitcoin_units::locktime::relative::LockTime::from_sequence(n: bitcoin_units::sequence::Sequence) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::DisabledLockTimeError>
-pub const fn bitcoin_units::locktime::relative::LockTime::is_block_height(self) -> bool
+pub const fn bitcoin_units::locktime::relative::LockTime::is_block_count(self) -> bool
 pub const fn bitcoin_units::locktime::relative::LockTime::is_block_time(self) -> bool
 pub fn bitcoin_units::locktime::relative::LockTime::is_implied_by(self, other: Self) -> bool
 pub fn bitcoin_units::locktime::relative::LockTime::is_implied_by_sequence(self, other: bitcoin_units::sequence::Sequence) -> bool
@@ -6635,11 +6635,11 @@ impl bitcoin_units::locktime::relative::NumberOfBlocks
 pub const bitcoin_units::locktime::relative::NumberOfBlocks::MAX: Self
 pub const bitcoin_units::locktime::relative::NumberOfBlocks::MIN: Self
 pub const bitcoin_units::locktime::relative::NumberOfBlocks::ZERO: Self
-pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::from_height(blocks: u16) -> Self
+pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::from_count(blocks: u16) -> Self
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::PrefixedHexError>
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError>
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockHeight, utxo_mined_at: bitcoin_units::block::BlockHeight) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::InvalidHeightError>
-pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::to_height(self) -> u16
+pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::to_count(self) -> u16
 impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOfBlocks
   pub fn bitcoin_units::locktime::relative::NumberOfBlocks::clone(&self) -> bitcoin_units::locktime::relative::NumberOfBlocks [impl: impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOfBlocks]
 impl core::cmp::Eq for bitcoin_units::locktime::relative::NumberOfBlocks

--- a/units/api/no-features.txt
+++ b/units/api/no-features.txt
@@ -3975,12 +3975,12 @@ impl bitcoin_units::locktime::relative::LockTime
 pub const bitcoin_units::locktime::relative::LockTime::SIZE: usize
 pub const bitcoin_units::locktime::relative::LockTime::ZERO: Self
 pub const fn bitcoin_units::locktime::relative::LockTime::from_512_second_intervals(intervals: u16) -> Self
+pub const fn bitcoin_units::locktime::relative::LockTime::from_block_count(n: u16) -> Self
 pub fn bitcoin_units::locktime::relative::LockTime::from_consensus(n: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::DisabledLockTimeError>
-pub const fn bitcoin_units::locktime::relative::LockTime::from_height(n: u16) -> Self
 pub const fn bitcoin_units::locktime::relative::LockTime::from_seconds_ceil(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::TimeOverflowError>
 pub const fn bitcoin_units::locktime::relative::LockTime::from_seconds_floor(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::TimeOverflowError>
 pub fn bitcoin_units::locktime::relative::LockTime::from_sequence(n: bitcoin_units::sequence::Sequence) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::DisabledLockTimeError>
-pub const fn bitcoin_units::locktime::relative::LockTime::is_block_height(self) -> bool
+pub const fn bitcoin_units::locktime::relative::LockTime::is_block_count(self) -> bool
 pub const fn bitcoin_units::locktime::relative::LockTime::is_block_time(self) -> bool
 pub fn bitcoin_units::locktime::relative::LockTime::is_implied_by(self, other: Self) -> bool
 pub fn bitcoin_units::locktime::relative::LockTime::is_implied_by_sequence(self, other: bitcoin_units::sequence::Sequence) -> bool
@@ -4309,11 +4309,11 @@ impl bitcoin_units::locktime::relative::NumberOfBlocks
 pub const bitcoin_units::locktime::relative::NumberOfBlocks::MAX: Self
 pub const bitcoin_units::locktime::relative::NumberOfBlocks::MIN: Self
 pub const bitcoin_units::locktime::relative::NumberOfBlocks::ZERO: Self
-pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::from_height(blocks: u16) -> Self
+pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::from_count(blocks: u16) -> Self
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::PrefixedHexError>
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError>
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockHeight, utxo_mined_at: bitcoin_units::block::BlockHeight) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::InvalidHeightError>
-pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::to_height(self) -> u16
+pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::to_count(self) -> u16
 impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOfBlocks
   pub fn bitcoin_units::locktime::relative::NumberOfBlocks::clone(&self) -> bitcoin_units::locktime::relative::NumberOfBlocks [impl: impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOfBlocks]
 impl core::cmp::Eq for bitcoin_units::locktime::relative::NumberOfBlocks
@@ -5521,12 +5521,12 @@ impl bitcoin_units::locktime::relative::LockTime
 pub const bitcoin_units::locktime::relative::LockTime::SIZE: usize
 pub const bitcoin_units::locktime::relative::LockTime::ZERO: Self
 pub const fn bitcoin_units::locktime::relative::LockTime::from_512_second_intervals(intervals: u16) -> Self
+pub const fn bitcoin_units::locktime::relative::LockTime::from_block_count(n: u16) -> Self
 pub fn bitcoin_units::locktime::relative::LockTime::from_consensus(n: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::DisabledLockTimeError>
-pub const fn bitcoin_units::locktime::relative::LockTime::from_height(n: u16) -> Self
 pub const fn bitcoin_units::locktime::relative::LockTime::from_seconds_ceil(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::TimeOverflowError>
 pub const fn bitcoin_units::locktime::relative::LockTime::from_seconds_floor(seconds: u32) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::TimeOverflowError>
 pub fn bitcoin_units::locktime::relative::LockTime::from_sequence(n: bitcoin_units::sequence::Sequence) -> core::result::Result<Self, bitcoin_units::locktime::relative::error::DisabledLockTimeError>
-pub const fn bitcoin_units::locktime::relative::LockTime::is_block_height(self) -> bool
+pub const fn bitcoin_units::locktime::relative::LockTime::is_block_count(self) -> bool
 pub const fn bitcoin_units::locktime::relative::LockTime::is_block_time(self) -> bool
 pub fn bitcoin_units::locktime::relative::LockTime::is_implied_by(self, other: Self) -> bool
 pub fn bitcoin_units::locktime::relative::LockTime::is_implied_by_sequence(self, other: bitcoin_units::sequence::Sequence) -> bool
@@ -5855,11 +5855,11 @@ impl bitcoin_units::locktime::relative::NumberOfBlocks
 pub const bitcoin_units::locktime::relative::NumberOfBlocks::MAX: Self
 pub const bitcoin_units::locktime::relative::NumberOfBlocks::MIN: Self
 pub const bitcoin_units::locktime::relative::NumberOfBlocks::ZERO: Self
-pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::from_height(blocks: u16) -> Self
+pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::from_count(blocks: u16) -> Self
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::PrefixedHexError>
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::from_unprefixed_hex(s: &str) -> core::result::Result<Self, bitcoin_units::parse_int::error::UnprefixedHexError>
 pub fn bitcoin_units::locktime::relative::NumberOfBlocks::is_satisfied_by(self, chain_tip: bitcoin_units::block::BlockHeight, utxo_mined_at: bitcoin_units::block::BlockHeight) -> core::result::Result<bool, bitcoin_units::locktime::relative::error::InvalidHeightError>
-pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::to_height(self) -> u16
+pub const fn bitcoin_units::locktime::relative::NumberOfBlocks::to_count(self) -> u16
 impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOfBlocks
   pub fn bitcoin_units::locktime::relative::NumberOfBlocks::clone(&self) -> bitcoin_units::locktime::relative::NumberOfBlocks [impl: impl core::clone::Clone for bitcoin_units::locktime::relative::NumberOfBlocks]
 impl core::cmp::Eq for bitcoin_units::locktime::relative::NumberOfBlocks

--- a/units/src/block.rs
+++ b/units/src/block.rs
@@ -295,7 +295,7 @@ impl From<relative::NumberOfBlocks> for BlockHeightInterval {
     /// A relative locktime block height has a maximum value of `u16::MAX` where as a
     /// [`BlockHeightInterval`] is a thin wrapper around a `u32`, the two types are not interchangeable.
     #[inline]
-    fn from(h: relative::NumberOfBlocks) -> Self { Self::from_u32(h.to_height().into()) }
+    fn from(h: relative::NumberOfBlocks) -> Self { Self::from_u32(h.to_count().into()) }
 }
 
 impl TryFrom<BlockHeightInterval> for relative::NumberOfBlocks {
@@ -308,7 +308,7 @@ impl TryFrom<BlockHeightInterval> for relative::NumberOfBlocks {
     #[inline]
     fn try_from(h: BlockHeightInterval) -> Result<Self, Self::Error> {
         u16::try_from(h.to_u32())
-            .map(Self::from_height)
+            .map(Self::from_count)
             .map_err(|_| TooBigForRelativeHeightError(h.into()))
     }
 }
@@ -709,7 +709,7 @@ mod tests {
         assert_eq!(interval, 100);
 
         let interval_from_height: BlockHeightInterval =
-            relative::NumberOfBlocks::from_height(10).into();
+            relative::NumberOfBlocks::from_count(10).into();
         assert_eq!(interval_from_height.to_u32(), 10u32);
 
         let invalid_height_greater =

--- a/units/src/locktime/absolute/mod.rs
+++ b/units/src/locktime/absolute/mod.rs
@@ -88,7 +88,7 @@ pub enum LockTime {
     ///
     /// let block: u32 = 741521;
     /// let n = absolute::LockTime::from_height(block).expect("valid height");
-    /// assert!(n.is_block_height());
+    /// assert!(n.is_lock_by_block_height());
     /// assert_eq!(n.to_consensus_u32(), block);
     /// ```
     Blocks(Height),
@@ -101,7 +101,7 @@ pub enum LockTime {
     ///
     /// let seconds: u32 = 1653195600; // May 22nd, 5am UTC.
     /// let n = absolute::LockTime::from_mtp(seconds).expect("valid time");
-    /// assert!(n.is_block_time());
+    /// assert!(n.is_lock_by_block_time());
     /// assert_eq!(n.to_consensus_u32(), seconds);
     /// ```
     Seconds(MedianTimePast),
@@ -253,11 +253,11 @@ impl LockTime {
 
     /// Returns true if this lock time value is a block height.
     #[inline]
-    pub const fn is_block_height(self) -> bool { matches!(self, Self::Blocks(_)) }
+    pub const fn is_lock_by_block_height(self) -> bool { matches!(self, Self::Blocks(_)) }
 
     /// Returns true if this lock time value is a block time (UNIX timestamp).
     #[inline]
-    pub const fn is_block_time(self) -> bool { !self.is_block_height() }
+    pub const fn is_lock_by_block_time(self) -> bool { !self.is_lock_by_block_height() }
 
     /// Returns true if this timelock constraint is satisfied by the respective `height`/`time`.
     ///
@@ -892,14 +892,14 @@ mod tests {
     fn parses_correctly_to_height_or_time() {
         let lock_by_height = LockTime::from_consensus(750_000);
 
-        assert!(lock_by_height.is_block_height());
-        assert!(!lock_by_height.is_block_time());
+        assert!(lock_by_height.is_lock_by_block_height());
+        assert!(!lock_by_height.is_lock_by_block_time());
 
         let t: u32 = 1_653_195_600; // May 22nd, 5am UTC.
         let lock_by_time = LockTime::from_consensus(t);
 
-        assert!(!lock_by_time.is_block_height());
-        assert!(lock_by_time.is_block_time());
+        assert!(!lock_by_time.is_lock_by_block_height());
+        assert!(lock_by_time.is_lock_by_block_time());
 
         // Test is_same_unit() logic
         assert!(lock_by_height.is_same_unit(LockTime::from_consensus(800_000)));

--- a/units/src/locktime/relative/error.rs
+++ b/units/src/locktime/relative/error.rs
@@ -326,7 +326,7 @@ mod tests {
 
         // IsSatisfiedBy*Error
         let time_lock = LockTime::from_512_second_intervals(10);
-        let height_lock = LockTime::from_height(10);
+        let height_lock = LockTime::from_block_count(10);
 
         // IsSatisfiedByError - wraps InvalidHeightError or InvalidTimeError
         // Error when chain_tip < utxo_mined_at (args wrong way around)

--- a/units/src/locktime/relative/error.rs
+++ b/units/src/locktime/relative/error.rs
@@ -309,7 +309,7 @@ mod tests {
         assert!(e.source().is_none());
 
         // InvalidHeightError - is_satisfied_by with invalid args
-        let blocks = NumberOfBlocks::from_height(10);
+        let blocks = NumberOfBlocks::from_count(10);
         let e = blocks
             .is_satisfied_by(BlockHeight::from_u32(5), BlockHeight::from_u32(10))
             .unwrap_err();

--- a/units/src/locktime/relative/mod.rs
+++ b/units/src/locktime/relative/mod.rs
@@ -108,7 +108,7 @@ impl LockTime {
     #[inline]
     pub fn to_consensus_u32(self) -> u32 {
         match self {
-            Self::Blocks(ref h) => u32::from(h.to_height()),
+            Self::Blocks(ref h) => u32::from(h.to_count()),
             Self::Time(ref t) => Sequence::LOCK_TYPE_MASK | u32::from(t.to_512_second_intervals()),
         }
     }
@@ -145,7 +145,7 @@ impl LockTime {
 
     /// Constructs a new `LockTime` from `n`, expecting `n` to be a 16-bit count of blocks.
     #[inline]
-    pub const fn from_height(n: u16) -> Self { Self::Blocks(NumberOfBlocks::from_height(n)) }
+    pub const fn from_height(n: u16) -> Self { Self::Blocks(NumberOfBlocks::from_count(n)) }
 
     /// Constructs a new `LockTime` from `n`, expecting `n` to be a count of 512-second intervals.
     ///
@@ -404,12 +404,12 @@ impl NumberOfBlocks {
 
     /// Constructs a new [`NumberOfBlocks`] using a count of blocks.
     #[inline]
-    pub const fn from_height(blocks: u16) -> Self { Self(blocks) }
+    pub const fn from_count(blocks: u16) -> Self { Self(blocks) }
 
     /// Express the [`NumberOfBlocks`] as a count of blocks.
     #[inline]
     #[must_use]
-    pub const fn to_height(self) -> u16 { self.0 }
+    pub const fn to_count(self) -> u16 { self.0 }
 
     /// Constructs a new `NumberOfBlocks` from a prefixed hex string.
     ///
@@ -420,7 +420,7 @@ impl NumberOfBlocks {
     #[inline]
     pub fn from_hex(s: &str) -> Result<Self, PrefixedHexError> {
         let block_count = parse_int::hex_u16_prefixed(s)?;
-        Ok(Self::from_height(block_count))
+        Ok(Self::from_count(block_count))
     }
 
     /// Constructs a new `NumberOfBlocks` from an unprefixed hex string.
@@ -432,7 +432,7 @@ impl NumberOfBlocks {
     #[inline]
     pub fn from_unprefixed_hex(s: &str) -> Result<Self, UnprefixedHexError> {
         let block_count = parse_int::hex_u16_unprefixed(s)?;
-        Ok(Self::from_height(block_count))
+        Ok(Self::from_count(block_count))
     }
 
     /// Returns true if an output locked by a block count can be spent in the next block.
@@ -448,13 +448,13 @@ impl NumberOfBlocks {
         chain_tip
             .checked_sub(utxo_mined_at)
             .ok_or(InvalidHeightError { chain_tip, utxo_mined_at })
-            .map(|diff| u32::from(self.to_height()).saturating_sub(1) <= diff.to_u32())
+            .map(|diff| u32::from(self.to_count()).saturating_sub(1) <= diff.to_u32())
     }
 }
 
 crate::internal_macros::impl_fmt_traits_for_u32_wrapper!(NumberOfBlocks);
 
-parse_int::impl_parse_str_from_int_infallible!(NumberOfBlocks, u16, from_height);
+parse_int::impl_parse_str_from_int_infallible!(NumberOfBlocks, u16, from_count);
 
 impl fmt::Display for NumberOfBlocks {
     #[inline]
@@ -467,7 +467,7 @@ impl Serialize for NumberOfBlocks {
     where
         S: Serializer,
     {
-        u16::serialize(&self.to_height(), s)
+        u16::serialize(&self.to_count(), s)
     }
 }
 
@@ -478,7 +478,7 @@ impl<'de> Deserialize<'de> for NumberOfBlocks {
     where
         D: Deserializer<'de>,
     {
-        Ok(Self::from_height(u16::deserialize(d)?))
+        Ok(Self::from_count(u16::deserialize(d)?))
     }
 }
 
@@ -640,7 +640,7 @@ impl<'a> Arbitrary<'a> for NumberOfBlocks {
         match choice {
             0 => Ok(Self::MIN),
             1 => Ok(Self::MAX),
-            _ => Ok(Self::from_height(u16::arbitrary(u)?)),
+            _ => Ok(Self::from_count(u16::arbitrary(u)?)),
         }
     }
 }
@@ -701,8 +701,8 @@ mod tests {
 
     #[test]
     fn parses_correctly_to_height_or_time() {
-        let height1 = NumberOfBlocks::from_height(10);
-        let height2 = NumberOfBlocks::from_height(11);
+        let height1 = NumberOfBlocks::from_count(10);
+        let height2 = NumberOfBlocks::from_count(11);
         let time1 = NumberOf512Seconds::from_512_second_intervals(70);
         let time2 = NumberOf512Seconds::from_512_second_intervals(71);
 
@@ -726,12 +726,12 @@ mod tests {
 
     #[test]
     fn height_correctly_implies() {
-        let height = NumberOfBlocks::from_height(10);
+        let height = NumberOfBlocks::from_count(10);
         let lock_by_height = LockTime::from(height);
 
-        assert!(!lock_by_height.is_implied_by(LockTime::from(NumberOfBlocks::from_height(9))));
-        assert!(lock_by_height.is_implied_by(LockTime::from(NumberOfBlocks::from_height(10))));
-        assert!(lock_by_height.is_implied_by(LockTime::from(NumberOfBlocks::from_height(11))));
+        assert!(!lock_by_height.is_implied_by(LockTime::from(NumberOfBlocks::from_count(9))));
+        assert!(lock_by_height.is_implied_by(LockTime::from(NumberOfBlocks::from_count(10))));
+        assert!(lock_by_height.is_implied_by(LockTime::from(NumberOfBlocks::from_count(11))));
     }
 
     #[test]
@@ -749,7 +749,7 @@ mod tests {
 
     #[test]
     fn sequence_correctly_implies() {
-        let height = NumberOfBlocks::from_height(10);
+        let height = NumberOfBlocks::from_count(10);
         let time = NumberOf512Seconds::from_512_second_intervals(70);
 
         let lock_by_height = LockTime::from(height);
@@ -772,7 +772,7 @@ mod tests {
     #[test]
     fn incorrect_units_do_not_imply() {
         let time = NumberOf512Seconds::from_512_second_intervals(70);
-        let height = NumberOfBlocks::from_height(10);
+        let height = NumberOfBlocks::from_count(10);
 
         let lock_by_time = LockTime::from(time);
         assert!(!lock_by_time.is_implied_by(LockTime::from(height)));
@@ -835,7 +835,7 @@ mod tests {
         let mined_at = BlockHeight::from_u32(900_000);
         let chain_tip = BlockHeight::from_u32(800_000);
 
-        let block_count = NumberOfBlocks::from_height(70); // Arbitrary value.
+        let block_count = NumberOfBlocks::from_count(70); // Arbitrary value.
         let err = block_count.is_satisfied_by(chain_tip, mined_at).unwrap_err();
 
         assert!(matches!(err, InvalidHeightError { chain_tip: _, utxo_mined_at: _ }));
@@ -851,7 +851,7 @@ mod tests {
         let lock_by_height = LockTime::from_height(10); // Arbitrary value.
         let err = lock_by_height.is_satisfied_by_time(chain_tip, mined_at).unwrap_err();
 
-        let expected_height = NumberOfBlocks::from_height(10);
+        let expected_height = NumberOfBlocks::from_count(10);
         assert_eq!(
             err,
             IsSatisfiedByTimeError::Incompatible(IncompatibleTimeError(expected_height))
@@ -890,10 +890,10 @@ mod tests {
         let utxo_height = BlockHeight::from_u32(80);
         let utxo_mtp = BlockMtp::new(utxo_timestamps);
 
-        let lock1 = LockTime::Blocks(NumberOfBlocks::from_height(10));
+        let lock1 = LockTime::Blocks(NumberOfBlocks::from_count(10));
         assert!(lock1.is_satisfied_by(chain_height, chain_mtp, utxo_height, utxo_mtp).unwrap());
 
-        let lock2 = LockTime::Blocks(NumberOfBlocks::from_height(21));
+        let lock2 = LockTime::Blocks(NumberOfBlocks::from_count(21));
         assert!(lock2.is_satisfied_by(chain_height, chain_mtp, utxo_height, utxo_mtp).unwrap());
 
         let lock3 = LockTime::Time(NumberOf512Seconds::from_512_second_intervals(10));
@@ -1073,7 +1073,7 @@ mod tests {
     #[test]
     fn satisfied_by_height_boundary() {
         for n in [0, 2, 5, 9, 20, u16::MAX] {
-            let lock = NumberOfBlocks::from_height(n);
+            let lock = NumberOfBlocks::from_count(n);
             let mined_at = BlockHeight::from_u32(100);
 
             let first_spendable_tip = BlockHeight::from_u32(100 + u32::from(n).saturating_sub(1));
@@ -1098,7 +1098,7 @@ mod tests {
         let mined_at = BlockHeight::from_u32(u32::MIN);
         let chain_tip = BlockHeight::from_u32(u32::MAX);
 
-        let block_height = NumberOfBlocks::from_height(10); // Arbitrary value.
+        let block_height = NumberOfBlocks::from_count(10); // Arbitrary value.
         assert!(block_height.is_satisfied_by(chain_tip, mined_at).unwrap());
     }
 }

--- a/units/src/locktime/relative/mod.rs
+++ b/units/src/locktime/relative/mod.rs
@@ -81,13 +81,13 @@ impl LockTime {
     /// // Values with bit 22 set to 0 will be interpreted as block-based lock times.
     /// let blocks: u32 = 144; // 144 blocks, approx 24h.
     /// let lock_time = relative::LockTime::from_consensus(blocks)?;
-    /// assert!(lock_time.is_block_height());
+    /// assert!(lock_time.is_lock_by_block_count());
     /// assert_eq!(lock_time.to_consensus_u32(), blocks);
     ///
     /// // Values with bit 22 set to 1 will be interpreted as time-based lock times.
     /// let time: u32 = 168 | (1 << 22) ; // Bit 22 is 1 with time approx 24h.
     /// let lock_time = relative::LockTime::from_consensus(time)?;
-    /// assert!(lock_time.is_block_time());
+    /// assert!(lock_time.is_lock_by_block_time());
     /// assert_eq!(lock_time.to_consensus_u32(), time);
     ///
     /// # Ok::<_, relative::error::DisabledLockTimeError>(())
@@ -130,7 +130,7 @@ impl LockTime {
     /// // Interpret a sequence number from a Bitcoin transaction input as a relative lock time
     /// let sequence_number = Sequence::from_consensus(144); // 144 blocks, approx 24h.
     /// let lock_time = relative::LockTime::from_sequence(sequence_number)?;
-    /// assert!(lock_time.is_block_height());
+    /// assert!(lock_time.is_lock_by_block_count());
     ///
     /// # Ok::<_, relative::error::DisabledLockTimeError>(())
     /// ```
@@ -145,7 +145,7 @@ impl LockTime {
 
     /// Constructs a new `LockTime` from `n`, expecting `n` to be a 16-bit count of blocks.
     #[inline]
-    pub const fn from_height(n: u16) -> Self { Self::Blocks(NumberOfBlocks::from_count(n)) }
+    pub const fn from_block_count(n: u16) -> Self { Self::Blocks(NumberOfBlocks::from_count(n)) }
 
     /// Constructs a new `LockTime` from `n`, expecting `n` to be a count of 512-second intervals.
     ///
@@ -192,11 +192,11 @@ impl LockTime {
 
     /// Returns true if this lock time value is in units of blocks.
     #[inline]
-    pub const fn is_block_height(self) -> bool { matches!(self, Self::Blocks(_)) }
+    pub const fn is_lock_by_block_count(self) -> bool { matches!(self, Self::Blocks(_)) }
 
     /// Returns true if this lock time value is in units of time.
     #[inline]
-    pub const fn is_block_time(self) -> bool { !self.is_block_height() }
+    pub const fn is_lock_by_block_time(self) -> bool { !self.is_lock_by_block_count() }
 
     /// Returns true if this [`relative::LockTime`] is satisfied by the given chain state.
     ///
@@ -316,7 +316,7 @@ impl LockTime {
     /// let sequence = Sequence::from_consensus(1 << 22 | 168); // Bit 22 is 1 with time approx 24h.
     /// let lock_time = relative::LockTime::from_sequence(sequence)?;
     /// let input_sequence = Sequence::from_consensus(1 << 22 | 336); // Approx 48h.
-    /// assert!(lock_time.is_block_time());
+    /// assert!(lock_time.is_lock_by_block_time());
     ///
     /// assert!(lock_time.is_implied_by_sequence(input_sequence));
     ///
@@ -671,7 +671,7 @@ mod tests {
     #[test]
     #[cfg(feature = "alloc")]
     fn display_and_alternate() {
-        let lock_by_height = LockTime::from_height(10);
+        let lock_by_height = LockTime::from_block_count(10);
         let lock_by_time = LockTime::from_512_second_intervals(70);
 
         assert_eq!(format!("{}", lock_by_height), "10");
@@ -711,11 +711,11 @@ mod tests {
         let lock_by_time1 = LockTime::from(time1);
         let lock_by_time2 = LockTime::from(time2);
 
-        assert!(lock_by_height1.is_block_height());
-        assert!(!lock_by_height1.is_block_time());
+        assert!(lock_by_height1.is_lock_by_block_count());
+        assert!(!lock_by_height1.is_lock_by_block_time());
 
-        assert!(!lock_by_time1.is_block_height());
-        assert!(lock_by_time1.is_block_time());
+        assert!(!lock_by_time1.is_lock_by_block_count());
+        assert!(lock_by_time1.is_lock_by_block_time());
 
         // Test is_same_unit() logic
         assert!(lock_by_height1.is_same_unit(lock_by_height2));
@@ -848,7 +848,7 @@ mod tests {
         let mined_at = BlockMtp::from_u32(1_234_567_890);
         let chain_tip = BlockMtp::from_u32(1_600_000_000);
 
-        let lock_by_height = LockTime::from_height(10); // Arbitrary value.
+        let lock_by_height = LockTime::from_block_count(10); // Arbitrary value.
         let err = lock_by_height.is_satisfied_by_time(chain_tip, mined_at).unwrap_err();
 
         let expected_height = NumberOfBlocks::from_count(10);

--- a/units/src/locktime/relative/mod.rs
+++ b/units/src/locktime/relative/mod.rs
@@ -81,7 +81,7 @@ impl LockTime {
     /// // Values with bit 22 set to 0 will be interpreted as block-based lock times.
     /// let blocks: u32 = 144; // 144 blocks, approx 24h.
     /// let lock_time = relative::LockTime::from_consensus(blocks)?;
-    /// assert!(lock_time.is_block_height());
+    /// assert!(lock_time.is_block_count());
     /// assert_eq!(lock_time.to_consensus_u32(), blocks);
     ///
     /// // Values with bit 22 set to 1 will be interpreted as time-based lock times.
@@ -130,7 +130,7 @@ impl LockTime {
     /// // Interpret a sequence number from a Bitcoin transaction input as a relative lock time
     /// let sequence_number = Sequence::from_consensus(144); // 144 blocks, approx 24h.
     /// let lock_time = relative::LockTime::from_sequence(sequence_number)?;
-    /// assert!(lock_time.is_block_height());
+    /// assert!(lock_time.is_block_count());
     ///
     /// # Ok::<_, relative::error::DisabledLockTimeError>(())
     /// ```
@@ -145,7 +145,7 @@ impl LockTime {
 
     /// Constructs a new `LockTime` from `n`, expecting `n` to be a 16-bit count of blocks.
     #[inline]
-    pub const fn from_height(n: u16) -> Self { Self::Blocks(NumberOfBlocks::from_count(n)) }
+    pub const fn from_block_count(n: u16) -> Self { Self::Blocks(NumberOfBlocks::from_count(n)) }
 
     /// Constructs a new `LockTime` from `n`, expecting `n` to be a count of 512-second intervals.
     ///
@@ -192,11 +192,11 @@ impl LockTime {
 
     /// Returns true if this lock time value is in units of blocks.
     #[inline]
-    pub const fn is_block_height(self) -> bool { matches!(self, Self::Blocks(_)) }
+    pub const fn is_block_count(self) -> bool { matches!(self, Self::Blocks(_)) }
 
     /// Returns true if this lock time value is in units of time.
     #[inline]
-    pub const fn is_block_time(self) -> bool { !self.is_block_height() }
+    pub const fn is_block_time(self) -> bool { !self.is_block_count() }
 
     /// Returns true if this [`relative::LockTime`] is satisfied by the given chain state.
     ///
@@ -671,7 +671,7 @@ mod tests {
     #[test]
     #[cfg(feature = "alloc")]
     fn display_and_alternate() {
-        let lock_by_height = LockTime::from_height(10);
+        let lock_by_height = LockTime::from_block_count(10);
         let lock_by_time = LockTime::from_512_second_intervals(70);
 
         assert_eq!(format!("{}", lock_by_height), "10");
@@ -711,10 +711,10 @@ mod tests {
         let lock_by_time1 = LockTime::from(time1);
         let lock_by_time2 = LockTime::from(time2);
 
-        assert!(lock_by_height1.is_block_height());
+        assert!(lock_by_height1.is_block_count());
         assert!(!lock_by_height1.is_block_time());
 
-        assert!(!lock_by_time1.is_block_height());
+        assert!(!lock_by_time1.is_block_count());
         assert!(lock_by_time1.is_block_time());
 
         // Test is_same_unit() logic
@@ -848,7 +848,7 @@ mod tests {
         let mined_at = BlockMtp::from_u32(1_234_567_890);
         let chain_tip = BlockMtp::from_u32(1_600_000_000);
 
-        let lock_by_height = LockTime::from_height(10); // Arbitrary value.
+        let lock_by_height = LockTime::from_block_count(10); // Arbitrary value.
         let err = lock_by_height.is_satisfied_by_time(chain_tip, mined_at).unwrap_err();
 
         let expected_height = NumberOfBlocks::from_count(10);

--- a/units/src/sequence.rs
+++ b/units/src/sequence.rs
@@ -215,7 +215,7 @@ impl Sequence {
         if self.is_time_locked() {
             Some(LockTime::from(NumberOf512Seconds::from_512_second_intervals(lock_value)))
         } else {
-            Some(LockTime::from(NumberOfBlocks::from_height(lock_value)))
+            Some(LockTime::from(NumberOfBlocks::from_count(lock_value)))
         }
     }
 
@@ -333,8 +333,8 @@ impl<'a> Arbitrary<'a> for Sequence {
             1 => Ok(Self::ZERO),
             2 => Ok(Self::MIN_NO_RBF),
             3 => Ok(Self::ENABLE_LOCKTIME_AND_RBF),
-            4 => Ok(Self::from_consensus(u32::from(relative::NumberOfBlocks::MIN.to_height()))),
-            5 => Ok(Self::from_consensus(u32::from(relative::NumberOfBlocks::MAX.to_height()))),
+            4 => Ok(Self::from_consensus(u32::from(relative::NumberOfBlocks::MIN.to_count()))),
+            5 => Ok(Self::from_consensus(u32::from(relative::NumberOfBlocks::MAX.to_count()))),
             6 => Ok(Self::from_consensus(
                 Self::LOCK_TYPE_MASK
                     | u32::from(relative::NumberOf512Seconds::MIN.to_512_second_intervals()),

--- a/units/tests/api.rs
+++ b/units/tests/api.rs
@@ -344,7 +344,7 @@ fn c_newtype_transparent_format() {
         assert_format_matches!(BlockMtpInterval::from(rand_num), rand_num);
         assert_format_matches!(BlockTime::from(rand_num), rand_num);
         assert_format_matches!(
-            relative::NumberOfBlocks::from_height(rand_num as u16),
+            relative::NumberOfBlocks::from_count(rand_num as u16),
             rand_num as u16
         );
         assert_format_matches!(

--- a/units/tests/parse.rs
+++ b/units/tests/parse.rs
@@ -98,7 +98,7 @@ test_hex_parse! {
     block_time, BlockTime, "5f000000", BlockTime::from_u32(0x5f00_0000);
     weight, Weight, "00000190", Weight::from_wu(400);
     sequence, Sequence, "ffffffff", Sequence::from_consensus(0xFFFF_FFFF);
-    number_of_blocks, relative::NumberOfBlocks, "000000ff", relative::NumberOfBlocks::from_height(255);
+    number_of_blocks, relative::NumberOfBlocks, "000000ff", relative::NumberOfBlocks::from_count(255);
     number_of_512_seconds, relative::NumberOf512Seconds, "00000001", relative::NumberOf512Seconds::from_512_second_intervals(1);
 }
 

--- a/units/tests/serde.rs
+++ b/units/tests/serde.rs
@@ -798,7 +798,7 @@ fn serde_as_locktime_from_blocks() {
 
     let orig = T {
         a_lt: AbsoluteLockTime::Blocks(Height::from_u32(1_000).unwrap()),
-        r_lt: RelativeLockTime::Blocks(NumberOfBlocks::from_height(1_000)),
+        r_lt: RelativeLockTime::Blocks(NumberOfBlocks::from_count(1_000)),
     };
 
     let json = "{\"a_lt\": 1000, \"r_lt\": 1000}";


### PR DESCRIPTION
The docs use "block count" everywhere, but api still says height.

This is a follow-up to [docs reword](https://github.com/rust-bitcoin/rust-bitcoin/pull/6671#issuecomment-5187855352) in the relative locktime module, incorporating rename suggestions from the review. A relative lock counts blocks elapsed since the UTXO was confirmed, not chain height.

Changes:
- `NumberOfBlocks::from_height` and `to_height` become `from_count` and `to_count`.
- Relative `LockTime::is_block_height` and `is_block_time` become `is_lock_by_block_count` and `is_lock_by_block_time`
- `from_height` becomes `from_block_count`.
- Absolute `LockTime` was touched because it has similar-looking modified names like `is_block_height`. The new `lock_by` infix match was necessary to avoid looking inconsistent.