### PR TITLE
benches: update to use the new consensus_encoding

### DIFF
--- a/benches/bitcoin/block.rs
+++ b/benches/bitcoin/block.rs
@@ -5,12 +5,11 @@ use std::hint::black_box;
 
 use bitcoin::block::Header;
 use bitcoin::blockdata::block::Block;
-use bitcoin::consensus::{deserialize, serialize, Decodable, Encodable};
 use bitcoin::io::sink;
 use bitcoin::script::{ScriptPubKeyBuf, ScriptSigBuf};
 use bitcoin::transaction::{OutPoint, Transaction, TxIn, TxOut, Version};
 use bitcoin::{Amount, BlockTime, CompactTarget, Sequence, TxMerkleNode, Witness};
-use encoding::decode_from_slice;
+use encoding::{decode_from_read, decode_from_slice, encode_to_vec, encode_to_writer};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 
 
@@ -54,13 +53,13 @@ fn build_test_block(num_tx: usize) -> Vec<u8> {
         nonce: 0,
     };
 
-    serialize(&Block::new_unchecked(header, txs))
+    encode_to_vec(&Block::new_unchecked(header, txs))
 }
 
 fn bench_block(c: &mut Criterion) {
     let raw_block = include_bytes!("../../bitcoin/tests/data/mainnet_block_000000000000000000000c835b2adcaedc20fdf6ee440009c249452c726dafae.raw");
     assert_eq!(raw_block.len(), 1_381_836);
-    let block: Block = deserialize(&raw_block[..]).unwrap();
+    let block: Block = decode_from_slice(&raw_block[..]).unwrap();
 
     let mut g = c.benchmark_group("block");
     g.throughput(Throughput::Bytes(raw_block.len() as u64));
@@ -70,7 +69,7 @@ fn bench_block(c: &mut Criterion) {
         let big_block = black_box(raw_block.as_ref());
         b.iter(|| {
             let mut reader = big_block;
-            let blk = Block::consensus_decode(&mut reader).unwrap();
+            let blk: Block = decode_from_read(&mut reader).unwrap();
             black_box(blk);
         });
     });
