### PR TITLE
fuzz: fix cargo-fuzz install issue, add bip-434 message targets, clean up scripts

### DIFF
--- a/.github/workflows/cron-daily-fuzz.yml
+++ b/.github/workflows/cron-daily-fuzz.yml
@@ -8,6 +8,7 @@ on:
     # - 6am CET
     # - 4pm AEDT
     - cron: '00 05 * * *'
+  workflow_dispatch:
 permissions: {}
 
 jobs:

--- a/.github/workflows/cron-daily-fuzz.yml
+++ b/.github/workflows/cron-daily-fuzz.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           toolchain: '1.74.0'
       - name: Install cargo-fuzz
-        run: cargo install --locked --version 0.12.0 cargo-fuzz
+        run: cargo install --locked --force --version 0.12.0 cargo-fuzz
       - name: Fuzz shard ${{ matrix.shard_id }}
         working-directory: fuzz
         shell: bash

--- a/.github/workflows/cron-daily-fuzz.yml
+++ b/.github/workflows/cron-daily-fuzz.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           toolchain: '1.74.0'
       - name: Install cargo-fuzz
-        run: cargo install --locked --force --version 0.12.0 cargo-fuzz
+        run: cargo install --locked --force --version 0.13.2 cargo-fuzz
       - name: Fuzz shard ${{ matrix.shard_id }}
         working-directory: fuzz
         shell: bash

--- a/.github/workflows/cron-daily-fuzz.yml
+++ b/.github/workflows/cron-daily-fuzz.yml
@@ -34,9 +34,7 @@ jobs:
             fuzz/target
             target
           key: cache-fuzz-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
-      - uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6 # stable
-        with:
-          toolchain: '1.74.0'
+      - uses: ./.github/actions/setup-rbmt
       - name: Install cargo-fuzz
         run: cargo install --locked --force --version 0.13.2 cargo-fuzz
       - name: Fuzz shard ${{ matrix.shard_id }}

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -58,432 +58,525 @@ path = "fuzz_targets/bitcoin/arbitrary_block.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_arbitrary_script"
 path = "fuzz_targets/bitcoin/arbitrary_script.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_arbitrary_transaction"
 path = "fuzz_targets/bitcoin/arbitrary_transaction.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_arbitrary_witness"
 path = "fuzz_targets/bitcoin/arbitrary_witness.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_compare_consensus_encoding"
 path = "fuzz_targets/bitcoin/compare_consensus_encoding.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_deserialize_block"
 path = "fuzz_targets/bitcoin/deserialize_block.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_deserialize_prefilled_transaction"
 path = "fuzz_targets/bitcoin/deserialize_prefilled_transaction.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_deserialize_script"
 path = "fuzz_targets/bitcoin/deserialize_script.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_deserialize_transaction"
 path = "fuzz_targets/bitcoin/deserialize_transaction.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_deserialize_witness"
 path = "fuzz_targets/bitcoin/deserialize_witness.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_absolute_lock_time"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/absolute_lock_time.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_amount"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/amount.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_block"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/block.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_block_hash"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/block_hash.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_block_header"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/block_header.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_block_height"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/block_height.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_block_time"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/block_time.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_block_version"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/block_version.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_compact_target"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/compact_target.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_out_point"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/out_point.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_address_addr_v1_message"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_address_addr_v1_message.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_address_addr_v2"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_address_addr_v2.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_address_addr_v2_message"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_address_addr_v2_message.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_address_address"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_address_address.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_bip152_block_transactions"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_bip152_block_transactions.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_bip152_block_transactions_request"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_bip152_block_transactions_request.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_bip152_header_and_short_ids"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_bip152_header_and_short_ids.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_bip152_prefilled_transaction"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_bip152_prefilled_transaction.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_bip152_short_id"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_bip152_short_id.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "bitcoin_encoding_roundtrip_p2p_bip434_feature"
