### PR TITLE
primitives: Flatten error constructors

### DIFF
--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -456,13 +456,13 @@ impl encoding::Decoder for TransactionDecoder {
             // Attempt to push to the currently-active decoder and return early on success.
             match &mut self.state {
                 State::Version(decoder) => {
-                    if decoder.push_bytes(bytes).map_err(|e| E(Inner::Version(e)))?.needs_more() {
+                    if decoder.push_bytes(bytes).map_err(Inner::Version).map_err(E)?.needs_more() {
                         // Still more bytes required.
                         return Ok(DecoderStatus::NeedsMore);
                     }
                 }
                 State::Inputs(_, _, decoder) =>
-                    if decoder.push_bytes(bytes).map_err(|e| E(Inner::Inputs(e)))?.needs_more() {
+                    if decoder.push_bytes(bytes).map_err(Inner::Inputs).map_err(E)?.needs_more() {
                         return Ok(DecoderStatus::NeedsMore);
                     },
                 State::SegwitFlag(_) =>
@@ -470,15 +470,15 @@ impl encoding::Decoder for TransactionDecoder {
                         return Ok(DecoderStatus::NeedsMore);
                     },
                 State::Outputs(_, _, _, decoder) =>
-                    if decoder.push_bytes(bytes).map_err(|e| E(Inner::Outputs(e)))?.needs_more() {
+                    if decoder.push_bytes(bytes).map_err(Inner::Outputs).map_err(E)?.needs_more() {
                         return Ok(DecoderStatus::NeedsMore);
                     },
                 State::Witnesses(_, _, _, _, decoder) =>
-                    if decoder.push_bytes(bytes).map_err(|e| E(Inner::Witness(e)))?.needs_more() {
+                    if decoder.push_bytes(bytes).map_err(Inner::Witness).map_err(E)?.needs_more() {
                         return Ok(DecoderStatus::NeedsMore);
                     },
                 State::LockTime(_, _, _, decoder) =>
-                    if decoder.push_bytes(bytes).map_err(|e| E(Inner::LockTime(e)))?.needs_more() {
+                    if decoder.push_bytes(bytes).map_err(Inner::LockTime).map_err(E)?.needs_more() {
                         return Ok(DecoderStatus::NeedsMore);
                     },
                 State::Done(..) => return Ok(DecoderStatus::Ready),
@@ -488,11 +488,11 @@ impl encoding::Decoder for TransactionDecoder {
             // If the above failed, end the current decoder and go to the next state.
             match mem::replace(&mut self.state, State::Errored) {
                 State::Version(decoder) => {
-                    let version = decoder.end().map_err(|e| E(Inner::Version(e)))?;
+                    let version = decoder.end().map_err(Inner::Version).map_err(E)?;
                     self.state = State::Inputs(version, Attempt::First, VecDecoder::<TxIn>::new());
                 }
                 State::Inputs(version, attempt, decoder) => {
-                    let inputs = decoder.end().map_err(|e| E(Inner::Inputs(e)))?;
+                    let inputs = decoder.end().map_err(Inner::Inputs).map_err(E)?;
 
                     if Attempt::First == attempt {
                         if inputs.is_empty() {
@@ -524,7 +524,7 @@ impl encoding::Decoder for TransactionDecoder {
                     self.state = State::Inputs(version, Attempt::Second, VecDecoder::<TxIn>::new());
                 }
                 State::Outputs(version, inputs, is_segwit, decoder) => {
-                    let outputs = decoder.end().map_err(|e| E(Inner::Outputs(e)))?;
+                    let outputs = decoder.end().map_err(Inner::Outputs).map_err(E)?;
                     // Handle the zero-input case described in the `Transaction` docs.
                     if is_segwit == IsSegwit::Yes && !inputs.is_empty() {
                         self.state = State::Witnesses(
@@ -542,7 +542,7 @@ impl encoding::Decoder for TransactionDecoder {
                 State::Witnesses(version, mut inputs, outputs, iteration, decoder) => {
                     let iteration = iteration.0;
 
-                    inputs[iteration].witness = decoder.end().map_err(|e| E(Inner::Witness(e)))?;
+                    inputs[iteration].witness = decoder.end().map_err(Inner::Witness).map_err(E)?;
                     if iteration < inputs.len() - 1 {
                         self.state = State::Witnesses(
                             version,
@@ -561,7 +561,7 @@ impl encoding::Decoder for TransactionDecoder {
                     }
                 }
                 State::LockTime(version, inputs, outputs, decoder) => {
-                    let lock_time = decoder.end().map_err(|e| E(Inner::LockTime(e)))?;
+                    let lock_time = decoder.end().map_err(Inner::LockTime).map_err(E)?;
                     self.state = State::Done(Transaction { version, lock_time, inputs, outputs });
                     return Ok(DecoderStatus::Ready);
                 }

--- a/primitives/src/witness.rs
+++ b/primitives/src/witness.rs
@@ -349,14 +349,15 @@ impl encoding::Decoder for WitnessDecoder {
             if self
                 .witness_count_decoder
                 .push_bytes(bytes)
-                .map_err(|e| E(Inner::LengthPrefixDecode(e)))?
+                .map_err(Inner::LengthPrefixDecode)
+                .map_err(E)?
                 .needs_more()
             {
                 return Ok(DecoderStatus::NeedsMore);
             }
             // Take ownership of the decoder in order to consume it.
             let decoder = core::mem::take(&mut self.witness_count_decoder);
-            let witness_elements = decoder.end().map_err(|e| E(Inner::LengthPrefixDecode(e)))?;
+            let witness_elements = decoder.end().map_err(Inner::LengthPrefixDecode).map_err(E)?;
             self.witness_elements = Some(witness_elements);
 
             // Short circuit for zero witness elements.
@@ -411,7 +412,8 @@ impl encoding::Decoder for WitnessDecoder {
                 if self
                     .element_length_decoder
                     .push_bytes(bytes)
-                    .map_err(|e| E(Inner::LengthPrefixDecode(e)))?
+                    .map_err(Inner::LengthPrefixDecode)
+                    .map_err(E)?
                     .needs_more()
                 {
                     return Ok(DecoderStatus::NeedsMore);
@@ -422,7 +424,7 @@ impl encoding::Decoder for WitnessDecoder {
                     &mut self.element_length_decoder,
                     CompactSizeDecoder::new_with_limit(MAX_WITNESS_ITEM_SIZE),
                 );
-                let element_length = decoder.end().map_err(|e| E(Inner::LengthPrefixDecode(e)))?;
+                let element_length = decoder.end().map_err(Inner::LengthPrefixDecode).map_err(E)?;
 
                 // keep the element length prefix in the content area.
                 let encoded_compact_size = crate::compact_size_encode(element_length);
@@ -446,7 +448,9 @@ impl encoding::Decoder for WitnessDecoder {
 
         let Some(witness_elements) = self.witness_elements else {
             // Never read the witness element count.
-            return Err(E(Inner::UnexpectedEof(UnexpectedEofError { missing_elements: 0 })));
+            return Err(UnexpectedEofError { missing_elements: 0 })
+                .map_err(Inner::UnexpectedEof)
+                .map_err(E);
         };
 
         let remaining = witness_elements - self.element_idx;
@@ -475,7 +479,9 @@ impl encoding::Decoder for WitnessDecoder {
 
             Ok(Witness { content: self.content, witness_elements, indices_start })
         } else {
-            Err(E(Inner::UnexpectedEof(UnexpectedEofError { missing_elements: remaining })))
+            Err(UnexpectedEofError { missing_elements: remaining })
+                .map_err(Inner::UnexpectedEof)
+                .map_err(E)
         }
     }
 


### PR DESCRIPTION
Typically speaking, nested error construction yields code that's not very readable. Instead, we can make use of map_err to repeatedly wrap inner error types to produce the final error types as needed.

Flatten nested error constructors in primitives to use repeated map_err calls.

Contributes to #6539
