### PR TITLE
fuzz: add custom mutators for checksum-gated targets

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -15,6 +15,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
+name = "autocfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23213af7601f0f2d929f73d2a772804562cb09063f50bba9c361f86d6a0376f8"
+
+[[package]]
 name = "base58ck"
 version = "0.1.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,6 +357,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5cde24d1b2e2216a726368b2363a273739c91f4e3eb4e0dd12d672d396ad989"
+
+[[package]]
+name = "bitflags"
 version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
@@ -362,10 +374,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60f0b0d4c0a382d2734228fd12b5a6b5dac185c60e938026fd31b265b94f9bd2"
 
 [[package]]
-name = "cc"
-version = "1.0.28"
+name = "c2-chacha"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749"
+checksum = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
+dependencies = [
+ "lazy_static",
+ "ppv-lite86",
+]
+
+[[package]]
+name = "cc"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "jobserver",
+ "libc",
+]
+
+[[package]]
+name = "cfg-if"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 
 [[package]]
 name = "cfg-if"
@@ -381,6 +413,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags 1.0.0",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,12 +431,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuchsia-cprng"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f7f8eb465745ea9b02e2704612a9946a59fa40572086c6fd49d6ddcf30bf31"
+
+[[package]]
+name = "getrandom"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e738b1f02e4d17217cae7648e774c03a19cd9de18bc294c538cc3e780f8c3bbd"
+dependencies = [
+ "cloudabi",
+ "fuchsia-cprng",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71393ecc86efbf00e4ca13953979ba8b94cfe549a4b74cc26d8b62f4d8feac2b"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi",
  "windows-targets",
@@ -447,6 +506,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 
 [[package]]
+name = "jobserver"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f74e73053eaf95399bf926e48fc7a2a3ce50bd0eaaa2357d391e95b2dcdd4f10"
+dependencies = [
+ "libc",
+ "log",
+ "rand 0.7.0",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
+
+[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,12 +530,21 @@ checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libfuzzer-sys"
-version = "0.4.0"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86c975d637bc2a2f99440932b731491fc34c7f785d239e38af3addd3c2fd0e46"
+checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
 dependencies = [
  "arbitrary",
  "cc",
+]
+
+[[package]]
+name = "log"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
+dependencies = [
+ "cfg-if 0.1.2",
 ]
 
 [[package]]
@@ -488,13 +573,37 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d47eab0e83d9693d40f825f86948aa16eff6750ead4bdffc4ab95b8b3a7f052c"
+dependencies = [
+ "getrandom 0.1.1",
+ "libc",
+ "rand_chacha 0.2.0",
+ "rand_core 0.5.0",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.0",
  "zerocopy",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e193067942ef6f485a349a113329140d0ab9e2168ce92274499bb0e9a4190d9d"
+dependencies = [
+ "autocfg",
+ "c2-chacha",
+ "rand_core 0.5.0",
 ]
 
 [[package]]
@@ -504,7 +613,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.0",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "615e683324e75af5d43d8f7a39ffe3ee4a9dc42c5c701167a71dc59c3a493aca"
+dependencies = [
+ "getrandom 0.1.1",
 ]
 
 [[package]]
@@ -513,8 +631,17 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.0",
  "zerocopy",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.0",
 ]
 
 [[package]]
@@ -541,7 +668,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5fdc7d6e800869d3fd60ff857c479bf0a83ea7bf44b389e64461e844204994"
 dependencies = [
  "arbitrary",
- "rand",
+ "rand 0.9.0",
  "secp256k1-sys 0.12.0",
  "serde",
 ]
@@ -647,9 +774,31 @@ version = "0.13.0+wasi-0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "652cd73449d0b957a2743b70c72d79d34a5fa505696488f4ca90b46f6da94118"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.2",
  "wit-bindgen-rt",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-targets"

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -446,9 +446,9 @@ checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "libfuzzer-sys"
-version = "0.4.10"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5037190e1f70cbeef565bd267599242926f724d3b8a9f510fd7e0b540cfa4404"
+checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
 dependencies = [
  "arbitrary",
  "cc",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -21,7 +21,7 @@ bitcoin_consensus_encoding = { path = "../consensus_encoding", package = "bitcoi
 p2p = { path = "../p2p", package = "bitcoin-p2p-messages", features = ["arbitrary"] }
 
 arbitrary = { version = "1.4.1" }
-libfuzzer-sys = { version = "0.4.0" }
+libfuzzer-sys = { version = "0.4.13" }
 serde = { version = "1.0.195", features = [ "derive" ] }
 serde_json = "1.0.68"
 serde_cbor = "0.9"

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -112,6 +112,50 @@ INFO: A corpus is not provided, starting from an empty corpus
 ```
 If you don't see this, you should quickly see an error.
 
+## Custom mutators
+
+Some targets sit behind a checksum, or behind a checksummed string encoding. Random byte
+mutation cannot satisfy those: changing any byte invalidates the envelope, so the fuzzer
+spends its whole budget being rejected and never reaches the parser inside.
+
+This is the same wall that [fuzzing with weak cryptography](#fuzzing-with-weak-cryptography)
+runs into, approached from the other side. Weak crypto lowers the wall for the whole binary,
+which is why that section warns about spurious bug reports: a hash the fuzzer can break no
+longer upholds the invariants the surrounding code was written against. A custom mutator leaves
+the wall where it is and computes the answer instead, so the target still runs against real
+hashing and whatever it finds is real.
+
+That only works where the answer is computable. A checksum over bytes we already hold is; a
+preimage or a forged signature is not, and those still need the weak-crypto build. So the two
+compose rather than compete: `fuzz.sh` passes `--cfg=hashes_fuzz` by default and the mutators
+work under it, because a mutator computes its checksum with the same hash implementation its
+target verifies with. Drop the flag and the checksummed targets keep working just as well.
+
+The mutators live in `src/mutate/`, one per envelope shape, and are attached to a target with
+`libfuzzer_sys::fuzz_mutator!`.
+
+Two things are worth knowing before writing another one.
+
+libFuzzer stops generating inputs of its own as soon as a custom mutator exists, so a mutator
+that only ever emits well-formed inputs makes every error path unreachable. The ones here
+deliberately leave a share of their output alone, or broken, for that reason.
+
+`libfuzzer_sys::fuzzer_mutate` is an `extern "C"` call into the libFuzzer runtime, which is
+only linked into a fuzz target binary. Mutators therefore take it as a parameter rather than
+calling it directly, which is what lets `src/mutate/` be an ordinary library with ordinary unit
+tests:
+
+```bash
+cargo test -p bitcoin-fuzz --lib
+```
+
+Those tests are worth extending along with any mutator, since a mutator that quietly stops
+producing valid inputs looks exactly like a target that has stopped finding bugs.
+
+libFuzzer prints `INFO: found LLVMFuzzerCustomMutator` on startup when a mutator is wired up
+correctly, and disables `-len_control` as a side effect. If that line is missing, the target is
+being fuzzed without its mutator.
+
 ## Reproducing Failures
 
 If a fuzztest fails, it will exit with a summary which looks something like

--- a/fuzz/fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_v1_network_message.rs
+++ b/fuzz/fuzz_targets/bitcoin/encoding_roundtrip/p2p_message_v1_network_message.rs
@@ -10,3 +10,13 @@ fn main() {}
 fuzz_target!(|data: &[u8]| {
     check_roundtrip::<p2p::message::V1NetworkMessage>(data);
 });
+
+libfuzzer_sys::fuzz_mutator!(|data: &mut [u8], size: usize, max_size: usize, seed: u32| {
+    bitcoin_fuzz::mutate::p2p_frame::mutate_payload(
+        data,
+        size,
+        max_size,
+        seed,
+        libfuzzer_sys::fuzzer_mutate,
+    )
+});

--- a/fuzz/fuzz_targets/bitcoin/parse_address.rs
+++ b/fuzz/fuzz_targets/bitcoin/parse_address.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(fuzzing, no_main)]
 #![cfg_attr(not(fuzzing), allow(unused))]
 
+use bitcoin_fuzz::mutate::address;
 use libfuzzer_sys::fuzz_target;
 
 #[cfg(not(fuzzing))]
@@ -30,4 +31,8 @@ fn do_test(data: &[u8]) {
 
 fuzz_target!(|data| {
     do_test(data);
+});
+
+libfuzzer_sys::fuzz_mutator!(|data: &mut [u8], size: usize, max_size: usize, seed: u32| {
+    address::mutate_payload(data, size, max_size, seed, libfuzzer_sys::fuzzer_mutate)
 });

--- a/fuzz/fuzz_targets/bitcoin/parse_address.rs
+++ b/fuzz/fuzz_targets/bitcoin/parse_address.rs
@@ -12,7 +12,20 @@ fn do_test(data: &[u8]) {
         Ok(addr) => addr.assume_checked(),
         Err(_) => return,
     };
-    assert_eq!(addr.to_string(), data_str);
+    let encoded = addr.to_string();
+
+    // `Display` writes the canonical encoding. base58 is case-sensitive and so round-trips
+    // exactly, but bech32 accepts an all-uppercase address and always writes it back lowercase.
+    if encoded != data_str {
+        assert_eq!(encoded, data_str.to_lowercase());
+    }
+
+    // Whatever it wrote has to parse back to the address it was written from.
+    let reparsed = encoded
+        .parse::<bitcoin::address::Address<_>>()
+        .expect("an encoded address should parse")
+        .assume_checked();
+    assert_eq!(reparsed, addr);
 }
 
 fuzz_target!(|data| {

--- a/fuzz/fuzz_targets/bitcoin_0_32/deser_net_msg.rs
+++ b/fuzz/fuzz_targets/bitcoin_0_32/deser_net_msg.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(fuzzing, no_main)]
 #![cfg_attr(not(fuzzing), allow(unused))]
 
+use bitcoin_fuzz::mutate::p2p_frame;
 use libfuzzer_sys::fuzz_target;
 
 #[cfg(not(fuzzing))]
@@ -13,4 +14,8 @@ fn do_test(data: &[u8]) {
 
 fuzz_target!(|data: &[u8]| {
     do_test(data);
+});
+
+libfuzzer_sys::fuzz_mutator!(|data: &mut [u8], size: usize, max_size: usize, seed: u32| {
+    p2p_frame::mutate_payload(data, size, max_size, seed, libfuzzer_sys::fuzzer_mutate)
 });

--- a/fuzz/fuzz_targets/bitcoin_0_32/deserialize_address.rs
+++ b/fuzz/fuzz_targets/bitcoin_0_32/deserialize_address.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(fuzzing, no_main)]
 #![cfg_attr(not(fuzzing), allow(unused))]
 
+use bitcoin_fuzz::mutate::address;
 use libfuzzer_sys::fuzz_target;
 
 #[cfg(not(fuzzing))]
@@ -30,4 +31,8 @@ fn do_test(data: &[u8]) {
 
 fuzz_target!(|data: &[u8]| {
     do_test(data);
+});
+
+libfuzzer_sys::fuzz_mutator!(|data: &mut [u8], size: usize, max_size: usize, seed: u32| {
+    address::mutate_payload(data, size, max_size, seed, libfuzzer_sys::fuzzer_mutate)
 });

--- a/fuzz/fuzz_targets/bitcoin_0_32/deserialize_address.rs
+++ b/fuzz/fuzz_targets/bitcoin_0_32/deserialize_address.rs
@@ -12,7 +12,20 @@ fn do_test(data: &[u8]) {
         Ok(addr) => addr.assume_checked(),
         Err(_) => return,
     };
-    assert_eq!(addr.to_string(), data_str);
+    let encoded = addr.to_string();
+
+    // `Display` writes the canonical encoding. base58 is case-sensitive and so round-trips
+    // exactly, but bech32 accepts an all-uppercase address and always writes it back lowercase.
+    if encoded != data_str {
+        assert_eq!(encoded, data_str.to_lowercase());
+    }
+
+    // Whatever it wrote has to parse back to the address it was written from.
+    let reparsed = encoded
+        .parse::<bitcoin_0_32::address::Address<_>>()
+        .expect("an encoded address should parse")
+        .assume_checked();
+    assert_eq!(reparsed, addr);
 }
 
 fuzz_target!(|data: &[u8]| {

--- a/fuzz/fuzz_targets/p2p/deserialize_raw_net_msg.rs
+++ b/fuzz/fuzz_targets/p2p/deserialize_raw_net_msg.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(fuzzing, no_main)]
 #![cfg_attr(not(fuzzing), allow(unused))]
 
+use bitcoin_fuzz::mutate::p2p_frame;
 use libfuzzer_sys::fuzz_target;
 
 #[cfg(not(fuzzing))]
@@ -13,4 +14,8 @@ fn do_test(data: &[u8]) {
 
 fuzz_target!(|data| {
     do_test(data);
+});
+
+libfuzzer_sys::fuzz_mutator!(|data: &mut [u8], size: usize, max_size: usize, seed: u32| {
+    p2p_frame::mutate_payload(data, size, max_size, seed, libfuzzer_sys::fuzzer_mutate)
 });

--- a/fuzz/generate-encoding-roundtrip.sh
+++ b/fuzz/generate-encoding-roundtrip.sh
@@ -129,6 +129,27 @@ type_to_stem() {
     echo "$result"
 }
 
+# Extra content appended to a target, for types whose encoding is checksum-gated and so need a
+# custom mutator to be fuzzable at all. See fuzz/src/mutate/.
+mutator_block() {
+    case "$1" in
+        p2p::message::V1NetworkMessage)
+            cat <<'RUST'
+
+libfuzzer_sys::fuzz_mutator!(|data: &mut [u8], size: usize, max_size: usize, seed: u32| {
+    bitcoin_fuzz::mutate::p2p_frame::mutate_payload(
+        data,
+        size,
+        max_size,
+        seed,
+        libfuzzer_sys::fuzzer_mutate,
+    )
+});
+RUST
+            ;;
+    esac
+}
+
 generate_roundtrip() {
     local type="$1"
     local stem filepath
@@ -149,6 +170,8 @@ fuzz_target!(|data: &[u8]| {
     check_roundtrip::<$type>(data);
 });
 RUST
+
+    mutator_block "$type" >> "$filepath"
 }
 
 generate_script_roundtrip() {

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -1,5 +1,7 @@
 //! Shared utilities for fuzz targets.
 
+pub mod mutate;
+
 use std::fmt;
 use std::ops::Deref;
 

--- a/fuzz/src/mutate/address.rs
+++ b/fuzz/src/mutate/address.rs
@@ -1,0 +1,458 @@
+//! Mutator for address strings.
+//!
+//! bech32's checksum is a BCH code, and base58's is four bytes of double SHA256 over a
+//! positional radix encoding. Neither is invertible by byte mutation, so an unaided fuzzer
+//! essentially never produces a parsable address and the whole segwit path goes unexercised.
+//!
+//! So rather than mutate the string, this mutator decodes it into a record, mutates the
+//! record, and re-encodes.
+
+use bitcoin::bech32::primitives::decode::CheckedHrpstring;
+use bitcoin::bech32::{self, Bech32, Bech32m, Fe32, Hrp};
+
+use super::{Mutate, Rng};
+
+/// Longest program the unchecked segwit encoder takes without silently truncating.
+///
+/// It writes into a fixed 90 byte buffer and drops whatever does not fit, which would leave a
+/// string whose checksum is wrong for the wrong reason. The worst case is the longest HRP:
+/// 4 (`bcrt`) + 1 separator + 1 version + ceil(48 * 8 / 5) = 77 data + 6 checksum = 89.
+const MAX_PROGRAM: usize = 48;
+
+/// Longest string `Address::from_base58_str` will look at before giving up.
+const MAX_BASE58_LEN: usize = 50;
+
+/// Length of the hash in a base58 address payload.
+const BASE58_HASH_LEN: usize = 20;
+
+/// The HRPs `KnownHrp::from_hrp` accepts.
+const HRPS: [Hrp; 3] = [bech32::hrp::BC, bech32::hrp::TB, bech32::hrp::BCRT];
+
+/// The prefix bytes `Address::from_base58_str` accepts.
+const BASE58_PREFIXES: [u8; 4] = [0x00, 0x05, 0x6F, 0xC4];
+
+/// Encodes a base58check payload, appending its checksum.
+fn base58_encode(payload: &[u8]) -> String {
+    bitcoin::base58::Base58CkString::encode_unbounded(payload).as_str().into()
+}
+
+/// Decodes a base58check string, returning the payload without its checksum.
+fn base58_decode(s: &str) -> Option<Vec<u8>> { bitcoin::base58::decode_check(s).ok() }
+
+/// What kind of address a record describes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Form {
+    /// A valid segwit address.
+    Segwit,
+    /// A segwit address with a correct checksum but an invalid witness program, which is what
+    /// reaches the error paths behind `bech32::segwit::decode`.
+    SegwitNearMiss,
+    /// A base58check address.
+    Base58,
+}
+
+impl Form {
+    /// Picks a form, weighted towards valid segwit addresses: those are the ones the target
+    /// could never reach on its own, and the only ones its roundtrip assertion runs on.
+    fn pick(rng: &mut Rng) -> Self {
+        match rng.below(4) {
+            0 | 1 => Self::Segwit,
+            2 => Self::SegwitNearMiss,
+            _ => Self::Base58,
+        }
+    }
+}
+
+/// The decoded form of an address, which is what actually gets mutated.
+struct Record {
+    form: Form,
+    /// Index into [`HRPS`].
+    hrp: usize,
+    uppercase: bool,
+    /// Whether to build a base58 payload the parser is bound to reject.
+    malform: bool,
+    /// Witness version for the segwit forms, prefix byte for base58.
+    version: u8,
+    program: [u8; MAX_PROGRAM],
+    program_len: usize,
+}
+
+impl Record {
+    fn new(form: Form, hrp: usize, version: u8, program: &[u8]) -> Self {
+        let mut record = Self {
+            form,
+            hrp,
+            uppercase: false,
+            malform: false,
+            version,
+            program: [0; MAX_PROGRAM],
+            program_len: program.len().min(MAX_PROGRAM),
+        };
+        record.program[..record.program_len].copy_from_slice(&program[..record.program_len]);
+        record
+    }
+
+    fn program(&self) -> &[u8] { &self.program[..self.program_len] }
+}
+
+/// Mutates an address by decoding it, mutating the decoded form, and re-encoding.
+pub fn mutate_payload(
+    data: &mut [u8],
+    size: usize,
+    max_size: usize,
+    seed: u32,
+    builtin_mutate: Mutate,
+) -> usize {
+    let mut rng = Rng::new(seed);
+
+    // Keep a share of plain mutations, so inputs that are not addresses at all, and the error
+    // paths only they reach, do not drop out of the corpus.
+    if rng.one_in(8) {
+        return builtin_mutate(data, size, max_size);
+    }
+
+    // An input that is not an address at all seeds a record from its raw bytes. The shape is
+    // drawn at random rather than fixed, so that exploration from an empty corpus is not stuck
+    // on one kind of address.
+    let mut record =
+        core::str::from_utf8(&data[..size]).ok().and_then(decode).unwrap_or_else(|| {
+            let form = Form::pick(&mut rng);
+            let hrp = rng.below(HRPS.len());
+            let version = rng.next_u64() as u8;
+            Record::new(form, hrp, version, &data[..size])
+        });
+
+    // Nudge the shape now and then. It is mostly carried over from the input, so that progress
+    // on one kind of address compounds instead of being re-rolled on every mutation.
+    if rng.one_in(8) {
+        record.form = Form::pick(&mut rng);
+    }
+    if rng.one_in(8) {
+        record.hrp = rng.below(HRPS.len());
+    }
+    if rng.one_in(8) {
+        record.uppercase = rng.one_in(2);
+    }
+    if rng.one_in(8) {
+        record.malform = rng.one_in(2);
+    }
+    if rng.one_in(8) {
+        record.version = rng.next_u64() as u8;
+    }
+
+    // `program` is `MAX_PROGRAM` long and `program_len` never exceeds it.
+    let program_len = builtin_mutate(&mut record.program, record.program_len, MAX_PROGRAM);
+    record.program_len = program_len;
+
+    match encode(&record) {
+        Some(address) if address.len() <= max_size => {
+            data[..address.len()].copy_from_slice(address.as_bytes());
+            address.len()
+        }
+        _ => builtin_mutate(data, size, max_size),
+    }
+}
+
+/// Rebuilds a record from an already-encoded address.
+///
+/// Returns `None` if `s` is not one, in which case the caller starts a record from scratch.
+fn decode(s: &str) -> Option<Record> {
+    let uppercase = s.bytes().any(|byte| byte.is_ascii_uppercase());
+
+    if let Ok((hrp, version, program)) = bech32::segwit::decode(s) {
+        let mut record = Record::new(Form::Segwit, hrp_index(hrp), version.to_u8(), &program);
+        record.uppercase = uppercase;
+        return Some(record);
+    }
+
+    // A near miss does not survive `segwit::decode`, which validates the witness program. Take
+    // it apart at the checksum layer instead, so those inputs keep a lineage of their own
+    // rather than being rediscovered from scratch every time.
+    if let Ok(mut checked) =
+        CheckedHrpstring::new::<Bech32m>(s).or_else(|_| CheckedHrpstring::new::<Bech32>(s))
+    {
+        if let Some(version) = checked.remove_witness_version() {
+            let program = checked.byte_iter().collect::<Vec<u8>>();
+            let mut record = Record::new(
+                Form::SegwitNearMiss,
+                hrp_index(checked.hrp()),
+                version.to_u8(),
+                &program,
+            );
+            record.uppercase = uppercase;
+            return Some(record);
+        }
+    }
+
+    // `from_base58_str` gives up past this length, and base58 decoding is quadratic in it, so
+    // there is nothing to gain by decoding a longer string.
+    if s.len() > MAX_BASE58_LEN {
+        return None;
+    }
+
+    let payload = base58_decode(s)?;
+    let (prefix, hash) = payload.split_first()?;
+
+    let mut record = Record::new(Form::Base58, 0, *prefix, hash);
+    record.malform = hash.len() != BASE58_HASH_LEN || !BASE58_PREFIXES.contains(prefix);
+    Some(record)
+}
+
+/// Encodes a record, or returns `None` if it does not describe an encodable address.
+fn encode(record: &Record) -> Option<String> {
+    let hrp = HRPS[record.hrp];
+
+    match record.form {
+        Form::Segwit => {
+            let version =
+                Fe32::try_from(record.version % 17).expect("0..17 are valid field elements");
+            let mut program = record.program().to_vec();
+            program.resize(valid_program_len(version, program.len()), 0);
+
+            let address = bech32::segwit::encode(hrp, version, &program).ok()?;
+            Some(cased(address, record.uppercase))
+        }
+        Form::SegwitNearMiss => {
+            // Mostly a legal version paired with an illegal program length: that clears the
+            // version check and the checksum, and so actually reaches
+            // `validate_witness_program_length`. A version above 16 is rejected before the
+            // checksum is even looked at, making it a much shallower probe.
+            let version =
+                if record.version >= 0xF0 { record.version % 32 } else { record.version % 17 };
+            let version = Fe32::try_from(version).expect("0..32 are valid field elements");
+
+            let mut address = String::new();
+            bech32::segwit::encode_lower_to_fmt_unchecked(
+                &mut address,
+                hrp,
+                version,
+                record.program(),
+            )
+            .ok()?;
+            Some(cased(address, record.uppercase))
+        }
+        Form::Base58 => {
+            let mut payload = vec![prefix(record.version, record.malform)];
+            let mut hash = record.program().to_vec();
+            hash.resize(base58_hash_len(hash.len(), record.malform), 0);
+            payload.extend_from_slice(&hash);
+
+            Some(base58_encode(&payload))
+        }
+    }
+}
+
+/// The index of `hrp` in [`HRPS`], defaulting to mainnet for anything else.
+fn hrp_index(hrp: Hrp) -> usize { HRPS.iter().position(|candidate| *candidate == hrp).unwrap_or(0) }
+
+/// Clamps a program to a length that is legal for `version`.
+fn valid_program_len(version: Fe32, len: usize) -> usize {
+    if version == bech32::segwit::VERSION_0 {
+        if len >= 32 {
+            32
+        } else {
+            20
+        }
+    } else {
+        len.clamp(2, 40)
+    }
+}
+
+/// The version byte of a base58 payload.
+///
+/// Usually one the parser recognises, so that the address is worth parsing at all, and
+/// occasionally not, so that `InvalidLegacyPrefixError` stays reachable.
+fn prefix(version: u8, malform: bool) -> u8 {
+    if malform {
+        version
+    } else {
+        BASE58_PREFIXES[usize::from(version) % BASE58_PREFIXES.len()]
+    }
+}
+
+/// The hash length of a base58 payload.
+///
+/// Usually 20, the only length the parser accepts, and occasionally not, so that
+/// `InvalidBase58PayloadLengthError` stays reachable.
+fn base58_hash_len(len: usize, malform: bool) -> usize {
+    if malform {
+        len.min(MAX_PROGRAM)
+    } else {
+        BASE58_HASH_LEN
+    }
+}
+
+/// Uppercases a bech32 string when the record asks for it.
+///
+/// bech32 permits an all-uppercase encoding, and parsing one is a distinct path.
+fn cased(address: String, uppercase: bool) -> String {
+    if uppercase {
+        address.to_uppercase()
+    } else {
+        address
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::address::{Address, NetworkUnchecked};
+
+    use super::*;
+
+    /// A mainnet P2WPKH address. bech32 involves no hashing, so this is stable regardless of
+    /// whether the tests are built with `--cfg=hashes_fuzz`.
+    const P2WPKH: &str = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+
+    /// Stands in for the built-in mutator, changing nothing.
+    fn identity(_: &mut [u8], size: usize, max_size: usize) -> usize { size.min(max_size) }
+
+    /// Stands in for the built-in mutator, overwriting the buffer with a known pattern.
+    fn fill(data: &mut [u8], _size: usize, max_size: usize) -> usize {
+        for (i, byte) in data[..max_size].iter_mut().enumerate() {
+            *byte = i as u8;
+        }
+        max_size
+    }
+
+    /// Runs the mutator the way libFuzzer would, and returns the mutated input.
+    fn run(input: &[u8], max_size: usize, seed: u32, builtin_mutate: Mutate) -> Vec<u8> {
+        // libFuzzer sizes the buffer at `max(size, max_size)`.
+        let mut data = vec![0u8; input.len().max(max_size)];
+        data[..input.len()].copy_from_slice(input);
+
+        let len = mutate_payload(&mut data, input.len(), max_size, seed, builtin_mutate);
+        assert!(len <= max_size, "returned {len} for a max_size of {max_size}");
+
+        data.truncate(len);
+        data
+    }
+
+    fn parses(bytes: &[u8]) -> bool {
+        core::str::from_utf8(bytes)
+            .ok()
+            .is_some_and(|s| s.parse::<Address<NetworkUnchecked>>().is_ok())
+    }
+
+    /// One valid address of each shape the mutator can produce.
+    fn samples() -> Vec<String> {
+        let p2pkh = {
+            let mut payload = vec![BASE58_PREFIXES[0]];
+            payload.extend_from_slice(&[4; BASE58_HASH_LEN]);
+            base58_encode(&payload)
+        };
+
+        vec![
+            P2WPKH.to_owned(),
+            bech32::segwit::encode(bech32::hrp::BC, Fe32::Q, &[1; 20]).unwrap(),
+            bech32::segwit::encode(bech32::hrp::TB, Fe32::P, &[2; 32]).unwrap(),
+            bech32::segwit::encode(bech32::hrp::BCRT, Fe32::Q, &[3; 32]).unwrap(),
+            p2pkh,
+        ]
+    }
+
+    #[test]
+    fn decode_then_encode_is_the_identity() {
+        for address in samples() {
+            let record = decode(&address).expect("{address} should decode");
+            assert_eq!(encode(&record).as_deref(), Some(address.as_str()));
+        }
+    }
+
+    #[test]
+    fn samples_are_addresses_in_the_first_place() {
+        for address in samples() {
+            assert!(parses(address.as_bytes()), "{address} is not a valid address");
+        }
+    }
+
+    #[test]
+    fn a_near_miss_keeps_its_lineage() {
+        // Witness version 0 with a 21 byte program: `segwit::decode` refuses it, so recovering
+        // the record has to go through the checksum layer instead.
+        let record = Record::new(Form::SegwitNearMiss, 0, 0, &[7; 21]);
+        let address = encode(&record).expect("near miss should encode");
+
+        let back = decode(&address).expect("a near miss should still rebuild a record");
+        assert_eq!(back.form, Form::SegwitNearMiss);
+        assert_eq!(back.version, 0);
+        assert_eq!(back.program(), &[7; 21]);
+    }
+
+    #[test]
+    fn a_near_miss_is_rejected_for_its_structure_and_not_its_checksum() {
+        let record = Record::new(Form::SegwitNearMiss, 0, 0, &[7; 21]);
+        let address = encode(&record).expect("near miss should encode");
+
+        // Recovering it above proves the checksum is correct, so this rejection can only be
+        // the witness program length rule.
+        assert!(!parses(address.as_bytes()), "{address} was supposed to be rejected");
+    }
+
+    #[test]
+    fn most_mutations_are_still_parsable_addresses() {
+        let parsed =
+            (0..512).filter(|&seed| parses(&run(P2WPKH.as_bytes(), 128, seed, fill))).count();
+
+        // The rest are the deliberate share of raw mutations, plus the near-miss form.
+        assert!(parsed > 320, "only {parsed} of 512 mutations parsed as an address");
+    }
+
+    #[test]
+    fn every_form_is_reachable() {
+        let mut seen = std::collections::BTreeSet::new();
+
+        for seed in 0..512 {
+            let out = run(P2WPKH.as_bytes(), 128, seed, fill);
+            if let Some(record) = core::str::from_utf8(&out).ok().and_then(decode) {
+                seen.insert(format!("{:?}", record.form));
+            }
+        }
+
+        assert_eq!(seen.len(), 3, "only reached {seen:?}");
+    }
+
+    #[test]
+    fn uppercase_addresses_are_produced_and_parse() {
+        let mut record = Record::new(Form::Segwit, 0, 0, &[7; 20]);
+        record.uppercase = true;
+
+        let address = encode(&record).expect("should encode");
+        assert_eq!(address, address.to_uppercase());
+        assert!(parses(address.as_bytes()), "{address} should parse");
+    }
+
+    #[test]
+    fn never_panics_on_arbitrary_input() {
+        let inputs: [&[u8]; 5] = [b"", b"\xff\xfe\xfd", b"bc1", &[0x41; 200], P2WPKH.as_bytes()];
+
+        for input in inputs {
+            for seed in 0..64 {
+                for builtin_mutate in [identity as Mutate, fill as Mutate] {
+                    for max_size in [0, 1, 20, 50, 128, 4096] {
+                        let _ = run(input, max_size, seed, builtin_mutate);
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn base58_codec_round_trips() {
+        let payload = [0x00u8; 21];
+        let encoded = base58_encode(&payload);
+
+        assert_eq!(base58_decode(&encoded).as_deref(), Some(&payload[..]));
+    }
+
+    /// The base58 checksum of both crate versions has to agree, or the `bitcoin 0.32` target
+    /// would be handed addresses its own parser rejects.
+    #[test]
+    fn both_crate_versions_agree_on_base58() {
+        for prefix in BASE58_PREFIXES {
+            let mut payload = vec![prefix];
+            payload.extend_from_slice(&[7; BASE58_HASH_LEN]);
+
+            assert_eq!(base58_encode(&payload), bitcoin_0_32::base58::encode_check(&payload));
+        }
+    }
+}

--- a/fuzz/src/mutate/mod.rs
+++ b/fuzz/src/mutate/mod.rs
@@ -13,6 +13,8 @@
 //! Note that libFuzzer stops using its built-in mutators as soon as a custom one is defined,
 //! so every path through a mutator has to call [`Mutate`] to keep them.
 
+pub mod p2p_frame;
+
 /// The signature of `libfuzzer_sys::fuzzer_mutate`.
 ///
 /// Mutates `data[..size]` in place, growing or shrinking it to at most `max_size`, and returns

--- a/fuzz/src/mutate/mod.rs
+++ b/fuzz/src/mutate/mod.rs
@@ -1,0 +1,94 @@
+//! Custom libFuzzer mutators.
+//!
+//! A few targets sit behind a checksum, or behind a checksummed string encoding. Random byte
+//! mutation cannot satisfy those: changing any byte invalidates the envelope, so the fuzzer
+//! spends its whole budget being rejected and never reaches the parser inside. These mutators
+//! keep the envelope well formed, so libFuzzer's mutations land on the payload instead.
+//!
+//! Each mutator takes libFuzzer's built-in mutator as a [`Mutate`] parameter rather than
+//! calling `libfuzzer_sys::fuzzer_mutate` itself. That function is an `extern "C"` call into
+//! the libFuzzer runtime, which is only linked into a fuzz target binary; taking it as a
+//! parameter keeps this library linkable, and its mutators unit testable, on their own.
+//!
+//! Note that libFuzzer stops using its built-in mutators as soon as a custom one is defined,
+//! so every path through a mutator has to call [`Mutate`] to keep them.
+
+/// The signature of `libfuzzer_sys::fuzzer_mutate`.
+///
+/// Mutates `data[..size]` in place, growing or shrinking it to at most `max_size`, and returns
+/// the new length.
+pub type Mutate = fn(&mut [u8], usize, usize) -> usize;
+
+/// A SplitMix64 generator.
+///
+/// libFuzzer requires that a mutation be a deterministic function of the seed it passes in, so
+/// mutators must not reach for any ambient source of randomness.
+pub struct Rng(u64);
+
+impl Rng {
+    /// Constructs a generator from libFuzzer's per-call seed.
+    pub fn new(seed: u32) -> Self { Self(u64::from(seed)) }
+
+    /// Returns the next value in the sequence.
+    pub fn next_u64(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+
+    /// Returns a value in `0..n`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `n` is zero.
+    pub fn below(&mut self, n: usize) -> usize {
+        assert!(n > 0, "below(0) has no valid result");
+        (self.next_u64() % n as u64) as usize
+    }
+
+    /// Returns `true` with probability `1 / n`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `n` is zero.
+    pub fn one_in(&mut self, n: usize) -> bool { self.below(n) == 0 }
+
+    /// Returns one of `choices`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `choices` is empty.
+    pub fn pick<'a, T>(&mut self, choices: &'a [T]) -> &'a T { &choices[self.below(choices.len())] }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rng_is_deterministic_in_the_seed() {
+        let sequence = |seed| {
+            let mut rng = Rng::new(seed);
+            [rng.next_u64(), rng.next_u64(), rng.next_u64()]
+        };
+
+        assert_eq!(sequence(7), sequence(7));
+        assert_ne!(sequence(7), sequence(8));
+    }
+
+    #[test]
+    fn rng_below_stays_in_range() {
+        let mut rng = Rng::new(0);
+        for _ in 0..1_000 {
+            assert!(rng.below(38) < 38);
+        }
+    }
+
+    #[test]
+    fn rng_below_one_is_always_zero() {
+        let mut rng = Rng::new(1);
+        assert_eq!(rng.below(1), 0);
+    }
+}

--- a/fuzz/src/mutate/mod.rs
+++ b/fuzz/src/mutate/mod.rs
@@ -13,6 +13,7 @@
 //! Note that libFuzzer stops using its built-in mutators as soon as a custom one is defined,
 //! so every path through a mutator has to call [`Mutate`] to keep them.
 
+pub mod address;
 pub mod p2p_frame;
 
 /// The signature of `libfuzzer_sys::fuzzer_mutate`.

--- a/fuzz/src/mutate/p2p_frame.rs
+++ b/fuzz/src/mutate/p2p_frame.rs
@@ -1,0 +1,351 @@
+//! Mutator for the v1 p2p message frame.
+//!
+//! A frame is `magic[0..4] || command[4..16] || length[16..20] || checksum[20..24] || payload`.
+//! Three things have to hold at once for one to decode: the command has to name a known
+//! message, `length` has to equal the payload length exactly, and `checksum` has to be the
+//! first four bytes of the payload's double SHA256. Mutating the payload breaks the last two
+//! every time, which is why an unaided fuzzer never gets past the header and into the payload
+//! parsers.
+//!
+//! This mutator confines mutation to the payload region and then rewrites `length` and
+//! `checksum`, so the frame it hands back is always decodable.
+
+use super::{Mutate, Rng};
+
+/// Size of the v1 message header, in bytes.
+pub const HEADER_LEN: usize = 24;
+
+/// Every command accepted by `NetworkMessageDecoderInner::new` in `p2p/src/message.rs`.
+///
+/// No public API exposes this list, so it is duplicated here. Anything absent decodes to
+/// `NetworkMessage::Unknown`, which means a stale entry costs a little fuzzing efficiency but
+/// never correctness. `bitcoin 0.32` does not know `sendtxrcncl` or `feature` and treats them
+/// as unknown commands.
+pub const COMMANDS: [&str; 38] = [
+    "version",
+    "verack",
+    "sendheaders",
+    "mempool",
+    "getaddr",
+    "wtxidrelay",
+    "filterclear",
+    "sendaddrv2",
+    "addr",
+    "inv",
+    "getdata",
+    "notfound",
+    "getblocks",
+    "getheaders",
+    "tx",
+    "block",
+    "headers",
+    "ping",
+    "pong",
+    "merkleblock",
+    "filterload",
+    "filteradd",
+    "getcfilters",
+    "cfilter",
+    "getcfheaders",
+    "cfheaders",
+    "getcfcheckpt",
+    "cfcheckpt",
+    "sendcmpct",
+    "cmpctblock",
+    "getblocktxn",
+    "blocktxn",
+    "alert",
+    "reject",
+    "feefilter",
+    "sendtxrcncl",
+    "addrv2",
+    "feature",
+];
+
+/// The payload size of each command that has exactly one.
+///
+/// A frame only decodes when the payload decoder consumes the region exactly: it stops at its
+/// own natural size and `decode_from_slice` then rejects the leftovers. For these commands any
+/// other length is wasted, so the mutator snaps to the one that can work. The
+/// `fixed_payload_lengths_are_accurate` test checks every entry, which is what keeps the table
+/// honest as the protocol grows.
+const FIXED_PAYLOAD_LEN: [(&str, usize); 15] = [
+    ("verack", 0),
+    ("sendheaders", 0),
+    ("mempool", 0),
+    ("getaddr", 0),
+    ("wtxidrelay", 0),
+    ("filterclear", 0),
+    ("sendaddrv2", 0),
+    ("ping", 8),
+    ("pong", 8),
+    ("feefilter", 8),
+    ("sendcmpct", 9),
+    ("sendtxrcncl", 12),
+    ("getcfcheckpt", 33),
+    ("getcfilters", 37),
+    ("getcfheaders", 37),
+];
+
+/// First four bytes of `sha256d(payload)`, as `p2p`'s private `sha2_checksum` computes it.
+fn checksum(payload: &[u8]) -> [u8; 4] {
+    let hash = bitcoin::hashes::sha256d::Hash::hash(payload).to_byte_array();
+    [hash[0], hash[1], hash[2], hash[3]]
+}
+
+/// Mutates the payload of a v1 p2p frame, then repairs the header around it.
+pub fn mutate_payload(
+    data: &mut [u8],
+    size: usize,
+    max_size: usize,
+    seed: u32,
+    builtin_mutate: Mutate,
+) -> usize {
+    // A frame needs a header and somewhere to put a payload. libFuzzer asserts `MaxSize > 0`
+    // inside its own mutator, so an empty payload region is not something we can hand it.
+    if max_size <= HEADER_LEN {
+        return builtin_mutate(data, size, max_size);
+    }
+
+    // libFuzzer sizes `data` at `max(size, max_size)`, and `max_size > HEADER_LEN` above, so
+    // the header is in bounds even when the input is shorter than one.
+    let mut size = size;
+    if size < HEADER_LEN {
+        data[size..HEADER_LEN].fill(0);
+        size = HEADER_LEN;
+    }
+
+    let mut rng = Rng::new(seed);
+
+    // Mutate the header itself now and then. libFuzzer stops generating inputs of its own once
+    // a custom mutator exists, so without this the command could only ever change by wholesale
+    // replacement below, and the decoder's own header error paths, such as a non-ASCII command
+    // or one with an interior NUL, would be unreachable.
+    if rng.one_in(8) {
+        let mut header = [0u8; HEADER_LEN];
+        header.copy_from_slice(&data[..HEADER_LEN]);
+        builtin_mutate(&mut header, HEADER_LEN, HEADER_LEN);
+        data[..HEADER_LEN].copy_from_slice(&header);
+    }
+
+    // Both arguments are within `data[HEADER_LEN..]`, whose length is
+    // `max(size, max_size) - HEADER_LEN`.
+    let mut payload_len =
+        builtin_mutate(&mut data[HEADER_LEN..], size - HEADER_LEN, max_size - HEADER_LEN);
+
+    // Swapping the command hands the payload to a different decoder, so do it rarely.
+    if rng.one_in(16) {
+        let command = rng.pick(&COMMANDS);
+        data[4..16].fill(0);
+        data[4..4 + command.len()].copy_from_slice(command.as_bytes());
+    }
+
+    // A command with a fixed size will only ever consume that many bytes, so snap the payload
+    // to it rather than leaving the fuzzer to rediscover the one length that can work.
+    if let Some(fixed) = fixed_payload_len(&data[4..16]) {
+        if HEADER_LEN + fixed <= max_size {
+            if fixed > payload_len {
+                data[HEADER_LEN + payload_len..HEADER_LEN + fixed].fill(0);
+            }
+            payload_len = fixed;
+        }
+    }
+
+    // Leave a frame broken now and then, for the same reason the header is mutated above: the
+    // checksum and length error paths are only reachable if something still produces them.
+    if !rng.one_in(32) {
+        let length =
+            u32::try_from(payload_len).expect("payload is bounded by libFuzzer's -max_len");
+        data[16..20].copy_from_slice(&length.to_le_bytes());
+
+        let checksum = checksum(&data[HEADER_LEN..HEADER_LEN + payload_len]);
+        data[20..24].copy_from_slice(&checksum);
+    }
+
+    // Never exceeds `max_size`, so the caller's clamp cannot truncate the frame and undo the
+    // length and checksum written above.
+    HEADER_LEN + payload_len
+}
+
+/// The fixed payload size of the command named in a header's command field, if it has one.
+fn fixed_payload_len(command: &[u8]) -> Option<usize> {
+    let trimmed = command.split(|byte| *byte == 0).next()?;
+    let command = core::str::from_utf8(trimmed).ok()?;
+
+    FIXED_PAYLOAD_LEN.iter().find(|(name, _)| *name == command).map(|(_, len)| *len)
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin_consensus_encoding::decode_from_slice;
+
+    use super::*;
+
+    /// Stands in for the built-in mutator, leaving the payload alone.
+    fn identity(_: &mut [u8], size: usize, max_size: usize) -> usize { size.min(max_size) }
+
+    /// Stands in for the built-in mutator, growing the payload to fill the space.
+    fn fill(data: &mut [u8], _size: usize, max_size: usize) -> usize {
+        for (i, byte) in data[..max_size].iter_mut().enumerate() {
+            *byte = i as u8;
+        }
+        max_size
+    }
+
+    /// Runs the mutator the way libFuzzer would, and returns the mutated input.
+    fn run(input: &[u8], max_size: usize, seed: u32, builtin_mutate: Mutate) -> Vec<u8> {
+        // libFuzzer sizes the buffer at `max(size, max_size)`.
+        let mut data = vec![0u8; input.len().max(max_size)];
+        data[..input.len()].copy_from_slice(input);
+
+        let len = mutate_payload(&mut data, input.len(), max_size, seed, builtin_mutate);
+        assert!(len <= max_size, "returned {len} for a max_size of {max_size}");
+
+        data.truncate(len);
+        data
+    }
+
+    /// Whether a frame's length and checksum fields describe its payload.
+    fn is_repaired(frame: &[u8]) -> bool {
+        let payload = &frame[HEADER_LEN..];
+        frame[16..20] == (payload.len() as u32).to_le_bytes() && frame[20..24] == checksum(payload)
+    }
+
+    /// A frame carrying a `verack`, which has an empty payload.
+    fn verack() -> Vec<u8> {
+        let mut frame = vec![0u8; HEADER_LEN];
+        frame[4..10].copy_from_slice(b"verack");
+        frame[20..24].copy_from_slice(&checksum(&[]));
+        frame
+    }
+
+    #[test]
+    fn the_header_almost_always_describes_the_payload() {
+        let cases = [(0, 25), (5, 30), (24, 25), (24, 4096), (100, 30), (200, 200)];
+        let (mut repaired, mut total) = (0, 0);
+
+        for seed in 0..256 {
+            for builtin_mutate in [identity as Mutate, fill as Mutate] {
+                for (size, max_size) in cases {
+                    let frame = run(&vec![0xAB; size], max_size, seed, builtin_mutate);
+                    assert!(frame.len() >= HEADER_LEN);
+
+                    total += 1;
+                    repaired += usize::from(is_repaired(&frame));
+                }
+            }
+        }
+
+        // The rest are the deliberate share left broken, so the decoder's checksum and length
+        // error paths stay reachable.
+        assert!(repaired * 10 > total * 9, "only {repaired} of {total} frames were repaired");
+        assert!(repaired < total, "no frame was left broken, so those error paths are dead");
+    }
+
+    #[test]
+    fn a_repaired_frame_decodes() {
+        let mut checked = 0;
+
+        for seed in 0..256 {
+            let frame = run(&verack(), 4096, seed, identity);
+
+            // Skip the seeds that rewrote the header or deliberately left it broken.
+            if &frame[4..10] != b"verack" || frame[10..16] != [0; 6] || !is_repaired(&frame) {
+                continue;
+            }
+
+            decode_from_slice::<p2p::message::V1NetworkMessage>(&frame)
+                .expect("a repaired verack frame should decode");
+            checked += 1;
+        }
+
+        assert!(checked > 0, "every seed was skipped, so nothing was checked");
+    }
+
+    #[test]
+    fn commands_are_valid_and_reach_a_real_parser() {
+        for command in COMMANDS {
+            assert!(command.is_ascii(), "{command} is not ASCII");
+            assert!(command.len() <= 12, "{command} does not fit in a CommandString");
+
+            let mut frame = vec![0u8; HEADER_LEN];
+            frame[4..4 + command.len()].copy_from_slice(command.as_bytes());
+            frame[20..24].copy_from_slice(&checksum(&[]));
+
+            // An empty payload will not satisfy most of these, but a command the decoder does
+            // not know is never a parse failure: it decodes to `Unknown`. So a command that
+            // fails to decode here has definitely been dispatched to a real parser.
+            if let Ok(message) = decode_from_slice::<p2p::message::V1NetworkMessage>(&frame) {
+                assert_ne!(
+                    message.payload().command().as_ref(),
+                    "unknown",
+                    "{command} is not in the decoder's dispatch table any more"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn fixed_payload_lengths_are_accurate() {
+        for (command, len) in FIXED_PAYLOAD_LEN {
+            assert!(COMMANDS.contains(&command), "{command} is not a known command");
+
+            let mut frame = vec![0u8; HEADER_LEN + len];
+            frame[4..4 + command.len()].copy_from_slice(command.as_bytes());
+            frame[16..20].copy_from_slice(&(len as u32).to_le_bytes());
+            let checksum = checksum(&frame[HEADER_LEN..]);
+            frame[20..24].copy_from_slice(&checksum);
+
+            let message = decode_from_slice::<p2p::message::V1NetworkMessage>(&frame)
+                .unwrap_or_else(|e| {
+                    panic!("{command} should decode with {len} payload bytes: {e:?}")
+                });
+            assert_eq!(message.payload().command().as_ref(), command);
+        }
+    }
+
+    #[test]
+    fn a_snapped_command_produces_a_decodable_frame() {
+        // Every seed that swaps in a fixed-size command should also resize the payload to
+        // match, so the frame it hands back decodes rather than tripping the checksum. The
+        // payload starts out zeroed because snapping fixes the length, not the content, and an
+        // arbitrary payload of the right length is still free to be an invalid message.
+        for seed in 0..2_048 {
+            let frame = run(&[0; 200], 4_096, seed, identity);
+            let Some(fixed) = fixed_payload_len(&frame[4..16]) else { continue };
+
+            if !is_repaired(&frame) {
+                continue; // Deliberately left broken.
+            }
+            assert_eq!(frame.len(), HEADER_LEN + fixed, "payload was not snapped to fit");
+            decode_from_slice::<p2p::message::V1NetworkMessage>(&frame)
+                .expect("a snapped frame should decode");
+        }
+    }
+
+    /// The checksum of both crate versions has to agree, or the `bitcoin 0.32` target would be
+    /// handed frames its own decoder rejects.
+    #[test]
+    fn both_crate_versions_agree_on_the_checksum() {
+        use bitcoin_0_32::hashes::Hash as _;
+
+        for len in [0, 1, 31, 32, 33, 63, 64, 65, 200] {
+            let payload = vec![0xAB; len];
+            let hash = bitcoin_0_32::hashes::sha256d::Hash::hash(&payload).to_byte_array();
+
+            assert_eq!(checksum(&payload), hash[..4], "mismatch on a {len} byte payload");
+        }
+    }
+
+    #[test]
+    fn tiny_max_size_falls_back_to_the_built_in_mutator() {
+        for max_size in 0..=HEADER_LEN {
+            let input = vec![0xAB; 40];
+            let mut data = vec![0u8; input.len().max(max_size)];
+            data[..input.len()].copy_from_slice(&input);
+
+            let len = mutate_payload(&mut data, input.len(), max_size, 0, identity);
+            assert!(len <= max_size);
+        }
+    }
+}


### PR DESCRIPTION
Five fuzz targets sit behind a checksum and never reach the parser inside: any
mutation invalidates the envelope, so the whole budget goes on rejected inputs.

Adds two custom mutators under `fuzz/src/mutate/`:

- `p2p_frame` confines mutation to a v1 message payload and rewrites the length
  and checksum around it
- `address` decodes an address, mutates the witness program or hash, and
  re-encodes

Also fixes a latent bug in the address targets roundtrip assertion: an
all-uppercase bech32 address parses but `Display` writes lowercase, so the
assertion fired on the first valid address a mutator produced.

Written with LLM assistance (Claude Opus 5).

More fuzz magic :)