### PR TITLE
ci: cache cargo install metadata in daily fuzz job

### DIFF
--- a/.github/workflows/cron-daily-fuzz.yml
+++ b/.github/workflows/cron-daily-fuzz.yml
@@ -29,11 +29,16 @@ jobs:
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: cache-fuzz
         with:
+          # Cargo's install metadata has to be cached along with the binaries it
+          # tracks, otherwise cargo refuses to overwrite the restored binaries.
           path: |
             ~/.cargo/bin
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
             fuzz/target
             target
-          key: cache-fuzz-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+          # cached cargo-rbmt binary goes stale when it is bumped.
+          key: cache-fuzz-${{ hashFiles('**/Cargo.toml','**/Cargo.lock','rbmt-version') }}
       - uses: ./.github/actions/setup-rbmt
       - name: Install cargo-fuzz
         run: cargo install --locked --force --version 0.13.2 cargo-fuzz


### PR DESCRIPTION
Fixes #6634.

The install-order part of #6634 (running `cargo fuzz list` before cargo-fuzz is installed) is already fixed on master (`6aec26dc8`). The daily job still is not fuzzing for a different reason.

The job caches `~/.cargo/bin` but not cargo's install metadata (`~/.cargo/.crates.toml` and `~/.cargo/.crates2.json`). On a cache hit the restored binaries are untracked, so `cargo install cargo-rbmt` in `setup-rbmt` (no `--force`) aborts with `error: binary cargo-rbmt already exists in destination`. All sixteen shards die there. Six of the last eight scheduled runs failed this way.

The corpus fuzzing workflow already caches those metadata files. This PR does the same, and adds `rbmt-version` to the cache key so the currently poisoned entry is not restored and a cargo-rbmt bump invalidates the cache.

`--force` on the cargo-fuzz install is left as-is. No fuzz targets or rustc flags are touched.

## Test plan
- A maintainer can `workflow_dispatch` twice: first dispatch populates the cache, second (the case that fails today) should hit the cache and still fuzz.
- Workflow still installs cargo-fuzz before `cargo fuzz list`.