### PR TITLE
units: Escape control characters in parse errors

### DIFF
--- a/internals/src/error/input_string.rs
+++ b/internals/src/error/input_string.rs
@@ -156,14 +156,14 @@ mod storage {
     where
         W: fmt::Display + ?Sized,
     {
-        write!(f, "failed to parse '{}' as {}", input, what)
+        write!(f, "failed to parse '{}' as {}", input.escape_debug(), what)
     }
 
     pub(super) fn unknown_variant<W>(inp: &Storage, what: &W, f: &mut fmt::Formatter) -> fmt::Result
     where
         W: fmt::Display + ?Sized,
     {
-        write!(f, "'{}' is not a known {}", inp, what)
+        write!(f, "'{}' is not a known {}", inp.escape_debug(), what)
     }
 
     impl_from!(alloc::string::String, alloc::boxed::Box<str>, alloc::borrow::Cow<'_, str>);

--- a/units/src/amount/error.rs
+++ b/units/src/amount/error.rs
@@ -334,7 +334,8 @@ impl fmt::Display for InvalidCharacterError {
             c => write!(
                 f,
                 "the character '{}' at position {} is not a valid digit",
-                c, self.position
+                c.escape_debug(),
+                self.position
             ),
         }
     }

--- a/units/src/amount/error.rs
+++ b/units/src/amount/error.rs
@@ -738,4 +738,18 @@ mod tests {
             assert!(e.source().is_some());
         }
     }
+
+    #[test]
+    #[cfg(feature = "alloc")]
+    fn denomination_error_display_escapes_control_characters() {
+        let e = Denomination::from_str("BTC\nFORGED: privileged action succeeded").unwrap_err();
+        assert!(!e.to_string().chars().any(char::is_control));
+    }
+
+    #[test]
+    #[cfg(feature = "alloc")]
+    fn invalid_character_error_display_escapes_control_characters() {
+        let e = Amount::from_str_in("1\n2", Denomination::Bitcoin).unwrap_err();
+        assert!(!e.to_string().chars().any(char::is_control));
+    }
 }

--- a/units/src/locktime/absolute/error.rs
+++ b/units/src/locktime/absolute/error.rs
@@ -446,4 +446,16 @@ mod tests {
             assert!(e.source().is_some());
         }
     }
+
+    #[test]
+    #[cfg(feature = "alloc")]
+    fn parse_error_display_escapes_control_characters() {
+        let height =
+            Height::from_str("1\nFORGED: privileged action succeeded").unwrap_err().to_string();
+        let time = MedianTimePast::from_str("\u{1b}[2JFORGED").unwrap_err().to_string();
+
+        for rendered in [height, time] {
+            assert!(!rendered.chars().any(char::is_control));
+        }
+    }
 }

--- a/units/src/parse_int.rs
+++ b/units/src/parse_int.rs
@@ -812,6 +812,20 @@ mod tests {
 
     #[test]
     #[cfg(feature = "alloc")]
+    fn missing_prefix_error_display_escapes_control_characters() {
+        let e = hex_u32_prefixed("bad\nlevel=INFO accepted=true").unwrap_err().to_string();
+        assert!(!e.chars().any(char::is_control));
+    }
+
+    #[test]
+    #[cfg(feature = "alloc")]
+    fn contains_prefix_error_display_escapes_control_characters() {
+        let e = hex_u32_unprefixed("0x1\nlevel=INFO accepted=true").unwrap_err().to_string();
+        assert!(!e.chars().any(char::is_control));
+    }
+
+    #[test]
+    #[cfg(feature = "alloc")]
     fn error_display_is_non_empty() {
         // ParseIntError - parse invalid integer
         let e = int_from_str::<u32>("not_a_number").unwrap_err();


### PR DESCRIPTION
Parse errors rendered input verbatim in their `Display` output, letting newlines or terminal escapes through.

Escape the stored input with `escape_debug` before formatting.

Closes project-loupe/audit-rust-bitcoin#88
Closes project-loupe/audit-rust-bitcoin#158
Closes project-loupe/audit-rust-bitcoin#163
Closes project-loupe/audit-rust-bitcoin#165
Closes project-loupe/audit-rust-bitcoin#166