### PR TITLE
primitives: Implement `Arbitrary` for `WitnessVersion`

### DIFF
--- a/primitives/api/all-features.txt
+++ b/primitives/api/all-features.txt
@@ -6458,6 +6458,8 @@ impl core::str::traits::FromStr for bitcoin_primitives::witness_version::Witness
   pub fn bitcoin_primitives::witness_version::WitnessVersion::from_str(s: &str) -> core::result::Result<Self, Self::Err> [impl: impl core::str::traits::FromStr for bitcoin_primitives::witness_version::WitnessVersion]
 impl serde::ser::Serialize for bitcoin_primitives::witness_version::WitnessVersion
   pub fn bitcoin_primitives::witness_version::WitnessVersion::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer [impl: impl serde::ser::Serialize for bitcoin_primitives::witness_version::WitnessVersion]
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::witness_version::WitnessVersion
+  pub fn bitcoin_primitives::witness_version::WitnessVersion::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self> [impl: impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::witness_version::WitnessVersion]
 impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::witness_version::WitnessVersion
   pub fn bitcoin_primitives::witness_version::WitnessVersion::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de> [impl: impl<'de> serde::de::Deserialize<'de> for bitcoin_primitives::witness_version::WitnessVersion]
 impl core::marker::Freeze for bitcoin_primitives::witness_version::WitnessVersion

--- a/primitives/src/witness_version.rs
+++ b/primitives/src/witness_version.rs
@@ -12,6 +12,8 @@
 use core::fmt;
 use core::str::FromStr;
 
+#[cfg(feature = "arbitrary")]
+use arbitrary::{Arbitrary, Unstructured};
 use units::parse_int;
 
 use crate::opcodes::all::{OP_1, OP_16};
@@ -206,6 +208,15 @@ impl<'de> serde::Deserialize<'de> for WitnessVersion {
     {
         let version = u8::deserialize(deserializer)?;
         Self::try_from(version).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> Arbitrary<'a> for WitnessVersion {
+    #[inline]
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let version = u.int_in_range(0..=16)?;
+        Ok(Self::try_from(version).expect("range is valid"))
     }
 }
 


### PR DESCRIPTION
Inspired on similar change for `Opcode`, on https://github.com/rust-bitcoin/rust-bitcoin/pull/6731. Nearly every primitive implements `Arbitrary` except `WitnessVersion`. This PR adds an implementation that samples uniformly over the valid 0 to 16 range. The goal is API completeness for primitives 1.0.0.

This PR does only `WitnessVersion` because it resembles `Opcode`, but one could argue that `PushBytes`/`PushBytesBuf`, of `primitives`, could also implement `Arbitrary`.