### PR TITLE
Automated weekly update to rustc (to nightly-2026-09-05) on 0.32.xxx

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 rbmt.version = "0.5.1"
 
 [workspace.metadata.rbmt.toolchains]
-nightly = "nightly-2026-07-17"
+nightly = "nightly-2026-09-05"
 stable = "1.97.1"
 
 # Patch secp256k1's dependency on bitcoin_hashes to use our local workspace version.


### PR DESCRIPTION
Automated update to Cargo.toml workspace metadata by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action