### PR TITLE
Release tracking PR: `units 0.6.0`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -96,7 +96,7 @@ dependencies = [
  "bitcoin-network-kind",
  "bitcoin-primitives",
  "bitcoin-taproot-primitives",
- "bitcoin-units 0.5.0",
+ "bitcoin-units 0.6.0",
  "bitcoin_hashes 1.2.0",
  "bitcoinconsensus",
  "hex-conservative 1.1.0",
@@ -258,7 +258,7 @@ dependencies = [
  "bitcoin-internals 0.6.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
- "bitcoin-units 0.5.0",
+ "bitcoin-units 0.6.0",
  "bitcoin_hashes 1.2.0",
  "hex-conservative 1.1.0",
  "serde",
@@ -272,7 +272,7 @@ dependencies = [
  "bincode",
  "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-internals 0.6.0",
- "bitcoin-units 0.5.0",
+ "bitcoin-units 0.6.0",
  "bitcoin_hashes 1.2.0",
  "hex-conservative 1.1.0",
  "serde",
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-units"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -89,7 +89,7 @@ dependencies = [
  "bitcoin-network-kind",
  "bitcoin-primitives",
  "bitcoin-taproot-primitives",
- "bitcoin-units 0.5.0",
+ "bitcoin-units 0.6.0",
  "bitcoin_hashes 1.2.0",
  "bitcoinconsensus",
  "hex-conservative 1.1.0",
@@ -251,7 +251,7 @@ dependencies = [
  "bitcoin-internals 0.6.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
- "bitcoin-units 0.5.0",
+ "bitcoin-units 0.6.0",
  "bitcoin_hashes 1.2.0",
  "hex-conservative 1.1.0",
  "serde",
@@ -265,7 +265,7 @@ dependencies = [
  "bincode",
  "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-internals 0.6.0",
- "bitcoin-units 0.5.0",
+ "bitcoin-units 0.6.0",
  "bitcoin_hashes 1.2.0",
  "hex-conservative 1.1.0",
  "serde",
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-units"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -40,7 +40,7 @@ network = { package = "bitcoin-network-kind", path = "../network", version = "1.
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.103.0", default-features = false, features = ["alloc", "hex"] }
 secp256k1 = { version = "0.33.0", default-features = false, features = ["alloc"] }
 taproot-primitives = { package = "bitcoin-taproot-primitives", path = "../taproot_primitives", version = "0.1.0", default-features = false, features = ["alloc", "hex"] }
-units = { package = "bitcoin-units", path = "../units", version = "0.5.0", default-features = false, features = ["alloc"] }
+units = { package = "bitcoin-units", path = "../units", version = "0.6.0", default-features = false, features = ["alloc"] }
 
 arbitrary = { version = "1.4.1", optional = true }
 base64 = { version = "0.22.0", optional = true, default-features = false, features = ["alloc"] }

--- a/bitcoin/embedded/Cargo.lock
+++ b/bitcoin/embedded/Cargo.lock
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-units"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bitcoin-consensus-encoding",
  "bitcoin-internals",

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -26,7 +26,7 @@ network = { package = "bitcoin-network-kind", path = "../network", version = "1.
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.103.0", features = ["hex", "alloc"], default-features = false }
 hex = { package = "hex-conservative", version = "1.1.0", default-features = false, features = ["alloc"] }
 internals = { package = "bitcoin-internals", path = "../internals", default-features = false }
-units = { package = "bitcoin-units", path = "../units", version = "0.5.0", default-features = false }
+units = { package = "bitcoin-units", path = "../units", version = "0.6.0", default-features = false }
 
 arbitrary = { version = "1.4.1", optional = true }
 serde = { version = "1.0.195", default-features = false, features = ["derive", "alloc"], optional = true }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -25,7 +25,7 @@ hex = ["dep:hex", "hashes/hex", "encoding/hex"]
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.1.0", default-features = false }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.1.0", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
-units = { package = "bitcoin-units", path = "../units", version = "0.5.0", default-features = false, features = [ "encoding" ] }
+units = { package = "bitcoin-units", path = "../units", version = "0.6.0", default-features = false, features = [ "encoding" ] }
 
 arbitrary = { version = "1.4.1", optional = true }
 hex = { package = "hex-conservative", version = "1.1.0", default-features = false, optional = true }

--- a/units/CHANGELOG.md
+++ b/units/CHANGELOG.md
@@ -2,8 +2,29 @@
 
 ## [Unreleased]
 
-- `Target`/`Work`'s internal `U256` type is now sourced from `bitcoin-internals` instead of a
-  duplicated `include!` module.
+## [0.6.0] - 2026-09-07
+
+* Separate mathematical operation and failure mode in `NumOpError` [#6812](https://github.com/rust-bitcoin/rust-bitcoin/pull/6812)
+* Preserve MvB precision in `FeeRate::mul_by_weight` [#6823](https://github.com/rust-bitcoin/rust-bitcoin/pull/6823)
+* Fix `OutOfRangeError::valid_range` [#6829](https://github.com/rust-bitcoin/rust-bitcoin/pull/6829)
+* Rename locktime height accessors and query methods [#6689](https://github.com/rust-bitcoin/rust-bitcoin/pull/6689)
+* Implement `Neg` for `Amount` and `NumOpResult` [#6710](https://github.com/rust-bitcoin/rust-bitcoin/pull/6710)
+* Add `Div` and `DivAssign` for `NonZero` to `Amount` types [#6676](https://github.com/rust-bitcoin/rust-bitcoin/pull/6676)
+* Add support for satisfaction of parent/child transactions [#6649](https://github.com/rust-bitcoin/rust-bitcoin/pull/6649)
+* Flatten error constructors [#6694](https://github.com/rust-bitcoin/rust-bitcoin/pull/6694)
+* Add `Weight::to_vb_*` functions, deprecating `to_vbytes_*` [#6678](https://github.com/rust-bitcoin/rust-bitcoin/pull/6678)
+* Implement `serde` traits for absolute locktime types [#6633](https://github.com/rust-bitcoin/rust-bitcoin/pull/6633)
+* Add `RemAssign` to `NumOpResult<Amount/SignedAmount>` [#6669](https://github.com/rust-bitcoin/rust-bitcoin/pull/6669)
+* Add `CompactTarget::to_consensus_u32` [#6683](https://github.com/rust-bitcoin/rust-bitcoin/pull/6683)
+* Remove `From<u16>` from `NumberOfBlocks` [#6661](https://github.com/rust-bitcoin/rust-bitcoin/pull/6661)
+* Make `Sum` impl generic for `Signed/Amount -> NumOpResult` [#6648](https://github.com/rust-bitcoin/rust-bitcoin/pull/6648)
+* Add `to_target` conversion to `CompactTarget` [#6650](https://github.com/rust-bitcoin/rust-bitcoin/pull/6650)
+* Make `Sequence` inner field private and remove default [#6645](https://github.com/rust-bitcoin/rust-bitcoin/pull/6645)
+* Make `Weight % Weight` return `Weight` [#6652](https://github.com/rust-bitcoin/rust-bitcoin/pull/6652)
+* Fix off-by-one error in satisfied by height [#6582](https://github.com/rust-bitcoin/rust-bitcoin/pull/6582)
+* Restore the +1 in relative locktime satisfied by height [#6640](https://github.com/rust-bitcoin/rust-bitcoin/pull/6640)
+* Fix off-by-one in `MedianTimePast::is_satisfied_by` [#6384](https://github.com/rust-bitcoin/rust-bitcoin/pull/6384)
+* `Target`/`Work`'s internal `U256` type is now sourced from `bitcoin-internals` instead of a duplicated `include!` module.
 
 ## [0.5.0] - 2026-06-09
 

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-units"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>", "Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"

--- a/units/src/pow.rs
+++ b/units/src/pow.rs
@@ -261,7 +261,7 @@ impl CompactTarget {
     pub fn from_consensus(bits: u32) -> Self { Self(bits) }
 
     /// Returns the consensus encoded `u32` representation of this [`CompactTarget`].
-    #[deprecated(since = "TBD", note = "use 'to_consensus_u32()' instead")]
+    #[deprecated(since = "0.6.0", note = "use 'to_consensus_u32()' instead")]
     #[inline]
     pub const fn to_consensus(self) -> u32 { self.0 }
 

--- a/units/src/weight.rs
+++ b/units/src/weight.rs
@@ -128,7 +128,7 @@ impl Weight {
 
     /// Converts to vB rounding down.
     #[inline]
-    #[deprecated(since = "TBD", note = "use `to_vb_floor()` instead")]
+    #[deprecated(since = "0.6.0", note = "use `to_vb_floor()` instead")]
     pub const fn to_vbytes_floor(self) -> u64 { self.to_wu() / Self::WITNESS_SCALE_FACTOR }
 
     /// Converts to vB rounding up.
@@ -137,7 +137,7 @@ impl Weight {
 
     /// Converts to vB rounding up.
     #[inline]
-    #[deprecated(since = "TBD", note = "use `to_vbytes_ceil()` instead")]
+    #[deprecated(since = "0.6.0", note = "use `to_vbytes_ceil()` instead")]
     pub const fn to_vbytes_ceil(self) -> u64 { self.to_wu().div_ceil(Self::WITNESS_SCALE_FACTOR) }
 
     /// Checked addition.


### PR DESCRIPTION
Another go at a last release candidate. A fair bit of stuff in this release. Well done team.

The plan is release up to `bitcoin beta`, let this sit, then pull the trigger on `1.0.0`. During that release we remove the deprecated code re-introduced here. 

## TODO

- https://github.com/rust-bitcoin/rust-bitcoin/pull/6914

(6914 is in the changelog already)
