### PR TITLE
units: Implement Neg for Amount and NumOpResult

### DIFF
--- a/units/api/all-features.txt
+++ b/units/api/all-features.txt
@@ -1852,6 +1852,9 @@ impl core::ops::arith::Mul<u64> for &bitcoin_units::Amount
 impl core::ops::arith::Mul<u64> for bitcoin_units::Amount
   pub type bitcoin_units::Amount::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Mul<u64> for bitcoin_units::Amount]
   pub fn bitcoin_units::Amount::mul(self, rhs: u64) -> Self::Output [impl: impl core::ops::arith::Mul<u64> for bitcoin_units::Amount]
+impl core::ops::arith::Neg for bitcoin_units::Amount
+  pub type bitcoin_units::Amount::Output = bitcoin_units::SignedAmount [impl: impl core::ops::arith::Neg for bitcoin_units::Amount]
+  pub fn bitcoin_units::Amount::neg(self) -> Self::Output [impl: impl core::ops::arith::Neg for bitcoin_units::Amount]
 impl core::ops::arith::Rem<&u64> for bitcoin_units::Amount
   pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Rem<u64>>::Output [impl: impl core::ops::arith::Rem<&u64> for bitcoin_units::Amount]
   pub fn bitcoin_units::Amount::rem(self, rhs: &u64) -> Self::Output [impl: impl core::ops::arith::Rem<&u64> for bitcoin_units::Amount]
