### PR TITLE
primitives: Add Arbitrary impl for Opcode

### DIFF
--- a/primitives/api/all-features.txt
+++ b/primitives/api/all-features.txt
@@ -1791,6 +1791,8 @@ impl core::hash::Hash for bitcoin_primitives::opcodes::Opcode
   pub fn bitcoin_primitives::opcodes::Opcode::hash<__H: core::hash::Hasher>(&self, state: &mut __H) [impl: impl core::hash::Hash for bitcoin_primitives::opcodes::Opcode]
 impl core::marker::Copy for bitcoin_primitives::opcodes::Opcode
 impl core::marker::StructuralPartialEq for bitcoin_primitives::opcodes::Opcode
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::opcodes::Opcode
+  pub fn bitcoin_primitives::opcodes::Opcode::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self> [impl: impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::opcodes::Opcode]
 impl core::marker::Freeze for bitcoin_primitives::opcodes::Opcode
 impl core::marker::Send for bitcoin_primitives::opcodes::Opcode
 impl core::marker::Sync for bitcoin_primitives::opcodes::Opcode

--- a/primitives/src/opcodes.rs
+++ b/primitives/src/opcodes.rs
@@ -10,6 +10,9 @@
 #[cfg(feature = "alloc")]
 use core::fmt;
 
+#[cfg(feature = "arbitrary")]
+use arbitrary::{Arbitrary, Unstructured};
+
 /// A script opcode.
 ///
 /// We do not implement `Ord` on this type because there is no natural ordering on opcodes, but there
@@ -275,6 +278,13 @@ pub(crate) fn fmt_opcode(op: u8, f: &mut fmt::Formatter) -> fmt::Result {
         0xba => f.write_str("OP_CHECKSIGADD"),
         0xbb..=0xfe => write!(f, "OP_RETURN_{}", op),
         0xff => f.write_str("OP_INVALIDOPCODE"),
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> Arbitrary<'a> for Opcode {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Self::from_u8(u8::arbitrary(u)?))
     }
 }
 


### PR DESCRIPTION
Returns a 'arbitrary' opcode, not an 'arbitrary valid' opcode.
