### PR TITLE
hashes: Fix Hkdf::expand panic

### DIFF
--- a/hashes/src/hkdf/mod.rs
+++ b/hashes/src/hkdf/mod.rs
@@ -233,6 +233,25 @@ mod tests {
     }
 
     #[test]
+    fn max_okm() {
+        let salt = hex::decode_to_vec("000102030405060708090a0b0c").unwrap();
+        let ikm = hex::decode_to_vec("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b").unwrap();
+        let info = hex::decode_to_vec("f0f1f2f3f4f5f6f7f8f9").unwrap();
+
+        let hkdf = Hkdf::<sha256::HashEngine>::new(&salt, &ikm);
+        // The RFC-5869 maximum output length of `255 * hash length` must not panic.
+        let mut okm = [0u8; 255 * 32];
+        hkdf.expand(&info, &mut okm).unwrap();
+
+        // HKDF output is a stable prefix stream, so the first 42 bytes match the
+        // RFC-5869 test case 1 vector.
+        assert_eq!(
+            okm[..42].to_lower_hex_string(),
+            "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865"
+        );
+    }
+
+    #[test]
     fn short_okm() {
         let salt = hex::decode_to_vec("000102030405060708090a0b0c").unwrap();
         let ikm = hex::decode_to_vec("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b").unwrap();

--- a/hashes/src/hkdf/mod.rs
+++ b/hashes/src/hkdf/mod.rs
@@ -71,36 +71,33 @@ where
             return Err(MaxLengthError { max: MAX_OUTPUT_BLOCKS * T::Hash::LEN });
         }
 
-        // Counter starts at "1" based on RFC5869 spec and is committed to in the hash.
-        let mut counter = 1u8;
         // Ceiling calculation for the total number of blocks (iterations) required for the expand.
         let total_blocks = okm.len().div_ceil(T::Hash::LEN);
 
-        while counter <= total_blocks as u8 {
+        // Counter starts at "1" based on RFC5869 spec and is committed to in the hash.
+        for counter in 1..=total_blocks {
             let mut engine: HmacEngine<T> = HmacEngine::new(self.prk.as_ref());
 
             // First block does not have a previous block,
             // all other blocks include last block in the HMAC input.
-            if counter != 1u8 {
-                let previous_start_index = (counter as usize - 2) * T::Hash::LEN;
-                let previous_end_index = (counter as usize - 1) * T::Hash::LEN;
+            if counter != 1 {
+                let previous_start_index = (counter - 2) * T::Hash::LEN;
+                let previous_end_index = (counter - 1) * T::Hash::LEN;
                 engine.input(&okm[previous_start_index..previous_end_index]);
             }
             engine.input(info);
-            engine.input(&[counter]);
+            engine.input(&[counter as u8]);
 
             let t = engine.finalize();
-            let start_index = (counter as usize - 1) * T::Hash::LEN;
+            let start_index = (counter - 1) * T::Hash::LEN;
             // Last block might not take full hash length.
-            let end_index = if counter == (total_blocks as u8) {
+            let end_index = if counter == total_blocks {
                 okm.len()
             } else {
-                counter as usize * T::Hash::LEN
+                counter * T::Hash::LEN
             };
 
             okm[start_index..end_index].copy_from_slice(&t.as_ref()[0..(end_index - start_index)]);
-
-            counter += 1;
         }
 
         Ok(())


### PR DESCRIPTION
Hkdf::expand accepts an output buffer up to the RFC-5869 maximum of 255 * T::Hash::LEN bytes, but the per-block counter was a u8. At the maximum length the counter reaches 255 on the final block and the subsequent counter += 1 overflows.  

Replace the u8 counter with a for loop which cannot overflow.

Closes project-loupe/audit-rust-bitcoin#5