### PR TITLE
network: add TryFrom string conversions for Network

### DIFF
--- a/network/api/all-features.txt
+++ b/network/api/all-features.txt
@@ -71,6 +71,21 @@ impl core::convert::AsRef<bitcoin_network_kind::Network> for bitcoin_network_kin
   pub fn bitcoin_network_kind::Network::as_ref(&self) -> &Self [impl: impl core::convert::AsRef<bitcoin_network_kind::Network> for bitcoin_network_kind::Network]
 impl core::convert::From<bitcoin_network_kind::Network> for bitcoin_network_kind::NetworkKind
   pub fn bitcoin_network_kind::NetworkKind::from(network: bitcoin_network_kind::Network) -> Self [impl: impl core::convert::From<bitcoin_network_kind::Network> for bitcoin_network_kind::NetworkKind]
+impl core::convert::TryFrom<&str> for bitcoin_network_kind::Network
+  pub type bitcoin_network_kind::Network::Error = bitcoin_network_kind::error::ParseNetworkError [impl: impl core::convert::TryFrom<&str> for bitcoin_network_kind::Network]
+  pub fn bitcoin_network_kind::Network::try_from(s: &str) -> core::result::Result<Self, Self::Error> [impl: impl core::convert::TryFrom<&str> for bitcoin_network_kind::Network]
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_network_kind::Network
+  pub type bitcoin_network_kind::Network::Error = bitcoin_network_kind::error::ParseNetworkError [impl: impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_network_kind::Network]
+  pub fn bitcoin_network_kind::Network::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error> [impl: impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_network_kind::Network]
+impl core::convert::TryFrom<alloc::rc::Rc<str>> for bitcoin_network_kind::Network
+  pub type bitcoin_network_kind::Network::Error = bitcoin_network_kind::error::ParseNetworkError [impl: impl core::convert::TryFrom<alloc::rc::Rc<str>> for bitcoin_network_kind::Network]
+  pub fn bitcoin_network_kind::Network::try_from(s: alloc::rc::Rc<str>) -> core::result::Result<Self, Self::Error> [impl: impl core::convert::TryFrom<alloc::rc::Rc<str>> for bitcoin_network_kind::Network]
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_network_kind::Network
+  pub type bitcoin_network_kind::Network::Error = bitcoin_network_kind::error::ParseNetworkError [impl: impl core::convert::TryFrom<alloc::string::String> for bitcoin_network_kind::Network]
+  pub fn bitcoin_network_kind::Network::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error> [impl: impl core::convert::TryFrom<alloc::string::String> for bitcoin_network_kind::Network]
+impl core::convert::TryFrom<alloc::sync::Arc<str>> for bitcoin_network_kind::Network
+  pub type bitcoin_network_kind::Network::Error = bitcoin_network_kind::error::ParseNetworkError [impl: impl core::convert::TryFrom<alloc::sync::Arc<str>> for bitcoin_network_kind::Network]
+  pub fn bitcoin_network_kind::Network::try_from(s: alloc::sync::Arc<str>) -> core::result::Result<Self, Self::Error> [impl: impl core::convert::TryFrom<alloc::sync::Arc<str>> for bitcoin_network_kind::Network]
 impl core::fmt::Debug for bitcoin_network_kind::Network
   pub fn bitcoin_network_kind::Network::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_network_kind::Network]
 impl core::fmt::Display for bitcoin_network_kind::Network

--- a/network/api/alloc-only.txt
+++ b/network/api/alloc-only.txt
@@ -65,6 +65,21 @@ impl core::convert::AsRef<bitcoin_network_kind::Network> for bitcoin_network_kin
   pub fn bitcoin_network_kind::Network::as_ref(&self) -> &Self [impl: impl core::convert::AsRef<bitcoin_network_kind::Network> for bitcoin_network_kind::Network]
 impl core::convert::From<bitcoin_network_kind::Network> for bitcoin_network_kind::NetworkKind
   pub fn bitcoin_network_kind::NetworkKind::from(network: bitcoin_network_kind::Network) -> Self [impl: impl core::convert::From<bitcoin_network_kind::Network> for bitcoin_network_kind::NetworkKind]
