### PR TITLE
Move `from_script` to `Address` and drop `AddressExt`

### DIFF
--- a/addresses/src/lib.rs
+++ b/addresses/src/lib.rs
@@ -856,6 +856,40 @@ impl Address {
     ///
     pub fn is_spend_standard(&self) -> bool { self.address_type().is_some() }
 
+    /// Constructs a new [`Address`] from an output script (`scriptPubkey`).
+    #[cfg(feature = "alloc")]
+    pub fn from_script(
+        script: &ScriptPubKey,
+        network: impl Into<Network>,
+    ) -> Result<Self, FromScriptError> {
+        let network = network.into();
+        if script.is_p2pkh() {
+            let bytes = script.as_bytes()[3..23].try_into().expect("statically 20B long");
+            let hash = PubkeyHash::from_byte_array(bytes);
+            Ok(Self::p2pkh(hash, network))
+        } else if script.is_p2sh() {
+            let bytes = script.as_bytes()[2..22].try_into().expect("statically 20B long");
+            let hash = ScriptHash::from_byte_array(bytes);
+            Ok(Self::p2sh_from_hash(hash, network))
+        } else if script.is_witness_program() {
+            // script.first_opcode() is from ScriptExt. The logic is inlined here.
+            let opcode = script
+                .as_bytes()
+                .first()
+                .copied()
+                .map(Opcode::from_u8)
+                .expect("is_witness_program guarantees len > 4");
+
+            let version = WitnessVersion::try_from(opcode)
+                .map_err(FromScriptError::WitnessVersion)?;
+            let program = WitnessProgram::new(version, &script.as_bytes()[2..])
+                .map_err(FromScriptError::WitnessProgram)?;
+            Ok(Self::from_witness_program(program, network))
+        } else {
+            Err(FromScriptError::UnrecognizedScript)
+        }
+    }
+
     /// Generates a script pubkey spending to this address.
     #[cfg(feature = "alloc")]
     pub fn script_pubkey(&self) -> ScriptPubKeyBuf {

--- a/addresses/src/lib.rs
+++ b/addresses/src/lib.rs
@@ -857,7 +857,17 @@ impl Address {
     pub fn is_spend_standard(&self) -> bool { self.address_type().is_some() }
 
     /// Constructs a new [`Address`] from an output script (`scriptPubkey`).
+    ///
+    /// # Errors
+    ///
+    /// - [`FromScriptError::UnrecognizedScript`] if the given script is not p2pkh, p2sh, or
+    ///   SegWit program.
+    /// - [`FromScriptError::WitnessVersion`] if the given script is a SegWit program but its
+    ///   version is not valid.
+    /// - [`FromScriptError::WitnessProgram`] if the given script has a valid SegWit version, but
+    ///   is not a valid witness program. See [`WitnessProgram::new`] for more details.
     #[cfg(feature = "alloc")]
+    #[allow(clippy::missing_panics_doc)] // Slices have known lengths before array casts
     pub fn from_script(
         script: &ScriptPubKey,
         network: impl Into<Network>,

--- a/bitcoin/src/address.rs
+++ b/bitcoin/src/address.rs
@@ -43,10 +43,9 @@
 use addresses::witness_program::WitnessProgram;
 use crypto::key::PubkeyHash;
 use network::Network;
+use primitives::opcodes::Opcode;
 use primitives::script::{ScriptHash, ScriptPubKey};
 use primitives::witness_version::WitnessVersion;
-
-use crate::script::ScriptExt as _;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(no_inline)]
@@ -84,7 +83,13 @@ crate::internal_macros::define_extension_trait! {
                 let hash = ScriptHash::from_byte_array(bytes);
                 Ok(Self::p2sh_from_hash(hash, network))
             } else if script.is_witness_program() {
-                let opcode = script.first_opcode().expect("is_witness_program guarantees len > 4");
+                // script.first_opcode() is from ScriptExt. The logic is inlined here.
+                let opcode = script
+                    .as_bytes()
+                    .first()
+                    .copied()
+                    .map(Opcode::from_u8)
+                    .expect("is_witness_program guarantees len > 4");
 
                 let version = WitnessVersion::try_from(opcode)
                     .map_err(FromScriptError::WitnessVersion)?;

--- a/bitcoin/src/address.rs
+++ b/bitcoin/src/address.rs
@@ -40,13 +40,6 @@
 //! # }
 //! ```
 
-use addresses::witness_program::WitnessProgram;
-use crypto::key::PubkeyHash;
-use network::Network;
-use primitives::opcodes::Opcode;
-use primitives::script::{ScriptHash, ScriptPubKey};
-use primitives::witness_version::WitnessVersion;
-
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(no_inline)]
 pub use self::error::{
@@ -59,49 +52,6 @@ pub use addresses::{
     Address, AddressData, AddressType, KnownHrp, NetworkUnchecked, NetworkValidation,
     NetworkValidationUnchecked,
 };
-
-mod sealed {
-    pub trait Sealed {}
-    impl Sealed for super::Address {}
-}
-
-crate::internal_macros::define_extension_trait! {
-    /// Extension functionality for the [`Address`] type
-    pub trait AddressExt impl for Address {
-        /// Constructs a new [`Address`] from an output script (`scriptPubkey`).
-        fn from_script(
-            script: &ScriptPubKey,
-            network: impl Into<Network>,
-        ) -> Result<Address, FromScriptError> {
-            let network = network.into();
-            if script.is_p2pkh() {
-                let bytes = script.as_bytes()[3..23].try_into().expect("statically 20B long");
-                let hash = PubkeyHash::from_byte_array(bytes);
-                Ok(Self::p2pkh(hash, network))
-            } else if script.is_p2sh() {
-                let bytes = script.as_bytes()[2..22].try_into().expect("statically 20B long");
-                let hash = ScriptHash::from_byte_array(bytes);
-                Ok(Self::p2sh_from_hash(hash, network))
-            } else if script.is_witness_program() {
-                // script.first_opcode() is from ScriptExt. The logic is inlined here.
-                let opcode = script
-                    .as_bytes()
-                    .first()
-                    .copied()
-                    .map(Opcode::from_u8)
-                    .expect("is_witness_program guarantees len > 4");
-
-                let version = WitnessVersion::try_from(opcode)
-                    .map_err(FromScriptError::WitnessVersion)?;
-                let program = WitnessProgram::new(version, &script.as_bytes()[2..])
-                    .map_err(FromScriptError::WitnessProgram)?;
-                Ok(Self::from_witness_program(program, network))
-            } else {
-                Err(FromScriptError::UnrecognizedScript)
-            }
-        }
-    }
-}
 
 /// Error code for the address module.
 pub mod error {
@@ -119,12 +69,15 @@ mod tests {
     use alloc::borrow::ToOwned;
     use alloc::string::ToString;
 
+    use addresses::witness_program::WitnessProgram;
+    use crypto::key::PubkeyHash;
     use hex::hex;
+    use primitives::witness_version::WitnessVersion;
 
     use super::*;
     use crate::network::Network::{Bitcoin, Testnet};
     use crate::network::{NetworkKind, TestnetVersion};
-    use crate::script::{RedeemScriptBuf, ScriptPubKeyBuf, WitnessScriptBuf};
+    use crate::script::{RedeemScriptBuf, ScriptHash, ScriptPubKeyBuf, WitnessScriptBuf};
     use crate::{FullPublicKey, LegacyPublicKey, Network, XOnlyPublicKey};
 
     fn roundtrips(addr: &Address, network: Network) {

--- a/bitcoin/src/address.rs
+++ b/bitcoin/src/address.rs
@@ -42,10 +42,10 @@
 
 use addresses::witness_program::WitnessProgram;
 use crypto::key::PubkeyHash;
+use network::Network;
 use primitives::script::{ScriptHash, ScriptPubKey};
 use primitives::witness_version::WitnessVersion;
 
-use crate::network::Params;
 use crate::script::ScriptExt as _;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
@@ -72,9 +72,9 @@ crate::internal_macros::define_extension_trait! {
         /// Constructs a new [`Address`] from an output script (`scriptPubkey`).
         fn from_script(
             script: &ScriptPubKey,
-            params: impl AsRef<Params>,
+            network: impl Into<Network>,
         ) -> Result<Address, FromScriptError> {
-            let network = params.as_ref().network;
+            let network = network.into();
             if script.is_p2pkh() {
                 let bytes = script.as_bytes()[3..23].try_into().expect("statically 20B long");
                 let hash = PubkeyHash::from_byte_array(bytes);
@@ -118,7 +118,7 @@ mod tests {
 
     use super::*;
     use crate::network::Network::{Bitcoin, Testnet};
-    use crate::network::{params, NetworkKind, TestnetVersion};
+    use crate::network::{NetworkKind, TestnetVersion};
     use crate::script::{RedeemScriptBuf, ScriptPubKeyBuf, WitnessScriptBuf};
     use crate::{FullPublicKey, LegacyPublicKey, Network, XOnlyPublicKey};
 
@@ -390,7 +390,7 @@ mod tests {
         assert_eq!(Address::from_script(&bad_p2wpkh, Network::Bitcoin), expected);
         assert_eq!(Address::from_script(&bad_p2wsh, Network::Bitcoin), expected);
         assert_eq!(
-            Address::from_script(&invalid_segwitv0_script, &params::MAINNET),
+            Address::from_script(&invalid_segwitv0_script, Network::Bitcoin),
             Err(FromScriptError::WitnessProgram(witness_program::Error::InvalidSegwitV0Length(17)))
         );
     }

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -103,7 +103,6 @@ pub mod ext {
     //! ```
     #[rustfmt::skip] // Use terse custom grouping.
     pub use crate::{
-        address::AddressExt as _,
         block::{BlockCheckedExt as _, HeaderExt as _},
         key::{FullPublicKeyExt as _, LegacyPublicKeyExt as _},
         network::NetworkExt as _,

--- a/fuzz/fuzz_targets/bitcoin/arbitrary_script.rs
+++ b/fuzz/fuzz_targets/bitcoin/arbitrary_script.rs
@@ -2,7 +2,7 @@
 #![cfg_attr(not(fuzzing), allow(unused))]
 
 use arbitrary::{Arbitrary, Unstructured};
-use bitcoin::address::{Address, AddressExt as _};
+use bitcoin::address::Address;
 use bitcoin::encoding::encode_to_vec;
 use bitcoin::script::{self, ScriptBuf, ScriptExt as _, ScriptPubKeyExt as _};
 use bitcoin::Network;


### PR DESCRIPTION
The Address::from_script method in AddressExt takes an AsRef\<Params> argument. This argument is only used to extract the contained Network. Rather than use the Params type in the signature, which requires a bitcoin dep, the stable Network type should be used directly. With this change, the method can be directly moved to the main Address type. With said move, the extension trait can also be dropped entirely.

Adjust and move AddressExt::from_script to the Address type in addresses. Drop the AddressExt trait.