+path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_bip434_feature.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "bitcoin_encoding_roundtrip_p2p_bip434_feature_data"
+path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_bip434_feature_data.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "bitcoin_encoding_roundtrip_p2p_bip434_feature_id"
+path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_bip434_feature_id.rs"
+test = false
+doc = false
+bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_magic"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_magic.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_merkle_tree_merkle_block"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_merkle_tree_merkle_block.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_merkle_tree_partial_merkle_tree"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_merkle_tree_partial_merkle_tree.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_message_addr_payload"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_addr_payload.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_message_addr_v2_payload"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_addr_v2_payload.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_message_blockdata_block_locator"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_blockdata_block_locator.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_message_blockdata_get_blocks_message"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_blockdata_get_blocks_message.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_message_blockdata_get_headers_message"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_blockdata_get_headers_message.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_message_blockdata_inventory"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_blockdata_inventory.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_message_bloom_bloom_flags"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_bloom_bloom_flags.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_message_bloom_filter_add"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_bloom_filter_add.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_message_bloom_filter_load"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_bloom_filter_load.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_message_command_string"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_command_string.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_message_compact_blocks_send_cmpct"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_compact_blocks_send_cmpct.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_message_erlay_send_tx_rcn_cl"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_erlay_send_tx_rcn_cl.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_message_fee_filter"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_fee_filter.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_message_filter_c_f_checkpt"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_filter_c_f_checkpt.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_message_filter_c_f_headers"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_filter_c_f_headers.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_message_filter_c_filter"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_filter_c_filter.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_message_filter_filter_hash"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_filter_filter_hash.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_message_filter_filter_header"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_filter_filter_header.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_message_filter_get_c_f_checkpt"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_filter_get_c_f_checkpt.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_message_filter_get_c_f_headers"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_filter_get_c_f_headers.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_message_filter_get_c_filters"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_filter_get_c_filters.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_message_headers_message"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_headers_message.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_message_inventory_payload"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_inventory_payload.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_message_network_alert"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_network_alert.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_message_network_header"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_network_header.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_message_network_reject"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_network_reject.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_message_network_reject_reason"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_network_reject_reason.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_message_network_user_agent"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_network_user_agent.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_message_network_version_message"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_network_version_message.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_message_ping"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_ping.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_message_pong"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_pong.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_message_v1_message_header"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_v1_message_header.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_message_v1_network_message"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_v1_network_message.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_protocol_version"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_protocol_version.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_p2p_service_flags"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/p2p_service_flags.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_redeem_script_buf"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/redeem_script_buf.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_script_pub_key_buf"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/script_pub_key_buf.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_script_sig_buf"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/script_sig_buf.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_sequence"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/sequence.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_tap_script_buf"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/tap_script_buf.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_taproot_primitives_tap_leaf_hash"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/taproot_primitives_tap_leaf_hash.rs"
@@ -497,213 +590,249 @@ path = "fuzz_targets/bitcoin/encoding_roundtrip/transaction.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_transaction_version"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/transaction_version.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_tx_in"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/tx_in.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_tx_merkle_node"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/tx_merkle_node.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_tx_out"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/tx_out.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_witness"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/witness.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_witness_merkle_node"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/witness_merkle_node.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_encoding_roundtrip_witness_script_buf"
 path = "fuzz_targets/bitcoin/encoding_roundtrip/witness_script_buf.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_parse_address"
 path = "fuzz_targets/bitcoin/parse_address.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_parse_outpoint"
 path = "fuzz_targets/bitcoin/parse_outpoint.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_script_bytes_to_asm_fmt"
 path = "fuzz_targets/bitcoin/script_bytes_to_asm_fmt.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_0_32_compare_consensus_encoding"
 path = "fuzz_targets/bitcoin_0_32/compare_consensus_encoding.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_0_32_deser_net_msg"
 path = "fuzz_targets/bitcoin_0_32/deser_net_msg.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_0_32_deserialize_address"
 path = "fuzz_targets/bitcoin_0_32/deserialize_address.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_0_32_deserialize_psbt"
 path = "fuzz_targets/bitcoin_0_32/deserialize_psbt.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "bitcoin_0_32_outpoint_string"
 path = "fuzz_targets/bitcoin_0_32/outpoint_string.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "consensus_encoding_decode_array"
 path = "fuzz_targets/consensus_encoding/decode_array.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "consensus_encoding_decode_byte_vec"
 path = "fuzz_targets/consensus_encoding/decode_byte_vec.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "consensus_encoding_decode_compact_size"
 path = "fuzz_targets/consensus_encoding/decode_compact_size.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "consensus_encoding_decode_decoder2"
 path = "fuzz_targets/consensus_encoding/decode_decoder2.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "hashes_arbitrary_json"
 path = "fuzz_targets/hashes/arbitrary_json.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "hashes_json"
 path = "fuzz_targets/hashes/json.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "hashes_ripemd160"
 path = "fuzz_targets/hashes/ripemd160.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "hashes_sha1"
 path = "fuzz_targets/hashes/sha1.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "hashes_sha256"
 path = "fuzz_targets/hashes/sha256.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "hashes_sha512"
 path = "fuzz_targets/hashes/sha512.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "hashes_sha512_256"
 path = "fuzz_targets/hashes/sha512_256.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "hashes_0_32_cbor"
 path = "fuzz_targets/hashes_0_32/cbor.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "p2p_arbitrary_addrv2"
 path = "fuzz_targets/p2p/arbitrary_addrv2.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "p2p_deserialize_addrv2"
 path = "fuzz_targets/p2p/deserialize_addrv2.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "p2p_deserialize_raw_net_msg"
 path = "fuzz_targets/p2p/deserialize_raw_net_msg.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "units_arbitrary_weight"
 path = "fuzz_targets/units/arbitrary_weight.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "units_parse_amount"
 path = "fuzz_targets/units/parse_amount.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "units_parse_int"
 path = "fuzz_targets/units/parse_int.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "units_standard_checks"
 path = "fuzz_targets/units/standard_checks.rs"
 test = false
 doc = false
 bench = false
