### PR TITLE
Automated weekly update to rustc (to nightly-2026-09-05) on 0.32.xx

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,5 @@ resolver = "2"
 
 [workspace.metadata]
 rbmt.version = "0.5.1"
-rbmt.toolchains.nightly = "nightly-2026-07-17"
+rbmt.toolchains.nightly = "nightly-2026-09-05"
 rbmt.toolchains.stable = "1.97.1"


### PR DESCRIPTION
Automated update to Cargo.toml workspace metadata by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action