### PR TITLE
consensus_encoding: expose lower level encoder/decoder interfaces

### DIFF
--- a/consensus_encoding/api/all-features.txt
+++ b/consensus_encoding/api/all-features.txt
@@ -1796,6 +1796,48 @@ impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::EncoderByteIt
   pub unsafe fn bitcoin_consensus_encoding::EncoderByteIter<T>::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::EncoderByteIter<T> where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::EncoderByteIter<T>
   pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_consensus_encoding::EncoderByteIter<T>]
+pub struct bitcoin_consensus_encoding::ExactVecDecoderWith<D: bitcoin_consensus_encoding::Decoder + core::default::Default>
+impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::ExactVecDecoderWith<D>
+pub const fn bitcoin_consensus_encoding::ExactVecDecoderWith<D>::new(count: usize) -> Self
+impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default + core::clone::Clone> core::clone::Clone for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where <D as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone
+  pub fn bitcoin_consensus_encoding::ExactVecDecoderWith<D>::clone(&self) -> Self [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default + core::clone::Clone> core::clone::Clone for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where <D as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone]
+impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default + core::fmt::Debug> core::fmt::Debug for bitcoin_consensus_encoding::ExactVecDecoderWith<D>
+  pub fn bitcoin_consensus_encoding::ExactVecDecoderWith<D>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default + core::fmt::Debug> core::fmt::Debug for bitcoin_consensus_encoding::ExactVecDecoderWith<D>]
+impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ExactVecDecoderWith<D>
+  pub type bitcoin_consensus_encoding::ExactVecDecoderWith<D>::Error = bitcoin_consensus_encoding::error::VecDecoderError<<D as bitcoin_consensus_encoding::Decoder>::Error> [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ExactVecDecoderWith<D>]
+  pub type bitcoin_consensus_encoding::ExactVecDecoderWith<D>::Output = alloc::vec::Vec<<D as bitcoin_consensus_encoding::Decoder>::Output> [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ExactVecDecoderWith<D>]
+  pub fn bitcoin_consensus_encoding::ExactVecDecoderWith<D>::end(self) -> core::result::Result<Self::Output, Self::Error> [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ExactVecDecoderWith<D>]
+  pub fn bitcoin_consensus_encoding::ExactVecDecoderWith<D>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error> [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ExactVecDecoderWith<D>]
+  pub fn bitcoin_consensus_encoding::ExactVecDecoderWith<D>::read_limit(&self) -> usize [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ExactVecDecoderWith<D>]
+impl<D> core::marker::Freeze for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where D: core::marker::Freeze
+impl<D> core::marker::Send for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where D: core::marker::Send, <D as bitcoin_consensus_encoding::Decoder>::Output: core::marker::Send
+impl<D> core::marker::Sync for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where D: core::marker::Sync, <D as bitcoin_consensus_encoding::Decoder>::Output: core::marker::Sync
+impl<D> core::marker::Unpin for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where D: core::marker::Unpin, <D as bitcoin_consensus_encoding::Decoder>::Output: core::marker::Unpin
+impl<D> core::marker::UnsafeUnpin for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where D: core::marker::UnsafeUnpin
+impl<D> core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where D: core::panic::unwind_safe::RefUnwindSafe, <D as bitcoin_consensus_encoding::Decoder>::Output: core::panic::unwind_safe::RefUnwindSafe
+impl<D> core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where D: core::panic::unwind_safe::UnwindSafe, <D as bitcoin_consensus_encoding::Decoder>::Output: core::panic::unwind_safe::UnwindSafe
+impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where U: core::convert::From<T>
+  pub fn bitcoin_consensus_encoding::ExactVecDecoderWith<D>::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where U: core::convert::Into<T>
+  pub type bitcoin_consensus_encoding::ExactVecDecoderWith<D>::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where U: core::convert::Into<T>]
+  pub fn bitcoin_consensus_encoding::ExactVecDecoderWith<D>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where U: core::convert::TryFrom<T>
+  pub type bitcoin_consensus_encoding::ExactVecDecoderWith<D>::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_consensus_encoding::ExactVecDecoderWith<D>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where U: core::convert::TryFrom<T>]
+impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where T: core::clone::Clone
+  pub type bitcoin_consensus_encoding::ExactVecDecoderWith<D>::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where T: core::clone::Clone]
+  pub fn bitcoin_consensus_encoding::ExactVecDecoderWith<D>::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where T: core::clone::Clone]
+  pub fn bitcoin_consensus_encoding::ExactVecDecoderWith<D>::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where T: core::clone::Clone]
+impl<T> core::any::Any for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::ExactVecDecoderWith<D>::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where T: ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::ExactVecDecoderWith<D>::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where T: ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::ExactVecDecoderWith<D>::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where T: core::clone::Clone
+  pub unsafe fn bitcoin_consensus_encoding::ExactVecDecoderWith<D>::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_consensus_encoding::ExactVecDecoderWith<D>
+  pub fn bitcoin_consensus_encoding::ExactVecDecoderWith<D>::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_consensus_encoding::ExactVecDecoderWith<D>]
 pub struct bitcoin_consensus_encoding::FromHexError<ParseErr>(_)
 impl<ParseErr: core::clone::Clone> core::clone::Clone for bitcoin_consensus_encoding::error::FromHexError<ParseErr>
   pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::clone(&self) -> bitcoin_consensus_encoding::error::FromHexError<ParseErr> [impl: impl<ParseErr: core::clone::Clone> core::clone::Clone for bitcoin_consensus_encoding::error::FromHexError<ParseErr>]
@@ -1842,6 +1884,45 @@ impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::error::FromHe
   pub unsafe fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::error::FromHexError<ParseErr> where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::error::FromHexError<ParseErr>
   pub fn bitcoin_consensus_encoding::error::FromHexError<ParseErr>::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_consensus_encoding::error::FromHexError<ParseErr>]
+pub struct bitcoin_consensus_encoding::IterEncoder<I: core::iter::traits::iterator::Iterator> where <I as core::iter::traits::iterator::Iterator>::Item: bitcoin_consensus_encoding::Encoder
+impl<I: core::iter::traits::iterator::Iterator> bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: bitcoin_consensus_encoding::Encoder
+pub fn bitcoin_consensus_encoding::IterEncoder<I>::new(iter: impl core::iter::traits::collect::IntoIterator<IntoIter = I>) -> Self
+impl<I: core::iter::traits::iterator::Iterator> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: bitcoin_consensus_encoding::Encoder
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl<I: core::iter::traits::iterator::Iterator> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: bitcoin_consensus_encoding::Encoder]
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::current_chunk(&self) -> &[u8] [impl: impl<I: core::iter::traits::iterator::Iterator> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: bitcoin_consensus_encoding::Encoder]
+impl<I: core::iter::traits::iterator::Iterator> core::fmt::Debug for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: bitcoin_consensus_encoding::Encoder + core::fmt::Debug
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<I: core::iter::traits::iterator::Iterator> core::fmt::Debug for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: bitcoin_consensus_encoding::Encoder + core::fmt::Debug]
+impl<I> core::clone::Clone for bitcoin_consensus_encoding::IterEncoder<I> where I: core::clone::Clone + core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: bitcoin_consensus_encoding::Encoder + core::clone::Clone
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::clone(&self) -> Self [impl: impl<I> core::clone::Clone for bitcoin_consensus_encoding::IterEncoder<I> where I: core::clone::Clone + core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: bitcoin_consensus_encoding::Encoder + core::clone::Clone]
+impl<I> core::marker::Freeze for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: core::marker::Freeze, I: core::marker::Freeze
+impl<I> core::marker::Send for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: core::marker::Send, I: core::marker::Send
+impl<I> core::marker::Sync for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: core::marker::Sync, I: core::marker::Sync
+impl<I> core::marker::Unpin for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: core::marker::Unpin, I: core::marker::Unpin
+impl<I> core::marker::UnsafeUnpin for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: core::marker::UnsafeUnpin, I: core::marker::UnsafeUnpin
+impl<I> core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: core::panic::unwind_safe::RefUnwindSafe, I: core::panic::unwind_safe::RefUnwindSafe
+impl<I> core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: core::panic::unwind_safe::UnwindSafe, I: core::panic::unwind_safe::UnwindSafe
+impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::IterEncoder<I> where U: core::convert::From<T>
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::IterEncoder<I> where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::IterEncoder<I> where U: core::convert::Into<T>
+  pub type bitcoin_consensus_encoding::IterEncoder<I>::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::IterEncoder<I> where U: core::convert::Into<T>]
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::IterEncoder<I> where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::IterEncoder<I> where U: core::convert::TryFrom<T>
+  pub type bitcoin_consensus_encoding::IterEncoder<I>::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::IterEncoder<I> where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::IterEncoder<I> where U: core::convert::TryFrom<T>]
+impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::IterEncoder<I> where T: core::clone::Clone
+  pub type bitcoin_consensus_encoding::IterEncoder<I>::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::IterEncoder<I> where T: core::clone::Clone]
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::IterEncoder<I> where T: core::clone::Clone]
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::IterEncoder<I> where T: core::clone::Clone]
+impl<T> core::any::Any for bitcoin_consensus_encoding::IterEncoder<I> where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_consensus_encoding::IterEncoder<I> where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::IterEncoder<I> where T: ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::IterEncoder<I> where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::IterEncoder<I> where T: ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::IterEncoder<I> where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::IterEncoder<I> where T: core::clone::Clone
+  pub unsafe fn bitcoin_consensus_encoding::IterEncoder<I>::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::IterEncoder<I> where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_consensus_encoding::IterEncoder<I>
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_consensus_encoding::IterEncoder<I>]
 pub struct bitcoin_consensus_encoding::LengthPrefixExceedsMaxError
 impl core::clone::Clone for bitcoin_consensus_encoding::error::LengthPrefixExceedsMaxError
   pub fn bitcoin_consensus_encoding::error::LengthPrefixExceedsMaxError::clone(&self) -> bitcoin_consensus_encoding::error::LengthPrefixExceedsMaxError [impl: impl core::clone::Clone for bitcoin_consensus_encoding::error::LengthPrefixExceedsMaxError]
@@ -1932,10 +2013,10 @@ impl<T> core::convert::From<T> for bitcoin_consensus_encoding::PrefixedBytesEnco
 pub struct bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T: bitcoin_consensus_encoding::Encode>(_)
 impl<'e, T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>
 pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::new(sl: &'e [T]) -> Self
-impl<'e, T: bitcoin_consensus_encoding::Encode> core::clone::Clone for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::clone::Clone
-  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::clone(&self) -> Self [impl: impl<'e, T: bitcoin_consensus_encoding::Encode> core::clone::Clone for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::clone::Clone]
-impl<'e, T: bitcoin_consensus_encoding::Encode> core::fmt::Debug for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::fmt::Debug
-  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<'e, T: bitcoin_consensus_encoding::Encode> core::fmt::Debug for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::fmt::Debug]
+impl<'e, T: bitcoin_consensus_encoding::Encode + 'e> core::clone::Clone for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::clone::Clone
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::clone(&self) -> Self [impl: impl<'e, T: bitcoin_consensus_encoding::Encode + 'e> core::clone::Clone for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::clone::Clone]
+impl<'e, T: bitcoin_consensus_encoding::Encode + 'e> core::fmt::Debug for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::fmt::Debug
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<'e, T: bitcoin_consensus_encoding::Encode + 'e> core::fmt::Debug for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::fmt::Debug]
 impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>
   pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>]
   pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>::current_chunk(&self) -> &[u8] [impl: impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>]
@@ -1968,13 +2049,13 @@ impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::PrefixedSlice
   pub unsafe fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>
   pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>]
-pub struct bitcoin_consensus_encoding::SliceEncoder<'e, T: bitcoin_consensus_encoding::Encode>
+pub struct bitcoin_consensus_encoding::SliceEncoder<'e, T: bitcoin_consensus_encoding::Encode>(_)
 impl<'e, T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::SliceEncoder<'e, T>
 pub fn bitcoin_consensus_encoding::SliceEncoder<'e, T>::without_length_prefix(sl: &'e [T]) -> Self
-impl<'e, T: bitcoin_consensus_encoding::Encode> core::clone::Clone for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::clone::Clone
-  pub fn bitcoin_consensus_encoding::SliceEncoder<'e, T>::clone(&self) -> Self [impl: impl<'e, T: bitcoin_consensus_encoding::Encode> core::clone::Clone for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::clone::Clone]
-impl<'e, T: bitcoin_consensus_encoding::Encode> core::fmt::Debug for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::fmt::Debug
-  pub fn bitcoin_consensus_encoding::SliceEncoder<'e, T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<'e, T: bitcoin_consensus_encoding::Encode> core::fmt::Debug for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::fmt::Debug]
+impl<'e, T: bitcoin_consensus_encoding::Encode + 'e> core::clone::Clone for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::clone::Clone
+  pub fn bitcoin_consensus_encoding::SliceEncoder<'e, T>::clone(&self) -> Self [impl: impl<'e, T: bitcoin_consensus_encoding::Encode + 'e> core::clone::Clone for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::clone::Clone]
+impl<'e, T: bitcoin_consensus_encoding::Encode + 'e> core::fmt::Debug for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::fmt::Debug
+  pub fn bitcoin_consensus_encoding::SliceEncoder<'e, T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<'e, T: bitcoin_consensus_encoding::Encode + 'e> core::fmt::Debug for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::fmt::Debug]
 impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::SliceEncoder<'_, T>
   pub fn bitcoin_consensus_encoding::SliceEncoder<'_, T>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::SliceEncoder<'_, T>]
   pub fn bitcoin_consensus_encoding::SliceEncoder<'_, T>::current_chunk(&self) -> &[u8] [impl: impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::SliceEncoder<'_, T>]
