### PR TITLE
ci: fail prepare job on bad nightly version read

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -164,7 +164,12 @@ jobs:
           persist-credentials: false
       - name: "Read workspace versions"
         id: read_toolchain
-        run: echo "nightly_version=$(cargo metadata --format-version 1 | jq -r '.metadata.rbmt.toolchains.nightly')" >> $GITHUB_OUTPUT
+        # Defining bash shell forces github actions pipefail behavior
+        shell: bash
+        run: |
+          nightly_version=$(cargo metadata --format-version 1 | jq -er '.metadata.rbmt.toolchains.nightly')
+          # To force pipefail on error, assign must be separate
+          echo "nightly_version=$nightly_version" >> "$GITHUB_OUTPUT"
 
   Arch32bit:
     name: Test 32-bit version


### PR DESCRIPTION
Depends on CI fix on https://github.com/rust-bitcoin/rust-bitcoin/pull/6798

The Prepare job was succeeding despite failing because of a yanked crate. It produced an empty nightly_version that would cause downstream ASAN job to fail at toolchain selection. Look at this [job failure](https://github.com/rust-bitcoin/rust-bitcoin/actions/runs/33193496599/job/98924670693) to see the problem in practice.

This PR sets `pipefail` so that `cargo metadata` error is not ignored and pass `-e` to `jq` so a missing field is an error too.
