### PR TITLE
ci: update all lockfiles in justfile recipe

### DIFF
--- a/benches/Cargo.lock
+++ b/benches/Cargo.lock
@@ -37,7 +37,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base58ck"
-version = "0.3.0"
+version = "0.5.0"
 dependencies = [
  "bitcoin-internals",
  "bitcoin_hashes",
@@ -57,21 +57,40 @@ checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
 name = "bitcoin"
-version = "0.33.0-beta.0"
+version = "0.33.0-beta"
 dependencies = [
  "base58ck",
  "base64",
  "bech32",
+ "bitcoin-addresses",
  "bitcoin-consensus-encoding",
+ "bitcoin-crypto",
  "bitcoin-internals",
  "bitcoin-io",
+ "bitcoin-key-expression",
  "bitcoin-network-kind",
  "bitcoin-primitives",
+ "bitcoin-taproot-primitives",
  "bitcoin-units",
  "bitcoin_hashes",
  "bitcoinconsensus",
- "hex-conservative 0.3.0",
+ "hex-conservative",
  "secp256k1",
+]
+
+[[package]]
+name = "bitcoin-addresses"
+version = "0.0.0"
+dependencies = [
+ "base58ck",
+ "bech32",
+ "bitcoin-crypto",
+ "bitcoin-internals",
+ "bitcoin-network-kind",
+ "bitcoin-primitives",
+ "bitcoin-taproot-primitives",
+ "bitcoin_hashes",
+ "serde",
 ]
 
 [[package]]
@@ -83,26 +102,39 @@ dependencies = [
  "bitcoin_hashes",
  "chacha20-poly1305",
  "criterion",
- "hex_lit",
+ "hex-conservative",
 ]
 
 [[package]]
 name = "bitcoin-consensus-encoding"
-version = "1.0.0-rc.3"
+version = "1.1.0"
 dependencies = [
  "bitcoin-internals",
+ "hex-conservative",
+ "serde",
+]
+
+[[package]]
+name = "bitcoin-crypto"
+version = "0.3.0"
+dependencies = [
+ "base58ck",
+ "bitcoin-internals",
+ "bitcoin-network-kind",
+ "bitcoin-primitives",
+ "bitcoin_hashes",
+ "hex-conservative",
+ "secp256k1",
+ "serde",
 ]
 
 [[package]]
 name = "bitcoin-internals"
-version = "0.5.0"
-dependencies = [
- "hex-conservative 0.3.0",
-]
+version = "0.6.0"
 
 [[package]]
 name = "bitcoin-io"
-version = "0.4.0-rc.0"
+version = "0.6.0"
 dependencies = [
  "bitcoin-consensus-encoding",
  "bitcoin-internals",
@@ -110,8 +142,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitcoin-network-kind"
+name = "bitcoin-key-expression"
 version = "0.1.0"
+dependencies = [
+ "base58ck",
+ "bitcoin-crypto",
+ "bitcoin-internals",
+ "bitcoin-network-kind",
+ "bitcoin_hashes",
+ "hex-conservative",
+ "secp256k1",
+ "serde",
+]
+
+[[package]]
+name = "bitcoin-network-kind"
+version = "1.0.0"
 dependencies = [
  "bitcoin-internals",
  "serde",
@@ -119,19 +165,30 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-primitives"
-version = "1.0.0-rc.2"
+version = "0.103.1"
 dependencies = [
  "bitcoin-consensus-encoding",
  "bitcoin-internals",
  "bitcoin-units",
  "bitcoin_hashes",
- "hex-conservative 0.3.0",
- "hex-conservative 1.0.1",
+ "hex-conservative",
+]
+
+[[package]]
+name = "bitcoin-taproot-primitives"
+version = "0.1.0"
+dependencies = [
+ "bitcoin-consensus-encoding",
+ "bitcoin-crypto",
+ "bitcoin-internals",
+ "bitcoin_hashes",
+ "secp256k1",
+ "serde",
 ]
 
 [[package]]
 name = "bitcoin-units"
-version = "1.0.0-rc.4"
+version = "0.5.0"
 dependencies = [
  "bitcoin-consensus-encoding",
  "bitcoin-internals",
@@ -140,11 +197,11 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.19.0"
+version = "1.2.0"
 dependencies = [
  "bitcoin-consensus-encoding",
  "bitcoin-internals",
- "hex-conservative 0.3.0",
+ "hex-conservative",
 ]
 
 [[package]]
@@ -186,7 +243,7 @@ checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "chacha20-poly1305"
-version = "0.1.2"
+version = "0.2.1"
 
 [[package]]
 name = "ciborium"
@@ -340,24 +397,12 @@ dependencies = [
 
 [[package]]
 name = "hex-conservative"
-version = "0.3.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afe881d0527571892c4034822e59bb10c6c991cce6abe8199b6f5cf10766f55"
+checksum = "35431185f361ccf3ffc58254628af5f1f5d5f28531da2e02e5d6c82bbc282a10"
 dependencies = [
  "arrayvec",
 ]
-
-[[package]]
-name = "hex-conservative"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "366fa3443ac84474447710ec17bb00b05dfbd096137817981e86f992f21a2793"
-
-[[package]]
-name = "hex_lit"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
 
 [[package]]
 name = "itertools"

--- a/hashes/embedded/Cargo.toml
+++ b/hashes/embedded/Cargo.toml
@@ -22,7 +22,7 @@ cortex-m-semihosting = "0.3.3"
 panic-halt = "0.2.0"
 alloc-cortex-m = { version = "0.4.1", optional = true }
 bitcoin_hashes = { path="../", default-features = false, features = [] }
-bitcoin-io = { path = "../../io", default_features = false, features = ["hashes"] }
+bitcoin-io = { path = "../../io", default-features = false, features = ["hashes"] }
 
 [lints.clippy]
 use_self = "warn"

--- a/justfile
+++ b/justfile
@@ -23,8 +23,11 @@ tools:
 # Check for API changes.
 check-api: (rbmt "api")
 
-# Update the recent and minimal lock files.
+# Update all lock files.
 @update-lock-files: (rbmt "lock")
+  cargo fetch --manifest-path {{justfile_directory()}}/benches/Cargo.toml
+  cargo fetch --manifest-path {{justfile_directory()}}/bitcoin/embedded/Cargo.toml
+  cargo fetch --manifest-path {{justfile_directory()}}/hashes/embedded/Cargo.toml
 
 # Query the current API.
 [group('scripts')]


### PR DESCRIPTION
`cargo rbmt lock` updates the lockfile of a workspace, but not nested workspaces inside that. For this repo, that now includes benches and the two embedded tests. Pain point exposed in https://github.com/rust-bitcoin/rust-bitcoin/pull/6716.

The `cargo fetch` command is used under the hood just because it is the lowest amount of work to get a convservative lockfile bump (compared to something like check).