### PR TITLE
addresses: Remove alloc feature gating for most functionality

### DIFF
--- a/addresses/src/error.rs
+++ b/addresses/src/error.rs
@@ -276,8 +276,6 @@ pub enum Base58Error {
     ParseBase58(base58::DecodeCheckArrayError),
     /// Legacy address is too long.
     LegacyAddressTooLong(LegacyAddressTooLongError),
-    /// Invalid base58 payload data length for legacy address.
-    InvalidBase58PayloadLength(InvalidBase58PayloadLengthError),
     /// Invalid legacy address prefix in base58 data payload.
     InvalidLegacyPrefix(InvalidLegacyPrefixError),
 }
@@ -291,8 +289,6 @@ impl fmt::Display for Base58Error {
         match self {
             Self::ParseBase58(ref e) => write_err!(f, "legacy parsing error"; e),
             Self::LegacyAddressTooLong(ref e) => write_err!(f, "legacy address length error"; e),
-            Self::InvalidBase58PayloadLength(ref e) =>
-                write_err!(f, "legacy payload length error"; e),
             Self::InvalidLegacyPrefix(ref e) => write_err!(f, "legacy prefix error"; e),
         }
     }
@@ -304,7 +300,6 @@ impl std::error::Error for Base58Error {
         match self {
             Self::ParseBase58(ref e) => Some(e),
             Self::LegacyAddressTooLong(ref e) => Some(e),
-            Self::InvalidBase58PayloadLength(ref e) => Some(e),
             Self::InvalidLegacyPrefix(ref e) => Some(e),
         }
     }
@@ -318,38 +313,8 @@ impl From<LegacyAddressTooLongError> for Base58Error {
     fn from(e: LegacyAddressTooLongError) -> Self { Self::LegacyAddressTooLong(e) }
 }
 
-impl From<InvalidBase58PayloadLengthError> for Base58Error {
-    fn from(e: InvalidBase58PayloadLengthError) -> Self { Self::InvalidBase58PayloadLength(e) }
-}
-
 impl From<InvalidLegacyPrefixError> for Base58Error {
     fn from(e: InvalidLegacyPrefixError) -> Self { Self::InvalidLegacyPrefix(e) }
-}
-
-/// Decoded base58 data was an invalid length.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct InvalidBase58PayloadLengthError {
-    /// The base58 payload length we got after decoding address string.
-    pub(crate) length: usize,
-}
-
-impl InvalidBase58PayloadLengthError {
-    /// Returns the invalid payload length.
-    pub fn invalid_base58_payload_length(&self) -> usize { self.length }
-}
-
-impl fmt::Display for InvalidBase58PayloadLengthError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "decoded base58 data was an invalid length: {} (expected 21)", self.length)
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for InvalidBase58PayloadLengthError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        let Self { length: _ } = self;
-        None
-    }
 }
 
 /// Legacy base58 address was too long, max 50 characters.

--- a/addresses/src/error.rs
+++ b/addresses/src/error.rs
@@ -1,10 +1,9 @@
 //! Error code for the address module.
 
-#[cfg(feature = "alloc")]
-use alloc::string::String;
 use core::convert::Infallible;
 use core::fmt;
 
+use internals::error::InputString;
 use internals::write_err;
 #[cfg(feature = "alloc")]
 use network::Network;
@@ -60,15 +59,14 @@ impl From<witness_version::InvalidWitnessVersionError> for FromScriptError {
 }
 
 /// Address type is either invalid or not supported in rust-bitcoin.
-#[cfg(feature = "alloc")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
-pub struct UnknownAddressTypeError(pub String);
+pub struct UnknownAddressTypeError(pub(super) InputString);
 
-#[cfg(feature = "alloc")]
 impl fmt::Display for UnknownAddressTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "failed to parse {} as address type", self.0)
+        // Outputs "failed to parse <input string> as address type".
+        write!(f, "{}", self.0.display_cannot_parse("address type"))
     }
 }
 
@@ -141,14 +139,15 @@ impl From<NetworkValidationError> for ParseError {
 }
 
 /// Unknown HRP error.
-#[cfg(feature = "alloc")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
-pub struct UnknownHrpError(pub String);
+pub struct UnknownHrpError(pub(super) InputString);
 
-#[cfg(feature = "alloc")]
 impl fmt::Display for UnknownHrpError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, "unknown hrp: {}", self.0) }
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // Outputs "'<input string>' is not a known hrp" or "unknown hrp"
+        self.0.unknown_variant("hrp", f)
+    }
 }
 
 #[cfg(feature = "std")]

--- a/addresses/src/error.rs
+++ b/addresses/src/error.rs
@@ -6,10 +6,13 @@ use core::convert::Infallible;
 use core::fmt;
 
 use internals::write_err;
+#[cfg(feature = "alloc")]
 use network::Network;
 use primitives::witness_version;
 
-use crate::{witness_program, Address, NetworkUnchecked};
+use crate::witness_program;
+#[cfg(feature = "alloc")]
+use crate::{Address, NetworkUnchecked};
 
 /// Error while generating address from script.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -57,10 +60,12 @@ impl From<witness_version::InvalidWitnessVersionError> for FromScriptError {
 }
 
 /// Address type is either invalid or not supported in rust-bitcoin.
+#[cfg(feature = "alloc")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct UnknownAddressTypeError(pub String);
 
+#[cfg(feature = "alloc")]
 impl fmt::Display for UnknownAddressTypeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "failed to parse {} as address type", self.0)
@@ -76,6 +81,7 @@ impl std::error::Error for UnknownAddressTypeError {
 }
 
 /// Address parsing error.
+#[cfg(feature = "alloc")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ParseError {
@@ -87,10 +93,12 @@ pub enum ParseError {
     NetworkValidation(NetworkValidationError),
 }
 
+#[cfg(feature = "alloc")]
 impl From<Infallible> for ParseError {
     fn from(never: Infallible) -> Self { match never {} }
 }
 
+#[cfg(feature = "alloc")]
 impl fmt::Display for ParseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
@@ -112,27 +120,33 @@ impl std::error::Error for ParseError {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl From<Base58Error> for ParseError {
     fn from(e: Base58Error) -> Self { Self::Base58(e) }
 }
 
+#[cfg(feature = "alloc")]
 impl From<Bech32Error> for ParseError {
     fn from(e: Bech32Error) -> Self { Self::Bech32(e) }
 }
 
+#[cfg(feature = "alloc")]
 impl From<UnknownHrpError> for ParseError {
     fn from(e: UnknownHrpError) -> Self { Self::Bech32(e.into()) }
 }
 
+#[cfg(feature = "alloc")]
 impl From<NetworkValidationError> for ParseError {
     fn from(e: NetworkValidationError) -> Self { Self::NetworkValidation(e) }
 }
 
 /// Unknown HRP error.
+#[cfg(feature = "alloc")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct UnknownHrpError(pub String);
 
+#[cfg(feature = "alloc")]
 impl fmt::Display for UnknownHrpError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, "unknown hrp: {}", self.0) }
 }