+impl core::convert::TryFrom<&str> for bitcoin_network_kind::Network
+  pub type bitcoin_network_kind::Network::Error = bitcoin_network_kind::error::ParseNetworkError [impl: impl core::convert::TryFrom<&str> for bitcoin_network_kind::Network]
+  pub fn bitcoin_network_kind::Network::try_from(s: &str) -> core::result::Result<Self, Self::Error> [impl: impl core::convert::TryFrom<&str> for bitcoin_network_kind::Network]
+impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_network_kind::Network
+  pub type bitcoin_network_kind::Network::Error = bitcoin_network_kind::error::ParseNetworkError [impl: impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_network_kind::Network]
+  pub fn bitcoin_network_kind::Network::try_from(s: alloc::boxed::Box<str>) -> core::result::Result<Self, Self::Error> [impl: impl core::convert::TryFrom<alloc::boxed::Box<str>> for bitcoin_network_kind::Network]
+impl core::convert::TryFrom<alloc::rc::Rc<str>> for bitcoin_network_kind::Network
+  pub type bitcoin_network_kind::Network::Error = bitcoin_network_kind::error::ParseNetworkError [impl: impl core::convert::TryFrom<alloc::rc::Rc<str>> for bitcoin_network_kind::Network]
+  pub fn bitcoin_network_kind::Network::try_from(s: alloc::rc::Rc<str>) -> core::result::Result<Self, Self::Error> [impl: impl core::convert::TryFrom<alloc::rc::Rc<str>> for bitcoin_network_kind::Network]
+impl core::convert::TryFrom<alloc::string::String> for bitcoin_network_kind::Network
+  pub type bitcoin_network_kind::Network::Error = bitcoin_network_kind::error::ParseNetworkError [impl: impl core::convert::TryFrom<alloc::string::String> for bitcoin_network_kind::Network]
+  pub fn bitcoin_network_kind::Network::try_from(s: alloc::string::String) -> core::result::Result<Self, Self::Error> [impl: impl core::convert::TryFrom<alloc::string::String> for bitcoin_network_kind::Network]
+impl core::convert::TryFrom<alloc::sync::Arc<str>> for bitcoin_network_kind::Network
+  pub type bitcoin_network_kind::Network::Error = bitcoin_network_kind::error::ParseNetworkError [impl: impl core::convert::TryFrom<alloc::sync::Arc<str>> for bitcoin_network_kind::Network]
+  pub fn bitcoin_network_kind::Network::try_from(s: alloc::sync::Arc<str>) -> core::result::Result<Self, Self::Error> [impl: impl core::convert::TryFrom<alloc::sync::Arc<str>> for bitcoin_network_kind::Network]
 impl core::fmt::Debug for bitcoin_network_kind::Network
   pub fn bitcoin_network_kind::Network::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_network_kind::Network]
 impl core::fmt::Display for bitcoin_network_kind::Network

--- a/network/api/no-features.txt
+++ b/network/api/no-features.txt
@@ -59,6 +59,9 @@ impl core::convert::AsRef<bitcoin_network_kind::Network> for bitcoin_network_kin
   pub fn bitcoin_network_kind::Network::as_ref(&self) -> &Self [impl: impl core::convert::AsRef<bitcoin_network_kind::Network> for bitcoin_network_kind::Network]
 impl core::convert::From<bitcoin_network_kind::Network> for bitcoin_network_kind::NetworkKind
   pub fn bitcoin_network_kind::NetworkKind::from(network: bitcoin_network_kind::Network) -> Self [impl: impl core::convert::From<bitcoin_network_kind::Network> for bitcoin_network_kind::NetworkKind]
+impl core::convert::TryFrom<&str> for bitcoin_network_kind::Network
+  pub type bitcoin_network_kind::Network::Error = bitcoin_network_kind::error::ParseNetworkError [impl: impl core::convert::TryFrom<&str> for bitcoin_network_kind::Network]
+  pub fn bitcoin_network_kind::Network::try_from(s: &str) -> core::result::Result<Self, Self::Error> [impl: impl core::convert::TryFrom<&str> for bitcoin_network_kind::Network]
 impl core::fmt::Debug for bitcoin_network_kind::Network
   pub fn bitcoin_network_kind::Network::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result [impl: impl core::fmt::Debug for bitcoin_network_kind::Network]
 impl core::fmt::Display for bitcoin_network_kind::Network

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -34,9 +34,10 @@ extern crate alloc;
 #[cfg(feature = "serde")]
 pub extern crate serde;
 
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+use alloc::sync::Arc;
 #[cfg(feature = "alloc")]
-use alloc::{boxed::Box, rc::Rc, string::String, sync::Arc};
-
+use alloc::{boxed::Box, rc::Rc, string::String};
 use core::fmt;
 use core::str::FromStr;
 
