### PR TITLE
base58: Remove `is_empty` from `Base58CkString`

### DIFF
--- a/base58/src/lib.rs
+++ b/base58/src/lib.rs
@@ -406,10 +406,8 @@ impl Base58CkString {
     }
 
     /// Returns the number of bytes/ASCII chars in the base58check-encoded string.
+    #[allow(clippy::len_without_is_empty)] // checksum means byte length is always > 0
     pub fn len(&self) -> usize { self.as_bytes().len() }
-
-    /// Returns true if the base58check-encoded string is empty.
-    pub fn is_empty(&self) -> bool { self.len() == 0 }
 }
 
 impl AsRef<str> for Base58CkString {


### PR DESCRIPTION
The Base58CkString can only encode with a checksum. As such, it always has a non-zero length. Since it always has a non-zero length, is_empty will always yield false and is thus useless.

Remove Base58CkString::is_empty.