@@ -2099,7 +2180,7 @@ impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::error::Unexpe
   pub unsafe fn bitcoin_consensus_encoding::error::UnexpectedEofError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::error::UnexpectedEofError where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::error::UnexpectedEofError
   pub fn bitcoin_consensus_encoding::error::UnexpectedEofError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_consensus_encoding::error::UnexpectedEofError]
-pub struct bitcoin_consensus_encoding::VecDecoder<T: bitcoin_consensus_encoding::Decode>
+pub struct bitcoin_consensus_encoding::VecDecoder<T: bitcoin_consensus_encoding::Decode>(_)
 impl<T: bitcoin_consensus_encoding::Decode> bitcoin_consensus_encoding::VecDecoder<T>
 pub const fn bitcoin_consensus_encoding::VecDecoder<T>::new() -> Self
 pub const fn bitcoin_consensus_encoding::VecDecoder<T>::new_with_limit(limit: usize) -> Self
@@ -2190,6 +2271,51 @@ impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::error::VecDec
   pub unsafe fn bitcoin_consensus_encoding::error::VecDecoderError<Err>::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::error::VecDecoderError<Err> where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::error::VecDecoderError<Err>
   pub fn bitcoin_consensus_encoding::error::VecDecoderError<Err>::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_consensus_encoding::error::VecDecoderError<Err>]
+pub struct bitcoin_consensus_encoding::VecDecoderWith<D: bitcoin_consensus_encoding::Decoder + core::default::Default>
+impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::VecDecoderWith<D>
+pub const fn bitcoin_consensus_encoding::VecDecoderWith<D>::new() -> Self
+pub const fn bitcoin_consensus_encoding::VecDecoderWith<D>::new_with_limit(limit: usize) -> Self
+impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default + core::clone::Clone> core::clone::Clone for bitcoin_consensus_encoding::VecDecoderWith<D> where <D as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone
+  pub fn bitcoin_consensus_encoding::VecDecoderWith<D>::clone(&self) -> Self [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default + core::clone::Clone> core::clone::Clone for bitcoin_consensus_encoding::VecDecoderWith<D> where <D as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone]
+impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default + core::fmt::Debug> core::fmt::Debug for bitcoin_consensus_encoding::VecDecoderWith<D>
+  pub fn bitcoin_consensus_encoding::VecDecoderWith<D>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default + core::fmt::Debug> core::fmt::Debug for bitcoin_consensus_encoding::VecDecoderWith<D>]
+impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::VecDecoderWith<D>
+  pub type bitcoin_consensus_encoding::VecDecoderWith<D>::Error = bitcoin_consensus_encoding::error::VecDecoderError<<D as bitcoin_consensus_encoding::Decoder>::Error> [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::VecDecoderWith<D>]
+  pub type bitcoin_consensus_encoding::VecDecoderWith<D>::Output = alloc::vec::Vec<<D as bitcoin_consensus_encoding::Decoder>::Output> [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::VecDecoderWith<D>]
+  pub fn bitcoin_consensus_encoding::VecDecoderWith<D>::end(self) -> core::result::Result<Self::Output, Self::Error> [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::VecDecoderWith<D>]
+  pub fn bitcoin_consensus_encoding::VecDecoderWith<D>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error> [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::VecDecoderWith<D>]
+  pub fn bitcoin_consensus_encoding::VecDecoderWith<D>::read_limit(&self) -> usize [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::VecDecoderWith<D>]
+impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> core::default::Default for bitcoin_consensus_encoding::VecDecoderWith<D>
+  pub fn bitcoin_consensus_encoding::VecDecoderWith<D>::default() -> Self [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> core::default::Default for bitcoin_consensus_encoding::VecDecoderWith<D>]
+impl<D> core::marker::Freeze for bitcoin_consensus_encoding::VecDecoderWith<D> where D: core::marker::Freeze
+impl<D> core::marker::Send for bitcoin_consensus_encoding::VecDecoderWith<D> where D: core::marker::Send, <D as bitcoin_consensus_encoding::Decoder>::Output: core::marker::Send
+impl<D> core::marker::Sync for bitcoin_consensus_encoding::VecDecoderWith<D> where D: core::marker::Sync, <D as bitcoin_consensus_encoding::Decoder>::Output: core::marker::Sync
+impl<D> core::marker::Unpin for bitcoin_consensus_encoding::VecDecoderWith<D> where D: core::marker::Unpin, <D as bitcoin_consensus_encoding::Decoder>::Output: core::marker::Unpin
+impl<D> core::marker::UnsafeUnpin for bitcoin_consensus_encoding::VecDecoderWith<D> where D: core::marker::UnsafeUnpin
+impl<D> core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::VecDecoderWith<D> where D: core::panic::unwind_safe::RefUnwindSafe, <D as bitcoin_consensus_encoding::Decoder>::Output: core::panic::unwind_safe::RefUnwindSafe
+impl<D> core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::VecDecoderWith<D> where D: core::panic::unwind_safe::UnwindSafe, <D as bitcoin_consensus_encoding::Decoder>::Output: core::panic::unwind_safe::UnwindSafe
+impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::VecDecoderWith<D> where U: core::convert::From<T>
+  pub fn bitcoin_consensus_encoding::VecDecoderWith<D>::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::VecDecoderWith<D> where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::VecDecoderWith<D> where U: core::convert::Into<T>
+  pub type bitcoin_consensus_encoding::VecDecoderWith<D>::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::VecDecoderWith<D> where U: core::convert::Into<T>]
+  pub fn bitcoin_consensus_encoding::VecDecoderWith<D>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::VecDecoderWith<D> where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::VecDecoderWith<D> where U: core::convert::TryFrom<T>
+  pub type bitcoin_consensus_encoding::VecDecoderWith<D>::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::VecDecoderWith<D> where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_consensus_encoding::VecDecoderWith<D>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::VecDecoderWith<D> where U: core::convert::TryFrom<T>]
+impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::VecDecoderWith<D> where T: core::clone::Clone
+  pub type bitcoin_consensus_encoding::VecDecoderWith<D>::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::VecDecoderWith<D> where T: core::clone::Clone]
+  pub fn bitcoin_consensus_encoding::VecDecoderWith<D>::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::VecDecoderWith<D> where T: core::clone::Clone]
+  pub fn bitcoin_consensus_encoding::VecDecoderWith<D>::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::VecDecoderWith<D> where T: core::clone::Clone]
+impl<T> core::any::Any for bitcoin_consensus_encoding::VecDecoderWith<D> where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::VecDecoderWith<D>::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_consensus_encoding::VecDecoderWith<D> where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::VecDecoderWith<D> where T: ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::VecDecoderWith<D>::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::VecDecoderWith<D> where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::VecDecoderWith<D> where T: ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::VecDecoderWith<D>::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::VecDecoderWith<D> where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::VecDecoderWith<D> where T: core::clone::Clone
+  pub unsafe fn bitcoin_consensus_encoding::VecDecoderWith<D>::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::VecDecoderWith<D> where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_consensus_encoding::VecDecoderWith<D>
+  pub fn bitcoin_consensus_encoding::VecDecoderWith<D>::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_consensus_encoding::VecDecoderWith<D>]
 pub trait bitcoin_consensus_encoding::Decode
 pub type bitcoin_consensus_encoding::Decode::Decoder: bitcoin_consensus_encoding::Decoder<Output = Self> + core::default::Default
 pub fn bitcoin_consensus_encoding::Decode::decoder() -> Self::Decoder
@@ -2241,6 +2367,18 @@ impl<A, B> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::D
   pub fn bitcoin_consensus_encoding::Decoder2<A, B>::end(self) -> core::result::Result<Self::Output, Self::Error> [impl: impl<A, B> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::Decoder2<A, B> where A: bitcoin_consensus_encoding::Decoder, B: bitcoin_consensus_encoding::Decoder]
   pub fn bitcoin_consensus_encoding::Decoder2<A, B>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error> [impl: impl<A, B> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::Decoder2<A, B> where A: bitcoin_consensus_encoding::Decoder, B: bitcoin_consensus_encoding::Decoder]
   pub fn bitcoin_consensus_encoding::Decoder2<A, B>::read_limit(&self) -> usize [impl: impl<A, B> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::Decoder2<A, B> where A: bitcoin_consensus_encoding::Decoder, B: bitcoin_consensus_encoding::Decoder]
+impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ExactVecDecoderWith<D>
+  pub type bitcoin_consensus_encoding::ExactVecDecoderWith<D>::Error = bitcoin_consensus_encoding::error::VecDecoderError<<D as bitcoin_consensus_encoding::Decoder>::Error> [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ExactVecDecoderWith<D>]
+  pub type bitcoin_consensus_encoding::ExactVecDecoderWith<D>::Output = alloc::vec::Vec<<D as bitcoin_consensus_encoding::Decoder>::Output> [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ExactVecDecoderWith<D>]
+  pub fn bitcoin_consensus_encoding::ExactVecDecoderWith<D>::end(self) -> core::result::Result<Self::Output, Self::Error> [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ExactVecDecoderWith<D>]
+  pub fn bitcoin_consensus_encoding::ExactVecDecoderWith<D>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error> [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ExactVecDecoderWith<D>]
+  pub fn bitcoin_consensus_encoding::ExactVecDecoderWith<D>::read_limit(&self) -> usize [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ExactVecDecoderWith<D>]
+impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::VecDecoderWith<D>
+  pub type bitcoin_consensus_encoding::VecDecoderWith<D>::Error = bitcoin_consensus_encoding::error::VecDecoderError<<D as bitcoin_consensus_encoding::Decoder>::Error> [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::VecDecoderWith<D>]
+  pub type bitcoin_consensus_encoding::VecDecoderWith<D>::Output = alloc::vec::Vec<<D as bitcoin_consensus_encoding::Decoder>::Output> [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::VecDecoderWith<D>]
+  pub fn bitcoin_consensus_encoding::VecDecoderWith<D>::end(self) -> core::result::Result<Self::Output, Self::Error> [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::VecDecoderWith<D>]
+  pub fn bitcoin_consensus_encoding::VecDecoderWith<D>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error> [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::VecDecoderWith<D>]
+  pub fn bitcoin_consensus_encoding::VecDecoderWith<D>::read_limit(&self) -> usize [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::VecDecoderWith<D>]
 impl<T: bitcoin_consensus_encoding::Decode> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::VecDecoder<T>
   pub type bitcoin_consensus_encoding::VecDecoder<T>::Error = bitcoin_consensus_encoding::error::VecDecoderError<<<T as bitcoin_consensus_encoding::Decode>::Decoder as bitcoin_consensus_encoding::Decoder>::Error> [impl: impl<T: bitcoin_consensus_encoding::Decode> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::VecDecoder<T>]
   pub type bitcoin_consensus_encoding::VecDecoder<T>::Output = alloc::vec::Vec<T> [impl: impl<T: bitcoin_consensus_encoding::Decode> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::VecDecoder<T>]
@@ -2280,6 +2418,9 @@ impl<A: bitcoin_consensus_encoding::Encoder, B: bitcoin_consensus_encoding::Enco
 impl<A: bitcoin_consensus_encoding::Encoder, B: bitcoin_consensus_encoding::Encoder> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::Encoder2<A, B>
   pub fn bitcoin_consensus_encoding::Encoder2<A, B>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl<A: bitcoin_consensus_encoding::Encoder, B: bitcoin_consensus_encoding::Encoder> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::Encoder2<A, B>]
   pub fn bitcoin_consensus_encoding::Encoder2<A, B>::current_chunk(&self) -> &[u8] [impl: impl<A: bitcoin_consensus_encoding::Encoder, B: bitcoin_consensus_encoding::Encoder> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::Encoder2<A, B>]
+impl<I: core::iter::traits::iterator::Iterator> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: bitcoin_consensus_encoding::Encoder
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl<I: core::iter::traits::iterator::Iterator> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: bitcoin_consensus_encoding::Encoder]
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::current_chunk(&self) -> &[u8] [impl: impl<I: core::iter::traits::iterator::Iterator> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: bitcoin_consensus_encoding::Encoder]
 impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>
   pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>]
   pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>::current_chunk(&self) -> &[u8] [impl: impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>]

--- a/consensus_encoding/api/alloc-only.txt
+++ b/consensus_encoding/api/alloc-only.txt
@@ -1631,6 +1631,87 @@ impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::EncoderByteIt
   pub unsafe fn bitcoin_consensus_encoding::EncoderByteIter<T>::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::EncoderByteIter<T> where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::EncoderByteIter<T>
   pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_consensus_encoding::EncoderByteIter<T>]