+
 [[bin]]
 name = "units_0_32_deserialize_amount"
 path = "fuzz_targets/units_0_32/deserialize_amount.rs"
 test = false
 doc = false
 bench = false
+

--- a/fuzz/fuzz.sh
+++ b/fuzz/fuzz.sh
@@ -10,7 +10,7 @@
 #   -cycle                  Continuous fuzzing: loop through all targets indefinitely,
 #                           running corpus minimization after each target, with low process priority
 
-set -euox pipefail
+set -euo pipefail
 
 target=
 max_total_time=

--- a/fuzz/fuzz.sh
+++ b/fuzz/fuzz.sh
@@ -59,6 +59,13 @@ if ! command -v cargo-fuzz &> /dev/null; then
   exit 127
 fi
 
+if ! command -v cargo-rbmt &> /dev/null; then
+  echo "ERROR: cargo-rbmt is required but not installed"
+  exit 127
+fi
+
+nightly_toolchain="$(cargo rbmt toolchains --nightly)"
+
 if [ -z "$target" ]; then
   targets=$(cargo fuzz list)
 else
@@ -80,10 +87,10 @@ while :; do
     if [ "$cycle_mode" = true ]; then
       chrt_cmd='chrt -i 0'
     fi
-    RUSTFLAGS="${RUSTFLAGS:-} ${fuzz_rustflags}" $chrt_cmd cargo +nightly fuzz run "$targetName" -- -max_total_time="$max_total_time"
+    RUSTFLAGS="${RUSTFLAGS:-} ${fuzz_rustflags}" $chrt_cmd cargo +"${nightly_toolchain}" fuzz run "$targetName" -- -max_total_time="$max_total_time"
 
     echo "Minimizing corpus for target $targetName"
-    cargo +nightly fuzz cmin "$targetName"
+    cargo +"${nightly_toolchain}" fuzz cmin "$targetName"
   done
 
   # Exit after one cycle if not in cycle mode.

--- a/fuzz/fuzz.sh
+++ b/fuzz/fuzz.sh
@@ -64,6 +64,11 @@ if ! command -v cargo-rbmt &> /dev/null; then
   exit 127
 fi
 
+if [ "$cycle_mode" = true ] && ! command -v chrt &> /dev/null; then
+  echo "ERROR: chrt is required for -cycle mode but not installed"
+  exit 127
+fi
+
 nightly_toolchain="$(cargo rbmt toolchains --nightly)"
 
 if [ -z "$target" ]; then

--- a/fuzz/fuzz.sh
+++ b/fuzz/fuzz.sh
@@ -54,9 +54,10 @@ case "$max_total_time" in
     ;;
 esac
 
