### PR TITLE
primitives: Add `Arbitrary` for `PushBytes` & `PushBytesBuf`

### DIFF
--- a/primitives/api/all-features.txt
+++ b/primitives/api/all-features.txt
@@ -2742,6 +2742,8 @@ impl core::ops::index::IndexMut<core::ops::range::RangeToInclusive<usize>> for b
   pub fn bitcoin_primitives::script::PushBytes::index_mut(&mut self, index: core::ops::range::RangeToInclusive<usize>) -> &mut Self::Output [impl: impl core::ops::index::IndexMut<core::ops::range::RangeToInclusive<usize>> for bitcoin_primitives::script::PushBytes]
 impl core::ops::index::IndexMut<usize> for bitcoin_primitives::script::PushBytes
   pub fn bitcoin_primitives::script::PushBytes::index_mut(&mut self, index: usize) -> &mut Self::Output [impl: impl core::ops::index::IndexMut<usize> for bitcoin_primitives::script::PushBytes]
+impl<'a> arbitrary::Arbitrary<'a> for &'a bitcoin_primitives::script::PushBytes
+  pub fn &'a bitcoin_primitives::script::PushBytes::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self> [impl: impl<'a> arbitrary::Arbitrary<'a> for &'a bitcoin_primitives::script::PushBytes]
 impl<'a> core::convert::From<&'a [u8; 0]> for &'a bitcoin_primitives::script::PushBytes
   pub fn &'a bitcoin_primitives::script::PushBytes::from(bytes: &'a [u8; 0]) -> Self [impl: impl<'a> core::convert::From<&'a [u8; 0]> for &'a bitcoin_primitives::script::PushBytes]
 impl<'a> core::convert::From<&'a [u8; 10]> for &'a bitcoin_primitives::script::PushBytes
@@ -3289,6 +3291,8 @@ impl core::ops::deref::Deref for bitcoin_primitives::script::PushBytesBuf
   pub fn bitcoin_primitives::script::PushBytesBuf::deref(&self) -> &Self::Target [impl: impl core::ops::deref::Deref for bitcoin_primitives::script::PushBytesBuf]
 impl core::ops::deref::DerefMut for bitcoin_primitives::script::PushBytesBuf
   pub fn bitcoin_primitives::script::PushBytesBuf::deref_mut(&mut self) -> &mut Self::Target [impl: impl core::ops::deref::DerefMut for bitcoin_primitives::script::PushBytesBuf]
+impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::script::PushBytesBuf
+  pub fn bitcoin_primitives::script::PushBytesBuf::arbitrary(u: &mut arbitrary::unstructured::Unstructured<'a>) -> arbitrary::error::Result<Self> [impl: impl<'a> arbitrary::Arbitrary<'a> for bitcoin_primitives::script::PushBytesBuf]
 impl<'a> core::convert::From<&'a [u8; 0]> for bitcoin_primitives::script::PushBytesBuf
   pub fn bitcoin_primitives::script::PushBytesBuf::from(bytes: &'a [u8; 0]) -> Self [impl: impl<'a> core::convert::From<&'a [u8; 0]> for bitcoin_primitives::script::PushBytesBuf]
 impl<'a> core::convert::From<&'a [u8; 10]> for bitcoin_primitives::script::PushBytesBuf

--- a/primitives/src/script/push_bytes.rs
+++ b/primitives/src/script/push_bytes.rs
@@ -10,6 +10,9 @@ use core::borrow::{Borrow, BorrowMut};
 use core::convert::Infallible;
 use core::ops::{Deref, DerefMut};
 
+#[cfg(feature = "arbitrary")]
+use arbitrary::{Arbitrary, Unstructured};
+
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(inline)]
 // This is not the usual re-export, `primitive` here is a code audit thing.
@@ -461,6 +464,14 @@ impl std::error::Error for PushBytesError {
         #[cfg(not(any(target_pointer_width = "16", target_pointer_width = "32")))]
         let Self { len: _ } = self;
         None
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> Arbitrary<'a> for &'a PushBytes {
+    #[inline]
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        <&'a [u8]>::arbitrary(u)?.try_into().map_err(|_| arbitrary::Error::IncorrectFormat)
     }
 }
 

--- a/primitives/src/script/push_bytes.rs
+++ b/primitives/src/script/push_bytes.rs
@@ -475,6 +475,14 @@ impl<'a> Arbitrary<'a> for &'a PushBytes {
     }
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a> Arbitrary<'a> for PushBytesBuf {
+    #[inline]
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        <&PushBytes>::arbitrary(u).map(PushBytes::to_owned)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use alloc::vec;


### PR DESCRIPTION
Most types in primitives have Arbitrary implementations, aside from those that have only recently been moved there. Like the Script types, the PushBytes types should also have arbitrary implementations.

Add Arbitrary implementation for PushBytes and PushBytesBuf.