### PR TITLE
ci: install rbmt from crates.io in replay job

### DIFF
--- a/.github/workflows/corpus-fuzzing.yml
+++ b/.github/workflows/corpus-fuzzing.yml
@@ -182,16 +182,14 @@ jobs:
             ~/.cargo/.crates2.json
             rust-bitcoin/fuzz/target
             rust-bitcoin/target
-          key: fuzz-${{ hashFiles('rust-bitcoin/**/Cargo.toml', 'rust-bitcoin/rbmt-version') }}
+          key: fuzz-${{ hashFiles('rust-bitcoin/**/Cargo.toml') }}
           restore-keys: fuzz-
       - name: Install cargo-rbmt
         working-directory: rust-bitcoin
         run: |
           cargo install \
-            --git https://git.rust-bitcoin.org/rust-bitcoin/rust-bitcoin-maintainer-tools \
-            --rev "$(cat rbmt-version)" \
-            cargo-rbmt \
-            --locked
+            --locked \
+            cargo-rbmt@$(grep "^rbmt.version" Cargo.toml | cut -d'"' -f2)
       - name: Install nightly toolchain
         working-directory: rust-bitcoin
         run: rustup toolchain install "$(cargo rbmt toolchains --nightly)" --profile minimal --no-self-update


### PR DESCRIPTION
Closes https://github.com/rust-bitcoin/rust-bitcoin/issues/6838

The newly added `replay-crash-store` job of corpus fuzzing installed `cargo-rbmt` from version of an outdated file `rbmt-version` file that doesn't exist anymore. Pull info from `Cargo.toml` `rbmt.version`. 100% my mistake here.