+pub struct bitcoin_consensus_encoding::ExactVecDecoderWith<D: bitcoin_consensus_encoding::Decoder + core::default::Default>
+impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::ExactVecDecoderWith<D>
+pub const fn bitcoin_consensus_encoding::ExactVecDecoderWith<D>::new(count: usize) -> Self
+impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default + core::clone::Clone> core::clone::Clone for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where <D as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone
+  pub fn bitcoin_consensus_encoding::ExactVecDecoderWith<D>::clone(&self) -> Self [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default + core::clone::Clone> core::clone::Clone for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where <D as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone]
+impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default + core::fmt::Debug> core::fmt::Debug for bitcoin_consensus_encoding::ExactVecDecoderWith<D>
+  pub fn bitcoin_consensus_encoding::ExactVecDecoderWith<D>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default + core::fmt::Debug> core::fmt::Debug for bitcoin_consensus_encoding::ExactVecDecoderWith<D>]
+impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ExactVecDecoderWith<D>
+  pub type bitcoin_consensus_encoding::ExactVecDecoderWith<D>::Error = bitcoin_consensus_encoding::error::VecDecoderError<<D as bitcoin_consensus_encoding::Decoder>::Error> [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ExactVecDecoderWith<D>]
+  pub type bitcoin_consensus_encoding::ExactVecDecoderWith<D>::Output = alloc::vec::Vec<<D as bitcoin_consensus_encoding::Decoder>::Output> [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ExactVecDecoderWith<D>]
+  pub fn bitcoin_consensus_encoding::ExactVecDecoderWith<D>::end(self) -> core::result::Result<Self::Output, Self::Error> [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ExactVecDecoderWith<D>]
+  pub fn bitcoin_consensus_encoding::ExactVecDecoderWith<D>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error> [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ExactVecDecoderWith<D>]
+  pub fn bitcoin_consensus_encoding::ExactVecDecoderWith<D>::read_limit(&self) -> usize [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ExactVecDecoderWith<D>]
+impl<D> core::marker::Freeze for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where D: core::marker::Freeze
+impl<D> core::marker::Send for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where D: core::marker::Send, <D as bitcoin_consensus_encoding::Decoder>::Output: core::marker::Send
+impl<D> core::marker::Sync for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where D: core::marker::Sync, <D as bitcoin_consensus_encoding::Decoder>::Output: core::marker::Sync
+impl<D> core::marker::Unpin for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where D: core::marker::Unpin, <D as bitcoin_consensus_encoding::Decoder>::Output: core::marker::Unpin
+impl<D> core::marker::UnsafeUnpin for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where D: core::marker::UnsafeUnpin
+impl<D> core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where D: core::panic::unwind_safe::RefUnwindSafe, <D as bitcoin_consensus_encoding::Decoder>::Output: core::panic::unwind_safe::RefUnwindSafe
+impl<D> core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where D: core::panic::unwind_safe::UnwindSafe, <D as bitcoin_consensus_encoding::Decoder>::Output: core::panic::unwind_safe::UnwindSafe
+impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where U: core::convert::From<T>
+  pub fn bitcoin_consensus_encoding::ExactVecDecoderWith<D>::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where U: core::convert::Into<T>
+  pub type bitcoin_consensus_encoding::ExactVecDecoderWith<D>::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where U: core::convert::Into<T>]
+  pub fn bitcoin_consensus_encoding::ExactVecDecoderWith<D>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where U: core::convert::TryFrom<T>
+  pub type bitcoin_consensus_encoding::ExactVecDecoderWith<D>::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_consensus_encoding::ExactVecDecoderWith<D>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where U: core::convert::TryFrom<T>]
+impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where T: core::clone::Clone
+  pub type bitcoin_consensus_encoding::ExactVecDecoderWith<D>::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where T: core::clone::Clone]
+  pub fn bitcoin_consensus_encoding::ExactVecDecoderWith<D>::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where T: core::clone::Clone]
+  pub fn bitcoin_consensus_encoding::ExactVecDecoderWith<D>::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where T: core::clone::Clone]
+impl<T> core::any::Any for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::ExactVecDecoderWith<D>::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where T: ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::ExactVecDecoderWith<D>::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where T: ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::ExactVecDecoderWith<D>::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where T: core::clone::Clone
+  pub unsafe fn bitcoin_consensus_encoding::ExactVecDecoderWith<D>::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::ExactVecDecoderWith<D> where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_consensus_encoding::ExactVecDecoderWith<D>
+  pub fn bitcoin_consensus_encoding::ExactVecDecoderWith<D>::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_consensus_encoding::ExactVecDecoderWith<D>]
+pub struct bitcoin_consensus_encoding::IterEncoder<I: core::iter::traits::iterator::Iterator> where <I as core::iter::traits::iterator::Iterator>::Item: bitcoin_consensus_encoding::Encoder
+impl<I: core::iter::traits::iterator::Iterator> bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: bitcoin_consensus_encoding::Encoder
+pub fn bitcoin_consensus_encoding::IterEncoder<I>::new(iter: impl core::iter::traits::collect::IntoIterator<IntoIter = I>) -> Self
+impl<I: core::iter::traits::iterator::Iterator> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: bitcoin_consensus_encoding::Encoder
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl<I: core::iter::traits::iterator::Iterator> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: bitcoin_consensus_encoding::Encoder]
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::current_chunk(&self) -> &[u8] [impl: impl<I: core::iter::traits::iterator::Iterator> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: bitcoin_consensus_encoding::Encoder]
+impl<I: core::iter::traits::iterator::Iterator> core::fmt::Debug for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: bitcoin_consensus_encoding::Encoder + core::fmt::Debug
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<I: core::iter::traits::iterator::Iterator> core::fmt::Debug for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: bitcoin_consensus_encoding::Encoder + core::fmt::Debug]
+impl<I> core::clone::Clone for bitcoin_consensus_encoding::IterEncoder<I> where I: core::clone::Clone + core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: bitcoin_consensus_encoding::Encoder + core::clone::Clone
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::clone(&self) -> Self [impl: impl<I> core::clone::Clone for bitcoin_consensus_encoding::IterEncoder<I> where I: core::clone::Clone + core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: bitcoin_consensus_encoding::Encoder + core::clone::Clone]
+impl<I> core::marker::Freeze for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: core::marker::Freeze, I: core::marker::Freeze
+impl<I> core::marker::Send for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: core::marker::Send, I: core::marker::Send
+impl<I> core::marker::Sync for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: core::marker::Sync, I: core::marker::Sync
+impl<I> core::marker::Unpin for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: core::marker::Unpin, I: core::marker::Unpin
+impl<I> core::marker::UnsafeUnpin for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: core::marker::UnsafeUnpin, I: core::marker::UnsafeUnpin
+impl<I> core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: core::panic::unwind_safe::RefUnwindSafe, I: core::panic::unwind_safe::RefUnwindSafe
+impl<I> core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: core::panic::unwind_safe::UnwindSafe, I: core::panic::unwind_safe::UnwindSafe
+impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::IterEncoder<I> where U: core::convert::From<T>
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::IterEncoder<I> where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::IterEncoder<I> where U: core::convert::Into<T>
+  pub type bitcoin_consensus_encoding::IterEncoder<I>::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::IterEncoder<I> where U: core::convert::Into<T>]
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::IterEncoder<I> where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::IterEncoder<I> where U: core::convert::TryFrom<T>
+  pub type bitcoin_consensus_encoding::IterEncoder<I>::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::IterEncoder<I> where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::IterEncoder<I> where U: core::convert::TryFrom<T>]
+impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::IterEncoder<I> where T: core::clone::Clone
+  pub type bitcoin_consensus_encoding::IterEncoder<I>::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::IterEncoder<I> where T: core::clone::Clone]
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::IterEncoder<I> where T: core::clone::Clone]
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::IterEncoder<I> where T: core::clone::Clone]
+impl<T> core::any::Any for bitcoin_consensus_encoding::IterEncoder<I> where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_consensus_encoding::IterEncoder<I> where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::IterEncoder<I> where T: ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::IterEncoder<I> where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::IterEncoder<I> where T: ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::IterEncoder<I> where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::IterEncoder<I> where T: core::clone::Clone
+  pub unsafe fn bitcoin_consensus_encoding::IterEncoder<I>::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::IterEncoder<I> where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_consensus_encoding::IterEncoder<I>
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_consensus_encoding::IterEncoder<I>]
 pub struct bitcoin_consensus_encoding::LengthPrefixExceedsMaxError
 impl core::clone::Clone for bitcoin_consensus_encoding::error::LengthPrefixExceedsMaxError
   pub fn bitcoin_consensus_encoding::error::LengthPrefixExceedsMaxError::clone(&self) -> bitcoin_consensus_encoding::error::LengthPrefixExceedsMaxError [impl: impl core::clone::Clone for bitcoin_consensus_encoding::error::LengthPrefixExceedsMaxError]
@@ -1719,10 +1800,10 @@ impl<T> core::convert::From<T> for bitcoin_consensus_encoding::PrefixedBytesEnco
 pub struct bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T: bitcoin_consensus_encoding::Encode>(_)
 impl<'e, T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>
 pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::new(sl: &'e [T]) -> Self
-impl<'e, T: bitcoin_consensus_encoding::Encode> core::clone::Clone for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::clone::Clone
-  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::clone(&self) -> Self [impl: impl<'e, T: bitcoin_consensus_encoding::Encode> core::clone::Clone for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::clone::Clone]
-impl<'e, T: bitcoin_consensus_encoding::Encode> core::fmt::Debug for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::fmt::Debug
-  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<'e, T: bitcoin_consensus_encoding::Encode> core::fmt::Debug for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::fmt::Debug]
+impl<'e, T: bitcoin_consensus_encoding::Encode + 'e> core::clone::Clone for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::clone::Clone
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::clone(&self) -> Self [impl: impl<'e, T: bitcoin_consensus_encoding::Encode + 'e> core::clone::Clone for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::clone::Clone]
+impl<'e, T: bitcoin_consensus_encoding::Encode + 'e> core::fmt::Debug for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::fmt::Debug
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<'e, T: bitcoin_consensus_encoding::Encode + 'e> core::fmt::Debug for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::fmt::Debug]
 impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>
   pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>]
   pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>::current_chunk(&self) -> &[u8] [impl: impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>]
@@ -1755,13 +1836,13 @@ impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::PrefixedSlice
   pub unsafe fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>
   pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>]
-pub struct bitcoin_consensus_encoding::SliceEncoder<'e, T: bitcoin_consensus_encoding::Encode>
+pub struct bitcoin_consensus_encoding::SliceEncoder<'e, T: bitcoin_consensus_encoding::Encode>(_)
 impl<'e, T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::SliceEncoder<'e, T>
 pub fn bitcoin_consensus_encoding::SliceEncoder<'e, T>::without_length_prefix(sl: &'e [T]) -> Self
-impl<'e, T: bitcoin_consensus_encoding::Encode> core::clone::Clone for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::clone::Clone
-  pub fn bitcoin_consensus_encoding::SliceEncoder<'e, T>::clone(&self) -> Self [impl: impl<'e, T: bitcoin_consensus_encoding::Encode> core::clone::Clone for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::clone::Clone]
-impl<'e, T: bitcoin_consensus_encoding::Encode> core::fmt::Debug for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::fmt::Debug
-  pub fn bitcoin_consensus_encoding::SliceEncoder<'e, T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<'e, T: bitcoin_consensus_encoding::Encode> core::fmt::Debug for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::fmt::Debug]
+impl<'e, T: bitcoin_consensus_encoding::Encode + 'e> core::clone::Clone for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::clone::Clone
+  pub fn bitcoin_consensus_encoding::SliceEncoder<'e, T>::clone(&self) -> Self [impl: impl<'e, T: bitcoin_consensus_encoding::Encode + 'e> core::clone::Clone for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::clone::Clone]
+impl<'e, T: bitcoin_consensus_encoding::Encode + 'e> core::fmt::Debug for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::fmt::Debug
+  pub fn bitcoin_consensus_encoding::SliceEncoder<'e, T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<'e, T: bitcoin_consensus_encoding::Encode + 'e> core::fmt::Debug for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::fmt::Debug]
 impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::SliceEncoder<'_, T>
   pub fn bitcoin_consensus_encoding::SliceEncoder<'_, T>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::SliceEncoder<'_, T>]
   pub fn bitcoin_consensus_encoding::SliceEncoder<'_, T>::current_chunk(&self) -> &[u8] [impl: impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::SliceEncoder<'_, T>]
@@ -1882,7 +1963,7 @@ impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::error::Unexpe
   pub unsafe fn bitcoin_consensus_encoding::error::UnexpectedEofError::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::error::UnexpectedEofError where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::error::UnexpectedEofError
   pub fn bitcoin_consensus_encoding::error::UnexpectedEofError::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_consensus_encoding::error::UnexpectedEofError]
-pub struct bitcoin_consensus_encoding::VecDecoder<T: bitcoin_consensus_encoding::Decode>
+pub struct bitcoin_consensus_encoding::VecDecoder<T: bitcoin_consensus_encoding::Decode>(_)
 impl<T: bitcoin_consensus_encoding::Decode> bitcoin_consensus_encoding::VecDecoder<T>
 pub const fn bitcoin_consensus_encoding::VecDecoder<T>::new() -> Self
 pub const fn bitcoin_consensus_encoding::VecDecoder<T>::new_with_limit(limit: usize) -> Self
@@ -1971,6 +2052,51 @@ impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::error::VecDec
   pub unsafe fn bitcoin_consensus_encoding::error::VecDecoderError<Err>::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::error::VecDecoderError<Err> where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::error::VecDecoderError<Err>
   pub fn bitcoin_consensus_encoding::error::VecDecoderError<Err>::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_consensus_encoding::error::VecDecoderError<Err>]