@@ -146,6 +160,7 @@ impl std::error::Error for UnknownHrpError {
 }
 
 /// Address's network differs from required one.
+#[cfg(feature = "alloc")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NetworkValidationError {
     /// Network that was required.
@@ -154,6 +169,7 @@ pub struct NetworkValidationError {
     pub(crate) address: Address<NetworkUnchecked>,
 }
 
+#[cfg(feature = "alloc")]
 impl fmt::Display for NetworkValidationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "address ")?;
@@ -171,6 +187,7 @@ impl std::error::Error for NetworkValidationError {
 }
 
 /// Bech32 related error.
+#[cfg(feature = "alloc")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Bech32Error {
@@ -184,10 +201,12 @@ pub enum Bech32Error {
     UnknownHrp(UnknownHrpError),
 }
 
+#[cfg(feature = "alloc")]
 impl From<Infallible> for Bech32Error {
     fn from(never: Infallible) -> Self { match never {} }
 }
 
+#[cfg(feature = "alloc")]
 impl fmt::Display for Bech32Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
@@ -212,27 +231,33 @@ impl std::error::Error for Bech32Error {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl From<witness_version::InvalidWitnessVersionError> for Bech32Error {
     fn from(e: witness_version::InvalidWitnessVersionError) -> Self { Self::WitnessVersion(e) }
 }
 
+#[cfg(feature = "alloc")]
 impl From<witness_program::Error> for Bech32Error {
     fn from(e: witness_program::Error) -> Self { Self::WitnessProgram(e) }
 }
 
+#[cfg(feature = "alloc")]
 impl From<UnknownHrpError> for Bech32Error {
     fn from(e: UnknownHrpError) -> Self { Self::UnknownHrp(e) }
 }
 
 /// Bech32 parsing related error.
 // This wrapper exists because we do not want to expose the `bech32` crate in our public API.
+#[cfg(feature = "alloc")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParseBech32Error(pub(crate) bech32::segwit::DecodeError);
 
+#[cfg(feature = "alloc")]
 impl From<Infallible> for ParseBech32Error {
     fn from(never: Infallible) -> Self { match never {} }
 }
 
+#[cfg(feature = "alloc")]
 impl fmt::Display for ParseBech32Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write_err!(f, "bech32 parsing error"; self.0)
@@ -245,6 +270,7 @@ impl std::error::Error for ParseBech32Error {
 }
 
 /// Base58 related error.
+#[cfg(feature = "alloc")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Base58Error {
@@ -258,10 +284,12 @@ pub enum Base58Error {
     InvalidLegacyPrefix(InvalidLegacyPrefixError),
 }
 
+#[cfg(feature = "alloc")]
 impl From<Infallible> for Base58Error {
     fn from(never: Infallible) -> Self { match never {} }
 }
 
+#[cfg(feature = "alloc")]
 impl fmt::Display for Base58Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
@@ -286,18 +314,22 @@ impl std::error::Error for Base58Error {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl From<base58::DecodeCheckError> for Base58Error {
     fn from(e: base58::DecodeCheckError) -> Self { Self::ParseBase58(e) }
 }
 
+#[cfg(feature = "alloc")]
 impl From<LegacyAddressTooLongError> for Base58Error {
     fn from(e: LegacyAddressTooLongError) -> Self { Self::LegacyAddressTooLong(e) }
 }
 
+#[cfg(feature = "alloc")]
 impl From<InvalidBase58PayloadLengthError> for Base58Error {
     fn from(e: InvalidBase58PayloadLengthError) -> Self { Self::InvalidBase58PayloadLength(e) }
 }
 
+#[cfg(feature = "alloc")]
 impl From<InvalidLegacyPrefixError> for Base58Error {
     fn from(e: InvalidLegacyPrefixError) -> Self { Self::InvalidLegacyPrefix(e) }
 }

--- a/addresses/src/error.rs
+++ b/addresses/src/error.rs
@@ -269,12 +269,11 @@ impl std::error::Error for ParseBech32Error {
 }
 
 /// Base58 related error.
-#[cfg(feature = "alloc")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Base58Error {
     /// Parse legacy Base58 error.
-    ParseBase58(base58::DecodeCheckError),
+    ParseBase58(base58::DecodeCheckArrayError),
     /// Legacy address is too long.
     LegacyAddressTooLong(LegacyAddressTooLongError),
     /// Invalid base58 payload data length for legacy address.
@@ -283,12 +282,10 @@ pub enum Base58Error {
     InvalidLegacyPrefix(InvalidLegacyPrefixError),
 }
 
-#[cfg(feature = "alloc")]
 impl From<Infallible> for Base58Error {
     fn from(never: Infallible) -> Self { match never {} }
 }
 
-#[cfg(feature = "alloc")]
 impl fmt::Display for Base58Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
@@ -313,22 +310,18 @@ impl std::error::Error for Base58Error {
     }
 }
 
-#[cfg(feature = "alloc")]
-impl From<base58::DecodeCheckError> for Base58Error {
-    fn from(e: base58::DecodeCheckError) -> Self { Self::ParseBase58(e) }
+impl From<base58::DecodeCheckArrayError> for Base58Error {
+    fn from(e: base58::DecodeCheckArrayError) -> Self { Self::ParseBase58(e) }
 }
 
-#[cfg(feature = "alloc")]
 impl From<LegacyAddressTooLongError> for Base58Error {
     fn from(e: LegacyAddressTooLongError) -> Self { Self::LegacyAddressTooLong(e) }
 }
 
-#[cfg(feature = "alloc")]
 impl From<InvalidBase58PayloadLengthError> for Base58Error {
     fn from(e: InvalidBase58PayloadLengthError) -> Self { Self::InvalidBase58PayloadLength(e) }
 }
 
-#[cfg(feature = "alloc")]
 impl From<InvalidLegacyPrefixError> for Base58Error {
     fn from(e: InvalidLegacyPrefixError) -> Self { Self::InvalidLegacyPrefix(e) }
 }

--- a/addresses/src/lib.rs
+++ b/addresses/src/lib.rs
@@ -50,7 +50,6 @@
 //! ref: <https://sprovoost.nl/2022/11/10/what-is-a-bitcoin-address/>
 
 #![no_std]
-#![cfg(feature = "alloc")]
 // Experimental features we need.
 #![doc(test(attr(warn(unused))))]
 // Coding conventions.
@@ -77,38 +76,60 @@ pub mod witness_program;
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(no_inline)]
 pub use self::error::{
-        Base58Error, Bech32Error, FromScriptError, InvalidBase58PayloadLengthError,
-        InvalidLegacyPrefixError, LegacyAddressTooLongError, NetworkValidationError,
+        FromScriptError, InvalidBase58PayloadLengthError,
+        InvalidLegacyPrefixError, LegacyAddressTooLongError,
+};
+#[cfg(feature = "alloc")]
+#[rustfmt::skip]                // Keep public re-exports separate.
+#[doc(no_inline)]
+pub use self::error::{
+        Base58Error, Bech32Error, NetworkValidationError,
         ParseError, UnknownAddressTypeError, UnknownHrpError, ParseBech32Error,
 };
 
+#[cfg(feature = "alloc")]
 use alloc::borrow::ToOwned;
+#[cfg(feature = "alloc")]
 use alloc::format;
+#[cfg(feature = "alloc")]
 use alloc::string::String;
 use core::fmt;
+#[cfg(feature = "alloc")]
 use core::marker::PhantomData;
+#[cfg(feature = "alloc")]
 use core::str::FromStr;
 
+#[cfg(feature = "alloc")]
 use bech32::{Fe32, Hrp};
+#[cfg(feature = "alloc")]
 use crypto::key::{
     FullPublicKey, LegacyPublicKey, PubkeyHash, TweakedPublicKey, UntweakedPublicKey,
     XOnlyPublicKey,
 };
+#[cfg(feature = "alloc")]
 use hashes::{hash160, HashEngine};
+#[cfg(feature = "alloc")]
 use internals::array::ArrayExt as _;
 use network::{Network, NetworkKind};
+#[cfg(feature = "alloc")]
 use primitives::opcodes::all::{OP_CHECKSIG, OP_DUP, OP_EQUALVERIFY, OP_HASH160};
+#[cfg(feature = "alloc")]
 use primitives::opcodes::Opcode;
+#[cfg(feature = "alloc")]
 use primitives::script::{
     Builder, PushBytes, RedeemScriptSizeError, Script, ScriptBuf, ScriptHash, ScriptHashableTag,
     ScriptPubKey, ScriptPubKeyBuf, WScriptHash, WitnessScript, WitnessScriptSizeError,
 };
+#[cfg(feature = "alloc")]
 use primitives::witness_version::WitnessVersion;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "alloc")]
 use taproot_primitives::{TapNodeHash, TapTweak as _};
