### PR TITLE
units: Make `MathOp` private

### DIFF
--- a/units/src/amount/tests.rs
+++ b/units/src/amount/tests.rs
@@ -1445,29 +1445,6 @@ fn amount_op_result_sum() {
 }
 
 #[test]
-fn math_op_errors() {
-    let overflow = Amount::MAX + Amount::from_sat(1).unwrap();
-    if let NumOpResult::Error(err) = overflow {
-        assert!(err.operation().is_overflow());
-        assert!(err.is_overflow());
-        assert!(!err.operation().is_div_by_zero());
-        assert!(!err.is_div_by_zero());
-    } else {
-        panic!("Expected an overflow error, but got a valid result");
-    }
-
-    let div_by_zero = Amount::from_sat(10).unwrap() / Amount::ZERO;
-    if let NumOpResult::Error(err) = div_by_zero {
-        assert!(!err.operation().is_overflow());
-        assert!(!err.is_overflow());
-        assert!(err.operation().is_div_by_zero());
-        assert!(err.is_div_by_zero());
-    } else {
-        panic!("Expected a division by zero error, but got a valid result");
-    }
-}
-
-#[test]
 #[allow(clippy::op_ref)]
 fn amount_div_nonzero() {
     let amount = Amount::from_sat(100).unwrap();
@@ -1656,7 +1633,7 @@ fn amount_div_by_weight_floor_error() {
 
     // Overflow case: Amount::MAX * 1000 overflows
     let err = Amount::MAX.div_by_weight_floor(Weight::from_wu(1)).unwrap_err();
-    assert_eq!(err, NumOpError::while_doing(MathOp::Mul));
+    assert_eq!(err, NumOpError::while_doing(MathOp::Div));
 }
 
 #[test]
@@ -1667,5 +1644,5 @@ fn amount_div_by_weight_ceil_error() {
 
     // Overflow case: Amount::MAX * 1000 overflows
     let err = Amount::MAX.div_by_weight_ceil(Weight::from_wu(1)).unwrap_err();
-    assert_eq!(err, NumOpError::while_doing(MathOp::Mul));
+    assert_eq!(err, NumOpError::while_doing(MathOp::Div));
 }

--- a/units/src/amount/unsigned.rs
+++ b/units/src/amount/unsigned.rs
@@ -474,8 +474,7 @@ impl Amount {
                 None => return R::Error(E::while_doing(MathOp::Div)),
             }
         }
-        // Use `MathOp::Mul` because `Div` implies div by zero.
-        R::Error(E::while_doing(MathOp::Mul))
+        R::Error(E::while_doing(MathOp::Div))
     }
 
     /// Checked weight ceiling division.
@@ -509,8 +508,7 @@ impl Amount {
                 return FeeRate::from_per_kwu(amount);
             }
         }
-        // Use `MathOp::Mul` because `Div` implies div by zero.
-        R::Error(E::while_doing(MathOp::Mul))
+        R::Error(E::while_doing(MathOp::Div))
     }
 
     /// Checked fee rate floor division.

--- a/units/src/result.rs
+++ b/units/src/result.rs
@@ -2,7 +2,6 @@
 
 //! Provides a monadic type returned by mathematical operations ([`core::ops`]).
 
-use core::convert::Infallible;
 use core::{fmt, ops};
 
 #[cfg(feature = "arbitrary")]
@@ -354,8 +353,7 @@ impl_opt_ext!(Amount, SignedAmount, u64, i64, FeeRate, Weight);
 
 /// The math operation that caused the error.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum MathOp {
+pub(crate) enum MathOp {
     /// Addition failed ([`core::ops::Add`] resulted in an invalid value).
     Add,
     /// Subtraction failed ([`core::ops::Sub`] resulted in an invalid value).
@@ -368,36 +366,26 @@ pub enum MathOp {
     Rem,
     /// Negation failed ([`core::ops::Neg`] resulted in an invalid value).
     Neg,
-    /// Stops users from casting this enum to an integer.
-    // May get removed if one day Rust supports disabling casts natively.
-    #[doc(hidden)]
-    _DoNotUse(Infallible),
 }
 
 impl MathOp {
     /// Returns `true` if this operation error'ed due to addition.
-    #[inline]
-    pub fn is_addition(self) -> bool { self == Self::Add }
+    fn is_addition(self) -> bool { self == Self::Add }
 
     /// Returns `true` if this operation error'ed due to subtraction.
-    #[inline]
-    pub fn is_subtraction(self) -> bool { self == Self::Sub }
+    fn is_subtraction(self) -> bool { self == Self::Sub }
 
     /// Returns `true` if this operation error'ed due to multiplication.
-    #[inline]
-    pub fn is_multiplication(self) -> bool { self == Self::Mul }
+    fn is_multiplication(self) -> bool { self == Self::Mul }
 
     /// Returns `true` if this operation error'ed due to division.
-    #[inline]
-    pub fn is_division(self) -> bool { self == Self::Div }
+    fn is_division(self) -> bool { self == Self::Div }
 
     /// Returns `true` if this operation error'ed due to remainder.
-    #[inline]
-    pub fn is_remainder(self) -> bool { self == Self::Rem }
+    fn is_remainder(self) -> bool { self == Self::Rem }
 
     /// Returns `true` if this operation error'ed due to negation.
-    #[inline]
-    pub fn is_negation(self) -> bool { self == Self::Neg }
+    fn is_negation(self) -> bool { self == Self::Neg }
 }
 
 impl fmt::Display for MathOp {
@@ -410,7 +398,6 @@ impl fmt::Display for MathOp {
             Self::Div => write!(f, "div"),
             Self::Rem => write!(f, "rem"),
             Self::Neg => write!(f, "neg"),
-            Self::_DoNotUse(infallible) => match infallible {},
         }
     }
 }