@@ -78,7 +77,7 @@ fn bench_block(c: &mut Criterion) {
     g.bench_function(BenchmarkId::new("serialize", "big"), |b| {
         let mut data = Vec::with_capacity(raw_block.len());
         b.iter(|| {
-            let result = block.consensus_encode(&mut data);
+            let result = encode_to_writer(&block, &mut data);
             black_box(&result);
             data.clear();
         });
@@ -86,14 +85,14 @@ fn bench_block(c: &mut Criterion) {
 
     g.bench_function(BenchmarkId::new("serialize_logic", "big"), |b| {
         b.iter(|| {
-            let size = block.consensus_encode(&mut sink());
+            let size = encode_to_writer(&block, sink());
             let _ = black_box(size);
         });
     });
 
     g.bench_function(BenchmarkId::new("deserialize", "big"), |b| {
         b.iter(|| {
-            let blk: Block = deserialize(&raw_block[..]).unwrap();
+            let blk: Block = decode_from_slice(&raw_block[..]).unwrap();
             black_box(blk);
         });
     });

--- a/benches/bitcoin/transaction.rs
+++ b/benches/bitcoin/transaction.rs
@@ -4,9 +4,9 @@ use std::hint::black_box;
 
 use bitcoin::blockdata::transaction::Transaction;
 use bitcoin::blockdata::transaction::TransactionExt as _; // for total_size()
-use bitcoin::consensus::{encode, Encodable};
 use bitcoin::io::sink;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use encoding::{decode_from_hex, decode_from_slice, encode_to_writer};
 
 const SOME_TX: &str = "0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000";
 
@@ -14,26 +14,26 @@ fn bench_tx(c: &mut Criterion) {
     let mut g = c.benchmark_group("transaction");
 
     g.bench_function(BenchmarkId::new("size", "some"), |b| {
-        let mut tx: Transaction = encode::deserialize_hex(SOME_TX).unwrap();
+        let mut tx: Transaction = decode_from_hex(SOME_TX).unwrap();
         b.iter(|| {
             black_box(black_box(&mut tx).total_size());
         });
     });
 
     g.bench_function(BenchmarkId::new("serialize", "some"), |b| {
-        let tx: Transaction = encode::deserialize_hex(SOME_TX).unwrap();
+        let tx: Transaction = decode_from_hex(SOME_TX).unwrap();
         let mut data = Vec::with_capacity(SOME_TX.len() / 2);
         b.iter(|| {
-            let result = tx.consensus_encode(&mut data);
+            let result = encode_to_writer(&tx, &mut data);
             black_box(&result);
             data.clear();
         });
     });
 
     g.bench_function(BenchmarkId::new("serialize_logic", "some"), |b| {
-        let tx: Transaction = encode::deserialize_hex(SOME_TX).unwrap();
+        let tx: Transaction = decode_from_hex(SOME_TX).unwrap();
         b.iter(|| {
-            let size = tx.consensus_encode(&mut sink());
+            let size = encode_to_writer(&tx, sink());
             let _ = black_box(size);
         });
     });
@@ -41,14 +41,14 @@ fn bench_tx(c: &mut Criterion) {
     g.bench_function(BenchmarkId::new("deserialize", "raw_bytes"), |b| {
         let raw_tx = hex::hex!(SOME_TX);
         b.iter(|| {
-            let tx: Transaction = encode::deserialize(&raw_tx).unwrap();
+            let tx: Transaction = decode_from_slice(&raw_tx).unwrap();
             black_box(tx);
         });
     });
 
     g.bench_function(BenchmarkId::new("deserialize_hex", "string"), |b| {
         b.iter(|| {
-            let tx: Transaction = encode::deserialize_hex(SOME_TX).unwrap();
+            let tx: Transaction = decode_from_hex(SOME_TX).unwrap();
             black_box(tx);
         });
     });

--- a/benches/bitcoin/witness.rs
+++ b/benches/bitcoin/witness.rs
@@ -3,9 +3,8 @@
 use std::hint::black_box;
 
 use bitcoin::blockdata::witness::{Witness, WitnessDecoder};
-use bitcoin::consensus::encode;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use encoding::{decode_from_slice, Decoder as _};
+use encoding::{decode_from_slice, encode_to_vec, Decoder as _};
 
 fn bench_witness(c: &mut Criterion) {
     let mut g = c.benchmark_group("witness");
@@ -29,7 +28,7 @@ fn bench_witness(c: &mut Criterion) {
     // Many small elements (100 and 1000).
     for count in [100, 1000] {
         let witness = Witness::from_slice(&vec![vec![0u8; 4]; count]);
-        let bytes = encode::serialize(&witness);
+        let bytes = encode_to_vec(&witness);
         g.bench_with_input(BenchmarkId::new("many_elements", count), &bytes, |b, bytes| {
             b.iter(|| black_box(decode_from_slice::<Witness>(bytes).unwrap()));
         });
@@ -38,7 +37,7 @@ fn bench_witness(c: &mut Criterion) {
     // Single element of different sizes.
     for size in [64, 256, 1024, 2048, 4096] {
         let witness = Witness::from_slice(&[vec![0u8; size]]);
-        let bytes = encode::serialize(&witness);
+        let bytes = encode_to_vec(&witness);
         g.bench_with_input(BenchmarkId::new("one_element", size), &bytes, |b, bytes| {
             b.iter(|| black_box(decode_from_slice::<Witness>(bytes).unwrap()));
         });
@@ -46,7 +45,7 @@ fn bench_witness(c: &mut Criterion) {
 
     // 64 KB element fed in different chunk sizes.
     let witness = Witness::from_slice(&[vec![0u8; 65536]]);
-    let bytes = encode::serialize(&witness);
+    let bytes = encode_to_vec(&witness);
     for chunk in [1, 64, 256, 1024, 4096] {
         g.bench_with_input(BenchmarkId::new("chunk_64kb", chunk), &bytes, |b, bytes| {
             b.iter(|| black_box(decode_chunked(bytes, chunk)));


### PR DESCRIPTION
`bitcoin::consensus` module was removed but we forgot to update these benchmark to use the new consensus_encoding crate