### PR TITLE
Release tracking PR: `internals 0.7.0`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -33,7 +33,7 @@ dependencies = [
 name = "base58ck"
 version = "0.5.0"
 dependencies = [
- "bitcoin-internals 0.6.0",
+ "bitcoin-internals 0.7.0",
  "bitcoin_hashes 1.2.0",
  "hex-conservative 1.1.0",
 ]
@@ -90,7 +90,7 @@ dependencies = [
  "bitcoin-addresses",
  "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-crypto",
- "bitcoin-internals 0.6.0",
+ "bitcoin-internals 0.7.0",
  "bitcoin-io 0.6.0",
  "bitcoin-key-expression",
  "bitcoin-network-kind",
@@ -113,7 +113,7 @@ dependencies = [
  "base58ck 0.5.0",
  "bech32",
  "bitcoin-crypto",
- "bitcoin-internals 0.6.0",
+ "bitcoin-internals 0.7.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
  "bitcoin-taproot-primitives",
@@ -127,7 +127,7 @@ name = "bitcoin-bip158"
 version = "0.0.0"
 dependencies = [
  "bitcoin-consensus-encoding 1.2.0",
- "bitcoin-internals 0.6.0",
+ "bitcoin-internals 0.7.0",
  "bitcoin-primitives",
  "bitcoin_hashes 1.2.0",
  "hex-conservative 1.1.0",
@@ -147,7 +147,7 @@ dependencies = [
 name = "bitcoin-consensus-encoding"
 version = "1.2.0"
 dependencies = [
- "bitcoin-internals 0.6.0",
+ "bitcoin-internals 0.7.0",
  "hex-conservative 1.1.0",
  "serde",
  "serde_json",
@@ -159,7 +159,7 @@ version = "0.3.0"
 dependencies = [
  "arbitrary",
  "base58ck 0.5.0",
- "bitcoin-internals 0.6.0",
+ "bitcoin-internals 0.7.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
  "bitcoin_hashes 1.2.0",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-internals"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bincode",
  "serde",
@@ -217,7 +217,7 @@ name = "bitcoin-io"
 version = "0.6.0"
 dependencies = [
  "bitcoin-consensus-encoding 1.2.0",
- "bitcoin-internals 0.6.0",
+ "bitcoin-internals 0.7.0",
  "bitcoin_hashes 1.2.0",
 ]
 
@@ -229,7 +229,7 @@ dependencies = [
  "base58ck 0.5.0",
  "bincode",
  "bitcoin-crypto",
- "bitcoin-internals 0.6.0",
+ "bitcoin-internals 0.7.0",
  "bitcoin-network-kind",
  "bitcoin_hashes 1.2.0",
  "hex-conservative 1.1.0",
@@ -243,7 +243,7 @@ name = "bitcoin-network-kind"
 version = "1.0.0"
 dependencies = [
  "arbitrary",
- "bitcoin-internals 0.6.0",
+ "bitcoin-internals 0.7.0",
  "serde",
  "serde_json",
  "serde_test",
@@ -255,7 +255,7 @@ version = "0.1.0"
 dependencies = [
  "arbitrary",
  "bitcoin-consensus-encoding 1.2.0",
- "bitcoin-internals 0.6.0",
+ "bitcoin-internals 0.7.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
  "bitcoin-units 0.5.0",
@@ -271,7 +271,7 @@ dependencies = [
  "arbitrary",
  "bincode",
  "bitcoin-consensus-encoding 1.2.0",
- "bitcoin-internals 0.6.0",
+ "bitcoin-internals 0.7.0",
  "bitcoin-units 0.5.0",
  "bitcoin_hashes 1.2.0",
  "hex-conservative 1.1.0",
@@ -292,7 +292,7 @@ dependencies = [
  "arbitrary",
  "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-crypto",
- "bitcoin-internals 0.6.0",
+ "bitcoin-internals 0.7.0",
  "bitcoin_hashes 1.2.0",
  "secp256k1 0.33.0",
  "serde",
@@ -315,7 +315,7 @@ dependencies = [
  "arbitrary",
  "bincode",
  "bitcoin-consensus-encoding 1.2.0",
- "bitcoin-internals 0.6.0",
+ "bitcoin-internals 0.7.0",
  "serde",
  "serde_json",
  "serde_test",
@@ -347,7 +347,7 @@ version = "1.2.0"
 dependencies = [
  "arbitrary",
  "bitcoin-consensus-encoding 1.2.0",
- "bitcoin-internals 0.6.0",
+ "bitcoin-internals 0.7.0",
  "cpufeatures",
  "hex-conservative 1.1.0",
  "serde",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -27,7 +27,7 @@ dependencies = [
 name = "base58ck"
 version = "0.5.0"
 dependencies = [
- "bitcoin-internals 0.6.0",
+ "bitcoin-internals 0.7.0",
  "bitcoin_hashes 1.2.0",
  "hex-conservative 1.1.0",
 ]
@@ -83,7 +83,7 @@ dependencies = [
  "bitcoin-addresses",
  "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-crypto",
- "bitcoin-internals 0.6.0",
+ "bitcoin-internals 0.7.0",
  "bitcoin-io 0.6.0",
  "bitcoin-key-expression",
  "bitcoin-network-kind",
@@ -106,7 +106,7 @@ dependencies = [
  "base58ck 0.5.0",
  "bech32",
  "bitcoin-crypto",
- "bitcoin-internals 0.6.0",
+ "bitcoin-internals 0.7.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
  "bitcoin-taproot-primitives",
@@ -120,7 +120,7 @@ name = "bitcoin-bip158"
 version = "0.0.0"
 dependencies = [
  "bitcoin-consensus-encoding 1.2.0",
- "bitcoin-internals 0.6.0",
+ "bitcoin-internals 0.7.0",
  "bitcoin-primitives",
  "bitcoin_hashes 1.2.0",
  "hex-conservative 1.1.0",
@@ -140,7 +140,7 @@ dependencies = [
 name = "bitcoin-consensus-encoding"
 version = "1.2.0"
 dependencies = [
- "bitcoin-internals 0.6.0",
+ "bitcoin-internals 0.7.0",
  "hex-conservative 1.1.0",
  "serde",
  "serde_json",
@@ -152,7 +152,7 @@ version = "0.3.0"
 dependencies = [
  "arbitrary",
  "base58ck 0.5.0",
- "bitcoin-internals 0.6.0",
+ "bitcoin-internals 0.7.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
  "bitcoin_hashes 1.2.0",
@@ -189,7 +189,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-internals"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bincode",
  "serde",
@@ -210,7 +210,7 @@ name = "bitcoin-io"
 version = "0.6.0"
 dependencies = [
  "bitcoin-consensus-encoding 1.2.0",
- "bitcoin-internals 0.6.0",
+ "bitcoin-internals 0.7.0",
  "bitcoin_hashes 1.2.0",
 ]
 
@@ -222,7 +222,7 @@ dependencies = [
  "base58ck 0.5.0",
  "bincode",
  "bitcoin-crypto",
- "bitcoin-internals 0.6.0",
+ "bitcoin-internals 0.7.0",
  "bitcoin-network-kind",
  "bitcoin_hashes 1.2.0",
  "hex-conservative 1.1.0",
@@ -236,7 +236,7 @@ name = "bitcoin-network-kind"
 version = "1.0.0"
 dependencies = [
  "arbitrary",
- "bitcoin-internals 0.6.0",
+ "bitcoin-internals 0.7.0",
  "serde",
  "serde_json",
  "serde_test",
@@ -248,7 +248,7 @@ version = "0.1.0"
 dependencies = [
  "arbitrary",
  "bitcoin-consensus-encoding 1.2.0",
- "bitcoin-internals 0.6.0",
+ "bitcoin-internals 0.7.0",
  "bitcoin-network-kind",
  "bitcoin-primitives",
  "bitcoin-units 0.5.0",
@@ -264,7 +264,7 @@ dependencies = [
  "arbitrary",
  "bincode",
  "bitcoin-consensus-encoding 1.2.0",
- "bitcoin-internals 0.6.0",
+ "bitcoin-internals 0.7.0",
  "bitcoin-units 0.5.0",
  "bitcoin_hashes 1.2.0",
  "hex-conservative 1.1.0",
@@ -279,7 +279,7 @@ dependencies = [
  "arbitrary",
  "bitcoin-consensus-encoding 1.2.0",
  "bitcoin-crypto",
- "bitcoin-internals 0.6.0",
+ "bitcoin-internals 0.7.0",
  "bitcoin_hashes 1.2.0",
  "secp256k1 0.33.0",
  "serde",
@@ -302,7 +302,7 @@ dependencies = [
  "arbitrary",
  "bincode",
  "bitcoin-consensus-encoding 1.2.0",
- "bitcoin-internals 0.6.0",
+ "bitcoin-internals 0.7.0",
  "serde",
  "serde_json",
  "serde_test",
@@ -325,7 +325,7 @@ version = "1.2.0"
 dependencies = [
  "arbitrary",
  "bitcoin-consensus-encoding 1.2.0",
- "bitcoin-internals 0.6.0",
+ "bitcoin-internals 0.7.0",
  "cpufeatures",
  "hex-conservative 1.1.0",
  "serde",

--- a/addresses/Cargo.toml
+++ b/addresses/Cargo.toml
@@ -23,7 +23,7 @@ base58 = { package = "base58ck", path = "../base58", version = "0.5.0", default-
 bech32 = { version = "0.11.0", default-features = false, features = [] }
 crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.3.0", default-features = false, features = ["hex"] }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.0.0", default-features = false, features = ["hex"] }
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.7.0" }
 taproot_primitives = { package = "bitcoin-taproot-primitives", path = "../taproot_primitives", version = "0.1.0", default-features = false, features = [] }
 network = { package = "bitcoin-network-kind", path = "../network", version = "1.0.0", default-features = false, features = []}
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.103.0", default-features = false, features = ["hex"] }

--- a/base58/Cargo.toml
+++ b/base58/Cargo.toml
@@ -20,7 +20,7 @@ alloc = ["hashes/alloc", "internals/alloc"]
 
 [dependencies]
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.0.0", default-features = false }
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.7.0" }
 
 [dev-dependencies]
 hex = { package = "hex-conservative", version = "1.1.0" }

--- a/benches/Cargo.lock
+++ b/benches/Cargo.lock
@@ -131,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-internals"
-version = "0.6.0"
+version = "0.7.0"
 
 [[package]]
 name = "bitcoin-io"

--- a/bip158/Cargo.toml
+++ b/bip158/Cargo.toml
@@ -23,7 +23,7 @@ hex = ["hashes/hex", "primitives/hex"]
 [dependencies]
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.2.0", default-features = false }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.2.0", default-features = false }
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.7.0" }
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.103.0", default-features = false }
 
 [dev-dependencies]

--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -34,7 +34,7 @@ hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.1.0", de
 key-expression = { package = "bitcoin-key-expression", path = "../key_expression", version = "0.1.0", default-features = false, features = ["alloc"] }
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.1.0", default-features = false, features = ["alloc", "hex"] }
 hex = { package = "hex-conservative", version = "1.1.0", default-features = false, features = ["alloc"] }
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0", features = ["alloc"] }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.7.0", features = ["alloc"] }
 io = { package = "bitcoin-io", path = "../io", version = "0.6.0", default-features = false, features = ["alloc", "hashes"] }
 network = { package = "bitcoin-network-kind", path = "../network", version = "1.0.0", default-features = false, features = ["alloc"]}
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.103.0", default-features = false, features = ["alloc", "hex"] }

--- a/bitcoin/embedded/Cargo.lock
+++ b/bitcoin/embedded/Cargo.lock
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-internals"
-version = "0.6.0"
+version = "0.7.0"
 
 [[package]]
 name = "bitcoin-io"

--- a/consensus_encoding/Cargo.toml
+++ b/consensus_encoding/Cargo.toml
@@ -21,7 +21,7 @@ alloc = ["internals/alloc", "hex?/alloc", "serde?/alloc"]
 serde = ["alloc", "hex", "dep:serde"]
 
 [dependencies]
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.7.0" }
 
 hex = { package = "hex-conservative", version = "1.1.0", default-features = false, features = [], optional = true }
 serde = { version = "1.0.195", default-features = false, features = ["derive"], optional = true }

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -25,7 +25,7 @@ hex = ["dep:hex", "hashes/hex", "primitives/hex"]
 [dependencies]
 base58 = { package = "base58ck", path = "../base58", version = "0.5.0", default-features = false }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.0.0", default-features = false, features = ["hex"] }
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.7.0" }
 network = { package = "bitcoin-network-kind", path = "../network", version = "1.0.0", default-features = false }
 # This is a temporary dep for the sake of PushBytes impls. This should not be retained for crypto 1.0.
 primitives = { package = "bitcoin-primitives", path = "../primitives", version = "0.103.0", default-features = false, features = [] }

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -23,7 +23,7 @@ serde = ["dep:serde", "hex"]
 small-hash = []
 
 [dependencies]
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.7.0" }
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0", default-features = false }
 
 arbitrary = { version = "1.4.1", optional = true}

--- a/hashes/embedded/Cargo.lock
+++ b/hashes/embedded/Cargo.lock
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-internals"
-version = "0.6.0"
+version = "0.7.0"
 
 [[package]]
 name = "bitcoin-io"

--- a/internals/CHANGELOG.md
+++ b/internals/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## [Unreleased]
 
-- Add `U256` type, moved from the private `include!` module duplicated in `units` and `bitcoin`.
+## [0.7.0] - 2026-09-07
+
+- Add `U256` type, moved from the private `include!` module duplicated in `units` and `bitcoin` [#6715](https://github.com/rust-bitcoin/rust-bitcoin/pull/6715)
+- Add const-compatible `u64` to `u128` cast [#6835](https://github.com/rust-bitcoin/rust-bitcoin/pull/6835)
 
 ## [0.6.0] - 2026-07-07
 

--- a/internals/Cargo.toml
+++ b/internals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-internals"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>", "The Rust Bitcoin developers"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/rust-bitcoin/"

--- a/io/Cargo.toml
+++ b/io/Cargo.toml
@@ -20,7 +20,7 @@ std = ["alloc", "encoding/std", "hashes?/std", "internals/std"]
 alloc = ["encoding/alloc", "hashes?/alloc", "internals/alloc"]
 
 [dependencies]
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.7.0" }
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0", default-features = false }
 
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.0.0", default-features = false, optional = true }

--- a/key_expression/Cargo.toml
+++ b/key_expression/Cargo.toml
@@ -25,7 +25,7 @@ base58 = { package = "base58ck", path = "../base58", version = "0.5.0", default-
 crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.3.0", default-features = false }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.0.0", default-features = false, features = ["hex"] }
 hex = { package = "hex-conservative", version = "1.1.0", default-features = false, features = ["alloc"] }
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.7.0" }
 network = { package = "bitcoin-network-kind", path = "../network", version = "1.0.0", default-features = false }
 secp256k1 = { version = "0.33.0", default-features = false }
 

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -19,7 +19,7 @@ std = ["alloc", "internals/std"]
 alloc = ["internals/alloc", "serde?/alloc"]
 
 [dependencies]
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.7.0" }
 
 arbitrary = { version = "1.4.1", optional = true }
 serde = { version = "1.0.195", default-features = false, features = [ "derive" ], optional = true }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -24,7 +24,7 @@ hex = ["dep:hex", "hashes/hex", "encoding/hex"]
 [dependencies]
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.1.0", default-features = false }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.1.0", default-features = false }
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.7.0" }
 units = { package = "bitcoin-units", path = "../units", version = "0.5.0", default-features = false, features = [ "encoding" ] }
 
 arbitrary = { version = "1.4.1", optional = true }

--- a/taproot_primitives/Cargo.toml
+++ b/taproot_primitives/Cargo.toml
@@ -24,7 +24,7 @@ hex = ["crypto/hex", "encoding/hex", "hashes/hex"]
 crypto = { package = "bitcoin-crypto", path = "../crypto", version = "0.3.0", default-features = false }
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.1.0", default-features = false, features = [] }
 hashes = { package = "bitcoin_hashes", path = "../hashes", version = "1.0.0", default-features = false }
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.7.0" }
 
 arbitrary = { version = "1.4.1", optional = true }
 secp256k1 = { version = "0.33.0", default-features = false }

--- a/units/Cargo.toml
+++ b/units/Cargo.toml
@@ -20,7 +20,7 @@ alloc = ["internals/alloc", "serde?/alloc", "encoding?/alloc"]
 serde = ["dep:serde", "internals/serde"]
 
 [dependencies]
-internals = { package = "bitcoin-internals", path = "../internals", version = "0.6.0" }
+internals = { package = "bitcoin-internals", path = "../internals", version = "0.7.0" }
 
 encoding = { package = "bitcoin-consensus-encoding", path = "../consensus_encoding", version = "1.0.0", default-features = false, optional = true }
 serde = { version = "1.0.195", default-features = false, features = ["derive"], optional = true }


### PR DESCRIPTION
In preparation for release add a changelog entry, bump the version number, and update the lock files.
