### PR TITLE
docs: add Amount parsing and formatting example

### DIFF
--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -36,6 +36,10 @@ serde_json = "1.0.68"
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
+[[example]]
+name = "amount_parsing_formatting"
+required-features = ["alloc"]
+
 [lints]
 workspace = true
 

--- a/units/examples/amount_parsing_formatting.rs
+++ b/units/examples/amount_parsing_formatting.rs
@@ -1,0 +1,14 @@
+//! Parse an [`Amount`] from a string and format it in different denominations.
+
+use bitcoin_units::{amount::Denomination, Amount};
+
+fn main() -> Result<(), bitcoin_units::amount::ParseError> {
+    let amount = "0.1 BTC".parse::<Amount>()?;
+    assert_eq!(amount.to_sat(), 10_000_000);
+
+    assert_eq!(amount.to_string_in(Denomination::Bitcoin), "0.1");
+    assert_eq!(amount.to_string_with_denomination(Denomination::Satoshi), "10000000 sat");
+
+    println!("{amount}");
+    Ok(())
+}


### PR DESCRIPTION
## Issue

Closes part of #4694. The units 1.0.0 cookbook did not show how to parse a human-readable Bitcoin amount or format an Amount in an explicitly selected denomination.

## Fix

- Add a runnable `units/examples/amount_parsing_formatting.rs` example.
- Demonstrate parsing `0.1 BTC`, converting to satoshis, and formatting with and without a denomination.
- Declare the example's `alloc` feature requirement so it is excluded from the repository's no-alloc test matrix while remaining covered by normal/default-feature builds.

The corresponding cookbook entry is proposed in rust-bitcoin/rust-bitcoin.github.io#47.

## Validation

- `cargo check -p bitcoin-units --example amount_parsing_formatting`
- `cargo check -p bitcoin-units --no-default-features --lib`