### PR TITLE
Release tracking PR: `consensus-encoding 1.2.0`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -82,7 +82,7 @@ dependencies = [
  "bech32",
  "bincode",
  "bitcoin-addresses",
- "bitcoin-consensus-encoding 1.1.0",
+ "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-crypto",
  "bitcoin-internals 0.6.0",
  "bitcoin-io 0.6.0",
@@ -131,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-consensus-encoding"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "bitcoin-internals 0.6.0",
  "hex-conservative 1.1.0",
@@ -162,7 +162,7 @@ dependencies = [
  "arbitrary",
  "bitcoin 0.32.102",
  "bitcoin 0.33.0-beta",
- "bitcoin-consensus-encoding 1.1.0",
+ "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-p2p-messages",
  "libfuzzer-sys",
  "serde",
@@ -202,7 +202,7 @@ dependencies = [
 name = "bitcoin-io"
 version = "0.6.0"
 dependencies = [
- "bitcoin-consensus-encoding 1.1.0",
+ "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-internals 0.6.0",
  "bitcoin_hashes 1.2.0",
 ]
@@ -240,7 +240,7 @@ name = "bitcoin-p2p-messages"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "bitcoin-consensus-encoding 1.1.0",
+ "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-internals 0.6.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
@@ -256,7 +256,7 @@ version = "0.103.1"
 dependencies = [
  "arbitrary",
  "bincode",
- "bitcoin-consensus-encoding 1.1.0",
+ "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-internals 0.6.0",
  "bitcoin-units 0.5.0",
  "bitcoin_hashes 1.2.0",
@@ -276,7 +276,7 @@ name = "bitcoin-taproot-primitives"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "bitcoin-consensus-encoding 1.1.0",
+ "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-crypto",
  "bitcoin-internals 0.6.0",
  "bitcoin_hashes 1.2.0",
@@ -300,7 +300,7 @@ version = "0.5.0"
 dependencies = [
  "arbitrary",
  "bincode",
- "bitcoin-consensus-encoding 1.1.0",
+ "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-internals 0.6.0",
  "serde",
  "serde_json",
@@ -332,7 +332,7 @@ name = "bitcoin_hashes"
 version = "1.2.0"
 dependencies = [
  "arbitrary",
- "bitcoin-consensus-encoding 1.1.0",
+ "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-internals 0.6.0",
  "cpufeatures",
  "hex-conservative 1.1.0",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -81,7 +81,7 @@ dependencies = [
  "bech32",
  "bincode",
  "bitcoin-addresses",
- "bitcoin-consensus-encoding 1.1.0",
+ "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-crypto",
  "bitcoin-internals 0.6.0",
  "bitcoin-io 0.6.0",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-consensus-encoding"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "bitcoin-internals 0.6.0",
  "hex-conservative 1.1.0",
@@ -161,7 +161,7 @@ dependencies = [
  "arbitrary",
  "bitcoin 0.32.102",
  "bitcoin 0.33.0-beta",
- "bitcoin-consensus-encoding 1.1.0",
+ "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-p2p-messages",
  "libfuzzer-sys",
  "serde",
@@ -201,7 +201,7 @@ dependencies = [
 name = "bitcoin-io"
 version = "0.6.0"
 dependencies = [
- "bitcoin-consensus-encoding 1.1.0",
+ "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-internals 0.6.0",
  "bitcoin_hashes 1.2.0",
 ]
@@ -239,7 +239,7 @@ name = "bitcoin-p2p-messages"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "bitcoin-consensus-encoding 1.1.0",
+ "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-internals 0.6.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
@@ -255,7 +255,7 @@ version = "0.103.1"
 dependencies = [
  "arbitrary",
  "bincode",
- "bitcoin-consensus-encoding 1.1.0",
+ "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-internals 0.6.0",
  "bitcoin-units 0.5.0",
  "bitcoin_hashes 1.2.0",
@@ -269,7 +269,7 @@ name = "bitcoin-taproot-primitives"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "bitcoin-consensus-encoding 1.1.0",
+ "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-crypto",
  "bitcoin-internals 0.6.0",
  "bitcoin_hashes 1.2.0",
@@ -293,7 +293,7 @@ version = "0.5.0"
 dependencies = [
  "arbitrary",
  "bincode",
- "bitcoin-consensus-encoding 1.1.0",
+ "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-internals 0.6.0",
  "serde",
  "serde_json",
@@ -316,7 +316,7 @@ name = "bitcoin_hashes"
 version = "1.2.0"
 dependencies = [
  "arbitrary",
- "bitcoin-consensus-encoding 1.1.0",
+ "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-internals 0.6.0",
  "cpufeatures",
  "hex-conservative 1.1.0",

--- a/bitcoin/embedded/Cargo.lock
+++ b/bitcoin/embedded/Cargo.lock
@@ -79,7 +79,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-consensus-encoding"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "bitcoin-internals",
  "hex-conservative",

--- a/consensus_encoding/CHANGELOG.md
+++ b/consensus_encoding/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-08-11
+
+- Expose lower level encoder/decoder interfaces [#6690](https://github.com/rust-bitcoin/rust-bitcoin/pull/6690)
+  - Add `IterEncoder` driver bound to the low-level `Encoder` trait.
+  - Expose `VecDecoderWith` and `ExactVecDecoderWith` drivers bound to the low-level `Decoder` trait.
+- Make distinction in docs about consensus [#6651](https://github.com/rust-bitcoin/rust-bitcoin/pull/6651)
+- Loosen `serde_as_consensus` trait bounds [#6629](https://github.com/rust-bitcoin/rust-bitcoin/pull/6629)
+- Flatten nested error constructors [#6546](https://github.com/rust-bitcoin/rust-bitcoin/pull/6546)
+
 ## [1.1.0] - 2026-07-14
 
 - Add `PrefixedBytesEncoder` and `PrefixedSliceEncoder` [#6476](https://github.com/rust-bitcoin/rust-bitcoin/pull/6476)
@@ -95,7 +104,8 @@ around but the work got done. Props to him for many of the ideas.
 
 Empty crate to reserve the name on crates.io
 
-[Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-consensus-encoding-1.1.0...HEAD
+[Unreleased]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-consensus-encoding-1.2.0...HEAD
+[1.2.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-consensus-encoding-1.1.0...bitcoin-consensus-encoding-1.2.0
 [1.1.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-consensus-encoding-1.0.0...bitcoin-consensus-encoding-1.1.0
 [1.0.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-consensus-encoding-0.2.0...bitcoin-consensus-encoding-1.0.0
 [0.2.0]: https://github.com/rust-bitcoin/rust-bitcoin/compare/bitcoin-consensus-encoding-0.1.0...bitcoin-consensus-encoding-0.2.0

--- a/consensus_encoding/Cargo.toml
+++ b/consensus_encoding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-consensus-encoding"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>", "Nick Johnson <nick@yonson.dev>", "Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 homepage = "https://rust-bitcoin.org/"

--- a/hashes/embedded/Cargo.lock
+++ b/hashes/embedded/Cargo.lock
@@ -29,7 +29,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-consensus-encoding"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "bitcoin-internals",
 ]


### PR DESCRIPTION
Release the new lower level encoder/decoder driver interfaces. There should only be additions to the API in this release.

I have a [rust-psbt branch](https://git.rust-bitcoin.org/rust-bitcoin/rust-psbt/pulls/208) showing off the new interfaces end to end.