-cargo --version
-rustc --version
-cargo install --force --locked --version 0.12.0 cargo-fuzz
+if ! command -v cargo-fuzz &> /dev/null; then
+  echo "ERROR: cargo-fuzz is required but not installed (cargo install --locked cargo-fuzz)"
+  exit 127
+fi
 
 if [ -z "$target" ]; then
   targets=$(cargo fuzz list)

--- a/fuzz/fuzz_targets/bitcoin/encoding_roundtrip/p2p_bip434_feature.rs
+++ b/fuzz/fuzz_targets/bitcoin/encoding_roundtrip/p2p_bip434_feature.rs
@@ -1,0 +1,12 @@
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use bitcoin_fuzz::check_roundtrip;
+use libfuzzer_sys::fuzz_target;
+
+#[cfg(not(fuzzing))]
+fn main() {}
+
+fuzz_target!(|data: &[u8]| {
+    check_roundtrip::<p2p::bip434::Feature>(data);
+});

--- a/fuzz/fuzz_targets/bitcoin/encoding_roundtrip/p2p_bip434_feature_data.rs
+++ b/fuzz/fuzz_targets/bitcoin/encoding_roundtrip/p2p_bip434_feature_data.rs
@@ -1,0 +1,12 @@
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use bitcoin_fuzz::check_roundtrip;
+use libfuzzer_sys::fuzz_target;
+
+#[cfg(not(fuzzing))]
+fn main() {}
+
+fuzz_target!(|data: &[u8]| {
+    check_roundtrip::<p2p::bip434::FeatureData>(data);
+});

--- a/fuzz/fuzz_targets/bitcoin/encoding_roundtrip/p2p_bip434_feature_id.rs
+++ b/fuzz/fuzz_targets/bitcoin/encoding_roundtrip/p2p_bip434_feature_id.rs
@@ -1,0 +1,12 @@
+#![cfg_attr(fuzzing, no_main)]
+#![cfg_attr(not(fuzzing), allow(unused))]
+
+use bitcoin_fuzz::check_roundtrip;
+use libfuzzer_sys::fuzz_target;
+
+#[cfg(not(fuzzing))]
+fn main() {}
+
+fuzz_target!(|data: &[u8]| {
+    check_roundtrip::<p2p::bip434::FeatureId>(data);
+});

--- a/fuzz/generate-bins.sh
+++ b/fuzz/generate-bins.sh
@@ -12,7 +12,7 @@ REPO_DIR=$(git rev-parse --show-toplevel)
 export LC_ALL=C
 
 # List all fuzz target files.
-listTargetFiles() {
+list_target_files() {
   pushd "$REPO_DIR/fuzz" > /dev/null || exit 1
   find fuzz_targets/ -type f -name "*.rs" | sort
   popd > /dev/null || exit 1
@@ -20,7 +20,7 @@ listTargetFiles() {
 
 # Convert fuzz target file path to target name
 # Example: fuzz_targets/bitcoin/deserialize_block.rs -> bitcoin_deserialize_block
-targetFileToName() {
+target_file_to_name() {
   echo "$1" \
     | sed 's/^fuzz_targets\///' \
     | sed 's/\.rs$//' \
@@ -39,12 +39,12 @@ trap 'rm -f "$CARGO_TOML_TMP"' EXIT
 awk '/^\[\[bin\]\]/{exit} {print}' "$CARGO_TOML" > "$CARGO_TOML_TMP"
 
 # Generate the [[bin]] sections.
-for targetFile in $(listTargetFiles); do
-    targetName=$(targetFileToName "$targetFile")
+for target_file in $(list_target_files); do
+    target_name=$(target_file_to_name "$target_file")
     cat >> "$CARGO_TOML_TMP" <<EOF
 [[bin]]
-name = "$targetName"
-path = "$targetFile"
+name = "$target_name"
+path = "$target_file"
 test = false
 doc = false
 bench = false


### PR DESCRIPTION
Fix the cargo-fuzz install issue and standardize a few more things with the fuzz scripts. Also add the new BIP 434 messages while here.

Will be doing a run on my fork remote to verify: https://github.com/nyonson/rust-bitcoin/actions/runs/31201696138/job/92942971443

Closes #6693 