### PR TITLE
ci: skip 7 very long miri tests

### DIFF
--- a/hashes/tests/nist_cavp.rs
+++ b/hashes/tests/nist_cavp.rs
@@ -35,6 +35,7 @@ macro_rules! nist_shavs_tests {
             }
 
             #[test]
+            #[cfg_attr(miri, ignore)]
             fn long_msg() {
                 let content = include_str!($long_file);
                 run_shavs_tests(content, hash_oneshot);

--- a/primitives/src/witness.rs
+++ b/primitives/src/witness.rs
@@ -1442,6 +1442,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn from_iter_does_not_silently_lose_elements() {
         let n: usize = 4_000_001;
         let witness: Witness = core::iter::repeat(&[0u8; 0]).take(n).collect();


### PR DESCRIPTION
Closes https://github.com/rust-bitcoin/rust-bitcoin/issues/6864

The nightly miri job hits the five hour runner limit then GA kills it.

Why not run the limit anyway? Running them prevents the rest from being run. The timeout kills the job midway, so later crates never get executed at all. 

So this PR skips from miri any the tests runs that take too long, to avoid timeout. We have 5 hour / 300 minutes budget. 

Jobs skipped:
- The witness test that builds 4000001 elements, took 118.7 minutes and still unfinished when the runner died on [this run](https://github.com/rust-bitcoin/rust-bitcoin/actions/runs/34487698737).
- 6 NIST `long_msg` vectors tests that hash megabytes of data, 140 minutes across the six of them. They are generated by one macro, so two of them cost only a few minutes each but get gated with the rest. 

The correct way to gate it is `#[cfg_attr(miri, ignore)]` https://github.com/rust-lang/miri#using-miri.

This PR is problematic because I can't prove the remaining tests would finish in the freed up time, but they certainly are not running now. That 6 NIST tests, had they not been skipped, may just fit within the time limit, but with the whole p2p crate supposed to be miri tested ahead of it that leaves us at only 13% time budget left.