### PR TITLE
Remove `test_` prefix from tests

### DIFF
--- a/bitcoin/src/sign_message.rs
+++ b/bitcoin/src/sign_message.rs
@@ -248,11 +248,9 @@ mod tests {
     use alloc::string::String;
     use alloc::string::ToString;
 
-    use super::*;
-
     #[test]
-    fn test_signed_msg_hash() {
-        let hash = signed_msg_hash("test");
+    fn signed_msg_hash() {
+        let hash = super::signed_msg_hash("test");
         assert_eq!(
             hash.to_string(),
             "a6f87fe6d58a032c320ff8d1541656f0282c2c7bfcc69d61af4c8e8ed528e49c"
@@ -273,7 +271,7 @@ mod tests {
         let privkey = PrivateKey::generate();
         let secp_key = secp256k1::SecretKey::from_secret_bytes(privkey.to_secret_bytes())
             .expect("to_secret_bytes yields underlying valid secp bytes");
-        let signature = MessageSignature::new(
+        let signature = super::MessageSignature::new(
             secp256k1::ecdsa::RecoverableSignature::sign_ecdsa_recoverable(msg, &secp_key),
             privkey.compressed(),
         );
@@ -292,12 +290,12 @@ mod tests {
         let p2wpkh = Address::p2wpkh(pubkey, Network::Bitcoin);
         assert_eq!(
             signature2.is_signed_by_address(&p2wpkh, msg_hash),
-            Err(MessageSignatureError::UnsupportedAddressType(AddressType::P2wpkh))
+            Err(super::MessageSignatureError::UnsupportedAddressType(AddressType::P2wpkh))
         );
         let p2shwpkh = Address::p2shwpkh(pubkey, NetworkKind::Main);
         assert_eq!(
             signature2.is_signed_by_address(&p2shwpkh, msg_hash),
-            Err(MessageSignatureError::UnsupportedAddressType(AddressType::P2sh))
+            Err(super::MessageSignatureError::UnsupportedAddressType(AddressType::P2sh))
         );
         let p2pkh = Address::p2pkh(pubkey, Network::Bitcoin);
         assert_eq!(signature2.is_signed_by_address(&p2pkh, msg_hash), Ok(true));

--- a/chacha20_poly1305/src/lib.rs
+++ b/chacha20_poly1305/src/lib.rs
@@ -220,32 +220,32 @@ mod tests {
 
     #[cfg(not(chacha20_poly1305_fuzz))]
     #[test]
-    fn test_constant_time_eq() {
+    fn constant_time_eq() {
         let tag_a = [0x42u8; 16];
         let tag_b = [0x42u8; 16];
         let tag_c = [0x00u8; 16];
 
         // full equality
-        assert!(constant_time_eq(&tag_a, &tag_b));
+        assert!(super::constant_time_eq(&tag_a, &tag_b));
 
         // full difference
-        assert!(!constant_time_eq(&tag_a, &tag_c));
+        assert!(!super::constant_time_eq(&tag_a, &tag_c));
 
         // edge case  - single byte diff
         let mut tag_d = tag_a;
 
         // first byte diff
         tag_d[0] ^= 1;
-        assert!(!constant_time_eq(&tag_a, &tag_d));
+        assert!(!super::constant_time_eq(&tag_a, &tag_d));
 
         // last byte only diff
         tag_d = tag_a;
         tag_d[15] ^= 1;
-        assert!(!constant_time_eq(&tag_a, &tag_d));
+        assert!(!super::constant_time_eq(&tag_a, &tag_d));
 
         // mid byte diff
         tag_d = tag_a;
         tag_d[7] ^= 0xff;
-        assert!(!constant_time_eq(&tag_a, &tag_d));
+        assert!(!super::constant_time_eq(&tag_a, &tag_d));
     }
 }

--- a/key_expression/src/bip32.rs
+++ b/key_expression/src/bip32.rs
@@ -1729,14 +1729,14 @@ mod tests {
     }
 
     #[test]
-    fn test_derivation_path_display() {
+    fn derivation_path_display() {
         let path = RelativeDerivationPath::from_str("84'/0'/0'/0/0").unwrap();
         assert_eq!(format!("{}", path), "84'/0'/0'/0/0");
         assert_eq!(format!("{:#}", path), "84h/0h/0h/0/0");
     }
 
     #[test]
-    fn test_lowerhex_formatting() {
+    fn lowerhex_formatting() {
         let normal = ChildNumber::from_normal_idx(42).unwrap();
         let hardened = ChildNumber::from_hardened_idx(42).unwrap();
 
@@ -1748,7 +1748,7 @@ mod tests {
     }
 
     #[test]
-    fn test_upperhex_formatting() {
+    fn upperhex_formatting() {
         let normal = ChildNumber::from_normal_idx(42).unwrap();
         let hardened = ChildNumber::from_hardened_idx(42).unwrap();
 
@@ -1760,7 +1760,7 @@ mod tests {
     }
 
     #[test]
-    fn test_octal_formatting() {
+    fn octal_formatting() {
         let normal = ChildNumber::from_normal_idx(42).unwrap();
         let hardened = ChildNumber::from_hardened_idx(42).unwrap();
 
@@ -1772,7 +1772,7 @@ mod tests {
     }
 
     #[test]
-    fn test_binary_formatting() {
+    fn binary_formatting() {
         let normal = ChildNumber::from_normal_idx(42).unwrap();
         let hardened = ChildNumber::from_hardened_idx(42).unwrap();
 
@@ -2121,7 +2121,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reject_xpriv_with_non_zero_byte_at_index_45() {
+    fn reject_xpriv_with_non_zero_byte_at_index_45() {
         let mut xpriv = base58::decode_check("xprv9wSp6B7kry3Vj9m1zSnLvN3xH8RdsPP1Mh7fAaR7aRLcQMKTR2vidYEeEg2mUCTAwCd6vnxVrcjfy2kRgVsFawNzmjuHc2YmYRmagcEPdU9").unwrap();
 
         // Modify byte at index 45 to be non-zero (e.g., 1)
@@ -2137,7 +2137,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reject_xpriv_with_zero_depth_and_non_zero_index() {
+    fn reject_xpriv_with_zero_depth_and_non_zero_index() {
         let result = "xprv9s21ZrQH4r4TsiLvyLXqM9P7k1K3EYhA1kkD6xuquB5i39AU8KF42acDyL3qsDbU9NmZn6MsGSUYZEsuoePmjzsB3eFKSUEh3Gu1N3cqVUN".parse::<Xpriv>();
         assert!(result.is_err());
 
@@ -2150,7 +2150,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reject_xpriv_with_zero_depth_and_non_zero_parent_fingerprint() {
+    fn reject_xpriv_with_zero_depth_and_non_zero_parent_fingerprint() {
         let result = "xprv9s2SPatNQ9Vc6GTbVMFPFo7jsaZySyzk7L8n2uqKXJen3KUmvQNTuLh3fhZMBoG3G4ZW1N2kZuHEPY53qmbZzCHshoQnNf4GvELZfqTUrcv".parse::<Xpriv>();
         assert!(result.is_err());
 

--- a/p2p/src/message_network.rs
+++ b/p2p/src/message_network.rs
@@ -915,7 +915,7 @@ mod tests {
     }
 
     #[test]
-    fn test_user_agent() {
+    fn user_agent() {
         let client_name = "Satoshi";
         let client_version = UserAgentVersion::new(ClientSoftwareVersion::SemVer {
             major: 5,
@@ -951,7 +951,7 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "user agent configuration cannot contain: / ( ) :")]
-    fn test_incorrect_user_agent() {
+    fn incorrect_user_agent() {
         let client_name = "Satoshi/";
         let client_version = UserAgentVersion::new(ClientSoftwareVersion::SemVer {
             major: 5,

--- a/primitives/src/merkle_tree.rs
+++ b/primitives/src/merkle_tree.rs
@@ -327,7 +327,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "alloc")]
-    fn test_merkle_root_batched() {
+    fn merkle_root_batched() {
         use alloc::vec::Vec;
 
         // copy of `MerkleNode::calculate_root` (stack-based) implementation to test against the new batched approach

--- a/primitives/src/script/tests.rs
+++ b/primitives/src/script/tests.rs
@@ -259,7 +259,7 @@ fn script_asm() {
 }
 
 #[test]
-fn test_index() {
+fn index() {
     let script = Script::from_bytes(&[1, 2, 3, 4, 5]);
 
     assert_eq!(script[1..3].as_bytes(), &[2, 3]);
@@ -271,7 +271,7 @@ fn test_index() {
 }
 
 #[test]
-fn test_index_bound_tuple() {
+fn index_bound_tuple() {
     let script = Script::from_bytes(&[1, 2, 3, 4, 5]);
 
     assert_eq!(script[(Bound::Included(1), Bound::Excluded(4))].as_bytes(), &[2, 3, 4]);

--- a/primitives/src/witness.rs
+++ b/primitives/src/witness.rs
@@ -1388,7 +1388,7 @@ mod test {
     }
 
     #[test]
-    fn test_witness_from_iterator() {
+    fn witness_from_iterator() {
         let bytes1 = [1u8, 2, 3];
         let bytes2 = [4u8, 5];
         let bytes3 = [6u8, 7, 8, 9];
@@ -1440,7 +1440,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "hex")]
-    fn test_from_hex() {
+    fn from_hex() {
         let hex_strings = [
             "30440220703350f1c8be5b41b4cb03b3b680c4f3337f987514a6b08e16d5d9f81e9b5f72022018fb269ba5b82864c0e1edeaf788829eb332fe34a859cc1f99c4a02edfb5d0df01",
             "0208689fe2cca52d8726cefaf274de8fa61d5faa5e1058ad35b49fb194c035f9a4",
@@ -1936,7 +1936,7 @@ mod test {
 
     #[cfg(feature = "alloc")]
     #[test]
-    fn test_dos_protection() {
+    fn dos_protection() {
         let mut encoded = Vec::new();
         encoded.extend_from_slice(&[0xFE, 0x00, 0x09, 0x3D, 0x00]); // 4_000_000 (witness count)
         encoded.extend_from_slice(&[0xFE, 0x00, 0x09, 0x3D, 0x00]); // 4_000_000 (1st element length)

--- a/units/src/amount/ops.rs
+++ b/units/src/amount/ops.rs
@@ -326,7 +326,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_sum_amounts() {
+    fn sum_amounts() {
         let amounts =
             [Amount::from_sat_u32(100), Amount::from_sat_u32(200), Amount::from_sat_u32(300)];
 
@@ -335,7 +335,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sum_amount_results() {
+    fn sum_amount_results() {
         let amounts = [
             NumOpResult::Valid(Amount::from_sat_u32(100)),
             NumOpResult::Valid(Amount::from_sat_u32(200)),
@@ -347,7 +347,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sum_amount_results_with_references() {
+    fn sum_amount_results_with_references() {
         let amounts = [
             NumOpResult::Valid(Amount::from_sat_u32(100)),
             NumOpResult::Valid(Amount::from_sat_u32(200)),
@@ -359,7 +359,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sum_amount_with_error_propagation() {
+    fn sum_amount_with_error_propagation() {
         let amounts = [
             NumOpResult::Valid(Amount::from_sat_u32(100)),
             NumOpResult::Error(NumOpError::while_doing(MathOp::Add)),
@@ -371,7 +371,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sum_signed_amounts() {
+    fn sum_signed_amounts() {
         let amounts = [
             SignedAmount::from_sat_i32(100),
             SignedAmount::from_sat_i32(-50),
@@ -383,7 +383,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sum_signed_amount_results() {
+    fn sum_signed_amount_results() {
         let amounts = [
             NumOpResult::Valid(SignedAmount::from_sat_i32(100)),
             NumOpResult::Valid(SignedAmount::from_sat_i32(-50)),
@@ -395,7 +395,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sum_signed_amount_results_with_references() {
+    fn sum_signed_amount_results_with_references() {
         let amounts = [
             NumOpResult::Valid(SignedAmount::from_sat_i32(100)),
             NumOpResult::Valid(SignedAmount::from_sat_i32(-50)),
@@ -407,7 +407,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sum_signed_amount_with_error_propagation() {
+    fn sum_signed_amount_with_error_propagation() {
         let amounts = [
             NumOpResult::Valid(SignedAmount::from_sat_i32(100)),
             NumOpResult::Error(NumOpError::while_doing(MathOp::Add)),
@@ -419,7 +419,7 @@ mod tests {
     }
 
     #[test]
-    fn test_op_assign_amount() {
+    fn op_assign_amount() {
         let sat = Amount::from_sat_u32(50);
 
         let mut res = sat + sat;
@@ -440,7 +440,7 @@ mod tests {
     }
 
     #[test]
-    fn test_op_assign_signed_amount() {
+    fn op_assign_signed_amount() {
         let ssat = SignedAmount::from_sat_i32(50);
 
         let mut res = ssat + ssat;
@@ -461,7 +461,7 @@ mod tests {
     }
 
     #[test]
-    fn test_rem_assign_amount() {
+    fn rem_assign_amount() {
         let sat = Amount::from_sat_u32(50);
         let mut res = sat + sat;
         res %= 30_u64;
@@ -478,7 +478,7 @@ mod tests {
     }
 
     #[test]
-    fn test_rem_assign_nz_amount() {
+    fn rem_assign_nz_amount() {
         fn nz(x: u64) -> NonZeroU64 { NonZeroU64::new(x).unwrap() }
 
         let mut res = Amount::from_sat_u32(100);
@@ -493,7 +493,7 @@ mod tests {
     }
 
     #[test]
-    fn test_rem_assign_signed_amount() {
+    fn rem_assign_signed_amount() {
         let ssat = SignedAmount::from_sat_i32(-50);
 
         let mut res = ssat + ssat;
@@ -511,7 +511,7 @@ mod tests {
     }
 
     #[test]
-    fn test_rem_assign_nz_signed_amount() {
+    fn rem_assign_nz_signed_amount() {
         fn nz(x: i64) -> NonZeroI64 { NonZeroI64::new(x).unwrap() }
 
         let mut res = SignedAmount::from_sat_i32(-100);
@@ -526,7 +526,7 @@ mod tests {
     }
 
     #[test]
-    fn test_div_assign_amount_nonzero() {
+    fn div_assign_amount_nonzero() {
         let mut amount = Amount::from_sat_u32(100);
         amount /= NonZeroU64::new(12).unwrap();
         assert_eq!(amount, Amount::from_sat_u32(8));
@@ -546,7 +546,7 @@ mod tests {
     }
 
     #[test]
-    fn test_div_assign_signed_amount_nonzero() {
+    fn div_assign_signed_amount_nonzero() {
         let mut ssat = SignedAmount::from_sat_i32(-100);
         ssat /= NonZeroI64::new(4).unwrap();
         assert_eq!(ssat, SignedAmount::from_sat_i32(-25));
@@ -569,7 +569,7 @@ mod tests {
     }
 
     #[test]
-    fn test_op_assign_amount_error() {
+    fn op_assign_amount_error() {
         let mut res: NumOpResult<Amount> = NumOpResult::Error(NumOpError::while_doing(MathOp::Add));
 
         // Adding a valid amount to an error should make an Add error

--- a/units/src/amount/tests.rs
+++ b/units/src/amount/tests.rs
@@ -527,10 +527,12 @@ fn to_string() {
 // May help identify a problem sooner
 #[test]
 #[cfg(feature = "alloc")]
-fn test_repeat_char() {
+fn repeat_char() {
     struct Repeat(char, usize);
     impl fmt::Display for Repeat {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { repeat_char(f, self.0, self.1) }
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            super::repeat_char(f, self.0, self.1)
+        }
     }
 
     let buf = Repeat('0', 0).to_string();

--- a/units/src/locktime/relative/mod.rs
+++ b/units/src/locktime/relative/mod.rs
@@ -926,7 +926,7 @@ mod tests {
     }
 
     #[test]
-    fn test_locktime_chain_state() {
+    fn locktime_chain_state() {
         fn generate_timestamps(start: u32, step: u16) -> [BlockTime; 11] {
             let mut timestamps = [BlockTime::from_u32(0); 11];
             for (i, ts) in timestamps.iter_mut().enumerate() {
@@ -1085,7 +1085,7 @@ mod tests {
     }
 
     #[test]
-    fn test_time_chain_state() {
+    fn time_chain_state() {
         use crate::BlockMtp;
 
         let timestamps: [BlockTime; 11] = generate_timestamps(1_600_000_000, 200);
@@ -1123,7 +1123,7 @@ mod tests {
     }
 
     #[test]
-    fn test_height_chain_state() {
+    fn height_chain_state() {
         let height_lock = LockTime::Blocks(NumberOfBlocks(10));
 
         // Test case 1: Satisfaction (current_height >= utxo_height + required)
@@ -1201,7 +1201,7 @@ mod tests {
     }
 
     #[test]
-    fn test_max_height_satisfaction() {
+    fn max_height_satisfaction() {
         // If the difference between these two is u32::MAX, we should get Ok(true)
         let mined_at = BlockHeight::from_u32(u32::MIN);
         let chain_tip = BlockHeight::from_u32(u32::MAX);


### PR DESCRIPTION
Some tests in the repo have a test_ prefix in their names. Initially this began to prevent conflicts with function names in the super namespace, but was applied inconsistently. Further, this pattern is not idiomatic, and should instead be removed entirely.

Remove test_ prefix from all test names, using super:: to reference parent module names where necessary.

Closes #6794