### PR TITLE
Automated weekly update to rustc stable (to 1.98.1) on 0.32.xxx

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ rbmt.version = "0.5.1"
 
 [workspace.metadata.rbmt.toolchains]
 nightly = "nightly-2026-07-17"
-stable = "1.97.1"
+stable = "1.98.1"
 
 # Patch secp256k1's dependency on bitcoin_hashes to use our local workspace version.
 # secp256k1 is a dependency of this workspace, but it has a dependency on the


### PR DESCRIPTION
Automated update to Cargo.toml workspace metadata by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action