### PR TITLE
internals: add const-compatible u64 to u128 cast

### DIFF
--- a/internals/src/const_casts.rs
+++ b/internals/src/const_casts.rs
@@ -13,6 +13,10 @@ pub const fn u16_to_u64(value: u16) -> u64 { value as u64 }
 #[must_use]
 pub const fn u32_to_u64(value: u32) -> u64 { value as u64 }
 
+/// Converts `u64` to `u128`
+#[must_use]
+pub const fn u64_to_u128(value: u64) -> u128 { value as u128 }
+
 /// Converts `i16` to `i64`
 #[must_use]
 pub const fn i16_to_i64(value: i16) -> i64 { value as i64 }
@@ -20,3 +24,14 @@ pub const fn i16_to_i64(value: i16) -> i64 { value as i64 }
 /// Converts `u16` to `u32`
 #[must_use]
 pub const fn u16_to_u32(value: u16) -> u32 { value as u32 }
+
+#[cfg(test)]
+mod tests {
+    use super::u64_to_u128;
+
+    #[test]
+    fn u64_to_u128_conversion() {
+        assert_eq!(u64_to_u128(0), 0);
+        assert_eq!(u64_to_u128(u64::MAX), u128::from(u64::MAX));
+    }
+}

--- a/units/src/fee_rate/mod.rs
+++ b/units/src/fee_rate/mod.rs
@@ -221,12 +221,13 @@ impl FeeRate {
     #[inline]
     pub const fn mul_by_weight(self, weight: Weight) -> NumOpResult<Amount> {
         // Keep the fee rate's sat/MvB precision until the final rounding step.
-        let numerator = self.to_sat_per_mvb() as u128 * weight.to_wu() as u128;
+        let numerator = const_casts::u64_to_u128(self.to_sat_per_mvb())
+            * const_casts::u64_to_u128(weight.to_wu());
         // 1 MvB = 4,000,000 wu.
         let denominator = 4_000_000_u128;
         let quotient = numerator / denominator;
         let fee_sat = if numerator % denominator == 0 { quotient } else { quotient + 1 };
-        if fee_sat <= Amount::MAX.to_sat() as u128 {
+        if fee_sat <= const_casts::u64_to_u128(Amount::MAX.to_sat()) {
             if let Ok(fee_amount) = Amount::from_sat(fee_sat as u64) {
                 return NumOpResult::Valid(fee_amount);
             }


### PR DESCRIPTION
Follow up to #6823.

Add a const-compatible helper for widening `u64` values to `u128` and use it in `FeeRate::mul_by_weight` instead of spelling these conversions with `as`.

This makes the conversion intent explicit while preserving const evaluation.


Tests:
- `cargo test -p bitcoin-internals`
- `cargo test -p bitcoin-units`