### PR TITLE
ci: rename daily fuzz job to 'Fuzz (from scratch)'

### DIFF
--- a/.github/workflows/ci-failure-issues.yml
+++ b/.github/workflows/ci-failure-issues.yml
@@ -3,7 +3,7 @@ name: CI Failure Issues
 on:
   workflow_run:  # zizmor: ignore[dangerous-triggers]
     workflows:
-      - Fuzz
+      - Fuzz (from scratch)
       - Kani CI
       - Miri
     types:
@@ -31,7 +31,7 @@ jobs:
             const workflow = run.name;
             const marker = `<!-- ci-failure-key:${workflow} -->`;
             const workflowFiles = {
-              "Fuzz": "cron-daily-fuzz.yml",
+              "Fuzz (from scratch)": "cron-daily-fuzz.yml",
               "Kani CI": "cron-daily-kani.yml",
               "Miri": "cron-daily-miri.yml",
             };

--- a/.github/workflows/cron-daily-fuzz.yml
+++ b/.github/workflows/cron-daily-fuzz.yml
@@ -1,6 +1,6 @@
 # Fuzz targets are distributed over a static number of jobs.
 
-name: Fuzz
+name: Fuzz (from scratch)
 on:
   schedule:
     # 5am every day UTC, this correlates to:


### PR DESCRIPTION
There was a legacy fuzz job named 'Fuzz' like the current master's daily fuzzing job. The actions page lists the two workflows as 'Fuzz'.

I propose we rename to `Fuzz (from scratch)` because https://github.com/rust-bitcoin/rust-bitcoin/pull/6729 will introduce yet another job called `Fuzz (corpus)`.

The change here is optional and not related to #6729 per se, so it is a separate PR.