### PR TITLE
Capitalize Bitcoin protocol references in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -300,7 +300,7 @@ apoelstra@wpsoftware.net, encrypted with his public key from
 
 ## Testing
 
-Related to the security aspect, rust bitcoin developers take testing very
+Related to the security aspect, rust-bitcoin developers take testing very
 seriously. Due to the modular nature of the project, writing new test cases is
 easy and good test coverage of the codebase is an important goal. Refactoring
 the project to enable fine-grained unit testing is also an ongoing effort.

--- a/addresses/README.md
+++ b/addresses/README.md
@@ -1,3 +1,3 @@
 # Bitcoin Receive
 
-Types and logic required to receive bitcoin - i.e., bitcoin addresses.
+Types and logic required to receive bitcoin - i.e., Bitcoin addresses.

--- a/addresses/src/lib.rs
+++ b/addresses/src/lib.rs
@@ -111,13 +111,13 @@ use witness_program::WitnessProgram;
 
 const OP_PUSHBYTES_0: Opcode = Opcode::from_u8(0x00);
 
-/// Mainnet (bitcoin) pubkey address prefix.
+/// Bitcoin Mainnet pubkey address prefix.
 pub const PUBKEY_ADDRESS_PREFIX_MAIN: u8 = 0; // 0x00
-/// Mainnet (bitcoin) script address prefix.
+/// Bitcoin Mainnet script address prefix.
 pub const SCRIPT_ADDRESS_PREFIX_MAIN: u8 = 5; // 0x05
-/// Test (testnet, signet, regtest) pubkey address prefix.
+/// Bitcoin test networks (testnet, signet, regtest) pubkey address prefix.
 pub const PUBKEY_ADDRESS_PREFIX_TEST: u8 = 111; // 0x6f
-/// Test (testnet, signet, regtest) script address prefix.
+/// Bitcoin test networks (testnet, signet, regtest) script address prefix.
 pub const SCRIPT_ADDRESS_PREFIX_TEST: u8 = 196; // 0xc4
 
 /// Extension functionality for the [`ScriptPubKeyBuf`] type.

