### PR TITLE
units: Add `#[inline]` to simple functions

### DIFF
--- a/units/src/amount/error.rs
+++ b/units/src/amount/error.rs
@@ -26,10 +26,12 @@ pub(crate) enum ParseErrorInner {
 }
 
 impl From<Infallible> for ParseError {
+    #[inline]
     fn from(never: Infallible) -> Self { match never {} }
 }
 
 impl fmt::Display for ParseError {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.0 {
             ParseErrorInner::Amount(ref e) => write_err!(f, "invalid amount"; e),
@@ -42,6 +44,7 @@ impl fmt::Display for ParseError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for ParseError {
+    #[inline]
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self.0 {
             ParseErrorInner::Amount(ref e) => Some(e),
@@ -77,10 +80,12 @@ pub(crate) enum ParseAmountErrorInner {
 }
 
 impl From<Infallible> for ParseAmountError {
+    #[inline]
     fn from(never: Infallible) -> Self { match never {} }
 }
 
 impl fmt::Display for ParseAmountError {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use ParseAmountErrorInner as E;
 
@@ -170,10 +175,12 @@ impl OutOfRangeError {
 }
 
 impl From<Infallible> for OutOfRangeError {
+    #[inline]
     fn from(never: Infallible) -> Self { match never {} }
 }
 
 impl fmt::Display for OutOfRangeError {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.is_greater_than_max {
             write!(f, "the amount is greater than {}", self.valid_range().1)
@@ -199,10 +206,12 @@ pub struct TooPreciseError {
 }
 
 impl From<Infallible> for TooPreciseError {
+    #[inline]
     fn from(never: Infallible) -> Self { match never {} }
 }
 
 impl fmt::Display for TooPreciseError {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.position {
             0 => f.write_str("the amount is less than 1 satoshi but it's not zero"),
@@ -231,10 +240,12 @@ pub struct InputTooLargeError {
 }
 
 impl From<Infallible> for InputTooLargeError {
+    #[inline]
     fn from(never: Infallible) -> Self { match never {} }
 }
 
 impl fmt::Display for InputTooLargeError {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.len - INPUT_STRING_LEN_LIMIT {
             1 => write!(
@@ -269,6 +280,7 @@ pub struct MissingDigitsError {
 }
 
 impl From<Infallible> for MissingDigitsError {
+    #[inline]
     fn from(never: Infallible) -> Self { match never {} }
 }
 
@@ -306,10 +318,12 @@ pub struct InvalidCharacterError {
 }
 
 impl From<Infallible> for InvalidCharacterError {
+    #[inline]
     fn from(never: Infallible) -> Self { match never {} }
 }
 
 impl fmt::Display for InvalidCharacterError {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.invalid_char {
             '.' => f.write_str("there is more than one decimal separator (dot) in the input"),
@@ -340,10 +354,12 @@ pub struct BadPositionError {
 }
 
 impl From<Infallible> for BadPositionError {
+    #[inline]
     fn from(never: Infallible) -> Self { match never {} }
 }
 
 impl fmt::Display for BadPositionError {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.char {
             '_' => match self.position {
@@ -379,10 +395,12 @@ pub enum ParseDenominationError {
 }
 
 impl From<Infallible> for ParseDenominationError {
+    #[inline]
     fn from(never: Infallible) -> Self { match never {} }
 }
 
 impl fmt::Display for ParseDenominationError {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Self::Unknown(ref e) => write_err!(f, "denomination parse error"; e),
@@ -408,10 +426,12 @@ impl std::error::Error for ParseDenominationError {
 pub struct MissingDenominationError;
 
 impl From<Infallible> for MissingDenominationError {
+    #[inline]
     fn from(never: Infallible) -> Self { match never {} }
 }
 
 impl fmt::Display for MissingDenominationError {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "the input does not contain a denomination")
     }
@@ -432,6 +452,7 @@ impl std::error::Error for MissingDenominationError {
 pub struct UnknownDenominationError(pub(super) InputString);
 
 impl From<Infallible> for UnknownDenominationError {
+    #[inline]
     fn from(never: Infallible) -> Self { match never {} }
 }
 
@@ -457,10 +478,12 @@ impl std::error::Error for UnknownDenominationError {
 pub struct PossiblyConfusingDenominationError(pub(super) InputString);
 
 impl From<Infallible> for PossiblyConfusingDenominationError {
+    #[inline]
     fn from(never: Infallible) -> Self { match never {} }
 }
 
 impl fmt::Display for PossiblyConfusingDenominationError {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}: possibly confusing denomination - we intentionally do not support 'M' and 'P' so as to not confuse mega/milli and peta/pico", self.0.display_cannot_parse("bitcoin denomination"))
     }
@@ -510,11 +533,13 @@ pub(super) enum AmountDecoderErrorInner {
 
 #[cfg(feature = "encoding")]
 impl From<Infallible> for AmountDecoderError {
+    #[inline]
     fn from(never: Infallible) -> Self { match never {} }
 }
 
 #[cfg(feature = "encoding")]
 impl fmt::Display for AmountDecoderError {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use AmountDecoderErrorInner as E;
 

--- a/units/src/amount/mod.rs
+++ b/units/src/amount/mod.rs
@@ -355,6 +355,7 @@ enum InnerParseError {
 }
 
 impl From<Infallible> for InnerParseError {
+    #[inline]
     fn from(never: Infallible) -> Self { match never {} }
 }
 
@@ -643,6 +644,7 @@ enum DisplayStyle {
 
 #[cfg(feature = "arbitrary")]
 impl<'a> Arbitrary<'a> for Denomination {
+    #[inline]
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         let choice = u.int_in_range(0..=5)?;
         match choice {

--- a/units/src/amount/result.rs
+++ b/units/src/amount/result.rs
@@ -225,6 +225,7 @@ impl_sub_assign_for_results!(SignedAmount);
 impl ops::Neg for Amount {
     type Output = SignedAmount;
 
+    #[inline]
     fn neg(self) -> Self::Output { self.to_signed().neg() }
 }
 
@@ -240,12 +241,14 @@ impl ops::Neg for SignedAmount {
 impl ops::Neg for NumOpResult<Amount> {
     type Output = NumOpResult<SignedAmount>;
 
+    #[inline]
     fn neg(self) -> Self::Output { self.map(ops::Neg::neg) }
 }
 
 impl ops::Neg for NumOpResult<SignedAmount> {
     type Output = Self;
 
+    #[inline]
     fn neg(self) -> Self::Output { self.map(ops::Neg::neg) }
 }
 

--- a/units/src/amount/serde.rs
+++ b/units/src/amount/serde.rs
@@ -49,6 +49,7 @@ impl fmt::Display for DisplayFullError {
 #[cfg(feature = "alloc")]
 #[cfg(not(feature = "std"))]
 impl fmt::Display for DisplayFullError {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(&self.0, f) }
 }
 
@@ -164,6 +165,7 @@ pub mod as_sat {
 
         use crate::SignedAmount;
 
+        #[inline]
         pub fn serialize<A, S: Serializer>(a: &[A], s: S) -> Result<S::Ok, S::Error>
         where
             A: Into<SignedAmount> + Copy,
@@ -328,6 +330,7 @@ pub mod as_btc {
 
         use crate::amount::{Denomination, SignedAmount};
 
+        #[inline]
         pub fn serialize<A, S: Serializer>(a: &[A], s: S) -> Result<S::Ok, S::Error>
         where
             A: Into<SignedAmount> + Copy,
@@ -497,6 +500,7 @@ pub mod as_str {
 
         use crate::amount::{Denomination, SignedAmount};
 
+        #[inline]
         pub fn serialize<A, S: Serializer>(a: &[A], s: S) -> Result<S::Ok, S::Error>
         where
             A: Into<SignedAmount> + Copy,

--- a/units/src/amount/signed.rs
+++ b/units/src/amount/signed.rs
@@ -526,6 +526,7 @@ impl default::Default for SignedAmount {
 }
 
 impl fmt::Debug for SignedAmount {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "SignedAmount({} SAT)", self.to_sat())
     }
@@ -574,6 +575,7 @@ impl From<Amount> for SignedAmount {
 
 #[cfg(feature = "arbitrary")]
 impl<'a> Arbitrary<'a> for SignedAmount {
+    #[inline]
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         let sats = u.int_in_range(Self::MIN.to_sat()..=Self::MAX.to_sat())?;
         Ok(Self::from_sat(sats).expect("range is valid"))

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -460,6 +460,7 @@ impl Amount {
     ///
     /// Be aware that integer division loses the remainder if no exact division
     /// can be made. See also [`Self::div_by_weight_ceil`].
+    #[inline]
     pub const fn div_by_weight_floor(self, weight: Weight) -> NumOpResult<FeeRate> {
         let wu = weight.to_wu();
 
@@ -493,6 +494,7 @@ impl Amount {
     /// assert_eq!(fee_rate, FeeRate::from_sat_per_kwu(34));
     /// # Ok::<_, amount::OutOfRangeError>(())
     /// ```
+    #[inline]
     pub const fn div_by_weight_ceil(self, weight: Weight) -> NumOpResult<FeeRate> {
         let wu = weight.to_wu();
         if wu == 0 {
@@ -516,6 +518,7 @@ impl Amount {
     /// Computes the maximum weight that would result in a fee less than or equal to this amount
     /// at the given `fee_rate`. Uses floor division to ensure the resulting weight doesn't cause
     /// the fee to exceed the amount.
+    #[inline]
     pub const fn div_by_fee_rate_floor(self, fee_rate: FeeRate) -> NumOpResult<Weight> {
         debug_assert!(Self::MAX.to_sat().checked_mul(1_000).is_some());
         let msats = self.to_sat() * 1_000;
@@ -529,6 +532,7 @@ impl Amount {
     ///
     /// Computes the minimum weight that would result in a fee greater than or equal to this amount
     /// at the given `fee_rate`. Uses ceiling division to ensure the resulting weight is sufficient.
+    #[inline]
     pub const fn div_by_fee_rate_ceil(self, fee_rate: FeeRate) -> NumOpResult<Weight> {
         // Use ceil because result is used as the divisor.
         let rate = fee_rate.to_sat_per_kwu_ceil();
@@ -551,6 +555,7 @@ impl default::Default for Amount {
 }
 
 impl fmt::Debug for Amount {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Amount({} SAT)", self.to_sat())
     }
@@ -642,6 +647,7 @@ crate::decoder_newtype! {
 
 #[cfg(feature = "arbitrary")]
 impl<'a> Arbitrary<'a> for Amount {
+    #[inline]
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         let sats = u.int_in_range(Self::MIN.to_sat()..=Self::MAX.to_sat())?;
         Ok(Self::from_sat(sats).expect("range is valid"))

--- a/units/src/block.rs
+++ b/units/src/block.rs
@@ -107,6 +107,7 @@ macro_rules! impl_u32_wrapper {
 
         #[cfg(feature = "arbitrary")]
         impl<'a> Arbitrary<'a> for $newtype {
+            #[inline]
             fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
                 let choice = u.int_in_range(0..=2)?;
                 match choice {
@@ -641,10 +642,12 @@ pub mod error {
     pub struct TooBigForRelativeHeightError(pub(super) u32);
 
     impl From<Infallible> for TooBigForRelativeHeightError {
+        #[inline]
         fn from(never: Infallible) -> Self { match never {} }
     }
 
     impl fmt::Display for TooBigForRelativeHeightError {
+        #[inline]
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             write!(
                 f,
@@ -657,6 +660,7 @@ pub mod error {
 
     #[cfg(feature = "std")]
     impl std::error::Error for TooBigForRelativeHeightError {
+        #[inline]
         fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
             let Self(_) = self;
             None
@@ -672,11 +676,13 @@ pub mod error {
 
     #[cfg(feature = "encoding")]
     impl From<Infallible> for BlockHeightDecoderError {
+        #[inline]
         fn from(never: Infallible) -> Self { match never {} }
     }
 
     #[cfg(feature = "encoding")]
     impl fmt::Display for BlockHeightDecoderError {
+        #[inline]
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             write_err!(f, "block height decoder error"; self.0)
         }
@@ -685,6 +691,7 @@ pub mod error {
     #[cfg(feature = "encoding")]
     #[cfg(feature = "std")]
     impl std::error::Error for BlockHeightDecoderError {
+        #[inline]
         fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
     }
 }

--- a/units/src/fee_rate/mod.rs
+++ b/units/src/fee_rate/mod.rs
@@ -209,6 +209,7 @@ impl FeeRate {
     /// Computes the absolute fee amount for a given [`Weight`] at this fee rate. When the resulting
     /// fee is a non-integer amount, the amount is rounded up, ensuring that the transaction fee is
     /// enough instead of falling short if rounded down.
+    #[inline]
     pub const fn mul_by_weight(self, weight: Weight) -> NumOpResult<Amount> {
         let wu = weight.to_wu();
         if let Some(fee_kwu) = self.to_sat_per_kwu_ceil().checked_mul(wu) {
@@ -265,6 +266,7 @@ impl<'a> core::iter::Sum<&'a Self> for FeeRate {
 
 #[cfg(feature = "arbitrary")]
 impl<'a> Arbitrary<'a> for FeeRate {
+    #[inline]
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         let choice = u.int_in_range(0..=4)?;
         match choice {

--- a/units/src/fee_rate/serde.rs
+++ b/units/src/fee_rate/serde.rs
@@ -111,6 +111,7 @@ pub mod as_sat_per_kwu_floor {
 
         use crate::FeeRate;
 
+        #[inline]
         pub fn serialize<S: Serializer>(f: &[FeeRate], s: S) -> Result<S::Ok, S::Error> {
             s.collect_seq(f.iter().map(|rate| rate.to_sat_per_kwu_floor()))
         }
@@ -236,6 +237,7 @@ pub mod as_sat_per_vb_floor {
 
         use crate::FeeRate;
 
+        #[inline]
         pub fn serialize<S: Serializer>(f: &[FeeRate], s: S) -> Result<S::Ok, S::Error> {
             s.collect_seq(f.iter().map(|rate| rate.to_sat_per_vb_floor()))
         }
@@ -361,6 +363,7 @@ pub mod as_sat_per_vb_ceil {
 
         use crate::FeeRate;
 
+        #[inline]
         pub fn serialize<S: Serializer>(f: &[FeeRate], s: S) -> Result<S::Ok, S::Error> {
             s.collect_seq(f.iter().map(|rate| rate.to_sat_per_vb_ceil()))
         }
@@ -408,10 +411,12 @@ pub mod error {
     pub struct OverflowError;
 
     impl From<Infallible> for OverflowError {
+        #[inline]
         fn from(never: Infallible) -> Self { match never {} }
     }
 
     impl fmt::Display for OverflowError {
+        #[inline]
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             write!(f, "overflow occurred while deserializing fee rate per virtual byte")
         }

--- a/units/src/internal_macros.rs
+++ b/units/src/internal_macros.rs
@@ -34,6 +34,7 @@ macro_rules! impl_op_for_references {
         $(where $($bounds)*)?
         {
             type Output = $($main_output)*;
+            #[inline]
             fn $op($($main_args)*) -> Self::Output {
                 $($main_impl)*
             }
@@ -43,6 +44,7 @@ macro_rules! impl_op_for_references {
         $(where $($bounds)*)?
         {
             type Output = <$ty as $($op_trait)::+<$other_ty>>::Output;
+            #[inline]
             fn $op(self, rhs: $other_ty) -> Self::Output {
                 (*self).$op(rhs)
             }
@@ -52,6 +54,7 @@ macro_rules! impl_op_for_references {
         $(where $($bounds)*)?
         {
             type Output = <$ty as $($op_trait)::+<$other_ty>>::Output;
+            #[inline]
             fn $op(self, rhs: &$other_ty) -> Self::Output {
                 self.$op(*rhs)
             }
@@ -61,6 +64,7 @@ macro_rules! impl_op_for_references {
         $(where $($bounds)*)?
         {
             type Output = <$ty as $($op_trait)::+<$other_ty>>::Output;
+            #[inline]
             fn $op(self, rhs: &$other_ty) -> Self::Output {
                 (*self).$op(*rhs)
             }

--- a/units/src/locktime/absolute/error.rs
+++ b/units/src/locktime/absolute/error.rs
@@ -21,11 +21,13 @@ pub struct LockTimeDecoderError(pub(super) encoding::UnexpectedEofError);
 
 #[cfg(feature = "encoding")]
 impl From<Infallible> for LockTimeDecoderError {
+    #[inline]
     fn from(never: Infallible) -> Self { match never {} }
 }
 
 #[cfg(feature = "encoding")]
 impl fmt::Display for LockTimeDecoderError {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write_err!(f, "lock time decoder error"; self.0)
     }
@@ -58,6 +60,7 @@ impl IncompatibleHeightError {
 }
 
 impl From<Infallible> for IncompatibleHeightError {
+    #[inline]
     fn from(never: Infallible) -> Self { match never {} }
 }
 
@@ -101,6 +104,7 @@ impl IncompatibleTimeError {
 }
 
 impl From<Infallible> for IncompatibleTimeError {
+    #[inline]
     fn from(never: Infallible) -> Self { match never {} }
 }
 
@@ -129,6 +133,7 @@ impl std::error::Error for IncompatibleTimeError {
 pub struct ParseHeightError(ParseError);
 
 impl From<Infallible> for ParseHeightError {
+    #[inline]
     fn from(never: Infallible) -> Self { match never {} }
 }
 
@@ -156,6 +161,7 @@ impl From<ParseError> for ParseHeightError {
 pub struct ParseTimeError(ParseError);
 
 impl From<Infallible> for ParseTimeError {
+    #[inline]
     fn from(never: Infallible) -> Self { match never {} }
 }
 
@@ -277,6 +283,7 @@ impl ParseError {
 }
 
 impl From<Infallible> for ParseError {
+    #[inline]
     fn from(never: Infallible) -> Self { match never {} }
 }
 
@@ -320,10 +327,12 @@ impl ConversionError {
 }
 
 impl From<Infallible> for ConversionError {
+    #[inline]
     fn from(never: Infallible) -> Self { match never {} }
 }
 
 impl fmt::Display for ConversionError {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "invalid lock time value {}, {}", self.input, self.unit)
     }
@@ -348,6 +357,7 @@ enum LockTimeUnit {
 }
 
 impl fmt::Display for LockTimeUnit {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Self::Blocks =>

--- a/units/src/locktime/absolute/mod.rs
+++ b/units/src/locktime/absolute/mod.rs
@@ -463,6 +463,7 @@ impl fmt::Debug for LockTime {
 }
 
 impl fmt::Display for LockTime {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if f.alternate() {
             match *self {
@@ -783,6 +784,7 @@ pub const fn is_block_time(n: u32) -> bool { n >= LOCK_TIME_THRESHOLD }
 
 #[cfg(feature = "arbitrary")]
 impl<'a> Arbitrary<'a> for LockTime {
+    #[inline]
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         let l = u32::arbitrary(u)?;
         Ok(Self::from_consensus(l))
@@ -791,6 +793,7 @@ impl<'a> Arbitrary<'a> for LockTime {
 
 #[cfg(feature = "arbitrary")]
 impl<'a> Arbitrary<'a> for Height {
+    #[inline]
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         let choice = u.int_in_range(0..=2)?;
         match choice {
@@ -808,6 +811,7 @@ impl<'a> Arbitrary<'a> for Height {
 
 #[cfg(feature = "arbitrary")]
 impl<'a> Arbitrary<'a> for MedianTimePast {
+    #[inline]
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         let choice = u.int_in_range(0..=2)?;
         match choice {

--- a/units/src/locktime/relative/error.rs
+++ b/units/src/locktime/relative/error.rs
@@ -22,6 +22,7 @@ impl DisabledLockTimeError {
 }
 
 impl From<Infallible> for DisabledLockTimeError {
+    #[inline]
     fn from(never: Infallible) -> Self { match never {} }
 }
 
@@ -51,6 +52,7 @@ pub enum IsSatisfiedByError {
 }
 
 impl From<Infallible> for IsSatisfiedByError {
+    #[inline]
     fn from(never: Infallible) -> Self { match never {} }
 }
 
@@ -87,6 +89,7 @@ pub enum IsSatisfiedByHeightError {
 }
 
 impl From<Infallible> for IsSatisfiedByHeightError {
+    #[inline]
     fn from(never: Infallible) -> Self { match never {} }
 }
 
@@ -118,6 +121,7 @@ impl std::error::Error for IsSatisfiedByHeightError {
 pub struct IncompatibleHeightError(pub(crate) NumberOf512Seconds);
 
 impl From<Infallible> for IncompatibleHeightError {
+    #[inline]
     fn from(never: Infallible) -> Self { match never {} }
 }
 
@@ -130,6 +134,7 @@ impl fmt::Display for IncompatibleHeightError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for IncompatibleHeightError {
+    #[inline]
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         let Self(_) = self;
         None
@@ -148,6 +153,7 @@ pub enum IsSatisfiedByTimeError {
 }
 
 impl From<Infallible> for IsSatisfiedByTimeError {
+    #[inline]
     fn from(never: Infallible) -> Self { match never {} }
 }
 
@@ -179,6 +185,7 @@ impl std::error::Error for IsSatisfiedByTimeError {
 pub struct IncompatibleTimeError(pub(crate) NumberOfBlocks);
 
 impl From<Infallible> for IncompatibleTimeError {
+    #[inline]
     fn from(never: Infallible) -> Self { match never {} }
 }
 
@@ -191,6 +198,7 @@ impl fmt::Display for IncompatibleTimeError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for IncompatibleTimeError {
+    #[inline]
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         let Self(_) = self;
         None
@@ -206,10 +214,12 @@ pub struct TimeOverflowError {
 }
 
 impl From<Infallible> for TimeOverflowError {
+    #[inline]
     fn from(never: Infallible) -> Self { match never {} }
 }
 
 impl fmt::Display for TimeOverflowError {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
@@ -238,10 +248,12 @@ pub struct InvalidHeightError {
 }
 
 impl From<Infallible> for InvalidHeightError {
+    #[inline]
     fn from(never: Infallible) -> Self { match never {} }
 }
 
 impl fmt::Display for InvalidHeightError {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "is_satisfied_by arguments invalid (probably the wrong way around) chain_tip: {} utxo_mined_at: {}", self.chain_tip, self.utxo_mined_at
         )
@@ -267,10 +279,12 @@ pub struct InvalidTimeError {
 }
 
 impl From<Infallible> for InvalidTimeError {
+    #[inline]
     fn from(never: Infallible) -> Self { match never {} }
 }
 
 impl fmt::Display for InvalidTimeError {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "is_satisfied_by arguments invalid (probably the wrong way around) chain_tip: {} utxo_mined_at: {}", self.chain_tip, self.utxo_mined_at
         )

--- a/units/src/locktime/relative/mod.rs
+++ b/units/src/locktime/relative/mod.rs
@@ -359,6 +359,7 @@ impl From<NumberOf512Seconds> for LockTime {
 }
 
 impl fmt::Display for LockTime {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if f.alternate() {
             match *self {
@@ -468,6 +469,7 @@ impl NumberOfBlocks {
     /// # Errors
     ///
     /// If `chain_tip` is not valid for `utxo_mined_at` i.e., if you get the args mixed up.
+    #[inline]
     pub fn is_satisfied_by(
         self,
         chain_tip: crate::BlockHeight,
@@ -620,6 +622,7 @@ impl NumberOf512Seconds {
     /// # Errors
     ///
     /// If `chain_tip` is not _after_ `utxo_mined_at` i.e., if you get the args mixed up.
+    #[inline]
     pub fn is_satisfied_by(
         self,
         chain_tip: crate::BlockMtp,
@@ -674,6 +677,7 @@ impl<'de> Deserialize<'de> for NumberOf512Seconds {
 
 #[cfg(feature = "arbitrary")]
 impl<'a> Arbitrary<'a> for LockTime {
+    #[inline]
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         let choice = u.int_in_range(0..=1)?;
 
@@ -686,6 +690,7 @@ impl<'a> Arbitrary<'a> for LockTime {
 
 #[cfg(feature = "arbitrary")]
 impl<'a> Arbitrary<'a> for NumberOfBlocks {
+    #[inline]
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         let choice = u.int_in_range(0..=2)?;
 
@@ -699,6 +704,7 @@ impl<'a> Arbitrary<'a> for NumberOfBlocks {
 
 #[cfg(feature = "arbitrary")]
 impl<'a> Arbitrary<'a> for NumberOf512Seconds {
+    #[inline]
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         let choice = u.int_in_range(0..=2)?;
 

--- a/units/src/parse_int.rs
+++ b/units/src/parse_int.rs
@@ -76,6 +76,7 @@ pub fn int_from_string<T: Integer>(s: alloc::string::String) -> Result<T, ParseI
 pub fn int_from_box<T: Integer>(s: alloc::boxed::Box<str>) -> Result<T, ParseIntError> { int(s) }
 
 // This must be private because we do not want `InputString` to appear in the public API.
+#[inline]
 fn int<T: Integer, S: AsRef<str> + Into<InputString>>(s: S) -> Result<T, ParseIntError> {
     s.as_ref().parse().map_err(|error| {
         ParseIntError {
@@ -363,6 +364,7 @@ parse_hex_for!(
     fn hex_u128_unchecked();
 );
 
+#[inline]
 pub(crate) fn hex_u256_prefixed(s: &str) -> Result<crate::pow::U256, PrefixedHexError> {
     let checked = hex_remove_prefix(s)?;
     hex_u256_unchecked(checked)
@@ -370,6 +372,7 @@ pub(crate) fn hex_u256_prefixed(s: &str) -> Result<crate::pow::U256, PrefixedHex
         .map_err(PrefixedHexError)
 }
 
+#[inline]
 pub(crate) fn hex_u256_unprefixed(s: &str) -> Result<crate::pow::U256, UnprefixedHexError> {
     let checked = hex_check_unprefixed(s)?;
     hex_u256_unchecked(checked)
@@ -453,10 +456,12 @@ pub mod error {
     }
 
     impl From<Infallible> for ParseIntError {
+        #[inline]
         fn from(never: Infallible) -> Self { match never {} }
     }
 
     impl fmt::Display for ParseIntError {
+        #[inline]
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             let signed = if self.is_signed { "signed" } else { "unsigned" };
             write_err!(f, "{} ({}, {}-bit)", self.input.display_cannot_parse("integer"), signed, self.bits; self.source)
@@ -493,10 +498,12 @@ pub mod error {
     }
 
     impl From<Infallible> for PrefixedHexError {
+        #[inline]
         fn from(never: Infallible) -> Self { match never {} }
     }
 
     impl fmt::Display for PrefixedHexError {
+        #[inline]
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             use PrefixedHexErrorInner as E;
 
@@ -533,10 +540,12 @@ pub mod error {
     }
 
     impl From<Infallible> for UnprefixedHexError {
+        #[inline]
         fn from(never: Infallible) -> Self { match never {} }
     }
 
     impl fmt::Display for UnprefixedHexError {
+        #[inline]
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             use UnprefixedHexErrorInner as E;
 
@@ -568,10 +577,12 @@ pub mod error {
 
     impl MissingPrefixError {
         /// Constructs a new error from the string with the missing prefix.
+        #[inline]
         pub(crate) fn new(hex: &str) -> Self { Self { hex: hex.into() } }
     }
 
     impl fmt::Display for MissingPrefixError {
+        #[inline]
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             write!(
                 f,
@@ -603,6 +614,7 @@ pub mod error {
     }
 
     impl fmt::Display for ContainsPrefixError {
+        #[inline]
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             write!(
                 f,

--- a/units/src/pow.rs
+++ b/units/src/pow.rs
@@ -32,6 +32,7 @@ macro_rules! do_impl {
             #[doc = "\n - If the input string is not a valid hex encoding of a [`"]
             #[doc = stringify!($ty)]
             #[doc = "`]."]
+            #[inline]
             pub fn from_hex(s: &str) -> Result<Self, PrefixedHexError> {
                 Ok($ty(U256::from_hex(s)?))
             }
@@ -44,6 +45,7 @@ macro_rules! do_impl {
             #[doc = "\n - If the input string is not a valid hex encoding of a [`"]
             #[doc = stringify!($ty)]
             #[doc = "`]."]
+            #[inline]
             pub fn from_unprefixed_hex(s: &str) -> Result<Self, UnprefixedHexError> {
                 Ok($ty(U256::from_unprefixed_hex(s)?))
             }
@@ -100,6 +102,7 @@ pub struct Work(U256);
 
 impl Work {
     /// Converts this [`Work`] to [`Target`].
+    #[inline]
     pub fn to_target(self) -> Target { Target(self.0.inverse()) }
 }
 
@@ -108,11 +111,13 @@ impl_fmt_traits_for_u32_wrapper!(Work);
 
 impl Add for Work {
     type Output = Self;
+    #[inline]
     fn add(self, rhs: Self) -> Self { Self(self.0 + rhs.0) }
 }
 
 impl Sub for Work {
     type Output = Self;
+    #[inline]
     fn sub(self, rhs: Self) -> Self { Self(self.0 - rhs.0) }
 }
 
@@ -225,6 +230,7 @@ impl Target {
     /// "Work" is defined as the work done to mine a block with this target value (recorded in the
     /// block header in compact form as nBits). This is not the same as the difficulty to mine a
     /// block with this target (see `Self::difficulty`).
+    #[inline]
     pub fn to_work(self) -> Work { Work(self.0.inverse()) }
 }
 do_impl!(Target, ParseTargetError);
@@ -265,6 +271,7 @@ impl CompactTarget {
     /// Computes the [`Target`] value from this compact representation.
     ///
     /// ref: <https://developer.bitcoin.org/reference/block_chain.html#target-nbits>
+    #[inline]
     pub fn to_target(self) -> Target { Target::from_compact(self) }
 
     /// Constructs a new [`CompactTarget`] from a prefixed hex string.
@@ -308,6 +315,7 @@ impl fmt::Display for CompactTarget {
 parse_int::impl_parse_str_from_int_infallible!(CompactTarget, u32, from_consensus);
 
 impl From<CompactTarget> for Target {
+    #[inline]
     fn from(c: CompactTarget) -> Self { Self::from_compact(c) }
 }
 
@@ -368,11 +376,13 @@ pub mod error {
 
     #[cfg(feature = "encoding")]
     impl From<Infallible> for CompactTargetDecoderError {
+        #[inline]
         fn from(never: Infallible) -> Self { match never {} }
     }
 
     #[cfg(feature = "encoding")]
     impl fmt::Display for CompactTargetDecoderError {
+        #[inline]
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             write_err!(f, "compact target decoder error"; self.0)
         }
@@ -381,6 +391,7 @@ pub mod error {
     #[cfg(feature = "std")]
     #[cfg(feature = "encoding")]
     impl std::error::Error for CompactTargetDecoderError {
+        #[inline]
         fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { Some(&self.0) }
     }
 
@@ -391,6 +402,7 @@ pub mod error {
     pub struct ParseWorkError(pub(super) ParseU256Error);
 
     impl From<Infallible> for ParseWorkError {
+        #[inline]
         fn from(never: Infallible) -> Self { match never {} }
     }
 
@@ -414,6 +426,7 @@ pub mod error {
     pub struct ParseTargetError(pub(super) ParseU256Error);
 
     impl From<Infallible> for ParseTargetError {
+        #[inline]
         fn from(never: Infallible) -> Self { match never {} }
     }
 
@@ -433,6 +446,7 @@ pub mod error {
 
 #[cfg(feature = "arbitrary")]
 impl<'a> Arbitrary<'a> for CompactTarget {
+    #[inline]
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self::from_consensus(u.arbitrary()?))
     }
@@ -440,6 +454,7 @@ impl<'a> Arbitrary<'a> for CompactTarget {
 
 #[cfg(feature = "arbitrary")]
 impl<'a> Arbitrary<'a> for Target {
+    #[inline]
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self::from_be_bytes(<[u8; 32]>::arbitrary(u)?))
     }
@@ -447,6 +462,7 @@ impl<'a> Arbitrary<'a> for Target {
 
 #[cfg(feature = "arbitrary")]
 impl<'a> Arbitrary<'a> for Work {
+    #[inline]
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self::from_be_bytes(<[u8; 32]>::arbitrary(u)?))
     }
@@ -456,9 +472,11 @@ include!("../include/u256.rs");
 
 impl U256 {
     /// Constructs a new [`U256`] from a prefixed hex string.
+    #[inline]
     fn from_hex(s: &str) -> Result<Self, PrefixedHexError> { parse_int::hex_u256_prefixed(s) }
 
     /// Constructs a new [`U256`] from an unprefixed hex string.
+    #[inline]
     fn from_unprefixed_hex(s: &str) -> Result<Self, UnprefixedHexError> {
         parse_int::hex_u256_unprefixed(s)
     }
@@ -467,6 +485,7 @@ impl U256 {
 macro_rules! impl_hex {
     ($hex:path, $lookup:expr) => {
         impl $hex for U256 {
+            #[inline]
             fn fmt(&self, f: &mut fmt::Formatter) -> core::fmt::Result {
                 if f.alternate() {
                     f.write_str("0x")?;
@@ -495,6 +514,7 @@ impl_hex!(
 
 #[cfg(feature = "serde")]
 impl serde::Serialize for U256 {
+    #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -502,6 +522,7 @@ impl serde::Serialize for U256 {
         struct DisplayHex(U256);
 
         impl fmt::Display for DisplayHex {
+            #[inline]
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, "{:x}", self.0) }
         }
 

--- a/units/src/result.rs
+++ b/units/src/result.rs
@@ -376,6 +376,7 @@ pub enum MathOp {
 
 impl MathOp {
     /// Returns `true` if this operation error'ed due to overflow.
+    #[inline]
     pub fn is_overflow(self) -> bool {
         matches!(self, Self::Add | Self::Sub | Self::Mul | Self::Neg)
     }
@@ -402,6 +403,7 @@ impl MathOp {
 }
 
 impl fmt::Display for MathOp {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Self::Add => write!(f, "add"),
@@ -446,10 +448,12 @@ pub mod error {
     }
 
     impl From<Infallible> for NumOpError {
+        #[inline]
         fn from(never: Infallible) -> Self { match never {} }
     }
 
     impl fmt::Display for NumOpError {
+        #[inline]
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             write!(f, "math operation '{}' gave an invalid numeric result", self.operation())
         }
@@ -467,6 +471,7 @@ pub mod error {
 
 #[cfg(feature = "arbitrary")]
 impl<'a, T: Arbitrary<'a>> Arbitrary<'a> for NumOpResult<T> {
+    #[inline]
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         match bool::arbitrary(u)? {
             true => Ok(Self::Valid(T::arbitrary(u)?)),
@@ -477,6 +482,7 @@ impl<'a, T: Arbitrary<'a>> Arbitrary<'a> for NumOpResult<T> {
 
 #[cfg(feature = "arbitrary")]
 impl<'a> Arbitrary<'a> for MathOp {
+    #[inline]
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         let choice = u.int_in_range(0..=5)?;
         match choice {

--- a/units/src/sequence.rs
+++ b/units/src/sequence.rs
@@ -306,11 +306,13 @@ pub mod error {
 
     #[cfg(feature = "encoding")]
     impl From<Infallible> for SequenceDecoderError {
+        #[inline]
         fn from(never: Infallible) -> Self { match never {} }
     }
 
     #[cfg(feature = "encoding")]
     impl fmt::Display for SequenceDecoderError {
+        #[inline]
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             write_err!(f, "sequence decoder error"; self.0)
         }
@@ -353,6 +355,7 @@ impl<'a> Arbitrary<'a> for Sequence {
 #[cfg(feature = "arbitrary")]
 #[cfg(not(feature = "alloc"))]
 impl<'a> Arbitrary<'a> for Sequence {
+    #[inline]
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         // Equally weight the cases of meaningful sequence numbers
         let choice = u.int_in_range(0..=4)?;

--- a/units/src/time.rs
+++ b/units/src/time.rs
@@ -175,11 +175,13 @@ pub mod error {
 
     #[cfg(feature = "encoding")]
     impl From<Infallible> for BlockTimeDecoderError {
+        #[inline]
         fn from(never: Infallible) -> Self { match never {} }
     }
 
     #[cfg(feature = "encoding")]
     impl fmt::Display for BlockTimeDecoderError {
+        #[inline]
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             write_err!(f, "block time decoder error"; self.0)
         }

--- a/units/src/weight.rs
+++ b/units/src/weight.rs
@@ -195,6 +195,7 @@ crate::internal_macros::impl_fmt_traits_for_u32_wrapper!(Weight, to_wu);
 
 /// Alternative will display the unit.
 impl fmt::Display for Weight {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if f.alternate() {
             write!(f, "{} wu", self.to_wu())
@@ -321,6 +322,7 @@ impl<'de> Deserialize<'de> for Weight {
 
 #[cfg(feature = "arbitrary")]
 impl<'a> Arbitrary<'a> for Weight {
+    #[inline]
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         let w = u64::arbitrary(u)?;
         Ok(Self::from_wu(w))


### PR DESCRIPTION
Where functions merely delegate to other functions, or only perform trivial operations, they should be annotated with #[inline] to nudge the compiler towards improving performance by inlining them. Before the final 1.0 release, any remaining simple functions should be tagged with the #[inline] attribute.

Add #[inline] to trivial functions in all modules.