### PR TITLE
ci: cache cargo install metadata in daily fuzz

### DIFF
--- a/.github/workflows/cron-daily-fuzz.yml
+++ b/.github/workflows/cron-daily-fuzz.yml
@@ -31,12 +31,13 @@ jobs:
         with:
           path: |
             ~/.cargo/bin
-            fuzz/target
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
             target
-          key: cache-fuzz-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+          key: cache-fuzz-v2-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
       - uses: ./.github/actions/setup-rbmt
       - name: Install cargo-fuzz
-        run: cargo install --locked --force --version 0.13.2 cargo-fuzz
+        run: cargo install --locked --version 0.13.2 cargo-fuzz
       - name: Fuzz shard ${{ matrix.shard_id }}
         working-directory: fuzz
         shell: bash


### PR DESCRIPTION
Closes https://github.com/rust-bitcoin/rust-bitcoin/issues/6727
Closes https://github.com/rust-bitcoin/rust-bitcoin/issues/6634
Closes https://github.com/rust-bitcoin/rust-bitcoin/issues/6783

[Fuzz job has been failing](https://github.com/rust-bitcoin/rust-bitcoin/actions/workflows/cron-daily-fuzz.yml). The cache did not save `.crates.toml` and `.crates2.json`. When cache hits, the rbmt install failed with error 'binary already exists in destination' because `cargo install` goes to write and finds files already sitting there with no database entry.

To ensure this fix is effective immediately, the key has been migrated to 'v2', entirely independent.

Tested in fork, first I ran this to generate cache: https://github.com/satsfy/rust-bitcoin/actions/runs/31741126469
Then I ran this, which leverages cache successfully: https://github.com/satsfy/rust-bitcoin/actions/runs/31741756971/job/94586598887#step:4:21, and the install log says "Ignored package `cargo-rbmt v0.4.1`" (upstream's current).

Why `.crates2.json`"? [Read this](https://doc.rust-lang.org/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci). We only needed these 2 folder to save state.