### PR TITLE
fuzz: fix p2p commands master and 0.32 divergence

### DIFF
--- a/fuzz/fuzz_targets/bitcoin/compare_consensus_encoding.rs
+++ b/fuzz/fuzz_targets/bitcoin/compare_consensus_encoding.rs
@@ -256,7 +256,7 @@ fuzz_target!(|data| {
     do_test(data);
 });
 
-#[cfg(all(test, fuzzing))]
+#[cfg(test)]
 mod tests {
     fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
         let mut b = 0;

--- a/fuzz/fuzz_targets/bitcoin/compare_consensus_encoding.rs
+++ b/fuzz/fuzz_targets/bitcoin/compare_consensus_encoding.rs
@@ -154,6 +154,16 @@ fn addrv2_payload_should_skip(data: &[u8]) -> bool {
     .unwrap_or(false)
 }
 
+/// Returns `true` if `V1NetworkMessage` carries a command that only the master decodes.
+fn v1_network_message_should_skip(data: &[u8]) -> bool {
+    const MASTER_ONLY: &[&str] = &["sendtxrcncl", "feature"];
+
+    // A V1 header is `magic(4) || command(12) || ...`
+    data.get(4..16)
+        .and_then(|command| std::str::from_utf8(command).ok())
+        .is_some_and(|command| MASTER_ONLY.contains(&command.trim_end_matches('\0')))
+}
+
 #[rustfmt::skip] // rustfmt butchers all of these with inconsistent newlines.
 fn do_test(data: &[u8]) {
     compare_encoding!(data, Block);
@@ -211,7 +221,11 @@ fn do_test(data: &[u8]) {
     compare_encoding!(data, p2p::message::NetworkHeader, (bitcoin_0_32::block::Header, u8));
     compare_encoding!(data, p2p::message::Ping, u64);
     compare_encoding!(data, p2p::message::Pong, u64);
-    compare_encoding!(data, p2p::message::V1NetworkMessage, bitcoin_0_32::p2p::message::RawNetworkMessage);
+    // Skip messages unknown to bitcoin 0.32, which never fails them, while master
+    // decoder parses can recognize and reject them.
+    if !v1_network_message_should_skip(data) {
+        compare_encoding!(data, p2p::message::V1NetworkMessage, bitcoin_0_32::p2p::message::RawNetworkMessage);
+    }
     compare_encoding!(data, p2p::message_blockdata::BlockLocator, Vec<bitcoin_0_32::BlockHash>);
     compare_encoding!(data, p2p::message_network::Alert, Vec<u8>);
     compare_encoding!(data, p2p::message_network::UserAgent, String);

--- a/fuzz/fuzz_targets/bitcoin/compare_consensus_encoding.rs
+++ b/fuzz/fuzz_targets/bitcoin/compare_consensus_encoding.rs
@@ -276,7 +276,37 @@ mod tests {
     }
 
     #[test]
-    fn duplicate_crash() {
+    fn v1_network_message_feature_is_skipped() {
+        let mut a = Vec::new();
+        extend_vec_from_hex(
+            concat!(
+                "1101fc00",                 // magic
+                "666561747572650000000000", // command: "feature"
+                "00000000",                 // payload_len: 0
+                "01000000",                 // checksum
+            ),
+            &mut a,
+        );
+        super::do_test(&a);
+    }
+
+    #[test]
+    fn v1_network_message_sendtxrcncl_is_skipped() {
+        let mut a = Vec::new();
+        extend_vec_from_hex(
+            concat!(
+                "1101fc00",                 // magic
+                "73656e64747872636e636c00", // command: "sendtxrcncl"
+                "00000000",                 // payload_len: 0
+                "01000000",                 // checksum
+            ),
+            &mut a,
+        );
+        super::do_test(&a);
+    }
+
+    #[test]
+    fn arbitrary_short_input_does_not_panic() {
         let mut a = Vec::new();
         extend_vec_from_hex("00003cb1133bb113", &mut a);
         super::do_test(&a);


### PR DESCRIPTION
Fixes https://github.com/rust-bitcoin/rust-bitcoin/issues/6784 (issue closed automatically but shouldn't have, I'll follow up with a PR for that).

The `compare_consensus_encoding` target panics when 0.32 decodes something master rejects. Bitcoin 0.32 stores unknown commands as `NetworkMessage::Unknown` without parsing, never fail. Master decodes `sendtxrcncl` and `feature` typed and rejects empty payloads.

Commits:
1. Skip the comparison for those two, keyed on the command in the V1 header
2. Gated the test module on `test` alone because `cfg(all(test, fuzzing))` could never run (optional, I may have misunderstood here).
3. Make both crash inputs into regression tests