+pub struct bitcoin_consensus_encoding::VecDecoderWith<D: bitcoin_consensus_encoding::Decoder + core::default::Default>
+impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::VecDecoderWith<D>
+pub const fn bitcoin_consensus_encoding::VecDecoderWith<D>::new() -> Self
+pub const fn bitcoin_consensus_encoding::VecDecoderWith<D>::new_with_limit(limit: usize) -> Self
+impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default + core::clone::Clone> core::clone::Clone for bitcoin_consensus_encoding::VecDecoderWith<D> where <D as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone
+  pub fn bitcoin_consensus_encoding::VecDecoderWith<D>::clone(&self) -> Self [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default + core::clone::Clone> core::clone::Clone for bitcoin_consensus_encoding::VecDecoderWith<D> where <D as bitcoin_consensus_encoding::Decoder>::Output: core::clone::Clone]
+impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default + core::fmt::Debug> core::fmt::Debug for bitcoin_consensus_encoding::VecDecoderWith<D>
+  pub fn bitcoin_consensus_encoding::VecDecoderWith<D>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default + core::fmt::Debug> core::fmt::Debug for bitcoin_consensus_encoding::VecDecoderWith<D>]
+impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::VecDecoderWith<D>
+  pub type bitcoin_consensus_encoding::VecDecoderWith<D>::Error = bitcoin_consensus_encoding::error::VecDecoderError<<D as bitcoin_consensus_encoding::Decoder>::Error> [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::VecDecoderWith<D>]
+  pub type bitcoin_consensus_encoding::VecDecoderWith<D>::Output = alloc::vec::Vec<<D as bitcoin_consensus_encoding::Decoder>::Output> [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::VecDecoderWith<D>]
+  pub fn bitcoin_consensus_encoding::VecDecoderWith<D>::end(self) -> core::result::Result<Self::Output, Self::Error> [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::VecDecoderWith<D>]
+  pub fn bitcoin_consensus_encoding::VecDecoderWith<D>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error> [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::VecDecoderWith<D>]
+  pub fn bitcoin_consensus_encoding::VecDecoderWith<D>::read_limit(&self) -> usize [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::VecDecoderWith<D>]
+impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> core::default::Default for bitcoin_consensus_encoding::VecDecoderWith<D>
+  pub fn bitcoin_consensus_encoding::VecDecoderWith<D>::default() -> Self [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> core::default::Default for bitcoin_consensus_encoding::VecDecoderWith<D>]
+impl<D> core::marker::Freeze for bitcoin_consensus_encoding::VecDecoderWith<D> where D: core::marker::Freeze
+impl<D> core::marker::Send for bitcoin_consensus_encoding::VecDecoderWith<D> where D: core::marker::Send, <D as bitcoin_consensus_encoding::Decoder>::Output: core::marker::Send
+impl<D> core::marker::Sync for bitcoin_consensus_encoding::VecDecoderWith<D> where D: core::marker::Sync, <D as bitcoin_consensus_encoding::Decoder>::Output: core::marker::Sync
+impl<D> core::marker::Unpin for bitcoin_consensus_encoding::VecDecoderWith<D> where D: core::marker::Unpin, <D as bitcoin_consensus_encoding::Decoder>::Output: core::marker::Unpin
+impl<D> core::marker::UnsafeUnpin for bitcoin_consensus_encoding::VecDecoderWith<D> where D: core::marker::UnsafeUnpin
+impl<D> core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::VecDecoderWith<D> where D: core::panic::unwind_safe::RefUnwindSafe, <D as bitcoin_consensus_encoding::Decoder>::Output: core::panic::unwind_safe::RefUnwindSafe
+impl<D> core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::VecDecoderWith<D> where D: core::panic::unwind_safe::UnwindSafe, <D as bitcoin_consensus_encoding::Decoder>::Output: core::panic::unwind_safe::UnwindSafe
+impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::VecDecoderWith<D> where U: core::convert::From<T>
+  pub fn bitcoin_consensus_encoding::VecDecoderWith<D>::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::VecDecoderWith<D> where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::VecDecoderWith<D> where U: core::convert::Into<T>
+  pub type bitcoin_consensus_encoding::VecDecoderWith<D>::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::VecDecoderWith<D> where U: core::convert::Into<T>]
+  pub fn bitcoin_consensus_encoding::VecDecoderWith<D>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::VecDecoderWith<D> where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::VecDecoderWith<D> where U: core::convert::TryFrom<T>
+  pub type bitcoin_consensus_encoding::VecDecoderWith<D>::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::VecDecoderWith<D> where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_consensus_encoding::VecDecoderWith<D>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::VecDecoderWith<D> where U: core::convert::TryFrom<T>]
+impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::VecDecoderWith<D> where T: core::clone::Clone
+  pub type bitcoin_consensus_encoding::VecDecoderWith<D>::Owned = T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::VecDecoderWith<D> where T: core::clone::Clone]
+  pub fn bitcoin_consensus_encoding::VecDecoderWith<D>::clone_into(&self, target: &mut T) [impl: impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::VecDecoderWith<D> where T: core::clone::Clone]
+  pub fn bitcoin_consensus_encoding::VecDecoderWith<D>::to_owned(&self) -> T [impl: impl<T> alloc::borrow::ToOwned for bitcoin_consensus_encoding::VecDecoderWith<D> where T: core::clone::Clone]
+impl<T> core::any::Any for bitcoin_consensus_encoding::VecDecoderWith<D> where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::VecDecoderWith<D>::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_consensus_encoding::VecDecoderWith<D> where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::VecDecoderWith<D> where T: ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::VecDecoderWith<D>::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::VecDecoderWith<D> where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::VecDecoderWith<D> where T: ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::VecDecoderWith<D>::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::VecDecoderWith<D> where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::VecDecoderWith<D> where T: core::clone::Clone
+  pub unsafe fn bitcoin_consensus_encoding::VecDecoderWith<D>::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::VecDecoderWith<D> where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_consensus_encoding::VecDecoderWith<D>
+  pub fn bitcoin_consensus_encoding::VecDecoderWith<D>::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_consensus_encoding::VecDecoderWith<D>]
 pub trait bitcoin_consensus_encoding::Decode
 pub type bitcoin_consensus_encoding::Decode::Decoder: bitcoin_consensus_encoding::Decoder<Output = Self> + core::default::Default
 pub fn bitcoin_consensus_encoding::Decode::decoder() -> Self::Decoder
@@ -2022,6 +2148,18 @@ impl<A, B> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::D
   pub fn bitcoin_consensus_encoding::Decoder2<A, B>::end(self) -> core::result::Result<Self::Output, Self::Error> [impl: impl<A, B> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::Decoder2<A, B> where A: bitcoin_consensus_encoding::Decoder, B: bitcoin_consensus_encoding::Decoder]
   pub fn bitcoin_consensus_encoding::Decoder2<A, B>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error> [impl: impl<A, B> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::Decoder2<A, B> where A: bitcoin_consensus_encoding::Decoder, B: bitcoin_consensus_encoding::Decoder]
   pub fn bitcoin_consensus_encoding::Decoder2<A, B>::read_limit(&self) -> usize [impl: impl<A, B> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::Decoder2<A, B> where A: bitcoin_consensus_encoding::Decoder, B: bitcoin_consensus_encoding::Decoder]
+impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ExactVecDecoderWith<D>
+  pub type bitcoin_consensus_encoding::ExactVecDecoderWith<D>::Error = bitcoin_consensus_encoding::error::VecDecoderError<<D as bitcoin_consensus_encoding::Decoder>::Error> [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ExactVecDecoderWith<D>]
+  pub type bitcoin_consensus_encoding::ExactVecDecoderWith<D>::Output = alloc::vec::Vec<<D as bitcoin_consensus_encoding::Decoder>::Output> [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ExactVecDecoderWith<D>]
+  pub fn bitcoin_consensus_encoding::ExactVecDecoderWith<D>::end(self) -> core::result::Result<Self::Output, Self::Error> [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ExactVecDecoderWith<D>]
+  pub fn bitcoin_consensus_encoding::ExactVecDecoderWith<D>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error> [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ExactVecDecoderWith<D>]
+  pub fn bitcoin_consensus_encoding::ExactVecDecoderWith<D>::read_limit(&self) -> usize [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::ExactVecDecoderWith<D>]
+impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::VecDecoderWith<D>
+  pub type bitcoin_consensus_encoding::VecDecoderWith<D>::Error = bitcoin_consensus_encoding::error::VecDecoderError<<D as bitcoin_consensus_encoding::Decoder>::Error> [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::VecDecoderWith<D>]
+  pub type bitcoin_consensus_encoding::VecDecoderWith<D>::Output = alloc::vec::Vec<<D as bitcoin_consensus_encoding::Decoder>::Output> [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::VecDecoderWith<D>]
+  pub fn bitcoin_consensus_encoding::VecDecoderWith<D>::end(self) -> core::result::Result<Self::Output, Self::Error> [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::VecDecoderWith<D>]
+  pub fn bitcoin_consensus_encoding::VecDecoderWith<D>::push_bytes(&mut self, bytes: &mut &[u8]) -> core::result::Result<bitcoin_consensus_encoding::DecoderStatus, Self::Error> [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::VecDecoderWith<D>]
+  pub fn bitcoin_consensus_encoding::VecDecoderWith<D>::read_limit(&self) -> usize [impl: impl<D: bitcoin_consensus_encoding::Decoder + core::default::Default> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::VecDecoderWith<D>]
 impl<T: bitcoin_consensus_encoding::Decode> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::VecDecoder<T>
   pub type bitcoin_consensus_encoding::VecDecoder<T>::Error = bitcoin_consensus_encoding::error::VecDecoderError<<<T as bitcoin_consensus_encoding::Decode>::Decoder as bitcoin_consensus_encoding::Decoder>::Error> [impl: impl<T: bitcoin_consensus_encoding::Decode> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::VecDecoder<T>]
   pub type bitcoin_consensus_encoding::VecDecoder<T>::Output = alloc::vec::Vec<T> [impl: impl<T: bitcoin_consensus_encoding::Decode> bitcoin_consensus_encoding::Decoder for bitcoin_consensus_encoding::VecDecoder<T>]
@@ -2061,6 +2199,9 @@ impl<A: bitcoin_consensus_encoding::Encoder, B: bitcoin_consensus_encoding::Enco
 impl<A: bitcoin_consensus_encoding::Encoder, B: bitcoin_consensus_encoding::Encoder> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::Encoder2<A, B>
   pub fn bitcoin_consensus_encoding::Encoder2<A, B>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl<A: bitcoin_consensus_encoding::Encoder, B: bitcoin_consensus_encoding::Encoder> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::Encoder2<A, B>]
   pub fn bitcoin_consensus_encoding::Encoder2<A, B>::current_chunk(&self) -> &[u8] [impl: impl<A: bitcoin_consensus_encoding::Encoder, B: bitcoin_consensus_encoding::Encoder> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::Encoder2<A, B>]
+impl<I: core::iter::traits::iterator::Iterator> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: bitcoin_consensus_encoding::Encoder
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl<I: core::iter::traits::iterator::Iterator> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: bitcoin_consensus_encoding::Encoder]
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::current_chunk(&self) -> &[u8] [impl: impl<I: core::iter::traits::iterator::Iterator> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: bitcoin_consensus_encoding::Encoder]
 impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>
   pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>]
   pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>::current_chunk(&self) -> &[u8] [impl: impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>]

--- a/consensus_encoding/api/no-features.txt
+++ b/consensus_encoding/api/no-features.txt
@@ -1292,6 +1292,41 @@ impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::EncoderByteIt
   pub unsafe fn bitcoin_consensus_encoding::EncoderByteIter<T>::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::EncoderByteIter<T> where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::EncoderByteIter<T>
   pub fn bitcoin_consensus_encoding::EncoderByteIter<T>::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_consensus_encoding::EncoderByteIter<T>]
+pub struct bitcoin_consensus_encoding::IterEncoder<I: core::iter::traits::iterator::Iterator> where <I as core::iter::traits::iterator::Iterator>::Item: bitcoin_consensus_encoding::Encoder
+impl<I: core::iter::traits::iterator::Iterator> bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: bitcoin_consensus_encoding::Encoder
+pub fn bitcoin_consensus_encoding::IterEncoder<I>::new(iter: impl core::iter::traits::collect::IntoIterator<IntoIter = I>) -> Self
+impl<I: core::iter::traits::iterator::Iterator> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: bitcoin_consensus_encoding::Encoder
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl<I: core::iter::traits::iterator::Iterator> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: bitcoin_consensus_encoding::Encoder]
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::current_chunk(&self) -> &[u8] [impl: impl<I: core::iter::traits::iterator::Iterator> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: bitcoin_consensus_encoding::Encoder]
+impl<I: core::iter::traits::iterator::Iterator> core::fmt::Debug for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: bitcoin_consensus_encoding::Encoder + core::fmt::Debug
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<I: core::iter::traits::iterator::Iterator> core::fmt::Debug for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: bitcoin_consensus_encoding::Encoder + core::fmt::Debug]
+impl<I> core::clone::Clone for bitcoin_consensus_encoding::IterEncoder<I> where I: core::clone::Clone + core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: bitcoin_consensus_encoding::Encoder + core::clone::Clone
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::clone(&self) -> Self [impl: impl<I> core::clone::Clone for bitcoin_consensus_encoding::IterEncoder<I> where I: core::clone::Clone + core::iter::traits::iterator::Iterator, <I as core::iter::traits::iterator::Iterator>::Item: bitcoin_consensus_encoding::Encoder + core::clone::Clone]
+impl<I> core::marker::Freeze for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: core::marker::Freeze, I: core::marker::Freeze
+impl<I> core::marker::Send for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: core::marker::Send, I: core::marker::Send
+impl<I> core::marker::Sync for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: core::marker::Sync, I: core::marker::Sync
+impl<I> core::marker::Unpin for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: core::marker::Unpin, I: core::marker::Unpin
+impl<I> core::marker::UnsafeUnpin for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: core::marker::UnsafeUnpin, I: core::marker::UnsafeUnpin
+impl<I> core::panic::unwind_safe::RefUnwindSafe for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: core::panic::unwind_safe::RefUnwindSafe, I: core::panic::unwind_safe::RefUnwindSafe
+impl<I> core::panic::unwind_safe::UnwindSafe for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: core::panic::unwind_safe::UnwindSafe, I: core::panic::unwind_safe::UnwindSafe
+impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::IterEncoder<I> where U: core::convert::From<T>
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::into(self) -> U [impl: impl<T, U> core::convert::Into<U> for bitcoin_consensus_encoding::IterEncoder<I> where U: core::convert::From<T>]
+impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::IterEncoder<I> where U: core::convert::Into<T>
+  pub type bitcoin_consensus_encoding::IterEncoder<I>::Error = core::convert::Infallible [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::IterEncoder<I> where U: core::convert::Into<T>]
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error> [impl: impl<T, U> core::convert::TryFrom<U> for bitcoin_consensus_encoding::IterEncoder<I> where U: core::convert::Into<T>]
+impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::IterEncoder<I> where U: core::convert::TryFrom<T>
+  pub type bitcoin_consensus_encoding::IterEncoder<I>::Error = <U as core::convert::TryFrom<T>>::Error [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::IterEncoder<I> where U: core::convert::TryFrom<T>]
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error> [impl: impl<T, U> core::convert::TryInto<U> for bitcoin_consensus_encoding::IterEncoder<I> where U: core::convert::TryFrom<T>]
+impl<T> core::any::Any for bitcoin_consensus_encoding::IterEncoder<I> where T: 'static + ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::type_id(&self) -> core::any::TypeId [impl: impl<T> core::any::Any for bitcoin_consensus_encoding::IterEncoder<I> where T: 'static + ?core::marker::Sized]
+impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::IterEncoder<I> where T: ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::borrow(&self) -> &T [impl: impl<T> core::borrow::Borrow<T> for bitcoin_consensus_encoding::IterEncoder<I> where T: ?core::marker::Sized]
+impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::IterEncoder<I> where T: ?core::marker::Sized
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::borrow_mut(&mut self) -> &mut T [impl: impl<T> core::borrow::BorrowMut<T> for bitcoin_consensus_encoding::IterEncoder<I> where T: ?core::marker::Sized]
+impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::IterEncoder<I> where T: core::clone::Clone
+  pub unsafe fn bitcoin_consensus_encoding::IterEncoder<I>::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::IterEncoder<I> where T: core::clone::Clone]
+impl<T> core::convert::From<T> for bitcoin_consensus_encoding::IterEncoder<I>
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_consensus_encoding::IterEncoder<I>]
 pub struct bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>(_)
 impl<'sl> bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>
 pub fn bitcoin_consensus_encoding::PrefixedBytesEncoder<'sl>::new(sl: &'sl [u8]) -> Self
