### PR TITLE
base58: Use `div_ceil` for reserve length calculation

### DIFF
--- a/base58/src/lib.rs
+++ b/base58/src/lib.rs
@@ -434,7 +434,7 @@ impl fmt::Debug for Base58CkString {
 #[cfg(feature = "alloc")]
 const fn encoded_reserve_len(unencoded_len: usize) -> usize {
     // log2(256) / log2(58) ~ 1.37 = 137 / 100
-    unencoded_len * 137 / 100
+    (unencoded_len * 137).div_ceil(100)
 }
 
 /// Returns the length to reserve when encoding base58 with checksum

--- a/base58/src/lib.rs
+++ b/base58/src/lib.rs
@@ -553,6 +553,10 @@ mod tests {
             Base58CkString::encode_unbounded(&addr[..]).as_str(),
             "1PfJpZsjreyVrqeoAfabrRwwjQyoSQMmHH"
         );
+
+        let data = [0xFFu8; 90];
+        #[cfg(feature = "alloc")]
+        let _ = Base58CkString::encode_unbounded(&data);
     }
 
     #[test]


### PR DESCRIPTION
When determining the size needed for an encoding buffer, the code currently uses an approximation by multiplying the payload length by 1.37. However, as this is done with integer operations, the value is rounded down, which for some payload lengths (namely 94), the encoding can panic due to an undersized buffer.

Use div_ceil for reserve length calculation to prevent panic on 94 byte encode.