### PR TITLE
units: Add and standardise doc and comment links

### DIFF
--- a/units/src/amount/error.rs
+++ b/units/src/amount/error.rs
@@ -475,7 +475,9 @@ impl std::error::Error for PossiblyConfusingDenominationError {
     }
 }
 
-/// An error consensus decoding an `Amount`.
+/// An error consensus decoding an [`Amount`].
+///
+/// [`Amount`]: super::Amount
 #[cfg(feature = "encoding")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AmountDecoderError(pub(super) AmountDecoderErrorInner);
@@ -488,7 +490,9 @@ impl AmountDecoderError {
         Self(AmountDecoderErrorInner::UnexpectedEof(e))
     }
 
-    /// Constructs an out of range (`Amount::from_sat`) error.
+    /// Constructs an out of range ([`Amount::from_sat`]) error.
+    ///
+    /// [`Amount::from_sat`]: super::Amount::from_sat
     #[inline]
     pub(super) fn out_of_range(e: OutOfRangeError) -> Self {
         Self(AmountDecoderErrorInner::OutOfRange(e))

--- a/units/src/amount/mod.rs
+++ b/units/src/amount/mod.rs
@@ -105,10 +105,10 @@ pub enum Denomination {
 }
 
 impl Denomination {
-    /// Convenience alias for `Denomination::Bitcoin`.
+    /// Convenience alias for [`Denomination::Bitcoin`].
     pub const BTC: Self = Self::Bitcoin;
 
-    /// Convenience alias for `Denomination::Satoshi`.
+    /// Convenience alias for [`Denomination::Satoshi`].
     pub const SAT: Self = Self::Satoshi;
 
     /// The number of decimal places more than a satoshi.
@@ -139,7 +139,7 @@ impl Denomination {
         }
     }
 
-    /// The different `str` forms of denominations that are recognized.
+    /// The different [`str`] forms of denominations that are recognized.
     #[inline]
     fn forms(s: &str) -> Option<Self> {
         match s {
@@ -156,7 +156,8 @@ impl Denomination {
 }
 
 /// These forms are ambiguous and could have many meanings. For example, M could denote Mega or Milli.
-/// If any of these forms are used, an error type `PossiblyConfusingDenomination` is returned.
+/// If any of these forms are used, an error type [`PossiblyConfusingDenominationError`] is
+/// returned.
 const CONFUSING_FORMS: [&str; 6] = ["CBTC", "Cbtc", "MBTC", "Mbtc", "UBTC", "Ubtc"];
 
 impl fmt::Display for Denomination {
@@ -167,7 +168,7 @@ impl fmt::Display for Denomination {
 impl FromStr for Denomination {
     type Err = ParseDenominationError;
 
-    /// Converts from a `str` to a `Denomination`.
+    /// Converts from a [`str`] to a [`Denomination`].
     ///
     /// # Errors
     ///
@@ -187,9 +188,11 @@ impl FromStr for Denomination {
     }
 }
 
-/// Returns `Some(position)` if the precision is not supported.
+/// Returns [`Some(position)`] if the precision is not supported.
 ///
 /// The position indicates the first digit that is too precise.
+///
+/// [`Some(position)`]: Some
 fn is_too_precise(s: &str, precision: usize) -> Option<usize> {
     match s.find('.') {
         Some(pos) if precision >= pos => Some(0),
@@ -212,7 +215,7 @@ const INPUT_STRING_LEN_LIMIT: usize = 50;
 /// Parses a decimal string in the given denomination into a satoshi value and a
 /// [`bool`] indicator for a negative amount.
 ///
-/// The `bool` is only needed to distinguish -0 from 0.
+/// The [`bool`] is only needed to distinguish -0 from 0.
 #[allow(clippy::too_many_lines)]
 fn parse_signed_to_satoshi(
     mut s: &str,
@@ -389,7 +392,7 @@ fn split_amount_and_denomination(s: &str) -> Result<(&str, Denomination), ParseE
     Ok((&s[..i], s[j..].parse().map_err(ParseErrorInner::Denomination).map_err(ParseError)?))
 }
 
-/// Options given by `fmt::Formatter`
+/// Options given by [`fmt::Formatter`]
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 struct FormatOptions {
     fill: char,
@@ -598,7 +601,9 @@ pub struct Display {
 }
 
 impl Display {
-    /// Makes subsequent calls to `Display::fmt` display denomination.
+    /// Makes subsequent calls to [`Display::fmt`] display denomination.
+    ///
+    /// [`Display::fmt`]: fmt::Display::fmt
     #[inline]
     #[must_use]
     pub fn show_denomination(mut self) -> Self {

--- a/units/src/amount/result.rs
+++ b/units/src/amount/result.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! Provides a monadic type returned by mathematical operations (`core::ops`).
+//! Provides a monadic type returned by mathematical operations ([`core::ops`]).
 
 use core::num::{NonZeroI64, NonZeroU64};
 use core::ops;

--- a/units/src/amount/serde.rs
+++ b/units/src/amount/serde.rs
@@ -86,8 +86,8 @@ pub mod as_sat {
     }
 
     pub mod opt {
-        //! Serialize and deserialize `Option<Amount>` and `Option<SignedAmount>` as real numbers
-        //! denominated in satoshi.
+        //! Serialize and deserialize [`Option<Amount>`] and [`Option<SignedAmount>`] as real
+        //! numbers denominated in satoshi.
         //!
         //! Use with `#[serde(default, with = "amount::serde::as_sat::opt")]`.
 
@@ -147,10 +147,13 @@ pub mod as_sat {
 
     #[cfg(feature = "alloc")]
     pub mod vec {
-        //! Serialize and deserialize `Vec<Amount>` and `Vec<SignedAmount>` as real numbers
+        //! Serialize and deserialize [`Vec<Amount>`] and [`Vec<SignedAmount>`] as real numbers
         //! denominated in satoshi.
         //!
         //! Use with `#[serde(with = "amount::serde::as_sat::vec")]`.
+        //!
+        //! [`Vec<Amount>`]: crate::Amount
+        //! [`Vec<SignedAmount>`]: crate::SignedAmount
 
         use alloc::vec::Vec;
         use core::fmt;
@@ -245,8 +248,8 @@ pub mod as_btc {
     }
 
     pub mod opt {
-        //! Serialize and deserialize `Option<Amount>` and `Option<SignedAmount>` as JSON numbers
-        //! denominated in BTC.
+        //! Serialize and deserialize [`Option<Amount>`] and [`Option<SignedAmount>`] as JSON
+        //! numbers denominated in BTC.
         //!
         //! Use with `#[serde(default, with = "amount::serde::as_btc::opt")]`.
 
@@ -308,10 +311,13 @@ pub mod as_btc {
     }
 
     pub mod vec {
-        //! Serialize and deserialize `Vec<Amount>` and `Vec<SignedAmount>` as JSON numbers
+        //! Serialize and deserialize [`Vec<Amount>`] and [`Vec<SignedAmount>`] as JSON numbers
         //! denominated in BTC.
         //!
         //! Use with `#[serde(with = "amount::serde::as_btc::vec")]`.
+        //!
+        //! [`Vec<Amount>`]: crate::Amount
+        //! [`Vec<SignedAmount>`]: crate::SignedAmount
 
         use alloc::vec::Vec;
         use core::fmt;
@@ -411,8 +417,8 @@ pub mod as_str {
     }
 
     pub mod opt {
-        //! Serialize and deserialize `Option<Amount>` and `Option<SignedAmount>` as a JSON string
-        //! denominated in BTC.
+        //! Serialize and deserialize [`Option<Amount>`] and [`Option<SignedAmount>`] as a JSON
+        //! string denominated in BTC.
         //!
         //! Use with `#[serde(default, with = "amount::serde::as_str::opt")]`.
 
@@ -474,10 +480,13 @@ pub mod as_str {
     }
 
     pub mod vec {
-        //! Serialize and deserialize `Vec<Amount>` and `Vec<SignedAmount>` as JSON strings
+        //! Serialize and deserialize [`Vec<Amount>`] and [`Vec<SignedAmount>`] as JSON strings
         //! denominated in BTC.
         //!
         //! Use with `#[serde(with = "amount::serde::as_str::vec")]`.
+        //!
+        //! [`Vec<Amount>`]: crate::Amount
+        //! [`Vec<SignedAmount>`]: crate::SignedAmount
 
         use alloc::vec::Vec;
         use core::fmt;

--- a/units/src/amount/signed.rs
+++ b/units/src/amount/signed.rs
@@ -247,7 +247,7 @@ impl SignedAmount {
         self.to_string_in(denom).parse::<f64>().unwrap()
     }
 
-    /// Constructs a new `SignedAmount` from a prefixed hex string.
+    /// Constructs a new [`SignedAmount`] from a prefixed hex string.
     ///
     /// This can only parse an unsigned quantity.
     ///
@@ -263,7 +263,7 @@ impl SignedAmount {
         Self::from_sat_u64(amount)
     }
 
-    /// Constructs a new `SignedAmount` from an unprefixed hex string.
+    /// Constructs a new [`SignedAmount`] from an unprefixed hex string.
     ///
     /// This can only parse an unsigned quantity.
     ///

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -278,7 +278,7 @@ impl Amount {
         Self::from_str_in(&value.to_string(), denom)
     }
 
-    /// Constructs a new `Amount` from a prefixed hex string.
+    /// Constructs a new [`Amount`] from a prefixed hex string.
     ///
     /// # Errors
     ///
@@ -292,7 +292,7 @@ impl Amount {
         Self::from_sat(amount).map_err(ParseAmountErrorInner::OutOfRange).map_err(ParseAmountError)
     }
 
-    /// Constructs a new `Amount` from an unprefixed hex string.
+    /// Constructs a new [`Amount`] from an unprefixed hex string.
     ///
     /// # Errors
     ///
@@ -445,10 +445,10 @@ impl Amount {
             .expect("range of Amount is within range of SignedAmount")
     }
 
-    /// Infallibly subtracts one `Amount` from another returning a [`SignedAmount`].
+    /// Infallibly subtracts one [`Amount`] from another returning a [`SignedAmount`].
     ///
-    /// Since `SignedAmount::MIN` is equivalent to `-Amount::MAX` subtraction of two signed amounts
-    /// can never overflow a `SignedAmount`.
+    /// Since [`SignedAmount::MIN`] is equivalent to `-`[`Amount::MAX`] subtraction of two signed
+    /// amounts can never overflow a [`SignedAmount`].
     #[inline]
     #[must_use]
     pub fn signed_sub(self, rhs: Self) -> SignedAmount {

--- a/units/src/block.rs
+++ b/units/src/block.rs
@@ -472,7 +472,7 @@ impl BlockMtpInterval {
 crate::internal_macros::impl_fmt_traits_for_u32_wrapper!(BlockMtpInterval);
 
 impl From<relative::NumberOf512Seconds> for BlockMtpInterval {
-    /// Converts a [`locktime::relative::NumberOf512Seconds`] to a [`BlockMtpInterval `].
+    /// Converts a [`locktime::relative::NumberOf512Seconds`] to a [`BlockMtpInterval`].
     ///
     /// A relative locktime MTP interval has a resolution of 512 seconds, and a maximum value
     /// of `u16::MAX` 512-second intervals. [`BlockMtpInterval`] may take the full range of

--- a/units/src/block.rs
+++ b/units/src/block.rs
@@ -39,26 +39,26 @@ macro_rules! impl_u32_wrapper {
         $type_vis struct $newtype($inner_vis u32);
 
         impl $newtype {
-            #[doc = "Constructs a new `"]
+            #[doc = "Constructs a new [`"]
             #[doc = stringify!($newtype)]
-            #[doc = "` from an unprefixed hex string.\n\n"]
+            #[doc = "`] from an unprefixed hex string.\n\n"]
             #[doc = "# Errors\n\n"]
-            #[doc = "If the input string is not a valid hex representation of a `"]
+            #[doc = "If the input string is not a valid hex representation of a [`"]
             #[doc = stringify!($newtype)]
-            #[doc = "` or it does not include the `0x` prefix."]
+            #[doc = "`] or it does not include the `0x` prefix."]
             #[inline]
             pub fn from_hex(s: &str) -> Result<Self, PrefixedHexError> {
                 let block_height = parse_int::hex_u32_prefixed(s)?;
                 Ok(Self(block_height))
             }
 
-            #[doc = "Constructs a new `"]
+            #[doc = "Constructs a new [`"]
             #[doc = stringify!($newtype)]
-            #[doc = "` from a prefixed hex string.\n\n"]
+            #[doc = "`] from a prefixed hex string.\n\n"]
             #[doc = "# Errors\n\n"]
-            #[doc = "If the input string is not a valid hex representation of a `"]
+            #[doc = "If the input string is not a valid hex representation of a [`"]
             #[doc = stringify!($newtype)]
-            #[doc = "` or if it includes the `0x` prefix."]
+            #[doc = "`] or if it includes the `0x` prefix."]
             #[inline]
             pub fn from_unprefixed_hex(s: &str) -> Result<Self, UnprefixedHexError> {
                 let block_height = parse_int::hex_u32_unprefixed(s)?;
@@ -149,14 +149,14 @@ impl BlockHeight {
     #[inline]
     pub const fn to_u32(self) -> u32 { self.0 }
 
-    /// Attempt to subtract two [`BlockHeight`]s, returning `None` if overflow occurred.
+    /// Attempt to subtract two [`BlockHeight`]s, returning [`None`] if overflow occurred.
     #[inline]
     #[must_use]
     pub fn checked_sub(self, other: Self) -> Option<BlockHeightInterval> {
         self.to_u32().checked_sub(other.to_u32()).map(BlockHeightInterval)
     }
 
-    /// Attempt to add an interval to this [`BlockHeight`], returning `None` if overflow occurred.
+    /// Attempt to add an interval to this [`BlockHeight`], returning [`None`] if overflow occurred.
     #[inline]
     #[must_use]
     pub fn checked_add(self, other: BlockHeightInterval) -> Option<Self> {
@@ -165,7 +165,7 @@ impl BlockHeight {
 
     /// Saturating integer addition.
     ///
-    /// Computes self + rhs, saturating at `BlockHeight::MAX` instead of overflowing.
+    /// Computes self + rhs, saturating at [`BlockHeight::MAX`] instead of overflowing.
     #[inline]
     #[must_use]
     pub const fn saturating_add(self, rhs: BlockHeightInterval) -> Self {
@@ -174,7 +174,7 @@ impl BlockHeight {
 
     /// Saturating integer subtraction.
     ///
-    /// Computes self - rhs, saturating at `BlockHeight::MIN` instead of overflowing.
+    /// Computes self - rhs, saturating at [`BlockHeight::MIN`] instead of overflowing.
     #[inline]
     #[must_use]
     pub const fn saturating_sub(self, rhs: BlockHeightInterval) -> Self {
@@ -258,7 +258,7 @@ impl BlockHeightInterval {
     /// Block interval 0.
     pub const ZERO: Self = Self(0);
 
-    /// The minimum block interval, equivalent to `Self::ZERO`.
+    /// The minimum block interval, equivalent to [`Self::ZERO`].
     pub const MIN: Self = Self::ZERO;
 
     /// The maximum block interval.
@@ -272,14 +272,14 @@ impl BlockHeightInterval {
     #[inline]
     pub const fn to_u32(self) -> u32 { self.0 }
 
-    /// Attempt to subtract two [`BlockHeightInterval`]s, returning `None` if overflow occurred.
+    /// Attempt to subtract two [`BlockHeightInterval`]s, returning [`None`] if overflow occurred.
     #[inline]
     #[must_use]
     pub fn checked_sub(self, other: Self) -> Option<Self> {
         self.to_u32().checked_sub(other.to_u32()).map(Self)
     }
 
-    /// Attempt to add two [`BlockHeightInterval`]s, returning `None` if overflow occurred.
+    /// Attempt to add two [`BlockHeightInterval`]s, returning [`None`] if overflow occurred.
     #[inline]
     #[must_use]
     pub fn checked_add(self, other: Self) -> Option<Self> {
@@ -331,7 +331,7 @@ impl BlockMtp {
     /// for some use cases e.g., folding a sum of intervals.
     pub const ZERO: Self = Self(0);
 
-    /// The minimum block MTP, equivalent to `Self::ZERO`.
+    /// The minimum block MTP, equivalent to [`Self::ZERO`].
     pub const MIN: Self = Self::ZERO;
 
     /// The maximum block MTP.
@@ -356,14 +356,14 @@ impl BlockMtp {
         Self::from_u32(u32::from(timestamps[5]))
     }
 
-    /// Attempt to subtract two [`BlockMtp`]s, returning `None` if overflow occurred.
+    /// Attempt to subtract two [`BlockMtp`]s, returning [`None`] if overflow occurred.
     #[inline]
     #[must_use]
     pub fn checked_sub(self, other: Self) -> Option<BlockMtpInterval> {
         self.to_u32().checked_sub(other.to_u32()).map(BlockMtpInterval)
     }
 
-    /// Attempt to add an interval to this [`BlockMtp`], returning `None` if overflow occurred.
+    /// Attempt to add an interval to this [`BlockMtp`], returning [`None`] if overflow occurred.
     #[inline]
     #[must_use]
     pub fn checked_add(self, other: BlockMtpInterval) -> Option<Self> {
@@ -408,7 +408,7 @@ impl BlockMtpInterval {
     /// Block MTP interval 0.
     pub const ZERO: Self = Self(0);
 
-    /// The minimum block MTP interval, equivalent to `Self::ZERO`.
+    /// The minimum block MTP interval, equivalent to [`Self::ZERO`].
     pub const MIN: Self = Self::ZERO;
 
     /// The maximum block MTP interval.
@@ -454,14 +454,14 @@ impl BlockMtpInterval {
         relative::NumberOf512Seconds::from_seconds_ceil(self.to_u32())
     }
 
-    /// Attempt to subtract two [`BlockMtpInterval`]s, returning `None` if overflow occurred.
+    /// Attempt to subtract two [`BlockMtpInterval`]s, returning [`None`] if overflow occurred.
     #[inline]
     #[must_use]
     pub fn checked_sub(self, other: Self) -> Option<Self> {
         self.to_u32().checked_sub(other.to_u32()).map(Self)
     }
 
-    /// Attempt to add two [`BlockMtpInterval`]s, returning `None` if overflow occurred.
+    /// Attempt to add two [`BlockMtpInterval`]s, returning [`None`] if overflow occurred.
     #[inline]
     #[must_use]
     pub fn checked_add(self, other: Self) -> Option<Self> {
@@ -663,7 +663,9 @@ pub mod error {
         }
     }
 
-    /// An error consensus decoding a `BlockHeight`.
+    /// An error consensus decoding a [`BlockHeight`].
+    ///
+    /// [`BlockHeight`]: super::BlockHeight
     #[cfg(feature = "encoding")]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct BlockHeightDecoderError(pub(super) encoding::UnexpectedEofError);

--- a/units/src/fee.rs
+++ b/units/src/fee.rs
@@ -11,7 +11,7 @@
 //! We provide `fee.div_by_weight_ceil(weight)` to calculate a minimum threshold fee rate
 //! required to pay at least `fee` for transaction with `weight`.
 //!
-//! We support various `core::ops` traits all of which return [`NumOpResult<T>`].
+//! We support various [`core::ops`] traits all of which return [`NumOpResult<T>`].
 //!
 //! For specific methods see:
 //!

--- a/units/src/fee_rate/mod.rs
+++ b/units/src/fee_rate/mod.rs
@@ -44,12 +44,16 @@ use internals::const_casts;
 impl FeeRate {
     /// The zero fee rate.
     ///
-    /// Equivalent to [`MIN`](Self::MIN), may better express intent in some contexts.
+    /// Equivalent to [`MIN`], may better express intent in some contexts.
+    ///
+    /// [`MIN`]: Self::MIN
     pub const ZERO: Self = Self::from_sat_per_mvb(0);
 
     /// The minimum possible value.
     ///
-    /// Equivalent to [`ZERO`](Self::ZERO), may better express intent in some contexts.
+    /// Equivalent to [`ZERO`], may better express intent in some contexts.
+    ///
+    /// [`ZERO`]: Self::ZERO
     pub const MIN: Self = Self::ZERO;
 
     /// The maximum possible value.

--- a/units/src/fee_rate/mod.rs
+++ b/units/src/fee_rate/mod.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! Implements `FeeRate` and associated features.
+//! Implements [`FeeRate`] and associated features.
 
 #[cfg(feature = "serde")]
 pub mod serde;
@@ -21,7 +21,7 @@ mod encapsulate {
     /// This is an integer newtype representing fee rate. It provides protection
     /// against mixing up the types, conversion functions, and basic formatting.
     ///
-    /// NOTE: `FeeRate` explicitly does not have any format/display trait implementations, as it
+    /// NOTE: [`FeeRate`] explicitly does not have any format/display trait implementations, as it
     /// doesn't have a standard unit for measure. Users are expected to format it on their own by
     /// extracting values in desired units with `to_sat_per*` functions.
     #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]

--- a/units/src/internal_macros.rs
+++ b/units/src/internal_macros.rs
@@ -87,8 +87,13 @@ pub(crate) use impl_add_assign;
 
 /// Implement `ops::AddAssign` for `$ty` and `NumOpResult<$ty>` on `NumOpResult<$ty>`
 ///
-/// This implements the same logic as the generic `NumOpResult` implementation in result.rs,
-/// but works for types that can't implement `AddAssign` on themselves (e.g. `Amount`, `SignedAmount`)
+/// This implements the same logic as the generic [`NumOpResult`] implementation in result.rs,
+/// but works for types that can't implement `AddAssign` on themselves (e.g. [`Amount`],
+/// [`SignedAmount`])
+///
+/// [`NumOpResult`]: crate::NumOpResult
+/// [`Amount`]: crate::Amount
+/// [`SignedAmount`]: crate::SignedAmount
 macro_rules! impl_add_assign_for_results {
     ($ty:ident) => {
         impl ops::AddAssign<$ty> for NumOpResult<$ty> {
@@ -116,8 +121,13 @@ pub(crate) use impl_add_assign_for_results;
 
 /// Implement `ops::SubAssign` for `$ty` and `NumOpResult<$ty>` on `NumOpResult<$ty>`
 ///
-/// This implements the same logic as the generic `NumOpResult` implementation in result.rs,
-/// but works for types that can't implement `SubAssign` on themselves (e.g. `Amount`, `SignedAmount`)
+/// This implements the same logic as the generic [`NumOpResult`] implementation in result.rs,
+/// but works for types that can't implement `SubAssign` on themselves (e.g. [`Amount`],
+/// [`SignedAmount`])
+///
+/// [`NumOpResult`]: crate::NumOpResult
+/// [`Amount`]: crate::Amount
+/// [`SignedAmount`]: crate::SignedAmount
 macro_rules! impl_sub_assign_for_results {
     ($ty:ident) => {
         impl ops::SubAssign<$ty> for NumOpResult<$ty> {
@@ -209,8 +219,10 @@ pub(crate) use impl_rem_assign;
 
 /// Implements Lower/UpperHex, Octal and Binary for a new-type `$ty`.
 ///
-/// This macro can be used on raw new-types (e.g. `BlockHeight`), or those encapsulated
+/// This macro can be used on raw new-types (e.g. [`BlockHeight`]), or those encapsulated
 /// per the privacy rules by accessing the inner value with a method `$fn`.
+///
+/// [`BlockHeight`]: crate::BlockHeight
 macro_rules! impl_fmt_traits_for_u32_wrapper {
     ($ty:ident) => {
         impl core::fmt::LowerHex for $ty {

--- a/units/src/locktime/absolute/error.rs
+++ b/units/src/locktime/absolute/error.rs
@@ -12,7 +12,9 @@ use internals::write_err;
 use super::{Height, MedianTimePast, LOCK_TIME_THRESHOLD};
 use crate::parse_int::{ParseIntError, PrefixedHexError, UnprefixedHexError};
 
-/// An error consensus decoding a `LockTime`.
+/// An error consensus decoding a [`LockTime`].
+///
+/// [`LockTime`]: super::LockTime
 #[cfg(feature = "encoding")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LockTimeDecoderError(pub(super) encoding::UnexpectedEofError);
@@ -304,13 +306,13 @@ pub struct ConversionError {
 }
 
 impl ConversionError {
-    /// Constructs a new `ConversionError` from an invalid `n` when expecting a height value.
+    /// Constructs a new [`ConversionError`] from an invalid `n` when expecting a height value.
     #[inline]
     pub(super) const fn invalid_height(n: u32) -> Self {
         Self { unit: LockTimeUnit::Blocks, input: n }
     }
 
-    /// Constructs a new `ConversionError` from an invalid `n` when expecting a time value.
+    /// Constructs a new [`ConversionError`] from an invalid `n` when expecting a time value.
     #[inline]
     pub(super) const fn invalid_time(n: u32) -> Self {
         Self { unit: LockTimeUnit::Seconds, input: n }

--- a/units/src/locktime/absolute/mod.rs
+++ b/units/src/locktime/absolute/mod.rs
@@ -273,8 +273,11 @@ impl LockTime {
     ///
     /// If you do not have, or do not wish to calculate, both parameters consider using:
     ///
-    /// * [`is_satisfied_by_height()`](absolute::LockTime::is_satisfied_by_height)
-    /// * [`is_satisfied_by_time()`](absolute::LockTime::is_satisfied_by_time)
+    /// * [`is_satisfied_by_height()`]
+    /// * [`is_satisfied_by_time()`]
+    ///
+    /// [`is_satisfied_by_height()`]: Self::is_satisfied_by_height
+    /// [`is_satisfied_by_time()`]: Self::is_satisfied_by_time
     ///
     /// # Examples
     ///

--- a/units/src/locktime/absolute/mod.rs
+++ b/units/src/locktime/absolute/mod.rs
@@ -3,7 +3,7 @@
 //! Provides type [`LockTime`] that implements the logic around `nLockTime`/`OP_CHECKLOCKTIMEVERIFY`.
 //!
 //! There are two types of lock time: lock-by-height and lock-by-time, distinguished by
-//! whether `LockTime < LOCKTIME_THRESHOLD`. To support these we provide the [`Height`] and
+//! whether [`LockTime`] < [`LOCK_TIME_THRESHOLD`]. To support these we provide the [`Height`] and
 //! [`MedianTimePast`] types.
 
 pub mod error;
@@ -32,7 +32,7 @@ pub use self::error::LockTimeDecoderError;
 
 /// The Threshold for deciding whether a lock time value is a height or a time (see [Bitcoin Core]).
 ///
-/// `LockTime` values _below_ the threshold are interpreted as block heights, values _above_ (or
+/// [`LockTime`] values _below_ the threshold are interpreted as block heights, values _above_ (or
 /// equal to) the threshold are interpreted as block times (UNIX timestamp, seconds since epoch).
 ///
 /// Bitcoin is able to safely use this value because a block height greater than 500,000,000 would
@@ -115,7 +115,7 @@ impl LockTime {
     /// The number of bytes that the locktime contributes to the size of a transaction.
     pub const SIZE: usize = 4; // Serialized length of a u32.
 
-    /// Constructs a new `LockTime` from a prefixed hex string.
+    /// Constructs a new [`LockTime`] from a prefixed hex string.
     ///
     /// # Errors
     ///
@@ -138,7 +138,7 @@ impl LockTime {
         Ok(Self::from_consensus(lock_time))
     }
 
-    /// Constructs a new `LockTime` from an unprefixed hex string.
+    /// Constructs a new [`LockTime`] from an unprefixed hex string.
     ///
     /// # Errors
     ///
@@ -161,7 +161,8 @@ impl LockTime {
         Ok(Self::from_consensus(lock_time))
     }
 
-    /// Constructs a new `LockTime` from an `nLockTime` value or the argument to `OP_CHECKLOCKTIMEVERIFY`.
+    /// Constructs a new [`LockTime`] from an `nLockTime` value or the argument to
+    /// `OP_CHECKLOCKTIMEVERIFY`.
     ///
     /// # Examples
     ///
@@ -183,7 +184,7 @@ impl LockTime {
         }
     }
 
-    /// Constructs a new `LockTime` from `n`, expecting `n` to be a valid block height.
+    /// Constructs a new [`LockTime`] from `n`, expecting `n` to be a valid block height.
     ///
     /// # Note
     ///
@@ -211,7 +212,7 @@ impl LockTime {
         Ok(Self::Blocks(height))
     }
 
-    /// Constructs a new `LockTime` from `n`, expecting `n` to be a median-time-past (MTP)
+    /// Constructs a new [`LockTime`] from `n`, expecting `n` to be a median-time-past (MTP)
     /// which is in range for a locktime.
     ///
     /// # Note
@@ -360,14 +361,17 @@ impl LockTime {
         }
     }
 
-    /// Returns the inner `u32` value. This is the value used when creating this `LockTime`
+    /// Returns the inner `u32` value. This is the value used when creating this [`LockTime`]
     /// i.e., `n OP_CHECKLOCKTIMEVERIFY` or `nLockTime`.
     ///
     /// # Warning
     ///
-    /// Do not compare values return by this method. The whole point of the `LockTime` type is to
-    /// assist in doing correct comparisons. Either use `is_satisfied_by`, `is_satisfied_by_time`,
-    /// or use the pattern below:
+    /// Do not compare values return by this method. The whole point of the [`LockTime`] type is to
+    /// assist in doing correct comparisons. Either use [`is_satisfied_by`],
+    /// [`is_satisfied_by_time`], or use the pattern below:
+    ///
+    /// [`is_satisfied_by`]: Self::is_satisfied_by
+    /// [`is_satisfied_by_time`]: Self::is_satisfied_by_time
     ///
     /// # Examples
     ///
@@ -571,7 +575,7 @@ impl Height {
 
     /// Returns true if a transaction with this locktime can be included in the next block.
     ///
-    /// `self` is value of the `LockTime` and if `height` is the current chain tip then
+    /// `self` is value of the [`LockTime`] and if `height` is the current chain tip then
     /// a transaction with this lock can be broadcast for inclusion in the next block.
     #[inline]
     pub fn is_satisfied_by(self, height: Self) -> bool {
@@ -715,9 +719,9 @@ impl MedianTimePast {
 
     /// Returns true if a transaction with this locktime can be included in the next block.
     ///
-    /// `self` is the value of the `LockTime` and if `time` is the median time past of the block at
-    /// the chain tip then a transaction with this lock can be broadcast for inclusion in the next
-    /// block.
+    /// `self` is the value of the [`LockTime`] and if `time` is the median time past of the block
+    /// at the chain tip then a transaction with this lock can be broadcast for inclusion in the
+    /// next block.
     #[inline]
     pub fn is_satisfied_by(self, time: Self) -> bool { self < time }
 }

--- a/units/src/locktime/relative/error.rs
+++ b/units/src/locktime/relative/error.rs
@@ -75,7 +75,9 @@ impl std::error::Error for IsSatisfiedByError {
     }
 }
 
-/// Error returned when `is_satisfied_by_height` fails.
+/// Error returned when [`is_satisfied_by_height`] fails.
+///
+/// [`is_satisfied_by_height`]: super::LockTime::is_satisfied_by_height
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IsSatisfiedByHeightError {
     /// Satisfaction of the lock height value failed.
@@ -109,7 +111,9 @@ impl std::error::Error for IsSatisfiedByHeightError {
     }
 }
 
-/// Error returned when `is_satisfied_by_height` fails with a block time.
+/// Error returned when [`is_satisfied_by_height`] fails with a block time.
+///
+/// [`is_satisfied_by_height`]: super::LockTime::is_satisfied_by_height
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IncompatibleHeightError(pub(crate) NumberOf512Seconds);
 
@@ -132,7 +136,9 @@ impl std::error::Error for IncompatibleHeightError {
     }
 }
 
-/// Error returned when `is_satisfied_by_time` fails.
+/// Error returned when [`is_satisfied_by_time`] fails.
+///
+/// [`is_satisfied_by_time`]: super::LockTime::is_satisfied_by_time
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IsSatisfiedByTimeError {
     /// Satisfaction of the lock time value failed.
@@ -166,7 +172,9 @@ impl std::error::Error for IsSatisfiedByTimeError {
     }
 }
 
-/// Error returned when `is_satisfied_by_time` fails with a block height.
+/// Error returned when [`is_satisfied_by_time`] fails with a block height.
+///
+/// [`is_satisfied_by_time`]: super::LockTime::is_satisfied_by_time
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IncompatibleTimeError(pub(crate) NumberOfBlocks);
 
@@ -220,7 +228,7 @@ impl std::error::Error for TimeOverflowError {
     }
 }
 
-/// Error returned when `NumberOfBlocks::is_satisfied_by` is incorrectly called.
+/// Error returned when [`NumberOfBlocks::is_satisfied_by`] is incorrectly called.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InvalidHeightError {
     /// The `chain_tip` argument.
@@ -249,7 +257,7 @@ impl std::error::Error for InvalidHeightError {
     }
 }
 
-/// Error returned when `NumberOf512Seconds::is_satisfied_by` is incorrectly called.
+/// Error returned when [`NumberOf512Seconds::is_satisfied_by`] is incorrectly called.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InvalidTimeError {
     /// The `chain_tip` argument.

--- a/units/src/locktime/relative/mod.rs
+++ b/units/src/locktime/relative/mod.rs
@@ -63,7 +63,8 @@ impl LockTime {
     /// The number of bytes that the locktime contributes to the size of a transaction.
     pub const SIZE: usize = 4; // Serialized length of a u32.
 
-    /// Constructs a new `LockTime` from an `nSequence` value or the argument to `OP_CHECKSEQUENCEVERIFY`.
+    /// Constructs a new [`LockTime`] from an `nSequence` value or the argument to
+    /// `OP_CHECKSEQUENCEVERIFY`.
     ///
     /// This method will **not** round-trip with [`Self::to_consensus_u32`], because relative
     /// locktimes only use some bits of the underlying `u32` value and discard the rest. If
@@ -113,7 +114,7 @@ impl LockTime {
         }
     }
 
-    /// Constructs a new `LockTime` from the sequence number of a Bitcoin input.
+    /// Constructs a new [`LockTime`] from the sequence number of a Bitcoin input.
     ///
     /// This method will **not** round-trip with [`Self::to_sequence`]. See the
     /// docs for [`Self::from_consensus`] for more information.
@@ -143,11 +144,12 @@ impl LockTime {
     #[inline]
     pub fn to_sequence(self) -> Sequence { Sequence::from_consensus(self.to_consensus_u32()) }
 
-    /// Constructs a new `LockTime` from `n`, expecting `n` to be a 16-bit count of blocks.
+    /// Constructs a new [`LockTime`] from `n`, expecting `n` to be a 16-bit count of blocks.
     #[inline]
     pub const fn from_block_count(n: u16) -> Self { Self::Blocks(NumberOfBlocks::from_count(n)) }
 
-    /// Constructs a new `LockTime` from `n`, expecting `n` to be a count of 512-second intervals.
+    /// Constructs a new [`LockTime`] from `n`, expecting `n` to be a count of 512-second
+    /// intervals.
     ///
     /// This function is a little awkward to use, and users may wish to instead use
     /// [`Self::from_seconds_floor`] or [`Self::from_seconds_ceil`].
@@ -272,8 +274,9 @@ impl LockTime {
     /// mathematical sense) the smaller one being satisfied.
     ///
     /// This function is useful when checking sequence values against a lock, first one checks the
-    /// sequence represents a relative lock time by converting to `LockTime` then use this function
-    /// to see if satisfaction of the newly created lock time would imply satisfaction of `self`.
+    /// sequence represents a relative lock time by converting to [`LockTime`] then use this
+    /// function to see if satisfaction of the newly created lock time would imply satisfaction of
+    /// `self`.
     ///
     /// Can also be used to remove the smaller value of two `OP_CHECKSEQUENCEVERIFY` operations
     /// within one branch of the script.
@@ -411,7 +414,7 @@ impl NumberOfBlocks {
     #[must_use]
     pub const fn to_count(self) -> u16 { self.0 }
 
-    /// Constructs a new `NumberOfBlocks` from a prefixed hex string.
+    /// Constructs a new [`NumberOfBlocks`] from a prefixed hex string.
     ///
     /// # Errors
     ///
@@ -423,7 +426,7 @@ impl NumberOfBlocks {
         Ok(Self::from_count(block_count))
     }
 
-    /// Constructs a new `NumberOfBlocks` from an unprefixed hex string.
+    /// Constructs a new [`NumberOfBlocks`] from an unprefixed hex string.
     ///
     /// # Errors
     ///
@@ -548,7 +551,7 @@ impl NumberOf512Seconds {
     #[inline]
     pub const fn to_seconds(self) -> u32 { const_casts::u16_to_u32(self.0) * 512 }
 
-    /// Constructs a new `NumberOf512Seconds` from a prefixed hex string.
+    /// Constructs a new [`NumberOf512Seconds`] from a prefixed hex string.
     ///
     /// # Errors
     ///
@@ -560,7 +563,7 @@ impl NumberOf512Seconds {
         Ok(Self::from_512_second_intervals(block_count))
     }
 
-    /// Constructs a new `NumberOf512Seconds` from an unprefixed hex string.
+    /// Constructs a new [`NumberOf512Seconds`] from an unprefixed hex string.
     ///
     /// # Errors
     ///

--- a/units/src/parse_int.rs
+++ b/units/src/parse_int.rs
@@ -30,7 +30,9 @@ macro_rules! impl_integer {
 impl_integer!(u8, i8, u16, i16, u32, i32, u64, i64, u128, i128);
 
 mod sealed {
-    /// Seals the `Integer` trait.
+    /// Seals the [`Integer`] trait.
+    ///
+    /// [`Integer`]: super::Integer
     pub trait Sealed {}
 }
 
@@ -41,9 +43,11 @@ mod sealed {
 /// allocates to copy the input string into the error return. If `alloc` is not enabled the input
 /// string is lost.
 ///
-/// If the caller has a `String` or `Box<str>` which is not used later it's better to call
+/// If the caller has a [`String`] or [`Box<str>`] which is not used later it's better to call
 /// [`parse_int::int_from_string`] or [`parse_int::int_from_box`] respectively.
 ///
+/// [`String`]: alloc::string::String
+/// [`Box<str>`]: alloc::boxed::Box
 /// [`parse_int::int_from_string`]: crate::parse_int::int_from_string
 /// [`parse_int::int_from_box`]: crate::parse_int::int_from_box
 ///
@@ -93,13 +97,13 @@ fn int<T: Integer, S: AsRef<str> + Into<InputString>>(s: S) -> Result<T, ParseIn
 ///
 /// Implements:
 ///
-/// * `FromStr`
-/// * `TryFrom<&str>`
+/// * [`FromStr`]
+/// * [`TryFrom<&str>`]
 ///
 /// And if `alloc` feature is enabled in calling crate:
 ///
-/// * `TryFrom<Box<str>>`
-/// * `TryFrom<String>`
+/// * [`TryFrom<Box<str>>`]
+/// * [`TryFrom<String>`]
 ///
 /// # Parameters
 ///
@@ -109,7 +113,11 @@ fn int<T: Integer, S: AsRef<str> + Into<InputString>>(s: S) -> Result<T, ParseIn
 ///
 /// # Errors
 ///
-/// If parsing the string fails then a `units::parse::ParseIntError` is returned.
+/// If parsing the string fails then a [`ParseIntError`] is returned.
+///
+/// [`TryFrom<&str>`]: core::convert::TryFrom
+/// [`TryFrom<Box<str>>`]: core::convert::TryFrom
+/// [`TryFrom<String>`]: core::convert::TryFrom
 macro_rules! impl_parse_str_from_int_infallible {
     ($to:ident, $inner:ident, $fn:ident) => {
         impl $crate::_export::_core::str::FromStr for $to {
@@ -161,23 +169,28 @@ pub(crate) use impl_parse_str_from_int_infallible;
 ///
 /// Implements:
 ///
-/// * `FromStr`
-/// * `TryFrom<&str>`
+/// * [`FromStr`]
+/// * [`TryFrom<&str>`]
 ///
 /// And if `alloc` feature is enabled in calling crate:
 ///
-/// * `TryFrom<Box<str>>`
-/// * `TryFrom<String>`
+/// * [`TryFrom<Box<str>>`]
+/// * [`TryFrom<String>`]
 ///
 /// # Parameters
 ///
 /// * `to` - the type converted to e.g., `impl From<&str> for $to`.
-/// * `err` - the error type returned by `$inner_fn` (implies returned by `FromStr` and `TryFrom`).
+/// * `err` - the error type returned by `$inner_fn` (implies returned by [`FromStr`] and
+///   [`TryFrom`]).
 /// * `inner_fn`: the fallible conversion function to call to convert from a string reference.
 ///
 /// # Errors
 ///
 /// All functions use the error returned by `$inner_fn`.
+///
+/// [`TryFrom<&str>`]: core::convert::TryFrom
+/// [`TryFrom<Box<str>>`]: core::convert::TryFrom
+/// [`TryFrom<String>`]: core::convert::TryFrom
 macro_rules! impl_parse_str {
     ($to:ty, $err:ty, $inner_fn:expr) => {
         $crate::parse_int::impl_tryfrom_str!(&str, $to, $err, $inner_fn);

--- a/units/src/pow.rs
+++ b/units/src/pow.rs
@@ -20,55 +20,55 @@ pub use self::error::CompactTargetDecoderError;
 #[doc(no_inline)]
 pub use self::error::{ParseTargetError, ParseWorkError};
 
-/// Implement traits and methods shared by `Target` and `Work`.
+/// Implement traits and methods shared by [`Target`] and [`Work`].
 macro_rules! do_impl {
     ($ty:ident, $err_ty:ident) => {
         impl $ty {
-            #[doc = "Constructs a new `"]
+            #[doc = "Constructs a new [`"]
             #[doc = stringify!($ty)]
-            #[doc = "` from a prefixed hex string.\n"]
+            #[doc = "`] from a prefixed hex string.\n"]
             #[doc = "\n# Errors\n"]
             #[doc = "\n - If the input string does not contain a `0x` (or `0X`) prefix."]
-            #[doc = "\n - If the input string is not a valid hex encoding of a `"]
+            #[doc = "\n - If the input string is not a valid hex encoding of a [`"]
             #[doc = stringify!($ty)]
-            #[doc = "`."]
+            #[doc = "`]."]
             pub fn from_hex(s: &str) -> Result<Self, PrefixedHexError> {
                 Ok($ty(U256::from_hex(s)?))
             }
 
-            #[doc = "Constructs a new `"]
+            #[doc = "Constructs a new [`"]
             #[doc = stringify!($ty)]
-            #[doc = "` from an unprefixed hex string.\n"]
+            #[doc = "`] from an unprefixed hex string.\n"]
             #[doc = "\n# Errors\n"]
             #[doc = "\n - If the input string contains a `0x` (or `0X`) prefix."]
-            #[doc = "\n - If the input string is not a valid hex encoding of a `"]
+            #[doc = "\n - If the input string is not a valid hex encoding of a [`"]
             #[doc = stringify!($ty)]
-            #[doc = "`."]
+            #[doc = "`]."]
             pub fn from_unprefixed_hex(s: &str) -> Result<Self, UnprefixedHexError> {
                 Ok($ty(U256::from_unprefixed_hex(s)?))
             }
 
-            #[doc = "Constructs `"]
+            #[doc = "Constructs [`"]
             #[doc = stringify!($ty)]
-            #[doc = "` from a big-endian byte array."]
+            #[doc = "`] from a big-endian byte array."]
             #[inline]
             pub fn from_be_bytes(bytes: [u8; 32]) -> $ty { $ty(U256::from_be_bytes(bytes)) }
 
-            #[doc = "Constructs `"]
+            #[doc = "Constructs [`"]
             #[doc = stringify!($ty)]
-            #[doc = "` from a little-endian byte array."]
+            #[doc = "`] from a little-endian byte array."]
             #[inline]
             pub fn from_le_bytes(bytes: [u8; 32]) -> $ty { $ty(U256::from_le_bytes(bytes)) }
 
-            #[doc = "Converts `"]
+            #[doc = "Converts [`"]
             #[doc = stringify!($ty)]
-            #[doc = "` to a big-endian byte array."]
+            #[doc = "`] to a big-endian byte array."]
             #[inline]
             pub fn to_be_bytes(self) -> [u8; 32] { self.0.to_be_bytes() }
 
-            #[doc = "Converts `"]
+            #[doc = "Converts [`"]
             #[doc = stringify!($ty)]
-            #[doc = "` to a little-endian byte array."]
+            #[doc = "`] to a little-endian byte array."]
             #[inline]
             pub fn to_le_bytes(self) -> [u8; 32] { self.0.to_le_bytes() }
         }
@@ -241,9 +241,9 @@ impl_fmt_traits_for_u32_wrapper!(Target);
 /// # Note on order/equality
 ///
 /// Usage of the ordering and equality traits for this type may be surprising. Converting between
-/// `CompactTarget` and `Target` is lossy *in both directions* (there are multiple `CompactTarget`
-/// values that map to the same `Target` value). Ordering and equality for this type are defined in
-/// terms of the underlying `u32`.
+/// [`CompactTarget`] and [`Target`] is lossy *in both directions* (there are multiple
+/// [`CompactTarget`] values that map to the same [`Target`] value). Ordering and equality for this
+/// type are defined in terms of the underlying `u32`.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CompactTarget(u32);
@@ -267,7 +267,7 @@ impl CompactTarget {
     /// ref: <https://developer.bitcoin.org/reference/block_chain.html#target-nbits>
     pub fn to_target(self) -> Target { Target::from_compact(self) }
 
-    /// Constructs a new `CompactTarget` from a prefixed hex string.
+    /// Constructs a new [`CompactTarget`] from a prefixed hex string.
     ///
     /// # Errors
     ///
@@ -282,7 +282,7 @@ impl CompactTarget {
         Ok(Self::from_consensus(target))
     }
 
-    /// Constructs a new `CompactTarget` from an unprefixed hex string.
+    /// Constructs a new [`CompactTarget`] from an unprefixed hex string.
     ///
     /// # Errors
     ///
@@ -359,7 +359,9 @@ pub mod error {
 
     use super::ParseU256Error;
 
-    /// An error consensus decoding a `CompactTarget`.
+    /// An error consensus decoding a [`CompactTarget`].
+    ///
+    /// [`CompactTarget`]: super::CompactTarget
     #[derive(Debug, Clone, PartialEq, Eq)]
     #[cfg(feature = "encoding")]
     pub struct CompactTargetDecoderError(pub(super) encoding::UnexpectedEofError);
@@ -439,10 +441,10 @@ impl<'a> Arbitrary<'a> for CompactTarget {
 include!("../include/u256.rs");
 
 impl U256 {
-    /// Constructs a new `U256` from a prefixed hex string.
+    /// Constructs a new [`U256`] from a prefixed hex string.
     fn from_hex(s: &str) -> Result<Self, PrefixedHexError> { parse_int::hex_u256_prefixed(s) }
 
-    /// Constructs a new `U256` from an unprefixed hex string.
+    /// Constructs a new [`U256`] from an unprefixed hex string.
     fn from_unprefixed_hex(s: &str) -> Result<Self, UnprefixedHexError> {
         parse_int::hex_u256_unprefixed(s)
     }

--- a/units/src/result.rs
+++ b/units/src/result.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! Provides a monadic type returned by mathematical operations (`core::ops`).
+//! Provides a monadic type returned by mathematical operations ([`core::ops`]).
 
 use core::convert::Infallible;
 use core::{fmt, ops};
@@ -21,12 +21,12 @@ pub use self::error::NumOpError;
 /// [`core::result::Result`] but implements mathematical operations (e.g. [`core::ops::Add`]) so that
 /// math operations can be chained ergonomically. This is very similar to how `NaN` works.
 ///
-/// `NumOpResult` is a monadic type that contains `Valid` and `Error` (similar to `Ok` and `Err`).
-/// It supports a subset of functions similar to `Result` (e.g. `unwrap`).
+/// [`NumOpResult`] is a monadic type that contains [`Valid`] and [`Error`] (similar to [`Ok`] and
+/// [`Err`]). It supports a subset of functions similar to [`Result`] (e.g. [`unwrap`]).
 ///
 /// # Examples
 ///
-/// The `NumOpResult` type provides protection against overflow and div-by-zero.
+/// The [`NumOpResult`] type provides protection against overflow and div-by-zero.
 ///
 /// ### Overflow protection
 ///
@@ -54,7 +54,7 @@ pub use self::error::NumOpError;
 /// # Ok::<_, amount::OutOfRangeError>(())
 /// ```
 ///
-/// ### Divide-by-zero (overflow in `Div` or `Rem`)
+/// ### Divide-by-zero (overflow in [`Div`] or [`Rem`])
 ///
 /// In some instances one may wish to differentiate div-by-zero from overflow.
 ///
@@ -84,6 +84,12 @@ pub use self::error::NumOpError;
 /// };
 /// # Ok::<_, NumOpError>(())
 /// ```
+///
+/// [`Valid`]: NumOpResult::Valid
+/// [`Error`]: NumOpResult::Error
+/// [`unwrap`]: NumOpResult::unwrap
+/// [`Div`]: core::ops::Div
+/// [`Rem`]: core::ops::Rem
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[must_use]
 pub enum NumOpResult<T> {
@@ -94,7 +100,7 @@ pub enum NumOpResult<T> {
 }
 
 impl<T> NumOpResult<T> {
-    /// Maps a `NumOpResult<T>` to `NumOpResult<U>` by applying a function to a
+    /// Maps a [`NumOpResult<T>`] to [`NumOpResult<U>`] by applying a function to a
     /// contained [`NumOpResult::Valid`] value, leaving a [`NumOpResult::Error`] value untouched.
     #[inline]
     pub fn map<U, F: FnOnce(T) -> U>(self, op: F) -> NumOpResult<U> {
@@ -110,7 +116,9 @@ impl<T: fmt::Debug> NumOpResult<T> {
     ///
     /// # Panics
     ///
-    /// Panics with `msg` if the numeric result is an `Error`.
+    /// Panics with `msg` if the numeric result is an [`Error`].
+    ///
+    /// [`Error`]: NumOpResult::Error
     #[inline]
     #[track_caller]
     pub fn expect(self, msg: &str) -> T {
@@ -124,7 +132,9 @@ impl<T: fmt::Debug> NumOpResult<T> {
     ///
     /// # Panics
     ///
-    /// Panics if the numeric result is an `Error`.
+    /// Panics if the numeric result is an [`Error`].
+    ///
+    /// [`Error`]: NumOpResult::Error
     #[inline]
     #[track_caller]
     pub fn unwrap(self) -> T {
@@ -148,10 +158,14 @@ impl<T: fmt::Debug> NumOpResult<T> {
         }
     }
 
-    /// Returns the contained `Valid` value or a provided default.
+    /// Returns the contained [`Valid`] value or a provided default.
     ///
-    /// Arguments passed to `unwrap_or` are eagerly evaluated; if you are passing the result of a
-    /// function call, it is recommended to use `unwrap_or_else`, which is lazily evaluated.
+    /// Arguments passed to [`unwrap_or`] are eagerly evaluated; if you are passing the result of a
+    /// function call, it is recommended to use [`unwrap_or_else`], which is lazily evaluated.
+    ///
+    /// [`Valid`]: NumOpResult::Valid
+    /// [`unwrap_or`]: NumOpResult::unwrap_or
+    /// [`unwrap_or_else`]: NumOpResult::unwrap_or_else
     #[inline]
     pub fn unwrap_or(self, default: T) -> T {
         match self {
@@ -160,7 +174,9 @@ impl<T: fmt::Debug> NumOpResult<T> {
         }
     }
 
-    /// Returns the contained `Valid` value or computes it from a closure.
+    /// Returns the contained [`Valid`] value or computes it from a closure.
+    ///
+    /// [`Valid`]: NumOpResult::Valid
     #[inline]
     pub fn unwrap_or_else<F>(self, f: F) -> T
     where
@@ -172,7 +188,7 @@ impl<T: fmt::Debug> NumOpResult<T> {
         }
     }
 
-    /// Converts this `NumOpResult` to an `Option<T>`.
+    /// Converts this [`NumOpResult`] to an [`Option<T>`].
     #[inline]
     pub fn ok(self) -> Option<T> {
         match self {
@@ -181,7 +197,7 @@ impl<T: fmt::Debug> NumOpResult<T> {
         }
     }
 
-    /// Converts this `NumOpResult` to a `Result<T, NumOpError>`.
+    /// Converts this [`NumOpResult`] to a [`Result<T, NumOpError>`].
     #[inline]
     #[allow(clippy::missing_errors_doc)]
     pub fn into_result(self) -> Result<T, NumOpError> {
@@ -191,7 +207,11 @@ impl<T: fmt::Debug> NumOpResult<T> {
         }
     }
 
-    /// Calls `op` if the numeric result is `Valid`, otherwise returns the `Error` value of `self`.
+    /// Calls `op` if the numeric result is [`Valid`], otherwise returns the [`Error`] value of
+    /// `self`.
+    ///
+    /// [`Valid`]: NumOpResult::Valid
+    /// [`Error`]: NumOpResult::Error
     #[inline]
     pub fn and_then<F>(self, op: F) -> Self
     where

--- a/units/src/sequence.rs
+++ b/units/src/sequence.rs
@@ -8,7 +8,7 @@
 //! - Indicating whether a transaction opts-in to [BIP-0125] replace-by-fee.
 //!
 //! Note that transactions spending an output with `OP_CHECKLOCKTIMEVERIFY` MUST NOT use
-//! `Sequence::MAX` for the corresponding input. [BIP-0065]
+//! [`Sequence::MAX`] for the corresponding input. [BIP-0065]
 //!
 //! [BIP-0065]: <https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki>
 //! [BIP-0068]: <https://github.com/bitcoin/bips/blob/master/bip-0068.mediawiki>
@@ -65,7 +65,7 @@ impl Sequence {
     /// The lowest sequence number that does not opt-in for replace-by-fee.
     ///
     /// A transaction is considered to have opted in to replacement of itself
-    /// if any of its inputs have a `Sequence` number less than this value
+    /// if any of its inputs have a [`Sequence`] number less than this value
     /// (Explicit Signalling [BIP-0125]).
     ///
     /// [BIP-0125]: <https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki>
@@ -126,7 +126,7 @@ impl Sequence {
         self.is_relative_lock_time() && (self.0 & Self::LOCK_TYPE_MASK > 0)
     }
 
-    /// Constructs a new `Sequence` from a prefixed hex string.
+    /// Constructs a new [`Sequence`] from a prefixed hex string.
     ///
     /// # Errors
     ///
@@ -138,7 +138,7 @@ impl Sequence {
         Ok(Self::from_consensus(lock_time))
     }
 
-    /// Constructs a new `Sequence` from an unprefixed hex string.
+    /// Constructs a new [`Sequence`] from an unprefixed hex string.
     ///
     /// # Errors
     ///
@@ -297,7 +297,9 @@ pub mod error {
     #[cfg(feature = "encoding")]
     use internals::write_err;
 
-    /// An error consensus decoding a `Sequence`.
+    /// An error consensus decoding a [`Sequence`].
+    ///
+    /// [`Sequence`]: super::Sequence
     #[cfg(feature = "encoding")]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct SequenceDecoderError(pub(super) encoding::UnexpectedEofError);

--- a/units/src/time.rs
+++ b/units/src/time.rs
@@ -51,7 +51,7 @@ mod encapsulate {
 pub use encapsulate::BlockTime;
 
 impl BlockTime {
-    /// Constructs a new `BlockTime` from a prefixed hex string.
+    /// Constructs a new [`BlockTime`] from a prefixed hex string.
     ///
     /// # Errors
     ///
@@ -63,7 +63,7 @@ impl BlockTime {
         Ok(Self::from_u32(block_time))
     }
 
-    /// Constructs a new `BlockTime` from an unprefixed hex string.
+    /// Constructs a new [`BlockTime`] from an unprefixed hex string.
     ///
     /// # Errors
     ///
@@ -166,7 +166,9 @@ pub mod error {
     #[cfg(feature = "encoding")]
     use internals::write_err;
 
-    /// An error consensus decoding an `BlockTime`.
+    /// An error consensus decoding a [`BlockTime`].
+    ///
+    /// [`BlockTime`]: super::BlockTime
     #[cfg(feature = "encoding")]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct BlockTimeDecoderError(pub(super) encoding::UnexpectedEofError);

--- a/units/src/weight.rs
+++ b/units/src/weight.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! Implements `Weight` and associated features.
+//! Implements [`Weight`] and associated features.
 
 use core::num::NonZeroU64;
 use core::{fmt, ops};
@@ -82,7 +82,7 @@ impl Weight {
         Self::from_wu(vb * Self::WITNESS_SCALE_FACTOR)
     }
 
-    /// Constructs a new `Weight` from a prefixed hex string.
+    /// Constructs a new [`Weight`] from a prefixed hex string.
     ///
     /// The hex string once parsed is assumed to represent weight units.
     ///
@@ -96,7 +96,7 @@ impl Weight {
         Ok(Self::from_wu(weight))
     }
 
-    /// Constructs a new `Weight` from an unprefixed hex string.
+    /// Constructs a new [`Weight`] from an unprefixed hex string.
     ///
     /// The hex string once parsed is assumed to represent weight units.
     ///

--- a/units/src/weight.rs
+++ b/units/src/weight.rs
@@ -42,12 +42,16 @@ pub use encapsulate::Weight;
 impl Weight {
     /// Zero weight units (wu).
     ///
-    /// Equivalent to [`MIN`](Self::MIN), may better express intent in some contexts.
+    /// Equivalent to [`MIN`], may better express intent in some contexts.
+    ///
+    /// [`MIN`]: Self::MIN
     pub const ZERO: Self = Self::from_wu(0);
 
     /// Minimum possible value (0 wu).
     ///
-    /// Equivalent to [`ZERO`](Self::ZERO), may better express intent in some contexts.
+    /// Equivalent to [`ZERO`], may better express intent in some contexts.
+    ///
+    /// [`ZERO`]: Self::ZERO
     pub const MIN: Self = Self::from_wu(u64::MIN);
 
     /// Maximum possible value.


### PR DESCRIPTION
The C-LINK docs guideline recommends including links for types and modules throughout the public-facing documentation. Additionally, at least in VSCode, these links can be followed through Ctrl-Click, even when in private code comments. As such, all types and modules should be modified to links to improve both user docs readability, and code navigation.