@@ -1332,10 +1367,10 @@ impl<T> core::convert::From<T> for bitcoin_consensus_encoding::PrefixedBytesEnco
 pub struct bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T: bitcoin_consensus_encoding::Encode>(_)
 impl<'e, T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>
 pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::new(sl: &'e [T]) -> Self
-impl<'e, T: bitcoin_consensus_encoding::Encode> core::clone::Clone for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::clone::Clone
-  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::clone(&self) -> Self [impl: impl<'e, T: bitcoin_consensus_encoding::Encode> core::clone::Clone for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::clone::Clone]
-impl<'e, T: bitcoin_consensus_encoding::Encode> core::fmt::Debug for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::fmt::Debug
-  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<'e, T: bitcoin_consensus_encoding::Encode> core::fmt::Debug for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::fmt::Debug]
+impl<'e, T: bitcoin_consensus_encoding::Encode + 'e> core::clone::Clone for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::clone::Clone
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::clone(&self) -> Self [impl: impl<'e, T: bitcoin_consensus_encoding::Encode + 'e> core::clone::Clone for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::clone::Clone]
+impl<'e, T: bitcoin_consensus_encoding::Encode + 'e> core::fmt::Debug for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::fmt::Debug
+  pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<'e, T: bitcoin_consensus_encoding::Encode + 'e> core::fmt::Debug for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::fmt::Debug]
 impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>
   pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>]
   pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>::current_chunk(&self) -> &[u8] [impl: impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>]
@@ -1364,13 +1399,13 @@ impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::PrefixedSlice
   pub unsafe fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::clone_to_uninit(&self, dest: *mut u8) [impl: impl<T> core::clone::CloneToUninit for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T> where T: core::clone::Clone]
 impl<T> core::convert::From<T> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>
   pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>::from(t: T) -> T [impl: impl<T> core::convert::From<T> for bitcoin_consensus_encoding::PrefixedSliceEncoder<'e, T>]
-pub struct bitcoin_consensus_encoding::SliceEncoder<'e, T: bitcoin_consensus_encoding::Encode>
+pub struct bitcoin_consensus_encoding::SliceEncoder<'e, T: bitcoin_consensus_encoding::Encode>(_)
 impl<'e, T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::SliceEncoder<'e, T>
 pub fn bitcoin_consensus_encoding::SliceEncoder<'e, T>::without_length_prefix(sl: &'e [T]) -> Self
-impl<'e, T: bitcoin_consensus_encoding::Encode> core::clone::Clone for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::clone::Clone
-  pub fn bitcoin_consensus_encoding::SliceEncoder<'e, T>::clone(&self) -> Self [impl: impl<'e, T: bitcoin_consensus_encoding::Encode> core::clone::Clone for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::clone::Clone]
-impl<'e, T: bitcoin_consensus_encoding::Encode> core::fmt::Debug for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::fmt::Debug
-  pub fn bitcoin_consensus_encoding::SliceEncoder<'e, T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<'e, T: bitcoin_consensus_encoding::Encode> core::fmt::Debug for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::fmt::Debug]
+impl<'e, T: bitcoin_consensus_encoding::Encode + 'e> core::clone::Clone for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::clone::Clone
+  pub fn bitcoin_consensus_encoding::SliceEncoder<'e, T>::clone(&self) -> Self [impl: impl<'e, T: bitcoin_consensus_encoding::Encode + 'e> core::clone::Clone for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::clone::Clone]
+impl<'e, T: bitcoin_consensus_encoding::Encode + 'e> core::fmt::Debug for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::fmt::Debug
+  pub fn bitcoin_consensus_encoding::SliceEncoder<'e, T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl<'e, T: bitcoin_consensus_encoding::Encode + 'e> core::fmt::Debug for bitcoin_consensus_encoding::SliceEncoder<'e, T> where <T as bitcoin_consensus_encoding::Encode>::Encoder: core::fmt::Debug]
 impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::SliceEncoder<'_, T>
   pub fn bitcoin_consensus_encoding::SliceEncoder<'_, T>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::SliceEncoder<'_, T>]
   pub fn bitcoin_consensus_encoding::SliceEncoder<'_, T>::current_chunk(&self) -> &[u8] [impl: impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::SliceEncoder<'_, T>]
@@ -1553,6 +1588,9 @@ impl<A: bitcoin_consensus_encoding::Encoder, B: bitcoin_consensus_encoding::Enco
 impl<A: bitcoin_consensus_encoding::Encoder, B: bitcoin_consensus_encoding::Encoder> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::Encoder2<A, B>
   pub fn bitcoin_consensus_encoding::Encoder2<A, B>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl<A: bitcoin_consensus_encoding::Encoder, B: bitcoin_consensus_encoding::Encoder> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::Encoder2<A, B>]
   pub fn bitcoin_consensus_encoding::Encoder2<A, B>::current_chunk(&self) -> &[u8] [impl: impl<A: bitcoin_consensus_encoding::Encoder, B: bitcoin_consensus_encoding::Encoder> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::Encoder2<A, B>]
+impl<I: core::iter::traits::iterator::Iterator> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: bitcoin_consensus_encoding::Encoder
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl<I: core::iter::traits::iterator::Iterator> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: bitcoin_consensus_encoding::Encoder]
+  pub fn bitcoin_consensus_encoding::IterEncoder<I>::current_chunk(&self) -> &[u8] [impl: impl<I: core::iter::traits::iterator::Iterator> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::IterEncoder<I> where <I as core::iter::traits::iterator::Iterator>::Item: bitcoin_consensus_encoding::Encoder]
 impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>
   pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>::advance(&mut self) -> bitcoin_consensus_encoding::EncoderStatus [impl: impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>]
   pub fn bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>::current_chunk(&self) -> &[u8] [impl: impl<T: bitcoin_consensus_encoding::Encode> bitcoin_consensus_encoding::Encoder for bitcoin_consensus_encoding::PrefixedSliceEncoder<'_, T>]

--- a/consensus_encoding/src/decode/decoders.rs
+++ b/consensus_encoding/src/decode/decoders.rs
@@ -141,28 +141,24 @@ impl Decoder for ByteVecDecoder {
     }
 }
 
-/// A decoder for a vector of consensus decodable types.
+/// A decoder for a vector of exactly `count` items, where the count is known at construction.
 ///
-/// The vector encoding must start with the number of items in the vector, encoded as a compact
-/// size.
+/// Use this when the item count is determined by context (e.g. from a previously decoded
+/// transaction) rather than from a length prefix in the byte stream. For the length-prefixed
+/// case, use [`VecDecoderWith`].
 #[cfg(feature = "alloc")]
