### PR TITLE
ci: add corpus based fuzzing

### DIFF
--- a/.github/workflows/ci-failure-issues.yml
+++ b/.github/workflows/ci-failure-issues.yml
@@ -4,6 +4,7 @@ on:
   workflow_run:  # zizmor: ignore[dangerous-triggers]
     workflows:
       - Fuzz (from scratch)
+      - Fuzz (corpus)
       - Kani CI
       - Miri
     types:
@@ -32,6 +33,7 @@ jobs:
             const marker = `<!-- ci-failure-key:${workflow} -->`;
             const workflowFiles = {
               "Fuzz (from scratch)": "cron-daily-fuzz.yml",
+              "Fuzz (corpus)": "corpus-fuzzing.yml",
               "Kani CI": "cron-daily-kani.yml",
               "Miri": "cron-daily-miri.yml",
             };

--- a/.github/workflows/corpus-fuzzing.yml
+++ b/.github/workflows/corpus-fuzzing.yml
@@ -104,6 +104,17 @@ jobs:
           name: corpus-${{ matrix.fuzz_target }}
           path: rust-bitcoin/fuzz/corpus/${{ matrix.fuzz_target }}
           if-no-files-found: warn
+      - name: Report crashes
+        if: failure()
+        working-directory: rust-bitcoin
+        run: ./fuzz/report-crashes.sh "crash-$TARGET"
+      - name: Upload crash artifacts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: crash-${{ matrix.fuzz_target }}
+          path: rust-bitcoin/fuzz/artifacts/${{ matrix.fuzz_target }}
+          if-no-files-found: ignore
 
   # Merges the corpus of each target back into the qa-assets repository.
   merge:

--- a/.github/workflows/corpus-fuzzing.yml
+++ b/.github/workflows/corpus-fuzzing.yml
@@ -1,0 +1,142 @@
+# Fuzz every target seeded from its corpus stored in rust-bitcoin/qa-assets.
+# Output gets minimized and pushed back to the origin repository.
+name: Fuzz (corpus)
+
+on:
+  schedule:
+    # 5am every day UTC
+    - cron: "00 05 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+env:
+  CARGO_FUZZ_VERSION: 0.13.2
+
+# Prevents race on the final push
+concurrency:
+  group: update-corpora
+  cancel-in-progress: false
+
+jobs:
+  setup:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      targets: ${{ steps.list.outputs.targets }}
+      source_sha: ${{ steps.list.outputs.source_sha }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: master
+          persist-credentials: false
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cargo/bin/cargo-fuzz
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
+          key: cargo-fuzz-${{ env.CARGO_FUZZ_VERSION }}
+      - name: Install cargo-fuzz
+        run: cargo install --locked --version "$CARGO_FUZZ_VERSION" cargo-fuzz
+      - name: List fuzz targets
+        id: list
+        run: |
+          echo "targets=$(cd fuzz && cargo fuzz list | jq -R . | jq -cs .)" >> "$GITHUB_OUTPUT"
+          echo "source_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+  fuzz:
+    needs: setup
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        fuzz_target: ${{ fromJSON(needs.setup.outputs.targets) }}
+    env:
+      TARGET: ${{ matrix.fuzz_target }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ github.repository_owner }}/qa-assets
+          persist-credentials: false
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.setup.outputs.source_sha }}
+          path: rust-bitcoin
+          persist-credentials: false
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
+            rust-bitcoin/fuzz/target
+            rust-bitcoin/target
+          # cached cargo-rbmt binary goes stale when it is bumped.
+          key: fuzz-${{ hashFiles('rust-bitcoin/**/Cargo.toml', 'rust-bitcoin/rbmt-version') }}
+          # On cache miss this loads the latest cache and avoids a rebuild from scratch.
+          restore-keys: fuzz-
+      - name: Install cargo-rbmt
+        working-directory: rust-bitcoin
+        run: |
+          cargo install \
+            --git https://git.rust-bitcoin.org/rust-bitcoin/rust-bitcoin-maintainer-tools \
+            --rev "$(cat rbmt-version)" \
+            cargo-rbmt \
+            --locked
+      - name: Install nightly toolchain
+        working-directory: rust-bitcoin
+        run: rustup toolchain install "$(cargo rbmt toolchains --nightly)" --profile minimal --no-self-update
+      - name: Install cargo-fuzz
+        run: cargo install --locked --version "$CARGO_FUZZ_VERSION" cargo-fuzz
+      - name: Seed corpus
+        run: rust-bitcoin/fuzz/corpora.sh seed . "$TARGET"
+      - name: Fuzz
+        working-directory: rust-bitcoin/fuzz
+        run: ./fuzz.sh "$TARGET" -max_total_time=300 # 5 minutes per target
+      # Only successful inputs reach fuzz_corpora.
+      - name: Upload corpus
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: corpus-${{ matrix.fuzz_target }}
+          path: rust-bitcoin/fuzz/corpus/${{ matrix.fuzz_target }}
+          if-no-files-found: warn
+
+  # Merges the corpus of each target back into the qa-assets repository.
+  merge:
+    needs: [setup, fuzz]
+    if: ${{ always() && needs.setup.result == 'success' && needs.fuzz.result != 'cancelled' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ github.repository_owner }}/qa-assets
+          token: ${{ secrets.QA_ASSETS_PUSH_TOKEN || github.token }}
+          persist-credentials: true # zizmor: ignore[artipacked] the push step uses this credential
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: rust-bitcoin
+          persist-credentials: false
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        continue-on-error: true
+        with:
+          pattern: corpus-*
+          path: incoming
+      - name: Refresh corpora
+        env:
+          TARGETS: ${{ needs.setup.outputs.targets }}
+        run: |
+          echo "$TARGETS" | jq -r '.[]' > "$RUNNER_TEMP/targets.txt"
+          rust-bitcoin/fuzz/corpora.sh refresh incoming "$RUNNER_TEMP/targets.txt"
+      - name: Commit and push
+        env:
+          QA_ASSETS_PUSH_TOKEN: ${{ secrets.QA_ASSETS_PUSH_TOKEN }}
+          SOURCE: ${{ github.repository }}@${{ needs.setup.outputs.source_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          BRANCH: master
+        run: rust-bitcoin/fuzz/corpora.sh push

--- a/fuzz/corpora.sh
+++ b/fuzz/corpora.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+# Manage the shared fuzz corpora stored in the qa-assets repository.
+#
+# Usage: corpora.sh {seed QA_DIR TARGET | refresh INCOMING_DIR TARGETS_FILE | push}
+#
+# Commands:
+#   seed     Copy a target's stored corpus into fuzz/corpus.
+#   refresh  Replace each stored corpus with the one under INCOMING_DIR and drop
+#            targets not listed in TARGETS_FILE.
+#   push     CI only, not meant to be run locally. Commit and push to
+#            qa-assets. Reads QA_ASSETS_PUSH_TOKEN, SOURCE, RUN_URL and
+#            BRANCH from the environment.
+
+set -euo pipefail
+
+usage="Usage: $0 {seed QA_DIR TARGET | refresh INCOMING_DIR TARGETS_FILE | push}"
+
+seed() {
+  local qa="${1:?$usage}" target="${2:?$usage}"
+  local corpus
+  corpus="$(dirname "$0")/corpus/$target"
+  mkdir -p "$corpus"
+  if [ -d "$qa/fuzz_corpora/$target" ]; then
+    find "$qa/fuzz_corpora/$target" -maxdepth 1 -type f -exec cp -t "$corpus/" {} +
+  fi
+}
+
+refresh() {
+  local incoming="${1:?$usage}" targets_file="${2:?$usage}"
+  local dir name
+  mkdir -p fuzz_corpora "$incoming"
+  for dir in "$incoming"/corpus-*/; do
+    [ -d "$dir" ] || continue # skip on empty corpora, string expansion yields literal pattern
+    name=$(basename "$dir")
+    name=${name#corpus-}
+    rm -rf "fuzz_corpora/$name"
+    mkdir -p "fuzz_corpora/$name"
+    find "$dir" -maxdepth 1 -type f -exec cp -t "fuzz_corpora/$name/" {} +
+  done
+  for dir in fuzz_corpora/*/; do
+    [ -d "$dir" ] || continue
+    name=$(basename "$dir")
+    grep -qx "$name" "$targets_file" || rm -rf "$dir" # drop targets that no longer exist upstream
+  done
+}
+
+push() {
+  git add -A fuzz_corpora
+  if git diff --cached --quiet; then
+    echo "No corpus changes"
+    exit 0
+  fi
+  if [ -z "${QA_ASSETS_PUSH_TOKEN:-}" ]; then
+    echo "::error::QA_ASSETS_PUSH_TOKEN is not set, refusing to drop the corpus updates"
+    exit 1
+  fi
+  git config user.name "github-actions[bot]"
+  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+  git commit -m "Update fuzz corpora" \
+    -m "Source: $SOURCE" \
+    -m "Run: $RUN_URL"
+  # try to push three times, rebasing on the remote branch if we race with it
+  for _ in 1 2 3; do
+    git push origin "HEAD:$BRANCH" && exit 0
+    git pull --rebase origin "$BRANCH"
+  done
+  exit 1
+}
+
+export LC_ALL=C
+cmd="${1:?$usage}"
+shift
+case "$cmd" in
+  seed | refresh | push) "$cmd" "$@" ;;
+  *)
+    echo "$usage" >&2
+    exit 2
+    ;;
+esac

--- a/fuzz/report-crashes.sh
+++ b/fuzz/report-crashes.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Report every crash input under fuzz/artifacts.
+
+set -euo pipefail
+
+artifact_name="${1:?Usage: $0 ARTIFACT_NAME}"
+summary="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
+
+cd "$(git rev-parse --show-toplevel)"
+
+found=0
+for tdir in fuzz/artifacts/*/; do
+  [ -d "$tdir" ] || continue
+  target=$(basename "$tdir")
+  for f in "$tdir"*; do
+    [ -f "$f" ] || continue
+    found=1
+    name=$(basename "$f")
+    size=$(wc -c < "$f")
+    {
+      echo "## Fuzz crash: $target"
+      echo ""
+      echo "\`$name\` ($size bytes)"
+      echo ""
+      if [ "$size" -gt 1024 ]; then
+        echo "First 1024 bytes:"
+        echo ""
+      fi
+      echo '```'
+      xxd -l 1024 "$f"
+      echo '```'
+      echo ""
+      if [ "$size" -le 65536 ]; then
+        echo "Reproduce locally (base64 of the full input):"
+        echo ""
+        echo '```'
+        base64 -w0 "$f"
+        echo ""
+        echo '```'
+        echo ""
+      else
+        echo "Input too large to inline, grab it from the $artifact_name artifact."
+        echo ""
+      fi
+      echo '```sh'
+      if [[ "$target" != hashes_* ]]; then
+        echo 'export RUSTFLAGS="--cfg=hashes_fuzz --cfg=secp256k1_fuzz"'
+      fi
+      echo "base64 -d > crash <<'EOF' # paste the base64 line above in terminal"
+      echo "EOF"
+      echo "cargo +nightly fuzz run $target crash"
+      echo '```'
+      echo ""
+    } >> "$summary"
+    echo "::error title=Fuzz crash in $target::$name ($size bytes), read the job summary github page for reproduction instructions"
+  done
+done
+
+if [ "$found" = 0 ]; then
+  echo "::error title=Fuzz failure::job failed without producing a crash artifact"
+fi


### PR DESCRIPTION
Closes https://github.com/rust-bitcoin/rust-bitcoin/issues/6511

Adds a new daily workflow that fuzzes every existing target, loading a fuzzing corpus from [qa-assets](https://github.com/rust-bitcoin/qa-assets) repo, and pushes back into the repo the updated fuzzing progress. The current daily fuzz job always starts from an empty corpus, meanwhile, a persisted one starts each run from the deepest coverage reached so far.

No changes are necessary in qa-assets repository. When this is merged, it should auto-start the process there. Tested in my own fork.

This change is orthogonal to existing fuzzing solution because it is in a probatory stage.

Commits:
- First commit is the job. 
- Second commit is issue creation based on fuzzing errors is separated so that it is easy to revert in case it becomes cumbersome for any reason.
- Third commit is a script created to report crashes conveniently in the CI job. It reports a hex dump plus repro steps. It is entirely optional but convenient, so I left it isolated at tip.

This is the first PR in a 3- or 4-part series, establishing the base for follow-ups such as: saving every fuzzing error in corpus, then replaying the corpus on PR CI to catch regressions (I'll create issue after I see how this solution behaves). Also, in the motivating issue, we may merge/replace existing daily fuzzing without a corpus if this fuzzing system proves itself.
