### PR TITLE
Remove uses of `Index` on `secp256k1::SecretKey`

### DIFF
--- a/crypto/src/key.rs
+++ b/crypto/src/key.rs
@@ -1169,7 +1169,7 @@ impl WifKey {
         let mut ret = [0; 34];
         ret[0] = if self.network_kind.is_mainnet() { 128 } else { 239 };
 
-        ret[1..33].copy_from_slice(&self.private_key.as_inner()[..]);
+        ret[1..33].copy_from_slice(&self.private_key.to_secret_bytes()[..]);
         let privkey = if self.private_key.compressed() {
             ret[33] = 1;
             base58::Base58CkString::encode(&ret[..])

--- a/key_expression/src/bip32.rs
+++ b/key_expression/src/bip32.rs
@@ -784,7 +784,7 @@ impl Xpriv {
         } else {
             // Hardened key: use only secret data to prevent public derivation.
             engine.input(&[0u8]);
-            engine.input(&self.private_key[..]);
+            engine.input(self.private_key.as_secret_bytes());
         }
 
         engine.input(&u32::from(child_number).to_be_bytes());
@@ -867,7 +867,7 @@ impl Xpriv {
         ret[9..13].copy_from_slice(&u32::from(self.child_number).to_be_bytes());
         ret[13..45].copy_from_slice(&self.chain_code[..]);
         ret[45] = 0;
-        ret[46..78].copy_from_slice(&self.private_key[..]);
+        ret[46..78].copy_from_slice(self.private_key.as_secret_bytes());
         ret
     }
 


### PR DESCRIPTION
The Index impl on secp256k1::SecretKey is considered upstream to be something we want to remove. In preparation for that, we should replace relevant uses of that trait with equivalent as_secret_bytes() calls.

Remove uses of the Index trait on the secp256k1::SecretKey.