### PR TITLE
addresses: Add network conversion method to `Address`

### DIFF
--- a/addresses/src/lib.rs
+++ b/addresses/src/lib.rs
@@ -649,6 +649,44 @@ impl<V: NetworkValidation> Address<V> {
             AddressInner::Segwit { program: _, ref hrp } => NetworkKind::from(*hrp),
         }
     }
+
+    /// Constructs a new address using the given [`Network`].
+    ///
+    /// Only the network of the address is changed, the payload (public key hash, script
+    /// hash, or witness program) is left untouched.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[cfg(feature = "alloc")]
+    /// # fn example() -> Result<(), bitcoin_addresses::ParseError> {
+    /// use bitcoin_addresses::Address;
+    /// use network::{Network, TestnetVersion};
+    ///
+    /// let mainnet: Address = "132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM".parse::<Address<_>>()?
+    ///     .require_network(Network::Bitcoin)?;
+    /// assert_eq!(mainnet.to_string(), "132F25rTsvBdp9JzLLBHP5mvGY66i1xdiM");
+    ///
+    /// // The same public key hash, but encoded with the testnet prefix.
+    /// let testnet = mainnet.with_network(Network::Testnet(TestnetVersion::V4));
+    /// assert_eq!(testnet.to_string(), "mhYCK8wSgwctbFnc3u9fCzzF8XgodR9KHX");
+    /// # Ok(())
+    /// # }
+    /// # #[cfg(feature = "alloc")]
+    /// # example().unwrap();
+    /// ```
+    pub fn with_network(&self, network: Network) -> Address {
+        let new_inner = match *self.inner() {
+            AddressInner::P2pkh { hash, network: _ } =>
+                AddressInner::P2pkh { hash, network: network.into() },
+            AddressInner::P2sh { hash, network: _ } =>
+                AddressInner::P2sh { hash, network: network.into() },
+            AddressInner::Segwit { program, hrp: _ } =>
+                AddressInner::Segwit { program, hrp: network.into() },
+        };
+        // Fine to return NetworkChecked, as .require_network(network) is infallible.
+        Address::from_inner(new_inner)
+    }
 }
 
 /// Methods and functions that can be called only on `Address<NetworkChecked>`.


### PR DESCRIPTION
Currently, conversion of the network on an Address requires round-tripping via the script and manually reconstructing with from_script. This necessitates both alloc, and the full bitcoin crate. Instead, we should provide a simple method on the Address that permits switching just the network while leaving the payload data unchanged.

Add Address::with_params that constructs a checked Address given a new AddressParams.

Closes #3567 