@@ -8474,6 +8477,12 @@ impl core::ops::arith::MulAssign<i64> for bitcoin_units::result::NumOpResult<bit
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::mul_assign(&mut self, rhs: i64) [impl: impl core::ops::arith::MulAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::MulAssign<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::mul_assign(&mut self, rhs: u64) [impl: impl core::ops::arith::MulAssign<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Neg for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> [impl: impl core::ops::arith::Neg for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::neg(self) -> Self::Output [impl: impl core::ops::arith::Neg for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Neg for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> [impl: impl core::ops::arith::Neg for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::neg(self) -> Self::Output [impl: impl core::ops::arith::Neg for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::Rem<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Rem<i64>>::Output [impl: impl core::ops::arith::Rem<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::rem(self, rhs: &i64) -> Self::Output [impl: impl core::ops::arith::Rem<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -9840,6 +9849,12 @@ impl core::ops::arith::MulAssign<i64> for bitcoin_units::result::NumOpResult<bit
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::mul_assign(&mut self, rhs: i64) [impl: impl core::ops::arith::MulAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::MulAssign<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::mul_assign(&mut self, rhs: u64) [impl: impl core::ops::arith::MulAssign<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Neg for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> [impl: impl core::ops::arith::Neg for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::neg(self) -> Self::Output [impl: impl core::ops::arith::Neg for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Neg for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> [impl: impl core::ops::arith::Neg for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::neg(self) -> Self::Output [impl: impl core::ops::arith::Neg for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::Rem<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Rem<i64>>::Output [impl: impl core::ops::arith::Rem<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::rem(self, rhs: &i64) -> Self::Output [impl: impl core::ops::arith::Rem<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -10249,6 +10264,9 @@ impl core::ops::arith::Mul<u64> for &bitcoin_units::Amount
 impl core::ops::arith::Mul<u64> for bitcoin_units::Amount
   pub type bitcoin_units::Amount::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Mul<u64> for bitcoin_units::Amount]
   pub fn bitcoin_units::Amount::mul(self, rhs: u64) -> Self::Output [impl: impl core::ops::arith::Mul<u64> for bitcoin_units::Amount]
+impl core::ops::arith::Neg for bitcoin_units::Amount
+  pub type bitcoin_units::Amount::Output = bitcoin_units::SignedAmount [impl: impl core::ops::arith::Neg for bitcoin_units::Amount]
+  pub fn bitcoin_units::Amount::neg(self) -> Self::Output [impl: impl core::ops::arith::Neg for bitcoin_units::Amount]
 impl core::ops::arith::Rem<&u64> for bitcoin_units::Amount
   pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Rem<u64>>::Output [impl: impl core::ops::arith::Rem<&u64> for bitcoin_units::Amount]
   pub fn bitcoin_units::Amount::rem(self, rhs: &u64) -> Self::Output [impl: impl core::ops::arith::Rem<&u64> for bitcoin_units::Amount]

--- a/units/api/alloc-only.txt
+++ b/units/api/alloc-only.txt
@@ -1521,6 +1521,9 @@ impl core::ops::arith::Mul<u64> for &bitcoin_units::Amount
 impl core::ops::arith::Mul<u64> for bitcoin_units::Amount
   pub type bitcoin_units::Amount::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Mul<u64> for bitcoin_units::Amount]
   pub fn bitcoin_units::Amount::mul(self, rhs: u64) -> Self::Output [impl: impl core::ops::arith::Mul<u64> for bitcoin_units::Amount]
+impl core::ops::arith::Neg for bitcoin_units::Amount
+  pub type bitcoin_units::Amount::Output = bitcoin_units::SignedAmount [impl: impl core::ops::arith::Neg for bitcoin_units::Amount]
+  pub fn bitcoin_units::Amount::neg(self) -> Self::Output [impl: impl core::ops::arith::Neg for bitcoin_units::Amount]
 impl core::ops::arith::Rem<&u64> for bitcoin_units::Amount
   pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Rem<u64>>::Output [impl: impl core::ops::arith::Rem<&u64> for bitcoin_units::Amount]
   pub fn bitcoin_units::Amount::rem(self, rhs: &u64) -> Self::Output [impl: impl core::ops::arith::Rem<&u64> for bitcoin_units::Amount]
@@ -7097,6 +7100,12 @@ impl core::ops::arith::MulAssign<i64> for bitcoin_units::result::NumOpResult<bit
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::mul_assign(&mut self, rhs: i64) [impl: impl core::ops::arith::MulAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::MulAssign<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::mul_assign(&mut self, rhs: u64) [impl: impl core::ops::arith::MulAssign<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Neg for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> [impl: impl core::ops::arith::Neg for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::neg(self) -> Self::Output [impl: impl core::ops::arith::Neg for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Neg for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> [impl: impl core::ops::arith::Neg for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::neg(self) -> Self::Output [impl: impl core::ops::arith::Neg for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::Rem<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Rem<i64>>::Output [impl: impl core::ops::arith::Rem<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::rem(self, rhs: &i64) -> Self::Output [impl: impl core::ops::arith::Rem<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -8078,6 +8087,12 @@ impl core::ops::arith::MulAssign<i64> for bitcoin_units::result::NumOpResult<bit
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::mul_assign(&mut self, rhs: i64) [impl: impl core::ops::arith::MulAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::MulAssign<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::mul_assign(&mut self, rhs: u64) [impl: impl core::ops::arith::MulAssign<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Neg for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> [impl: impl core::ops::arith::Neg for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::neg(self) -> Self::Output [impl: impl core::ops::arith::Neg for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Neg for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> [impl: impl core::ops::arith::Neg for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::neg(self) -> Self::Output [impl: impl core::ops::arith::Neg for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::Rem<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Rem<i64>>::Output [impl: impl core::ops::arith::Rem<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::rem(self, rhs: &i64) -> Self::Output [impl: impl core::ops::arith::Rem<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -8480,6 +8495,9 @@ impl core::ops::arith::Mul<u64> for &bitcoin_units::Amount
 impl core::ops::arith::Mul<u64> for bitcoin_units::Amount
   pub type bitcoin_units::Amount::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Mul<u64> for bitcoin_units::Amount]
   pub fn bitcoin_units::Amount::mul(self, rhs: u64) -> Self::Output [impl: impl core::ops::arith::Mul<u64> for bitcoin_units::Amount]
+impl core::ops::arith::Neg for bitcoin_units::Amount
+  pub type bitcoin_units::Amount::Output = bitcoin_units::SignedAmount [impl: impl core::ops::arith::Neg for bitcoin_units::Amount]
+  pub fn bitcoin_units::Amount::neg(self) -> Self::Output [impl: impl core::ops::arith::Neg for bitcoin_units::Amount]
 impl core::ops::arith::Rem<&u64> for bitcoin_units::Amount
   pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Rem<u64>>::Output [impl: impl core::ops::arith::Rem<&u64> for bitcoin_units::Amount]
   pub fn bitcoin_units::Amount::rem(self, rhs: &u64) -> Self::Output [impl: impl core::ops::arith::Rem<&u64> for bitcoin_units::Amount]

--- a/units/api/no-features.txt
+++ b/units/api/no-features.txt
@@ -1335,6 +1335,9 @@ impl core::ops::arith::Mul<u64> for &bitcoin_units::Amount
 impl core::ops::arith::Mul<u64> for bitcoin_units::Amount
   pub type bitcoin_units::Amount::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Mul<u64> for bitcoin_units::Amount]
   pub fn bitcoin_units::Amount::mul(self, rhs: u64) -> Self::Output [impl: impl core::ops::arith::Mul<u64> for bitcoin_units::Amount]
+impl core::ops::arith::Neg for bitcoin_units::Amount
+  pub type bitcoin_units::Amount::Output = bitcoin_units::SignedAmount [impl: impl core::ops::arith::Neg for bitcoin_units::Amount]
+  pub fn bitcoin_units::Amount::neg(self) -> Self::Output [impl: impl core::ops::arith::Neg for bitcoin_units::Amount]
 impl core::ops::arith::Rem<&u64> for bitcoin_units::Amount
   pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Rem<u64>>::Output [impl: impl core::ops::arith::Rem<&u64> for bitcoin_units::Amount]
   pub fn bitcoin_units::Amount::rem(self, rhs: &u64) -> Self::Output [impl: impl core::ops::arith::Rem<&u64> for bitcoin_units::Amount]
@@ -6287,6 +6290,12 @@ impl core::ops::arith::MulAssign<i64> for bitcoin_units::result::NumOpResult<bit
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::mul_assign(&mut self, rhs: i64) [impl: impl core::ops::arith::MulAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::MulAssign<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::mul_assign(&mut self, rhs: u64) [impl: impl core::ops::arith::MulAssign<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Neg for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> [impl: impl core::ops::arith::Neg for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::neg(self) -> Self::Output [impl: impl core::ops::arith::Neg for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Neg for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> [impl: impl core::ops::arith::Neg for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::neg(self) -> Self::Output [impl: impl core::ops::arith::Neg for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::Rem<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Rem<i64>>::Output [impl: impl core::ops::arith::Rem<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::rem(self, rhs: &i64) -> Self::Output [impl: impl core::ops::arith::Rem<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -7222,6 +7231,12 @@ impl core::ops::arith::MulAssign<i64> for bitcoin_units::result::NumOpResult<bit
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::mul_assign(&mut self, rhs: i64) [impl: impl core::ops::arith::MulAssign<i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::MulAssign<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::mul_assign(&mut self, rhs: u64) [impl: impl core::ops::arith::MulAssign<u64> for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Neg for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> [impl: impl core::ops::arith::Neg for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::Amount>::neg(self) -> Self::Output [impl: impl core::ops::arith::Neg for bitcoin_units::result::NumOpResult<bitcoin_units::Amount>]
+impl core::ops::arith::Neg for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
+  pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> [impl: impl core::ops::arith::Neg for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
+  pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::neg(self) -> Self::Output [impl: impl core::ops::arith::Neg for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
 impl core::ops::arith::Rem<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>
   pub type bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::Output = <bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount> as core::ops::arith::Rem<i64>>::Output [impl: impl core::ops::arith::Rem<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
   pub fn bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>::rem(self, rhs: &i64) -> Self::Output [impl: impl core::ops::arith::Rem<&i64> for bitcoin_units::result::NumOpResult<bitcoin_units::SignedAmount>]
@@ -7614,6 +7629,9 @@ impl core::ops::arith::Mul<u64> for &bitcoin_units::Amount
 impl core::ops::arith::Mul<u64> for bitcoin_units::Amount
   pub type bitcoin_units::Amount::Output = bitcoin_units::result::NumOpResult<bitcoin_units::Amount> [impl: impl core::ops::arith::Mul<u64> for bitcoin_units::Amount]
   pub fn bitcoin_units::Amount::mul(self, rhs: u64) -> Self::Output [impl: impl core::ops::arith::Mul<u64> for bitcoin_units::Amount]
+impl core::ops::arith::Neg for bitcoin_units::Amount
+  pub type bitcoin_units::Amount::Output = bitcoin_units::SignedAmount [impl: impl core::ops::arith::Neg for bitcoin_units::Amount]
+  pub fn bitcoin_units::Amount::neg(self) -> Self::Output [impl: impl core::ops::arith::Neg for bitcoin_units::Amount]
 impl core::ops::arith::Rem<&u64> for bitcoin_units::Amount
   pub type bitcoin_units::Amount::Output = <bitcoin_units::Amount as core::ops::arith::Rem<u64>>::Output [impl: impl core::ops::arith::Rem<&u64> for bitcoin_units::Amount]
   pub fn bitcoin_units::Amount::rem(self, rhs: &u64) -> Self::Output [impl: impl core::ops::arith::Rem<&u64> for bitcoin_units::Amount]

--- a/units/src/amount/result.rs
+++ b/units/src/amount/result.rs
@@ -208,6 +208,12 @@ impl_add_assign_for_results!(SignedAmount);
 impl_sub_assign_for_results!(Amount);
 impl_sub_assign_for_results!(SignedAmount);
 
+impl ops::Neg for Amount {
+    type Output = SignedAmount;
+
+    fn neg(self) -> Self::Output { self.to_signed().neg() }
+}
+
 impl ops::Neg for SignedAmount {
     type Output = Self;
 
@@ -215,6 +221,18 @@ impl ops::Neg for SignedAmount {
     fn neg(self) -> Self::Output {
         Self::from_sat(self.to_sat().neg()).expect("all +ve and -ve values are valid")
     }
+}
+
+impl ops::Neg for NumOpResult<Amount> {
+    type Output = NumOpResult<SignedAmount>;
+
+    fn neg(self) -> Self::Output { self.map(ops::Neg::neg) }
+}
+
+impl ops::Neg for NumOpResult<SignedAmount> {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output { self.map(ops::Neg::neg) }
 }
 
 impl<T: Into<Self>> core::iter::Sum<T> for NumOpResult<Amount> {

--- a/units/src/amount/tests.rs
+++ b/units/src/amount/tests.rs
@@ -1395,13 +1395,40 @@ fn num_op_result_ops_integer() {
 // Verify we have implemented all `Neg` for the amount types.
 #[test]
 fn amount_op_result_neg() {
-    // let sat = Amount::from_sat(1).unwrap();
+    let sat = Amount::from_sat(1).unwrap();
     let ssat = SignedAmount::from_sat(1).unwrap();
 
-    // let _ = -sat;
-    let _ = -ssat;
-    // let _ = -res;
-    // let _ = -sres;
+    // Test negation of Amount (returns SignedAmount)
+    let neg_sat = -sat;
+    assert_eq!(neg_sat, SignedAmount::from_sat(-1).unwrap());
+
+    // Test negation of SignedAmount
+    let neg_ssat = -ssat;
+    assert_eq!(neg_ssat, SignedAmount::from_sat(-1).unwrap());
+
+    // Test negation of NumOpResult<Amount>
+    let res = NumOpResult::from(sat);
+    let neg_res = -res;
+    assert_eq!(neg_res, NumOpResult::from(SignedAmount::from_sat(-1).unwrap()));
+
+    // Test negation of NumOpResult<SignedAmount>
+    let sres = NumOpResult::from(ssat);
+    let neg_sres = -sres;
+    assert_eq!(neg_sres, NumOpResult::from(SignedAmount::from_sat(-1).unwrap()));
+
+    // Test double negation
+    let double_neg = -(-sat);
+    assert_eq!(double_neg, ssat);
+
+    // Test negation of zero
+    let zero = Amount::ZERO;
+    let neg_zero = -zero;
+    assert_eq!(neg_zero, SignedAmount::ZERO);
+
+    // Test negation of MAX_MONEY
+    let max = Amount::MAX_MONEY;
+    let neg_max = -max;
+    assert_eq!(neg_max, SignedAmount::MIN);
 }
 
 // Verify we have implemented all `Sum` for the `NumOpResult` type.


### PR DESCRIPTION
Implements `Neg` for `Amount`, returning a `SignedAmount`, and for the `NumOpResult<Amount>` and `NumOpResult<SignedAmount>` result types.

Update API files.

Original work by stringsbuilder in #5875. Cherry picked and reviewer comments addressed.