### PR TITLE
Release tracking PR: `primitives 0.104.0`

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -40,6 +40,7 @@ exclude_re = [
     "units/.* Weight::to_vbytes_ceil", # Deprecated
     "units/.* Sequence::from_512_second_intervals", # Mutant from replacing | with ^, this returns the same value since the XOR is taken against the u16 with an all-zero bitmask
     "units/.* \\| with \\^ in Target::to_compact_lossy", # compact | (size << 24). compact and size are bitwise independent, so impossible to tell ^ from |.
+    "units/.* Weight::from_non_witness_data_size", # Deprecated
 
     # primitives
     "primitives/.* Opcode::classify", # Not possible to kill all mutants without individually checking every opcode classification

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -90,7 +90,7 @@ dependencies = [
  "bitcoin-network-kind",
  "bitcoin-primitives",
  "bitcoin-taproot-primitives",
- "bitcoin-units 0.5.0",
+ "bitcoin-units 0.6.0",
  "bitcoin_hashes 1.2.0",
  "bitcoinconsensus",
  "hex-conservative 1.1.0",
@@ -244,7 +244,7 @@ dependencies = [
  "bitcoin-internals 0.6.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
- "bitcoin-units 0.5.0",
+ "bitcoin-units 0.6.0",
  "bitcoin_hashes 1.2.0",
  "hex-conservative 1.1.0",
  "serde",
@@ -258,7 +258,7 @@ dependencies = [
  "bincode",
  "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-internals 0.6.0",
- "bitcoin-units 0.5.0",
+ "bitcoin-units 0.6.0",
  "bitcoin_hashes 1.2.0",
  "hex-conservative 1.1.0",
  "serde",
@@ -296,7 +296,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-units"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -89,7 +89,7 @@ dependencies = [
  "bitcoin-network-kind",
  "bitcoin-primitives",
  "bitcoin-taproot-primitives",
- "bitcoin-units 0.5.0",
+ "bitcoin-units 0.6.0",
  "bitcoin_hashes 1.2.0",
  "bitcoinconsensus",
  "hex-conservative 1.1.0",
@@ -243,7 +243,7 @@ dependencies = [
  "bitcoin-internals 0.6.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
- "bitcoin-units 0.5.0",
+ "bitcoin-units 0.6.0",
  "bitcoin_hashes 1.2.0",
  "hex-conservative 1.1.0",
  "serde",
@@ -257,7 +257,7 @@ dependencies = [
  "bincode",
  "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-internals 0.6.0",
- "bitcoin-units 0.5.0",
+ "bitcoin-units 0.6.0",
  "bitcoin_hashes 1.2.0",
  "hex-conservative 1.1.0",
  "serde",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-units"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/addresses/Cargo.toml
+++ b/addresses/Cargo.toml
@@ -26,7 +26,7 @@ hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.0.0", de
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
 taproot_primitives = { package = "bitcoin-taproot-primitives", path = "../taproot_primitives", version = "0.1.0", default-features = false, features = [] }
 network = { package = "bitcoin-network-kind", path = "../network", version = "1.0.0", default-features = false, features = []}
-primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.103.0", default-features = false, features = ["hex"] }
+primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.104.0", default-features = false, features = ["hex"] }
 
 serde = { version = "1.0.195", default-features = false, features = [ "derive" ], optional = true }
 

--- a/benches/Cargo.lock
+++ b/benches/Cargo.lock
@@ -37,7 +37,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base58ck"
-version = "0.3.0"
+version = "0.5.0"
 dependencies = [
  "bitcoin-internals",
  "bitcoin_hashes",
@@ -57,21 +57,40 @@ checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
 name = "bitcoin"
-version = "0.33.0-beta.0"
+version = "0.33.0-beta"
 dependencies = [
  "base58ck",
  "base64",
  "bech32",
+ "bitcoin-addresses",
  "bitcoin-consensus-encoding",
+ "bitcoin-crypto",
  "bitcoin-internals",
  "bitcoin-io",
+ "bitcoin-key-expression",
  "bitcoin-network-kind",
  "bitcoin-primitives",
+ "bitcoin-taproot-primitives",
  "bitcoin-units",
  "bitcoin_hashes",
  "bitcoinconsensus",
- "hex-conservative 0.3.0",
+ "hex-conservative",
  "secp256k1",
+]
+
+[[package]]
+name = "bitcoin-addresses"
+version = "0.0.0"
+dependencies = [
+ "base58ck",
+ "bech32",
+ "bitcoin-crypto",
+ "bitcoin-internals",
+ "bitcoin-network-kind",
+ "bitcoin-primitives",
+ "bitcoin-taproot-primitives",
+ "bitcoin_hashes",
+ "serde",
 ]
 
 [[package]]
@@ -83,26 +102,39 @@ dependencies = [
  "bitcoin_hashes",
  "chacha20-poly1305",
  "criterion",
- "hex_lit",
+ "hex-conservative",
 ]
 
 [[package]]
 name = "bitcoin-consensus-encoding"
-version = "1.0.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "bitcoin-internals",
+ "hex-conservative",
+ "serde",
+]
+
+[[package]]
+name = "bitcoin-crypto"
+version = "0.3.0"
+dependencies = [
+ "base58ck",
+ "bitcoin-internals",
+ "bitcoin-network-kind",
+ "bitcoin-primitives",
+ "bitcoin_hashes",
+ "hex-conservative",
+ "secp256k1",
+ "serde",
 ]
 
 [[package]]
 name = "bitcoin-internals"
-version = "0.5.0"
-dependencies = [
- "hex-conservative 0.3.0",
-]
+version = "0.6.0"
 
 [[package]]
 name = "bitcoin-io"
-version = "0.4.0-rc.0"
+version = "0.6.0"
 dependencies = [
  "bitcoin-consensus-encoding",
  "bitcoin-internals",
@@ -110,8 +142,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitcoin-network-kind"
+name = "bitcoin-key-expression"
 version = "0.1.0"
+dependencies = [
+ "base58ck",
+ "bitcoin-crypto",
+ "bitcoin-internals",
+ "bitcoin-network-kind",
+ "bitcoin_hashes",
+ "hex-conservative",
+ "secp256k1",
+ "serde",
+]
+
+[[package]]
+name = "bitcoin-network-kind"
+version = "1.0.0"
 dependencies = [
  "bitcoin-internals",
  "serde",
@@ -119,19 +165,30 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-primitives"
-version = "1.0.0-rc.2"
+version = "0.103.1"
 dependencies = [
  "bitcoin-consensus-encoding",
  "bitcoin-internals",
  "bitcoin-units",
  "bitcoin_hashes",
- "hex-conservative 0.3.0",
- "hex-conservative 1.0.1",
+ "hex-conservative",
+]
+
+[[package]]
+name = "bitcoin-taproot-primitives"
+version = "0.1.0"
+dependencies = [
+ "bitcoin-consensus-encoding",
+ "bitcoin-crypto",
+ "bitcoin-internals",
+ "bitcoin_hashes",
+ "secp256k1",
+ "serde",
 ]
 
 [[package]]
 name = "bitcoin-units"
-version = "1.0.0-rc.4"
+version = "0.6.0"
 dependencies = [
  "bitcoin-consensus-encoding",
  "bitcoin-internals",
@@ -140,11 +197,11 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.19.0"
+version = "1.2.0"
 dependencies = [
  "bitcoin-consensus-encoding",
  "bitcoin-internals",
- "hex-conservative 0.3.0",
+ "hex-conservative",
 ]
 
 [[package]]
@@ -186,7 +243,7 @@ checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "chacha20-poly1305"
-version = "0.1.2"
+version = "0.2.1"
 
 [[package]]
 name = "ciborium"
@@ -340,24 +397,12 @@ dependencies = [
 
 [[package]]
 name = "hex-conservative"
-version = "0.3.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afe881d0527571892c4034822e59bb10c6c991cce6abe8199b6f5cf10766f55"
+checksum = "35431185f361ccf3ffc58254628af5f1f5d5f28531da2e02e5d6c82bbc282a10"
 dependencies = [
  "arrayvec",
 ]
-
-[[package]]
-name = "hex-conservative"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "366fa3443ac84474447710ec17bb00b05dfbd096137817981e86f992f21a2793"
-
-[[package]]
-name = "hex_lit"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
 
 [[package]]
 name = "itertools"

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -40,7 +40,7 @@ network = { package = "bitcoin-network-kind", path = "../network", version = "1.
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.103.0", default-features = false, features = ["alloc", "hex"] }
 secp256k1 = { version = "0.32.0-beta.2", default-features = false, features = ["alloc"] }
 taproot-primitives = { package = "bitcoin-taproot-primitives", path = "../taproot_primitives", version = "0.1.0", default-features = false, features = ["alloc", "hex"] }
-units = { package = "bitcoin-units", path = "../units", version = "0.5.0", default-features = false, features = ["alloc"] }
+units = { package = "bitcoin-units", path = "../units", version = "0.6.0", default-features = false, features = ["alloc"] }
 
 arbitrary = { version = "1.4.1", optional = true }
 base64 = { version = "0.22.0", optional = true, default-features = false, features = ["alloc"] }

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -37,7 +37,7 @@ hex = { package = "hex-conservative", version = "1.1.0", default-features = fals
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0", features = ["alloc"] }
 io = { package = "bitcoin-io", path = "../io", version = "0.6.0", default-features = false, features = ["alloc", "hashes"] }
 network = { package = "bitcoin-network-kind", path = "../network", version = "1.0.0", default-features = false, features = ["alloc"]}
-primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.103.0", default-features = false, features = ["alloc", "hex"] }
+primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.104.0", default-features = false, features = ["alloc", "hex"] }
 secp256k1 = { version = "0.32.0-beta.2", default-features = false, features = ["alloc"] }
 taproot-primitives = { package = "bitcoin-taproot-primitives", path = "../taproot_primitives", version = "0.1.0", default-features = false, features = ["alloc", "hex"] }
 units = { package = "bitcoin-units", version = "0.6.0", default-features = false, features = ["alloc"] }

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -40,7 +40,7 @@ network = { package = "bitcoin-network-kind", path = "../network", version = "1.
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.103.0", default-features = false, features = ["alloc", "hex"] }
 secp256k1 = { version = "0.32.0-beta.2", default-features = false, features = ["alloc"] }
 taproot-primitives = { package = "bitcoin-taproot-primitives", path = "../taproot_primitives", version = "0.1.0", default-features = false, features = ["alloc", "hex"] }
-units = { package = "bitcoin-units", path = "../units", version = "0.6.0", default-features = false, features = ["alloc"] }
+units = { package = "bitcoin-units", version = "0.6.0", default-features = false, features = ["alloc"] }
 
 arbitrary = { version = "1.4.1", optional = true }
 base64 = { version = "0.22.0", optional = true, default-features = false, features = ["alloc"] }

--- a/bitcoin/embedded/Cargo.lock
+++ b/bitcoin/embedded/Cargo.lock
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-units"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bitcoin-consensus-encoding",
  "bitcoin-internals",

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -28,7 +28,7 @@ hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.0.0", de
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
 network = { package = "bitcoin-network-kind", path = "../network", version = "1.0.0", default-features = false }
 # This is a temporary dep for the sake of PushBytes impls. This should not be retained for crypto 1.0.
-primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.103.0", default-features = false, features = [] }
+primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.104.0", default-features = false, features = [] }
 secp256k1 = { version = "0.32.0-beta.2", default-features = false }
 
 arbitrary = { version = "1.4.1", optional = true }

--- a/hashes/embedded/Cargo.toml
+++ b/hashes/embedded/Cargo.toml
@@ -22,7 +22,7 @@ cortex-m-semihosting = "0.3.3"
 panic-halt = "0.2.0"
 alloc-cortex-m = { version = "0.4.1", optional = true }
 bitcoin_hashes = { path="../", default-features = false, features = [] }
-bitcoin-io = { path = "../../io", default_features = false, features = ["hashes"] }
+bitcoin-io = { path = "../../io", default-features = false, features = ["hashes"] }
 
 [lints.clippy]
 use_self = "warn"

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -26,7 +26,7 @@ network = { package = "bitcoin-network-kind", path = "../network", version = "1.
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.103.0", features = ["hex", "alloc"], default-features = false }
 hex = { package = "hex-conservative", version = "1.1.0", default-features = false, features = ["alloc"] }
 internals = { package = "bitcoin-internals", path = "../internals", default-features = false }
-units = { package = "bitcoin-units", path = "../units", version = "0.5.0", default-features = false }
+units = { package = "bitcoin-units", path = "../units", version = "0.6.0", default-features = false }
 
 arbitrary = { version = "1.4.1", optional = true }
 serde = { version = "1.0.195", default-features = false, features = ["derive", "alloc"], optional = true }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -23,7 +23,7 @@ serde = ["dep:serde", "hashes/serde"]
 encoding = { package = "bitcoin-consensus-encoding", version = "1.0.0", path = "../consensus_encoding", features = ["alloc"], default-features = false }
 hashes = { package = "bitcoin_hashes", version = "1.0.0", path = "../hashes", default-features = false }
 network = { package = "bitcoin-network-kind", path = "../network", version = "1.0.0", default-features = false }
-primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.103.0", features = ["hex", "alloc"], default-features = false }
+primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.104.0", features = ["hex", "alloc"], default-features = false }
 hex = { package = "hex-conservative", version = "1.1.0", default-features = false, features = ["alloc"] }
 internals = { package = "bitcoin-internals", path = "../internals", default-features = false }
 units = { package = "bitcoin-units", version = "0.6.0", default-features = false }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -26,7 +26,7 @@ network = { package = "bitcoin-network-kind", path = "../network", version = "1.
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.103.0", features = ["hex", "alloc"], default-features = false }
 hex = { package = "hex-conservative", version = "1.1.0", default-features = false, features = ["alloc"] }
 internals = { package = "bitcoin-internals", path = "../internals", default-features = false }
-units = { package = "bitcoin-units", path = "../units", version = "0.6.0", default-features = false }
+units = { package = "bitcoin-units", version = "0.6.0", default-features = false }
 
 arbitrary = { version = "1.4.1", optional = true }
 serde = { version = "1.0.195", default-features = false, features = ["derive", "alloc"], optional = true }

--- a/primitives/CHANGELOG.md
+++ b/primitives/CHANGELOG.md
@@ -2,7 +2,32 @@
 
 ## [Unreleased]
 
+# [0.104.0] - 2026-08-20
+
+- Make `ScriptHash` and `WScriptHash` `no-alloc` [#6711](https://github.com/rust-bitcoin/rust-bitcoin/pull/6711)
+- Remove `BlockHashDecoder` from `transaction` module [#6730](https://github.com/rust-bitcoin/rust-bitcoin/pull/6730)
+- Make the `WitnessesEncoder` private [#6667](https://github.com/rust-bitcoin/rust-bitcoin/pull/6667)
+- Fix witness commitment check (BIP-141) [#6250](https://github.com/rust-bitcoin/rust-bitcoin/pull/6250)
+- Add serde impls for `WitnessVersion` [#6644]()
+- Add impl `Clone` for `Box<{custom DST}>` [#6571]()
+- Apply the witness item size limit to every element [#6642]()
+- Replace Block `PartialEq`/`Eq` derive with manual impl [#6623]()
+- Add `fmt` traits for `WitnessVersion` [#6621]()
+- Add `Hash` derive to `Opcode` [#6622]()
+- Use generic arguments for functions [#6606]()
+- Rename `witness_version` errors [#6583]()
+- Make `Witness` `FromIterator` infallible [#6554]()
+- Seal `PushBytesErrorReport` [#6590]()
+- Add `Extend` impl to `Witness` [#6561]()
+- Drop `WitnessCommitment::GENESIS_PREVIOUS_BLOCK_HASH` [#6584]()
+- Add `Debug` impl to `witness::Iter` [#6562]()
+- Depend on `crypto 0.3.0`
+- Depend on `units 0.6.0`
+- Depend on `consensus-encoding 1.1.0`
+
 # [0.103.1] - 2026-08-06
+
+**YANKED**
 
 - Explicitly depend on `consensus-encoding 1.1.0`
 

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -25,7 +25,7 @@ hex = ["dep:hex", "hashes/hex", "encoding/hex"]
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.1.0", default-features = false }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.1.0", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
-units = { package = "bitcoin-units", path = "../units", version = "0.5.0", default-features = false, features = [ "encoding" ] }
+units = { package = "bitcoin-units", path = "../units", version = "0.6.0", default-features = false, features = [ "encoding" ] }
 
 arbitrary = { version = "1.4.1", optional = true }
 hex = { package = "hex-conservative", version = "1.1.0", default-features = false, optional = true }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-primitives"
-version = "0.103.1"
+version = "0.104.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>", "Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin"

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -25,7 +25,7 @@ hex = ["dep:hex", "hashes/hex", "encoding/hex"]
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.1.0", default-features = false }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.1.0", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
-units = { package = "bitcoin-units", path = "../units", version = "0.6.0", default-features = false, features = [ "encoding" ] }
+units = { package = "bitcoin-units", version = "0.6.0", default-features = false, features = [ "encoding" ] }
 
 arbitrary = { version = "1.4.1", optional = true }
 hex = { package = "hex-conservative", version = "1.1.0", default-features = false, optional = true }

--- a/units/CHANGELOG.md
+++ b/units/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-08-20
+
+* Rename locktime height accessors and query methods [#6689](https://github.com/rust-bitcoin/rust-bitcoin/pull/6689)
+* Implement `Neg` for `Amount` and `NumOpResult` [#6710](https://github.com/rust-bitcoin/rust-bitcoin/pull/6710)
+* Add `Div` and `DivAssign` for `NonZero` to `Amount` types [#6676](https://github.com/rust-bitcoin/rust-bitcoin/pull/6676)
+* Add support for satisfaction of parent/child transactions [#6649](https://github.com/rust-bitcoin/rust-bitcoin/pull/6649)
+* Flatten error constructors [#6694](https://github.com/rust-bitcoin/rust-bitcoin/pull/6694)
+* Add `Weight::to_vb_*` functions, deprecating `to_vbytes_*` [#6678](https://github.com/rust-bitcoin/rust-bitcoin/pull/6678)
+* Implement `serde` traits for absolute locktime types [#6633](https://github.com/rust-bitcoin/rust-bitcoin/pull/6633)
+* Add `RemAssign` to `NumOpResult<Amount/SignedAmount>` [#6669](https://github.com/rust-bitcoin/rust-bitcoin/pull/6669)
+* Add `CompactTarget::to_consensus_u32` [#6683](https://github.com/rust-bitcoin/rust-bitcoin/pull/6683)
+* Remove `From<u16>` from `NumberOfBlocks` [#6661](https://github.com/rust-bitcoin/rust-bitcoin/pull/6661)
+* Make `Sum` impl generic for `Signed/Amount -> NumOpResult` [#6648](https://github.com/rust-bitcoin/rust-bitcoin/pull/6648)
+* Add `to_target` conversion to `CompactTarget` [#6650](https://github.com/rust-bitcoin/rust-bitcoin/pull/6650)
+* Make `Sequence` inner field private and remove default [#6645](https://github.com/rust-bitcoin/rust-bitcoin/pull/6645)
+* Make `Weight % Weight` return `Weight` [#6652](https://github.com/rust-bitcoin/rust-bitcoin/pull/6652)
+* Fix off-by-one error in satisfied by height [#6582](https://github.com/rust-bitcoin/rust-bitcoin/pull/6582)
+* Restore the +1 in relative locktime satisfied by height [#6640](https://github.com/rust-bitcoin/rust-bitcoin/pull/6640)
+* Fix off-by-one in `MedianTimePast::is_satisfied_by` [#6384](https://github.com/rust-bitcoin/rust-bitcoin/pull/6384)
+
 ## [0.5.0] - 2026-06-09
 
 * Remove `_unchecked` hex parsing function [#6292](https://github.com/rust-bitcoin/rust-bitcoin/pull/6292)

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-units"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>", "Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"

--- a/units/src/pow.rs
+++ b/units/src/pow.rs
@@ -254,7 +254,7 @@ impl CompactTarget {
     pub fn from_consensus(bits: u32) -> Self { Self(bits) }
 
     /// Returns the consensus encoded `u32` representation of this [`CompactTarget`].
-    #[deprecated(since = "TBD", note = "use 'to_consensus_u32()' instead")]
+    #[deprecated(since = "0.6.0", note = "use 'to_consensus_u32()' instead")]
     #[inline]
     pub const fn to_consensus(self) -> u32 { self.0 }
 

--- a/units/src/weight.rs
+++ b/units/src/weight.rs
@@ -124,7 +124,7 @@ impl Weight {
 
     /// Converts to vB rounding down.
     #[inline]
-    #[deprecated(since = "TBD", note = "use `to_vb_floor()` instead")]
+    #[deprecated(since = "0.6.0", note = "use `to_vb_floor()` instead")]
     pub const fn to_vbytes_floor(self) -> u64 { self.to_wu() / Self::WITNESS_SCALE_FACTOR }
 
     /// Converts to vB rounding up.
@@ -133,7 +133,7 @@ impl Weight {
 
     /// Converts to vB rounding up.
     #[inline]
-    #[deprecated(since = "TBD", note = "use `to_vbytes_ceil()` instead")]
+    #[deprecated(since = "0.6.0", note = "use `to_vbytes_ceil()` instead")]
     pub const fn to_vbytes_ceil(self) -> u64 { self.to_wu().div_ceil(Self::WITNESS_SCALE_FACTOR) }
 
     /// Checked addition.


### PR DESCRIPTION
Draft because on top of https://github.com/rust-bitcoin/rust-bitcoin/pull/6716

Also if the remove `path` thing flys we should do the same here.