### PR TITLE
ci: gen PR labels from master instead of fork

### DIFF
--- a/.github/workflows/manage-pr.yml
+++ b/.github/workflows/manage-pr.yml
@@ -13,18 +13,11 @@ jobs:
       - name: Checkout master
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          path: master
-          persist-credentials: false
-      - name: Checkout merge commit
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          path: merge
-          ref: "refs/pull/${{ github.event.number }}/merge"
           persist-credentials: false
       - name: Generate label config
-        run: cd master && SCAN_DIR=../merge ./.github/gen_label_config.sh
+        run: ./.github/gen_label_config.sh
       - name: Update labels
         uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
         with:
-          configuration-path: master/.github/labeler.yml
+          configuration-path: .github/labeler.yml
           sync-labels: true


### PR DESCRIPTION
This fixes a CI issue and doubles as a security fix.

The labeler job now fails on every fork PR. This is because, [yesterday](https://github.com/rust-bitcoin/rust-bitcoin/commit/2d138d732b791f7d1a7ef715794f5c2f4fad3b62), CI's `actions/checkout` was updated to v7 and refuses to fetch fork PR code from a `pull_request_target` workflow unless the step opts in with `allow-unsafe-pr-checkout`. IIUC, that was a safety issue because the old job checked out the fork and ran `cargo metadata` on its manifests while holding the base repo's token (known as [pwn-request vulnerability](https://www.endorlabs.com/learn/pwn-request-threat-a-hidden-danger-in-github-actions)).

But from my understanding of this workflow, the fork checkout is not necessary. So I dropped it and, making the problem go away.

One consequence is: if a PR adds a new crate, the PR will not get label `C-<crate>`. Seems acceptable to me.

Btw I see 0.32.xx and 0.32.xxx have this same issue.