@@ -432,9 +419,29 @@ pub mod error {
         #[inline]
         pub(crate) const fn while_doing(op: MathOp) -> Self { Self(op) }
 
-        /// Returns the [`MathOp`] that caused this error.
+        /// Returns `true` if this operation error'ed due to addition.
         #[inline]
-        pub fn operation(self) -> MathOp { self.0 }
+        pub fn is_addition(self) -> bool { self.0.is_addition() }
+
+        /// Returns `true` if this operation error'ed due to subtraction.
+        #[inline]
+        pub fn is_subtraction(self) -> bool { self.0.is_subtraction() }
+
+        /// Returns `true` if this operation error'ed due to multiplication.
+        #[inline]
+        pub fn is_multiplication(self) -> bool { self.0.is_multiplication() }
+
+        /// Returns `true` if this operation error'ed due to division.
+        #[inline]
+        pub fn is_division(self) -> bool { self.0.is_division() }
+
+        /// Returns `true` if this operation error'ed due to remainder.
+        #[inline]
+        pub fn is_remainder(self) -> bool { self.0.is_remainder() }
+
+        /// Returns `true` if this operation error'ed due to negation.
+        #[inline]
+        pub fn is_negation(self) -> bool { self.0.is_negation() }
     }
 
     impl From<Infallible> for NumOpError {
@@ -445,7 +452,7 @@ pub mod error {
     impl fmt::Display for NumOpError {
         #[inline]
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            write!(f, "math operation '{}' gave an invalid numeric result", self.operation())
+            write!(f, "math operation '{}' gave an invalid numeric result", self.0)
         }
     }
 

--- a/units/src/result.rs
+++ b/units/src/result.rs
@@ -54,9 +54,9 @@ pub use self::error::NumOpError;
 /// # Ok::<_, amount::OutOfRangeError>(())
 /// ```
 ///
-/// ### Divide-by-zero (overflow in [`Div`] or [`Rem`])
+/// ### Failure in chained operations
 ///
-/// In some instances one may wish to differentiate div-by-zero from overflow.
+/// In some instances one may wish to differentiate one math op failure from another.
 ///
 /// ```
 /// # use bitcoin_units::{Amount, FeeRate, NumOpResult, result::NumOpError};
@@ -70,12 +70,12 @@ pub use self::error::NumOpError;
 /// let max_fee = a + b;
 /// let _fee = match max_fee / fee_rate {
 ///     NumOpResult::Valid(fee) => fee,
-///     NumOpResult::Error(e) if e.is_div_by_zero() => {
-///         // Do something when div by zero.
+///     NumOpResult::Error(e) if e.is_division() => {
+///         // Do something when division fails (div by zero or perhaps MIN / -1).
 ///         return Err(e);
 ///     },
 ///     NumOpResult::Error(e) => {
-///         // We separate div-by-zero from overflow in case it needs to be handled separately.
+///         // And something else if the addition overflowed.
 ///         //
 ///         // This branch could be hit since `max_fee` came from some previous calculation. And if
 ///         // an input to that calculation was from the user then overflow could be an attack vector.
@@ -375,16 +375,6 @@ pub enum MathOp {
 }
 
 impl MathOp {
-    /// Returns `true` if this operation error'ed due to overflow.
-    #[inline]
-    pub fn is_overflow(self) -> bool {
-        matches!(self, Self::Add | Self::Sub | Self::Mul | Self::Neg)
-    }
-
-    /// Returns `true` if this operation error'ed due to division by zero.
-    #[inline]
-    pub fn is_div_by_zero(self) -> bool { !self.is_overflow() }
-
     /// Returns `true` if this operation error'ed due to addition.
     #[inline]
     pub fn is_addition(self) -> bool { self == Self::Add }
@@ -396,6 +386,14 @@ impl MathOp {
     /// Returns `true` if this operation error'ed due to multiplication.
     #[inline]
     pub fn is_multiplication(self) -> bool { self == Self::Mul }
+
+    /// Returns `true` if this operation error'ed due to division.
+    #[inline]
+    pub fn is_division(self) -> bool { self == Self::Div }
+
+    /// Returns `true` if this operation error'ed due to remainder.
+    #[inline]
+    pub fn is_remainder(self) -> bool { self == Self::Rem }
 
     /// Returns `true` if this operation error'ed due to negation.
     #[inline]
@@ -433,14 +431,6 @@ pub mod error {
         /// Constructs a [`NumOpError`] caused by `op`.
         #[inline]
         pub(crate) const fn while_doing(op: MathOp) -> Self { Self(op) }
-
-        /// Returns `true` if this operation error'ed due to overflow.
-        #[inline]
-        pub fn is_overflow(self) -> bool { self.0.is_overflow() }
-
-        /// Returns `true` if this operation error'ed due to division by zero.
-        #[inline]
-        pub fn is_div_by_zero(self) -> bool { self.0.is_div_by_zero() }
 
         /// Returns the [`MathOp`] that caused this error.
         #[inline]
@@ -508,17 +498,6 @@ mod tests {
 
     #[test]
     fn mathop_predicates() {
-        assert!(MathOp::Add.is_overflow());
-        assert!(MathOp::Sub.is_overflow());
-        assert!(MathOp::Mul.is_overflow());
-        assert!(MathOp::Neg.is_overflow());
-        assert!(!MathOp::Div.is_overflow());
-        assert!(!MathOp::Rem.is_overflow());
-
-        assert!(MathOp::Div.is_div_by_zero());
-        assert!(MathOp::Rem.is_div_by_zero());
-        assert!(!MathOp::Add.is_div_by_zero());
-
         assert!(MathOp::Add.is_addition());
         assert!(!MathOp::Sub.is_addition());
 
@@ -530,6 +509,12 @@ mod tests {
 
         assert!(MathOp::Neg.is_negation());
         assert!(!MathOp::Add.is_negation());
+
+        assert!(MathOp::Div.is_division());
+        assert!(!MathOp::Rem.is_division());
+
+        assert!(MathOp::Rem.is_remainder());
+        assert!(!MathOp::Div.is_remainder());
     }
 
     #[test]

--- a/units/tests/api.rs
+++ b/units/tests/api.rs
@@ -23,7 +23,6 @@ struct Enums {
     a: amount::Denomination,
     b: absolute::LockTime,
     c: relative::LockTime,
-    d: result::MathOp,
     e: result::NumOpResult<Amount>,
 }
 
@@ -33,7 +32,6 @@ impl Enums {
             a: amount::Denomination::Bitcoin,
             b: absolute::LockTime::Blocks(absolute::Height::MAX),
             c: relative::LockTime::Blocks(relative::NumberOfBlocks::MAX),
-            d: result::MathOp::Add,
             e: result::NumOpResult::Valid(Amount::MAX),
         }
     }
@@ -195,8 +193,6 @@ fn c_debug_nonempty() {
     let debug = format!("{:?}", t.a.b);
     assert!(!debug.is_empty());
     let debug = format!("{:?}", t.a.c);
-    assert!(!debug.is_empty());
-    let debug = format!("{:?}", t.a.d);
     assert!(!debug.is_empty());
     let debug = format!("{:?}", t.a.e);
     assert!(!debug.is_empty());
@@ -474,7 +470,7 @@ fn p_consistent_exports_parse() {
 /// P-CONSISTENT-EXPORTS: Tests that all types can be imported from the `result` module.
 #[test]
 fn p_consistent_exports_result() {
-    use bitcoin_units::result::{MathOp, NumOpError, NumOpResult};
+    use bitcoin_units::result::{NumOpError, NumOpResult};
 }
 
 /// P-CONSISTENT-EXPORTS: Tests that all types can be imported from the `pow` module.
@@ -569,7 +565,6 @@ impl<'a> Arbitrary<'a> for Enums {
             a: amount::Denomination::arbitrary(u)?,
             b: absolute::LockTime::arbitrary(u)?,
             c: relative::LockTime::arbitrary(u)?,
-            d: result::MathOp::arbitrary(u)?,
             e: result::NumOpResult::<Amount>::arbitrary(u)?,
         };
         Ok(a)


### PR DESCRIPTION
This is an alternative to #6681. Please note this is not me being facetious but rather trying to find an acceptable way forward so we can get `units` out the door.

N.B the `NumOpResult` docs changes are substantial and an argument may be made that this PR reduces functionality (albeit currently broken functionality).

Close #4672