### PR TITLE
bitcoin: fix changelog and forward port 0.32.xx and 0.32.xxx entries

### DIFF
--- a/bitcoin/CHANGELOG.md
+++ b/bitcoin/CHANGELOG.md
@@ -47,47 +47,6 @@ The `serde` serialization for `Psbt` has changed.
 
 - BREAKING: Change `Psbt` serde implementations [#4496](https://github.com/rust-bitcoin/rust-bitcoin/pull/4496)
 
-## [0.32.101] - 2026-06-24
-
-**Bump the MSRV to Rust 1.60.0**
-
-Exposes the new stabilized encoding library through the optional `encoding` feature. Note that enabling it bumps the MSRV to 1.74.0.
-
-- Remove mutagen [#6337](https://github.com/rust-bitcoin/rust-bitcoin/pull/6337)
-- Use `write!` in `ParseNetwork` and `UnknownAddressType` error displays [#6386](https://github.com/rust-bitcoin/rust-bitcoin/pull/6386)
-- Add `consensus_encoding` to types present in units 1.0 [#6184](https://github.com/rust-bitcoin/rust-bitcoin/pull/6184)
-
-## [0.32.100] - 2026-05-26 [YANKED]
-
-> This release was yanked because the MSRV bump to 1.74.0 was too aggressive for some users. See version 0.32.101 for a smaller upgrade to 1.60.0.
-
-**Bump the MSRV to Rust 1.74.0**
-
-Note the version number jump. We jumped to `v0.32.100` when doing the MSRV bump so as to
-leave room for a bunch of secuity releases up to this number if needed.
-
-- Our primary users (BDK and LDK) are at 1.85 already well ahead of `1.74`.
-- We would like to deliver the new sans-IO `consensus_encoding` crate in a point release.
-- The would like to later support ergonomic conversion to other 1.0 types (from `bitcoin-units`, and
-  and `bitcoin-primitives`) without forcing the whole ecosystem to upgrade.
-- Opens the door to the possibility of doing releases and then using the semver trick.
-
-## [0.32.10] - 2026-04-23
-
-- Fix bug in `LeafVerison::Future`'s `Display` output [#6208](https://github.com/rust-bitcoin/rust-bitcoin/pull/6208)
-- Manually revert `VarInt` range check [#6182](https://github.com/rust-bitcoin/rust-bitcoin/pull/6182)
-- Backport - p2p: Add a hash value to `Inventory`'s `Error` variant [#6147](https://github.com/rust-bitcoin/rust-bitcoin/pull/6147)
-- Backport - p2p: Error on `RawNetworkMessage` decode if payload partly consumed [#6140](https://github.com/rust-bitcoin/rust-bitcoin/pull/6140)
-- Backport - p2p: Error on invalid `FeeRate` in `FeeFilter` decode [#6142](https://github.com/rust-bitcoin/rust-bitcoin/pull/6142)
-- Backport - Validate ASCII and preserve embedded nulls in `CommandString` parsing [#6136](https://github.com/rust-bitcoin/rust-bitcoin/pull/6136)
-- Remove the `internals` dependency [#6200](https://github.com/rust-bitcoin/rust-bitcoin/pull/6200)
-
-## [0.32.9] - 2025-03-26
-
-- Backport - Fix `Unknown` `NetworkMessage` encoding [#6106](https://github.com/rust-bitcoin/rust-bitcoin/pull/6106)
-- Backport - `Arbitrary` [#5085](https://github.com/rust-bitcoin/rust-bitcoin/pull/5085)
-- Backport - Add `CompactSize` range check to deserialization [#5921](https://github.com/rust-bitcoin/rust-bitcoin/pull/5921)
-
 ### Changes
 
 - Bump MSRV from 1.63.0 to 1.74.0 for all crates in the repo [#4926](https://github.com/rust-bitcoin/rust-bitcoin/pull/4926)
@@ -188,6 +147,47 @@ leave room for a bunch of secuity releases up to this number if needed.
 - Change `TxIn::default()` to `TxIn::EMPTY_COINBASE` if appropriate.
 - Change `to_raw_hash()` to `to_byte_array()`.
 - `bitcoin::error::UnprefixedHexError` moved to `bitcoin::parse::UnprefixedHexError`.
+
+## [0.32.101] - 2026-06-24
+
+**Bump the MSRV to Rust 1.60.0**
+
+Exposes the new stabilized encoding library through the optional `encoding` feature. Note that enabling it bumps the MSRV to 1.74.0.
+
+- Remove mutagen [#6337](https://github.com/rust-bitcoin/rust-bitcoin/pull/6337)
+- Use `write!` in `ParseNetwork` and `UnknownAddressType` error displays [#6386](https://github.com/rust-bitcoin/rust-bitcoin/pull/6386)
+- Add `consensus_encoding` to types present in units 1.0 [#6184](https://github.com/rust-bitcoin/rust-bitcoin/pull/6184)
+
+## [0.32.100] - 2026-05-26 [YANKED]
+
+> This release was yanked because the MSRV bump to 1.74.0 was too aggressive for some users. See version 0.32.101 for a smaller upgrade to 1.60.0.
+
+**Bump the MSRV to Rust 1.74.0**
+
+Note the version number jump. We jumped to `v0.32.100` when doing the MSRV bump so as to
+leave room for a bunch of secuity releases up to this number if needed.
+
+- Our primary users (BDK and LDK) are at 1.85 already well ahead of `1.74`.
+- We would like to deliver the new sans-IO `consensus_encoding` crate in a point release.
+- The would like to later support ergonomic conversion to other 1.0 types (from `bitcoin-units`, and
+  and `bitcoin-primitives`) without forcing the whole ecosystem to upgrade.
+- Opens the door to the possibility of doing releases and then using the semver trick.
+
+## [0.32.10] - 2026-04-23
+
+- Fix bug in `LeafVerison::Future`'s `Display` output [#6208](https://github.com/rust-bitcoin/rust-bitcoin/pull/6208)
+- Manually revert `VarInt` range check [#6182](https://github.com/rust-bitcoin/rust-bitcoin/pull/6182)
+- Backport - p2p: Add a hash value to `Inventory`'s `Error` variant [#6147](https://github.com/rust-bitcoin/rust-bitcoin/pull/6147)
+- Backport - p2p: Error on `RawNetworkMessage` decode if payload partly consumed [#6140](https://github.com/rust-bitcoin/rust-bitcoin/pull/6140)
+- Backport - p2p: Error on invalid `FeeRate` in `FeeFilter` decode [#6142](https://github.com/rust-bitcoin/rust-bitcoin/pull/6142)
+- Backport - Validate ASCII and preserve embedded nulls in `CommandString` parsing [#6136](https://github.com/rust-bitcoin/rust-bitcoin/pull/6136)
+- Remove the `internals` dependency [#6200](https://github.com/rust-bitcoin/rust-bitcoin/pull/6200)
+
+## [0.32.9] - 2025-03-26
+
+- Backport - Fix `Unknown` `NetworkMessage` encoding [#6106](https://github.com/rust-bitcoin/rust-bitcoin/pull/6106)
+- Backport - `Arbitrary` [#5085](https://github.com/rust-bitcoin/rust-bitcoin/pull/5085)
+- Backport - Add `CompactSize` range check to deserialization [#5921](https://github.com/rust-bitcoin/rust-bitcoin/pull/5921)
 
 ## [0.32.8] - 2025-11-24
 

--- a/bitcoin/CHANGELOG.md
+++ b/bitcoin/CHANGELOG.md
@@ -148,6 +148,15 @@ The `serde` serialization for `Psbt` has changed.
 - Change `to_raw_hash()` to `to_byte_array()`.
 - `bitcoin::error::UnprefixedHexError` moved to `bitcoin::parse::UnprefixedHexError`.
 
+## [0.32.102] - 2026-07-06
+
+- Backport: Make `SendCmpct` idempotent [#6525](https://github.com/rust-bitcoin/rust-bitcoin/pull/6525)
+- Add `consensus_encoding` to block/compact-block p2p message types [#6457](https://github.com/rust-bitcoin/rust-bitcoin/pull/6457)
+- Add `consensus_encoding` support to types in `bitcoin-primitives` [#6333](https://github.com/rust-bitcoin/rust-bitcoin/pull/6333)
+- Add `consensus_encoding` support to core p2p message types [#6443](https://github.com/rust-bitcoin/rust-bitcoin/pull/6443)
+- Add `consensus_encoding` support to BIP157/158 filter message types [#6444](https://github.com/rust-bitcoin/rust-bitcoin/pull/6444)
+- Use `write!` in `ParseNetwork` and `UnknownAddressType` error displays [#6386](https://github.com/rust-bitcoin/rust-bitcoin/pull/6386)
+
 ## [0.32.101] - 2026-06-24
 
 **Bump the MSRV to Rust 1.60.0**
@@ -172,6 +181,10 @@ leave room for a bunch of secuity releases up to this number if needed.
 - The would like to later support ergonomic conversion to other 1.0 types (from `bitcoin-units`, and
   and `bitcoin-primitives`) without forcing the whole ecosystem to upgrade.
 - Opens the door to the possibility of doing releases and then using the semver trick.
+
+## [0.32.11] - 2026-07-14
+
+- Backport: Make `SendCmpct` idempotent [#6527](https://github.com/rust-bitcoin/rust-bitcoin/pull/6527)
 
 ## [0.32.10] - 2026-04-23
 
@@ -905,8 +918,10 @@ downstream users to also have a `num` dependency just so they can use `Uint256::
 
 [Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.33.0-beta...HEAD
 [0.33.0-beta]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.100...bitcoin-0.33.0-beta
+[0.32.102]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.101...bitcoin-0.32.102
 [0.32.101]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.100...bitcoin-0.32.101
 [0.32.100]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.10...bitcoin-0.32.100
+[0.32.11]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.10...bitcoin-0.32.11
 [0.32.10]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.9...bitcoin-0.32.10
 [0.32.9]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.8...bitcoin-0.32.9
 [0.32.8]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-0.32.7...bitcoin-0.32.8


### PR DESCRIPTION
Last time I forward port'd some entries, I somehow managed to splice them into the big 0.33.0-beta one, which leads to a very confusing read. First commit fixes that and the second forwardports a few more new releases (this time correctly hopefully).