### PR TITLE
primitives: Add links in docs and update encoding trait names

### DIFF
--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -65,7 +65,7 @@ const WITNESS_COMMITMENT_MAGIC: [u8; 6] = [0x6a, 0x24, 0xaa, 0x21, 0xa9, 0xed];
 /// See `bitcoin::block::BlockUncheckedExt::validate()`.
 #[cfg(feature = "alloc")]
 pub trait Validation: sealed::Validation + Sync + Send + Sized + Unpin {
-    /// Indicates whether this `Validation` is `Checked` or not.
+    /// Indicates whether this [`Validation`] is [`Checked`] or not.
     const IS_CHECKED: bool;
 }
 
@@ -98,7 +98,7 @@ where
 
 #[cfg(feature = "alloc")]
 impl Block<Unchecked> {
-    /// Constructs a new `Block` without doing any validation.
+    /// Constructs a new [`Block`] without doing any validation.
     #[inline]
     pub fn new_unchecked(header: Header, transactions: Vec<Transaction>) -> Self {
         Self { header, transactions, witness_root: None, _marker: PhantomData::<Unchecked> }
@@ -380,7 +380,7 @@ type BlockInnerDecoder = Decoder2<HeaderDecoder, VecDecoder<Transaction>>;
 crate::decoder_newtype! {
     /// The decoder for the [`Block`] type.
     ///
-    /// This decoder can only produce a `Block<Unchecked>`.
+    /// This decoder can only produce a [`Block<Unchecked>`].
     #[derive(Debug, Clone)]
     pub struct BlockDecoder(BlockInnerDecoder);
 
@@ -395,13 +395,13 @@ crate::decoder_newtype! {
 
 /// Computes the Merkle root for a list of transactions.
 ///
-/// Returns `None` if the iterator was empty, or if the transaction list contains
+/// Returns [`None`] if the iterator was empty, or if the transaction list contains
 /// consecutive duplicates which would trigger CVE 2012-2459. Blocks with duplicate
 /// transactions will always be invalid, so there is no harm in us refusing to
 /// compute their merkle roots.
 ///
 /// Unless you are certain your transaction list is nonempty and has no duplicates,
-/// you should not unwrap the `Option` returned by this method!
+/// you should not unwrap the [`Option`] returned by this method!
 #[cfg(feature = "alloc")]
 pub fn compute_merkle_root<T>(transactions: T) -> Option<TxMerkleNode>
 where
@@ -414,13 +414,13 @@ where
 
 /// Computes the Merkle root of transactions hashed for witness.
 ///
-/// Returns `None` if the iterator was empty, or if the transaction list contains
+/// Returns [`None`] if the iterator was empty, or if the transaction list contains
 /// consecutive duplicates which would trigger CVE 2012-2459. Blocks with duplicate
 /// transactions will always be invalid, so there is no harm in us refusing to
 /// compute their merkle roots.
 ///
 /// Unless you are certain your transaction list is nonempty and has no duplicates,
-/// you should not unwrap the `Option` returned by this method!
+/// you should not unwrap the [`Option`] returned by this method!
 #[cfg(feature = "alloc")]
 pub fn compute_witness_root<T>(transactions: T) -> Option<WitnessMerkleNode>
 where
@@ -851,7 +851,7 @@ pub mod error {
         }
     }
 
-    /// An error consensus decoding a `Header`.
+    /// An error consensus decoding a [`Header`](super::Header).
     #[derive(Debug, Clone, PartialEq, Eq)]
     #[non_exhaustive]
     pub enum HeaderDecoderError {
@@ -900,7 +900,7 @@ pub mod error {
         }
     }
 
-    /// An error consensus decoding a `Version`.
+    /// An error consensus decoding a [`Version`](super::Version).
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct VersionDecoderError(pub(super) encoding::UnexpectedEofError);
 

--- a/primitives/src/hash_types/block_hash.rs
+++ b/primitives/src/hash_types/block_hash.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! The `BlockHash` type.
+//! The [`BlockHash`] type.
 
 use core::convert::Infallible;
 use core::fmt;
@@ -64,7 +64,7 @@ crate::decoder_newtype! {
     }
 }
 
-/// An error consensus decoding a `BlockHash`.
+/// An error consensus decoding a [`BlockHash`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BlockHashDecoderError(encoding::UnexpectedEofError);
 

--- a/primitives/src/hash_types/ntxid.rs
+++ b/primitives/src/hash_types/ntxid.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! The `Ntxid` type.
+//! The [`Ntxid`] type.
 
 #[cfg(feature = "hex")]
 use core::{fmt, str};

--- a/primitives/src/hash_types/script_hash.rs
+++ b/primitives/src/hash_types/script_hash.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! The `ScriptHash` type.
+//! The [`ScriptHash`] type.
 
 use core::convert::Infallible;
 use core::fmt;
@@ -25,7 +25,7 @@ super::impl_debug!(ScriptHash);
 crate::impl_asref_push_bytes!(ScriptHash);
 
 impl ScriptHash {
-    /// Constructs a new `ScriptHash` after first checking the script size.
+    /// Constructs a new [`ScriptHash`] after first checking the script size.
     ///
     /// # 520-byte limitation on serialized script size
     ///
@@ -52,7 +52,7 @@ impl ScriptHash {
         Ok(Self::from_script_unchecked(redeem_script))
     }
 
-    /// Constructs a new `ScriptHash` from any script irrespective of script size.
+    /// Constructs a new [`ScriptHash`] from any script irrespective of script size.
     ///
     /// If you hash a script that exceeds 520 bytes in size and use it to create a P2SH output
     /// then the output will be unspendable (see [BIP-0016]).

--- a/primitives/src/hash_types/transaction_merkle_node.rs
+++ b/primitives/src/hash_types/transaction_merkle_node.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! The `TxMerkleNode` type.
+//! The [`TxMerkleNode`] type.
 
 use core::convert::Infallible;
 use core::fmt;
@@ -38,13 +38,13 @@ impl TxMerkleNode {
 
     /// Given an iterator of leaves, compute the Merkle root.
     ///
-    /// Returns `None` if the iterator was empty, or if the transaction list contains
+    /// Returns [`None`] if the iterator was empty, or if the transaction list contains
     /// consecutive duplicates which would trigger CVE 2012-2459. Blocks with duplicate
     /// transactions will always be invalid, so there is no harm in us refusing to
     /// compute their merkle roots.
     ///
     /// Unless you are certain your transaction list is nonempty and has no duplicates,
-    /// you should not unwrap the `Option` returned by this method!
+    /// you should not unwrap the [`Option`] returned by this method!
     pub fn calculate_root<I: IntoIterator<Item = Txid>>(iter: I) -> Option<Self> {
         MerkleNode::calculate_root(iter.into_iter())
     }
@@ -84,7 +84,7 @@ crate::decoder_newtype! {
     }
 }
 
-/// An error consensus decoding a `TxMerkleNode`.
+/// An error consensus decoding a [`TxMerkleNode`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TxMerkleNodeDecoderError(encoding::UnexpectedEofError);
 

--- a/primitives/src/hash_types/txid.rs
+++ b/primitives/src/hash_types/txid.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! The `Txid` type.
+//! The [`Txid`] type.
 //!
 //! In order to print and parse txids enable the "hex" feature.
 
@@ -26,7 +26,7 @@ pub struct Txid(sha256d::Hash);
 super::impl_debug!(Txid);
 
 impl Txid {
-    /// The `Txid` used in a coinbase prevout.
+    /// The [`Txid`] used in a coinbase prevout.
     ///
     /// This is used as the "txid" of the dummy input of a coinbase transaction. This is not a real
     /// TXID and should not be used in any other contexts. See [`OutPoint::COINBASE_PREVOUT`].

--- a/primitives/src/hash_types/witness_commitment.rs
+++ b/primitives/src/hash_types/witness_commitment.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! The `WitnessCommitment` type.
+//! The [`WitnessCommitment`] type.
 
 #[cfg(feature = "hex")]
 use core::{fmt, str};

--- a/primitives/src/hash_types/witness_merkle_node.rs
+++ b/primitives/src/hash_types/witness_merkle_node.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! The `WitnessMerkleNode` type.
+//! The [`WitnessMerkleNode`] type.
 
 use core::convert::Infallible;
 use core::fmt;
@@ -38,13 +38,13 @@ impl WitnessMerkleNode {
 
     /// Given an iterator of leaves, compute the Merkle root.
     ///
-    /// Returns `None` if the iterator was empty, or if the transaction list contains
+    /// Returns [`None`] if the iterator was empty, or if the transaction list contains
     /// consecutive duplicates which would trigger CVE 2012-2459. Blocks with duplicate
     /// transactions will always be invalid, so there is no harm in us refusing to
     /// compute their merkle roots.
     ///
     /// Unless you are certain your transaction list is nonempty and has no duplicates,
-    /// you should not unwrap the `Option` returned by this method!
+    /// you should not unwrap the [`Option`] returned by this method!
     pub fn calculate_root<I: IntoIterator<Item = Wtxid>>(iter: I) -> Option<Self> {
         MerkleNode::calculate_root(iter.into_iter())
     }
@@ -84,7 +84,7 @@ crate::decoder_newtype! {
     }
 }
 
-/// An error consensus decoding a `WitnessMerkleNode`.
+/// An error consensus decoding a [`WitnessMerkleNode`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WitnessMerkleNodeDecoderError(encoding::UnexpectedEofError);
 

--- a/primitives/src/hash_types/witness_script_hash.rs
+++ b/primitives/src/hash_types/witness_script_hash.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! The `WScriptHash` type.
+//! The [`WScriptHash`] type.
 
 use core::convert::Infallible;
 use core::fmt;
@@ -25,7 +25,7 @@ super::impl_debug!(WScriptHash);
 crate::impl_asref_push_bytes!(WScriptHash);
 
 impl WScriptHash {
-    /// Constructs a new `WScriptHash` after first checking the script size.
+    /// Constructs a new [`WScriptHash`] after first checking the script size.
     ///
     /// # 10,000-byte limit on the witness script
     ///
@@ -47,7 +47,7 @@ impl WScriptHash {
         Ok(Self::from_script_unchecked(witness_script))
     }
 
-    /// Constructs a new `WScriptHash` from any script irrespective of script size.
+    /// Constructs a new [`WScriptHash`] from any script irrespective of script size.
     ///
     /// If you hash a script that exceeds 10,000 bytes in size and use it to create a Segwit
     /// output then the output will be unspendable (see [BIP-0141]).

--- a/primitives/src/hash_types/wtxid.rs
+++ b/primitives/src/hash_types/wtxid.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! The `Wtxid` type.
+//! The [`Wtxid`] type.
 //!
 //! In order to print and parse txids enable the "hex" feature.
 
@@ -18,7 +18,7 @@ pub struct Wtxid(sha256d::Hash);
 super::impl_debug!(Wtxid);
 
 impl Wtxid {
-    /// The `Wtxid` of a coinbase transaction.
+    /// The [`Wtxid`] of a coinbase transaction.
     ///
     /// This is used as the wTXID for the coinbase transaction when constructing blocks (in the
     /// witness commitment tree) since the coinbase transaction contains a commitment to all

--- a/primitives/src/hex_codec.rs
+++ b/primitives/src/hex_codec.rs
@@ -5,7 +5,7 @@
 //! Various types in primitives need to be rendered in hexadecimal.
 //! Since `consensus_encoding` only provides a method using `alloc`
 //! to do this, this module provides utilities for alloc-less encoding
-//! of `Encodable` types within the primitives crate.
+//! of [`Encode`](encoding::Encode) types within the primitives crate.
 
 use core::fmt;
 use core::fmt::Write as _;

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -12,9 +12,9 @@
 //!
 //! ### serde
 //!
-//! The consensus encodable types (`Block`, `block::Header`, `Transaction`, `TxIn`, and `TxOut`)
-//! deliberately do not implement serde traits. Instead, they can be de/serialized with the
-//! `bitcoin_consensus_encoding::serde_as_consensus` module.
+//! The consensus encodable types ([`Block`], [`block::Header`], [`Transaction`], [`TxIn`], and
+//! [`TxOut`]) deliberately do not implement serde traits. Instead, they can be de/serialized with
+//! the `bitcoin_consensus_encoding::serde_as_consensus` module.
 //!
 //! ```rust
 //! # #[cfg(feature = "serde")] {
@@ -93,7 +93,7 @@ pub use units::{
     weight::{self, Weight},
 };
 
-#[deprecated(since = "1.0.0-rc.0", note = "use `BlockHeightInterval` instead")]
+#[deprecated(since = "1.0.0-rc.0", note = "use [`BlockHeightInterval`] instead")]
 #[doc(hidden)]
 pub type BlockInterval = BlockHeightInterval;
 

--- a/primitives/src/merkle_tree.rs
+++ b/primitives/src/merkle_tree.rs
@@ -46,16 +46,16 @@ pub(crate) trait MerkleNode: Copy + PartialEq {
 
     /// Given an iterator of leaves, compute the Merkle root.
     ///
-    /// Returns `None` if the iterator was empty, or if the transaction list contains
+    /// Returns [`None`] if the iterator was empty, or if the transaction list contains
     /// consecutive duplicates which would trigger CVE 2012-2459. Blocks with duplicate
     /// transactions will always be invalid, so there is no harm in us refusing to
     /// compute their merkle roots.
     ///
-    /// Also returns `None` if the `alloc` feature is disabled and `iter` has more than
+    /// Also returns [`None`] if the `alloc` feature is disabled and `iter` has more than
     /// 32,767 transactions.
     ///
     /// Unless you are certain your transaction list is nonempty and has no duplicates,
-    /// you should not unwrap the `Option` returned by this method!
+    /// you should not unwrap the [`Option`] returned by this method!
     fn calculate_root<I: Iterator<Item = Self::Leaf>>(iter: I) -> Option<Self> {
         {
             #[cfg(feature = "alloc")]

--- a/primitives/src/opcodes.rs
+++ b/primitives/src/opcodes.rs
@@ -12,7 +12,7 @@ use core::fmt;
 
 /// A script opcode.
 ///
-/// We do not implement `Ord` on this type because there is no natural ordering on opcodes, but there
+/// We do not implement [`Ord`] on this type because there is no natural ordering on opcodes, but there
 /// may appear to be one (e.g. because all the push opcodes appear in a consecutive block) and we
 /// don't want to encourage subtly buggy code.
 ///
@@ -52,7 +52,7 @@ macro_rules! all_opcodes {
         /// Enables wildcard imports to bring into scope all opcodes and nothing else.
         ///
         /// The `all` module is provided so one can use a wildcard import `use primitives::opcodes::all::*`
-        /// to get all the `OP_FOO` opcodes without getting other types defined in `opcodes` (e.g. `Opcode`).
+        /// to get all the `OP_FOO` opcodes without getting other types defined in `opcodes` (e.g. [`Opcode`](crate::opcodes::Opcode)).
         ///
         /// This module is guaranteed to never contain anything except opcode constants and all opcode
         /// constants are guaranteed to begin with `OP_`.

--- a/primitives/src/script/borrowed.rs
+++ b/primitives/src/script/borrowed.rs
@@ -29,13 +29,13 @@ crate::transparent_newtype! {
     ///
     /// *[See also the `bitcoin::script` module](super).*
     ///
-    /// `Script` is a script slice, the most primitive script type. It's usually seen in its borrowed
+    /// [`Script`] is a script slice, the most primitive script type. It's usually seen in its borrowed
     /// form `&Script`. It is always encoded as a series of bytes representing the opcodes and data
     /// pushes.
     ///
     /// # Validity
     ///
-    /// `Script` does not have any validity invariants - it's essentially just a marked slice of
+    /// [`Script`] does not have any validity invariants - it's essentially just a marked slice of
     /// bytes. This is similar to [`Path`](std::path::Path) vs [`OsStr`](std::ffi::OsStr) where they
     /// are trivially cast-able to each-other and `Path` doesn't guarantee being a usable FS path but
     /// having a newtype still has value because of added methods, readability and basic type checking.
@@ -81,10 +81,10 @@ crate::transparent_newtype! {
     pub struct Script<T>(PhantomData<T>, [u8]);
 
     impl<T> Script<T> {
-        /// Treat byte slice as `Script`
+        /// Treat byte slice as [`Script`]
         pub const fn from_bytes(bytes: &_) -> &Self;
 
-        /// Treat mutable byte slice as `Script`
+        /// Treat mutable byte slice as [`Script`]
         pub fn from_bytes_mut(bytes: &mut _) -> &mut Self;
 
         pub(crate) fn from_boxed_bytes(bytes: Box<_>) -> Box<Self>;

--- a/primitives/src/script/builder.rs
+++ b/primitives/src/script/builder.rs
@@ -10,7 +10,7 @@ use crate::prelude::Vec;
 ///
 /// # Panics
 ///
-/// `Builder` is backed by [`ScriptBuf`] and inherits its panic behavior. This means that
+/// [`Builder`] is backed by [`ScriptBuf`] and inherits its panic behavior. This means that
 /// attempting to construct scripts larger than `isize::MAX` bytes will panic.
 #[derive(PartialEq, Eq, Clone)]
 pub struct Builder<T>(ScriptBuf<T>);
@@ -55,7 +55,7 @@ impl<T> Builder<T> {
         self
     }
 
-    /// Converts the `Builder` into `ScriptBuf`.
+    /// Converts the [`Builder`] into [`ScriptBuf`].
     pub fn into_script(self) -> ScriptBuf<T> { self.0 }
 
     /// Returns the internal script

--- a/primitives/src/script/mod.rs
+++ b/primitives/src/script/mod.rs
@@ -448,7 +448,7 @@ impl<T: PartialOrd> PartialOrd<ScriptBuf<T>> for Script<T> {
 
 #[cfg(feature = "serde")]
 impl<T> serde::Serialize for Script<T> {
-    /// User-facing serialization for `Script`.
+    /// User-facing serialization for [`Script`].
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,

--- a/primitives/src/script/owned.rs
+++ b/primitives/src/script/owned.rs
@@ -17,11 +17,11 @@ use crate::ScriptPubKeyBuf;
 
 /// An owned, growable script.
 ///
-/// `ScriptBuf` is the most common script type that has the ownership over the contents of the
+/// [`ScriptBuf`] is the most common script type that has the ownership over the contents of the
 /// script. It has a close relationship with its borrowed counterpart, [`Script`].
 ///
 /// Just as other similar types, this implements [`Deref`], so [deref coercions] apply. Also note
-/// that all the safety/validity restrictions that apply to [`Script`] apply to `ScriptBuf` as well.
+/// that all the safety/validity restrictions that apply to [`Script`] apply to [`ScriptBuf`] as well.
 ///
 /// # Hexadecimal strings
 ///
@@ -36,7 +36,7 @@ use crate::ScriptPubKeyBuf;
 ///
 /// # Panics
 ///
-/// `ScriptBuf` is backed by [`Vec`] and inherits its panic behavior. This means that attempting to
+/// [`ScriptBuf`] is backed by [`Vec`] and inherits its panic behavior. This means that attempting to
 /// construct scripts larger than `isize::MAX` bytes will panic.
 #[derive(Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct ScriptBuf<T>(PhantomData<T>, Vec<u8>);
@@ -71,7 +71,7 @@ impl<T> ScriptBuf<T> {
     /// Constructs a new [`ScriptBuf`] from a hex string.
     ///
     /// This is **not** consensus encoding. If your hex string is a consensus encoded script
-    /// then use `ScriptBuf::from_hex_prefixed`.
+    /// then use [`ScriptBuf::from_hex_prefixed`].
     ///
     /// There is no script decoding error path because what ever is in the hex input string is
     /// assumed to be the script. This means if you pass a consensus encoded hex string into this
@@ -104,7 +104,7 @@ impl<T> ScriptBuf<T> {
     #[inline]
     pub fn into_bytes(self) -> Vec<u8> { self.1 }
 
-    /// Converts this `ScriptBuf` into a [boxed](Box) [`Script`].
+    /// Converts this [`ScriptBuf`] into a [boxed](Box) [`Script`].
     ///
     /// This method reallocates if the capacity is greater than length of the script but should not
     /// when they are equal. If you know beforehand that you need to create a script of exact size
@@ -226,7 +226,7 @@ impl<T> ScriptBuf<T> {
 
     /// Pretends to convert `&mut ScriptBuf` to `&mut Vec<u8>` so that it can be modified.
     ///
-    /// Note: if the returned value leaks the original `ScriptBuf` will become empty.
+    /// Note: if the returned value leaks the original [`ScriptBuf`] will become empty.
     fn as_byte_vec(&mut self) -> ScriptBufAsVec<'_, T> {
         let vec = core::mem::take(self).into_bytes();
         ScriptBufAsVec(self, vec)

--- a/primitives/src/script/push_bytes.rs
+++ b/primitives/src/script/push_bytes.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! Contains `PushBytes` & co
+//! Contains [`PushBytes`] & co
 
 #[cfg(feature = "alloc")]
 use alloc::borrow::ToOwned as _;
@@ -198,16 +198,16 @@ mod primitive {
         71, 72, 73, 74, 75, 76
     }
 
-    /// Owned, growable counterpart to `PushBytes`.
+    /// Owned, growable counterpart to [`PushBytes`].
     #[derive(Default, Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
     pub struct PushBytesBuf(Vec<u8>);
 
     impl PushBytesBuf {
-        /// Constructs an empty `PushBytesBuf`.
+        /// Constructs an empty [`PushBytesBuf`].
         #[inline]
         pub const fn new() -> Self { Self(Vec::new()) }
 
-        /// Constructs an empty `PushBytesBuf` with reserved capacity.
+        /// Constructs an empty [`PushBytesBuf`] with reserved capacity.
         pub fn with_capacity(capacity: usize) -> Self { Self(Vec::with_capacity(capacity)) }
 
         /// Reserve capacity for `additional_capacity` bytes.
@@ -228,7 +228,7 @@ mod primitive {
             Ok(())
         }
 
-        /// Try appending a slice to `PushBytesBuf`
+        /// Try appending a slice to [`PushBytesBuf`]
         ///
         /// # Errors
         ///
@@ -257,13 +257,13 @@ mod primitive {
         /// Remove bytes from buffer past `len`.
         pub fn truncate(&mut self, len: usize) { self.0.truncate(len) }
 
-        /// Extracts `PushBytes` slice
+        /// Extracts [`PushBytes`] slice
         pub fn as_push_bytes(&self) -> &PushBytes {
             // length guaranteed by our invariant
             PushBytes::from_slice_unchecked(&self.0)
         }
 
-        /// Extracts mutable `PushBytes` slice
+        /// Extracts mutable [`PushBytes`] slice
         pub fn as_mut_push_bytes(&mut self) -> &mut PushBytes {
             // length guaranteed by our invariant
             PushBytes::from_mut_slice_unchecked(&mut self.0)
@@ -372,9 +372,9 @@ crate::impl_asref_push_bytes! {
     hashes::sha256d::Hash,
 }
 
-/// Reports information about failed conversion into `PushBytes`.
+/// Reports information about failed conversion into [`PushBytes`].
 ///
-/// This should not be needed by general public, except as an additional bound on `TryFrom` when
+/// This should not be needed by general public, except as an additional bound on [`TryFrom`] when
 /// converting to `WitnessProgram`.
 pub trait PushBytesErrorReport: sealed::Sealed {
     /// How many bytes the input had.
@@ -399,7 +399,9 @@ pub use error::PushBytesError;
 mod error {
     use core::fmt;
 
-    /// Error returned on attempt to create too large `PushBytes`.
+    /// Error returned on attempt to create too large [`PushBytes`].
+    ///
+    /// [`PushBytes`]: super::PushBytes
     #[allow(unused)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct PushBytesError {
@@ -422,7 +424,9 @@ mod error {
 mod error {
     use core::fmt;
 
-    /// Error returned on attempt to create too large `PushBytes`.
+    /// Error returned on attempt to create too large [`PushBytes`].
+    ///
+    /// [`PushBytes`]: super::PushBytes
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct PushBytesError {
         /// How long the input was.

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -329,7 +329,7 @@ fn hash_transaction(tx: &Transaction, uses_segwit_serialization: bool) -> sha256
     let input_len = tx.inputs.len();
     enc.input(crate::compact_size_encode(input_len).as_slice());
     for input in &tx.inputs {
-        // Encode each input same as we do in `Encodable for TxIn`.
+        // Encode each input same as we do in `Encode for TxIn`.
         enc.input(input.previous_output.txid.as_byte_array());
         enc.input(&input.previous_output.vout.to_le_bytes());
 
@@ -344,7 +344,7 @@ fn hash_transaction(tx: &Transaction, uses_segwit_serialization: bool) -> sha256
     let output_len = tx.outputs.len();
     enc.input(crate::compact_size_encode(output_len).as_slice());
     for output in &tx.outputs {
-        // Encode each output same as we do in `Encodable for TxOut`.
+        // Encode each output same as we do in `Encode for TxOut`.
         enc.input(&output.amount.to_sat().to_le_bytes());
 
         let script_pubkey_bytes = output.script_pubkey.as_bytes();
@@ -355,7 +355,7 @@ fn hash_transaction(tx: &Transaction, uses_segwit_serialization: bool) -> sha256
     if uses_segwit_serialization {
         // BIP-0141 (SegWit) transaction serialization also includes the witness data.
         for input in &tx.inputs {
-            // Same as `Encodable for Witness`.
+            // Same as `Encode for Witness`.
             enc.input(crate::compact_size_encode(input.witness.len()).as_slice());
             for element in &input.witness {
                 enc.input(crate::compact_size_encode(element.len()).as_slice());
@@ -364,7 +364,7 @@ fn hash_transaction(tx: &Transaction, uses_segwit_serialization: bool) -> sha256
         }
     }
 
-    // Same as `Encodable for absolute::LockTime`.
+    // Same as `Encode for absolute::LockTime`.
     enc.input(&tx.lock_time.to_consensus_u32().to_le_bytes());
 
     sha256d::Hash::from_engine(enc)
@@ -777,9 +777,9 @@ pub struct TxIn {
     pub sequence: Sequence,
     /// Witness data: an array of byte-arrays.
     /// Note that this field is *not* (de)serialized with the rest of the [`TxIn`] in
-    /// Encodable/Decodable, as it is (de)serialized at the end of the full
-    /// [`Transaction`]. It *is* (de)serialized with the rest of the [`TxIn`] in other
-    /// (de)serialization routines.
+    /// [`Encode`](encoding::Encode)/[`Decode`](encoding::Decode), as it is (de)serialized at the
+    /// end of the full [`Transaction`]. It *is* (de)serialized with the rest of the [`TxIn`] in
+    /// other (de)serialization routines.
     pub witness: Witness,
 }
 

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -114,11 +114,11 @@ pub use crate::hash_types::{BlockHashDecoder, Ntxid, Txid, Wtxid};
 ///
 /// # A note on ordering
 ///
-/// This type implements `Ord`, even though it contains a locktime, which is not
-/// itself `Ord`. This was done to simplify applications that may need to hold
+/// This type implements [`Ord`], even though it contains a locktime, which is not
+/// itself [`Ord`]. This was done to simplify applications that may need to hold
 /// transactions inside a sorted container. We have ordered the locktimes based
 /// on their representation as a `u32`, which is not a semantically meaningful
-/// order, and therefore the ordering on `Transaction` itself is not semantically
+/// order, and therefore the ordering on [`Transaction`] itself is not semantically
 /// meaningful either.
 ///
 /// The ordering is, however, consistent with the ordering present in this library
@@ -297,7 +297,7 @@ impl From<&Transaction> for Wtxid {
     fn from(tx: &Transaction) -> Self { tx.compute_wtxid() }
 }
 
-/// Trait that abstracts over a transaction identifier i.e., `Txid` and `Wtxid`.
+/// Trait that abstracts over a transaction identifier i.e., [`Txid`] and [`Wtxid`].
 pub(crate) trait TxIdentifier: AsRef<[u8]> {}
 
 impl TxIdentifier for Txid {}
@@ -776,9 +776,9 @@ pub struct TxIn {
     /// the miner behavior cannot be enforced.
     pub sequence: Sequence,
     /// Witness data: an array of byte-arrays.
-    /// Note that this field is *not* (de)serialized with the rest of the `TxIn` in
+    /// Note that this field is *not* (de)serialized with the rest of the [`TxIn`] in
     /// Encodable/Decodable, as it is (de)serialized at the end of the full
-    /// Transaction. It *is* (de)serialized with the rest of the `TxIn` in other
+    /// [`Transaction`]. It *is* (de)serialized with the rest of the [`TxIn`] in other
     /// (de)serialization routines.
     pub witness: Witness,
 }
@@ -937,7 +937,7 @@ impl OutPoint {
     /// The number of bytes that an outpoint contributes to the size of a transaction.
     pub const SIZE: usize = 32 + 4; // The serialized lengths of txid and vout.
 
-    /// The `OutPoint` used in a coinbase prevout.
+    /// The [`OutPoint`] used in a coinbase prevout.
     ///
     /// This is used as the dummy input for coinbase transactions because they don't have any
     /// previous outputs. In other words, does not point to a real transaction.
@@ -1180,7 +1180,7 @@ impl Version {
     #[inline]
     pub const fn maybe_non_standard(version: u32) -> Self { Self(version) }
 
-    /// Returns the inner `u32` value of this `Version`.
+    /// Returns the inner `u32` value of this [`Version`].
     #[inline]
     pub const fn to_u32(self) -> u32 { self.0 }
 
@@ -1277,7 +1277,7 @@ pub mod error {
     #[cfg(feature = "alloc")]
     use crate::witness::WitnessDecoderError;
 
-    /// An error consensus decoding a `Transaction`.
+    /// An error consensus decoding a [`Transaction`](super::Transaction).
     #[cfg(feature = "alloc")]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct TransactionDecoderError(pub(super) TransactionDecoderErrorInner);
@@ -1377,7 +1377,7 @@ pub mod error {
         }
     }
 
-    /// An error consensus decoding a `TxIn`.
+    /// An error consensus decoding a [`TxIn`](super::TxIn).
     #[cfg(feature = "alloc")]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct TxInDecoderError(pub(super) <super::TxInInnerDecoder as encoding::Decoder>::Error);
@@ -1400,7 +1400,7 @@ pub mod error {
         fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
     }
 
-    /// An error consensus decoding a `TxOut`.
+    /// An error consensus decoding a [`TxOut`](super::TxOut).
     #[cfg(feature = "alloc")]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct TxOutDecoderError(pub(super) <super::TxOutInnerDecoder as encoding::Decoder>::Error);
@@ -1422,7 +1422,7 @@ pub mod error {
         fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
     }
 
-    /// Error while decoding an `OutPoint`.
+    /// Error while decoding an [`OutPoint`].
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct OutPointDecoderError(pub(super) encoding::UnexpectedEofError);
 
@@ -1492,7 +1492,7 @@ pub mod error {
         }
     }
 
-    /// An error consensus decoding a `Version`.
+    /// An error consensus decoding a [`Version`](super::Version).
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct VersionDecoderError(pub(super) encoding::UnexpectedEofError);
 

--- a/primitives/src/witness.rs
+++ b/primitives/src/witness.rs
@@ -46,17 +46,17 @@ const MAX_WITNESS_ITEM_SIZE: usize = 4_000_000;
 
 /// The Witness is the data used to unlock bitcoin since the [SegWit upgrade].
 ///
-/// Can be logically seen as an array of bytestrings, i.e. `Vec<Vec<u8>>`, and it is serialized on the wire
-/// in that format. You can convert between this type and `Vec<Vec<u8>>` by using [`Witness::from_slice`]
+/// Can be logically seen as an array of bytestrings, i.e. [`Vec<Vec<u8>>`], and it is serialized on the wire
+/// in that format. You can convert between this type and [`Vec<Vec<u8>>`] by using [`Witness::from_slice`]
 /// and [`Witness::to_vec`].
 ///
-/// For serialization and deserialization performance it is stored internally as a single `Vec`,
+/// For serialization and deserialization performance it is stored internally as a single [`Vec`],
 /// saving some allocations.
 ///
 /// [SegWit upgrade]: <https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki>
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Witness {
-    /// Contains the witness `Vec<Vec<u8>>` serialization.
+    /// Contains the witness [`Vec<Vec<u8>>`] serialization.
     ///
     /// Does not include the initial length prefix indicating the number of elements. Each element
     /// however, does include a [`CompactSize`] indicating the element length. The number of
@@ -198,7 +198,7 @@ impl Witness {
     ///
     /// `index` is 0-based from the end, where 0 is the last element, 1 is the second-to-last, etc.
     ///
-    /// Returns `None` if the requested index is beyond the witness's elements.
+    /// Returns [`None`] if the requested index is beyond the witness's elements.
     ///
     /// # Examples
     /// ```


### PR DESCRIPTION
According to the C-LINK API guideline, docs should make use of links to reference functions and types throughout, as this allows users to quickly click-through to the referenced function/type. During this change, the old encoding trait names should be changed so that they can be linked.

Wrap backticked types and functions as links throughout.
Replace old encoding trait names with renamed versions in docs and comments.