### PR TITLE
consensus_encoding: Bump version to 1.2.0

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -82,7 +82,7 @@ dependencies = [
  "bech32",
  "bincode",
  "bitcoin-addresses",
- "bitcoin-consensus-encoding 1.1.0",
+ "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-crypto",
  "bitcoin-internals 0.6.0",
  "bitcoin-io 0.6.0",
@@ -131,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-consensus-encoding"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "bitcoin-internals 0.6.0",
  "hex-conservative 1.1.0",
@@ -162,7 +162,7 @@ dependencies = [
  "arbitrary",
  "bitcoin 0.32.102",
  "bitcoin 0.33.0-beta",
- "bitcoin-consensus-encoding 1.1.0",
+ "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-p2p-messages",
  "libfuzzer-sys",
  "serde",
@@ -202,7 +202,7 @@ dependencies = [
 name = "bitcoin-io"
 version = "0.6.0"
 dependencies = [
- "bitcoin-consensus-encoding 1.1.0",
+ "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-internals 0.6.0",
  "bitcoin_hashes 1.2.0",
 ]
@@ -240,7 +240,7 @@ name = "bitcoin-p2p-messages"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "bitcoin-consensus-encoding 1.1.0",
+ "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-internals 0.6.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
@@ -256,7 +256,7 @@ version = "0.103.1"
 dependencies = [
  "arbitrary",
  "bincode",
- "bitcoin-consensus-encoding 1.1.0",
+ "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-internals 0.6.0",
  "bitcoin-units 0.5.0",
  "bitcoin_hashes 1.2.0",
@@ -276,7 +276,7 @@ name = "bitcoin-taproot-primitives"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "bitcoin-consensus-encoding 1.1.0",
+ "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-crypto",
  "bitcoin-internals 0.6.0",
  "bitcoin_hashes 1.2.0",
@@ -300,7 +300,7 @@ version = "0.5.0"
 dependencies = [
  "arbitrary",
  "bincode",
- "bitcoin-consensus-encoding 1.1.0",
+ "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-internals 0.6.0",
  "serde",
  "serde_json",
@@ -332,7 +332,7 @@ name = "bitcoin_hashes"
 version = "1.2.0"
 dependencies = [
  "arbitrary",
- "bitcoin-consensus-encoding 1.1.0",
+ "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-internals 0.6.0",
  "cpufeatures",
  "hex-conservative 1.1.0",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -81,7 +81,7 @@ dependencies = [
  "bech32",
  "bincode",
  "bitcoin-addresses",
- "bitcoin-consensus-encoding 1.1.0",
+ "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-crypto",
  "bitcoin-internals 0.6.0",
  "bitcoin-io 0.6.0",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-consensus-encoding"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "bitcoin-internals 0.6.0",
  "hex-conservative 1.1.0",
@@ -161,7 +161,7 @@ dependencies = [
  "arbitrary",
  "bitcoin 0.32.102",
  "bitcoin 0.33.0-beta",
- "bitcoin-consensus-encoding 1.1.0",
+ "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-p2p-messages",
  "libfuzzer-sys",
  "serde",
@@ -201,7 +201,7 @@ dependencies = [
 name = "bitcoin-io"
 version = "0.6.0"
 dependencies = [
- "bitcoin-consensus-encoding 1.1.0",
+ "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-internals 0.6.0",
  "bitcoin_hashes 1.2.0",
 ]
@@ -239,7 +239,7 @@ name = "bitcoin-p2p-messages"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "bitcoin-consensus-encoding 1.1.0",
+ "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-internals 0.6.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
@@ -255,7 +255,7 @@ version = "0.103.1"
 dependencies = [
  "arbitrary",
  "bincode",
- "bitcoin-consensus-encoding 1.1.0",
+ "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-internals 0.6.0",
  "bitcoin-units 0.5.0",
  "bitcoin_hashes 1.2.0",
@@ -269,7 +269,7 @@ name = "bitcoin-taproot-primitives"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "bitcoin-consensus-encoding 1.1.0",
+ "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-crypto",
  "bitcoin-internals 0.6.0",
  "bitcoin_hashes 1.2.0",
@@ -293,7 +293,7 @@ version = "0.5.0"
 dependencies = [
  "arbitrary",
  "bincode",
- "bitcoin-consensus-encoding 1.1.0",
+ "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-internals 0.6.0",
  "serde",
  "serde_json",
@@ -316,7 +316,7 @@ name = "bitcoin_hashes"
 version = "1.2.0"
 dependencies = [
  "arbitrary",
- "bitcoin-consensus-encoding 1.1.0",
+ "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-internals 0.6.0",
  "cpufeatures",
  "hex-conservative 1.1.0",

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -32,7 +32,7 @@ bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
 crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.3.0", default-features = false, features = ["alloc", "hex"] }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.1.0", default-features = false, features = ["alloc", "hex"] }
 key-expression = { package = "bitcoin-key-expression", path = "../key_expression", version = "0.1.0", default-features = false, features = ["alloc"] }
-encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.1.0", default-features = false, features = ["alloc", "hex"] }
+encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.2.0", default-features = false, features = ["alloc", "hex"] }
 hex = { package = "hex-conservative", version = "1.1.0", default-features = false, features = ["alloc"] }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0", features = ["alloc"] }
 io = { package = "bitcoin-io", path = "../io", version = "0.6.0", default-features = false, features = ["alloc", "hashes"] }

--- a/consensus_encoding/CHANGELOG.md
+++ b/consensus_encoding/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-08-12
+
+- Expose lower level encoder/decoder interfaces [#6690](https://github.com/rust-bitcoin/rust-bitcoin/pull/6690)
+- Make distinction in docs about consensus [#6651](https://github.com/rust-bitcoin/rust-bitcoin/pull/6651)
+- Loosen `serde_as_consensus` trait bounds [#6629](https://github.com/rust-bitcoin/rust-bitcoin/pull/6629)
+
 ## [1.1.0] - 2026-07-14
 
 - Add `PrefixedBytesEncoder` and `PrefixedSliceEncoder` [#6476](https://github.com/rust-bitcoin/rust-bitcoin/pull/6476)

--- a/consensus_encoding/Cargo.toml
+++ b/consensus_encoding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-consensus-encoding"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>", "Nick Johnson <nick@yonson.dev>", "Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 homepage = "https://rust-bitcoin.org/"

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -22,7 +22,7 @@ arbitrary = ["dep:arbitrary", "units/arbitrary"]
 hex = ["dep:hex", "hashes/hex", "encoding/hex"]
 
 [dependencies]
-encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.1.0", default-features = false }
+encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.2.0", default-features = false }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.1.0", default-features = false }
 internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
 units = { package = "bitcoin-units", path = "../units", version = "0.5.0", default-features = false, features = [ "encoding" ] }


### PR DESCRIPTION
In preparation to release a few API additions add a changelog entry, bump the version number, and update the lock files.

Includes bump of the dep in `bitcoin` and `primitives` because they use the `serde_as_consensus` module. Don't know if its totally required.

This release should slot in just fine now because we are waiting on a `units` release anyways. And we'd like to use this over in `rust-psbt`.