--- a/bitcoin/src/address.rs
+++ b/bitcoin/src/address.rs
@@ -422,7 +422,7 @@ mod tests {
     #[test]
     fn pay_to_anchor_address_regtest() {
         // Verify that P2A uses the expected address for regtest.
-        // This test-vector is borrowed from the bitcoin source code.
+        // This test-vector is borrowed from the Bitcoin Core source code.
         let address_str = "bcrt1pfeesnyr2tx";
 
         let script = ScriptPubKeyBuf::new_p2a();

--- a/bitcoin/src/blockdata/constants.rs
+++ b/bitcoin/src/blockdata/constants.rs
@@ -209,33 +209,33 @@ impl_array_newtype_stringify!(ChainHash, 32);
 
 impl ChainHash {
     // Mainnet value can be verified at https://github.com/lightning/bolts/blob/master/00-introduction.md
-    /// `ChainHash` for mainnet bitcoin.
+    /// `ChainHash` for Bitcoin Mainnet.
     pub const BITCOIN: Self = Self([
         111, 226, 140, 10, 182, 241, 179, 114, 193, 166, 162, 70, 174, 99, 247, 79, 147, 30, 131,
         101, 225, 90, 8, 156, 104, 214, 25, 0, 0, 0, 0, 0,
     ]);
-    /// `ChainHash` for testnet3 bitcoin.
+    /// `ChainHash` for Bitcoin testnet3.
     #[deprecated(since = "TBD", note = "use `TESTNET3` instead")]
     pub const TESTNET: Self = Self([
         67, 73, 127, 215, 248, 38, 149, 113, 8, 244, 163, 15, 217, 206, 195, 174, 186, 121, 151,
         32, 132, 233, 14, 173, 1, 234, 51, 9, 0, 0, 0, 0,
     ]);
-    /// `ChainHash` for testnet3 bitcoin.
+    /// `ChainHash` for Bitcoin testnet3.
     pub const TESTNET3: Self = Self([
         67, 73, 127, 215, 248, 38, 149, 113, 8, 244, 163, 15, 217, 206, 195, 174, 186, 121, 151,
         32, 132, 233, 14, 173, 1, 234, 51, 9, 0, 0, 0, 0,
     ]);
-    /// `ChainHash` for testnet4 bitcoin.
+    /// `ChainHash` for Bitcoin testnet4.
     pub const TESTNET4: Self = Self([
         67, 240, 139, 218, 176, 80, 227, 91, 86, 124, 134, 75, 145, 244, 127, 80, 174, 114, 90,
         226, 222, 83, 188, 251, 186, 242, 132, 218, 0, 0, 0, 0,
     ]);
-    /// `ChainHash` for signet bitcoin.
+    /// `ChainHash` for Bitcoin signet.
     pub const SIGNET: Self = Self([
         246, 30, 238, 59, 99, 163, 128, 164, 119, 160, 99, 175, 50, 178, 187, 201, 124, 159, 249,
         240, 31, 44, 66, 37, 233, 115, 152, 129, 8, 0, 0, 0,
     ]);
-    /// `ChainHash` for regtest bitcoin.
+    /// `ChainHash` for Bitcoin regtest.
     pub const REGTEST: Self = Self([
         6, 34, 110, 70, 17, 26, 11, 89, 202, 175, 18, 96, 67, 235, 91, 191, 40, 195, 79, 58, 94,
         51, 42, 31, 199, 178, 183, 60, 241, 136, 145, 15,

--- a/bitcoin/src/blockdata/transaction.rs
+++ b/bitcoin/src/blockdata/transaction.rs
@@ -1185,7 +1185,7 @@ mod tests {
         // will also fail. But these will show you where the failure is so I'll leave them in.
         assert_eq!(realtx.version, Version::ONE);
         assert_eq!(realtx.inputs.len(), 1);
-        // In particular this one is easy to get backward -- in bitcoin hashes are encoded
+        // In particular this one is easy to get backward -- in Bitcoin hashes are encoded
         // as little-endian 256-bit numbers rather than as data strings.
         assert_eq!(
             format!("{:x}", realtx.inputs[0].previous_output.txid),
@@ -1225,7 +1225,7 @@ mod tests {
         // will also fail. But these will show you where the failure is so I'll leave them in.
         assert_eq!(realtx.version, Version::TWO);
         assert_eq!(realtx.inputs.len(), 1);
-        // In particular this one is easy to get backward -- in bitcoin hashes are encoded
+        // In particular this one is easy to get backward -- in Bitcoin hashes are encoded
         // as little-endian 256-bit numbers rather than as data strings.
         assert_eq!(
             format!("{:x}", realtx.inputs[0].previous_output.txid),

--- a/chacha20_poly1305/README.md
+++ b/chacha20_poly1305/README.md
@@ -2,4 +2,4 @@
 
 An authenticated encryption with associated data (AEAD) algorithm implemented with the ChaCha20 stream cipher and the Poly1305 message authentication code (MAC).
 
-This implementation is maintained by the rust-bitcoin community and has a focus on a bare-bones API suitable for the bitcoin ecosystem.
+This implementation is maintained by the rust-bitcoin community and has a focus on a bare-bones API suitable for the Bitcoin ecosystem.

--- a/consensus_encoding/src/compact_size.rs
+++ b/consensus_encoding/src/compact_size.rs
@@ -18,7 +18,7 @@ use crate::DecoderStatus;
 /// Default maximum size of a decoded object in bytes.
 ///
 /// Matches Bitcoin Core's default [serialization limit]. This is
-/// a high level anti-DoS limit which all bitcoin types should
+/// a high level anti-DoS limit which all Bitcoin types should
 /// easily fit within.
 ///
 /// [serialization limit]: https://github.com/bitcoin/bitcoin/blob/a7c29df0e5ace05b6186612671d6103c112ec922/src/serialize.h#L32

--- a/crypto/README.md
+++ b/crypto/README.md
@@ -1,3 +1,3 @@
 # Cryptography
 
-Types and logic required to support cryptography i.e., bitcoin keys.
+Types and logic required to support cryptography i.e., Bitcoin keys.

--- a/crypto/src/key.rs
+++ b/crypto/src/key.rs
@@ -675,11 +675,11 @@ impl LegacyPublicKey {
     #[inline]
     pub fn serialize_uncompressed(&self) -> [u8; 65] { self.to_inner().serialize_uncompressed() }
 
-    /// Returns bitcoin 160-bit hash of the public key.
+    /// Returns the Bitcoin 160-bit hash of the public key.
     #[inline]
     pub fn pubkey_hash(&self) -> PubkeyHash { PubkeyHash(hash160::Hash::hash(&self.serialize())) }
 
-    /// Returns bitcoin 160-bit hash of the public key for witness program
+    /// Returns the Bitcoin 160-bit hash of the public key for witness program
     ///
     /// # Errors
     ///
@@ -921,11 +921,11 @@ impl From<&FullPublicKey> for WPubkeyHash {
 }
 
 impl FullPublicKey {
-    /// Returns bitcoin 160-bit hash of the public key.
+    /// Returns the Bitcoin 160-bit hash of the public key.
     #[inline]
     pub fn pubkey_hash(&self) -> PubkeyHash { PubkeyHash(hash160::Hash::hash(&self.to_bytes())) }
 
-    /// Returns bitcoin 160-bit hash of the public key for witness program.
+    /// Returns the Bitcoin 160-bit hash of the public key for witness program.
     #[inline]
     pub fn wpubkey_hash(&self) -> WPubkeyHash {
         WPubkeyHash::from_byte_array(hash160::Hash::hash(&self.to_bytes()).to_byte_array())
@@ -1139,7 +1139,7 @@ impl PrivateKey {
     /// ECDSA signs a [`Message`] with this private key.
     ///
     /// This functions grinds the nonce to produce a signature less than 71 bytes and compatible
-    /// with the low r signature implementation of bitcoin core.
+    /// with the low r signature implementation of Bitcoin Core.
     ///
     /// See [`secp256k1::ecdsa::sign_low_r`] for details.
     ///
@@ -1582,7 +1582,7 @@ impl fmt::Debug for SerializedXOnlyPublicKey {
     }
 }
 
-/// Error types for bitcoin keys.
+/// Error types for Bitcoin keys.
 pub mod error {
     use core::convert::Infallible;
     use core::fmt;

--- a/docs/adr/0001_consensus_encoding.md
+++ b/docs/adr/0001_consensus_encoding.md
@@ -44,16 +44,16 @@ Martin Habovštiak wrote a general purpose sans-I/O encoding/decoding crate, [`p
 
 **Cons:**
 
-* Is general purpose, so has a few layers of abstraction and complexity not required in the bitcoin domain.
+* Is general purpose, so has a few layers of abstraction and complexity not required in the Bitcoin domain.
 
 #### Option 3: Create dedicated consensus_encoding crate
 
-Extract consensus encoding/decoding logic into a new crate which is sans-I/O and focused only on the bitcoin domain.
+Extract consensus encoding/decoding logic into a new crate which is sans-I/O and focused only on the Bitcoin domain.
 
 **Pros:**
 
 * Removes ties to std I/O and I/O errors.
-* Interface is tailored for the bitcoin domain.
+* Interface is tailored for the Bitcoin domain.
 
 **Cons:**
 

--- a/key_expression/src/bip32.rs
+++ b/key_expression/src/bip32.rs
@@ -27,9 +27,9 @@ pub use self::error::{
     ParseXprivError, ParseXpubError, XkeyDecodeError, XprivDecodeError, XpubDecodeError
 };
 
-/// Version bytes for extended public keys on the Bitcoin network.
+/// Version bytes for extended public keys on Bitcoin Mainnet.
 const VERSION_BYTES_MAINNET_PUBLIC: [u8; 4] = [0x04, 0x88, 0xB2, 0x1E];
-/// Version bytes for extended private keys on the Bitcoin network.
+/// Version bytes for extended private keys on Bitcoin Mainnet.
 const VERSION_BYTES_MAINNET_PRIVATE: [u8; 4] = [0x04, 0x88, 0xAD, 0xE4];
 /// Version bytes for extended public keys on any of the testnet networks.
 const VERSION_BYTES_TESTNETS_PUBLIC: [u8; 4] = [0x04, 0x35, 0x87, 0xCF];

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -48,14 +48,14 @@ pub use self::error::ParseNetworkError;
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum NetworkKind {
-    /// The Bitcoin mainnet network.
+    /// Bitcoin Mainnet.
     Main,
-    /// Some kind of testnet network (testnet, signet, regtest).
+    /// Some kind of Bitcoin testnet network (testnet, signet, regtest).
     Test,
 }
 
 impl NetworkKind {
-    /// Returns `true` if this represents the Bitcoin mainnet.
+    /// Returns `true` if this represents Bitcoin Mainnet.
     pub const fn is_mainnet(self) -> bool { matches!(self, Self::Main) }
 }
 
@@ -79,7 +79,7 @@ impl From<Network> for NetworkKind {
 /// crate instead.
 #[derive(Copy, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Debug)]
 pub enum Network {
-    /// Mainnet Bitcoin.
+    /// Bitcoin Mainnet.
     Bitcoin,
     /// Bitcoin's testnet network.
     Testnet(TestnetVersion),

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -339,7 +339,7 @@ impl encoding::Decode for ServiceFlags {
 pub struct Magic([u8; 4]);
 
 impl Magic {
-    /// Bitcoin mainnet network magic bytes.
+    /// Bitcoin Mainnet network magic bytes.
     pub const BITCOIN: Self = Self([0xF9, 0xBE, 0xB4, 0xD9]);
     /// Bitcoin testnet3 network magic bytes.
     pub const TESTNET3: Self = Self([0x0B, 0x11, 0x09, 0x07]);

--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -1582,7 +1582,7 @@ impl encoding::Decode for NetworkHeader {
     type Decoder = NetworkHeaderDecoder;
 }
 
-/// A list of bitcoin block headers.
+/// A list of Bitcoin block headers.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HeadersMessage(pub Vec<NetworkHeader>);
 

--- a/p2p/src/message_network.rs
+++ b/p2p/src/message_network.rs
@@ -185,7 +185,7 @@ crate::decoder_newtype! {
     }
 }
 
-/// A bitcoin user agent defined by BIP-0014. The user agent is sent in the version message when a
+/// A Bitcoin user agent defined by BIP-0014. The user agent is sent in the version message when a
 /// connection between two peers is established. It is intended to advertise client software in a
 /// well-defined format.
 ///

--- a/primitives/src/hash_types/block_hash.rs
+++ b/primitives/src/hash_types/block_hash.rs
@@ -12,7 +12,7 @@ use arbitrary::{Arbitrary, Unstructured};
 use hashes::sha256d;
 use internals::write_err;
 
-/// A bitcoin block hash.
+/// A Bitcoin block hash.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BlockHash(sha256d::Hash);
 

--- a/primitives/src/hash_types/script_hash.rs
+++ b/primitives/src/hash_types/script_hash.rs
@@ -18,7 +18,7 @@ use crate::script::{PushBytes, PushBytesBuf, Script, ScriptHashableTag, MAX_REDE
 
 /// A 160-bit hash of Bitcoin Script bytecode.
 ///
-/// Note: there is another "script hash" object in bitcoin ecosystem (Electrum protocol) that
+/// Note: there is another "script hash" object in the Bitcoin ecosystem (Electrum protocol) that
 /// uses 256-bit hash and hashes a semantically different script. Thus, this type cannot
 /// represent it.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/primitives/src/hash_types/txid.rs
+++ b/primitives/src/hash_types/txid.rs
@@ -14,7 +14,7 @@ use hashes::sha256d;
 #[cfg(doc)]
 use crate::OutPoint;
 
-/// A bitcoin transaction hash/transaction ID.
+/// A Bitcoin transaction hash/transaction ID.
 ///
 /// For compatibility with the existing Bitcoin infrastructure and historical and current
 /// versions of the Bitcoin Core software itself, this and other [`sha256d::Hash`] types, are

--- a/primitives/src/hash_types/witness_script_hash.rs
+++ b/primitives/src/hash_types/witness_script_hash.rs
@@ -18,7 +18,7 @@ use crate::script::{PushBytes, PushBytesBuf, WitnessScript, MAX_WITNESS_SCRIPT_S
 
 /// SegWit (256-bit) version of a Bitcoin Script bytecode hash.
 ///
-/// Note: there is another "script hash" object in bitcoin ecosystem (Electrum protocol) that
+/// Note: there is another "script hash" object in the Bitcoin ecosystem (Electrum protocol) that
 /// looks similar to this one also being SHA256, however, they hash semantically different
 /// scripts and have reversed representations, so this type cannot be used for both.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/primitives/src/hash_types/wtxid.rs
+++ b/primitives/src/hash_types/wtxid.rs
@@ -11,7 +11,7 @@ use core::{fmt, str};
 use arbitrary::{Arbitrary, Unstructured};
 use hashes::sha256d;
 
-/// A bitcoin witness transaction ID.
+/// A Bitcoin witness transaction ID.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Wtxid(sha256d::Hash);
 

--- a/primitives/src/witness_version.rs
+++ b/primitives/src/witness_version.rs
@@ -71,8 +71,8 @@ impl WitnessVersion {
     /// Returns integer version number representation for a given [`WitnessVersion`] value.
     ///
     /// NB: this is not the same as an integer representation of the opcode signifying witness
-    /// version in bitcoin script. Thus, there is no function to directly convert witness version
-    /// into a byte since the conversion requires context (bitcoin script or just a version number).
+    /// version in Bitcoin script. Thus, there is no function to directly convert witness version
+    /// into a byte since the conversion requires context (Bitcoin script or just a version number).
     pub fn to_num(self) -> u8 { self as u8 }
 }
 

--- a/primitives/tests/encoding.rs
+++ b/primitives/tests/encoding.rs
@@ -264,7 +264,7 @@ fn decode_segwit_transaction() {
     // will also fail. But these will show you where the failure is so I'll leave them in.
     assert_eq!(tx.version, Version::TWO);
     assert_eq!(tx.inputs.len(), 1);
-    // In particular this one is easy to get backward -- in bitcoin hashes are encoded
+    // In particular this one is easy to get backward -- in Bitcoin hashes are encoded
     // as little-endian 256-bit numbers rather than as data strings.
     assert_eq!(
         format!("{:x}", tx.inputs[0].previous_output.txid),
@@ -297,7 +297,7 @@ fn decode_nonsegwit_transaction() {
     // will also fail. But these will show you where the failure is so I'll leave them in.
     assert_eq!(tx.version, Version::ONE);
     assert_eq!(tx.inputs.len(), 1);
-    // In particular this one is easy to get backward -- in bitcoin hashes are encoded
+    // In particular this one is easy to get backward -- in Bitcoin hashes are encoded
     // as little-endian 256-bit numbers rather than as data strings.
     assert_eq!(
         format!("{:x}", tx.inputs[0].previous_output.txid),

--- a/units/src/amount/signed.rs
+++ b/units/src/amount/signed.rs
@@ -22,7 +22,7 @@ mod encapsulate {
 
     /// A signed amount.
     ///
-    /// The [`SignedAmount`] type can be used to express Bitcoin amounts that support arithmetic and
+    /// The [`SignedAmount`] type can be used to express bitcoin amounts that support arithmetic and
     /// conversion to various denominations. The [`SignedAmount`] type does not implement [`serde`]
     /// traits but we do provide modules for serializing as satoshis or bitcoin.
     ///
@@ -279,7 +279,7 @@ impl SignedAmount {
         Self::from_sat_u64(amount)
     }
 
-    /// Expresses this [`SignedAmount`] as a floating-point value in Bitcoin.
+    /// Expresses this [`SignedAmount`] as a floating-point value in bitcoin.
     ///
     /// Please be aware of the risk of using floating-point numbers.
     ///
@@ -532,7 +532,7 @@ impl fmt::Debug for SignedAmount {
 }
 
 // No one should depend on a binding contract for Display for this type.
-// Just using Bitcoin denominated string.
+// Just using bitcoin denominated string.
 impl fmt::Display for SignedAmount {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -27,7 +27,7 @@ mod encapsulate {
 
     /// An amount.
     ///
-    /// The [`Amount`] type can be used to express Bitcoin amounts that support arithmetic and
+    /// The [`Amount`] type can be used to express bitcoin amounts that support arithmetic and
     /// conversion to various denominations. The [`Amount`] type does not implement [`serde`] traits
     /// but we do provide modules for serializing as satoshis or bitcoin.
     ///
@@ -242,7 +242,7 @@ impl Amount {
         self.to_string_in(denom).parse::<f64>().unwrap()
     }
 
-    /// Expresses this [`Amount`] as a floating-point value in Bitcoin.
+    /// Expresses this [`Amount`] as a floating-point value in bitcoin.
     ///
     /// Please be aware of the risk of using floating-point numbers.
     ///
@@ -557,7 +557,7 @@ impl fmt::Debug for Amount {
 }
 
 // No one should depend on a binding contract for Display for this type.
-// Just using Bitcoin denominated string.
+// Just using bitcoin denominated string.
 impl fmt::Display for Amount {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/units/src/pow.rs
+++ b/units/src/pow.rs
@@ -235,7 +235,7 @@ impl_fmt_traits_for_u32_wrapper!(Target);
 /// This is used to encode a target into the block header. Satoshi made this part of consensus code
 /// in the original version of Bitcoin, likely copying an idea from OpenSSL.
 ///
-/// OpenSSL's bignum (BN) type has an encoding, which is even called "compact" as in bitcoin, which
+/// OpenSSL's bignum (BN) type has an encoding, which is even called "compact" as in Bitcoin, which
 /// is exactly this format.
 ///
 /// # Note on order/equality


### PR DESCRIPTION
Bitcoin should have a capital `B` when referring to the protocol, network,  or software. And lower case `b` when referring to the currency.

Correct all of the docs so that the capitalization is consistent. Including a couple of other minor adjacent corrections.

Standardize docs to `Bitcoin {network}`.