### PR TITLE
addresses: Remove version extraction from `Address::from_script` and error variant

### DIFF
--- a/addresses/src/error.rs
+++ b/addresses/src/error.rs
@@ -7,6 +7,7 @@ use internals::error::InputString;
 use internals::write_err;
 #[cfg(feature = "alloc")]
 use network::Network;
+#[cfg(feature = "alloc")]
 use primitives::witness_version;
 
 use crate::witness_program;
@@ -21,8 +22,6 @@ pub enum FromScriptError {
     UnrecognizedScript,
     /// A witness program error.
     WitnessProgram(witness_program::Error),
-    /// A witness version construction error.
-    WitnessVersion(witness_version::InvalidWitnessVersionError),
 }
 
 impl From<Infallible> for FromScriptError {
@@ -32,7 +31,6 @@ impl From<Infallible> for FromScriptError {
 impl fmt::Display for FromScriptError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::WitnessVersion(ref e) => write_err!(f, "witness version construction error"; e),
             Self::WitnessProgram(ref e) => write_err!(f, "witness program error"; e),
             Self::UnrecognizedScript => write!(f, "script is not a p2pkh, p2sh or witness program"),
         }
@@ -44,7 +42,6 @@ impl std::error::Error for FromScriptError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::UnrecognizedScript => None,
-            Self::WitnessVersion(ref e) => Some(e),
             Self::WitnessProgram(ref e) => Some(e),
         }
     }

--- a/bitcoin/src/address.rs
+++ b/bitcoin/src/address.rs
@@ -43,10 +43,8 @@
 use addresses::witness_program::WitnessProgram;
 use crypto::key::PubkeyHash;
 use primitives::script::{ScriptHash, ScriptPubKey};
-use primitives::witness_version::WitnessVersion;
 
 use crate::network::Params;
-use crate::script::ScriptExt as _;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 #[doc(no_inline)]
@@ -83,11 +81,7 @@ crate::internal_macros::define_extension_trait! {
                 let bytes = script.as_bytes()[2..22].try_into().expect("statically 20B long");
                 let hash = ScriptHash::from_byte_array(bytes);
                 Ok(Self::p2sh_from_hash(hash, network))
-            } else if script.is_witness_program() {
-                let opcode = script.first_opcode().expect("is_witness_program guarantees len > 4");
-
-                let version = WitnessVersion::try_from(opcode)
-                    .map_err(FromScriptError::WitnessVersion)?;
+            } else if let Some(version) = script.witness_version() {
                 let program = WitnessProgram::new(version, &script.as_bytes()[2..])
                     .map_err(FromScriptError::WitnessProgram)?;
                 Ok(Self::from_witness_program(program, network))
@@ -120,6 +114,7 @@ mod tests {
     use crate::network::Network::{Bitcoin, Testnet};
     use crate::network::{params, NetworkKind, TestnetVersion};
     use crate::script::{RedeemScriptBuf, ScriptPubKeyBuf, WitnessScriptBuf};
+    use crate::witness_version::WitnessVersion;
     use crate::{FullPublicKey, LegacyPublicKey, Network, XOnlyPublicKey};
 
     fn roundtrips(addr: &Address, network: Network) {


### PR DESCRIPTION
In Address::from_script, the script is checked to be a witness program. If so, the first opcode is extracted and fallibly converted to a WitnessVersion. However, the check for script as a witness program only checks that the witness version is some. Instead, we can directly check if let Some(version) = script.witness_version() and thus only extract the version once while performing the same check.

Remove manual opcode extraction and version construction in favour of if let Some(version) = script.witness_version().
Remove impossible FromScriptError::WitnessVersion error variant.