@@ -212,7 +213,7 @@ impl TryFrom<Rc<str>> for Network {
     fn try_from(s: Rc<str>) -> Result<Self, Self::Error> { Self::from_str(&s) }
 }
 
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
 impl TryFrom<Arc<str>> for Network {
     type Error = ParseNetworkError;
 
@@ -470,11 +471,19 @@ mod tests {
     #[test]
     #[cfg(feature = "alloc")]
     fn try_from_alloc_string_types() {
-        use alloc::{rc::Rc, sync::Arc};
+        use alloc::boxed::Box;
+        use alloc::rc::Rc;
+        use alloc::string::String;
 
-        assert_eq!(Network::try_from("bitcoin".to_string()), Ok(Network::Bitcoin));
-        assert_eq!(Network::try_from("bitcoin".to_string().into_boxed_str()), Ok(Network::Bitcoin));
+        assert_eq!(Network::try_from(String::from("bitcoin")), Ok(Network::Bitcoin));
+        assert_eq!(Network::try_from(Box::<str>::from("bitcoin")), Ok(Network::Bitcoin));
         assert_eq!(Network::try_from(Rc::<str>::from("bitcoin")), Ok(Network::Bitcoin));
-        assert_eq!(Network::try_from(Arc::<str>::from("bitcoin")), Ok(Network::Bitcoin));
+
+        #[cfg(target_has_atomic = "ptr")]
+        {
+            use alloc::sync::Arc;
+
+            assert_eq!(Network::try_from(Arc::<str>::from("bitcoin")), Ok(Network::Bitcoin));
+        }
     }
 }

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -28,8 +28,14 @@
 #[cfg(feature = "std")]
 extern crate std;
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
 #[cfg(feature = "serde")]
 pub extern crate serde;
+
+#[cfg(feature = "alloc")]
+use alloc::{boxed::Box, rc::Rc, string::String, sync::Arc};
 
 use core::fmt;
 use core::str::FromStr;
@@ -175,6 +181,45 @@ impl FromStr for Network {
     }
 }
 
+impl TryFrom<&str> for Network {
+    type Error = ParseNetworkError;
+
+    #[inline]
+    fn try_from(s: &str) -> Result<Self, Self::Error> { Self::from_str(s) }
+}
+
+#[cfg(feature = "alloc")]
+impl TryFrom<String> for Network {
+    type Error = ParseNetworkError;
+
+    #[inline]
+    fn try_from(s: String) -> Result<Self, Self::Error> { Self::from_str(&s) }
+}
+
+#[cfg(feature = "alloc")]
+impl TryFrom<Box<str>> for Network {
+    type Error = ParseNetworkError;
+
+    #[inline]
+    fn try_from(s: Box<str>) -> Result<Self, Self::Error> { Self::from_str(&s) }
+}
+
+#[cfg(feature = "alloc")]
+impl TryFrom<Rc<str>> for Network {
+    type Error = ParseNetworkError;
+
+    #[inline]
+    fn try_from(s: Rc<str>) -> Result<Self, Self::Error> { Self::from_str(&s) }
+}
+
+#[cfg(feature = "alloc")]
+impl TryFrom<Arc<str>> for Network {
+    type Error = ParseNetworkError;
+
+    #[inline]
+    fn try_from(s: Arc<str>) -> Result<Self, Self::Error> { Self::from_str(&s) }
+}
+
 impl AsRef<Self> for Network {
     fn as_ref(&self) -> &Self { self }
 }
@@ -236,7 +281,6 @@ pub mod as_core_arg {
     //!     network: Network,
     //! }
     //! ```
-
     // No need to document these functions, they are well known.
     #![allow(missing_docs)]
     #![allow(clippy::missing_errors_doc)]
@@ -411,5 +455,26 @@ mod tests {
                 serde_test::Token::StructEnd,
             ],
         );
+    }
+
+    #[test]
+    fn try_from_str() {
+        assert_eq!(Network::try_from("bitcoin"), Ok(Network::Bitcoin));
+        assert_eq!(Network::try_from("testnet"), Ok(Network::Testnet(TestnetVersion::V3)));
+        assert_eq!(Network::try_from("testnet4"), Ok(Network::Testnet(TestnetVersion::V4)));
+        assert_eq!(Network::try_from("regtest"), Ok(Network::Regtest));
+        assert_eq!(Network::try_from("signet"), Ok(Network::Signet));
+        assert!(Network::try_from("fakenet").is_err());
+    }
+
+    #[test]
+    #[cfg(feature = "alloc")]
+    fn try_from_alloc_string_types() {
+        use alloc::{rc::Rc, sync::Arc};
+
+        assert_eq!(Network::try_from("bitcoin".to_string()), Ok(Network::Bitcoin));
+        assert_eq!(Network::try_from("bitcoin".to_string().into_boxed_str()), Ok(Network::Bitcoin));
+        assert_eq!(Network::try_from(Rc::<str>::from("bitcoin")), Ok(Network::Bitcoin));
+        assert_eq!(Network::try_from(Arc::<str>::from("bitcoin")), Ok(Network::Bitcoin));
     }
 }


### PR DESCRIPTION
Add TryFrom conversions for string types while reusing the existing FromStr parser. Owned string conversions remain gated behind alloc.

Refs #1802