+#[cfg(feature = "alloc")]
 use witness_program::WitnessProgram;
 
+#[cfg(feature = "alloc")]
 const OP_PUSHBYTES_0: Opcode = Opcode::from_u8(0x00);
 
 /// Mainnet (bitcoin) pubkey address prefix.
@@ -213,6 +234,7 @@ impl fmt::Display for AddressType {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl FromStr for AddressType {
     type Err = UnknownAddressTypeError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -236,7 +258,9 @@ mod sealed {
     pub trait NetworkValidationUnchecked {}
     impl NetworkValidationUnchecked for super::NetworkUnchecked {}
 
+    #[cfg(feature = "alloc")]
     pub trait Sealed {}
+    #[cfg(feature = "alloc")]
     impl Sealed for super::ScriptPubKeyBuf {}
 }
 
@@ -283,6 +307,7 @@ impl NetworkValidationUnchecked for NetworkUnchecked {}
 ///
 /// This struct represents the inner representation of an address without the network validation
 /// tag, which is used to ensure that addresses are used only on the appropriate network.
+#[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 enum AddressInner {
     P2pkh { hash: PubkeyHash, network: NetworkKind },
@@ -291,6 +316,7 @@ enum AddressInner {
 }
 
 /// Formats bech32 as upper case if alternate formatting is chosen (`{:#}`).
+#[cfg(feature = "alloc")]
 impl fmt::Display for AddressInner {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match self {
@@ -354,6 +380,7 @@ impl KnownHrp {
     }
 
     /// Constructs a new [`KnownHrp`] from a [`bech32::Hrp`].
+    #[cfg(feature = "alloc")]
     fn from_hrp(hrp: Hrp) -> Result<Self, UnknownHrpError> {
         if hrp == bech32::hrp::BC {
             Ok(Self::Mainnet)
@@ -367,6 +394,7 @@ impl KnownHrp {
     }
 
     /// Converts, infallibly a known HRP to a [`bech32::Hrp`].
+    #[cfg(feature = "alloc")]
     fn to_hrp(self) -> Hrp {
         match self {
             Self::Mainnet => bech32::hrp::BC,
@@ -394,6 +422,7 @@ impl From<KnownHrp> for NetworkKind {
 ///
 /// This is the data used to encumber an output that pays to this address i.e., it is the address
 /// excluding the network information.
+#[cfg(feature = "alloc")]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 pub enum AddressData {
@@ -415,6 +444,7 @@ pub enum AddressData {
 }
 
 // Defined in `REPO_DIR/include/newtype.rs`.
+#[cfg(feature = "alloc")]
 transparent_newtype! {
     /// A Bitcoin address.
     ///
@@ -511,9 +541,11 @@ transparent_newtype! {
     }
 }
 
+#[cfg(feature = "alloc")]
 #[cfg(feature = "serde")]
 struct DisplayUnchecked<'a, N: NetworkValidation>(&'a Address<N>);
 
+#[cfg(feature = "alloc")]
 #[cfg(feature = "serde")]
 impl<N: NetworkValidation> fmt::Display for DisplayUnchecked<'_, N> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
@@ -521,6 +553,7 @@ impl<N: NetworkValidation> fmt::Display for DisplayUnchecked<'_, N> {
     }
 }
 
+#[cfg(feature = "alloc")]
 #[cfg(feature = "serde")]
 impl<'de, U: NetworkValidationUnchecked> serde::Deserialize<'de> for Address<U> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -555,6 +588,7 @@ impl<'de, U: NetworkValidationUnchecked> serde::Deserialize<'de> for Address<U> 
     }
 }
 
+#[cfg(feature = "alloc")]
 #[cfg(feature = "serde")]
 impl<V: NetworkValidation> serde::Serialize for Address<V> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -567,6 +601,7 @@ impl<V: NetworkValidation> serde::Serialize for Address<V> {
 
 /// Methods on [`Address`] that can be called on both `Address<NetworkChecked>` and
 /// `Address<NetworkUnchecked>`.
+#[cfg(feature = "alloc")]
 impl<V: NetworkValidation> Address<V> {
     fn from_inner(inner: AddressInner) -> Self { Self(PhantomData, inner) }
 
@@ -599,6 +634,7 @@ impl<V: NetworkValidation> Address<V> {
 }
 
 /// Methods and functions that can be called only on `Address<NetworkChecked>`.
+#[cfg(feature = "alloc")]
 impl Address {
     /// Constructs a new pay-to-public-key-hash (P2PKH) [`Address`] from a public key.
     ///
@@ -900,6 +936,7 @@ impl Address {
 }
 
 /// Methods that can be called only on `Address<NetworkUnchecked>`.
+#[cfg(feature = "alloc")]
 impl Address<NetworkUnchecked> {
     /// Returns a reference to the checked address.
     ///
@@ -1066,16 +1103,19 @@ impl Address<NetworkUnchecked> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl From<Address> for ScriptPubKeyBuf {
     fn from(a: Address) -> Self { a.script_pubkey() }
 }
 
 // Alternate formatting `{:#}` is used to return an uppercase version of bech32 addresses which should
 // be used in QR codes, see [`Address::to_qr_uri`].
+#[cfg(feature = "alloc")]
 impl fmt::Display for Address {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(&self.inner(), fmt) }
 }
 
+#[cfg(feature = "alloc")]
 impl<V: NetworkValidation> fmt::Debug for Address<V> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if V::IS_CHECKED {
@@ -1103,6 +1143,7 @@ impl<V: NetworkValidation> fmt::Debug for Address<V> {
 ///
 /// - [`UnknownHrpError`] if the address does not begin with one of the above SegWit or
 ///   legacy prefixes.
+#[cfg(feature = "alloc")]
 impl<U: NetworkValidationUnchecked> FromStr for Address<U> {
     type Err = ParseError;
 
@@ -1125,6 +1166,7 @@ impl<U: NetworkValidationUnchecked> FromStr for Address<U> {
 }
 
 /// Convert a byte array of a pubkey hash into a SegWit redeem hash
+#[cfg(feature = "alloc")]
 fn segwit_redeem_hash(pubkey_hash: PubkeyHash) -> hash160::Hash {
     let mut sha_engine = hash160::Hash::engine();
     sha_engine.input(&[0, 20]);
@@ -1138,6 +1180,7 @@ fn segwit_redeem_hash(pubkey_hash: PubkeyHash) -> hash160::Hash {
 ///
 /// Convenience method used by `new_p2a`, `new_p2wpkh`, `new_p2wsh`, `new_p2tr`, and `new_p2tr_tweaked`.
 // This function is duplicated in bitcoin and primitives. If you make any changes, please update all three.
+#[cfg(feature = "alloc")]
 fn new_witness_program_unchecked<T: AsRef<PushBytes>, Tg>(
     version: WitnessVersion,
     program: T,
@@ -1149,8 +1192,10 @@ fn new_witness_program_unchecked<T: AsRef<PushBytes>, Tg>(
     Builder::new().push_opcode(version.into()).push_slice(program).into_script()
 }
 
+#[cfg(feature = "alloc")]
 include!("../include/newtype.rs"); // Explained in `REPO_DIR/docs/README.md`.
 
+#[cfg(feature = "alloc")]
 #[cfg(test)]
 mod tests {
     use alloc::string::ToString;

--- a/addresses/src/lib.rs
+++ b/addresses/src/lib.rs
@@ -5,7 +5,30 @@
 //! Bitcoin addresses do not appear on chain; rather, they are conventions used by Bitcoin (wallet)
 //! software to communicate where coins should be sent and are based on the output type e.g., P2WPKH.
 //!
-//! This crate can be used in a no-std environment but requires an allocator.
+//! This crate can be used in a no-std environment, with or without an allocator.
+//!
+//! # Working without an allocator
+//!
+//! Substantial portions of the crate functionality are available without an allocator
+//! (i.e. the `alloc` feature).
+//!
+//! Available without `alloc`:
+//!
+//! - Constructing addresses: [`Address::p2pkh`], [`Address::p2sh_from_hash`], [`Address::p2wpkh`],
+//!   [`Address::p2wsh_from_hash`], [`Address::p2tr`], [`Address::p2tr_tweaked`], [`Address::p2a`],
+//!   and [`Address::from_witness_program`].
+//! - Parsing legacy (base58) addresses with [`Address::from_base58_str`].
+//! - Formatting addresses using `Display` and `Debug`. Both legacy and SegWit addresses can be
+//!   displayed.
+//! - Inspecting addresses e.g., [`Address::address_type`], [`Address::to_address_data`],
+//!   [`Address::is_valid_for_network`], and [`Address::is_related_to_pubkey`].
+//!
+//! Requires `alloc`:
+//!
+//! - Parsing bech32 (SegWit) addresses i.e., `Address::from_bech32_str`. Importantly, this also
+//!   means `FromStr`/`str::parse` and `serde` deserialization require `alloc`.
+//! - Anything that builds a script e.g., `Address::script_pubkey`, `Address::p2sh`,
+//!   `Address::p2wsh`, `Address::p2shwpkh`, `Address::p2shwsh`, and `ScriptPubKeyBufExt`.
 //!
 //! # Examples
 //!

--- a/addresses/src/lib.rs
+++ b/addresses/src/lib.rs
@@ -94,18 +94,15 @@ use alloc::format;
 #[cfg(feature = "alloc")]
 use alloc::string::String;
 use core::fmt;
-#[cfg(feature = "alloc")]
 use core::marker::PhantomData;
 #[cfg(feature = "alloc")]
 use core::str::FromStr;
 
 use bech32::{Fe32, Hrp};
-use crypto::key::PubkeyHash;
-#[cfg(feature = "alloc")]
 use crypto::key::{
-    FullPublicKey, LegacyPublicKey, TweakedPublicKey, UntweakedPublicKey, XOnlyPublicKey,
+    FullPublicKey, LegacyPublicKey, PubkeyHash, TweakedPublicKey, UntweakedPublicKey,
+    XOnlyPublicKey,
 };
-#[cfg(feature = "alloc")]
 use hashes::{hash160, HashEngine};
 #[cfg(feature = "alloc")]
 use internals::array::ArrayExt as _;
@@ -114,18 +111,19 @@ use network::{Network, NetworkKind};
 use primitives::opcodes::all::{OP_CHECKSIG, OP_DUP, OP_EQUALVERIFY, OP_HASH160};
 #[cfg(feature = "alloc")]
 use primitives::opcodes::Opcode;
-use primitives::script::ScriptHash;
 #[cfg(feature = "alloc")]
 use primitives::script::{
     Builder, PushBytes, RedeemScriptSizeError, Script, ScriptBuf, ScriptHashableTag, ScriptPubKey,
-    ScriptPubKeyBuf, WScriptHash, WitnessScript, WitnessScriptSizeError,
+    ScriptPubKeyBuf, WitnessScript, WitnessScriptSizeError,
 };
+use primitives::script::{ScriptHash, WScriptHash};
 #[cfg(feature = "alloc")]
 use primitives::witness_version::WitnessVersion;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+use taproot_primitives::TapNodeHash;
 #[cfg(feature = "alloc")]
-use taproot_primitives::{TapNodeHash, TapTweak as _};
+use taproot_primitives::TapTweak as _;
 use witness_program::WitnessProgram;
 
 #[cfg(feature = "alloc")]
@@ -443,7 +441,6 @@ pub enum AddressData {
 }
 
 // Defined in `REPO_DIR/include/newtype.rs`.
-#[cfg(feature = "alloc")]
 transparent_newtype! {
     /// A Bitcoin address.
     ///
@@ -464,6 +461,7 @@ transparent_newtype! {
     /// The types `Address` and `Address<NetworkChecked>` are synonymous, i.e. they can be used interchangeably.
     ///
     /// ```rust
+    /// # #[cfg(feature = "alloc")] {
     /// use std::str::FromStr;
     /// use bitcoin_addresses::{Address, NetworkUnchecked, NetworkChecked};
     /// use bitcoin_addresses::network::Network;
@@ -479,6 +477,7 @@ transparent_newtype! {
     /// // variant 3
     /// let _address: Address<NetworkChecked> = "32iVBEu4dxkUQk9dJbZUiBiQdmypcEyJRf".parse::<Address<_>>()
     ///                .unwrap().require_network(Network::Bitcoin).unwrap();
+    /// # }
     /// ```
     ///
     /// ### Formatting addresses
@@ -489,10 +488,12 @@ transparent_newtype! {
     /// 1. `Display` is implemented only for `Address<NetworkChecked>`:
     ///
     /// ```
+    /// # #[cfg(feature = "alloc")] {
     /// # use bitcoin_addresses::{Address, NetworkChecked};
     /// let address: Address<NetworkChecked> = "132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM".parse::<Address<_>>()
     ///                .unwrap().assume_checked();
     /// assert_eq!(address.to_string(), "132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM");
+    /// # }
     /// ```
     ///
     /// ```ignore
@@ -507,17 +508,21 @@ transparent_newtype! {
     ///    check the network and use `Display` in user-facing context.
     ///
     /// ```
+    /// # #[cfg(feature = "alloc")] {
     /// # use bitcoin_addresses::{Address, NetworkUnchecked};
     /// let address: Address<NetworkUnchecked> = "132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM".parse::<Address<_>>()
     ///                .unwrap();
     /// assert_eq!(format!("{:?}", address), "Address<NetworkUnchecked>(132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM)");
+    /// # }
     /// ```
     ///
     /// ```
+    /// # #[cfg(feature = "alloc")] {
     /// # use bitcoin_addresses::{Address, NetworkChecked};
     /// let address: Address<NetworkChecked> = "132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM".parse::<Address<_>>()
     ///                .unwrap().assume_checked();
     /// assert_eq!(format!("{:?}", address), "132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM");
+    /// # }
     /// ```
     ///
     /// # Relevant BIPs
@@ -540,11 +545,9 @@ transparent_newtype! {
     }
 }
 
-#[cfg(feature = "alloc")]
 #[cfg(feature = "serde")]
 struct DisplayUnchecked<'a, N: NetworkValidation>(&'a Address<N>);
 
-#[cfg(feature = "alloc")]
 #[cfg(feature = "serde")]
 impl<N: NetworkValidation> fmt::Display for DisplayUnchecked<'_, N> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
@@ -587,7 +590,6 @@ impl<'de, U: NetworkValidationUnchecked> serde::Deserialize<'de> for Address<U> 
     }
 }
 
-#[cfg(feature = "alloc")]
 #[cfg(feature = "serde")]
 impl<V: NetworkValidation> serde::Serialize for Address<V> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -600,7 +602,6 @@ impl<V: NetworkValidation> serde::Serialize for Address<V> {
 
 /// Methods on [`Address`] that can be called on both `Address<NetworkChecked>` and
 /// `Address<NetworkUnchecked>`.
-#[cfg(feature = "alloc")]
 impl<V: NetworkValidation> Address<V> {
     fn from_inner(inner: AddressInner) -> Self { Self(PhantomData, inner) }
 
@@ -633,7 +634,6 @@ impl<V: NetworkValidation> Address<V> {
 }
 
 /// Methods and functions that can be called only on `Address<NetworkChecked>`.
-#[cfg(feature = "alloc")]
 impl Address {
     /// Constructs a new pay-to-public-key-hash (P2PKH) [`Address`] from a public key.
     ///
@@ -653,6 +653,7 @@ impl Address {
     ///
     /// Returns an error if the script exceeds 520 bytes.
     #[inline]
+    #[cfg(feature = "alloc")]
     pub fn p2sh<T: ScriptHashableTag>(
         redeem_script: &Script<T>,
         network: impl Into<NetworkKind>,
@@ -684,6 +685,7 @@ impl Address {
     ///
     /// This is a SegWit address type that looks familiar (as p2sh) to legacy clients.
     #[allow(clippy::missing_panics_doc)] // script cannot cause hash failure due to size
+    #[cfg(feature = "alloc")]
     pub fn p2shwpkh(pk: FullPublicKey, network: impl Into<NetworkKind>) -> Self {
         let builder =
             ScriptPubKey::builder().push_opcode(OP_PUSHBYTES_0).push_slice(pk.wpubkey_hash());
@@ -696,6 +698,7 @@ impl Address {
     /// # Errors
     ///
     /// Returns an error if the script exceeds 10,000 bytes.
+    #[cfg(feature = "alloc")]
     pub fn p2wsh(
         witness_script: &WitnessScript,
         hrp: impl Into<KnownHrp>,
@@ -719,6 +722,7 @@ impl Address {
     ///
     /// Returns an error if the script exceeds 10,000 bytes.
     #[allow(clippy::missing_panics_doc)] // script cannot cause hash failure due to size
+    #[cfg(feature = "alloc")]
     pub fn p2shwsh(
         witness_script: &WitnessScript,
         network: impl Into<NetworkKind>,
@@ -835,6 +839,7 @@ impl Address {
     pub fn is_spend_standard(&self) -> bool { self.address_type().is_some() }
 
     /// Generates a script pubkey spending to this address.
+    #[cfg(feature = "alloc")]
     pub fn script_pubkey(&self) -> ScriptPubKeyBuf {
         use AddressInner::{P2pkh, P2sh, Segwit};
 
@@ -876,6 +881,7 @@ impl Address {
     /// # })().unwrap();
     /// # assert_eq!(writer, ADDRESS);
     /// ```
+    #[cfg(feature = "alloc")]
     pub fn to_qr_uri(self) -> String { format!("bitcoin:{:#}", self) }
 
     /// Returns true if the given pubkey is directly related to the address payload.
@@ -903,6 +909,7 @@ impl Address {
 
     /// Returns true if the address creates a particular script
     /// This function doesn't make any allocations.
+    #[cfg(feature = "alloc")]
     pub fn matches_script_pubkey(&self, script: &ScriptPubKey) -> bool {
         use AddressInner::{P2pkh, P2sh, Segwit};
 
@@ -929,13 +936,12 @@ impl Address {
         match *self.inner() {
             AddressInner::P2sh { ref hash, network: _ } => hash.as_ref(),
             AddressInner::P2pkh { ref hash, network: _ } => hash.as_ref(),
-            AddressInner::Segwit { ref program, hrp: _ } => program.program().as_bytes(),
+            AddressInner::Segwit { ref program, hrp: _ } => program.program.as_slice(),
         }
     }
 }
 
 /// Methods that can be called only on `Address<NetworkUnchecked>`.
-#[cfg(feature = "alloc")]
 impl Address<NetworkUnchecked> {
     /// Returns a reference to the checked address.
     ///
@@ -949,6 +955,7 @@ impl Address<NetworkUnchecked> {
     /// network a simple comparison is not enough anymore. Instead this function can be used.
     ///
     /// ```rust
+    /// # #[cfg(feature = "alloc")] {
     /// use network::{Network, TestnetVersion};
     /// use bitcoin_addresses::{Address, NetworkUnchecked};
     ///
@@ -962,6 +969,7 @@ impl Address<NetworkUnchecked> {
     /// let address: Address<NetworkUnchecked> = "32iVBEu4dxkUQk9dJbZUiBiQdmypcEyJRf".parse().unwrap();
     /// assert!(address.is_valid_for_network(Network::Bitcoin));
     /// assert_eq!(address.is_valid_for_network(Network::Testnet(TestnetVersion::V4)), false);
+    /// # }
     /// ```
     pub fn is_valid_for_network(&self, n: Network) -> bool {
         match *self.inner() {
@@ -1014,6 +1022,7 @@ impl Address<NetworkUnchecked> {
     /// let _ = parse_and_validate_address_show_types(network).unwrap();
     /// ```
     #[inline]
+    #[cfg(feature = "alloc")]
     pub fn require_network(self, required: Network) -> Result<Address, ParseError> {
         if self.is_valid_for_network(required) {
             Ok(self.assume_checked())
@@ -1041,6 +1050,7 @@ impl Address<NetworkUnchecked> {
     /// - [`Bech32Error::UnknownHrp`] if the human-readable part is not one of the known Bitcoin
     ///   HRPs (`bc`, `tb`, or `bcrt`).
     #[allow(clippy::missing_panics_doc)]
+    #[cfg(feature = "alloc")]
     pub fn from_bech32_str(s: &str) -> Result<Self, Bech32Error> {
         let (hrp, witness_version, data) =
             bech32::segwit::decode(s).map_err(|e| Bech32Error::ParseBech32(ParseBech32Error(e)))?;
@@ -1067,6 +1077,7 @@ impl Address<NetworkUnchecked> {
     ///   - [`PUBKEY_ADDRESS_PREFIX_TEST`]
     ///   - [`SCRIPT_ADDRESS_PREFIX_MAIN`]
     ///   - [`SCRIPT_ADDRESS_PREFIX_TEST`]
+    #[cfg(feature = "alloc")]
     pub fn from_base58_str(s: &str) -> Result<Self, Base58Error> {
         if s.len() > 50 {
             return Err(LegacyAddressTooLongError { length: s.len() }.into());
@@ -1109,12 +1120,10 @@ impl From<Address> for ScriptPubKeyBuf {
 
 // Alternate formatting `{:#}` is used to return an uppercase version of bech32 addresses which should
 // be used in QR codes, see [`Address::to_qr_uri`].
-#[cfg(feature = "alloc")]
 impl fmt::Display for Address {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(&self.inner(), fmt) }
 }
 
-#[cfg(feature = "alloc")]
 impl<V: NetworkValidation> fmt::Debug for Address<V> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if V::IS_CHECKED {
@@ -1165,7 +1174,6 @@ impl<U: NetworkValidationUnchecked> FromStr for Address<U> {
 }
 
 /// Convert a byte array of a pubkey hash into a SegWit redeem hash
-#[cfg(feature = "alloc")]
 fn segwit_redeem_hash(pubkey_hash: PubkeyHash) -> hash160::Hash {
     let mut sha_engine = hash160::Hash::engine();
     sha_engine.input(&[0, 20]);
@@ -1191,7 +1199,6 @@ fn new_witness_program_unchecked<T: AsRef<PushBytes>, Tg>(
     Builder::new().push_opcode(version.into()).push_slice(program).into_script()
 }
 
-#[cfg(feature = "alloc")]
 include!("../include/newtype.rs"); // Explained in `REPO_DIR/docs/README.md`.
 
 #[cfg(feature = "alloc")]

--- a/addresses/src/lib.rs
+++ b/addresses/src/lib.rs
@@ -76,26 +76,23 @@ pub mod witness_program;
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(no_inline)]
 pub use self::error::{
-        FromScriptError, InvalidBase58PayloadLengthError,
-        InvalidLegacyPrefixError, LegacyAddressTooLongError,
+    FromScriptError, InvalidBase58PayloadLengthError, InvalidLegacyPrefixError,
+    LegacyAddressTooLongError, UnknownAddressTypeError, UnknownHrpError
 };
 #[cfg(feature = "alloc")]
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(no_inline)]
 pub use self::error::{
-        Base58Error, Bech32Error, NetworkValidationError,
-        ParseError, UnknownAddressTypeError, UnknownHrpError, ParseBech32Error,
+    Base58Error, Bech32Error, NetworkValidationError,
+    ParseError, ParseBech32Error,
 };
 
-#[cfg(feature = "alloc")]
-use alloc::borrow::ToOwned;
 #[cfg(feature = "alloc")]
 use alloc::format;
 #[cfg(feature = "alloc")]
 use alloc::string::String;
 use core::fmt;
 use core::marker::PhantomData;
-#[cfg(feature = "alloc")]
 use core::str::FromStr;
 
 use bech32::{Fe32, Hrp};
@@ -231,7 +228,6 @@ impl fmt::Display for AddressType {
     }
 }
 
-#[cfg(feature = "alloc")]
 impl FromStr for AddressType {
     type Err = UnknownAddressTypeError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -242,7 +238,7 @@ impl FromStr for AddressType {
             "p2wsh" => Ok(Self::P2wsh),
             "p2tr" => Ok(Self::P2tr),
             "p2a" => Ok(Self::P2a),
-            _ => Err(UnknownAddressTypeError(s.to_owned())),
+            _ => Err(UnknownAddressTypeError(s.into())),
         }
     }
 }
@@ -388,7 +384,7 @@ impl KnownHrp {
         } else if hrp == bech32::hrp::BCRT {
             Ok(Self::Regtest)
         } else {
-            Err(UnknownHrpError(hrp.to_lowercase()))
+            Err(UnknownHrpError(hrp.as_str().into()))
         }
     }
 
@@ -1168,7 +1164,7 @@ impl<U: NetworkValidationUnchecked> FromStr for Address<U> {
                 Some(pos) => &s[..pos],
                 None => s,
             };
-            Err(UnknownHrpError(hrp.to_owned()).into())
+            Err(UnknownHrpError(hrp.into()).into())
         }
     }
 }
@@ -1204,8 +1200,6 @@ include!("../include/newtype.rs"); // Explained in `REPO_DIR/docs/README.md`.
 #[cfg(feature = "alloc")]
 #[cfg(test)]
 mod tests {
-    use alloc::string::ToString;
-
     use network::TestnetVersion;
     use primitives::RedeemScriptBuf;
 
@@ -1432,7 +1426,7 @@ mod tests {
     #[test]
     fn invalid_address_parses_error() {
         let got = "invalid".parse::<AddressType>();
-        let want = Err(UnknownAddressTypeError("invalid".to_string()));
+        let want = Err(UnknownAddressTypeError("invalid".into()));
         assert_eq!(got, want);
     }
 

--- a/addresses/src/lib.rs
+++ b/addresses/src/lib.rs
@@ -99,12 +99,11 @@ use core::marker::PhantomData;
 #[cfg(feature = "alloc")]
 use core::str::FromStr;
 
-#[cfg(feature = "alloc")]
 use bech32::{Fe32, Hrp};
+use crypto::key::PubkeyHash;
 #[cfg(feature = "alloc")]
 use crypto::key::{
-    FullPublicKey, LegacyPublicKey, PubkeyHash, TweakedPublicKey, UntweakedPublicKey,
-    XOnlyPublicKey,
+    FullPublicKey, LegacyPublicKey, TweakedPublicKey, UntweakedPublicKey, XOnlyPublicKey,
 };
 #[cfg(feature = "alloc")]
 use hashes::{hash160, HashEngine};
@@ -115,10 +114,11 @@ use network::{Network, NetworkKind};
 use primitives::opcodes::all::{OP_CHECKSIG, OP_DUP, OP_EQUALVERIFY, OP_HASH160};
 #[cfg(feature = "alloc")]
 use primitives::opcodes::Opcode;
+use primitives::script::ScriptHash;
 #[cfg(feature = "alloc")]
 use primitives::script::{
-    Builder, PushBytes, RedeemScriptSizeError, Script, ScriptBuf, ScriptHash, ScriptHashableTag,
-    ScriptPubKey, ScriptPubKeyBuf, WScriptHash, WitnessScript, WitnessScriptSizeError,
+    Builder, PushBytes, RedeemScriptSizeError, Script, ScriptBuf, ScriptHashableTag, ScriptPubKey,
+    ScriptPubKeyBuf, WScriptHash, WitnessScript, WitnessScriptSizeError,
 };
 #[cfg(feature = "alloc")]
 use primitives::witness_version::WitnessVersion;
@@ -126,7 +126,6 @@ use primitives::witness_version::WitnessVersion;
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "alloc")]
 use taproot_primitives::{TapNodeHash, TapTweak as _};
-#[cfg(feature = "alloc")]
 use witness_program::WitnessProgram;
 
 #[cfg(feature = "alloc")]
@@ -307,7 +306,6 @@ impl NetworkValidationUnchecked for NetworkUnchecked {}
 ///
 /// This struct represents the inner representation of an address without the network validation
 /// tag, which is used to ensure that addresses are used only on the appropriate network.
-#[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 enum AddressInner {
     P2pkh { hash: PubkeyHash, network: NetworkKind },
@@ -316,7 +314,6 @@ enum AddressInner {
 }
 
 /// Formats bech32 as upper case if alternate formatting is chosen (`{:#}`).
-#[cfg(feature = "alloc")]
 impl fmt::Display for AddressInner {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match self {
@@ -327,7 +324,9 @@ impl fmt::Display for AddressInner {
                     NetworkKind::Test => PUBKEY_ADDRESS_PREFIX_TEST,
                 };
                 prefixed[1..].copy_from_slice(hash.as_byte_array());
-                base58::Base58CkString::encode_unbounded(&prefixed[..]).fmt(fmt)
+                base58::Base58CkString::encode(&prefixed[..])
+                    .expect("prefixed is short enough to be encode infallibly")
+                    .fmt(fmt)
             }
             Self::P2sh { hash, network } => {
                 let mut prefixed = [0; 21];
@@ -336,13 +335,15 @@ impl fmt::Display for AddressInner {
                     NetworkKind::Test => SCRIPT_ADDRESS_PREFIX_TEST,
                 };
                 prefixed[1..].copy_from_slice(hash.as_byte_array());
-                base58::Base58CkString::encode_unbounded(&prefixed[..]).fmt(fmt)
+                base58::Base58CkString::encode(&prefixed[..])
+                    .expect("prefixed is short enough to be encode infallibly")
+                    .fmt(fmt)
             }
             Self::Segwit { program, hrp } => {
                 let hrp = hrp.to_hrp();
                 let version = Fe32::try_from(program.version().to_num())
                     .expect("version nums 0-16 are valid fe32 values");
-                let program = program.program().as_ref();
+                let program = program.program.as_slice();
 
                 if fmt.alternate() {
                     bech32::segwit::encode_upper_to_fmt_unchecked(fmt, hrp, version, program)
@@ -394,7 +395,6 @@ impl KnownHrp {
     }
 
     /// Converts, infallibly a known HRP to a [`bech32::Hrp`].
-    #[cfg(feature = "alloc")]
     fn to_hrp(self) -> Hrp {
         match self {
             Self::Mainnet => bech32::hrp::BC,
@@ -422,7 +422,6 @@ impl From<KnownHrp> for NetworkKind {
 ///
 /// This is the data used to encumber an output that pays to this address i.e., it is the address
 /// excluding the network information.
-#[cfg(feature = "alloc")]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 pub enum AddressData {

--- a/addresses/src/lib.rs
+++ b/addresses/src/lib.rs
@@ -76,14 +76,14 @@ pub mod witness_program;
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(no_inline)]
 pub use self::error::{
-    FromScriptError, InvalidBase58PayloadLengthError, InvalidLegacyPrefixError,
+    Base58Error, FromScriptError, InvalidLegacyPrefixError,
     LegacyAddressTooLongError, UnknownAddressTypeError, UnknownHrpError
 };
 #[cfg(feature = "alloc")]
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(no_inline)]
 pub use self::error::{
-    Base58Error, Bech32Error, NetworkValidationError,
+    Bech32Error, NetworkValidationError,
     ParseError, ParseBech32Error,
 };
 
@@ -101,7 +101,6 @@ use crypto::key::{
     XOnlyPublicKey,
 };
 use hashes::{hash160, HashEngine};
-#[cfg(feature = "alloc")]
 use internals::array::ArrayExt as _;
 use network::{Network, NetworkKind};
 #[cfg(feature = "alloc")]
@@ -1064,24 +1063,18 @@ impl Address<NetworkUnchecked> {
     /// # Errors
     ///
     /// - [`Base58Error::LegacyAddressTooLong`] if the input string is longer than 50 characters.
-    /// - [`Base58Error::ParseBase58`] if the input string is invalid base58, less than 4 bytes or
-    ///   the checksum does not match the expected value.
-    /// - [`Base58Error::InvalidBase58PayloadLength`] if the resulting decoded slice is not 21
-    ///   bytes.
+    /// - [`Base58Error::ParseBase58`] if the input string is invalid base58, or the string doesn't
+    ///   decode to exactly 21 bytes.
     /// - [`Base58Error::InvalidLegacyPrefix`] if the address prefix is not one of:
     ///   - [`PUBKEY_ADDRESS_PREFIX_MAIN`]
     ///   - [`PUBKEY_ADDRESS_PREFIX_TEST`]
     ///   - [`SCRIPT_ADDRESS_PREFIX_MAIN`]
     ///   - [`SCRIPT_ADDRESS_PREFIX_TEST`]
-    #[cfg(feature = "alloc")]
     pub fn from_base58_str(s: &str) -> Result<Self, Base58Error> {
         if s.len() > 50 {
             return Err(LegacyAddressTooLongError { length: s.len() }.into());
         }
-        let data = base58::decode_check(s)?;
-        let data: &[u8; 21] = (&*data)
-            .try_into()
-            .map_err(|_| InvalidBase58PayloadLengthError { length: data.len() })?;
+        let data = base58::decode_check_to_array::<21>(s)?;
 
         let (prefix, &data) = data.split_first();
 
@@ -1470,12 +1463,6 @@ mod tests {
         let encoded = base58::Base58CkString::encode_unbounded(&payload);
 
         let err = Address::<NetworkUnchecked>::from_base58_str(encoded.as_str()).unwrap_err();
-        match err {
-            Base58Error::InvalidBase58PayloadLength(inner) => {
-                assert_eq!(inner.invalid_base58_payload_length(), 22); // Payload size
-                assert_ne!(inner.invalid_base58_payload_length(), encoded.len()); // Not string size
-            }
-            other => panic!("unexpected error: {other:?}"),
-        }
+        assert!(matches!(err, Base58Error::ParseBase58(_)));
     }
 }

--- a/addresses/src/witness_program.rs
+++ b/addresses/src/witness_program.rs
@@ -37,7 +37,7 @@ pub struct WitnessProgram {
     /// The SegWit version associated with this witness program.
     version: WitnessVersion,
     /// The witness program (between 2 and 40 bytes).
-    program: ArrayVec<u8, MAX_SIZE>,
+    pub(super) program: ArrayVec<u8, MAX_SIZE>,
 }
 
 impl WitnessProgram {

--- a/addresses/src/witness_program.rs
+++ b/addresses/src/witness_program.rs
@@ -9,6 +9,7 @@
 
 use crypto::key::{FullPublicKey, TweakedPublicKey, UntweakedPublicKey};
 use internals::array_vec::ArrayVec;
+#[cfg(feature = "alloc")]
 use primitives::script::{PushBytes, WScriptHash, WitnessScript, WitnessScriptSizeError};
 use primitives::witness_version::WitnessVersion;
 use taproot_primitives::{TapNodeHash, TapTweak as _};
@@ -69,6 +70,7 @@ impl WitnessProgram {
     }
 
     /// Constructs a new [`WitnessProgram`] from a 32 byte script hash.
+    #[cfg(feature = "alloc")]
     fn new_p2wsh(program: [u8; 32]) -> Self {
         Self { version: WitnessVersion::V0, program: ArrayVec::from_slice(&program) }
     }
@@ -89,11 +91,13 @@ impl WitnessProgram {
     /// # Errors
     ///
     /// Returns an error if the script exceeds 10,000 bytes.
+    #[cfg(feature = "alloc")]
     pub fn p2wsh(script: &WitnessScript) -> Result<Self, WitnessScriptSizeError> {
         WScriptHash::from_script(script).map(Self::p2wsh_from_hash)
     }
 
     /// Constructs a new [`WitnessProgram`] from `script` for a P2WSH output.
+    #[cfg(feature = "alloc")]
     pub fn p2wsh_from_hash(hash: WScriptHash) -> Self { Self::new_p2wsh(hash.to_byte_array()) }
 
     /// Constructs a new [`WitnessProgram`] from an untweaked key for a P2TR output.
@@ -125,6 +129,7 @@ impl WitnessProgram {
     pub fn version(&self) -> WitnessVersion { self.version }
 
     /// Returns the witness program.
+    #[cfg(feature = "alloc")]
     #[allow(clippy::missing_panics_doc)] // expect panic is unreachable by witness program limit
     pub fn program(&self) -> &PushBytes {
         self.program

--- a/addresses/src/witness_program.rs
+++ b/addresses/src/witness_program.rs
@@ -9,8 +9,9 @@
 
 use crypto::key::{FullPublicKey, TweakedPublicKey, UntweakedPublicKey};
 use internals::array_vec::ArrayVec;
+use primitives::script::WScriptHash;
 #[cfg(feature = "alloc")]
-use primitives::script::{PushBytes, WScriptHash, WitnessScript, WitnessScriptSizeError};
+use primitives::script::{PushBytes, WitnessScript, WitnessScriptSizeError};
 use primitives::witness_version::WitnessVersion;
 use taproot_primitives::{TapNodeHash, TapTweak as _};
 
@@ -70,7 +71,6 @@ impl WitnessProgram {
     }
 
     /// Constructs a new [`WitnessProgram`] from a 32 byte script hash.
-    #[cfg(feature = "alloc")]
     fn new_p2wsh(program: [u8; 32]) -> Self {
         Self { version: WitnessVersion::V0, program: ArrayVec::from_slice(&program) }
     }
@@ -97,7 +97,6 @@ impl WitnessProgram {
     }
 
     /// Constructs a new [`WitnessProgram`] from `script` for a P2WSH output.
-    #[cfg(feature = "alloc")]
     pub fn p2wsh_from_hash(hash: WScriptHash) -> Self { Self::new_p2wsh(hash.to_byte_array()) }
 
     /// Constructs a new [`WitnessProgram`] from an untweaked key for a P2TR output.

--- a/bitcoin/src/address.rs
+++ b/bitcoin/src/address.rs
@@ -51,7 +51,7 @@ use crate::script::ScriptExt as _;
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(no_inline)]
 pub use self::error::{
-    Base58Error, Bech32Error, FromScriptError, InvalidBase58PayloadLengthError,
+    Base58Error, Bech32Error, FromScriptError,
     InvalidLegacyPrefixError, LegacyAddressTooLongError, NetworkValidationError,
     ParseError, UnknownAddressTypeError, UnknownHrpError, ParseBech32Error,
 };
@@ -100,9 +100,9 @@ crate::internal_macros::define_extension_trait! {
 pub mod error {
     #[doc(inline)]
     pub use addresses::error::{
-        Base58Error, Bech32Error, FromScriptError, InvalidBase58PayloadLengthError,
-        InvalidLegacyPrefixError, LegacyAddressTooLongError, NetworkValidationError,
-        ParseBech32Error, ParseError, UnknownAddressTypeError, UnknownHrpError,
+        Base58Error, Bech32Error, FromScriptError, InvalidLegacyPrefixError,
+        LegacyAddressTooLongError, NetworkValidationError, ParseBech32Error, ParseError,
+        UnknownAddressTypeError, UnknownHrpError,
     };
 }
 


### PR DESCRIPTION
During the initial code move into the new crate, the addresses crate was crate-level gated on alloc to simplify the code move. With the move complete, the crate can now be largely ungated to provide no-alloc users with substantial portions of the addresses functionality.

- Patch 1 removes the crate-level alloc gate, replicating the same gating with individual item feature gating.
- Patch 2 makes WitnessProgram progrtam field pub(super) to replace use of program() method later on.
- Patch 3 drops the alloc gating on the inner data of Address, including minor modifications to functionality.
- Patch 4 removes alloc gating from the Address type.
- Patch 5 removes pub String fields from error types, replacing them with pub(super) InputString.
- Patch 6 removes alloc gating from the base58 parse Address constructor.
- Patch 7 removes the unused InvalidBase58PayloadLength error type and variant.
- Patch 8 updates the crate-level docs to reference the new no-alloc functionality.