### PR TITLE
base58: Simplify and flatten error types

### DIFF
--- a/base58/src/error.rs
+++ b/base58/src/error.rs
@@ -17,11 +17,7 @@ pub type Error = DecodeCheckError;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DecodeCheckError(pub(super) DecodeCheckErrorInner);
 
-#[cfg(not(feature = "alloc"))]
-/// An error occurred during base58 decoding (with checksum).
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct DecodeCheckError(pub(super) DecodeCheckErrorInner);
-
+#[cfg(feature = "alloc")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum DecodeCheckErrorInner {
     /// Invalid character while decoding.
@@ -32,6 +28,7 @@ pub(super) enum DecodeCheckErrorInner {
     TooShort(TooShortError),
 }
 
+#[cfg(feature = "alloc")]
 impl DecodeCheckError {
     /// Returns the invalid base58 character, if encountered.
     pub fn invalid_character(&self) -> Option<u8> {
@@ -58,10 +55,12 @@ impl DecodeCheckError {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl From<Infallible> for DecodeCheckError {
     fn from(never: Infallible) -> Self { match never {} }
 }
 
+#[cfg(feature = "alloc")]
 impl fmt::Display for DecodeCheckError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use DecodeCheckErrorInner::{Decode, IncorrectChecksum, TooShort};
@@ -119,16 +118,19 @@ impl std::error::Error for IncorrectChecksumError {
 }
 
 /// The decoded base58 data was too short (require at least 4 bytes for checksum).
+#[cfg(feature = "alloc")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct TooShortError {
     /// The length of the decoded data.
     pub(super) length: usize,
 }
 
+#[cfg(feature = "alloc")]
 impl From<Infallible> for TooShortError {
     fn from(never: Infallible) -> Self { match never {} }
 }
 
+#[cfg(feature = "alloc")]
 impl fmt::Display for TooShortError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
@@ -192,8 +194,10 @@ pub struct DecodeCheckArrayError(pub(super) DecodeCheckArrayErrorInner);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum DecodeCheckArrayErrorInner {
-    /// Decoding the base58check string failed (invalid character, bad checksum or too short).
-    Decode(DecodeCheckError),
+    /// Invalid character while decoding.
+    InvalidCharacter(InvalidCharacterError),
+    /// Checksum was not correct.
+    IncorrectChecksum(IncorrectChecksumError),
     /// The decoded payload length did not match the requested array length.
     UnexpectedLength(UnexpectedLengthError),
 }
@@ -202,24 +206,24 @@ impl DecodeCheckArrayError {
     /// Returns the invalid base58 character, if encountered.
     pub fn invalid_character(&self) -> Option<u8> {
         match self.0 {
-            DecodeCheckArrayErrorInner::Decode(ref e) => e.invalid_character(),
-            DecodeCheckArrayErrorInner::UnexpectedLength(_) => None,
+            DecodeCheckArrayErrorInner::InvalidCharacter(ref e) => Some(e.invalid_character()),
+            _ => None,
         }
     }
 
     /// Returns the incorrect checksum along with the expected checksum, if encountered.
     pub fn incorrect_checksum(&self) -> Option<(u32, u32)> {
         match self.0 {
-            DecodeCheckArrayErrorInner::Decode(ref e) => e.incorrect_checksum(),
-            DecodeCheckArrayErrorInner::UnexpectedLength(_) => None,
+            DecodeCheckArrayErrorInner::IncorrectChecksum(ref e) => Some((e.incorrect, e.expected)),
+            _ => None,
         }
     }
 
-    /// Returns the invalid base58 string length (require at least 4 bytes for checksum), if encountered.
-    pub fn invalid_length(&self) -> Option<usize> {
+    /// Returns the decoded data length along with the expected length, if the two did not match.
+    pub fn invalid_length(&self) -> Option<(usize, usize)> {
         match self.0 {
-            DecodeCheckArrayErrorInner::Decode(ref e) => e.invalid_length(),
-            DecodeCheckArrayErrorInner::UnexpectedLength(_) => None,
+            DecodeCheckArrayErrorInner::UnexpectedLength(ref e) => Some((e.actual, e.expected)),
+            _ => None,
         }
     }
 }
@@ -230,10 +234,11 @@ impl From<Infallible> for DecodeCheckArrayError {
 
 impl fmt::Display for DecodeCheckArrayError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use DecodeCheckArrayErrorInner::{Decode, UnexpectedLength};
+        use DecodeCheckArrayErrorInner::{IncorrectChecksum, InvalidCharacter, UnexpectedLength};
 
         match self.0 {
-            Decode(ref e) => write_err!(f, "decode"; e),
+            InvalidCharacter(ref e) => write_err!(f, "decode"; e),
+            IncorrectChecksum(ref e) => write_err!(f, "incorrect checksum"; e),
             UnexpectedLength(ref e) => write_err!(f, "unexpected length"; e),
         }
     }
@@ -242,10 +247,11 @@ impl fmt::Display for DecodeCheckArrayError {
 #[cfg(feature = "std")]
 impl std::error::Error for DecodeCheckArrayError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        use DecodeCheckArrayErrorInner::{Decode, UnexpectedLength};
+        use DecodeCheckArrayErrorInner::{IncorrectChecksum, InvalidCharacter, UnexpectedLength};
 
         match self.0 {
-            Decode(ref e) => Some(e),
+            InvalidCharacter(ref e) => Some(e),
+            IncorrectChecksum(ref e) => Some(e),
             UnexpectedLength(ref e) => Some(e),
         }
     }

--- a/base58/src/lib.rs
+++ b/base58/src/lib.rs
@@ -74,9 +74,11 @@ use internals::array_vec::ArrayVec;
 #[allow(unused)] // MSRV polyfill
 use internals::slice::SliceExt;
 
+#[cfg(feature = "alloc")]
+use crate::error::TooShortError;
 use crate::error::{
     Base256Error, DecodeCheckArrayErrorInner, DecodeCheckErrorInner, IncorrectChecksumError,
-    TooShortError, UnexpectedLengthError,
+    UnexpectedLengthError,
 };
 #[cfg(not(feature = "alloc"))]
 use crate::error::{DecodeCheckError, InputTooLongErrorInner, InvalidCharacterError};
@@ -249,31 +251,24 @@ pub fn decode_check_to_array<const N: usize>(data: &str) -> Result<[u8; N], Deco
     let leading_zeros = data.bytes().take_while(|&x| x == BASE58_CHARS[0]).count();
     let decoded_len = leading_zeros + scratch.len();
 
+    if decoded_len != N + 4 {
+        return Err(UnexpectedLengthError { expected: N, actual: decoded_len.saturating_sub(4) })
+            .map_err(DecodeCheckArrayErrorInner::UnexpectedLength)
+            .map_err(DecodeCheckArrayError);
+    }
+
     let mut decoded = [0u8; SHORT_OPT_BUFFER_LEN];
     scratch.as_mut_slice().reverse();
 
     // Copy the scratch into a subslice, erroring if out of range.
-    let write_slice = decoded
+    decoded
         .get_mut(leading_zeros..decoded_len)
-        .ok_or(UnexpectedLengthError { expected: N, actual: data.len() * 11 / 15 })
-        .map_err(DecodeCheckArrayErrorInner::UnexpectedLength)
-        .map_err(DecodeCheckArrayError)?;
-    write_slice.copy_from_slice(&scratch);
+        .expect("decoded_len = N + 4 <= 128 per above and compile-time check")
+        .copy_from_slice(&scratch);
     let decoded = &decoded[..decoded_len];
 
-    let (payload, &data_check) = decoded
-        .split_last_chunk::<4>()
-        .ok_or(TooShortError { length: decoded_len })
-        .map_err(DecodeCheckErrorInner::TooShort)
-        .map_err(DecodeCheckError)
-        .map_err(DecodeCheckArrayErrorInner::Decode)
-        .map_err(DecodeCheckArrayError)?;
-
-    if payload.len() != N {
-        return Err(UnexpectedLengthError { expected: N, actual: payload.len() })
-            .map_err(DecodeCheckArrayErrorInner::UnexpectedLength)
-            .map_err(DecodeCheckArrayError);
-    }
+    let (payload, &data_check) =
+        decoded.split_last_chunk::<4>().expect("decoded length checked as >= 4 above");
 
     let hash_check = *sha256d::Hash::hash(payload).as_byte_array().sub_array::<0, 4>();
     let expected = u32::from_le_bytes(hash_check);
@@ -620,7 +615,7 @@ mod tests {
         use crate::error::DecodeCheckArrayErrorInner;
 
         const STRING_LEN: usize = SHORT_OPT_BUFFER_LEN + 1;
-        const APPROX_LEN: usize = STRING_LEN * 11 / 15;
+        const DECODE_LEN: usize = STRING_LEN - 4;
 
         let encoded = "1PfJpZsjreyVrqeoAfabrRwwjQyoSQMmHH"; // 21 byte payload
 
@@ -646,7 +641,7 @@ mod tests {
         assert!(matches!(
             decode_check_to_array::<21>(&long).unwrap_err(),
             DecodeCheckArrayError(DecodeCheckArrayErrorInner::UnexpectedLength(
-                crate::UnexpectedLengthError { expected: 21, actual: APPROX_LEN }
+                crate::UnexpectedLengthError { expected: 21, actual: DECODE_LEN }
             ))
         ));
     }

--- a/base58/src/lib.rs
+++ b/base58/src/lib.rs
@@ -116,9 +116,9 @@ static BASE58_DIGITS: [Option<u8>; 128] = [
 ///
 /// # Errors
 ///
-/// Returns an error if the input contains an invalid base58 character (not in the base58 alphabet).
+/// Returns an error if the input contains an invalid base58 character (not in the base58 alphabet)
+/// or the scratch buffer is unable to be written to.
 fn build_base256<T: Buffer>(data: &str, scratch: &mut T) -> Result<(), Base256Error<T::Err>> {
-    // Build in base 256
     for d58 in data.bytes() {
         // Compute "X = X * 58 + next_digit" in base 256
         let mut carry = BASE58_DIGITS.get(usize::from(d58))
@@ -132,7 +132,6 @@ fn build_base256<T: Buffer>(data: &str, scratch: &mut T) -> Result<(), Base256Er
             carry /= 256;
         }
         while carry > 0 {
-            // This function (build_base256) is only ever called with a Vec (infallible) or an ArrayVec with a pre-checked size.
             scratch.try_push(carry as u8).map_err(Base256Error::Buffer)?; // cast loses data intentionally
             carry /= 256;
         }
@@ -227,11 +226,10 @@ pub fn decode_check(data: &str) -> Result<Vec<u8>, DecodeCheckError> {
 /// assert!(decode_check_to_array::<20>("1PfJpZsjreyVrqeoAfabrRwwjQyoSQMmHH").is_err());
 /// # Ok::<_, base58ck::DecodeCheckArrayError>(())
 /// ```
-#[allow(clippy::missing_panics_doc)] // payload length is checked before cast unwrap
+#[allow(clippy::missing_panics_doc)] // All lengths are checked before each expect.
 pub fn decode_check_to_array<const N: usize>(data: &str) -> Result<[u8; N], DecodeCheckArrayError> {
     let () = AssertPayloadFits::<N>::OK;
 
-    // 11/15 is just over log_256(58), so the decoded length never exceeds the input length.
     let mut scratch = ArrayVec::<u8, SHORT_OPT_BUFFER_LEN>::new();
     build_base256(data, &mut scratch)
         .map_err(|e| match e {
@@ -257,7 +255,6 @@ pub fn decode_check_to_array<const N: usize>(data: &str) -> Result<[u8; N], Deco
     let mut decoded = [0u8; SHORT_OPT_BUFFER_LEN];
     scratch.as_mut_slice().reverse();
 
-    // Copy the scratch into a subslice, erroring if out of range.
     decoded
         .get_mut(leading_zeros..decoded_len)
         .expect("decoded_len = N + 4 <= 128 per above and compile-time check")

--- a/base58/src/lib.rs
+++ b/base58/src/lib.rs
@@ -11,9 +11,9 @@
 //!
 //! Decoding can be done with [`decode_check_to_array`] or [`decode_check`], both of which verify
 //! the checksum. [`decode_check_to_array`] decodes into a fixed-size array, but only accepts
-//! inputs of at most 128 characters. The expected decoded length must be specified by the generic
-//! `usize`. With the `alloc` feature enabled, [`decode_check`] decodes strings of any length into
-//! a `Vec<u8>`.
+//! inputs that decode to at most 128 bytes (including checksum). The expected decoded length must
+//! be specified by the generic `usize`. With the `alloc` feature enabled, [`decode_check`] decodes
+//! strings of any length into a `Vec<u8>`.
 //!
 //! # Examples
 //!
@@ -199,9 +199,9 @@ pub fn decode_check(data: &str) -> Result<Vec<u8>, DecodeCheckError> {
 
 /// Decodes a base58check-encoded string into a fixed-size array, verifying the checksum.
 ///
-/// This does not require `alloc`, but it only works for inputs up to 128 characters long. `N` is
-/// the expected length of the decoded payload (excluding the 4 byte checksum). Decoding will fail if
-/// the payload is any other length.
+/// This does not require `alloc`, but it only works for inputs that decode to at most 128 bytes.
+/// `N` is the expected length of the decoded payload (excluding the 4 byte checksum). Decoding
+/// will fail if the payload is any other length.
 ///
 /// `N` is compile-time checked to ensure that `N + 4` does not exceed the 128 byte limit, since
 /// such a call could never succeed. Use [`decode_check`] for payloads that large.
@@ -209,10 +209,9 @@ pub fn decode_check(data: &str) -> Result<Vec<u8>, DecodeCheckError> {
 /// # Errors
 ///
 /// * The input contains an invalid base58 character.
-/// * The decoded data is less than 4 bytes (too short for checksum verification).
+/// * The input does not decode to exactly `N` bytes followed by a 4 byte checksum.
+/// * The input decodes to more than 128 bytes (including the checksum).
 /// * The checksum does not match the expected value.
-/// * The input is longer than 128 characters.
-/// * The decoded payload length is not exactly `N` bytes.
 ///
 /// # Examples
 ///

--- a/base58/src/lib.rs
+++ b/base58/src/lib.rs
@@ -169,7 +169,7 @@ pub fn decode_check(data: &str) -> Result<Vec<u8>, DecodeCheckError> {
     let mut scratch = Vec::with_capacity(1 + data.len() * 11 / 15);
     build_base256(data, &mut scratch)
         .map_err(|e| match e {
-            Base256Error::Buffer(_) => unreachable!("Vec cannot fail try_push"),
+            Base256Error::Buffer(never) => match never {},
             Base256Error::InvalidChar(err) => err,
         })
         .map_err(DecodeCheckErrorInner::Decode)

--- a/base58/src/lib.rs
+++ b/base58/src/lib.rs
@@ -203,6 +203,9 @@ pub fn decode_check(data: &str) -> Result<Vec<u8>, DecodeCheckError> {
 /// the expected length of the decoded payload (excluding the 4 byte checksum). Decoding will fail if
 /// the payload is any other length.
 ///
+/// `N` is compile-time checked to ensure that `N + 4` does not exceed the 128 byte limit, since
+/// such a call could never succeed. Use [`decode_check`] for payloads that large.
+///
 /// # Errors
 ///
 /// * The input contains an invalid base58 character.
@@ -226,6 +229,8 @@ pub fn decode_check(data: &str) -> Result<Vec<u8>, DecodeCheckError> {
 /// ```
 #[allow(clippy::missing_panics_doc)] // payload length is checked before cast unwrap
 pub fn decode_check_to_array<const N: usize>(data: &str) -> Result<[u8; N], DecodeCheckArrayError> {
+    let () = AssertPayloadFits::<N>::OK;
+
     // 11/15 is just over log_256(58), so the decoded length never exceeds the input length.
     let mut scratch = ArrayVec::<u8, SHORT_OPT_BUFFER_LEN>::new();
     build_base256(data, &mut scratch)
@@ -284,6 +289,17 @@ pub fn decode_check_to_array<const N: usize>(data: &str) -> Result<[u8; N], Deco
     }
 
     Ok(payload.try_into().expect("payload length checked to equal N"))
+}
+
+/// Compile-time check that `decode_check_to_array` was asked for a payload that can fit in the
+/// fixed-size buffer, along with its 4 byte checksum.
+struct AssertPayloadFits<const N: usize>;
+
+impl<const N: usize> AssertPayloadFits<N> {
+    const OK: () = assert!(
+        N + 4 <= SHORT_OPT_BUFFER_LEN,
+        "decode_check_to_array cannot decode a payload this large, use decode_check instead"
+    );
 }
 
 const SHORT_OPT_BUFFER_LEN: usize = 128;

--- a/base58/src/lib.rs
+++ b/base58/src/lib.rs
@@ -74,14 +74,13 @@ use internals::array_vec::ArrayVec;
 #[allow(unused)] // MSRV polyfill
 use internals::slice::SliceExt;
 
-#[cfg(feature = "alloc")]
-use crate::error::TooShortError;
 use crate::error::{
-    Base256Error, DecodeCheckArrayErrorInner, DecodeCheckErrorInner, IncorrectChecksumError,
-    UnexpectedLengthError,
+    Base256Error, DecodeCheckArrayErrorInner, IncorrectChecksumError, UnexpectedLengthError,
 };
+#[cfg(feature = "alloc")]
+use crate::error::{DecodeCheckErrorInner, TooShortError};
 #[cfg(not(feature = "alloc"))]
-use crate::error::{DecodeCheckError, InputTooLongErrorInner, InvalidCharacterError};
+use crate::error::{InputTooLongErrorInner, InvalidCharacterError};
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[cfg(feature = "alloc")]
@@ -242,9 +241,7 @@ pub fn decode_check_to_array<const N: usize>(data: &str) -> Result<[u8; N], Deco
                     expected: N,
                     actual: data.len() * 11 / 15,
                 }),
-            Base256Error::InvalidChar(err) => DecodeCheckArrayErrorInner::Decode(DecodeCheckError(
-                DecodeCheckErrorInner::Decode(err),
-            )),
+            Base256Error::InvalidChar(err) => DecodeCheckArrayErrorInner::InvalidCharacter(err),
         })
         .map_err(DecodeCheckArrayError)?;
 
@@ -276,9 +273,7 @@ pub fn decode_check_to_array<const N: usize>(data: &str) -> Result<[u8; N], Deco
 
     if actual != expected {
         return Err(IncorrectChecksumError { incorrect: actual, expected })
-            .map_err(DecodeCheckErrorInner::IncorrectChecksum)
-            .map_err(DecodeCheckError)
-            .map_err(DecodeCheckArrayErrorInner::Decode)
+            .map_err(DecodeCheckArrayErrorInner::IncorrectChecksum)
             .map_err(DecodeCheckArrayError);
     }
 
@@ -629,12 +624,12 @@ mod tests {
 
         assert!(matches!(
             decode_check_to_array::<21>("¢").unwrap_err(),
-            DecodeCheckArrayError(DecodeCheckArrayErrorInner::Decode(_))
+            DecodeCheckArrayError(DecodeCheckArrayErrorInner::InvalidCharacter(_))
         ));
 
         assert!(matches!(
             decode_check_to_array::<21>("1PfJpZsjreyVrqeoAfabrRwwjQyoSQMmHG").unwrap_err(),
-            DecodeCheckArrayError(DecodeCheckArrayErrorInner::Decode(_))
+            DecodeCheckArrayError(DecodeCheckArrayErrorInner::IncorrectChecksum(_))
         ));
 
         let long = "1".repeat(STRING_LEN);

--- a/base58/src/lib.rs
+++ b/base58/src/lib.rs
@@ -120,15 +120,11 @@ fn build_base256<T: Buffer>(data: &str, scratch: &mut T) -> Result<(), Base256Er
     // Build in base 256
     for d58 in data.bytes() {
         // Compute "X = X * 58 + next_digit" in base 256
-        if usize::from(d58) >= BASE58_DIGITS.len() {
-            return Err(InvalidCharacterError::new(d58)).map_err(Base256Error::InvalidChar);
-        }
-        let mut carry = match BASE58_DIGITS[usize::from(d58)] {
-            Some(d58) => u32::from(d58),
-            None => {
-                return Err(InvalidCharacterError::new(d58)).map_err(Base256Error::InvalidChar);
-            }
-        };
+        let mut carry = BASE58_DIGITS.get(usize::from(d58))
+            .copied()
+            .flatten()
+            .ok_or(Base256Error::InvalidChar(InvalidCharacterError::new(d58)))
+            .map(u32::from)?;
         for d256 in scratch.slice_mut() {
             carry += u32::from(*d256) * 58;
             *d256 = carry as u8; // cast loses data intentionally


### PR DESCRIPTION
Following the overhaul of the base58 crate to introduce no-alloc functionality, many of the errors have become convoluted, and in some cases confused (byte vs characters, etc). In order to improve this situation, the DecodeCheckArrayError should ideally be separated from the DecodeCheckError and other tweaks made to simplify the error handling throughout.

- Patch 1 removes the unreachable in decode_check, replacing it with a match never {}.
- Patch 2 simplifies error catching in build_base256 by flattening an Option chain.
- Patch 3 adds a compile time range check on N in decode_check_to_array.
- Patch 4 adjusts the docs to clarify the 128 byte decoded payload + checksum limit from decode_check_to_array.
- Patch 5 rearranges length checks in decode_check_to_array to simplify the unexpected length cases to a single error variant.
- Patch 6 flattens the DecodeCheckArrayError::Decode variant into variants in DecodeCheckArrayError.
- Patch 7 removes stale or incorrect comments remaining from various recent changes.