-pub struct VecDecoder<T: Decode> {
-    prefix_decoder: Option<CompactSizeDecoder>,
+pub struct ExactVecDecoderWith<D: Decoder + Default> {
     length: usize,
-    buffer: Vec<T>,
-    decoder: Option<<T as Decode>::Decoder>,
+    buffer: Vec<D::Output>,
+    decoder: Option<D>,
 }
 
 #[cfg(feature = "alloc")]
-impl<T: Decode> fmt::Debug for VecDecoder<T>
-where
-    T::Decoder: fmt::Debug,
-{
+impl<D: Decoder + Default + fmt::Debug> fmt::Debug for ExactVecDecoderWith<D> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("VecDecoder")
-            .field("prefix_decoder", &self.prefix_decoder)
+        f.debug_struct("ExactVecDecoderWith")
             .field("length", &self.length)
-            // Print the count rather than contents to avoid requiring `T: Debug`.
+            // Print the count rather than contents to avoid requiring `D::Output: Debug`.
             .field("buffer_len", &self.buffer.len())
             .field("decoder", &self.decoder)
             .finish()
@@ -170,40 +166,26 @@ where
 }
 
 #[cfg(feature = "alloc")]
-impl<T: Decode> Clone for VecDecoder<T>
+impl<D: Decoder + Default + Clone> Clone for ExactVecDecoderWith<D>
 where
-    T: Clone,
-    T::Decoder: Clone,
+    D::Output: Clone,
 {
     fn clone(&self) -> Self {
-        Self {
-            prefix_decoder: self.prefix_decoder.clone(),
-            length: self.length,
-            buffer: self.buffer.clone(),
-            decoder: self.decoder.clone(),
-        }
+        Self { length: self.length, buffer: self.buffer.clone(), decoder: self.decoder.clone() }
     }
 }
 
 #[cfg(feature = "alloc")]
-impl<T: Decode> VecDecoder<T> {
-    /// Constructs a new typed vector decoder with the default limit of 4,000,000 elements.
-    pub const fn new() -> Self { Self::new_with_limit(MAX_VEC_SIZE) }
-
-    /// Constructs a new typed vector decoder with a custom limit of elements.
-    pub const fn new_with_limit(limit: usize) -> Self {
-        Self {
-            prefix_decoder: Some(CompactSizeDecoder::new_with_limit(limit)),
-            length: 0,
-            buffer: Vec::new(),
-            decoder: None,
-        }
+impl<D: Decoder + Default> ExactVecDecoderWith<D> {
+    /// Constructs a decoder that will decode exactly `count` items.
+    pub const fn new(count: usize) -> Self {
+        Self { length: count, buffer: Vec::new(), decoder: None }
     }
 
     /// Reserves capacity for typed vectors in batches.
     ///
-    /// Calculates how many elements of type `T` fit within `MAX_VECTOR_ALLOCATE` bytes and reserves
-    /// up to that amount when the buffer reaches capacity.
+    /// Calculates how many elements of type `D::Output` fit within `MAX_VECTOR_ALLOCATE` bytes
+    /// and reserves up to that amount when the buffer reaches capacity.
     ///
     /// Documentation adapted from Bitcoin Core:
     ///
@@ -215,7 +197,7 @@ impl<T: Decode> VecDecoder<T> {
     fn reserve(&mut self) {
         if self.buffer.len() == self.buffer.capacity() {
             let elements_remaining = self.length - self.buffer.len();
-            let element_size = mem::size_of::<T>().max(1);
+            let element_size = mem::size_of::<D::Output>().max(1);
             let batch_elements = MAX_VECTOR_ALLOCATE / element_size;
             let elements_to_reserve = elements_remaining.min(batch_elements);
             self.buffer.reserve_exact(elements_to_reserve);
@@ -224,39 +206,21 @@ impl<T: Decode> VecDecoder<T> {
 }
 
 #[cfg(feature = "alloc")]
-impl<T: Decode> Default for VecDecoder<T> {
-    fn default() -> Self { Self::new() }
-}
-
-#[cfg(feature = "alloc")]
-impl<T: Decode> Decoder for VecDecoder<T> {
-    type Output = Vec<T>;
-    type Error = VecDecoderError<<<T as Decode>::Decoder as Decoder>::Error>;
+impl<D: Decoder + Default> Decoder for ExactVecDecoderWith<D> {
+    type Output = Vec<D::Output>;
+    type Error = VecDecoderError<D::Error>;
 
     fn push_bytes(&mut self, bytes: &mut &[u8]) -> Result<DecoderStatus, Self::Error> {
         use VecDecoderError as E;
         use VecDecoderErrorInner as Inner;
 
-        if let Some(mut decoder) = self.prefix_decoder.take() {
-            if decoder.push_bytes(bytes).map_err(|e| E(Inner::LengthPrefixDecode(e)))?.needs_more()
-            {
-                self.prefix_decoder = Some(decoder);
-                return Ok(DecoderStatus::NeedsMore);
-            }
-            self.length = decoder.end().map_err(|e| E(Inner::LengthPrefixDecode(e)))?;
-            if self.length == 0 {
-                return Ok(DecoderStatus::Ready);
-            }
-
-            self.prefix_decoder = None;
-
-            // For DoS prevention, let's not allocate all memory upfront.
+        if self.buffer.len() == self.length {
+            return Ok(DecoderStatus::Ready);
         }
 
         while !bytes.is_empty() {
             self.reserve();
-
-            let mut decoder = self.decoder.take().unwrap_or_else(T::decoder);
+            let mut decoder = self.decoder.take().unwrap_or_default();
 
             if decoder.push_bytes(bytes).map_err(|e| E(Inner::Item(e)))?.needs_more() {
                 self.decoder = Some(decoder);
@@ -281,30 +245,181 @@ impl<T: Decode> Decoder for VecDecoder<T> {
         use VecDecoderErrorInner as E;
 
         let len = self.buffer.len();
-        let missing = if let Some(prefix_decoder) = self.prefix_decoder {
-            prefix_decoder.read_limit()
-        } else if len != self.length {
-            self.length - len
-        } else {
+        if len == self.length {
             return Ok(self.buffer);
-        };
+        }
+        let missing = self.length - len;
 
         Err(VecDecoderError(E::UnexpectedEof(UnexpectedEofError { missing })))
     }
 
     fn read_limit(&self) -> usize {
-        match (&self.prefix_decoder, &self.decoder) {
-            (Some(pd), _) => pd.read_limit(),
-            (None, Some(d)) => d.read_limit(),
-            (None, None) if self.buffer.len() == self.length => 0, // Totally done
-            (None, None) => {
+        match &self.decoder {
+            Some(d) => d.read_limit(),
+            None if self.buffer.len() == self.length => 0,
+            None => {
                 let items_left_to_decode = self.length - self.buffer.len();
-                // This could be inaccurate (eg 1 for a `ByteVecDecoder`) but its the best we can do.
-                let limit_per_decoder = T::decoder().read_limit();
+                // This could be inaccurate but it is the best we can do without decoding.
+                let limit_per_decoder = D::default().read_limit();
                 items_left_to_decode * limit_per_decoder
             }
         }
     }
+}
+
+/// A decoder for a compact sized length-prefixed vector of items, generic over the item decoder
+/// type.
+///
+/// When the item count is known from context rather than a length prefix, use
+/// [`ExactVecDecoderWith`] instead.
+#[cfg(feature = "alloc")]
+pub struct VecDecoderWith<D: Decoder + Default> {
+    prefix_decoder: Option<CompactSizeDecoder>,
+    items: ExactVecDecoderWith<D>,
+}
+
+#[cfg(feature = "alloc")]
+impl<D: Decoder + Default + fmt::Debug> fmt::Debug for VecDecoderWith<D> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("VecDecoderWith")
+            .field("prefix_decoder", &self.prefix_decoder)
+            .field("items", &self.items)
+            .finish()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<D: Decoder + Default + Clone> Clone for VecDecoderWith<D>
+where
+    D::Output: Clone,
+{
+    fn clone(&self) -> Self {
+        Self { prefix_decoder: self.prefix_decoder.clone(), items: self.items.clone() }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<D: Decoder + Default> VecDecoderWith<D> {
+    /// Constructs a new decoder with the default limit of 4,000,000 elements.
+    pub const fn new() -> Self { Self::new_with_limit(MAX_VEC_SIZE) }
+
+    /// Constructs a new decoder with a custom element limit.
+    pub const fn new_with_limit(limit: usize) -> Self {
+        Self {
+            prefix_decoder: Some(CompactSizeDecoder::new_with_limit(limit)),
+            items: ExactVecDecoderWith::new(0),
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<D: Decoder + Default> Default for VecDecoderWith<D> {
+    fn default() -> Self { Self::new() }
+}
+
+#[cfg(feature = "alloc")]
+impl<D: Decoder + Default> Decoder for VecDecoderWith<D> {
+    type Output = Vec<D::Output>;
+    type Error = VecDecoderError<D::Error>;
+
+    fn push_bytes(&mut self, bytes: &mut &[u8]) -> Result<DecoderStatus, Self::Error> {
+        use VecDecoderError as E;
+        use VecDecoderErrorInner as Inner;
+
+        if let Some(mut pd) = self.prefix_decoder.take() {
+            if pd.push_bytes(bytes).map_err(|e| E(Inner::LengthPrefixDecode(e)))?.needs_more() {
+                self.prefix_decoder = Some(pd);
+                return Ok(DecoderStatus::NeedsMore);
+            }
+            let count = pd.end().map_err(|e| E(Inner::LengthPrefixDecode(e)))?;
+            self.items = ExactVecDecoderWith::new(count);
+        }
+
+        self.items.push_bytes(bytes)
+    }
+
+    fn end(self) -> Result<Self::Output, Self::Error> {
+        use VecDecoderErrorInner as Inner;
+
+        if let Some(pd) = self.prefix_decoder {
+            return Err(VecDecoderError(Inner::UnexpectedEof(UnexpectedEofError {
+                missing: pd.read_limit(),
+            })));
+        }
+
+        self.items.end()
+    }
+
+    fn read_limit(&self) -> usize {
+        self.prefix_decoder
+            .as_ref()
+            .map_or_else(|| self.items.read_limit(), CompactSizeDecoder::read_limit)
+    }
+}
+
+/// A decoder for a vector of consensus decodable types.
+///
+/// The vector encoding must start with the number of items in the vector, encoded as a compact
+/// size.
+#[cfg(feature = "alloc")]
+pub struct VecDecoder<T: Decode>(VecDecoderWith<<T as Decode>::Decoder>);
+
+#[cfg(feature = "alloc")]
+impl<T: Decode> fmt::Debug for VecDecoder<T>
+where
+    <T as Decode>::Decoder: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut s = f.debug_struct("VecDecoder");
+        if let Some(ref pd) = self.0.prefix_decoder {
+            s.field("prefix_decoder", pd);
+        } else {
+            s.field("length", &self.0.items.length);
+            // Print the count rather than contents to avoid requiring `T: Debug`.
+            s.field("buffer_len", &self.0.items.buffer.len());
+            s.field("decoder", &self.0.items.decoder);
+        }
+        s.finish()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Decode> Clone for VecDecoder<T>
+where
+    T: Clone,
+    <T as Decode>::Decoder: Clone,
+{
+    fn clone(&self) -> Self { Self(self.0.clone()) }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Decode> VecDecoder<T> {
+    /// Constructs a new typed vector decoder with the default limit of 4,000,000 elements.
+    pub const fn new() -> Self { Self(VecDecoderWith::new()) }
+
+    /// Constructs a new typed vector decoder with a custom limit of elements.
+    pub const fn new_with_limit(limit: usize) -> Self {
+        Self(VecDecoderWith::new_with_limit(limit))
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Decode> Default for VecDecoder<T> {
+    fn default() -> Self { Self::new() }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Decode> Decoder for VecDecoder<T> {
+    type Output = Vec<T>;
+    type Error = VecDecoderError<<<T as Decode>::Decoder as Decoder>::Error>;
+
+    fn push_bytes(&mut self, bytes: &mut &[u8]) -> Result<DecoderStatus, Self::Error> {
+        self.0.push_bytes(bytes)
+    }
+
+    fn end(self) -> Result<Self::Output, Self::Error> { self.0.end() }
+
+    fn read_limit(&self) -> usize { self.0.read_limit() }
 }
 
 /// A decoder that expects exactly N bytes and returns them as an array.
@@ -1039,18 +1154,18 @@ mod tests {
         decoder.push_bytes(&mut prefix_slice).expect("length plus first element");
         assert!(prefix_slice.is_empty());
 
-        assert_eq!(decoder.0.buffer.capacity(), batch_length);
-        assert_eq!(decoder.0.buffer.len(), 1);
-        assert_eq!(decoder.0.buffer[0], Inner(0xAA));
+        assert_eq!(decoder.0 .0.items.buffer.capacity(), batch_length);
+        assert_eq!(decoder.0 .0.items.buffer.len(), 1);
+        assert_eq!(decoder.0 .0.items.buffer[0], Inner(0xAA));
 
         let fill = 0xBB_u32.to_le_bytes().repeat(batch_length - 1);
         let mut fill_slice = fill.as_slice();
         decoder.push_bytes(&mut fill_slice).expect("fills to batch boundary, full capacity");
         assert!(fill_slice.is_empty());
 
-        assert_eq!(decoder.0.buffer.capacity(), batch_length);
-        assert_eq!(decoder.0.buffer.len(), batch_length);
-        assert_eq!(decoder.0.buffer[batch_length - 1], Inner(0xBB));
+        assert_eq!(decoder.0 .0.items.buffer.capacity(), batch_length);
+        assert_eq!(decoder.0 .0.items.buffer.len(), batch_length);
+        assert_eq!(decoder.0 .0.items.buffer[batch_length - 1], Inner(0xBB));
 
         let mut tail = 0xCC_u32.to_le_bytes().to_vec();
         tail.extend(0xDD_u32.to_le_bytes().repeat(tail_length - 1));
@@ -1058,9 +1173,9 @@ mod tests {
         decoder.push_bytes(&mut tail_slice).expect("fills the remaining bytes");
         assert!(tail_slice.is_empty());
 
-        assert_eq!(decoder.0.buffer.capacity(), batch_length + tail_length);
-        assert_eq!(decoder.0.buffer.len(), total_len);
-        assert_eq!(decoder.0.buffer[batch_length], Inner(0xCC));
+        assert_eq!(decoder.0 .0.items.buffer.capacity(), batch_length + tail_length);
+        assert_eq!(decoder.0 .0.items.buffer.len(), total_len);
+        assert_eq!(decoder.0 .0.items.buffer[batch_length], Inner(0xCC));
 
         let Test(result) = decoder.end().unwrap();
         assert_eq!(result.len(), total_len);

--- a/consensus_encoding/src/encode/encoders.rs
+++ b/consensus_encoding/src/encode/encoders.rs
@@ -11,6 +11,7 @@
 
 use core::fmt;
 
+use super::iter::{Encoders, IterEncoder};
 use super::{Encode, Encoder, EncoderStatus, ExactSizeEncoder};
 use crate::CompactSizeEncoder;
 
@@ -116,78 +117,36 @@ impl<const N: usize> ExactSizeEncoder for ArrayRefEncoder<'_, N> {
 }
 
 /// An encoder for a list of consensus encodable types.
-pub struct SliceEncoder<'e, T: Encode> {
-    /// The list of references to the objects we are encoding.
-    sl: &'e [T],
-    /// Encoder for the current object being encoded.
-    cur_enc: Option<T::Encoder<'e>>,
-}
+pub struct SliceEncoder<'e, T: Encode>(IterEncoder<Encoders<'e, T>>);
 
 impl<'e, T: Encode> SliceEncoder<'e, T> {
     /// Constructs an encoder which encodes the slice _without_ adding the length prefix.
     ///
     /// To encode with a length prefix, use [`PrefixedSliceEncoder`] instead.
-    pub fn without_length_prefix(sl: &'e [T]) -> Self {
-        // In this `map` call we cannot remove the closure. Seems to be a bug in the compiler.
-        // Perhaps https://github.com/rust-lang/rust/issues/102540 which is 3 years old with
-        // no replies or even an acknowledgement. We will not bother filing our own issue.
-        Self { sl, cur_enc: sl.first().map(|x| T::encoder(x)) }
-    }
+    pub fn without_length_prefix(sl: &'e [T]) -> Self { Self(IterEncoder::new(Encoders::new(sl))) }
 }
 
-impl<'e, T: Encode> fmt::Debug for SliceEncoder<'e, T>
+impl<'e, T: Encode + 'e> fmt::Debug for SliceEncoder<'e, T>
 where
     T::Encoder<'e>: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SliceEncoder")
-            .field("sl", &self.sl.len())
-            .field("cur_enc", &self.cur_enc)
-            .finish()
+        f.debug_tuple("SliceEncoder").field(&self.0).finish()
     }
 }
 
 // Manual impl rather than #[derive(Clone)] because derive would constrain `where T: Clone`,
 // but `T` itself is never cloned, only the associated type `T::Encoder<'e>`.
-impl<'e, T: Encode> Clone for SliceEncoder<'e, T>
+impl<'e, T: Encode + 'e> Clone for SliceEncoder<'e, T>
 where
     T::Encoder<'e>: Clone,
 {
-    fn clone(&self) -> Self { Self { sl: self.sl, cur_enc: self.cur_enc.clone() } }
+    fn clone(&self) -> Self { Self(self.0.clone()) }
 }
 
 impl<T: Encode> Encoder for SliceEncoder<'_, T> {
-    fn current_chunk(&self) -> &[u8] {
-        // `advance` sets `cur_enc` to `None` once the slice encoder is completely exhausted.
-        self.cur_enc.as_ref().map(T::Encoder::current_chunk).unwrap_or_default()
-    }
-
-    fn advance(&mut self) -> EncoderStatus {
-        let Some(cur) = self.cur_enc.as_mut() else {
-            return EncoderStatus::Finished;
-        };
-
-        loop {
-            // On subsequent calls, attempt to advance the current encoder and return
-            // success if this succeeds.
-            if cur.advance().has_more() {
-                return EncoderStatus::HasMore;
-            }
-            // self.sl guaranteed to be non-empty if cur is non-None.
-            self.sl = &self.sl[1..];
-
-            // If advancing the current encoder failed, attempt to move to the next encoder.
-            if let Some(x) = self.sl.first() {
-                *cur = x.encoder();
-                if !cur.current_chunk().is_empty() {
-                    return EncoderStatus::HasMore;
-                }
-            } else {
-                self.cur_enc = None; // shortcut the next call to advance()
-                return EncoderStatus::Finished;
-            }
-        }
-    }
+    fn current_chunk(&self) -> &[u8] { self.0.current_chunk() }
+    fn advance(&mut self) -> EncoderStatus { self.0.advance() }
 }
 
 /// An encoder for a list of consensus encodable types, including a length prefix.
@@ -204,7 +163,7 @@ impl<'e, T: Encode> PrefixedSliceEncoder<'e, T> {
     }
 }
 
-impl<'e, T: Encode> fmt::Debug for PrefixedSliceEncoder<'e, T>
+impl<'e, T: Encode + 'e> fmt::Debug for PrefixedSliceEncoder<'e, T>
 where
     T::Encoder<'e>: fmt::Debug,
 {
@@ -212,7 +171,7 @@ where
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { self.0.fmt(f) }
 }
 
-impl<'e, T: Encode> Clone for PrefixedSliceEncoder<'e, T>
+impl<'e, T: Encode + 'e> Clone for PrefixedSliceEncoder<'e, T>
 where
     T::Encoder<'e>: Clone,
 {

--- a/consensus_encoding/src/encode/iter.rs
+++ b/consensus_encoding/src/encode/iter.rs
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: CC0-1.0
+
+use core::fmt;
+
+use super::{Encode, Encoder, EncoderStatus};
+
+/// An iterator bridge which maps consensus encodable items to its encoder.
+///
+/// This type is a wrapper around [`core::slice::Iter`] that bridges it to the [`IterEncoder`]
+/// driver. This allows drivers such as [`SliceEncoder`] to store an [`IterEncoder`] with a
+/// nameable type.
+///
+/// [`SliceEncoder`]: super::encoders::SliceEncoder
+pub(super) struct Encoders<'e, T: Encode> {
+    iter: core::slice::Iter<'e, T>,
+}
+
+impl<'e, T: Encode> Encoders<'e, T> {
+    pub(super) fn new(sl: &'e [T]) -> Self { Self { iter: sl.iter() } }
+}
+
+impl<'e, T: Encode> Iterator for Encoders<'e, T> {
+    type Item = T::Encoder<'e>;
+    fn next(&mut self) -> Option<T::Encoder<'e>> {
+        // A closure is required since MSRV (1.74.0) cannot infer the `Self: 'e` GAT bound on
+        // `Encode::encoder` when passed as a bare function item here.
+        #[allow(clippy::redundant_closure_for_method_calls)]
+        self.iter.next().map(|item| item.encoder())
+    }
+}
+
+impl<'e, T: Encode> fmt::Debug for Encoders<'e, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Encoders").field("remaining", &self.iter.as_slice().len()).finish()
+    }
+}
+
+impl<'e, T: Encode> Clone for Encoders<'e, T> {
+    fn clone(&self) -> Self { Self { iter: self.iter.clone() } }
+}
+
+enum EncoderState<I: Iterator>
+where
+    I::Item: Encoder,
+{
+    Encoding { current: I::Item, remaining: core::iter::Fuse<I> },
+    Done,
+}
+
+/// An encoder that drives a sequence of encoders yielded by an iterator.
+///
+/// Items are encoded one after another with no separators.
+pub struct IterEncoder<I: Iterator>
+where
+    I::Item: Encoder,
+{
+    state: EncoderState<I>,
+}
+
+impl<I: Iterator> IterEncoder<I>
+where
+    I::Item: Encoder,
+{
+    /// Constructs an `IterEncoder` from anything that can produce an iterator of encoders.
+    pub fn new(iter: impl IntoIterator<IntoIter = I>) -> Self {
+        // Protect against poorly implemented iterators.
+        let mut iter = iter.into_iter().fuse();
+        // Advance past any leading empty encoders so that the first call to
+        // `current_chunk` satisfies the `Encoder` contract that it must return
+        // non-empty bytes or the encoder must be `Done`.
+        let state = loop {
+            match iter.next() {
+                Some(enc) if !enc.current_chunk().is_empty() =>
+                    break EncoderState::Encoding { current: enc, remaining: iter },
+                Some(_) => {}
+                None => break EncoderState::Done,
+            }
+        };
+        Self { state }
+    }
+}
+
+impl<I: Iterator> fmt::Debug for IterEncoder<I>
+where
+    I::Item: Encoder + fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.state {
+            EncoderState::Encoding { current, .. } =>
+                f.debug_struct("IterEncoder").field("current", current).finish(),
+            EncoderState::Done => f.debug_struct("IterEncoder").finish(),
+        }
+    }
+}
+
+impl<I: Iterator> Clone for IterEncoder<I>
+where
+    I: Clone,
+    I::Item: Encoder + Clone,
+{
+    fn clone(&self) -> Self {
+        let state = match &self.state {
+            EncoderState::Encoding { current, remaining } =>
+                EncoderState::Encoding { current: current.clone(), remaining: remaining.clone() },
+            EncoderState::Done => EncoderState::Done,
+        };
+        Self { state }
+    }
+}
+
+impl<I: Iterator> Encoder for IterEncoder<I>
+where
+    I::Item: Encoder,
+{
+    fn current_chunk(&self) -> &[u8] {
+        match &self.state {
+            EncoderState::Encoding { current, .. } => current.current_chunk(),
+            EncoderState::Done => &[],
+        }
+    }
+
+    fn advance(&mut self) -> EncoderStatus {
+        let EncoderState::Encoding { current, remaining } = &mut self.state else {
+            return EncoderStatus::Finished;
+        };
+
+        loop {
+            if current.advance().has_more() {
+                return EncoderStatus::HasMore;
+            }
+
+            if let Some(next) = remaining.next() {
+                *current = next;
+                // If the next encoder is empty, skip in order to maintain `Encoder` contract
+                // that it must return non-empty bytes or the encoder must be `Done`
+                if !current.current_chunk().is_empty() {
+                    return EncoderStatus::HasMore;
+                }
+            } else {
+                self.state = EncoderState::Done;
+                return EncoderStatus::Finished;
+            }
+        }
+    }
+}

--- a/consensus_encoding/src/encode/iter.rs
+++ b/consensus_encoding/src/encode/iter.rs
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: CC0-1.0
+
+use core::fmt;
+
+use super::{Encode, Encoder, EncoderStatus};
+
+/// An iterator bridge which maps consensus encodable items to its encoder.
+///
+/// This type is a wrapper around [`core::slice::Iter`] that bridges it to the [`IterEncoder`]
+/// driver. This allows drivers such as [`SliceEncoder`] to store an [`IterEncoder`] with a
+/// nameable type.
+///
+/// [`SliceEncoder`]: super::encoders::SliceEncoder
+pub(super) struct Encoders<'e, T: Encode> {
+    iter: core::slice::Iter<'e, T>,
+}
+
+impl<'e, T: Encode> Encoders<'e, T> {
+    pub(super) fn new(sl: &'e [T]) -> Self { Self { iter: sl.iter() } }
+}
+
+impl<'e, T: Encode> Iterator for Encoders<'e, T> {
+    type Item = T::Encoder<'e>;
+    fn next(&mut self) -> Option<T::Encoder<'e>> { self.iter.next().map(Encode::encoder) }
+}
+
+impl<'e, T: Encode> fmt::Debug for Encoders<'e, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Encoders").field("remaining", &self.iter.as_slice().len()).finish()
+    }
+}
+
+impl<'e, T: Encode> Clone for Encoders<'e, T> {
+    fn clone(&self) -> Self { Self { iter: self.iter.clone() } }
+}
+
+enum EncoderState<I: Iterator>
+where
+    I::Item: Encoder,
+{
+    Encoding { current: I::Item, remaining: core::iter::Fuse<I> },
+    Done,
+}
+
+/// An encoder that drives a sequence of encoders yielded by an iterator.
+///
+/// Items are encoded one after another with no separators.
+pub struct IterEncoder<I: Iterator>
+where
+    I::Item: Encoder,
+{
+    state: EncoderState<I>,
+}
+
+impl<I: Iterator> IterEncoder<I>
+where
+    I::Item: Encoder,
+{
+    /// Constructs an `IterEncoder` from anything that can produce an iterator of encoders.
+    pub fn new(iter: impl IntoIterator<IntoIter = I>) -> Self {
+        // Protect against poorly implemented iterators.
+        let mut iter = iter.into_iter().fuse();
+        // Advance past any leading empty encoders so that the first call to
+        // `current_chunk` satisfies the `Encoder` contract that it must return
+        // non-empty bytes or the encoder must be `Done`.
+        let state = loop {
+            match iter.next() {
+                Some(enc) if !enc.current_chunk().is_empty() =>
+                    break EncoderState::Encoding { current: enc, remaining: iter },
+                Some(_) => {}
+                None => break EncoderState::Done,
+            }
+        };
+        Self { state }
+    }
+}
+
+impl<I: Iterator> fmt::Debug for IterEncoder<I>
+where
+    I::Item: Encoder + fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.state {
+            EncoderState::Encoding { current, .. } =>
+                f.debug_struct("IterEncoder").field("current", current).finish(),
+            EncoderState::Done => f.debug_struct("IterEncoder").finish(),
+        }
+    }
+}
+
+impl<I: Iterator> Clone for IterEncoder<I>
+where
+    I: Clone,
+    I::Item: Encoder + Clone,
+{
+    fn clone(&self) -> Self {
+        let state = match &self.state {
+            EncoderState::Encoding { current, remaining } =>
+                EncoderState::Encoding { current: current.clone(), remaining: remaining.clone() },
+            EncoderState::Done => EncoderState::Done,
+        };
+        Self { state }
+    }
+}
+
+impl<I: Iterator> Encoder for IterEncoder<I>
+where
+    I::Item: Encoder,
+{
+    fn current_chunk(&self) -> &[u8] {
+        match &self.state {
+            EncoderState::Encoding { current, .. } => current.current_chunk(),
+            EncoderState::Done => &[],
+        }
+    }
+
+    fn advance(&mut self) -> EncoderStatus {
+        let EncoderState::Encoding { current, remaining } = &mut self.state else {
+            return EncoderStatus::Finished;
+        };
+
+        loop {
+            if current.advance().has_more() {
+                return EncoderStatus::HasMore;
+            }
+
+            if let Some(next) = remaining.next() {
+                *current = next;
+                // If the next encoder is empty, skip in order to maintain `Encoder` contract
+                // that it must return non-empty bytes or the encoder must be `Done`
+                if !current.current_chunk().is_empty() {
+                    return EncoderStatus::HasMore;
+                }
+            } else {
+                self.state = EncoderState::Done;
+                return EncoderStatus::Finished;
+            }
+        }
+    }
+}

--- a/consensus_encoding/src/encode/mod.rs
+++ b/consensus_encoding/src/encode/mod.rs
@@ -7,6 +7,7 @@ use alloc::string::String;
 use alloc::vec::Vec;
 
 pub mod encoders;
+pub mod iter;
 
 /// A Bitcoin object which can be consensus encoded.
 ///

--- a/consensus_encoding/src/lib.rs
+++ b/consensus_encoding/src/lib.rs
@@ -64,6 +64,16 @@
 //! * [`drain_to_vec`]: Drain an encoder to the heap.
 //! * [`drain_to_hex`]: Drain an encoder to a hex string.
 //!
+//! # Collections
+//!
+//! This crate provides types for encoding and decoding sequences of items. On the decoding side,
+//! [`VecDecoder`] decodes a length-prefixed sequence of consensus encodable types into a `Vec`.
+//!
+//! On the encoding side, [`SliceEncoder`] and [`PrefixedSliceEncoder`] encode slices of consensus
+//! encodable types without and with a compact-size length prefix respectively.
+//!
+//! The lower-level [`IterEncoder`] drives any iterator whose items implement [`Encoder`].
+//!
 //! # Feature Flags
 //!
 //! * `std` - Enables std lib I/O driver functions and `std::error::Error` impls (implies `alloc`).
@@ -122,6 +132,8 @@ pub use self::encode::encoders::{
     ArrayEncoder, ArrayRefEncoder, BytesEncoder, Encoder2, Encoder3, Encoder4, Encoder6,
     PrefixedBytesEncoder, PrefixedSliceEncoder, SliceEncoder,
 };
+#[doc(inline)]
+pub use self::encode::iter::IterEncoder;
 #[doc(inline)]
 pub use self::encode::{
     check_encode, check_encoder, Encode, Encoder, EncoderByteIter, EncoderStatus, ExactSizeEncoder,

--- a/consensus_encoding/src/lib.rs
+++ b/consensus_encoding/src/lib.rs
@@ -68,6 +68,9 @@
 //!
 //! This crate provides types for encoding and decoding sequences of items. On the decoding side,
 //! [`VecDecoder`] decodes a length-prefixed sequence of consensus encodable types into a `Vec`.
+//! [`VecDecoderWith`] and [`ExactVecDecoderWith`] are the underlying implementations, bound
+//! directly on [`Decoder`] allowing them to be used with decoder types that do not have a
+//! corresponding [`Decode`] implementation.
 //!
 //! On the encoding side, [`SliceEncoder`] and [`PrefixedSliceEncoder`] encode slices of consensus
 //! encodable types without and with a compact-size length prefix respectively.
@@ -111,7 +114,7 @@ pub use self::compact_size::{CompactSizeDecoder, CompactSizeEncoder, CompactSize
 pub use self::decode::decoders::{ArrayDecoder, Decoder2, Decoder3, Decoder4, Decoder6};
 #[cfg(feature = "alloc")]
 #[doc(inline)]
-pub use self::decode::decoders::{ByteVecDecoder, VecDecoder};
+pub use self::decode::decoders::{ByteVecDecoder, ExactVecDecoderWith, VecDecoder, VecDecoderWith};
 #[doc(inline)]
 pub use self::decode::{
     check_decode, check_decoder, decode_from_slice, decode_from_slice_unbounded,

--- a/consensus_encoding/tests/api.rs
+++ b/consensus_encoding/tests/api.rs
@@ -21,7 +21,8 @@ use encoding::error::{DecodeError, UnconsumedError};
 use encoding::ReadError;
 #[cfg(feature = "alloc")]
 use encoding::{
-    ByteVecDecoder, ByteVecDecoderError, LengthPrefixExceedsMaxError, VecDecoder, VecDecoderError,
+    ByteVecDecoder, ByteVecDecoderError, ExactVecDecoderWith, LengthPrefixExceedsMaxError,
+    VecDecoder, VecDecoderError, VecDecoderWith,
 };
 
 static BYTES: &[u8] = &[];
@@ -47,6 +48,10 @@ struct Structs {
     o: SliceEncoder<'static, Foo>,
     #[cfg(feature = "alloc")]
     p: VecDecoder<Foo>,
+    #[cfg(feature = "alloc")]
+    q: VecDecoderWith<FooDecoder>,
+    #[cfg(feature = "alloc")]
+    r: ExactVecDecoderWith<FooDecoder>,
 }
 
 // Dummy decoder to use in place of generic.
@@ -116,6 +121,10 @@ struct Clone {
     o: SliceEncoder<'static, Foo>,
     #[cfg(feature = "alloc")]
     p: VecDecoder<Foo>,
+    #[cfg(feature = "alloc")]
+    q: VecDecoderWith<FooDecoder>,
+    #[cfg(feature = "alloc")]
+    r: ExactVecDecoderWith<FooDecoder>,
 }
 
 /// A struct that includes all types that implement `Default` (implies decoders).
@@ -134,6 +143,8 @@ struct Default {
     // l: Decoder6<D, D, D, D, D, D>,
     #[cfg(feature = "alloc")]
     o: VecDecoder<Foo>,
+    #[cfg(feature = "alloc")]
+    p: VecDecoderWith<FooDecoder>,
 }
 
 /// A struct that includes all public error types.
@@ -212,6 +223,10 @@ fn c_debug_nonempty() {
     #[cfg(feature = "alloc")]
     {
         let debug = format!("{:?}", VecDecoder::<Foo>::default());
+        assert!(!debug.is_empty());
+        let debug = format!("{:?}", VecDecoderWith::<FooDecoder>::default());
+        assert!(!debug.is_empty());
+        let debug = format!("{:?}", ExactVecDecoderWith::<FooDecoder>::new(0));
         assert!(!debug.is_empty());
     }
 }

--- a/consensus_encoding/tests/api.rs
+++ b/consensus_encoding/tests/api.rs
@@ -13,8 +13,8 @@ use core::fmt;
 use bitcoin_consensus_encoding::{
     self as encoding, encoder_newtype, ArrayDecoder, ArrayEncoder, ArrayRefEncoder, BytesEncoder,
     CompactSizeDecoder, CompactSizeDecoderError, CompactSizeEncoder, CompactSizeU64Decoder, Decode,
-    Decoder, Decoder2, Decoder3, Decoder4, Decoder6, Encode, EncoderByteIter, SliceEncoder,
-    UnexpectedEofError,
+    Decoder, Decoder2, Decoder3, Decoder4, Decoder6, Encode, EncoderByteIter, IterEncoder,
+    SliceEncoder, UnexpectedEofError,
 };
 use encoding::error::{DecodeError, UnconsumedError};
 #[cfg(feature = "std")]
@@ -43,9 +43,10 @@ struct Structs {
     k: Decoder4<D, D, D, D>,
     l: Decoder6<D, D, D, D, D, D>,
     m: EncoderByteIter<FooEncoder<'static>>,
-    n: SliceEncoder<'static, Foo>,
+    n: IterEncoder<core::iter::Empty<FooEncoder<'static>>>,
+    o: SliceEncoder<'static, Foo>,
     #[cfg(feature = "alloc")]
-    o: VecDecoder<Foo>,
+    p: VecDecoder<Foo>,
 }
 
 // Dummy decoder to use in place of generic.
@@ -111,9 +112,10 @@ struct Clone {
     // k: Decoder4<D, D, D, D>,
     // l: Decoder6<D, D, D, D, D, D>,
     m: EncoderByteIter<FooEncoder<'static>>,
-    n: SliceEncoder<'static, Foo>,
+    n: IterEncoder<core::iter::Empty<FooEncoder<'static>>>,
+    o: SliceEncoder<'static, Foo>,
     #[cfg(feature = "alloc")]
-    o: VecDecoder<Foo>,
+    p: VecDecoder<Foo>,
 }
 
 /// A struct that includes all types that implement `Default` (implies decoders).
@@ -202,6 +204,8 @@ fn c_debug_nonempty() {
     assert!(!debug.is_empty());
 
     let debug = format!("{:?}", EncoderByteIter::new(Foo::dummy().encoder()));
+    assert!(!debug.is_empty());
+    let debug = format!("{:?}", IterEncoder::new(core::iter::empty::<FooEncoder<'static>>()));
     assert!(!debug.is_empty());
     let debug = format!("{:?}", SliceEncoder::without_length_prefix(&[Foo::dummy()]));
     assert!(!debug.is_empty());

--- a/consensus_encoding/tests/iter_encoder.rs
+++ b/consensus_encoding/tests/iter_encoder.rs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Integration tests for [`IterEncoder`].
+
+#![cfg(feature = "alloc")]
+
+use bitcoin_consensus_encoding::{drain_to_vec, BytesEncoder, IterEncoder};
+
+/// Constructs a [`BytesEncoder`] from a static byte slice for use in tests.
+fn enc(b: &'static [u8]) -> BytesEncoder<'static> { BytesEncoder::without_length_prefix(b) }
+
+/// Drives an [`IterEncoder`] built from `iter` to completion, returning the encoded bytes.
+fn encode<I>(iter: I) -> Vec<u8>
+where
+    I: IntoIterator,
+    I::IntoIter: Iterator,
+    <I::IntoIter as Iterator>::Item: bitcoin_consensus_encoding::Encoder,
+{
+    drain_to_vec(&mut IterEncoder::new(iter))
+}
+
+#[test]
+fn empty_iterator() {
+    let result = drain_to_vec(&mut IterEncoder::new(core::iter::empty::<BytesEncoder<'static>>()));
+    assert_eq!(result, Vec::<u8>::new());
+}
+
+#[test]
+fn iterator_of_empty_encoders() {
+    assert_eq!(encode([enc(&[]), enc(&[])]), Vec::<u8>::new());
+}
+
+#[test]
+fn single_encoder() {
+    assert_eq!(encode([enc(&[1, 2, 3, 4])]), [1, 2, 3, 4]);
+}
+
+#[test]
+fn multiple_encoders_in_sequence() {
+    assert_eq!(encode([enc(&[1, 2]), enc(&[3, 4])]), [1, 2, 3, 4]);
+}
+
+#[test]
+fn leading_empty_encoders_skipped() {
+    assert_eq!(encode([enc(&[]), enc(&[]), enc(&[1, 2, 3])]), [1, 2, 3]);
+}
+
+#[test]
+fn trailing_empty_encoders_skipped() {
+    assert_eq!(encode([enc(&[1, 2, 3]), enc(&[]), enc(&[])]), [1, 2, 3]);
+}
+
+#[test]
+fn interleaved_empty_encoders_skipped() {
+    assert_eq!(encode([enc(&[1]), enc(&[]), enc(&[2]), enc(&[]), enc(&[3])]), [1, 2, 3]);
+}

--- a/consensus_encoding/tests/vec_decoder.rs
+++ b/consensus_encoding/tests/vec_decoder.rs
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Tests for [`VecDecoderWith`] and [`ExactVecDecoderWith`].
+
+#![cfg(feature = "alloc")]
+
+use bitcoin_consensus_encoding::{
+    ArrayDecoder, Decoder, DecoderStatus, ExactVecDecoderWith, UnexpectedEofError, VecDecoderWith,
+};
+
+/// A test item decoded from 4 little-endian bytes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Item(u32);
+
+/// Decoder for [`Item`]: reads exactly 4 bytes and interprets them as a LE u32.
+#[derive(Default, Clone)]
+struct ItemDecoder(ArrayDecoder<4>);
+
+impl Decoder for ItemDecoder {
+    type Output = Item;
+    type Error = UnexpectedEofError;
+
+    fn push_bytes(&mut self, bytes: &mut &[u8]) -> Result<DecoderStatus, Self::Error> {
+        self.0.push_bytes(bytes)
+    }
+
+    fn end(self) -> Result<Self::Output, Self::Error> {
+        Ok(Item(u32::from_le_bytes(self.0.end()?)))
+    }
+
+    fn read_limit(&self) -> usize { self.0.read_limit() }
+}
+
+/// Decodes a [`VecDecoderWith`] from `bytes` in a single call, returning the decoded items.
+fn decode_vec(bytes: &[u8]) -> Vec<Item> {
+    let mut decoder = VecDecoderWith::<ItemDecoder>::new();
+    let mut slice = bytes;
+    decoder.push_bytes(&mut slice).unwrap();
+    decoder.end().unwrap()
+}
+
+/// Decodes an [`ExactVecDecoderWith`] of the given `count` from `bytes` in a single call.
+fn decode_exact(count: usize, bytes: &[u8]) -> Vec<Item> {
+    let mut decoder = ExactVecDecoderWith::<ItemDecoder>::new(count);
+    let mut slice = bytes;
+    decoder.push_bytes(&mut slice).unwrap();
+    decoder.end().unwrap()
+}
+
+#[test]
+fn vec_decoder_with_empty() {
+    assert_eq!(decode_vec(&[0x00]), vec![]);
+}
+
+#[test]
+fn vec_decoder_with_single_item() {
+    let bytes = [0x01, 0xEF, 0xBE, 0xAD, 0xDE];
+    assert_eq!(decode_vec(&bytes), vec![Item(0xDEAD_BEEF)]);
+}
+
+#[test]
+fn vec_decoder_with_multiple_items() {
+    let bytes = [0x02, 0xEF, 0xBE, 0xAD, 0xDE, 0xBE, 0xBA, 0xFE, 0xCA];
+    assert_eq!(decode_vec(&bytes), vec![Item(0xDEAD_BEEF), Item(0xCAFE_BABE)]);
+}
+
+#[test]
+fn vec_decoder_with_needs_more_during_prefix() {
+    let mut decoder = VecDecoderWith::<ItemDecoder>::new();
+    let mut empty: &[u8] = &[];
+    assert!(decoder.push_bytes(&mut empty).unwrap().needs_more());
+}
+
+#[test]
+fn vec_decoder_with_needs_more_during_items() {
+    let mut decoder = VecDecoderWith::<ItemDecoder>::new();
+    // Prefix says 1 item but we only provide 2 of the 4 bytes.
+    let mut partial: &[u8] = &[0x01, 0xEF, 0xBE];
+    assert!(decoder.push_bytes(&mut partial).unwrap().needs_more());
+}
+
+#[test]
+fn exact_vec_decoder_with_zero_count() {
+    assert_eq!(decode_exact(0, &[]), vec![]);
+}
+
+#[test]
+fn exact_vec_decoder_with_single_item() {
+    let bytes = [0xEF, 0xBE, 0xAD, 0xDE];
+    assert_eq!(decode_exact(1, &bytes), vec![Item(0xDEAD_BEEF)]);
+}
+
+#[test]
+fn exact_vec_decoder_with_multiple_items() {
+    let bytes = [0xEF, 0xBE, 0xAD, 0xDE, 0xBE, 0xBA, 0xFE, 0xCA];
+    assert_eq!(decode_exact(2, &bytes), vec![Item(0xDEAD_BEEF), Item(0xCAFE_BABE)]);
+}
+
+#[test]
+fn exact_vec_decoder_with_needs_more() {
+    let mut decoder = ExactVecDecoderWith::<ItemDecoder>::new(1);
+    // Only provide 2 of the 4 bytes needed.
+    let mut partial: &[u8] = &[0xEF, 0xBE];
+    assert!(decoder.push_bytes(&mut partial).unwrap().needs_more());
+}
+
+#[test]
+fn exact_vec_decoder_with_zero_count_ignores_trailing_bytes() {
+    // Bytes present, but count is 0. Decoder is immediately ready and leaves bytes unconsumed.
+    let mut decoder = ExactVecDecoderWith::<ItemDecoder>::new(0);
+    let mut bytes: &[u8] = &[0xFF, 0xFF];
+    assert!(decoder.push_bytes(&mut bytes).unwrap().is_ready());
+    assert_eq!(bytes.len(), 2);
+}


### PR DESCRIPTION
From the doc findings in https://github.com/rust-bitcoin/rust-bitcoin/pull/6651, there are only a handful (like, 2.5) of collection-based types in `consensus_encoding` which are tied to the higher level consensus codec `Encode`/`Decode` traits. These two patches expose the internals of the lower-level `Encoder`/`Decoder` traits which is a nice to have in rust-psbt where simple wrappers could then be defined for `PsbtEncode`/`PsbtDecode`.

## Encoding

I first tried to make some sort of `SliceEncoderWith` type following the pattern on the decoding-side, but this gets hairy due to the lifetimes present on the encoding-side. So I turned to `push_decode` and saw how Kixunil used an [iterator pattern there](https://github.com/Kixunil/push_decode/blob/master/src/encoders/iter.rs). I copied that over with a few tweaks and updated `SliceEncoder` to delegate to it.

One question I have here is that the new `IterEncoder` type defensively fuses the input iterator `let mut iter = iter.into_iter().fuse();`. I figure this is best practice, but it is useless for the existing `SliceEncoder` and there might be a performance hit?

The biggest change from `push_decode` is dropping the `I::Item: Into<E>, E: Encoder` bound and instead have an explicit type mapping, `Encoders`, for the type glue. This isn't a huge deal since not exposed to the caller, but it is what connects the `IterEncoder` logic to the existing `SliceEncoder`. But here are the details.

The little wrapper class in action:

```rust
IterEncoder::new(Encoders::new(txs))
```

vs. potentially the `Into` approach with a turbofish:

```rust
IterEncoder::<_, TransactionEncoder>::new(txs.iter())
```

I think to avoid having to add some `From` impl manually to every existing encodable type, we would want some sort of blanket impl. As far as I can tell, the type system can't handle this because of the orphan rule. `From` is external *and* `<T as Encode>::Encoder<'e>` is uncovered, external. We could add a new trait, but that would have the same issues outside of `consensus_encoding`. Maybe I am missing a better pattern for this though.

```rust
impl<'e, T: Encode> From<&'e T> for <T as Encode>::Encoder<'e> {
    fn from(t: &'e T) -> Self { t.encoder() }
}
```

## Decoding

The decoding side is simpler on paper since there are no lifetimes to worry about, but I ended up exposing two new types for necessary flexibility: `VecDecoderWith` and `ExactVecDecoderWith`. While the API expands, these all delegate to each other so I don't think a large maintenance burden.

I maintained the use of a `Default` bound like we have on our existing `Decoder` drivers. Recently convinced myself that this is fine: https://github.com/rust-bitcoin/rust-bitcoin/issues/6674.