### PR TITLE
ci: pin dependabot to Sunday 16:00 America/Chicago

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
+      day: "sunday"
+      time: "16:00"
+      timezone: "America/Chicago"
     # Defines a cooldown period for dependency updates,
     # allowing updates to be delayed for a configurable number of days.
     cooldown:


### PR DESCRIPTION
Per apoelstra's ask on https://github.com/rust-bitcoin/rust-bitcoin/pull/6773#issuecomment-5395628053. Pinned to 16:00 at Austin city time which is the same as `America/Chicago`, the official IANA timezone name.

Dependabot used to run at [random moments](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#interval).