### PR TITLE
primitives: fix witness commitment check (BIP-141)

### DIFF
--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -712,6 +712,38 @@ mod tests {
         assert!(segwit_signal.is_signalling_soft_fork(1));
         assert!(!segwit_signal.is_signalling_soft_fork(2));
     }
+
+    #[test]
+    fn block_rejects_empty_coinbase_witness_commitment() {
+        let mut script = Vec::from(WITNESS_COMMITMENT_MAGIC);
+        script.extend_from_slice(&[0; 32]);
+
+        let coinbase = Transaction {
+            version: crate::transaction::Version::ONE,
+            lock_time: crate::absolute::LockTime::ZERO,
+            input: vec![crate::TxIn::default()],
+            output: vec![crate::TxOut {
+                value: crate::Amount::ZERO,
+                script_pubkey: crate::ScriptBuf::from_bytes(script),
+            }],
+        };
+
+        let header = Header {
+            version: Version::ONE,
+            prev_blockhash: BlockHash::all_zeros(),
+            merkle_root: TxMerkleNode::all_zeros(),
+            time: 0,
+            bits: CompactTarget::from_consensus(0x1d00ffff),
+            nonce: 0,
+        };
+
+        let mut block = Block { header, txdata: vec![coinbase] };
+        block.header.merkle_root = block.compute_merkle_root().unwrap();
+
+        assert!(block.check_merkle_root());
+        // BIP-141 requires the witness reserved value, so the commitment is invalid.
+        assert!(!block.check_witness_commitment());
+    }
 }
 
 #[cfg(bench)]

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -25,6 +25,9 @@ use crate::pow::{CompactTarget, Target, Work};
 use crate::prelude::*;
 use crate::{merkle_tree, VarInt};
 
+// Consists of OP_RETURN, OP_PUSHBYTES_36, and four "witness header" bytes.
+const WITNESS_COMMITMENT_MAGIC: [u8; 6] = [0x6a, 0x24, 0xaa, 0x21, 0xa9, 0xed];
+
 hashes::hash_newtype! {
     /// A bitcoin block hash.
     pub struct BlockHash(sha256d::Hash);
@@ -255,8 +258,6 @@ impl Block {
 
     /// Checks if witness commitment in coinbase matches the transaction list.
     pub fn check_witness_commitment(&self) -> bool {
-        const MAGIC: [u8; 6] = [0x6a, 0x24, 0xaa, 0x21, 0xa9, 0xed];
-
         if self.txdata.is_empty() {
             return false;
         }
@@ -267,11 +268,10 @@ impl Block {
         }
 
         // Commitment is in the last output that starts with magic bytes.
-        if let Some(pos) = coinbase
-            .output
-            .iter()
-            .rposition(|o| o.script_pubkey.len() >= 38 && o.script_pubkey.as_bytes()[0..6] == MAGIC)
-        {
+        if let Some(pos) = coinbase.output.iter().rposition(|o| {
+            o.script_pubkey.len() >= 38
+                && o.script_pubkey.as_bytes()[0..6] == WITNESS_COMMITMENT_MAGIC
+        }) {
             let commitment = WitnessCommitment::from_slice(
                 &coinbase.output[pos].script_pubkey.as_bytes()[6..38],
             )

--- a/bitcoin/src/blockdata/block.rs
+++ b/bitcoin/src/blockdata/block.rs
@@ -256,10 +256,6 @@ impl Block {
     /// Checks if witness commitment in coinbase matches the transaction list.
     pub fn check_witness_commitment(&self) -> bool {
         const MAGIC: [u8; 6] = [0x6a, 0x24, 0xaa, 0x21, 0xa9, 0xed];
-        // Witness commitment is optional if there are no transactions using SegWit in the block.
-        if self.txdata.iter().all(|t| t.input.iter().all(|i| i.witness.is_empty())) {
-            return true;
-        }
 
         if self.txdata.is_empty() {
             return false;
@@ -288,6 +284,12 @@ impl Block {
                         == Self::compute_witness_commitment(&witness_root, witness_vec[0]);
                 }
             }
+            return false;
+        }
+
+        // Witness commitment is optional if there are no transactions using SegWit in the block.
+        if self.txdata.iter().all(|t| t.input.iter().all(|i| i.witness.is_empty())) {
+            return true;
         }
 
         false


### PR DESCRIPTION
Backport of #6250.

---

I found a small divergence between the block-checking code and [BIP-141](https://bips.dev/141/).

If a block has a witness commitment, it must also contain exactly one 32-byte witness reserved value. The code in the current master does not enforce this if no transactions use SegWit.

Exact BIP-0141 wording of the rule: "... and the coinbase's input's witness must consist of a single 32-byte array for the witness reserved value."

The PR enforces this check by moving the "there are no transactions using SegWit" check after the coinbase witness commitment and witness reserved value checks. Now the check is in line with Bitcoin Core and btcd.

I also added a regression test to cover this check. If the fix is not applied, the test fails